### PR TITLE
Update SparkInterpreter.java

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -88,6 +88,8 @@ public class SparkInterpreter extends Interpreter {
         "spark",
         SparkInterpreter.class.getName(),
         new InterpreterPropertyBuilder()
+            .add("spark.executor.instances", "2", "Number of executors.")
+            .add("spark.executor.cores", "1", "The number of cores to use on each executor.")
             .add("spark.app.name", "Zeppelin", "The name of spark application.")
             .add("master",
                 getSystemDefault("MASTER", "spark.master", "local[*]"),


### PR DESCRIPTION
Ability to specify number of executors and number of executors per core. Only by adding above two lines had a actual impact.