### PR TITLE
[MINOR] Removed classloaderInterpreter on RemoteInterpreterServer

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -157,7 +157,6 @@ public class RemoteInterpreterServer
           replClass.getConstructor(new Class[] {Properties.class});
       Interpreter repl = constructor.newInstance(p);
 
-      ClassLoader cl = ClassLoader.getSystemClassLoader();
       repl.setClassloaderUrls(new URL[]{});
 
       synchronized (interpreterGroup) {
@@ -167,7 +166,7 @@ public class RemoteInterpreterServer
           interpreterGroup.put(noteId, interpreters);
         }
 
-        interpreters.add(new LazyOpenInterpreter(new ClassloaderInterpreter(repl, cl)));
+        interpreters.add(new LazyOpenInterpreter(repl));
       }
 
       logger.info("Instantiate interpreter {}", className);


### PR DESCRIPTION
### What is this PR for?
Removed usage of ClassloaderInterpreter while RemoteInterpreter is being created.

### What type of PR is it?
[Refactoring]

### Todos
* [x] - Fixed the codes for not using ClassloaderInterpreter

### What is the Jira issue?
N/A

### How should this be tested?
This PR should not change any user experience

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

Classloader in RemoteInterpreter uses system classloader, thus there's no reason why interpreter is wrapped by Classloader