### PR TITLE
ZEPPELIN-278 fix build warnings and rat hang

### DIFF
--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -82,7 +82,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -172,30 +172,8 @@
         <plugins>
             <!-- Plugin to compile Scala code -->
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <phase>compile</phase>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <phase>test-compile</phase>
-                    </execution>
-                    <execution>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -231,7 +231,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -166,43 +166,17 @@
 
       <!-- Scala Compiler -->
       <plugin>
-	<groupId>net.alchim31.maven</groupId>
-	<artifactId>scala-maven-plugin</artifactId>
-	<version>3.1.4</version>
-	<executions>
-	  <!-- Run scala compiler in the process-resources phase, so that dependencies on
-	       scala classes can be resolved later in the (Java) compile phase -->
-	  <execution>
-	    <id>scala-compile-first</id>
-	    <phase>process-resources</phase>
-	    <goals>
-	      <goal>compile</goal>
-	    </goals>
-	  </execution>
-          
-	  <!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-	       scala classes can be resolved later in the (Java) test-compile phase -->
-	  <execution>
-	    <id>scala-test-compile</id>
-	    <phase>process-test-resources</phase>
-	    <goals>
-	      <goal>testCompile</goal>
-	    </goals>
-	  </execution>
-	</executions>
-	<configuration>
-	  <jvmArgs>
-	    <jvmArg>-Xms128m</jvmArg>
-	    <jvmArg>-Xmx512m</jvmArg>
-	  </jvmArgs>
-	  <compilerPlugins combine.children="append">
-	    <compilerPlugin>
-	      <groupId>org.scalamacros</groupId>
-	      <artifactId>paradise_${flink.scala.version}</artifactId>
-	      <version>${scala.macros.version}</version>
-	    </compilerPlugin>
-	  </compilerPlugins>
-	</configuration>
+        <groupId>net.alchim31.maven</groupId>
+	      <artifactId>scala-maven-plugin</artifactId>
+	      <configuration>
+	        <compilerPlugins combine.children="append">
+	          <compilerPlugin>
+	            <groupId>org.scalamacros</groupId>
+	            <artifactId>paradise_${flink.scala.version}</artifactId>
+	            <version>${scala.macros.version}</version>
+	          </compilerPlugin>
+	        </compilerPlugins>
+	      </configuration>
       </plugin>
 
       <!-- Eclipse Integration -->

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -299,30 +299,7 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <id>copy-dependencies</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/../../interpreter/flink</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -347,6 +324,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -106,7 +106,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -119,7 +119,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -129,7 +129,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -83,7 +83,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -168,7 +168,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -88,7 +88,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/phoenix/pom.xml
+++ b/phoenix/pom.xml
@@ -97,7 +97,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
           </compilerArgs>
         </configuration>
       </plugin>
+
       <!-- Test coverage plugin -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -257,6 +258,7 @@
           </execution>
         </executions>
       </plugin>
+
       <!-- Checkstyle plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -319,7 +321,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -112,8 +112,13 @@
     <gson.version>2.2</gson.version>
     <guava.version>15.0</guava.version>
 
+    <java.version>1.7</java.version>
+    <scala.version>2.10.4</scala.version>
+    <scala.binary.version>2.10</scala.binary.version>
+
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
+    <CodeCacheSize>512m</CodeCacheSize>
   </properties>
 
   <dependencyManagement>
@@ -216,12 +221,19 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <encoding>UTF-8</encoding>
+          <maxmem>1024m</maxmem>
+          <fork>true</fork>
+          <compilerArgs>
+            <arg>-Xlint:all,-serial,-path</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <!-- Test coverage plugin -->
@@ -558,6 +570,66 @@
                 <followSymlinks>false</followSymlinks>
               </fileset>
             </filesets>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>3.2.2</version>
+          <executions>
+            <execution>
+              <id>eclipse-add-source</id>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>scala-compile-first</id>
+              <phase>process-resources</phase>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>scala-test-compile-first</id>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>attach-scaladocs</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>doc-jar</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <scalaVersion>${scala.version}</scalaVersion>
+            <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
+            <!--<recompileMode>incremental</recompileMode>-->
+            <useZincServer>true</useZincServer>
+            <args>
+              <arg>-unchecked</arg>
+              <arg>-deprecation</arg>
+              <arg>-feature</arg>
+            </args>
+            <jvmArgs>
+              <jvmArg>-Xms1024m</jvmArg>
+              <jvmArg>-Xmx1024m</jvmArg>
+              <jvmArg>-XX:PermSize=${PermGen}</jvmArg>
+              <jvmArg>-XX:MaxPermSize=${MaxPermGen}</jvmArg>
+              <jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
+            </jvmArgs>
+            <javacArgs>
+              <javacArg>-source</javacArg>
+              <javacArg>${java.version}</javacArg>
+              <javacArg>-target</javacArg>
+              <javacArg>${java.version}</javacArg>
+              <javacArg>-Xlint:all,-serial,-path</javacArg>
+            </javacArgs>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,13 +602,14 @@
                 <goal>testCompile</goal>
               </goals>
             </execution>
+            <!-- This is good, but somehow is failing on Cassandra interpreter :(
             <execution>
               <id>attach-scaladocs</id>
               <phase>verify</phase>
               <goals>
                 <goal>doc-jar</goal>
               </goals>
-            </execution>
+            </execution>-->
           </executions>
           <configuration>
             <scalaVersion>${scala.version}</scalaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,6 @@
               <exclude>reports/**</exclude>
               <exclude>**/.idea/</exclude>
               <exclude>**/*.iml</exclude>
-              <exclude>.git/</exclude>
               <exclude>.gitignore</exclude>
               <exclude>.repository/</exclude>
               <exclude>**/*.diff</exclude>
@@ -498,6 +497,10 @@
 
               <!-- bundled from jekyll -->
               <exclude>docs/assets/themes/zeppelin/css/syntax.css</exclude>
+
+              <!-- frontend build tools -->
+              <exclude>zeppelin-web/node/</exclude>
+              <exclude>zeppelin-web/node_modules/</exclude>
 
               <!-- docs (website) build target dir -->
               <exclude>docs/_site/**</exclude>

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -117,7 +117,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -88,7 +88,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -888,7 +888,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -352,6 +352,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+<<<<<<< HEAD
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
         <configuration>
@@ -392,21 +393,6 @@
             <goals>
               <goal>copy</goal>
             </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/../../interpreter/spark</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>false</overWriteSnapshots>
-              <overWriteIfNewer>true</overWriteIfNewer>
-              <includeScope>runtime</includeScope>              
-              <artifactItems>
-                <artifactItem>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <version>${project.version}</version>
-                  <type>${project.packaging}</type>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -413,30 +413,8 @@
 
       <!-- Plugin to compile Scala code -->
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>test-compile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-          <execution>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
 
     </plugins>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -352,7 +352,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-<<<<<<< HEAD
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
         <configuration>

--- a/tajo/pom.xml
+++ b/tajo/pom.xml
@@ -92,7 +92,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -320,16 +320,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
`mvn apache-rat:check` passes

All sub-modules now use same version of:
 - maven-dependency-plugin
 - scala compiler