### PR TITLE
[MINOR] Make nav zeppelin version to point ZEPPELIN_VERSION in _config.yml

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,6 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 ## Bumping up version in a new release
 
    * `ZEPPELIN_VERSION` and `BASE_PATH` property in _config.yml
-   * `Zeppelin <small>([VERSION])</small>` in _includes/themes/zeppelin/_navigation.html
-should be updated
-
 
 ## Deploy to ASF svnpubsub infra (for committers only)
  1. generate static website in `./_site`

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -10,7 +10,7 @@
           <a class="navbar-brand" href="{{BASE_PATH}}">
             <img src="/assets/themes/zeppelin/img/zeppelin_logo.png" width="50" alt="I'm zeppelin">
             <span style="vertical-align:middle">Zeppelin</span>
-            <span style="vertical-align:baseline"><small>(0.6.0-SNAPSHOT)</small></span>
+            <span style="vertical-align:baseline"><small>{{site.ZEPPELIN_VERSION}}</small></span>
           </a>
         </div>
         <nav class="navbar-collapse collapse" role="navigation">

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -501,8 +501,9 @@ a.anchor {
 
 .navbar-brand small {
   font-size: 14px;
-  font-family: 'Helvetica Neue', Helvetica;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica;
   color: white;
+  vertical-align: bottom;
 }
 
 .navbar-collapse.collapse {


### PR DESCRIPTION
### What is this PR for?
One less line to change when releasing docs by making `ZEPPELIN_VERSION` to be retrieved from `_config.yml`.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Will be updated in https://cwiki.apache.org/confluence/display/ZEPPELIN/Preparing+Zeppelin+Release

