### PR TITLE
[ZEPPELIN-986] Create publish release script

### DIFF
--- a/alluxio/pom.xml
+++ b/alluxio/pom.xml
@@ -133,15 +133,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -61,15 +61,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -231,15 +231,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>

--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# common fucntions
+
+if [[ -z "${TAR}" ]]; then
+  TAR="/usr/bin/tar"
+fi
+
+if [[ -z "${SHASUM}" ]]; then
+  SHASUM="/usr/bin/shasum"
+fi
+
+if [[ -z "${WORKING_DIR}" ]]; then
+  WORKING_DIR="/tmp/zeppelin-release"
+fi
+
+mkdir "${WORKING_DIR}"
+
+usage() {
+  echo "usage) $0 [Release version] [Branch or Tag]"
+  echo "   ex. $0 0.6.0 v0.6.0"
+  exit 1
+}
+
+function git_clone() { 
+  echo "Clone the source"
+  # clone source
+  git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git "${WORKING_DIR}/zeppelin"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Can not clone source repository"
+    exit 1
+  fi
+
+  cd "${WORKING_DIR}/zeppelin"
+  git checkout "${GIT_TAG}"
+  echo "Checked out ${GIT_TAG}"
+
+  # remove unnecessary files
+  rm "${WORKING_DIR}/zeppelin/.gitignore"
+  rm -rf "${WORKING_DIR}/zeppelin/.git"
+  rm -rf "${WORKING_DIR}/zeppelin/.github"
+  rm -rf "${WORKING_DIR}/zeppelin/docs"
+}

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -102,7 +102,7 @@ function make_binary_release() {
 
 git_clone
 make_source_package
-make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
+make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -27,105 +27,108 @@
 # http://www.apache.org/dev/publishing-maven-artifacts.html
 
 if [[ -z "${TAR}" ]]; then
-    TAR=/usr/bin/tar
+  TAR=/usr/bin/tar
 fi
 
 if [[ -z "${SHASUM}" ]]; then
-    SHASUM="/usr/bin/shasum -a 512"
+  SHASUM="/usr/bin/shasum -a 512"
 fi
 
 
 if [[ -z "${WORKING_DIR}" ]]; then
-    WORKING_DIR=/tmp/zeppelin-release
+  WORKING_DIR=/tmp/zeppelin-release
 fi
 
 if [[ -z "${GPG_PASSPHRASE}" ]]; then
-    echo "You need GPG_PASSPHRASE variable set"
-    exit 1
+  echo "You need GPG_PASSPHRASE variable set"
+  exit 1
 fi
 
 
 if [[ $# -ne 2 ]]; then
-    echo "usage) $0 [Release name] [Branch or Tag]"
-    echo "   ex. $0 0.6.0 branch-0.6"
-    exit 1
+  echo "usage) $0 [Release version] [Tag]"
+  echo "   ex. $0 0.6.0 v0.6.0-rc1"
+  exit 1
 fi
 
-RELEASE_NAME="${1}"
-BRANCH="${2}"
-
+RELEASE_VERSION="${1}"
+GIT_TAG="${2}"
 
 if [[ -d "${WORKING_DIR}" ]]; then
-    echo "Dir ${WORKING_DIR} already exists"
-    exit 1
+  echo "Dir ${WORKING_DIR} already exists"
+  exit 1
 fi
 
 mkdir ${WORKING_DIR}
 
 echo "Cloning the source and packaging"
 # clone source
-git clone -b ${BRANCH} git@github.com:apache/zeppelin.git ${WORKING_DIR}/zeppelin
+git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git ${WORKING_DIR}/zeppelin
+
 if [[ $? -ne 0 ]]; then
-    echo "Can not clone source repository"
-    exit 1
+  echo "Can not clone source repository"
+  exit 1
 fi
+
+cd ${WORKING_DIR}/zeppelin
+git checkout ${GIT_TAG}
+echo "Checked out ${GIT_TAG}"
 
 # remove unnecessary files
 rm ${WORKING_DIR}/zeppelin/.gitignore
 rm -rf ${WORKING_DIR}/zeppelin/.git
 
 
-
 # create source package
 cd ${WORKING_DIR}
-cp -r zeppelin zeppelin-${RELEASE_NAME}
-${TAR} cvzf zeppelin-${RELEASE_NAME}.tgz zeppelin-${RELEASE_NAME}
+cp -r zeppelin zeppelin-${RELEASE_VERSION}
+${TAR} cvzf zeppelin-${RELEASE_VERSION}.tgz zeppelin-${RELEASE_VERSION}
 
 echo "Signing the source package"
 cd ${WORKING_DIR}
-echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_NAME}.tgz.asc --detach-sig ${WORKING_DIR}/zeppelin-${RELEASE_NAME}.tgz
-echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_NAME}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_NAME}.tgz.md5
-${SHASUM} zeppelin-${RELEASE_NAME}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_NAME}.tgz.sha512
+echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_VERSION}.tgz.asc --detach-sig ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz
+echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_VERSION}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.md5
+${SHASUM} zeppelin-${RELEASE_VERSION}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.sha512
 
 
 function make_binary_release() {
-    BIN_RELEASE_NAME="${1}"
-    BUILD_FLAGS="${2}"
+  BIN_RELEASE_NAME="${1}"
+  BUILD_FLAGS="${2}"
 
-    cp -r ${WORKING_DIR}/zeppelin ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
-    cd ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
-    echo "mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}"
-    mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}
-    if [[ $? -ne 0 ]]; then
-        echo "Build failed. ${BUILD_FLAGS}"
-        exit 1
-    fi
+  cp -r ${WORKING_DIR}/zeppelin ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  cd ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  echo "mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}"
+  mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}
+  if [[ $? -ne 0 ]]; then
+    echo "Build failed. ${BUILD_FLAGS}"
+    exit 1
+  fi
 
-    # re-create package with proper dir name with binary license
-    cd zeppelin-distribution/target/zeppelin-*
-    mv zeppelin-* zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
-    cat ../../src/bin_license/LICENSE >> zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}/LICENSE
-    cat ../../src/bin_license/NOTICE >> zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}/NOTICE
-    cp ../../src/bin_license/licenses/* zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}/licenses/
-    ${TAR} cvzf zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
+  # re-create package with proper dir name with binary license
+  cd zeppelin-distribution/target/zeppelin-*
+  mv zeppelin-* zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  cat ../../src/bin_license/LICENSE >> zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/LICENSE
+  cat ../../src/bin_license/NOTICE >> zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/NOTICE
+  cp ../../src/bin_license/licenses/* zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/licenses/
+  ${TAR} cvzf zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
 
-    # sign bin package
-    echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.asc --detach-sig zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz
-    echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.md5
-    ${SHASUM} zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.sha512
+  # sign bin package
+  echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc --detach-sig zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz
+  echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5
+  ${SHASUM} zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512
 
-    mv zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz ${WORKING_DIR}/
-    mv zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.asc ${WORKING_DIR}/
-    mv zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.md5 ${WORKING_DIR}/
-    mv zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}.tgz.sha512 ${WORKING_DIR}/
+  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz ${WORKING_DIR}/
+  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc ${WORKING_DIR}/
+  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5 ${WORKING_DIR}/
+  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512 ${WORKING_DIR}/
 
-    # clean up build dir
-    rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}-bin-${BIN_RELEASE_NAME}
+  # clean up build dir
+  rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
 }
 
 make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
 
 # remove non release files and dirs
 rm -rf ${WORKING_DIR}/zeppelin
-rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_NAME}
+rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}
 echo "Release files are created under ${WORKING_DIR}"

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -18,25 +18,19 @@
 #
 
 # The script helps making a release.
-# You need specify a release name and branch|tag name.
+# You need to specify release version and branch|tag name.
 #
-# Here's some helpful documents for the release
+# Here are some helpful documents for the release.
 # http://www.apache.org/dev/release.html
 # http://www.apache.org/dev/release-publishing
 # http://www.apache.org/dev/release-signing.html
-# http://www.apache.org/dev/publishing-maven-artifacts.html
 
-if [[ -z "${TAR}" ]]; then
-  TAR=/usr/bin/tar
-fi
+BASEDIR="$(dirname "$0")"
+. "${BASEDIR}/common_release.sh"
+echo "${BASEDIR}/common_release.sh"
 
-if [[ -z "${SHASUM}" ]]; then
-  SHASUM="/usr/bin/shasum -a 512"
-fi
-
-
-if [[ -z "${WORKING_DIR}" ]]; then
-  WORKING_DIR=/tmp/zeppelin-release
+if [[ $# -ne 2 ]]; then
+  usage
 fi
 
 if [[ -z "${GPG_PASSPHRASE}" ]]; then
@@ -44,59 +38,34 @@ if [[ -z "${GPG_PASSPHRASE}" ]]; then
   exit 1
 fi
 
+RELEASE_VERSION="$1"
+GIT_TAG="$2"
 
-if [[ $# -ne 2 ]]; then
-  echo "usage) $0 [Release version] [Tag]"
-  echo "   ex. $0 0.6.0 v0.6.0-rc1"
-  exit 1
-fi
+function make_source_package() {
+  # create source package
+  cd ${WORKING_DIR}
+  cp -r "zeppelin" "zeppelin-${RELEASE_VERSION}"
+  ${TAR} cvzf "zeppelin-${RELEASE_VERSION}.tgz" "zeppelin-${RELEASE_VERSION}"
 
-RELEASE_VERSION="${1}"
-GIT_TAG="${2}"
-
-if [[ -d "${WORKING_DIR}" ]]; then
-  echo "Dir ${WORKING_DIR} already exists"
-  exit 1
-fi
-
-mkdir ${WORKING_DIR}
-
-echo "Cloning the source and packaging"
-# clone source
-git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git ${WORKING_DIR}/zeppelin
-
-if [[ $? -ne 0 ]]; then
-  echo "Can not clone source repository"
-  exit 1
-fi
-
-cd ${WORKING_DIR}/zeppelin
-git checkout ${GIT_TAG}
-echo "Checked out ${GIT_TAG}"
-
-# remove unnecessary files
-rm ${WORKING_DIR}/zeppelin/.gitignore
-rm -rf ${WORKING_DIR}/zeppelin/.git
-
-
-# create source package
-cd ${WORKING_DIR}
-cp -r zeppelin zeppelin-${RELEASE_VERSION}
-${TAR} cvzf zeppelin-${RELEASE_VERSION}.tgz zeppelin-${RELEASE_VERSION}
-
-echo "Signing the source package"
-cd ${WORKING_DIR}
-echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_VERSION}.tgz.asc --detach-sig ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz
-echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_VERSION}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.md5
-${SHASUM} zeppelin-${RELEASE_VERSION}.tgz > ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.sha512
-
+  echo "Signing the source package"
+  cd "${WORKING_DIR}"
+  echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 --armor \
+    --output "zeppelin-${RELEASE_VERSION}.tgz.asc" \
+    --detach-sig "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz"
+  echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 \
+    --print-md MD5 "zeppelin-${RELEASE_VERSION}.tgz" > \
+    "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.md5"
+  echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 \
+    --print-md SHA512 "zeppelin-${RELEASE_VERSION}.tgz" > \
+    "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}.tgz.sha512"
+}
 
 function make_binary_release() {
-  BIN_RELEASE_NAME="${1}"
-  BUILD_FLAGS="${2}"
+  BIN_RELEASE_NAME="$1"
+  BUILD_FLAGS="$2"
 
-  cp -r ${WORKING_DIR}/zeppelin ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
-  cd ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  cp -r "${WORKING_DIR}/zeppelin" "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
+  cd "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
   echo "mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}"
   mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}
   if [[ $? -ne 0 ]]; then
@@ -106,29 +75,36 @@ function make_binary_release() {
 
   # re-create package with proper dir name with binary license
   cd zeppelin-distribution/target/zeppelin-*
-  mv zeppelin-* zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
-  cat ../../src/bin_license/LICENSE >> zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/LICENSE
-  cat ../../src/bin_license/NOTICE >> zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/NOTICE
-  cp ../../src/bin_license/licenses/* zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/licenses/
-  ${TAR} cvzf zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  mv zeppelin-* "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
+  cat ../../src/bin_license/LICENSE >> "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/LICENSE"
+  cat ../../src/bin_license/NOTICE >> "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/NOTICE"
+  cp ../../src/bin_license/licenses/* "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/licenses/"
+  ${TAR} cvzf "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz" "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
 
   # sign bin package
-  echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --armor --output zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc --detach-sig zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz
-  echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --print-md MD5 zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5
-  ${SHASUM} zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz > zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512
+  echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 --armor \
+    --output "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc" \
+    --detach-sig "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz"
+  echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 --print-md MD5 \
+    "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz" > \
+    "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5"
+  ${SHASUM} -a 512 "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz" > \
+    "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512"
 
-  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz ${WORKING_DIR}/
-  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc ${WORKING_DIR}/
-  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5 ${WORKING_DIR}/
-  mv zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512 ${WORKING_DIR}/
+  mv "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz" "${WORKING_DIR}/"
+  mv "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.asc" "${WORKING_DIR}/"
+  mv "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.md5" "${WORKING_DIR}/"
+  mv "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}.tgz.sha512" "${WORKING_DIR}/"
 
   # clean up build dir
-  rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}
+  rm -rf "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
 }
 
+git_clone
+make_source_package
 make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
 
 # remove non release files and dirs
-rm -rf ${WORKING_DIR}/zeppelin
-rm -rf ${WORKING_DIR}/zeppelin-${RELEASE_VERSION}
+rm -rf "${WORKING_DIR}/zeppelin"
+rm -rf "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}"
 echo "Release files are created under ${WORKING_DIR}"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The script helps publishing release to mavene.
+# You need to specify release version and tag name.
+#
+# Here are some helpful documents for the release.
+# http://www.apache.org/dev/release.html
+# http://www.apache.org/dev/release-publishing
+# http://www.apache.org/dev/release-signing.html
+# http://www.apache.org/dev/publishing-maven-artifacts.html
+
+if [[ -z "${SHASUM}" ]]; then
+  SHASUM="/usr/bin/shasum -a 1"
+fi
+
+if [[ -z "${WORKING_DIR}" ]]; then
+  WORKING_DIR=/tmp/zeppelin-release
+fi
+
+if [ $# -ne 2 ]; then
+  echo "usage) $0 [Release version] [Tag]"
+  echo "   ex. $0 0.6.0 v0.6.0"
+  exit 1
+fi
+
+for var in GPG_PASSPHRASE ASF_USERID ASF_PASSWORD
+do
+  if [[ -z "${!var}" ]]; then
+    echo "You need ${var} variable set"
+    exit 1
+  fi
+done
+
+export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512m"
+
+RELEASE_VERSION="${1}"
+GIT_TAG="${2}"
+
+PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
+PROJECT_OPTIONS="-pl !zeppelin-server,!zeppelin-distribution"
+NEXUS_STAGING="https://repository.apache.org/service/local/staging"
+NEXUS_PROFILE="153446d1ac37c4"
+
+if [[ -d "${WORKING_DIR}" ]]; then
+  echo "Dir ${WORKING_DIR} already exists"
+  exit 1
+fi
+
+mkdir ${WORKING_DIR}
+
+echo "Cloning the source"
+# clone source
+git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git ${WORKING_DIR}/zeppelin
+
+if [[ $? -ne 0 ]]; then
+  echo "Can not clone source repository"
+  exit 1
+fi
+
+cd ${WORKING_DIR}/zeppelin
+git checkout ${GIT_TAG}
+echo "Checked out ${GIT_TAG}"
+
+# remove unnecessary files
+rm ${WORKING_DIR}/zeppelin/.gitignore
+rm -rf ${WORKING_DIR}/zeppelin/.git
+
+function publish_to_maven() {
+  cd ${WORKING_DIR}/zeppelin
+
+  # Force release version
+  mvn versions:set -DnewVersion=$RELEASE_VERSION
+
+  # Using Nexus API documented here:
+  # https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
+  echo "Creating Nexus staging repository"
+  repo_request="<promoteRequest><data><description>Apache Zeppelin $RELEASE_VERSION</description></data></promoteRequest>"
+  out=$(curl -X POST -d "$repo_request" -u $ASF_USERID:$ASF_PASSWORD \
+    -H "Content-Type:application/xml" -v \
+    $NEXUS_STAGING/profiles/$NEXUS_PROFILE/start)
+  staged_repo_id=$(echo $out | sed -e "s/.*\(orgapachezeppelin-[0-9]\{4\}\).*/\1/")
+  echo "Created Nexus staging repository: $staged_repo_id"
+
+  tmp_repo=$(mktemp -d /tmp/zeppelin-repo-XXXXX)
+
+  echo "mvn clean install -Ppublish-distr \
+    -Dmaven.repo.local=$tmp_repo \
+    $PUBLISH_PROFILES $PROJECT_OPTIONS"
+  mvn clean install -Ppublish-distr -Dmaven.repo.local=$tmp_repo \
+    $PUBLISH_PROFILES $PROJECT_OPTIONS
+  if [[ $? -ne 0 ]]; then
+    echo "Build failed."
+    exit 1
+  fi
+
+  pushd $tmp_repo/org/apache/zeppelin
+  find . -type f | grep -v \.jar$ | grep -v \.pom$ |grep -v \.war$ | xargs rm
+
+  echo "Creating hash and signature files"
+  for file in $(find . -type f)
+  do
+    echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --output $file.asc \
+      --detach-sig --armor $file;
+    md5 -q $file > $file.md5
+    $SHASUM $file | cut -f1 -d' ' > $file.sha1
+  done
+
+  nexus_upload=$NEXUS_STAGING/deployByRepositoryId/$staged_repo_id
+  echo "Uplading files to $nexus_upload"
+  for file in $(find . -type f)
+  do
+    # strip leading ./
+    file_short=$(echo $file | sed -e "s/\.\///")
+    dest_url="$nexus_upload/org/apache/zeppelin/$file_short"
+    echo "  Uploading $file_short"
+    curl -u $ASF_USERID:$ASF_PASSWORD --upload-file $file_short $dest_url
+  done
+
+  echo "Closing nexus staging repository"
+  repo_request="<promoteRequest><data><stagedRepositoryId>$staged_repo_id</stagedRepositoryId><description>Apache Zeppelin $RELEASE_VERSION</description></data></promoteRequest>"
+  out=$(curl -X POST -d "$repo_request" -u $ASF_USERID:$ASF_PASSWORD \
+    -H "Content-Type:application/xml" -v \
+    $NEXUS_STAGING/profiles/$NEXUS_PROFILE/finish)
+  echo "Closed Nexus staging repository: $staged_repo_id"
+  popd
+  rm -rf $tmp_repo
+}
+
+publish_to_maven
+
+# remove working directory
+rm -rf ${WORKING_DIR}

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -53,7 +53,7 @@ RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
 PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
-PROJECT_OPTIONS="-pl !zeppelin-server,!zeppelin-distribution"
+PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"
 

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Pgeode -Pscalding"
+PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -31,7 +31,7 @@ if [[ -z "${SHASUM}" ]]; then
 fi
 
 if [[ -z "${WORKING_DIR}" ]]; then
-  WORKING_DIR=/tmp/zeppelin-release
+  WORKING_DIR="/tmp/zeppelin-release"
 fi
 
 if [ $# -ne 2 ]; then
@@ -40,8 +40,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-for var in GPG_PASSPHRASE ASF_USERID ASF_PASSWORD
-do
+for var in GPG_PASSPHRASE; do ASF_USERID ASF_PASSWORD; do
   if [[ -z "${!var}" ]]; then
     echo "You need ${var} variable set"
     exit 1
@@ -50,8 +49,8 @@ done
 
 export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512m"
 
-RELEASE_VERSION="${1}"
-GIT_TAG="${2}"
+RELEASE_VERSION="$1"
+GIT_TAG="$2"
 
 PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-server,!zeppelin-distribution"
@@ -63,87 +62,85 @@ if [[ -d "${WORKING_DIR}" ]]; then
   exit 1
 fi
 
-mkdir ${WORKING_DIR}
+mkdir "${WORKING_DIR}"
 
 echo "Cloning the source"
 # clone source
-git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git ${WORKING_DIR}/zeppelin
+git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git "${WORKING_DIR}/zeppelin"
 
 if [[ $? -ne 0 ]]; then
   echo "Can not clone source repository"
   exit 1
 fi
 
-cd ${WORKING_DIR}/zeppelin
-git checkout ${GIT_TAG}
+cd "${WORKING_DIR}/zeppelin"
+git checkout "${GIT_TAG}"
 echo "Checked out ${GIT_TAG}"
 
 # remove unnecessary files
-rm ${WORKING_DIR}/zeppelin/.gitignore
-rm -rf ${WORKING_DIR}/zeppelin/.git
+rm "${WORKING_DIR}/zeppelin/.gitignore"
+rm -rf "${WORKING_DIR}/zeppelin/.git"
 
 function publish_to_maven() {
-  cd ${WORKING_DIR}/zeppelin
+  cd "${WORKING_DIR}/zeppelin"
 
   # Force release version
-  mvn versions:set -DnewVersion=$RELEASE_VERSION
+  mvn versions:set -DnewVersion="${RELEASE_VERSION}"
 
   # Using Nexus API documented here:
   # https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
   echo "Creating Nexus staging repository"
-  repo_request="<promoteRequest><data><description>Apache Zeppelin $RELEASE_VERSION</description></data></promoteRequest>"
-  out=$(curl -X POST -d "$repo_request" -u $ASF_USERID:$ASF_PASSWORD \
-    -H "Content-Type:application/xml" -v \
-    $NEXUS_STAGING/profiles/$NEXUS_PROFILE/start)
-  staged_repo_id=$(echo $out | sed -e "s/.*\(orgapachezeppelin-[0-9]\{4\}\).*/\1/")
-  echo "Created Nexus staging repository: $staged_repo_id"
+  repo_request="<promoteRequest><data><description>Apache Zeppelin ${RELEASE_VERSION}</description></data></promoteRequest>"
+  out="$(curl -X POST -d "${repo_request}" -u "${ASF_USERID}:${ASF_PASSWORD}" \
+    -H 'Content-Type:application/xml' -v \
+    "${NEXUS_STAGING}/profiles/${NEXUS_PROFILE}/start")"
+  staged_repo_id="$(echo "${out}" | sed -e 's/.*\(orgapachezeppelin-[0-9]\{4\}\).*/\1/')"
+  echo "Created Nexus staging repository: ${staged_repo_id}"
 
-  tmp_repo=$(mktemp -d /tmp/zeppelin-repo-XXXXX)
+  tmp_repo="$(mktemp -d /tmp/zeppelin-repo-XXXXX)"
 
   echo "mvn clean install -Ppublish-distr \
-    -Dmaven.repo.local=$tmp_repo \
-    $PUBLISH_PROFILES $PROJECT_OPTIONS"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local=$tmp_repo \
-    $PUBLISH_PROFILES $PROJECT_OPTIONS
+    -Dmaven.repo.local=${tmp_repo} \
+    ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
+  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" \
+    ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build failed."
     exit 1
   fi
 
-  pushd $tmp_repo/org/apache/zeppelin
-  find . -type f | grep -v \.jar$ | grep -v \.pom$ |grep -v \.war$ | xargs rm
+  pushd "${tmp_repo}/org/apache/zeppelin"
+  find . -type f | grep -v '\.jar$' | grep -v '\.pom$' |grep -v '\.war$' | xargs rm
 
   echo "Creating hash and signature files"
-  for file in $(find . -type f)
-  do
-    echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 --output $file.asc \
-      --detach-sig --armor $file;
-    md5 -q $file > $file.md5
-    $SHASUM $file | cut -f1 -d' ' > $file.sha1
+  for file in $(find . -type f); do
+    echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 --output "${file}.asc" \
+      --detach-sig --armor "${file}"
+    md5 -q "${file}" > "${file}.md5"
+    ${SHASUM} "${file}" | cut -f1 -d' ' > "${file}.sha1"
   done
 
-  nexus_upload=$NEXUS_STAGING/deployByRepositoryId/$staged_repo_id
-  echo "Uplading files to $nexus_upload"
-  for file in $(find . -type f)
-  do
+  nexus_upload="${NEXUS_STAGING}/deployByRepositoryId/${staged_repo_id}"
+  echo "Uplading files to ${nexus_upload}"
+  for file in $(find . -type f); do
     # strip leading ./
-    file_short=$(echo $file | sed -e "s/\.\///")
-    dest_url="$nexus_upload/org/apache/zeppelin/$file_short"
-    echo "  Uploading $file_short"
-    curl -u $ASF_USERID:$ASF_PASSWORD --upload-file $file_short $dest_url
+    file_short="$(echo "${file}" | sed -e 's/\.\///')"
+    dest_url="${nexus_upload}/org/apache/zeppelin/$file_short"
+    echo "  Uploading ${file_short}"
+    curl -u "${ASF_USERID}:${ASF_PASSWORD}" --upload-file "${file_short}" "${dest_url}"
   done
 
   echo "Closing nexus staging repository"
-  repo_request="<promoteRequest><data><stagedRepositoryId>$staged_repo_id</stagedRepositoryId><description>Apache Zeppelin $RELEASE_VERSION</description></data></promoteRequest>"
-  out=$(curl -X POST -d "$repo_request" -u $ASF_USERID:$ASF_PASSWORD \
-    -H "Content-Type:application/xml" -v \
-    $NEXUS_STAGING/profiles/$NEXUS_PROFILE/finish)
-  echo "Closed Nexus staging repository: $staged_repo_id"
+  repo_request="<promoteRequest><data><stagedRepositoryId>${staged_repo_id}</stagedRepositoryId><description>Apache Zeppelin ${RELEASE_VERSION}</description></data></promoteRequest>"
+  out="$(curl -X POST -d "${repo_request}" -u "${ASF_USERID}:${ASF_PASSWORD}" \
+    -H 'Content-Type:application/xml' -v \
+    "${NEXUS_STAGING}}/profiles/${NEXUS_PROFILE}/finish")"
+  echo "Closed Nexus staging repository: ${staged_repo_id}"
   popd
-  rm -rf $tmp_repo
+  rm -rf "${tmp_repo}"
 }
 
 publish_to_maven
 
 # remove working directory
-rm -rf ${WORKING_DIR}
+rm -rf "${WORKING_DIR}"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -42,7 +42,7 @@ export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512m"
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
+PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Pgeode -Pscalding"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -42,7 +42,7 @@ export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=512m"
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark"
+PUBLISH_PROFILES="-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -80,15 +80,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -74,15 +74,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
       </plugin>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -295,15 +295,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -85,15 +85,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -110,15 +110,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -108,15 +108,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -103,15 +103,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -62,15 +62,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -147,15 +147,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -101,15 +101,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -67,15 +67,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/pom.xml
+++ b/pom.xml
@@ -366,24 +366,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <configuration><!-- Default configuration for all reports -->
-        </configuration>
-        <executions>
-          <execution>
-            <id>aggregate</id>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-            <phase>site</phase>
-            <configuration><!-- Specific configuration for the aggregate report -->
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-scm-plugin</artifactId>
         <version>1.8.1</version>
         <configuration>
@@ -724,6 +706,7 @@
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
+
       <build>
         <plugins>
           <plugin>
@@ -731,6 +714,34 @@
             <configuration>
               <skipTests>true</skipTests>
             </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.3</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -96,15 +96,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -88,15 +88,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -206,15 +206,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -143,15 +143,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -67,15 +67,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>            
         <executions> 

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -971,15 +971,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>
         <executions>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -133,15 +133,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
         <version>2.15.2</version>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -72,8 +72,15 @@
           </descriptors>
         </configuration>
       </plugin>
-    </plugins>
 
+     <plugin>
+        <!--assembly does all the job here-->
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -72,24 +72,6 @@
           </descriptors>
         </configuration>
       </plugin>
-
-      <plugin>
-        <!--assembly does all the job here-->
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
     </plugins>
 
   </build>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -73,7 +73,7 @@
         </configuration>
       </plugin>
 
-     <plugin>
+      <plugin>
         <!--assembly does all the job here-->
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -328,15 +328,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
         <version>2.15.2</version>


### PR DESCRIPTION
### What is this PR for?
This PR is to automate release publish to maven repository.
We used to use maven-deploy-plugin and maven-release-plugin for release but somehow it didn't work well with Zeppelin so 0.5.5 and 0.5.6 haven't been published to maven repository.

Publishing release to maven repository will eventually help zeppelin to reduce binary package size by leading users to use Dynamic interpreter loading(#908).
Originally below modules were skipped for maven release
 - all interpreters(except spark)
 - zeppelin-display
 - zeppelin-server 
 - zeppelin-distribution

on the other hand this pr will skip only:
 - zeppelin-distribution

### What type of PR is it?
Infra

### Todos
- [x] Include SparkR/R interpreter in release
- [x] Create common_release.sh to remove build configuration duplication
- [x] Check curl networking failure

### What is the Jira issue?
[ZEPPELIN-986](https://issues.apache.org/jira/browse/ZEPPELIN-986)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, https://cwiki.apache.org/confluence/display/ZEPPELIN/Preparing+Zeppelin+Release will be updated accordingly once this pr is merged.
