### PR TITLE
support changing tabsize of paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -76,6 +76,16 @@ limitations under the License.
            ng-show="!paragraph.config.lineNumbers"><span class="fa fa-list-ol"></span> Show line numbers</a>
       </li>
       <li>
+        <a ng-click="$event.stopPropagation()" class="dropdown"><span class="fa fa-ellipsis-h"></span> TabSize
+          <form style="display:inline; margin-left:5px;">
+            <select ng-model="paragraph.config.tabSize"
+                    class="selectpicker"
+                    ng-change="changeTabSize()"
+                    ng-options="col for col in tabSizeOption"></select>
+          </form>
+        </a>
+      </li>
+      <li>
         <a ng-click="toggleEnableDisable()"><span class="icon-control-play"></span>
           {{paragraph.config.enabled ? "Disable" : "Enable"}} run</a>
       </li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -93,6 +93,7 @@ angular.module('zeppelinWebApp')
     $scope.originalText = angular.copy(newParagraph.text);
     $scope.chart = {};
     $scope.colWidthOption = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ];
+    $scope.tabSizeOption = [ 1, 2, 3, 4, 5, 6, 7, 8 ];
     $scope.showTitleEditor = false;
     $scope.paragraphFocused = false;
     if (newParagraph.focus) {
@@ -283,6 +284,10 @@ angular.module('zeppelinWebApp')
 
     if (!config.colWidth) {
       config.colWidth = 12;
+    }
+
+    if (!config.tabSize) {
+      config.tabSize = 4;
     }
 
     if (!config.graph) {
@@ -639,6 +644,14 @@ angular.module('zeppelinWebApp')
     angular.element('.navbar-right.open').removeClass('open');
     var newParams = angular.copy($scope.paragraph.settings.params);
     var newConfig = angular.copy($scope.paragraph.config);
+
+    commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
+  };
+
+  $scope.changeTabSize = function() {
+    var newParams = angular.copy($scope.paragraph.settings.params);
+    var newConfig = angular.copy($scope.paragraph.config);
+    $scope.editor.getSession().setTabSize($scope.paragraph.config.tabSize);
 
     commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
   };


### PR DESCRIPTION
### What is this PR for?
The code editor tab size is fixed as 4.
It would be better to support changing tabsize to users.


### What type of PR is it?
Improvement


### Todos
* [ ] - Suppport REST API.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-887


### How should this be tested?
1. change the tab size in the righ-menu on paragraph.
2. type tab on paragraph.


### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/3348133/15568595/abcf9e32-2367-11e6-9322-40ca13d8d42e.png)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

