### PR TITLE
Save all repos, and not just the first two

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -92,16 +92,17 @@ public class NotebookRepoSync implements NotebookRepo{
   
   /* by default saves to all repos */
   public void save(Note note) throws IOException {
-    getRepo(0).save(note);
-    if (getRepoCount() > 1) {
+    int repoCount = getRepoCount();
+    for(int index=0;index<repoCount;index++){
       try {
-        getRepo(1).save(note);
+        getRepo(index).save(note);
       }
       catch (IOException e) {
         LOG.info(e.getMessage() + ": Failed to write to secondary storage");
       }
     }
   }
+
 
   /* save note to specific repo (for tests) */
   void save(int repoIndex, Note note) throws IOException {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -99,8 +99,8 @@ public class NotebookRepoSync implements NotebookRepo{
       }
       catch (IOException e) {
         LOG.info(e.getMessage() + ": Failed to write Notebook " 
-          + note.getName() + " in the storage "+
-            getRepo(i).getClass().getSimpleName());
+          + note.getName() + " in the storage "
+          + getRepo(i).getClass().getSimpleName());
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -92,13 +92,14 @@ public class NotebookRepoSync implements NotebookRepo{
   
   /* by default saves to all repos */
   public void save(Note note) throws IOException {
-    int repoCount = getRepoCount();
-    for(int index=0;index<repoCount;index++){
+        int repoCount = getRepoCount();
+    for (int i = 0; i < repoCount; i++){
       try {
-        getRepo(index).save(note);
+        getRepo(i).save(note);
       }
       catch (IOException e) {
-        LOG.info(e.getMessage() + ": Failed to write to secondary storage");
+        LOG.info(e.getMessage() + ": Failed to write Notebook " + note.getName() + " in the storage "+
+                getRepo(i).getClass().getSimpleName());
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -98,9 +98,9 @@ public class NotebookRepoSync implements NotebookRepo{
         getRepo(i).save(note);
       }
       catch (IOException e) {
-        LOG.info(e.getMessage() + ": Failed to write Notebook " 
-          + note.getName() + " in the storage "
-          + getRepo(i).getClass().getSimpleName());
+        LOG.info(e.getMessage() + ": Failed to write Notebook " +
+          note.getName() + " in the storage " +
+          getRepo(i).getClass().getSimpleName());
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -92,14 +92,15 @@ public class NotebookRepoSync implements NotebookRepo{
   
   /* by default saves to all repos */
   public void save(Note note) throws IOException {
-        int repoCount = getRepoCount();
+    int repoCount = getRepoCount();
     for (int i = 0; i < repoCount; i++){
       try {
         getRepo(i).save(note);
       }
       catch (IOException e) {
-        LOG.info(e.getMessage() + ": Failed to write Notebook " + note.getName() + " in the storage "+
-                getRepo(i).getClass().getSimpleName());
+        LOG.info(e.getMessage() + ": Failed to write Notebook " 
+          + note.getName() + " in the storage "+
+            getRepo(i).getClass().getSimpleName());
       }
     }
   }


### PR DESCRIPTION
This PR modify the save repos method.
Now it is saving only the first two backend repos of the list, which is OK because this is the current behavior.
The code change this to save all the bachend repos , and it will be usefull when more than 2 backend repos is supported.
