### PR TITLE
[ZEPPELIN-987] Enable user to secure interpreter setting, credentials and configurations info

### DIFF
--- a/SECURITY-README.md
+++ b/SECURITY-README.md
@@ -17,7 +17,7 @@ To connect to Zeppelin, users will be asked to enter their credentials. Once log
 This a a first step toward full security as implemented by this pull request (https://github.com/apache/zeppelin/pull/53).
 
 # Security setup
-1. Secure the HTTP channel: Comment the line "/** = anon" and uncomment the line "/** = authcBasic" in the file conf/shiro.ini. Read more about he shiro.ini file format at the following URL http://shiro.apache.org/configuration.html#Configuration-INISections.  
+1. Secure the HTTP channel: Comment the line "/** = anon" and uncomment the line "/** = authc" in the file conf/shiro.ini. Read more about he shiro.ini file format at the following URL http://shiro.apache.org/configuration.html#Configuration-INISections.  
 2. Secure the Websocket channel : Set to property "zeppelin.anonymous.allowed" to "false" in the file conf/zeppelin-site.xml. You can start by renaming conf/zeppelin-site.xml.template to conf/zeppelin-site.xml
 3. Start Zeppelin : bin/zeppelin.sh
 4. point your browser to http://localhost:8080

--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -58,6 +58,7 @@ shiro.loginUrl = /api/login
 role1 = *
 role2 = *
 role3 = *
+admin = *
 
 [urls]
 # This section is used for url-based security.
@@ -66,8 +67,8 @@ role3 = *
 # authc means Form based Auth Security
 # To enfore security, comment the line below and uncomment the next one
 /api/version = anon
-#/api/interpreter/** = authc, roles[admin]
-#/api/configurations/** = authc, roles[admin]
-#/api/credential/** = authc, roles[admin]
-/** = anon
-#/** = authc
+/api/interpreter/** = authc, roles[admin]
+/api/configurations/** = authc, roles[admin]
+/api/credential/** = authc, roles[admin]
+#/** = anon
+/** = authc

--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -18,7 +18,7 @@
 [users]
 # List of users with their password allowed to access Zeppelin.
 # To use a different strategy (LDAP / Database / ...) check the shiro doc at http://shiro.apache.org/configuration.html#Configuration-INISections
-admin = password1
+admin = password1, admin
 user1 = password2, role1, role2
 user2 = password3, role3
 user3 = password4, role2
@@ -60,10 +60,14 @@ role2 = *
 role3 = *
 
 [urls]
+# This section is used for url-based security.
+# You can secure interpreter, configuration and credential information by urls. Comment or uncomment the below urls that you want to hide. 
 # anon means the access is anonymous.
-# authcBasic means Basic Auth Security
 # authc means Form based Auth Security
 # To enfore security, comment the line below and uncomment the next one
 /api/version = anon
+#/api/interpreter/** = authc, roles[admin]
+#/api/configurations/** = authc, roles[admin]
+#/api/credential/** = authc, roles[admin]
 /** = anon
 #/** = authc

--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -66,9 +66,9 @@ admin = *
 # anon means the access is anonymous.
 # authc means Form based Auth Security
 # To enfore security, comment the line below and uncomment the next one
-/api/version = anon
-/api/interpreter/** = authc, roles[admin]
-/api/configurations/** = authc, roles[admin]
-/api/credential/** = authc, roles[admin]
-#/** = anon
-/** = authc
+# /api/version = anon
+# /api/interpreter/** = authc, roles[admin]
+# /api/configurations/** = authc, roles[admin]
+# /api/credential/** = authc, roles[admin]
+/** = anon
+#/** = authc

--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -66,9 +66,9 @@ admin = *
 # anon means the access is anonymous.
 # authc means Form based Auth Security
 # To enfore security, comment the line below and uncomment the next one
-# /api/version = anon
-# /api/interpreter/** = authc, roles[admin]
-# /api/configurations/** = authc, roles[admin]
-# /api/credential/** = authc, roles[admin]
+/api/version = anon
+#/api/interpreter/** = authc, roles[admin]
+#/api/configurations/** = authc, roles[admin]
+#/api/credential/** = authc, roles[admin]
 /** = anon
 #/** = authc

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -66,13 +66,17 @@ Finally, you can login using one of the below **username/password** combinations
 <center><img src="../assets/themes/zeppelin/img/docs-img/zeppelin-login.png"></center>
 
 ```
-admin = password1
-user1 = password2
-user2 = password3
-```
+[users]
 
-### 5. Groups and permissions (optional)
-In case you want to leverage user groups and permissions, use one of the following configuration for LDAP or AD under `[main]` segment in `shiro.ini`
+admin = password1, admin
+user1 = password2, role1, role2
+user2 = password3, role3
+user3 = password4, role2
+```
+You can set the roles for each users next to the password.
+
+## Groups and permissions (optional)
+In case you want to leverage user groups and permissions, use one of the following configuration for LDAP or AD under `[main]` segment in `shiro.ini`.
 
 ```
 activeDirectoryRealm = org.apache.zeppelin.server.ActiveDirectoryGroupRealm
@@ -101,6 +105,21 @@ finance = *
 group1 = *
 ```
 
-All of above configurations are defined in the `conf/shiro.ini` file.
+## Secure your Zeppelin information (optional)
+By default, anyone who defined in `[users]` can share **Interpreter Setting**, **Credential** and **Configuration** information in Apache Zeppelin. 
+Sometimes you might want to hide these information for your use case. 
+Since Shiro provides **url-based security**, you can hide the information by commenting or uncommenting these below lines in `conf/shiro.ini`.
 
-> **NOTE :** This documentation is originally from [SECURITY-README.md](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md).
+```
+[urls]
+
+/api/interpreter/** = authc, roles[admin]
+/api/configurations/** = authc, roles[admin]
+/api/credential/** = authc, roles[admin]
+```
+
+In this case, only who have `admin` role can see **Interpreter Setting**, **Credential** and **Configuration** information. 
+If you want to grant this permission to other users, you can change **roles[ ]** as you defined at `[users]` section.
+
+<br/>
+> **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file. This documentation is originally from [SECURITY-README.md](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md).

--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -14,7 +14,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('ConfigurationCtrl', function($scope, $route, $routeParams, $location,
-                                                                          $rootScope, $http, baseUrlSrv) {
+                                                                          $rootScope, $http, baseUrlSrv, ngToast) {
   $scope.configrations = [];
   $scope._ = _;
 
@@ -24,6 +24,16 @@ angular.module('zeppelinWebApp').controller('ConfigurationCtrl', function($scope
       $scope.configurations = data.body;
     }).
     error(function(data, status, headers, config) {
+      if (status === 401) {
+        ngToast.danger({
+          content: 'You don\'t have permission on this page',
+          verticalPosition: 'bottom',
+          timeout: '3000'
+        });
+        setTimeout(function() {
+          window.location.replace('/');
+        }, 3000);
+      }
       console.log('Error %o %o', status, data.message);
     });
   };

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -30,6 +30,16 @@ angular.module('zeppelinWebApp').controller('CredentialCtrl', function($scope, $
       console.log('Success %o %o', status, $scope.credentialInfo);
     }).
     error(function(data, status, headers, config) {
+      if (status === 401) {
+        ngToast.danger({
+          content: 'You don\'t have permission on this page',
+          verticalPosition: 'bottom',
+          timeout: '3000'
+        });
+        setTimeout(function() {
+          window.location.replace('/');
+        }, 3000);
+      }
       console.log('Error %o %o', status, data.message);
     });
   };

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -27,6 +27,16 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl',
       $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/setting').success(function(data, status, headers, config) {
         $scope.interpreterSettings = data.body;
       }).error(function(data, status, headers, config) {
+        if (status === 401) {
+          ngToast.danger({
+            content: 'You don\'t have permission on this page',
+            verticalPosition: 'bottom',
+            timeout: '3000'
+          });
+          setTimeout(function() {
+            window.location.replace('/');
+          }, 3000);
+        }
         console.log('Error %o %o', status, data.message);
       });
     };


### PR DESCRIPTION
### What is this PR for?
For some user cases, people might want to hide **Interpreter Setting**, **Credentials** and **Configurations** information to other users (who are defined in `conf/shiro.ini`). So I added 

```
#/api/interpreter/** = authc, roles[admin]
#/api/configurations/** = authc, roles[admin]
#/api/credential/** = authc, roles[admin]
``` 
below the [ [urls] ](https://github.com/apache/zeppelin/blob/master/conf/shiro.ini#L38) section. 

This issue was originally suggested at [Zeppelin user mailing list](https://mail-archives.apache.org/mod_mbox/zeppelin-users/201606.mbox/%3CCAPgU7Y%3DBJrXQ_P0ond4PTukoya0FEjwoPuUb31iN3qwo8iyM1Q%40mail.gmail.com%3E) by @TomNorden


### What type of PR is it?
Improvement | Documentation

### Todos
* [x] - Add `interpreter`, `credential` and `configuration` url to `conf/shiro.ini`
* [x] - Update `shiroauthentication.md` for this change
* [x] - Redirect to home with ngToast error message when status is `401`
* [x] - Rebase after #1100 merged and add error message to `Credential` menu as well


### What is the Jira issue?
[ZEPPELIN-987](https://issues.apache.org/jira/browse/ZEPPELIN-987)

### How should this be tested?
1. Apply this patch and restart Zeppelin
2. Login with `admin` and `password1`
3. Go to interpreter, credential and configuration tab -> You can see all of the information in each tabs 
4. Logout -> Login again with `user1` and `password2`
5. Go to interpreter, credential and configuration tab -> In this time, you can't see all of the information in each tabs 

### Screenshots (if appropriate)
- When you login with `user1` (doesn't have permission to see the interpreter, credential and cofiguration info)
  - interpreter menu
![interpreters](https://cloud.githubusercontent.com/assets/10060731/16708520/bedc8732-4631-11e6-938c-ff41d1fbab93.gif)
  - configuration menu
![configurations](https://cloud.githubusercontent.com/assets/10060731/16708525/ce5eb7c0-4631-11e6-9f36-8b97e2b7914a.gif)
  - credential menu
![credential-after](https://cloud.githubusercontent.com/assets/10060731/16726180/e56cfa52-4795-11e6-9a5d-740681092e96.gif)



- `shiroauthentication.md`
<img width="807" alt="screen shot 2016-06-10 at 12 25 02 pm" src="https://cloud.githubusercontent.com/assets/10060731/15976949/a49bc542-2f0a-11e6-8869-8575ba8f1875.png">



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, so I updated. 
