### PR TITLE
ZEPPELIN-985 ] Fixed bug in the Pyspark completion

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -118,6 +118,9 @@ class SparkVersion(object):
     return self.version >= self.SPARK_1_3_0
 
 class PySparkCompletion:
+  def __init__(self, interpreterObject):
+    self.interpreterObject = interpreterObject
+
   def getGlobalCompletion(self):
     objectDefList = []
     try:
@@ -159,9 +162,10 @@ class PySparkCompletion:
         for completionItem in list(objectCompletionList):
           completionList.add(completionItem)
     if len(completionList) <= 0:
-      print("")
+      self.interpreterObject.setStatementsFinished("", False)
     else:
-      print(json.dumps(list(filter(lambda x : not re.match("^__.*", x), list(completionList)))))
+      result = json.dumps(list(filter(lambda x : not re.match("^__.*", x), list(completionList))))
+      self.interpreterObject.setStatementsFinished(result, False)
 
 
 output = Logger()
@@ -205,7 +209,7 @@ sc = SparkContext(jsc=jsc, gateway=gateway, conf=conf)
 sqlc = SQLContext(sc, intp.getSQLContext())
 sqlContext = sqlc
 
-completion = PySparkCompletion()
+completion = PySparkCompletion(intp)
 z = PyZeppelinContext(intp.getZeppelinContext())
 
 while True :


### PR DESCRIPTION
### What is this PR for?
Currently, does not work 'pyspark completion'.

### What type of PR is it?
Bug Fix

### Todos
- [x] - change standard output for completion to interpreter outer.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-985

### How should this be tested?
Try keyword completion for pyspark interpreter.

### Screenshots (if appropriate)
#### Before
![pycompletion_err2](https://cloud.githubusercontent.com/assets/10525473/15961476/ed5eae40-2f3f-11e6-8e22-e0df6b7012c9.gif)

#### After
![pycompletion](https://cloud.githubusercontent.com/assets/10525473/15961433/b60d534c-2f3f-11e6-84f1-cd828f7db9e0.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
