### PR TITLE
[ZEPPELIN-9]: Provide Spark profiles for older 1.2.x and 1.1.x versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1280,7 +1280,17 @@
     </profile>
 
     <profile>
-      <id>spark-1.1</id>
+      <id>spark-1.1.0</id>
+      <dependencies>
+
+      </dependencies>
+      <properties>
+        <spark.version>1.1.0</spark.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-1.1.1</id>
       <dependencies>
 
       </dependencies>
@@ -1290,12 +1300,12 @@
     </profile>
 
     <profile>
-      <id>spark-1.2</id>
+      <id>spark-1.2.0</id>
       <dependencies>
       </dependencies>
       <properties>
+        <spark.version>1.2.0</spark.version>
         <akka.version>2.3.4-spark</akka.version>
-        <spark.version>1.2.1</spark.version>
         <hive.version>0.13.1a</hive.version>
         <derby.version>10.10.1.1</derby.version>
         <parquet.version>1.6.0rc3</parquet.version>
@@ -1307,12 +1317,76 @@
     </profile>
 
     <profile>
-      <id>spark-1.3</id>
+      <id>spark-1.2.1</id>
       <dependencies>
       </dependencies>
       <properties>
+        <spark.version>1.2.1</spark.version>
         <akka.version>2.3.4-spark</akka.version>
+        <hive.version>0.13.1a</hive.version>
+        <derby.version>10.10.1.1</derby.version>
+        <parquet.version>1.6.0rc3</parquet.version>
+        <chill.version>0.5.0</chill.version>
+        <commons.httpclient.version>4.2.6</commons.httpclient.version>
+        <commons.math3.version>3.1.1</commons.math3.version>
+        <io.netty.version>4.0.23.Final</io.netty.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-1.2.2</id>
+      <dependencies>
+      </dependencies>
+      <properties>
+        <spark.version>1.2.2</spark.version>
+        <akka.version>2.3.4-spark</akka.version>
+        <hive.version>0.13.1a</hive.version>
+        <derby.version>10.10.1.1</derby.version>
+        <parquet.version>1.6.0rc3</parquet.version>
+        <chill.version>0.5.0</chill.version>
+        <commons.httpclient.version>4.2.6</commons.httpclient.version>
+        <commons.math3.version>3.1.1</commons.math3.version>
+        <io.netty.version>4.0.23.Final</io.netty.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-1.3.0</id>
+      <dependencies>
+      </dependencies>
+      <properties>
         <spark.version>1.3.0</spark.version>
+        <akka.version>2.3.4-spark</akka.version>
+        <mesos.version>0.21.0</mesos.version>
+        <hbase.version>0.98.7</hbase.version>
+        <hbase.artifact>hbase</hbase.artifact>
+        <hive.group>org.spark-project.hive</hive.group>
+        <hive.version>0.13.1a</hive.version>
+        <derby.version>10.10.1.1</derby.version>
+        <orbit.version>3.0.0.v201112011016</orbit.version>
+        <parquet.version>1.6.0rc3</parquet.version>
+        <chill.version>0.5.0</chill.version>
+        <ivy.version>2.4.0</ivy.version>
+        <oro.version>2.0.8</oro.version>
+        <avro.mapred.classifier></avro.mapred.classifier>
+        <codahale.metrics.version>3.1.0</codahale.metrics.version>
+        <commons.httpclient.version>4.2.6</commons.httpclient.version>
+        <commons.math3.version>3.1.1</commons.math3.version>
+        <io.netty.version>4.0.23.Final</io.netty.version>
+        <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
+        <fasterxml.jackson.version>2.4.4</fasterxml.jackson.version>
+        <snappy.version>1.1.1.6</snappy.version>
+        <mesos.version>0.21.0</mesos.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-1.3.1</id>
+      <dependencies>
+      </dependencies>
+      <properties>
+        <spark.version>1.3.1</spark.version>
+        <akka.version>2.3.4-spark</akka.version>
         <mesos.version>0.21.0</mesos.version>
         <hbase.version>0.98.7</hbase.version>
         <hbase.artifact>hbase</hbase.artifact>


### PR DESCRIPTION
Added patch versions to the spark profiles (i.e. `1.3` to `1.3.1` and `1.3.0`).