### PR TITLE
Add dockerfile (and makefile) to build local version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -- Documentation
+#
+# Build:
+#   docker build -t incubator-zeppelin .
+# Run:
+#   docker run -p :8080 incubator-zeppelin
+# 
+FROM base-incubator-zeppelin
+MAINTAINER Zeppelin Project (incubating)
+
+ADD . /usr/share/local/incubator-zeppelin
+WORKDIR /usr/share/local/incubator-zeppelin
+
+RUN mvn clean package -DskipTests -Drat.skip=true -e
+CMD /usr/share/local/incubator-zeppelin/bin/zeppelin.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -- Documentation
+#
+#We need to build image:
+#    docker build -t incubator-zeppelin .
+#
+#We can play with the image to run goal maven:
+#  docker run -ti p 8080:8080 --rm [-v ~/.m2:/home/zeppelin/.m2] $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin mvn clean install -DskipTests [-Pspark-XXX -Dhadoop.version=XXX -Phadoop-XXX]
+#
+# We must mount your project directory with "/home/zeppelin/incubator-zeppelin"
+#  -v "$(path project zeppelin):/home/zeppelin/incubator-zeppelin"
+# We can mount your directory ".m2" with VOLUME "/home/zeppelin/.m2"
+#  -v "~/.m2:/home/zeppelin/.m2"
+#
+#Remove container:
+#  docker rm -f iz
+#Stop:
+#  docker stop iz
+#Remove image:
+#  docker rmi -f incubator-zeppelin
+#Run with bash: 
+#  docker run -p 8080:8080 -ti --rm [-v ~/.m2:/home/zeppelin/.m2] -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+#Push:
+#  docker push incubator-zeppelin
+FROM centos:latest
+
+MAINTAINER Zeppelin Project (incubating) 
+
+#for plugin frontend-maven-plugin we need maven >= 3.1.0
+ENV MAVEN_VERSION=3.3.3 
+ENV MAVEN_HOME=/usr/local/maven 
+ENV MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=256m"
+
+ENV PATH=${PATH}:${MAVEN_HOME}/bin
+
+
+EXPOSE 8080
+
+#bzip2 for npm (tar .bz2)
+RUN yum -y update
+#fontconfig to phantomJS
+#bzip2 to install modules npm
+RUN yum install -y git bzip2 fontconfig 
+RUN yum clean all
+
+#install jdk
+RUN curl http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-x64.rpm -L -C - -b "oraclelicense=accept-securebackup-cookie" -o /tmp/jdk.rpm
+RUN rpm -ivh /tmp/jdk.rpm
+
+#install maven
+RUN curl -L http://wwwftp.ciril.fr/pub/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -o /tmp/apache-maven.tar.gz 
+RUN mkdir -p $MAVEN_HOME 
+RUN tar --strip-components 1 -xzvf /tmp/apache-maven.tar.gz -C $MAVEN_HOME 
+RUN curl -L http://central.maven.org/maven2/org/apache/maven/wagon/wagon-http-lightweight/2.10/wagon-http-lightweight-2.10.jar -o /usr/local/maven/lib/ext/wagon-http-lightweight-2.10.jar
+
+#clear download
+RUN rm -f /tmp/apache-maven.tar.gz /tmp/jdk.rpm
+
+
+#Add user zeppelin
+RUN useradd -ms /bin/bash zeppelin
+RUN mkdir -p touch /home/zeppelin/.m2; touch /home/zeppelin/.m2/toChown.txt
+RUN mkdir -p /home/zeppelin/incubator-zeppelin; touch /home/zeppelin/incubator-zeppelin/toChown.txt
+RUN chown -R zeppelin:zeppelin /home/zeppelin/.m2
+RUN chown -R zeppelin:zeppelin /home/zeppelin/incubator-zeppelin
+
+USER zeppelin
+WORKDIR /home/zeppelin/incubator-zeppelin
+
+VOLUME ["/home/zeppelin/.m2", "/home/zeppelin/incubator-zeppelin"]

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -17,26 +17,24 @@
 # -- Documentation
 #
 #We need to build image:
-#    docker build -t incubator-zeppelin .
+#    docker build -t base-incubator-zeppelin .
 #
 #We can play with the image to run goal maven:
-#  docker run -ti p 8080:8080 --rm [-v ~/.m2:/home/zeppelin/.m2] $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin mvn clean install -DskipTests [-Pspark-XXX -Dhadoop.version=XXX -Phadoop-XXX]
+#  docker run -ti p 8080:8080 --rm [-v ~/.m2:/root/.m2] $(pwd):/root/incubator-zeppelin -w /root/incubator-zeppelin --name iz base-incubator-zeppelin mvn clean install -DskipTests [-Pspark-XXX -Dhadoop.version=XXX -Phadoop-XXX]
 #
-# We must mount your project directory with "/home/zeppelin/incubator-zeppelin"
-#  -v "$(path project zeppelin):/home/zeppelin/incubator-zeppelin"
+# We must mount your project directory with "/root/incubator-zeppelin"
+#  -v "$(path project zeppelin):/root/incubator-zeppelin"
 # We can mount your directory ".m2" with VOLUME "/home/zeppelin/.m2"
-#  -v "~/.m2:/home/zeppelin/.m2"
+#  -v "~/.m2:/root/.m2"
 #
 #Remove container:
 #  docker rm -f iz
 #Stop:
 #  docker stop iz
 #Remove image:
-#  docker rmi -f incubator-zeppelin
-#Run with bash: 
-#  docker run -p 8080:8080 -ti --rm [-v ~/.m2:/home/zeppelin/.m2] -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+#  docker rmi -f base-incubator-zeppelin
 #Push:
-#  docker push incubator-zeppelin
+#  docker push base-incubator-zeppelin
 FROM centos:latest
 
 MAINTAINER Zeppelin Project (incubating) 
@@ -66,20 +64,6 @@ RUN rpm -ivh /tmp/jdk.rpm
 RUN curl -L http://wwwftp.ciril.fr/pub/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -o /tmp/apache-maven.tar.gz 
 RUN mkdir -p $MAVEN_HOME 
 RUN tar --strip-components 1 -xzvf /tmp/apache-maven.tar.gz -C $MAVEN_HOME 
-RUN curl -L http://central.maven.org/maven2/org/apache/maven/wagon/wagon-http-lightweight/2.10/wagon-http-lightweight-2.10.jar -o /usr/local/maven/lib/ext/wagon-http-lightweight-2.10.jar
 
 #clear download
 RUN rm -f /tmp/apache-maven.tar.gz /tmp/jdk.rpm
-
-
-#Add user zeppelin
-RUN useradd -ms /bin/bash zeppelin
-RUN mkdir -p touch /home/zeppelin/.m2; touch /home/zeppelin/.m2/toChown.txt
-RUN mkdir -p /home/zeppelin/incubator-zeppelin; touch /home/zeppelin/incubator-zeppelin/toChown.txt
-RUN chown -R zeppelin:zeppelin /home/zeppelin/.m2
-RUN chown -R zeppelin:zeppelin /home/zeppelin/incubator-zeppelin
-
-USER zeppelin
-WORKDIR /home/zeppelin/incubator-zeppelin
-
-VOLUME ["/home/zeppelin/.m2", "/home/zeppelin/incubator-zeppelin"]

--- a/dev-tools/docker-zeppelin.sh
+++ b/dev-tools/docker-zeppelin.sh
@@ -26,23 +26,25 @@ display_usage() {
  echo -e "$0 run-zeppelin [-Pspark-XXX -Dhadoop.version=XXX -Phadoop-XXX] $green#to run the image \"incubator-zeppelin\" in daemon, mount your ~.m2 with container and run goal maven and start zeppelin$reset_color" 
 } 
 
+current=$(dirname "${BASH_SOURCE-$0}")
+folderZeppelin=$(cd "${current}/..">/dev/null; pwd)
 command="${1}"
 
 case ${command} in
   build)
      echo "Build docker incubator-zeppelin"
-     docker build -t incubator-zeppelin .
+     docker build -t base-incubator-zeppelin -f $current/Dockerfile .
      ;;
   run)
-     docker run -p 8080:8080 -ti --rm -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+     docker run -p :8080 -ti --rm -v $folderZeppelin:/root/incubator-zeppelin -w /root/incubator-zeppelin --name iz base-incubator-zeppelin
      ;;
   run-with-m2)
-     docker run -p 8080:8080 -ti --rm -v ~/.m2:/home/zeppelin/.m2 -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+     docker run -p :8080 -ti --rm -v ~/.m2:/root/.m2 -v $folderZeppelin:/root/incubator-zeppelin -w /root/incubator-zeppelin --name iz base-incubator-zeppelin
      ;;
   run-zeppelin)
      configuration_maven=${@:2}
      container=$(date "+iz-%Y%m%d%H%M")
-     docker run -p 8080:8080 -d -v ~/.m2:/home/zeppelin/.m2 -v $(pwd):/home/zeppelin/incubator-zeppelin --name $container incubator-zeppelin \
+     docker run -p :8080 -d -v ~/.m2:/root/.m2 -v $folderZeppelin:/root/incubator-zeppelin -w /root/incubator-zeppelin --name $container base-incubator-zeppelin \
         /bin/bash -c  "mvn clean package -DskipTests $configuration_maven; /home/zeppelin/incubator-zeppelin/bin/zeppelin.sh"
      echo "You can follow logs docker logs -f $container" 
      ;;

--- a/docker-zeppelin.sh
+++ b/docker-zeppelin.sh
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#!/bin/bash
+
+
+display_usage() {
+ green="\033[0;32m"
+ reset_color="\033[0m" 
+ echo "Usage:"
+ echo -e "$0 build         $green#to build the Dockerfile$reset_color"
+ echo -e "$0 run           $green#to run the image \"incubator-zeppelin\" with interaction$reset_color"
+ echo -e "$0 run-with-m2   $green#to run the image \"incubator-zeppelin\" with interaction and mount your ~.m2 with container$reset_color" 
+ echo -e "$0 run-zeppelin [-Pspark-XXX -Dhadoop.version=XXX -Phadoop-XXX] $green#to run the image \"incubator-zeppelin\" in daemon, mount your ~.m2 with container and run goal maven and start zeppelin$reset_color" 
+} 
+
+command="${1}"
+
+case ${command} in
+  build)
+     echo "Build docker incubator-zeppelin"
+     docker build -t incubator-zeppelin .
+     ;;
+  run)
+     docker run -p 8080:8080 -ti --rm -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+     ;;
+  run-with-m2)
+     docker run -p 8080:8080 -ti --rm -v ~/.m2:/home/zeppelin/.m2 -v $(pwd):/home/zeppelin/incubator-zeppelin --name iz incubator-zeppelin
+     ;;
+  run-zeppelin)
+     configuration_maven=${@:2}
+     container=$(date "+iz-%Y%m%d%H%M")
+     docker run -p 8080:8080 -d -v ~/.m2:/home/zeppelin/.m2 -v $(pwd):/home/zeppelin/incubator-zeppelin --name $container incubator-zeppelin \
+        /bin/bash -c  "mvn clean package -DskipTests $configuration_maven; /home/zeppelin/incubator-zeppelin/bin/zeppelin.sh"
+     echo "You can follow logs docker logs -f $container" 
+     ;;
+  *)
+     display_usage 
+     exit 1 # Command to come out of the program with status 1
+     ;;
+esac


### PR DESCRIPTION
- [x] Dockerfile contains:
	* jdk-7u80-linux-x64
        * maven >= 3.10
        * git gcc-c++ make bzip2

- [x] Makefile contains goals:
  - [x] **build** the image 
  - [x] **run** with image
  - [x] **install-local** runs goal maven => `mvn clean install -DskipTests`
  - [x] add goal to build differently version
  - [x] add goal to run zeppelin (modify Dockerfile with port 8080)

- [x] change `MAINTAINER` into `Zeppelin Project (incubating)`
- [x] Expose "~/.m2" repository in Dockerfile as `VOLUME`
- [x] Add comments at the top of file => how to build it and how to use it 
- [x] see why grunt fails (**fontconfig**)
- [x] add user in Dockerfile (not use `root`)
- [x] split into many layer (command curl, yum)
- [x] manage `ENTRYPOINT`
- [x] find a better solution => goal maven

```
[INFO] Running "connect:test" (connect) task
[INFO] Started connect web server on http://localhost:9001
[INFO]
[INFO] Running "karma:unit" (karma) task
[INFO] INFO [karma]: Karma v0.12.37 server started at http://localhost:9002/
[INFO] INFO [launcher]: Starting browser PhantomJS
[INFO] ERROR [launcher]: Cannot start PhantomJS
[INFO]
[INFO] INFO [launcher]: Trying to start PhantomJS again (1/2).
[INFO] ERROR [launcher]: Cannot start PhantomJS
[INFO]
[INFO] INFO [launcher]: Trying to start PhantomJS again (2/2).
[INFO] ERROR [launcher]: Cannot start PhantomJS
[INFO]
[INFO] ERROR [launcher]: PhantomJS failed 2 times (cannot start). Giving up.
[INFO] Warning: Task "karma:unit" failed. Use --force to continue.
[INFO]
[INFO] Aborted due to warnings.
[INFO]
[INFO]
[INFO] Execution Time (2015-10-13 21:47:21 UTC)
[INFO] wiredep:app        890ms  ?????????????????? 12%
[INFO] wiredep:test       101ms  ??? 1%
[INFO] concurrent:test     5.6s  ?????????????????????????????????????????????????????????????????????????????????????????????????????? 78%
[INFO] autoprefixer:dist  162ms  ??? 2%
[INFO] karma:unit         278ms  ?????? 4%
[INFO] Total 7.1s
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 31.687 s
[INFO] Finished at: 2015-10-13T21:47:29+00:00
[INFO] Final Memory: 15M/37M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.23:grunt (grunt build) on project zeppelin-web: Failed to run task: 'grunt --no-color' failed. (error code 3) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.23:grunt (grunt build) on project zeppelin-web: Failed to run task
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:862)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoFailureException: Failed to run task
	at com.github.eirslett.maven.plugins.frontend.mojo.GruntMojo.execute(GruntMojo.java:71)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 20 more
Caused by: com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException: 'grunt --no-color' failed. (error code 3)
	at com.github.eirslett.maven.plugins.frontend.lib.NodeTaskExecutor.execute(NodeTaskExecutor.java:38)
	at com.github.eirslett.maven.plugins.frontend.mojo.GruntMojo.execute(GruntMojo.java:69)
	... 22 more
```
