### PR TITLE
Restart spark interpreter when the spark context has shutdown

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -109,6 +109,8 @@ public class SparkInterpreter extends Interpreter {
             .add("zeppelin.spark.maxResult",
                 getSystemDefault("ZEPPELIN_SPARK_MAXRESULT", "zeppelin.spark.maxResult", "1000"),
                 "Max number of SparkSQL result to display.")
+            .add("spark.auto.restart.sc", "true", "spark context will automatically restart" +
+              "if a job is submitted after it has stopped due to idle timeout.")
             .add("args", "", "spark commandline args").build());
 
   }
@@ -791,5 +793,15 @@ public class SparkInterpreter extends Interpreter {
 
   public ZeppelinContext getZeppelinContext() {
     return z;
+  }
+
+  @Override
+  public boolean restartRequired() {
+    boolean restartEnabled = Boolean.parseBoolean(getProperty("spark.auto.restart.sc"));
+    boolean required = (restartEnabled && sc != null && sc.taskScheduler() == null);
+    if (required) {
+      logger.info("Spark interpreter restart required");
+    }
+    return required;
   }
 }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -292,4 +292,9 @@ public class SparkSqlInterpreter extends Interpreter {
   public List<String> completion(String buf, int cursor) {
     return null;
   }
+
+  @Override
+  public boolean restartRequired() {
+    return getSparkInterpreter().restartRequired();
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ClassloaderInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ClassloaderInterpreter.java
@@ -276,4 +276,9 @@ public class ClassloaderInterpreter
       Thread.currentThread().setContextClassLoader(oldcl);
     }
   }
+
+  @Override
+  public boolean restartRequired() {
+    return intp.restartRequired();
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -279,4 +279,8 @@ public abstract class Interpreter {
     }
     return null;
   }
+
+  public boolean restartRequired() {
+    return false;
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -119,4 +119,14 @@ public class InterpreterGroup extends LinkedList<Interpreter>{
       }
     }
   }
+
+  public boolean restartRequired() {
+    for (Interpreter intp : this) {
+      if (intp.restartRequired()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -148,7 +148,7 @@ public class LazyOpenInterpreter
 
   @Override
   public boolean restartRequired() {
-    if (isOpen()) {
+    if (opened) {
       return intp.restartRequired();
     } else {
       return false;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -145,4 +145,13 @@ public class LazyOpenInterpreter
   public void setClassloaderUrls(URL [] urls) {
     intp.setClassloaderUrls(urls);
   }
+
+  @Override
+  public boolean restartRequired() {
+    if (isOpen()) {
+      return intp.restartRequired();
+    } else {
+      return false;
+    }
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -371,4 +371,23 @@ public class RemoteInterpreter extends Interpreter {
         Type.valueOf(result.getType()),
         result.getMsg());
   }
+
+  @Override
+  public boolean restartRequired() {
+    RemoteInterpreterProcess interpreterProcess = getInterpreterProcess();
+    Client client = null;
+    try {
+      client = interpreterProcess.getClient();
+    } catch (Exception e1) {
+      throw new InterpreterException(e1);
+    }
+
+    try {
+      return client.restartRequired(className);
+    } catch (TException e) {
+      throw new InterpreterException(e);
+    } finally {
+      interpreterProcess.releaseClient(client);
+    }
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -524,4 +524,10 @@ public class RemoteInterpreterServer
     AngularObjectRegistry registry = interpreterGroup.getAngularObjectRegistry();
     registry.remove(name, noteId, false);
   }
+
+  @Override
+  public boolean restartRequired(String className) throws TException {
+    Interpreter intp = getInterpreter(className);
+    return intp.restartRequired();
+  }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
@@ -84,6 +84,8 @@ public class RemoteInterpreterService {
 
     public void angularObjectRemove(String name, String noteId) throws org.apache.thrift.TException;
 
+    public boolean restartRequired(String className) throws org.apache.thrift.TException;
+
   }
 
   public interface AsyncIface {
@@ -115,6 +117,8 @@ public class RemoteInterpreterService {
     public void angularObjectAdd(String name, String noteId, String object, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
     public void angularObjectRemove(String name, String noteId, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
+
+    public void restartRequired(String className, org.apache.thrift.async.AsyncMethodCallback<AsyncClient.restartRequired_call> resultHandler) throws org.apache.thrift.TException;
 
   }
 
@@ -444,6 +448,29 @@ public class RemoteInterpreterService {
       angularObjectRemove_result result = new angularObjectRemove_result();
       receiveBase(result, "angularObjectRemove");
       return;
+    }
+
+    public boolean restartRequired(String className) throws org.apache.thrift.TException
+    {
+      send_restartRequired(className);
+      return recv_restartRequired();
+    }
+
+    public void send_restartRequired(String className) throws org.apache.thrift.TException
+    {
+      restartRequired_args args = new restartRequired_args();
+      args.setClassName(className);
+      sendBase("restartRequired", args);
+    }
+
+    public boolean recv_restartRequired() throws org.apache.thrift.TException
+    {
+      restartRequired_result result = new restartRequired_result();
+      receiveBase(result, "restartRequired");
+      if (result.isSetSuccess()) {
+        return result.success;
+      }
+      throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "restartRequired failed: unknown result");
     }
 
   }
@@ -808,6 +835,12 @@ public class RemoteInterpreterService {
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
+    public void restartRequired(String className, org.apache.thrift.async.AsyncMethodCallback<restartRequired_call> resultHandler) throws org.apache.thrift.TException {
+      checkReady();
+      restartRequired_call method_call = new restartRequired_call(className, resultHandler, this, ___protocolFactory, ___transport);
+      this.___currentMethod = method_call;
+      ___manager.call(method_call);
+    }
 
     public static class getEvent_call extends org.apache.thrift.async.TAsyncMethodCall {
       public getEvent_call(org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
@@ -820,7 +853,7 @@ public class RemoteInterpreterService {
         args.write(prot);
         prot.writeMessageEnd();
       }
-
+      
       public RemoteInterpreterEvent getResult() throws org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new IllegalStateException("Method call not finished!");
@@ -942,6 +975,31 @@ public class RemoteInterpreterService {
       }
     }
 
+    public static class restartRequired_call extends org.apache.thrift.async.TAsyncMethodCall {
+      private String className;
+      public restartRequired_call(String className, org.apache.thrift.async.AsyncMethodCallback<restartRequired_call> resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+        super(client, protocolFactory, transport, resultHandler, false);
+        this.className = className;
+      }
+
+      public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
+        prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("restartRequired", org.apache.thrift.protocol.TMessageType.CALL, 0));
+        restartRequired_args args = new restartRequired_args();
+        args.setClassName(className);
+        args.write(prot);
+        prot.writeMessageEnd();
+      }
+
+      public boolean getResult() throws org.apache.thrift.TException {
+        if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
+          throw new IllegalStateException("Method call not finished!");
+        }
+        org.apache.thrift.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());
+        org.apache.thrift.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
+        return (new Client(prot)).recv_restartRequired();
+      }
+    }
+
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
@@ -969,6 +1027,7 @@ public class RemoteInterpreterService {
       processMap.put("angularObjectUpdate", new angularObjectUpdate());
       processMap.put("angularObjectAdd", new angularObjectAdd());
       processMap.put("angularObjectRemove", new angularObjectRemove());
+      processMap.put("restartRequired", new restartRequired());
       return processMap;
     }
 
@@ -1249,6 +1308,28 @@ public class RemoteInterpreterService {
       public angularObjectRemove_result getResult(I iface, angularObjectRemove_args args) throws org.apache.thrift.TException {
         angularObjectRemove_result result = new angularObjectRemove_result();
         iface.angularObjectRemove(args.name, args.noteId);
+        return result;
+      }
+    }
+
+
+    public static class restartRequired<I extends Iface> extends org.apache.thrift.ProcessFunction<I, restartRequired_args> {
+      public restartRequired() {
+        super("restartRequired");
+      }
+
+      public restartRequired_args getEmptyArgsInstance() {
+        return new restartRequired_args();
+      }
+
+      protected boolean isOneway() {
+        return false;
+      }
+
+      public restartRequired_result getResult(I iface, restartRequired_args args) throws org.apache.thrift.TException {
+        restartRequired_result result = new restartRequired_result();
+        result.success = iface.restartRequired(args.className);
+        result.setSuccessIsSet(true);
         return result;
       }
     }
@@ -12349,6 +12430,714 @@ public class RemoteInterpreterService {
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, angularObjectRemove_result struct) throws org.apache.thrift.TException {
         TTupleProtocol iprot = (TTupleProtocol) prot;
+      }
+    }
+
+  }
+
+  public static class restartRequired_args implements org.apache.thrift.TBase<restartRequired_args, restartRequired_args._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("restartRequired_args");
+
+    private static final org.apache.thrift.protocol.TField CLASS_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("className", org.apache.thrift.protocol.TType.STRING, (short)1);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new restartRequired_argsStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new restartRequired_argsTupleSchemeFactory());
+    }
+
+    public String className; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      CLASS_NAME((short)1, "className");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 1: // CLASS_NAME
+            return CLASS_NAME;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.CLASS_NAME, new org.apache.thrift.meta_data.FieldMetaData("className", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(restartRequired_args.class, metaDataMap);
+    }
+
+    public restartRequired_args() {
+    }
+
+    public restartRequired_args(
+      String className)
+    {
+      this();
+      this.className = className;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public restartRequired_args(restartRequired_args other) {
+      if (other.isSetClassName()) {
+        this.className = other.className;
+      }
+    }
+
+    public restartRequired_args deepCopy() {
+      return new restartRequired_args(this);
+    }
+
+    @Override
+    public void clear() {
+      this.className = null;
+    }
+
+    public String getClassName() {
+      return this.className;
+    }
+
+    public restartRequired_args setClassName(String className) {
+      this.className = className;
+      return this;
+    }
+
+    public void unsetClassName() {
+      this.className = null;
+    }
+
+    /** Returns true if field className is set (has been assigned a value) and false otherwise */
+    public boolean isSetClassName() {
+      return this.className != null;
+    }
+
+    public void setClassNameIsSet(boolean value) {
+      if (!value) {
+        this.className = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case CLASS_NAME:
+        if (value == null) {
+          unsetClassName();
+        } else {
+          setClassName((String)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case CLASS_NAME:
+        return getClassName();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case CLASS_NAME:
+        return isSetClassName();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof restartRequired_args)
+        return this.equals((restartRequired_args)that);
+      return false;
+    }
+
+    public boolean equals(restartRequired_args that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_className = true && this.isSetClassName();
+      boolean that_present_className = true && that.isSetClassName();
+      if (this_present_className || that_present_className) {
+        if (!(this_present_className && that_present_className))
+          return false;
+        if (!this.className.equals(that.className))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int compareTo(restartRequired_args other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      restartRequired_args typedOther = (restartRequired_args)other;
+
+      lastComparison = Boolean.valueOf(isSetClassName()).compareTo(typedOther.isSetClassName());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetClassName()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.className, typedOther.className);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("restartRequired_args(");
+      boolean first = true;
+
+      sb.append("className:");
+      if (this.className == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.className);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class restartRequired_argsStandardSchemeFactory implements SchemeFactory {
+      public restartRequired_argsStandardScheme getScheme() {
+        return new restartRequired_argsStandardScheme();
+      }
+    }
+
+    private static class restartRequired_argsStandardScheme extends StandardScheme<restartRequired_args> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, restartRequired_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 1: // CLASS_NAME
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+                struct.className = iprot.readString();
+                struct.setClassNameIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, restartRequired_args struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.className != null) {
+          oprot.writeFieldBegin(CLASS_NAME_FIELD_DESC);
+          oprot.writeString(struct.className);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class restartRequired_argsTupleSchemeFactory implements SchemeFactory {
+      public restartRequired_argsTupleScheme getScheme() {
+        return new restartRequired_argsTupleScheme();
+      }
+    }
+
+    private static class restartRequired_argsTupleScheme extends TupleScheme<restartRequired_args> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, restartRequired_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.isSetClassName()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetClassName()) {
+          oprot.writeString(struct.className);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, restartRequired_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.className = iprot.readString();
+          struct.setClassNameIsSet(true);
+        }
+      }
+    }
+
+  }
+
+  public static class restartRequired_result implements org.apache.thrift.TBase<restartRequired_result, restartRequired_result._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("restartRequired_result");
+
+    private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.BOOL, (short)0);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new restartRequired_resultStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new restartRequired_resultTupleSchemeFactory());
+    }
+
+    public boolean success; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      SUCCESS((short)0, "success");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 0: // SUCCESS
+            return SUCCESS;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    private static final int __SUCCESS_ISSET_ID = 0;
+    private byte __isset_bitfield = 0;
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(restartRequired_result.class, metaDataMap);
+    }
+
+    public restartRequired_result() {
+    }
+
+    public restartRequired_result(
+      boolean success)
+    {
+      this();
+      this.success = success;
+      setSuccessIsSet(true);
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public restartRequired_result(restartRequired_result other) {
+      __isset_bitfield = other.__isset_bitfield;
+      this.success = other.success;
+    }
+
+    public restartRequired_result deepCopy() {
+      return new restartRequired_result(this);
+    }
+
+    @Override
+    public void clear() {
+      setSuccessIsSet(false);
+      this.success = false;
+    }
+
+    public boolean isSuccess() {
+      return this.success;
+    }
+
+    public restartRequired_result setSuccess(boolean success) {
+      this.success = success;
+      setSuccessIsSet(true);
+      return this;
+    }
+
+    public void unsetSuccess() {
+      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __SUCCESS_ISSET_ID);
+    }
+
+    /** Returns true if field success is set (has been assigned a value) and false otherwise */
+    public boolean isSetSuccess() {
+      return EncodingUtils.testBit(__isset_bitfield, __SUCCESS_ISSET_ID);
+    }
+
+    public void setSuccessIsSet(boolean value) {
+      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __SUCCESS_ISSET_ID, value);
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case SUCCESS:
+        if (value == null) {
+          unsetSuccess();
+        } else {
+          setSuccess((Boolean)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case SUCCESS:
+        return Boolean.valueOf(isSuccess());
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case SUCCESS:
+        return isSetSuccess();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof restartRequired_result)
+        return this.equals((restartRequired_result)that);
+      return false;
+    }
+
+    public boolean equals(restartRequired_result that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_success = true;
+      boolean that_present_success = true;
+      if (this_present_success || that_present_success) {
+        if (!(this_present_success && that_present_success))
+          return false;
+        if (this.success != that.success)
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    public int compareTo(restartRequired_result other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      restartRequired_result typedOther = (restartRequired_result)other;
+
+      lastComparison = Boolean.valueOf(isSetSuccess()).compareTo(typedOther.isSetSuccess());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetSuccess()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, typedOther.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+      }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("restartRequired_result(");
+      boolean first = true;
+
+      sb.append("success:");
+      sb.append(this.success);
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bitfield = 0;
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class restartRequired_resultStandardSchemeFactory implements SchemeFactory {
+      public restartRequired_resultStandardScheme getScheme() {
+        return new restartRequired_resultStandardScheme();
+      }
+    }
+
+    private static class restartRequired_resultStandardScheme extends StandardScheme<restartRequired_result> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, restartRequired_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 0: // SUCCESS
+              if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+                struct.success = iprot.readBool();
+                struct.setSuccessIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+
+        // check for required fields of primitive type, which can't be checked in the validate method
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, restartRequired_result struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.isSetSuccess()) {
+          oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
+          oprot.writeBool(struct.success);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class restartRequired_resultTupleSchemeFactory implements SchemeFactory {
+      public restartRequired_resultTupleScheme getScheme() {
+        return new restartRequired_resultTupleScheme();
+      }
+    }
+
+    private static class restartRequired_resultTupleScheme extends TupleScheme<restartRequired_result> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, restartRequired_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.isSetSuccess()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.isSetSuccess()) {
+          oprot.writeBool(struct.success);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, restartRequired_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.success = iprot.readBool();
+          struct.setSuccessIsSet(true);
+        }
       }
     }
 

--- a/zeppelin-interpreter/src/main/thrift/RemoteInterpreterService.thrift
+++ b/zeppelin-interpreter/src/main/thrift/RemoteInterpreterService.thrift
@@ -68,4 +68,5 @@ service RemoteInterpreterService {
   void angularObjectUpdate(1: string name, 2: string noteId, 3: string object);
   void angularObjectAdd(1: string name, 2: string noteId, 3: string object);
   void angularObjectRemove(1: string name, 2: string noteId);
+  bool restartRequired(1: string className);
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -81,6 +81,13 @@ public class InterpreterSetting {
     return interpreterGroup;
   }
 
+  public InterpreterGroup getInterpreterGroupWithRefresh(InterpreterFactory factory) {
+    if (interpreterGroup.restartRequired()) {
+      factory.restart(id);
+    }
+    return interpreterGroup;
+  }
+
   public void setInterpreterGroup(InterpreterGroup interpreterGroup) {
     this.interpreterGroup = interpreterGroup;
     this.properties = interpreterGroup.getProperty();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -249,7 +249,7 @@ public class Note implements Serializable, JobListener {
       for (Paragraph p : paragraphs) {
         p.setNoteReplLoader(replLoader);
         p.setListener(jobListenerFactory.getParagraphJobListener(this));
-        Interpreter intp = replLoader.get(p.getRequiredReplName());
+        Interpreter intp = replLoader.get(p.getRequiredReplName(), true);
         intp.getScheduler().submit(p);
       }
     }
@@ -264,7 +264,7 @@ public class Note implements Serializable, JobListener {
     Paragraph p = getParagraph(paragraphId);
     p.setNoteReplLoader(replLoader);
     p.setListener(jobListenerFactory.getParagraphJobListener(this));
-    Interpreter intp = replLoader.get(p.getRequiredReplName());
+    Interpreter intp = replLoader.get(p.getRequiredReplName(), true);
     if (intp == null) {
       throw new InterpreterException("Interpreter " + p.getRequiredReplName() + " not found");
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteInterpreterLoader.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteInterpreterLoader.java
@@ -74,6 +74,10 @@ public class NoteInterpreterLoader {
   }
 
   public Interpreter get(String replName) {
+    return get(replName, false);
+  }
+
+  public Interpreter get(String replName, boolean withRestart) {
     List<InterpreterSetting> settings = getInterpreterSettings();
 
     if (settings == null || settings.size() == 0) {
@@ -81,7 +85,11 @@ public class NoteInterpreterLoader {
     }
 
     if (replName == null || replName.trim().length() == 0) {
-      return settings.get(0).getInterpreterGroup().getFirst();
+      if (withRestart) {
+        return settings.get(0).getInterpreterGroupWithRefresh(factory).getFirst();
+      } else {
+        return settings.get(0).getInterpreterGroup().getFirst();
+      }
     }
 
     if (Interpreter.registeredInterpreters == null) {
@@ -104,7 +112,12 @@ public class NoteInterpreterLoader {
       String interpreterClassName = registeredInterpreter.getClassName();
 
       for (InterpreterSetting setting : settings) {
-        InterpreterGroup intpGroup = setting.getInterpreterGroup();
+        InterpreterGroup intpGroup;
+        if (withRestart) {
+          intpGroup = setting.getInterpreterGroupWithRefresh(factory);
+        } else {
+          intpGroup = setting.getInterpreterGroup();
+        }
         for (Interpreter interpreter : intpGroup) {
           if (interpreterClassName.equals(interpreter.getClassName())) {
             return interpreter;
@@ -114,7 +127,12 @@ public class NoteInterpreterLoader {
     } else {
       // first assume replName is 'name' of interpreter. ('groupName' is ommitted)
       // search 'name' from first (default) interpreter group
-      InterpreterGroup intpGroup = settings.get(0).getInterpreterGroup();
+      InterpreterGroup intpGroup;
+      if (withRestart) {
+        intpGroup = settings.get(0).getInterpreterGroupWithRefresh(factory);
+      } else {
+        intpGroup = settings.get(0).getInterpreterGroup();
+      }
       for (Interpreter interpreter : intpGroup) {
         RegisteredInterpreter intp = Interpreter
             .findRegisteredInterpreterByClassName(interpreter.getClassName());
@@ -131,7 +149,11 @@ public class NoteInterpreterLoader {
       // next, assume replName is 'group' of interpreter ('name' is ommitted)
       // search interpreter group and return first interpreter.
       for (InterpreterSetting setting : settings) {
-        intpGroup = setting.getInterpreterGroup();
+        if (withRestart) {
+          intpGroup = setting.getInterpreterGroupWithRefresh(factory);
+        } else {
+          intpGroup = setting.getInterpreterGroup();
+        }
         Interpreter interpreter = intpGroup.get(0);
         RegisteredInterpreter intp = Interpreter
             .findRegisteredInterpreterByClassName(interpreter.getClassName());


### PR DESCRIPTION
When an interpreter is loaded from `NoteInterpreterLoader`, if this is a `SparkInterpreter` and the spark context has terminated (say, due to `sc.stop()` being called), this interpreter is useless. Right now, the user needs to go to the interpreter settings and restart this group before it can be used. Restarting the spark interpreter creates a new spark context.

In this patch, we do this automatically. When we load a spark interpreter and the spark context has stopped, we automatically restart it. We also give the user an option whether or not to enable this automatic restart or not (default true).

To check whether restart is required, we perform a thrift RPC call `restartRequired`. All interpreters except SparkInterpreter return false. SparkInterpreter returns `restartEnabled && sc != null && sc.taskScheduler() == null`, which is true if automatic restart is enabled and spark context has been stopped (stopping a spark context makes its taskScheduler null).
