### PR TITLE
Add JDBC Interpreter for Mysql

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -66,7 +66,7 @@
 
 <property>
   <name>zeppelin.interpreters</name>
-  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter</value>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.jdbc.JDBCInterpreter</value>
   <description>Comma separated interpreter configurations. First interpreter become a default</description>
 </property>
 

--- a/jdbc/COPYING
+++ b/jdbc/COPYING
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @Author Hyungu Roh <hyungu.roh@navercorp.com>
+#

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zeppelin</artifactId>
+    <groupId>org.apache.zeppelin</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.apache.zeppelin</groupId>
+  <artifactId>zeppelin-jdbc</artifactId>
+  <packaging>jar</packaging>
+  <version>0.5.0-SNAPSHOT</version>
+  <name>Zeppelin: JDBC interpreter</name>
+  <url>http://zeppelin.incubator.apache.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-interpreter</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>            
+        <executions> 
+          <execution> 
+            <id>enforce</id> 
+            <phase>none</phase> 
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/jdbc</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-artifact</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../interpreter/jdbc</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <includeScope>runtime</includeScope>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${project.version}</version>
+                  <type>${project.packaging}</type>
+                </artifactItem>
+              </artifactItems>              
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -65,8 +65,9 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.6</version>
+      <version>5.1.35</version>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/DBConnection.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/DBConnection.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.zeppelin.jdbc;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+
+/**
+ * DBConnection
+ *
+ * @author Hyungu Roh hyungu.roh@navercorp.com
+ *
+ */
+
+public interface DBConnection {
+  void open();
+  void close();
+  InterpreterResult executeSql(String sql);
+  void cancel();
+}
+

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/DBConnectionFactory.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/DBConnectionFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.zeppelin.jdbc;
+
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.sql.Connection;
+
+/**
+ * DBConnectionFactory
+ *
+ * @author Hyungu Roh hyungu.roh@navercorp.com
+ *
+ */
+
+public class DBConnectionFactory {
+  Logger logger = LoggerFactory.getLogger(DBConnectionFactory.class);
+
+  String jdbc = "";
+  String host = "";
+  String port = "";
+  String user = "";
+  String password = "";
+
+  public DBConnectionFactory(Properties currentProperty) {
+    for (Object k : currentProperty.keySet()) {
+      String key = (String) k;
+      String value = (String) currentProperty.get(key);
+
+      if ( key.equals("jdbc") ) {
+        this.jdbc = value.toLowerCase();
+      } else if ( key.equals("host") ) {
+        this.host = value;
+      } else if ( key.equals("password") ) {
+        this.password = value;
+      } else if ( key.equals("user") ) {
+        this.user = value;
+      } else if ( key.equals("port") ) {
+        this.port = value;
+      } else {
+        logger.info("else key : " +  key);
+      }
+    }
+  }
+
+  public DBConnection getDBConnection() {
+    DBConnection currentConnection;
+
+    // add other jdbc
+    if ( jdbc.equals("mysql") ) {
+      currentConnection = new MysqlConnection(host, port, user, password);
+    } else {
+      currentConnection = null;
+    }
+
+    return currentConnection;
+  }
+}
+

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.zeppelin.jdbc;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.Vector;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.scheduler.Scheduler;
+import org.apache.zeppelin.scheduler.SchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * JDBC interpreter for Zeppelin.
+ *
+ * @author Hyungu Roh hyungu.roh@navercorp.com
+ *
+ */
+
+public class JDBCInterpreter extends Interpreter {
+  Logger logger = LoggerFactory.getLogger(JDBCInterpreter.class);
+  int commandTimeOut = 600000;
+
+  static {
+    Interpreter.register("jdbc", JDBCInterpreter.class.getName());
+  }
+
+  DBConnection jdbcConnection;
+ 
+  public JDBCInterpreter(Properties property) {
+    super(property);
+    Properties currentProperty = getProperty();
+    DBConnectionFactory DBFactory = new DBConnectionFactory(currentProperty);
+    this.jdbcConnection = DBFactory.getDBConnection();
+  }
+
+  @Override
+  public void open() {
+    jdbcConnection.open();
+  }
+
+  @Override
+  public void close() {
+    jdbcConnection.close();
+  }
+
+  @Override
+  public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
+    logger.info("Run SQL command '" + cmd + "'");
+    return jdbcConnection.executeSql(cmd);
+  }
+
+  @Override
+  public void cancel(InterpreterContext context) {
+    jdbcConnection.cancel();
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return 0;
+  }
+
+  @Override
+  public Scheduler getScheduler() {
+    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
+        JDBCInterpreter.class.getName() + this.hashCode());
+  }
+
+  @Override
+  public List<String> completion(String buf, int cursor) {
+    return null;
+  }
+
+}

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/MysqlConnection.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/MysqlConnection.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.zeppelin.jdbc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang.StringUtils;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+
+import java.util.Vector;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * MysqlConnection
+ *
+ * @author Hyungu Roh hyungu.roh@navercorp.com
+ *
+ */
+
+public class MysqlConnection implements DBConnection {
+  Logger logger = LoggerFactory.getLogger(MysqlConnection.class);
+
+  String host;
+  String port;
+  String user;
+  String passwd;
+
+  public MysqlConnection(String host, String port, String user, String passwd) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.passwd = passwd;
+  }
+
+  Connection mysqlConnection;
+  Exception exceptionOnConnect;
+  Statement currentStatement;
+  ResultSet resultSet; 
+
+  @Override
+  public void open() {
+    String driver = "com.mysql.jdbc.Driver";
+    String url = "jdbc:mysql://";
+    url += host;
+    url += port != "" ? ":" + port : "";
+    url += "/?user=" + user;
+
+    try {
+      Class.forName(driver);
+      mysqlConnection = DriverManager.getConnection(url, user, passwd);
+    } catch ( ClassNotFoundException | SQLException e ) {
+      logger.error("Can not open connection", e);
+      exceptionOnConnect = e;
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      mysqlConnection.close();
+      currentStatement.close();
+      resultSet.close();
+    } catch ( SQLException e ) {
+      logger.error("Can not close connection", e);
+    }
+
+    mysqlConnection = null;
+    exceptionOnConnect = null;
+    currentStatement = null;
+    resultSet = null;
+  }
+
+  @Override
+  public InterpreterResult executeSql(String sql) {
+    try {
+      if (exceptionOnConnect != null) {
+        return new InterpreterResult(Code.ERROR, exceptionOnConnect.getMessage());
+      }
+      currentStatement = mysqlConnection.createStatement();
+      StringBuilder msg = null;
+      if (StringUtils.containsIgnoreCase(sql, "EXPLAIN ")) {
+        //return the explain as text, make this visual explain later
+        msg = new StringBuilder();
+      }
+      else {
+        msg = new StringBuilder("%table ");
+      }
+      resultSet = currentStatement.executeQuery(sql);
+      try {
+        ResultSetMetaData md = resultSet.getMetaData();
+        for (int i = 1; i < md.getColumnCount() + 1; i++) {
+          if (i == 1) {
+            msg.append(md.getColumnName(i));
+          } else {
+            msg.append("\t" + md.getColumnName(i));
+          }
+        }
+        msg.append("\n");
+        while (resultSet.next()) {
+          for (int i = 1; i < md.getColumnCount() + 1; i++) {
+            msg.append(resultSet.getString(i) + "\t");
+          }
+          msg.append("\n");
+        }
+      } catch ( NullPointerException e ) {
+  
+      }
+
+      InterpreterResult rett = new InterpreterResult(Code.SUCCESS, msg.toString());
+      return rett;
+    }
+    catch (SQLException ex) {
+      logger.error("Can not run " + sql, ex);
+      return new InterpreterResult(Code.ERROR, ex.getMessage());
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (currentStatement != null) {
+      try {
+        currentStatement.cancel();
+      }
+      catch (SQLException ex) {
+      }
+      finally {
+        currentStatement = null;
+      }
+    }
+  }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>shell</module>
     <module>hive</module>
     <module>tajo</module>
+    <module>jdbc</module>
     <module>zeppelin-web</module>
     <module>zeppelin-server</module>
     <module>zeppelin-distribution</module>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -389,7 +389,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         + "org.apache.zeppelin.angular.AngularInterpreter,"
         + "org.apache.zeppelin.shell.ShellInterpreter,"
         + "org.apache.zeppelin.hive.HiveInterpreter,"
-        + "org.apache.zeppelin.tajo.TajoInterpreter"),
+        + "org.apache.zeppelin.tajo.TajoInterpreter,"
+        + "org.apache.zeppelin.jdbc.JDBCInterpreter"),
         ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "interpreter"),
         ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
         ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),


### PR DESCRIPTION
I added jdbc interpreter for mysql

I used Abstract Factory Pattern
It has the advantage that can be separated using the JDBC Connection only argument value

![1](https://cloud.githubusercontent.com/assets/4284583/7451786/c3b44b10-f28f-11e4-8332-fe9133fe8f06.PNG)

How to add your jdbc driver
1. add dependency for your jdbc driver (pom.xml)
2. implement Sub-Class (like MysqlConnection)
3. add branch connection in Factory Class (DBConnectionFactory)
> It can be extended any jdbc. Such as Oracle, HIVE, Tajo, hBase, MariaDB, ...

Set interpreter
![2015-05-04 18 47 59](https://cloud.githubusercontent.com/assets/4284583/7451794/e48ec89c-f28f-11e4-8318-cc060061d320.PNG)

How  to Use
![2015-05-04 19 02 27](https://cloud.githubusercontent.com/assets/4284583/7451821/2bf1ad6c-f290-11e4-872a-2936baf9f139.PNG)