### PR TITLE
Switch to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,8 +234,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <!-- Test coverage plugin -->


### PR DESCRIPTION
### What is this PR for?

Java 7 is now officially no longer supported by Oracle and Java 8 has been released quite a while. We should take the opportunity to switch to Java 8.
### What type of PR is it?

[Improvement]
### Todos
- [ ] - Task
### Is there a relevant Jira issue?

**[ZEPPELIN-621](https://issues.apache.org/jira/browse/ZEPPELIN-621)**
### How should this be tested?
- Hava Java 8 installed locally
- Build Zeppelin with `mvn clean -Pxxxx -DskipTests`
- Create some notes with spark/angular/shell interpreter and test some basic use-case

This PR is low risk because Java 8 is backward-compatible with Java 7 source code.
### Screenshots (if appropriate)

N/A
### Questions:
- Does the licenses files need update? --> No
- Is there breaking changes for older versions? --> No
- Does this needs documentation? --> No
