### PR TITLE
[ZEPPELIN-958] Support syntax highlight for python and r interpreter

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -79,8 +79,9 @@ angular.module('zeppelinWebApp')
   var angularObjectRegistry = {};
 
   var editorModes = {
-    'ace/mode/python': /^%(\w*\.)?pyspark\s*$/,
+    'ace/mode/python': /^%(\w*\.)?(pyspark|python)\s*$/,
     'ace/mode/scala': /^%(\w*\.)?spark\s*$/,
+    'ace/mode/r': /^%(\w*\.)?(r|sparkr|knitr)\s*$/,
     'ace/mode/sql': /^%(\w*\.)?\wql/,
     'ace/mode/markdown': /^%md/,
     'ace/mode/sh': /^%sh/

--- a/zeppelin-web/src/app/search/result-list.controller.js
+++ b/zeppelin-web/src/app/search/result-list.controller.js
@@ -43,7 +43,9 @@ angular
     return function(_editor) {
       function getEditorMode(text) {
         var editorModes = {
-          'ace/mode/scala': /^%spark/,
+          'ace/mode/scala': /^%(\w*\.)?spark/,
+          'ace/mode/python': /^%(\w*\.)?(pyspark|python)/,
+          'ace/mode/r': /^%(\w*\.)?(r|sparkr|knitr)/,
           'ace/mode/sql': /^%(\w*\.)?\wql/,
           'ace/mode/markdown': /^%md/,
           'ace/mode/sh': /^%sh/


### PR DESCRIPTION
### What is this PR for?
Support syntax highlight for python and r interpreter

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-958](https://issues.apache.org/jira/browse/ZEPPELIN-958)


### Screenshots (if appropriate)
**Before**
<img width="411" alt="screen shot 2016-06-06 at 12 21 56 am" src="https://cloud.githubusercontent.com/assets/8503346/15814633/be1550ba-2b7c-11e6-89ee-8e8534f89ec7.png">


**After**
<img width="412" alt="screen shot 2016-06-05 at 7 42 55 pm" src="https://cloud.githubusercontent.com/assets/8503346/15810670/cd7960fe-2b55-11e6-8145-50517eaf2195.png">

**Before**
<img width="647" alt="screen shot 2016-06-05 at 7 30 53 pm" src="https://cloud.githubusercontent.com/assets/8503346/15810554/c6e49ec6-2b54-11e6-8b8b-a327dd76d437.png">

**After**
<img width="604" alt="screen shot 2016-06-05 at 7 30 31 pm" src="https://cloud.githubusercontent.com/assets/8503346/15810551/bf48cfc0-2b54-11e6-9ad1-bc16596074ee.png">



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No