### PR TITLE
[ZEPPELIN-980] Move git repository from incubator-zeppelin to zeppelin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 ### What is this PR for?
 A few sentences describing the overall goals of the pull request's commits.
-First time? Check out the contributing guide - https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md
+First time? Check out the contributing guide - https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md
 
 
 ### What type of PR is it?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-**Zeppelin** is [Apache2 License](https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md) Software.
+**Zeppelin** is [Apache2 License](https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md) Software.
 Contributing to Zeppelin (Source code, Documents, Image, Website) means you agree to the Apache2 License.
 
 1. Make sure your issue is not already in the [Jira issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN)
@@ -17,7 +17,7 @@ In order to make the review process easier, please follow this template when mak
 ```
 ### What is this PR for?
 A few sentences describing the overall goals of the pull request's commits.
-First time? Check out the contributing guide - https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md
+First time? Check out the contributing guide - https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md
 
 ### What type of PR is it?
 [Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]
@@ -58,7 +58,7 @@ You can also test and review a particular Pull Request. Here are two useful ways
 * Another way is using [github/hub](https://github.com/github/hub). 
      
     ```
-    hub checkout https://github.com/apache/incubator-zeppelin/pull/[# of PR]
+    hub checkout https://github.com/apache/zeppelin/pull/[# of PR]
     ```
 
 The above two methods will help you test and review Pull Requests.
@@ -91,8 +91,8 @@ Here are some things you will need to build and test Zeppelin.
 
 ### Software Configuration Management (SCM)
 
-Zeppelin uses Git for its SCM system. `http://git.apache.org/incubator-zeppelin.git` you'll need git client installed in your development machine.
-For write access, `https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git`
+Zeppelin uses Git for its SCM system. `http://git.apache.org/zeppelin.git` you'll need git client installed in your development machine.
+For write access, `https://git-wip-us.apache.org/repos/asf/zeppelin.git`
 
 ### Integrated Development Environment (IDE)
 
@@ -121,7 +121,7 @@ The top-level pom.xml describes the basic project structure. Currently Zeppelin 
     
 ### Web Project Contribution Guidelines
 If you plan on making a contribution to Zeppelin's WebApplication,
-please check [its own contribution guidelines](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-web/CONTRIBUTING.md)
+please check [its own contribution guidelines](https://github.com/apache/zeppelin/blob/master/zeppelin-web/CONTRIBUTING.md)
 
 ### Code convention
 We are following Google Code style:
@@ -138,31 +138,31 @@ To build the code, install
  * Apache Maven
 
 ## Getting the source code
-First of all, you need the Zeppelin source code. The official location for Zeppelin is [http://git.apache.org/incubator-zeppelin.git](http://git.apache.org/incubator-zeppelin.git).
+First of all, you need the Zeppelin source code. The official location for Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
 
 ### git access
 
 Get the source code on your development machine using git.
 
 ```
-git clone git://git.apache.org/incubator-zeppelin.git zeppelin
+git clone git://git.apache.org/zeppelin.git zeppelin
 ```
 
 You may also want to develop against a specific branch. For example, for branch-0.5.6
 
 ```
-git clone -b branch-0.5.6 git://git.apache.org/incubator-zeppelin.git zeppelin
+git clone -b branch-0.5.6 git://git.apache.org/zeppelin.git zeppelin
 ```
 
 or with write access
 
 ```
-git clone https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git
+git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git
 ```
 
 ### Fork repository
 
-If you want not only build Zeppelin but also make change, then you need fork Zeppelin github mirror repository (https://github.com/apache/incubator-zeppelin) and make pull request.
+If you want not only build Zeppelin but also make change, then you need fork Zeppelin github mirror repository (https://github.com/apache/zeppelin) and make pull request.
 
 
 ## Build
@@ -193,11 +193,11 @@ Zeppelin has 3 types of tests:
   2. Integration Tests: The integration tests run after all modules are build. The integration tests launch an instance of Zeppelin server. ZeppelinRestApiTest is an example integration test. 
   3. GUI integration tests: These tests validate the Zeppelin UI elements. These tests require a running Zeppelin server and launches a web browser to validate Notebook UI elements like Notes and their execution. See ZeppelinIT as an example.  
 
-Currently the GUI integration tests are not run in the Maven and are only run in the CI environment when the pull request is submitted to github. Make sure to watch the [CI results] (https://travis-ci.org/apache/incubator-zeppelin/pull_requests) for your pull request.
+Currently the GUI integration tests are not run in the Maven and are only run in the CI environment when the pull request is submitted to github. Make sure to watch the [CI results] (https://travis-ci.org/apache/zeppelin/pull_requests) for your pull request.
 
 ## Continuous Integration
 
-Zeppelin uses Travis for CI. In the project root there is .travis.yml that configures CI and [publishes CI results] (https://travis-ci.org/apache/incubator-zeppelin/builds)
+Zeppelin uses Travis for CI. In the project root there is .travis.yml that configures CI and [publishes CI results] (https://travis-ci.org/apache/zeppelin/builds)
   
 
 ## Run Zeppelin server in development mode
@@ -225,6 +225,6 @@ You can find issues for [beginner](https://issues.apache.org/jira/browse/ZEPPELI
 ## Stay involved
 Everyone is welcome to join our mailing list:
 
- * [users@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/) is for usage questions, help, and announcements [ [subscribe](mailto:users-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:users-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/) ]
- * [dev@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-users/) is for people who want to contribute code to Zeppelin.[ [subscribe](mailto:dev-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:dev-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-dev/) ]
- * [commits@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-commits/) is for commit messages and patches to Zeppelin. [ [subscribe](mailto:commits-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:commits-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/incubator-zeppelin-commits/) ]
+ * [users@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/zeppelin-users/) is for usage questions, help, and announcements [ [subscribe](mailto:users-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:users-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/zeppelin-users/) ]
+ * [dev@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/zeppelin-users/) is for people who want to contribute code to Zeppelin.[ [subscribe](mailto:dev-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:dev-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/zeppelin-dev/) ]
+ * [commits@zeppelin.apache.org](http://mail-archives.apache.org/mod_mbox/zeppelin-commits/) is for commit messages and patches to Zeppelin. [ [subscribe](mailto:commits-subscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20subscribe), [unsubscribe](mailto:commits-unsubscribe@zeppelin.apache.org?subject=send%20this%20email%20to%20unsubscribe), [archive](http://mail-archives.apache.org/mod_mbox/zeppelin-commits/) ]

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Zeppelin (incubating)
+Apache Zeppelin
 Copyright 2015 - 2016 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Documentation:** [User Guide](http://zeppelin.apache.org/docs/latest/index.html)<br/>
 **Mailing Lists:** [User and Dev mailing list](http://zeppelin.apache.org/community.html)<br/>
-**Continuous Integration:** [![Build Status](https://secure.travis-ci.org/apache/incubator-zeppelin.png?branch=master)](https://travis-ci.org/apache/incubator-zeppelin) <br/>
+**Continuous Integration:** [![Build Status](https://secure.travis-ci.org/apache/zeppelin.png?branch=master)](https://travis-ci.org/apache/zeppelin) <br/>
 **Contributing:** [Contribution Guide](https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md)<br/>
 **Issue Tracker:** [Jira](https://issues.apache.org/jira/browse/ZEPPELIN)<br/>
 **License:** [Apache 2.0](https://github.com/apache/zeppelin/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 **Documentation:** [User Guide](http://zeppelin.apache.org/docs/latest/index.html)<br/>
 **Mailing Lists:** [User and Dev mailing list](http://zeppelin.apache.org/community.html)<br/>
 **Continuous Integration:** [![Build Status](https://secure.travis-ci.org/apache/incubator-zeppelin.png?branch=master)](https://travis-ci.org/apache/incubator-zeppelin) <br/>
-**Contributing:** [Contribution Guide](https://github.com/apache/incubator-zeppelin/blob/master/CONTRIBUTING.md)<br/>
+**Contributing:** [Contribution Guide](https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md)<br/>
 **Issue Tracker:** [Jira](https://issues.apache.org/jira/browse/ZEPPELIN)<br/>
-**License:** [Apache 2.0](https://github.com/apache/incubator-zeppelin/blob/master/LICENSE)
+**License:** [Apache 2.0](https://github.com/apache/zeppelin/blob/master/LICENSE)
 
 
 **Zeppelin**, a web-based notebook that enables interactive data analytics. You can make beautiful data-driven, interactive and collaborative documents with SQL, Scala and more.
@@ -287,4 +287,4 @@ mvn verify
 mvn verify -P using-packaged-distr
 ```
 
-[![Analytics](https://ga-beacon.appspot.com/UA-45176241-4/apache/incubator-zeppelin/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-45176241-4/apache/zeppelin/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/SECURITY-README.md
+++ b/SECURITY-README.md
@@ -14,7 +14,7 @@ limitations under the License.
 
 # Shiro Authentication
 To connect to Zeppelin, users will be asked to enter their credentials. Once logged, a user has access to all notes including other users notes.
-This a a first step toward full security as implemented by this pull request (https://github.com/apache/incubator-zeppelin/pull/53).
+This a a first step toward full security as implemented by this pull request (https://github.com/apache/zeppelin/pull/53).
 
 # Security setup
 1. Secure the HTTP channel: Comment the line "/** = anon" and uncomment the line "/** = authcBasic" in the file conf/shiro.ini. Read more about he shiro.ini file format at the following URL http://shiro.apache.org/configuration.html#Configuration-INISections.  

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -23,8 +23,6 @@
 # Here's some helpful documents for the release
 # http://www.apache.org/dev/release.html
 # http://www.apache.org/dev/release-publishing
-# http://incubator.apache.org/guides/releasemanagement.html
-# http://incubator.apache.org/guides/release.html
 # http://www.apache.org/dev/release-signing.html
 # http://www.apache.org/dev/publishing-maven-artifacts.html
 
@@ -38,7 +36,7 @@ fi
 
 
 if [[ -z "${WORKING_DIR}" ]]; then
-    WORKING_DIR=/tmp/incubator-zeppelin-release
+    WORKING_DIR=/tmp/zeppelin-release
 fi
 
 if [[ -z "${GPG_PASSPHRASE}" ]]; then
@@ -49,7 +47,7 @@ fi
 
 if [[ $# -ne 2 ]]; then
     echo "usage) $0 [Release name] [Branch or Tag]"
-    echo "   ex. $0 0.5.0-incubating branch-0.5"
+    echo "   ex. $0 0.6.0 branch-0.6"
     exit 1
 fi
 
@@ -66,7 +64,7 @@ mkdir ${WORKING_DIR}
 
 echo "Cloning the source and packaging"
 # clone source
-git clone -b ${BRANCH} git@github.com:apache/incubator-zeppelin.git ${WORKING_DIR}/zeppelin
+git clone -b ${BRANCH} git@github.com:apache/zeppelin.git ${WORKING_DIR}/zeppelin
 if [[ $? -ne 0 ]]; then
     echo "Can not clone source repository"
     exit 1

--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -48,8 +48,8 @@ JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "moon")
 # ASF JIRA password
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "00000")
 
-GITHUB_BASE = "https://github.com/apache/incubator-zeppelin/pull"
-GITHUB_API_BASE = "https://api.github.com/repos/apache/incubator-zeppelin"
+GITHUB_BASE = "https://github.com/apache/zeppelin/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/apache/zeppelin"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"
 # Prefix added to temporary branches

--- a/dev/test_zeppelin_pr.py
+++ b/dev/test_zeppelin_pr.py
@@ -34,7 +34,7 @@ if len(sys.argv) == 1:
 
 
 pr=sys.argv[1]
-githubApi="https://api.github.com/repos/apache/incubator-zeppelin"
+githubApi="https://api.github.com/repos/apache/zeppelin"
 
 prInfo = json.load(urllib.urlopen(githubApi + "/pulls/" + pr))
 if "message" in prInfo and prInfo["message"] == "Not Found":

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ should be updated
 
  2. checkout ASF repo
     ```
-    svn co https://svn.apache.org/repos/asf/incubator/zeppelin asf-zeppelin
+    svn co https://svn.apache.org/repos/asf/zeppelin asf-zeppelin
     ```
  3. copy `zeppelin/docs/_site` to `asf-zeppelin/site/docs/[VERSION]`
  4. ```svn commit```

--- a/docs/development/howtocontribute.md
+++ b/docs/development/howtocontribute.md
@@ -30,24 +30,24 @@ To build the code, install
   * Apache Maven
 
 ## Getting the source code
-First of all, you need Zeppelin source code. The official location of Zeppelin is [http://git.apache.org/incubator-zeppelin.git](http://git.apache.org/incubator-zeppelin.git).
+First of all, you need Zeppelin source code. The official location of Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
 
 ### git access
 
 Get the source code on your development machine using git.
 
 ```
-git clone git://git.apache.org/incubator-zeppelin.git zeppelin
+git clone git://git.apache.org/zeppelin.git zeppelin
 ```
 
 You may also want to develop against a specific branch. For example, for branch-0.5.6
 
 ```
-git clone -b branch-0.5.6 git://git.apache.org/incubator-zeppelin.git zeppelin
+git clone -b branch-0.5.6 git://git.apache.org/zeppelin.git zeppelin
 ```
 
 #### Fork repository
-If you want not only build Zeppelin but also make any changes, then you need fork [Zeppelin github mirror repository](https://github.com/apache/incubator-zeppelin) and make a pull request.
+If you want not only build Zeppelin but also make any changes, then you need fork [Zeppelin github mirror repository](https://github.com/apache/zeppelin) and make a pull request.
 
 ###Build
 

--- a/docs/development/howtocontributewebsite.md
+++ b/docs/development/howtocontributewebsite.md
@@ -17,22 +17,22 @@ Any contribution to Zeppelin (Source code, Documents, Image, Website) means you 
 #### Getting the source code
 Website is hosted in 'master' branch under `/docs/` dir.
 
-First of all, you need the website source code. The official location of mirror for Zeppelin is [http://git.apache.org/incubator-zeppelin.git](http://git.apache.org/incubator-zeppelin.git).
+First of all, you need the website source code. The official location of mirror for Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
 
 Get the source code on your development machine using git.
 
 ```
-git clone git://git.apache.org/incubator-zeppelin.git
+git clone git://git.apache.org/zeppelin.git
 cd docs
 ```
 
 #### Build
 
-To build, you'll need to install some prerequisites. Please check 'Build documentation' section in [docs/README.md](https://github.com/apache/incubator-zeppelin/blob/master/docs/README.md#build-documentation).
+To build, you'll need to install some prerequisites. Please check 'Build documentation' section in [docs/README.md](https://github.com/apache/zeppelin/blob/master/docs/README.md#build-documentation).
 
 #### Run website in development mode
 
-While you're modifying website, you'll want to see preview of it. Please check 'Run website' section in [docs/README.md](https://github.com/apache/incubator-zeppelin/blob/master/docs/README.md#run-website).
+While you're modifying website, you'll want to see preview of it. Please check 'Run website' section in [docs/README.md](https://github.com/apache/zeppelin/blob/master/docs/README.md#run-website).
 
 You'll be able to access it on [http://localhost:4000](http://localhost:4000) with your web browser.
 

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -35,7 +35,7 @@ In 'Separate Interpreter for each note' mode, new Interpreter instance will be c
 
 ### Make your own Interpreter
 
-Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.interpreter](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
+Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.interpreter](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
 You can include `org.apache.zeppelin:zeppelin-interpreter:[VERSION]` artifact in your build system. And you should your jars under your interpreter directory with specific directory name. Zeppelin server reads interpreter directories recursively and initializes interpreters including your own interpreter.
 
 There are three locations where you can store your interpreter group, name and other information. Zeppelin server tries to find the location below. Next, Zeppelin tries to find `interpareter-setting.json` in your interpreter jar. 
@@ -126,14 +126,14 @@ To configure your interpreter you need to follow these steps:
 </property>
 ```
 
-2. Add your interpreter to the [default configuration](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L397) which is used when there is no `zeppelin-site.xml`.
+2. Add your interpreter to the [default configuration](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L397) which is used when there is no `zeppelin-site.xml`.
 
 3. Start Zeppelin by running `./bin/zeppelin-daemon.sh start`.
 
 4. In the interpreter page, click the `+Create` button and configure your interpreter properties.
 Now you are done and ready to use your interpreter.
 
-Note that the interpreters released with zeppelin have a [default configuration](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L397) which is used when there is no `conf/zeppelin-site.xml`.
+Note that the interpreters released with zeppelin have a [default configuration](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L397) which is used when there is no `conf/zeppelin-site.xml`.
 
 ### Use your interpreter
 
@@ -196,10 +196,10 @@ codes for myintp2
 
 Checkout some interpreters released with Zeppelin by default.
 
- - [spark](https://github.com/apache/incubator-zeppelin/tree/master/spark)
- - [markdown](https://github.com/apache/incubator-zeppelin/tree/master/markdown)
- - [shell](https://github.com/apache/incubator-zeppelin/tree/master/shell)
- - [jdbc](https://github.com/apache/incubator-zeppelin/tree/master/jdbc)
+ - [spark](https://github.com/apache/zeppelin/tree/master/spark)
+ - [markdown](https://github.com/apache/zeppelin/tree/master/markdown)
+ - [shell](https://github.com/apache/zeppelin/tree/master/shell)
+ - [jdbc](https://github.com/apache/zeppelin/tree/master/jdbc)
 
 ### Contributing a new Interpreter to Zeppelin releases
 
@@ -207,9 +207,9 @@ We welcome contribution to a new interpreter. Please follow these few steps:
 
  - First, check out the general contribution guide [here](./howtocontributewebsite.html).
  - Follow the steps in "Make your own Interpreter" section above.
- - Add your interpreter as in the "Configure your interpreter" section above; also add it to the example template [zeppelin-site.xml.template](https://github.com/apache/incubator-zeppelin/blob/master/conf/zeppelin-site.xml.template).
+ - Add your interpreter as in the "Configure your interpreter" section above; also add it to the example template [zeppelin-site.xml.template](https://github.com/apache/zeppelin/blob/master/conf/zeppelin-site.xml.template).
  - Add tests! They are run by Travis for all changes and it is important that they are self-contained.
- - Include your interpreter as a module in [`pom.xml`](https://github.com/apache/incubator-zeppelin/blob/master/pom.xml).
- - Add documentation on how to use your interpreter under `docs/interpreter/`. Follow the Markdown style as this [example](https://github.com/apache/incubator-zeppelin/blob/master/docs/interpreter/elasticsearch.md). Make sure you list config settings and provide working examples on using your interpreter in code boxes in Markdown. Link to images as appropriate (images should go to `docs/assets/themes/zeppelin/img/docs-img/`). And add a link to your documentation in the navigation menu (`docs/_includes/themes/zeppelin/_navigation.html`).
- - Most importantly, ensure licenses of the transitive closure of all dependencies are list in [license file](https://github.com/apache/incubator-zeppelin/blob/master/zeppelin-distribution/src/bin_license/LICENSE).
- - Commit your changes and open a Pull Request on the project [Mirror on GitHub](https://github.com/apache/incubator-zeppelin); check to make sure Travis CI build is passing.
+ - Include your interpreter as a module in [`pom.xml`](https://github.com/apache/zeppelin/blob/master/pom.xml).
+ - Add documentation on how to use your interpreter under `docs/interpreter/`. Follow the Markdown style as this [example](https://github.com/apache/zeppelin/blob/master/docs/interpreter/elasticsearch.md). Make sure you list config settings and provide working examples on using your interpreter in code boxes in Markdown. Link to images as appropriate (images should go to `docs/assets/themes/zeppelin/img/docs-img/`). And add a link to your documentation in the navigation menu (`docs/_includes/themes/zeppelin/_navigation.html`).
+ - Most importantly, ensure licenses of the transitive closure of all dependencies are list in [license file](https://github.com/apache/zeppelin/blob/master/zeppelin-distribution/src/bin_license/LICENSE).
+ - Commit your changes and open a Pull Request on the project [Mirror on GitHub](https://github.com/apache/zeppelin); check to make sure Travis CI build is passing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ If you want to learn more about this feature, please visit [this page](./manual/
 <br />
 ### 100% Opensource
 
-Apache Zeppelin is Apache2 Licensed software. Please check out the [source repository](http://git.apache.org/incubator-zeppelin.git) and [How to contribute](./development/howtocontribute.html)
+Apache Zeppelin is Apache2 Licensed software. Please check out the [source repository](http://git.apache.org/zeppelin.git) and [How to contribute](./development/howtocontribute.html)
 
 Zeppelin has a very active development community.
 Join the [Mailing list](https://zeppelin.apache.org/community.html) and report issues on our [Issue tracker](https://issues.apache.org/jira/browse/ZEPPELIN).

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -40,7 +40,7 @@ You can also build Zeppelin from the source.
  * Maven(3.1.x or higher)
  * Node.js Package Manager
 
-If you don't have requirements prepared, please check instructions in [README.md](https://github.com/apache/incubator-zeppelin/blob/master/README.md) for the details.
+If you don't have requirements prepared, please check instructions in [README.md](https://github.com/apache/zeppelin/blob/master/README.md) for the details.
 
 <a name="zeppelin-configuration"> </a>
 ## Zeppelin Configuration

--- a/docs/install/yarn_install.md
+++ b/docs/install/yarn_install.md
@@ -53,7 +53,7 @@ Its assumed in the rest of the document that zeppelin user is indeed created and
 It's assumed that the node has CentOS 6.x installed on it. Although any version of Linux distribution should work fine.
 
 #### Hadoop client
-Zeppelin can work with multiple versions & distributions of Hadoop. A complete list is available [here](https://github.com/apache/incubator-zeppelin#build). This document assumes Hadoop 2.7.x client libraries including configuration files are installed on Zeppelin node. It also assumes /etc/hadoop/conf contains various Hadoop configuration files. The location of Hadoop configuration files may vary, hence use appropriate location.
+Zeppelin can work with multiple versions & distributions of Hadoop. A complete list is available [here](https://github.com/apache/zeppelin#build). This document assumes Hadoop 2.7.x client libraries including configuration files are installed on Zeppelin node. It also assumes /etc/hadoop/conf contains various Hadoop configuration files. The location of Hadoop configuration files may vary, hence use appropriate location.
 
 ```bash
 hadoop version
@@ -67,7 +67,7 @@ This command was run using /usr/hdp/2.3.1.0-2574/hadoop/lib/hadoop-common-2.7.1.
 
 #### Spark
 Spark is supported out of the box and to take advantage of this, you need to Download appropriate version of Spark binary packages from [Spark Download page](http://spark.apache.org/downloads.html) and unzip it.
-Zeppelin can work with multiple versions of Spark. A complete list is available [here](https://github.com/apache/incubator-zeppelin#build).
+Zeppelin can work with multiple versions of Spark. A complete list is available [here](https://github.com/apache/zeppelin#build).
 This document assumes Spark 1.6.0 is installed at /usr/lib/spark.
 > Note: Spark should be installed on the same node as Zeppelin.
 
@@ -75,15 +75,15 @@ This document assumes Spark 1.6.0 is installed at /usr/lib/spark.
 
 #### Zeppelin
 
-Checkout source code from [git://git.apache.org/incubator-zeppelin.git](https://github.com/apache/incubator-zeppelin.git) or download binary package from [Download page](https://zeppelin.apache.org/download.html).
+Checkout source code from [git://git.apache.org/zeppelin.git](https://github.com/apache/zeppelin.git) or download binary package from [Download page](https://zeppelin.apache.org/download.html).
 You can refer [Install](install.html) page for the details.
-This document assumes that Zeppelin is located under `/home/zeppelin/incubator-zeppelin`.
+This document assumes that Zeppelin is located under `/home/zeppelin/zeppelin`.
 
 ## Zeppelin Configuration
 Zeppelin configuration needs to be modified to connect to YARN cluster. Create a copy of zeppelin environment shell script.
 
 ```bash
-cp /home/zeppelin/incubator-zeppelin/conf/zeppelin-env.sh.template /home/zeppelin/incubator-zeppelin/conf/zeppelin-env.sh
+cp /home/zeppelin/zeppelin/conf/zeppelin-env.sh.template /home/zeppelin/zeppelin/conf/zeppelin-env.sh
 ```
 
 Set the following properties
@@ -106,7 +106,7 @@ hdp-select status hadoop-client | sed 's/hadoop-client - \(.*\)/\1/'
 ### Start Zeppelin
 
 ```
-cd /home/zeppelin/incubator-zeppelin
+cd /home/zeppelin/zeppelin
 bin/zeppelin-daemon.sh start
 ```
 After successful start, visit http://[zeppelin-server-host-name]:8080 with your web browser.
@@ -161,7 +161,7 @@ Zeppelin does not emit any kind of error messages on web interface when notebook
 
 ```bash
 [zeppelin@zeppelin-3529 logs]$ pwd
-/home/zeppelin/incubator-zeppelin/logs
+/home/zeppelin/zeppelin/logs
 [zeppelin@zeppelin-3529 logs]$ ls -l
 total 844
 -rw-rw-r-- 1 zeppelin zeppelin  14648 Aug  3 14:45 zeppelin-interpreter-hive-zeppelin-zeppelin-3529.log

--- a/docs/manual/dynamicinterpreterload.md
+++ b/docs/manual/dynamicinterpreterload.md
@@ -56,7 +56,7 @@ http://127.0.0.1:8080/api/interpreter/load/md/markdown
 
 ```
 {
-  "artifact": "org.apache.zeppelin:zeppelin-markdown:0.6.0-incubating-SNAPSHOT",
+  "artifact": "org.apache.zeppelin:zeppelin-markdown:0.6.0-SNAPSHOT",
   "className": "org.apache.zeppelin.markdown.Markdown",
   "repository": {
     "url": "http://dl.bintray.com/spark-packages/maven",
@@ -71,7 +71,7 @@ The meaning of each parameters is:
   1. **Artifact**
 	- groupId: org.apache.zeppelin
 	- artifactId: zeppelin-markdown
-	- version: 0.6.0-incubating-SNAPSHOT
+	- version: 0.6.0-SNAPSHOT
 
   2. **Class Name**
 	- Package Name: org.apache.zeppelin

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -119,7 +119,7 @@ This instruction based on Ubuntu 14.04 LTS but may work with other OS with few c
 1. More security consideration
 
 * Using HTTPS connection with Basic Authentication is highly recommended since basic auth without encryption may expose your important credential information over the network.
-* Using [Shiro Security feature built-into Zeppelin](https://github.com/apache/incubator-zeppelin/blob/master/SECURITY-README.md) is recommended if you prefer all-in-one solution for authentication but NGINX may provides ad-hoc solution for re-use authentication served by your system's NGINX server or in case of you need to separate authentication from zeppelin server.
+* Using [Shiro Security feature built-into Zeppelin](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md) is recommended if you prefer all-in-one solution for authentication but NGINX may provides ad-hoc solution for re-use authentication served by your system's NGINX server or in case of you need to separate authentication from zeppelin server.
 * It is recommended to isolate direct connection to Zeppelin server from public internet or external services to secure your zeppelin instance from unexpected attack or problems caused by public zone.
 
 ### Another option

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -69,4 +69,4 @@ user2 = password3
 
 Those combinations are defined in the `conf/shiro.ini` file.
 
-> **NOTE :** This documentation is originally from [SECURITY-README.md](https://github.com/apache/incubator-zeppelin/blob/master/SECURITY-README.md).
+> **NOTE :** This documentation is originally from [SECURITY-README.md](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md).

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
   </licenses>
 
   <scm>
-    <url>https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</url>
-    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git</developerConnection>
+    <url>https://git-wip-us.apache.org/repos/asf/zeppelin.git</url>
+    <connection>scm:git:https://git-wip-us.apache.org/repos/asf/zeppelin.git</connection>
+    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/zeppelin.git</developerConnection>
   </scm>
 
   <inceptionYear>2013</inceptionYear>
@@ -361,8 +361,6 @@
               <resourceBundles>
                 <!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
                 <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
-                <!-- Will generate META-INF/DISCLAIMER  -->
-                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>

--- a/r/R/rzeppelin/DESCRIPTION
+++ b/r/R/rzeppelin/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rzeppelin
 Type: Package
-Title: Interface from scala to R, based on rscala, for the Apache (Incubation) Zeppelin project
+Title: Interface from scala to R, based on rscala, for the Apache Zeppelin project
 Version: 0.1.0
 Date: 2015-12-01
 Authors@R: c(person(given="David B.",family="Dahl",role=c("aut","cre"),email="dahl@stat.byu.edu"),

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -41,6 +41,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:apache/incubator-zeppelin.git"
+    "url": "git@github.com:apache/zeppelin.git"
   }
 }

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -87,7 +87,7 @@ limitations under the License.
              target="_blank"><i style="font-size: 15px;" class="fa fa-users"></i> Mailing list</a><br>
           <a style="text-decoration: none;" href="https://issues.apache.org/jira/browse/ZEPPELIN"
              target="_blank"><i style="font-size: 15px;" class="fa fa-bug"></i> Issues tracking</a><br>
-          <a style="text-decoration: none;" href="https://github.com/apache/incubator-zeppelin"
+          <a style="text-decoration: none;" href="https://github.com/apache/zeppelin"
              target="_blank"><i style="font-size: 20px;" class="fa fa-github"></i> Github</a>
         </div>
       </div>


### PR DESCRIPTION
### What is this PR for?
git repo infra have moved from incubator-zeppelin to zeppelin

### What type of PR is it?
Hot Fix

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

