### PR TITLE
Add ability to truncate displayed results while exporting full results to S3

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -77,6 +77,48 @@
   <description>notebook persistence layer implementation</description>
 </property>
 
+<!-- Options to truncate results. -->
+<property>
+  <name>zeppelin.paragraph.truncate.results</name>
+  <value>false</value>
+  <description>
+    Should large results be truncated? This is useful if results are large
+    enough to slow down your browser's Javascript rendering. You can enable
+    S3 export to get access to the full result set.
+  </description>
+</property>
+
+<property>
+  <name>zeppelin.paragraph.max.result.lines</name>
+  <value>25</value>
+  <description>
+    Only used if zeppelin.truncate.paragraph.results is true.
+    The maximum number of lines of a raw result to store into the note.json.
+  </description>
+</property>
+
+<!-- Options to export results to S3 -->
+<property>
+  <name>zeppelin.export.results</name>
+  <value>false</value>
+  <description>S3 bucket for exporting results.</description>
+</property>
+
+<property>
+  <name>zeppelin.export.s3.bucket</name>
+  <value>zeppelin</value>
+  <description>S3 bucket for exporting results.</description>
+</property>
+
+<property>
+  <name>zeppelin.export.s3.prefix</name>
+  <value>export</value>
+  <description>
+    Prefix of exported S3 objects. The note and paragraph ID will be appended
+    to this prefix to form the S3 key.
+  </description>
+</property>
+
 <property>
   <name>zeppelin.interpreter.dir</name>
   <value>interpreter</value>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/Message.java
@@ -77,6 +77,9 @@ public class Message {
                     // @param id paragraph id
                     // @param index index the paragraph want to go
 
+    DOWNLOAD_PARAGRAPH_RESULT, // Download link to paragraph output
+                               // @param id paragraph id
+
     INSERT_PARAGRAPH, // [c-s] create new paragraph below current paragraph
                       // @param target index
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -150,6 +150,17 @@ angular.module('zeppelinWebApp')
     }
   });
 
+  $scope.$on('downloadParagraphResult', function(event, data) {
+    // window.location.assign(data.url);
+    if (data.id === $scope.paragraph.id) {
+      if (typeof data.error !== 'undefined') {
+        $window.alert(data.error);
+      } else {
+        $window.open(data.url);
+      }
+    }
+  });
+
   // TODO: this may have impact on performance when there are many paragraphs in a note.
   $scope.$on('updateParagraph', function(event, data) {
     if (data.paragraph.id === $scope.paragraph.id &&
@@ -279,6 +290,10 @@ angular.module('zeppelinWebApp')
       console.log('Remove paragraph');
       websocketMsgSrv.removeParagraph($scope.paragraph.id);
     }
+  };
+
+  $scope.downloadParagraphResult = function() {
+    websocketMsgSrv.downloadParagraphResult($scope.paragraph.id);
   };
 
   $scope.toggleEditor = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -396,6 +396,8 @@ limitations under the License.
           ng-click="toggleEditor()"></span>
     <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" style="cursor:pointer;" tooltip-placement="top" tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide') + ' output'}}"
           ng-click="toggleOutput()"></span>
+    <span class="glyphicon glyphicon-save" style="cursor:pointer" tooltip-placement="top" tooltip="Download Full Result"
+          ng-click="downloadParagraphResult()" ></span>
     <span  style="cursor:pointer;"
           ng-click="saveParagraph()"
           ng-show="dirtyText"></span>

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -54,6 +54,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
       $rootScope.$broadcast('updateProgress', data);
     } else if (op === 'COMPLETION_LIST') {
       $rootScope.$broadcast('completionList', data);
+    } else if (op === 'DOWNLOAD_PARAGRAPH_RESULT') {
+      $rootScope.$broadcast('downloadParagraphResult', data);
     } else if (op === 'ANGULAR_OBJECT_UPDATE') {
       $rootScope.$broadcast('angularObjectUpdate', data);
     } else if (op === 'ANGULAR_OBJECT_REMOVE') {

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -96,6 +96,15 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
+    downloadParagraphResult: function(paragraphId) {
+      websocketEvents.sendNewEvent({
+        op: 'DOWNLOAD_PARAGRAPH_RESULT',
+        data: {
+          id: paragraphId
+        }
+      });
+    },
+
     commitParagraph: function(paragraphId, paragraphTitle, paragraphData, paragraphConfig, paragraphParams) {
       websocketEvents.sendNewEvent({
         op: 'COMMIT_PARAGRAPH',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -322,7 +322,27 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   public String getNotebookDir() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_DIR);
   }
-  
+
+  public boolean truncateResults() {
+    return getBoolean(ConfVars.ZEPPELIN_TRUNCATE_RESULTS);
+  }
+
+  public int getParagraphMaxResultLines() {
+    return getInt(ConfVars.ZEPPELIN_PARAGRAPH_MAX_RESULT_LINES);
+  }
+
+  public boolean exportResults() {
+    return getBoolean(ConfVars.ZEPPELIN_EXPORT_RESULTS);
+  }
+
+  public String getExportS3Bucket() {
+    return getString(ConfVars.ZEPPELIN_EXPORT_S3_BUCKET);
+  }
+
+  public String getExportS3Prefix() {
+    return getString(ConfVars.ZEPPELIN_EXPORT_S3_PREFIX);
+  }
+
   public String getUser() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_USER);
   }
@@ -415,6 +435,11 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 30000),
     ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
     ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),
+    ZEPPELIN_TRUNCATE_RESULTS("zeppelin.paragraph.truncate.results", false),
+    ZEPPELIN_PARAGRAPH_MAX_RESULT_LINES("zeppelin.paragraph.max.result.lines", 25),
+    ZEPPELIN_EXPORT_RESULTS("zeppelin.export.results", false),
+    ZEPPELIN_EXPORT_S3_BUCKET("zeppelin.export.s3.bucket", "zeppelin"),
+    ZEPPELIN_EXPORT_S3_PREFIX("zeppelin.export.s3.prefix", ""),
     // use specified notebook (id) as homescreen
     ZEPPELIN_NOTEBOOK_HOMESCREEN("zeppelin.notebook.homescreen", null),
     // whether homescreen notebook will be hidden from notebook list or not

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -73,9 +73,11 @@ public class Note implements Serializable, JobListener {
 
   public Note() {}
 
-  public Note(NotebookRepo repo,
+  public Note(ZeppelinConfiguration conf,
+      NotebookRepo repo,
       NoteInterpreterLoader replLoader,
       JobListenerFactory jobListenerFactory) {
+    this.conf = conf;
     this.repo = repo;
     this.replLoader = replLoader;
     this.jobListenerFactory = jobListenerFactory;
@@ -116,6 +118,14 @@ public class Note implements Serializable, JobListener {
 
   public NotebookRepo getNotebookRepo() {
     return repo;
+  }
+
+  public ZeppelinConfiguration getConf() {
+    return conf;
+  }
+
+  public void setConf(ZeppelinConfiguration conf) {
+    this.conf = conf;
   }
 
   public void setNotebookRepo(NotebookRepo repo) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -105,7 +105,7 @@ public class Notebook {
    */
   public Note createNote(List<String> interpreterIds) throws IOException {
     NoteInterpreterLoader intpLoader = new NoteInterpreterLoader(replFactory);
-    Note note = new Note(notebookRepo, intpLoader, jobListenerFactory);
+    Note note = new Note(conf, notebookRepo, intpLoader, jobListenerFactory);
     intpLoader.setNoteId(note.id());
     synchronized (notes) {
       notes.put(note.id(), note);
@@ -184,6 +184,9 @@ public class Notebook {
     if (note == null) {
       return null;
     }
+
+    // Pass down the ZeppelinConfiguration
+    note.setConf(conf);
 
     // set NoteInterpreterLoader
     NoteInterpreterLoader noteInterpreterLoader = new NoteInterpreterLoader(


### PR DESCRIPTION
This is a feature I personally find useful and hopefully others feel the same way.

All the result of executing a paragraph must be rendered by the client brower's Javascript engine. But when the result is sufficiently large, the rendering takes a long time, or completely hangs, which makes inspecting the result very difficult. But it may be useful to be able to retrieve the paragraph results regardless. This PR adds in two features that can help solve this problem.

The first feature enabled by the option `zeppelin.paragraph.truncate.results` is an option is to truncate results, and `zeppelin.paragraph.max.result.lines` determines how many lines are stored in the note.json. With a small number of lines, it's possible to get a preview of large result sets, and not hang the Javascript rendering.

The second feature enabled by `zeppelin.export.results` is an option to store the entire result into S3 and expose a button that generates a pre-signed URL to download the file. So the user is still able to download larger results (say a couple hundred MB) and inspect it offline. The user may specify the export `zeppelin.export.s3.bucket` and export prefix `zeppelin.export.s3.prefix`.

Feedbacks are welcome.