### PR TITLE
[ZEPPELIN-975] Move download data button outside the paragraph settings

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -12,38 +12,45 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div id="{{paragraph.id}}_switch"
-     ng-if="paragraph.result.type == 'TABLE' && !asIframe && !viewOnly"
-     class="btn-group"
+<div ng-if="paragraph.result.type == 'TABLE' && !asIframe && !viewOnly"
      style='margin-bottom: 10px;'>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('table')}"
-          ng-click="setGraphMode('table', true)" ><i class="fa fa-table"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('multiBarChart')}"
-          ng-click="setGraphMode('multiBarChart', true)"><i class="fa fa-bar-chart"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('pieChart')}"
-          ng-click="setGraphMode('pieChart', true)"><i class="fa fa-pie-chart"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('stackedAreaChart')}"
-          ng-click="setGraphMode('stackedAreaChart', true)"><i class="fa fa-area-chart"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('lineChart') || isGraphMode('lineWithFocusChart')}"
-          ng-click="paragraph.config.graph.lineWithFocus ? setGraphMode('lineWithFocusChart', true) : setGraphMode('lineChart', true)"><i class="fa fa-line-chart"></i>
-  </button>
-  <button type="button" class="btn btn-default btn-sm"
-          ng-class="{'active': isGraphMode('scatterChart')}"
-          ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
-  </button>
+  <div id="{{paragraph.id}}_switch"
+       class="btn-group">
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('table')}"
+            ng-click="setGraphMode('table', true)" ><i class="fa fa-table"></i>
+    </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('multiBarChart')}"
+            ng-click="setGraphMode('multiBarChart', true)"><i class="fa fa-bar-chart"></i>
+    </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('pieChart')}"
+            ng-click="setGraphMode('pieChart', true)"><i class="fa fa-pie-chart"></i>
+    </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('stackedAreaChart')}"
+            ng-click="setGraphMode('stackedAreaChart', true)"><i class="fa fa-area-chart"></i>
+    </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('lineChart') || isGraphMode('lineWithFocusChart')}"
+            ng-click="paragraph.config.graph.lineWithFocus ? setGraphMode('lineWithFocusChart', true) : setGraphMode('lineChart', true)"><i class="fa fa-line-chart"></i>
+    </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('scatterChart')}"
+            ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
+    </button>
+  </div>
+  <span>
+    <button type="button" class="btn btn-default btn-sm" style="margin-left:10px"
+            tooltip="Download Data as TSV" tooltip-placement="bottom"
+            ng-click="exportToTSV()"><i class="fa fa-download"></i>
+    </button>
+  </span>
+  <span ng-if="getGraphMode()!='table'"
+        style="margin-left:5px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">
+    <a class="btnText" ng-click="toggleGraphOption()">
+      settings <span ng-class="paragraph.config.graph.optionOpen ? 'fa fa-caret-up' : 'fa fa-caret-down'"></span>
+    </a>
+  </span>
 </div>
-<span ng-if="getResultType()=='TABLE' && getGraphMode()!='table' && !asIframe && !viewOnly"
-      style="margin-left:10px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">
-  <a class="btnText" ng-click="toggleGraphOption()">
-    settings <span ng-class="paragraph.config.graph.optionOpen ? 'fa fa-caret-up' : 'fa fa-caret-down'"></span>
-  </a>
-</span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -83,9 +83,6 @@ limitations under the License.
         <a ng-click="goToSingleParagraph()"><span class="icon-share-alt"></span> Link this paragraph</a>
       </li>
       <li>
-        <a ng-click="exportToTSV()"><span class="icon-share-alt"></span> Export to TSV</a>
-      </li>
-      <li>
         <a ng-click="clearParagraphOutput()"><span class="fa fa-eraser"></span> Clear output</a>
       </li>
       <li>


### PR DESCRIPTION
### What is this PR for?
Following the PR #714 and its comments, we are moving the download data outside the paragraph settings. Which would allow a possible drop down to choose backend data download in the future.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-975

### How should this be tested?
Show a %Table type of result (you can use below code in a paragraph for that).
You should see the icon, click on it to download the data.
```
print(s"""%table
name\tsize
sun\t127.6
moon\t0.6458
gerard\t45.234856803""")
```

### Screenshots (if appropriate)
![screen shot 2016-06-08 at 4 15 22 pm](https://cloud.githubusercontent.com/assets/710411/15886052/bf3f8648-2d95-11e6-837f-47f112a76031.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No, but maybe feature announcement during release
