### PR TITLE
ZEPPELIN-963 ] Jobmanagement - (1) basic backend.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -686,7 +686,52 @@ public class NotebookRestApi {
     }
     
     return new JsonResponse<>(Status.OK, note.getConfig().get("cron")).build();
-  }  
+  }
+
+  /**
+   * Get notebook jobs for job manager
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @GET
+  @Path("jobmanager/")
+  @ZeppelinApi
+  public Response getJobListforNotebook() throws IOException, IllegalArgumentException {
+    LOG.info("Get notebook jobs for job manager");
+
+    List<Map<String, Object>> notebookJobs = notebook.getJobListforNotebook(false, 0);
+    Map<String, Object> response = new HashMap<>();
+
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("jobs", notebookJobs);
+
+    return new JsonResponse<>(Status.OK, response).build();
+  }
+
+  /**
+   * Get updated notebook jobs for job manager
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @GET
+  @Path("jobmanager/{lastUpdateUnixtime}/")
+  @ZeppelinApi
+  public Response getUpdatedJobListforNotebook(
+      @PathParam("lastUpdateUnixtime") long lastUpdateUnixTime) throws
+      IOException, IllegalArgumentException {
+    LOG.info("Get updated notebook jobs lastUpdateTime {}", lastUpdateUnixTime);
+
+    List<Map<String, Object>> notebookJobs;
+    notebookJobs = notebook.getJobListforNotebook(false, lastUpdateUnixTime);
+    Map<String, Object> response = new HashMap<>();
+
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("jobs", notebookJobs);
+
+    return new JsonResponse<>(Status.OK, response).build();
+  }
 
   /**
    * Search for a Notes with permissions

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -61,6 +61,20 @@ import org.slf4j.LoggerFactory;
 public class NotebookServer extends WebSocketServlet implements
         NotebookSocketListener, JobListenerFactory, AngularObjectRegistryListener,
         RemoteInterpreterProcessListener {
+  /**
+   * Job manager service type
+   */
+  protected enum JOB_MANAGER_SERVICE {
+    JOB_MANAGER_PAGE("JOB_MANAGER_PAGE");
+    private String serviceTypeKey;
+    JOB_MANAGER_SERVICE(String serviceType) {
+      this.serviceTypeKey = serviceType;
+    }
+    String getKey() {
+      return this.serviceTypeKey;
+    }
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(NotebookServer.class);
   Gson gson = new GsonBuilder()
           .setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
@@ -202,6 +216,12 @@ public class NotebookServer extends WebSocketServlet implements
             break;
           case CHECKPOINT_NOTEBOOK:
             checkpointNotebook(conn, notebook, messagereceived);
+            break;
+          case LIST_NOTEBOOK_JOBS:
+            unicastNotebookJobInfo(conn);
+            break;
+          case LIST_UPDATE_NOTEBOOK_JOBS:
+            unicastUpdateNotebookJobInfo(conn, messagereceived);
             break;
           default:
             break;
@@ -348,6 +368,34 @@ public class NotebookServer extends WebSocketServlet implements
     } catch (IOException e) {
       LOG.error("socket error", e);
     }
+  }
+
+  public void unicastNotebookJobInfo(NotebookSocket conn) throws IOException {
+
+    List<Map<String, Object>> notebookJobs = notebook().getJobListforNotebook(false, 0);
+    Map<String, Object> response = new HashMap<>();
+
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("jobs", notebookJobs);
+
+    conn.send(serializeMessage(new Message(OP.LIST_NOTEBOOK_JOBS)
+      .put("notebookJobs", response)));
+  }
+
+  public void unicastUpdateNotebookJobInfo(NotebookSocket conn, Message fromMessage)
+      throws IOException {
+    double lastUpdateUnixTimeRaw = (double) fromMessage.get("lastUpdateUnixTime");
+    long lastUpdateUnixTime = new Double(lastUpdateUnixTimeRaw).longValue();
+
+    List<Map<String, Object>> notebookJobs;
+    notebookJobs = notebook().getJobListforNotebook(false, lastUpdateUnixTime);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("jobs", notebookJobs);
+
+    conn.send(serializeMessage(new Message(OP.LIST_UPDATE_NOTEBOOK_JOBS)
+            .put("notebookRunningJobs", response)));
   }
 
   public List<Map<String, String>> generateNotebooksInfo(boolean needsReload) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -570,8 +570,8 @@ public class Notebook {
       }
 
       // set notebook type ( cron or normal )
-      if (note.getConfig().containsKey(CRON_TYPE_NOTEBOOK_KEYWORD) == true
-              && !note.getConfig().get(CRON_TYPE_NOTEBOOK_KEYWORD).equals("")) {
+      if (note.getConfig().containsKey(CRON_TYPE_NOTEBOOK_KEYWORD) == true &&
+          !note.getConfig().get(CRON_TYPE_NOTEBOOK_KEYWORD).equals("")) {
         info.put("notebookType", "cron");
       }
       else {
@@ -600,8 +600,8 @@ public class Notebook {
 
       // set interpreter bind type
       String interpreterGroupName = null;
-      if (note.getNoteReplLoader().getInterpreterSettings() != null
-              && note.getNoteReplLoader().getInterpreterSettings().size() >= 1) {
+      if (note.getNoteReplLoader().getInterpreterSettings() != null &&
+          note.getNoteReplLoader().getInterpreterSettings().size() >= 1) {
         interpreterGroupName = note.getNoteReplLoader().getInterpreterSettings().get(0).getGroup();
       }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -111,10 +111,12 @@ public class Message {
     CONFIGURATIONS_INFO, // [s-c] all key/value pairs of configurations
                   // @param settings serialized Map<String, String> object
 
-    CHECKPOINT_NOTEBOOK     // [c-s] checkpoint notebook to storage repository
-                            // @param noteId
-                            // @param checkpointName
-
+    CHECKPOINT_NOTEBOOK,     // [c-s] checkpoint notebook to storage repository
+                             // @param noteId
+                             // @param checkpointName
+    LIST_NOTEBOOK_JOBS,     // [c-s] get notebook job management infomations
+    LIST_UPDATE_NOTEBOOK_JOBS // [c-s] get job management informations for until unixtime
+                               // @param unixTime
   }
 
   public OP op;


### PR DESCRIPTION
### What is this PR for?
Job management basic backend.
was divided into smaller " PR ". - https://github.com/apache/incubator-zeppelin/pull/921
Receive the basic data of Job manager api and the backend have been implemented.

### What type of PR is it?
Feature

### Todos
- [x] - Basic backend for job manager.
- [x] - Basic backend api

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-963

### How should this be tested?
#### step 1. 
First, calling the rest api as follows receives the data of "job" of the whole.
```shell
curl -H "Content-Type: application/json" -X GET http://127.0.0.1:8080/api/notebook/jobmanager/
```
result 
```json
{
   "status":"OK", // result for api request
   "body":{
      "lastResponseUnixTime":1465289938763, // last get server unixtime stamp.
      "jobs":[  // job list
         {
            "notebookId":"2BMQZ9QP6",  // notebook id.
            "unixTimeLastRun":1465289017310, // notebook last running unixtime.
            "notebookType":"normal", // cron or normal
            "isRunningJob":false, // is Running?
            "notebookName":"Untitled Note 1226", // notebook name.
            "interpreter":"spark", // default interpreter group name or If you have not selected it does not exist.
            "paragraphs":[
               {
                  "name":"20160607-174331_232775609", // paragraph name 'undefined is notebook id'
                  "id":"20160607-174331_232775609", // paragraph id
                  "status":"FINISHED" // paragraph job status
               }
            ]
         }
      ]
   }
}
```

#### step 2.
For example, it showed the result of receiving the information as one of the notebook.
focus on "lastResponseUnixTime" value.
This value is inserted as an argument when you call the following restapi, us to be able to get the updated data.

**Create a Notebook, or run the Paragraph.**
And, **call updated notebook api**

**"lastResponseUnixTime": 1465289938763** (step 1 get value)
```shell
curl -H "Content-Type: application/json" -X GET http://127.0.0.1:8080/api/notebook/jobmanager/1465289938763
```

#### step 3.
If you created a Notebook, a new Notebook information is displayed.
If there is a Notebook that if there is a Paragraph of the running, the information will also be displayed.

#### step 4.
When you restart the step1 of api, if you created a Notebook, the number of Notebook is +1 than when the first call.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? yes

