### PR TITLE
ZEPPELIN-947: Change docs link to point the same Zeppelin version

### DIFF
--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -78,7 +78,7 @@ limitations under the License.
         <div class="col-md-6">
           <h4>Help</h4>
           Get started with <a style="text-decoration: none;" target="_blank"
-                              href="http://zeppelin.apache.org/docs/latest/index.html">Zeppelin documentation</a><br>
+                              href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html">Zeppelin documentation</a><br>
 
           <h4>Community</h4>
           Please feel free to help us to improve Zeppelin, <br>


### PR DESCRIPTION
### What is this PR for?
Currently, Zeppelin documentation link in Zeppelin home is pointing to http://zeppelin.apache.org/docs/latest/index.html. But maybe some people is not using the latest version. So the link should point to the same Zeppelin version that user is using now.

I just change the `latest` -> `{{zeppelinVersion}}`

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-947](https://issues.apache.org/jira/browse/ZEPPELIN-947)

### How should this be tested?
1. After applying this patch and browse Zeppelin home. 
2. Just click `Zeppelin Documentation` link in here 
<img width="357" alt="screen shot 2016-06-02 at 1 11 17 pm" src="https://cloud.githubusercontent.com/assets/10060731/15759461/8b69ee5c-28c3-11e6-8181-2fc2978c0297.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
