### PR TITLE
Fix compilation issues on branch 0.5.6 by backporting fixes from master

### DIFF
--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -22,14 +22,14 @@
   <parent>
     <artifactId>zeppelin</artifactId>
     <groupId>org.apache.zeppelin</groupId>
-    <version>0.6.0-incubating-SNAPSHOT</version>
+    <version>0.5.7-incubating-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
   <artifactId>zeppelin-scalding</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.0-incubating-SNAPSHOT</version>
+  <version>0.5.7-incubating-SNAPSHOT</version>
   <name>Zeppelin: Scalding interpreter</name>
   <url>http://zeppelin.incubator.apache.org</url>
 

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.1.0",
-    "bower": "",
+    "bower": "1.7.2",
     "grunt": "^0.4.1",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -95,8 +95,8 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v0.10.22</nodeVersion>
-              <npmVersion>1.3.8</npmVersion>
+              <nodeVersion>v0.12.13</nodeVersion>
+              <npmVersion>2.15.0</npmVersion>
             </configuration>
           </execution>
 


### PR DESCRIPTION
### What is this PR for?

Fix the zeppelin-web build errors:
```
[ERROR] npm ERR! registry error parsing json
[ERROR] npm http 200 https://registry.npmjs.org/bower/1.7.2
[ERROR] npm ERR! SyntaxError: Unexpected token 
[ERROR] npm ERR! ï¿½ï¿½Y[oï¿½6ï¿½+ï¿½ï¿½6ï¿½ï¿½ulEï¿½ï¿½ï¿½
[ERROR] npm ERR! ï¿½{hï¿½ï¿½Cï¿½Ë‘ï¿½L=RJï¿½ï¿½oï¿½9bï¿½4ï¿½ï¿½ï¿½ï¿½W4ï¿½["ï¿½ï¿½wnï¿½ï¿½ï¿½Eï¿½ï¿½ï¿½2Cï¿½Ï•nï¿½ï¿½ï¿½U`ï¿½ï¿½aï¿½
[ERROR] npm ERR! Gï¿½p^ï¿½ï¿½$eï¿½Ley,ï¿½ï¿½IUï¿½"/Kï¿½,qrï¿½[8ï¿½Fï¿½ï¿½ï¿½^ï¿½ï¿½ï¿½pï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Zï¿½ï¿½ï¿½ï¿½ï¿½=x?ï¿½}ï¿½ï¿½{Wï¿½+ï¿½ï¿½ï¿½Ü³Ð€ìµ±ï¿½ï¿½ï¿½}
```
```
[ERROR] npm ERR! not a package /home/travis/build/apache/incubator-zeppelin/zeppelin-web/bower
```

Fix the maven build error:
```
[ERROR]   The project org.apache.zeppelin:zeppelin-scalding:0.6.0-incubating-SNAPSHOT (/home/travis/build/apache/incubator-zeppelin/scalding/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM: Could not transfer artifact org.apache.zeppelin:zeppelin:pom:0.6.0-incubating-SNAPSHOT from/to codehaus-snapshots (https://nexus.codehaus.org/snapshots/): nexus.codehaus.org and 'parent.relativePath' points at wrong local POM @ line 22, column 11: Unknown host nexus.codehaus.org -> [Help 2]
```

### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix zeppelin-web build error
* [x] - Fix the global maven build error

### What is the Jira issue?

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? AFAIK no
* Does this needs documentation? no