### PR TITLE
Authenticated user aware notebook storage layer

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ByteBufferInputStream.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ByteBufferInputStream.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+
 /**
  * InputStream from bytebuffer
  */

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -28,6 +28,10 @@ public class AuthenticationInfo {
 
   public AuthenticationInfo() {}
 
+  public AuthenticationInfo(String user) {
+    this.user = user;
+  }
+
   /***
    *
    * @param user

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -46,6 +46,7 @@ import org.apache.zeppelin.rest.message.RunParagraphWithParametersRequest;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.socket.NotebookServer;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
@@ -224,7 +225,8 @@ public class NotebookRestApi {
   @Path("/")
   @ZeppelinApi
   public Response getNotebookList() throws IOException {
-    List<Map<String, String>> notesInfo = notebookServer.generateNotebooksInfo(false);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    List<Map<String, String>> notesInfo = notebookServer.generateNotebooksInfo(false, subject);
     return new JsonResponse<>(Status.OK, "", notesInfo ).build();
   }
 
@@ -297,10 +299,11 @@ public class NotebookRestApi {
     if (noteName.isEmpty()) {
       noteName = "Note " + note.getId();
     }
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     note.setName(noteName);
     note.persist();
     notebookServer.broadcastNote(note);
-    notebookServer.broadcastNoteList();
+    notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.CREATED, "", note.getId() ).build();
   }
 
@@ -321,7 +324,8 @@ public class NotebookRestApi {
         notebook.removeNote(notebookId);
       }
     }
-    notebookServer.broadcastNoteList();
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.OK, "").build();
   }
   
@@ -342,7 +346,8 @@ public class NotebookRestApi {
     String newNoteName = request.getName();
     Note newNote = notebook.cloneNote(notebookId, newNoteName);
     notebookServer.broadcastNote(newNote);
-    notebookServer.broadcastNoteList();
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -159,7 +159,8 @@ public class NotebookRestApi {
             notebookAuthorization.getOwners(noteId),
             notebookAuthorization.getReaders(noteId),
             notebookAuthorization.getWriters(noteId));
-    note.persist();
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    note.persist(subject);
     notebookServer.broadcastNote(note);
     return new JsonResponse<>(Status.OK).build();
   }
@@ -268,7 +269,8 @@ public class NotebookRestApi {
   @Path("import")
   @ZeppelinApi
   public Response importNotebook(String req) throws IOException {
-    Note newNote = notebook.importNote(req, null);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    Note newNote = notebook.importNote(req, null, subject);
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
   
@@ -285,7 +287,8 @@ public class NotebookRestApi {
     LOG.info("Create new notebook by JSON {}" , message);
     NewNotebookRequest request = gson.fromJson(message,
         NewNotebookRequest.class);
-    Note note = notebook.createNote();
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    Note note = notebook.createNote(subject);
     List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
     if (initialParagraphs != null) {
       for (NewParagraphRequest paragraphRequest : initialParagraphs) {
@@ -299,9 +302,9 @@ public class NotebookRestApi {
     if (noteName.isEmpty()) {
       noteName = "Note " + note.getId();
     }
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+
     note.setName(noteName);
-    note.persist();
+    note.persist(subject);
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.CREATED, "", note.getId() ).build();
@@ -344,9 +347,9 @@ public class NotebookRestApi {
     NewNotebookRequest request = gson.fromJson(message,
         NewNotebookRequest.class);
     String newNoteName = request.getName();
-    Note newNote = notebook.cloneNote(notebookId, newNoteName);
-    notebookServer.broadcastNote(newNote);
     AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    Note newNote = notebook.cloneNote(notebookId, newNoteName, subject);
+    notebookServer.broadcastNote(newNote);
     notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
@@ -381,7 +384,8 @@ public class NotebookRestApi {
     p.setTitle(request.getTitle());
     p.setText(request.getText());
 
-    note.persist();
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    note.persist(subject);
     notebookServer.broadcastNote(note);
     return new JsonResponse(Status.CREATED, "", p.getId()).build();
   }
@@ -439,7 +443,8 @@ public class NotebookRestApi {
     try {
       note.moveParagraph(paragraphId, Integer.parseInt(newIndex), true);
 
-      note.persist();
+      AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+      note.persist(subject);
       notebookServer.broadcastNote(note);
       return new JsonResponse(Status.OK, "").build();
     } catch (IndexOutOfBoundsException e) {
@@ -471,8 +476,9 @@ public class NotebookRestApi {
       return new JsonResponse(Status.NOT_FOUND, "paragraph not found.").build();
     }
 
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     note.removeParagraph(paragraphId);
-    note.persist();
+    note.persist(subject);
     notebookServer.broadcastNote(note);
 
     return new JsonResponse(Status.OK, "").build();
@@ -579,7 +585,8 @@ public class NotebookRestApi {
       Map<String, Object> paramsForUpdating = request.getParams();
       if (paramsForUpdating != null) {
         paragraph.settings.getParams().putAll(paramsForUpdating);
-        note.persist();
+        AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+        note.persist(subject);
       }
     }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -321,13 +321,14 @@ public class NotebookRestApi {
   @ZeppelinApi
   public Response deleteNote(@PathParam("notebookId") String notebookId) throws IOException {
     LOG.info("Delete notebook {} ", notebookId);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     if (!(notebookId.isEmpty())) {
       Note note = notebook.getNote(notebookId);
       if (note != null) {
-        notebook.removeNote(notebookId);
+        notebook.removeNote(notebookId, subject);
       }
     }
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+
     notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.OK, "").build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -713,7 +713,8 @@ public class NotebookRestApi {
   public Response getJobListforNotebook() throws IOException, IllegalArgumentException {
     LOG.info("Get notebook jobs for job manager");
 
-    List<Map<String, Object>> notebookJobs = notebook.getJobListforNotebook(false, 0);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    List<Map<String, Object>> notebookJobs = notebook.getJobListforNotebook(false, 0, subject);
     Map<String, Object> response = new HashMap<>();
 
     response.put("lastResponseUnixTime", System.currentTimeMillis());
@@ -737,7 +738,8 @@ public class NotebookRestApi {
     LOG.info("Get updated notebook jobs lastUpdateTime {}", lastUpdateUnixTime);
 
     List<Map<String, Object>> notebookJobs;
-    notebookJobs = notebook.getJobListforNotebook(false, lastUpdateUnixTime);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    notebookJobs = notebook.getJobListforNotebook(false, lastUpdateUnixTime, subject);
     Map<String, Object> response = new HashMap<>();
 
     response.put("lastResponseUnixTime", System.currentTimeMillis());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -220,7 +220,7 @@ public class NotebookServer extends WebSocketServlet implements
             checkpointNotebook(conn, notebook, messagereceived);
             break;
           case LIST_NOTEBOOK_JOBS:
-            unicastNotebookJobInfo(conn);
+            unicastNotebookJobInfo(conn, messagereceived);
             break;
           case LIST_UPDATE_NOTEBOOK_JOBS:
             unicastUpdateNotebookJobInfo(conn, messagereceived);
@@ -372,9 +372,10 @@ public class NotebookServer extends WebSocketServlet implements
     }
   }
 
-  public void unicastNotebookJobInfo(NotebookSocket conn) throws IOException {
+  public void unicastNotebookJobInfo(NotebookSocket conn, Message fromMessage) throws IOException {
 
-    List<Map<String, Object>> notebookJobs = notebook().getJobListforNotebook(false, 0);
+    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+    List<Map<String, Object>> notebookJobs = notebook().getJobListforNotebook(false, 0, subject);
     Map<String, Object> response = new HashMap<>();
 
     response.put("lastResponseUnixTime", System.currentTimeMillis());
@@ -390,7 +391,8 @@ public class NotebookServer extends WebSocketServlet implements
     long lastUpdateUnixTime = new Double(lastUpdateUnixTimeRaw).longValue();
 
     List<Map<String, Object>> notebookJobs;
-    notebookJobs = notebook().getJobListforNotebook(false, lastUpdateUnixTime);
+    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+    notebookJobs = notebook().getJobListforNotebook(false, lastUpdateUnixTime, subject);
 
     Map<String, Object> response = new HashMap<>();
     response.put("lastResponseUnixTime", System.currentTimeMillis());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -603,7 +603,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-    notebook.removeNote(noteId);
+    notebook.removeNote(noteId, subject);
     removeNote(noteId);
     broadcastNoteList(subject);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1106,7 +1106,8 @@ public class NotebookServer extends WebSocketServlet implements
       Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("noteId");
     String commitMessage = (String) fromMessage.get("commitMessage");
-    notebook.checkpointNote(noteId, commitMessage);
+    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+    notebook.checkpointNote(noteId, commitMessage, subject);
   }
 
   /**

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -123,7 +123,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   @Test
   public void testInterpreterAutoBinding() throws IOException {
     // create note
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     // check interpreter is binded
     GetMethod get = httpGet("/notebook/interpreter/bind/" + note.id());
@@ -142,7 +142,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   @Test
   public void testInterpreterRestart() throws IOException, InterruptedException {
     // create new note
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     note.addParagraph();
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -136,7 +136,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
 
     get.releaseConnection();
     //cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -179,7 +179,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
     }
     assertEquals("<p>markdown restarted</p>\n", p.getResult().message());
     //cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -61,7 +61,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testPermissions() throws IOException {
-    Note note1 = ZeppelinServer.notebook.createNote();
+    Note note1 = ZeppelinServer.notebook.createNote(null);
     // Set only readers
     String jsonRequest = "{\"readers\":[\"admin-team\"],\"owners\":[]," +
             "\"writers\":[]}";
@@ -84,7 +84,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     get.releaseConnection();
 
 
-    Note note2 = ZeppelinServer.notebook.createNote();
+    Note note2 = ZeppelinServer.notebook.createNote(null);
     // Set only writers
     jsonRequest = "{\"readers\":[],\"owners\":[]," +
             "\"writers\":[\"admin-team\"]}";

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -118,8 +118,8 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     assertEquals(authInfo.get("owners"), Lists.newArrayList());
     get.releaseConnection();
     //cleanup
-    ZeppelinServer.notebook.removeNote(note1.getId());
-    ZeppelinServer.notebook.removeNote(note2.getId());
+    ZeppelinServer.notebook.removeNote(note1.getId(), null);
+    ZeppelinServer.notebook.removeNote(note2.getId(), null);
 
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -77,7 +77,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testGetNotebookInfo() throws IOException {
     LOG.info("testGetNotebookInfo");
     // Create note to get info
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("note");
     Paragraph paragraph = note.addParagraph();
@@ -86,7 +86,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     paragraph.setConfig(config);
     String paragraphText = "%md This is my new paragraph in my new note";
     paragraph.setText(paragraphText);
-    note.persist();
+    note.persist(null);
 
     String sourceNoteID = note.getId();
     GetMethod get = httpGet("/notebook/" + sourceNoteID);
@@ -189,7 +189,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testDeleteNote() throws IOException {
     LOG.info("testDeleteNote");
     //Create note and get ID
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     String noteId = note.getId();
     testDeleteNotebook(noteId);
   }
@@ -205,7 +205,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testExportNotebook() throws IOException {
     LOG.info("testExportNotebook");
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
     Paragraph paragraph = note.addParagraph();
@@ -213,7 +213,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     config.put("enabled", true);
     paragraph.setConfig(config);
     paragraph.setText("%md This is my new paragraph in my new note");
-    note.persist();
+    note.persist(null);
     String sourceNoteID = note.getId();
     // Call export Notebook REST API
     GetMethod get = httpGet("/notebook/export/" + sourceNoteID);
@@ -238,7 +238,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String noteName = "source note for import";
     LOG.info("testImortNotebook");
     // create test notebook
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName(noteName);
     Paragraph paragraph = note.addParagraph();
@@ -246,7 +246,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     config.put("enabled", true);
     paragraph.setConfig(config);
     paragraph.setText("%md This is my new paragraph in my new note");
-    note.persist();
+    note.persist(null);
     String sourceNoteID = note.getId();
     // get note content as JSON
     String oldJson = getNoteContent(sourceNoteID);
@@ -300,7 +300,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testCloneNotebook() throws IOException, CloneNotSupportedException, IllegalArgumentException {
     LOG.info("testCloneNotebook");
     // Create note to clone
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("source note for clone");
     Paragraph paragraph = note.addParagraph();
@@ -308,7 +308,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     config.put("enabled", true);
     paragraph.setConfig(config);
     paragraph.setText("%md This is my new paragraph in my new note");
-    note.persist();
+    note.persist(null);
     String sourceNoteID = note.getId();
 
     String noteName = "clone Note Name";
@@ -349,7 +349,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testNoteJobs() throws IOException, InterruptedException {
     LOG.info("testNoteJobs");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -359,7 +359,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     paragraph.setConfig(config);
     
     paragraph.setText("%md This is test paragraph.");
-    note.persist();
+    note.persist(null);
     String noteID = note.getId();
 
     note.runAll();
@@ -404,7 +404,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testGetNotebookJob() throws IOException, InterruptedException {
     LOG.info("testGetNotebookJob");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -414,7 +414,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     paragraph.setConfig(config);
 
     paragraph.setText("%sh sleep 1");
-    note.persist();
+    note.persist(null);
     String noteID = note.getId();
 
     note.runAll();
@@ -457,7 +457,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testRunParagraphWithParams() throws IOException, InterruptedException {
     LOG.info("testRunParagraphWithParams");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -467,7 +467,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     paragraph.setConfig(config);
 
     paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
-    note.persist();
+    note.persist(null);
     String noteID = note.getId();
 
     note.runAll();
@@ -501,7 +501,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testCronJobs() throws InterruptedException, IOException{
     // create a note and a paragraph
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -550,13 +550,13 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testRegressionZEPPELIN_527() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
     paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
 
-    note.persist();
+    note.persist(null);
 
     GetMethod getNoteJobs = httpGet("/notebook/job/" + note.getId());
     assertThat("test notebook jobs run:", getNoteJobs, isAllowed());
@@ -572,7 +572,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testInsertParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
     PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
@@ -612,12 +612,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testGetParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     Paragraph p = note.addParagraph();
     p.setTitle("hello");
     p.setText("world");
-    note.persist();
+    note.persist(null);
 
     GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p.getId());
     LOG.info("testGetParagraph response\n" + get.getResponseBodyAsString());
@@ -641,7 +641,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testMoveParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
@@ -651,7 +651,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     p2.setTitle("title2");
     p2.setText("text2");
 
-    note.persist();
+    note.persist(null);
 
     PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph/" + p2.getId() + "/move/" + 0, "");
     assertThat("Test post method: ", post, isAllowed());
@@ -673,13 +673,13 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testDeleteParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
     p.setText("text1");
 
-    note.persist();
+    note.persist(null);
 
     DeleteMethod delete = httpDelete("/notebook/" + note.getId() + "/paragraph/" + p.getId());
     assertThat("Test delete method: ", delete, isAllowed());
@@ -705,12 +705,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String username = body.get("principal");
     getSecurityTicket.releaseConnection();
 
-    Note note1 = ZeppelinServer.notebook.createNote();
+    Note note1 = ZeppelinServer.notebook.createNote(null);
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 1\"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note1.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
 
-    Note note2 = ZeppelinServer.notebook.createNote();
+    Note note2 = ZeppelinServer.notebook.createNote(null);
     jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 2\"}";
     postNotebookText = httpPost("/notebook/" + note2.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
@@ -758,7 +758,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testTitleSearch() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote();
+    Note note = ZeppelinServer.notebook.createNote(null);
     String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", \"text\": \"ThisIsToTestSearchMethodWithTitle \"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -153,7 +153,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       assertTrue("paragraph text check failed", p.getText().startsWith("text"));
     }
     // cleanup
-    ZeppelinServer.notebook.removeNote(newNotebookId);
+    ZeppelinServer.notebook.removeNote(newNotebookId, null);
     post.releaseConnection();
   }
 
@@ -180,7 +180,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     }
     assertEquals("compare note name", expectedNoteName, newNoteName);
     // cleanup
-    ZeppelinServer.notebook.removeNote(newNotebookId);
+    ZeppelinServer.notebook.removeNote(newNotebookId, null);
     post.releaseConnection();
 
   }
@@ -227,7 +227,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String exportJSON = (String) resp.get("body");
     assertNotNull("Can not find new notejson", exportJSON);
     LOG.info("export JSON:=" + exportJSON);
-    ZeppelinServer.notebook.removeNote(sourceNoteID);
+    ZeppelinServer.notebook.removeNote(sourceNoteID, null);
     get.releaseConnection();
 
   }
@@ -264,8 +264,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs()
         .size());
     // cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
-    ZeppelinServer.notebook.removeNote(newNote.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
+    ZeppelinServer.notebook.removeNote(newNote.getId(), null);
     importPost.releaseConnection();
   }
 
@@ -328,8 +328,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("Compare note names", noteName, newNote.getName());
     assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs().size());
     //cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
-    ZeppelinServer.notebook.removeNote(newNote.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
+    ZeppelinServer.notebook.removeNote(newNote.getId(), null);
     post.releaseConnection();
   }
 
@@ -397,7 +397,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Thread.sleep(1000);
     
     //cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -450,7 +450,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       }
     }
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -495,7 +495,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("world", params.get("param2"));
 
     //cleanup
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -545,7 +545,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
     assertThat("", deleteCron, isAllowed());
     deleteCron.releaseConnection();
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -567,7 +567,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertFalse(body.get(0).containsKey("finished"));
     getNoteJobs.releaseConnection();
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -607,7 +607,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("title2", paragraphAtIdx0.getTitle());
     assertEquals("text2", paragraphAtIdx0.getText());
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -636,7 +636,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("hello", body.get("title"));
     assertEquals("world", body.get("text"));
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -668,7 +668,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertThat("Test post method: ", post2, isBadRequest());
     post.releaseConnection();
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -689,7 +689,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Paragraph retrParagrah = retrNote.getParagraph(p.getId());
     assertNull("paragraph should be deleted", retrParagrah);
 
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -752,8 +752,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       getPermission.releaseConnection();
     }
     searchNotebook.releaseConnection();
-    ZeppelinServer.notebook.removeNote(note1.getId());
-    ZeppelinServer.notebook.removeNote(note2.getId());
+    ZeppelinServer.notebook.removeNote(note1.getId(), null);
+    ZeppelinServer.notebook.removeNote(note2.getId(), null);
   }
 
   @Test
@@ -779,7 +779,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     }
     assertEquals("Paragraph title hits must be at-least one", true, numberOfTitleHits >= 1);
     searchNotebook.releaseConnection();
-    ZeppelinServer.notebook.removeNote(note.getId());
+    ZeppelinServer.notebook.removeNote(note.getId(), null);
   }
 
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -68,7 +68,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void basicRDDTransformationAndActionTest() throws IOException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote();
+        Note note = ZeppelinServer.notebook.createNote(null);
 
         // run markdown paragraph, again
         Paragraph p = note.addParagraph();
@@ -86,7 +86,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void sparkRTest() throws IOException {
       // create new note
-      Note note = ZeppelinServer.notebook.createNote();
+      Note note = ZeppelinServer.notebook.createNote(null);
       int sparkVersion = getSparkVersionNumber(note);
 
       if (isSparkR() && sparkVersion >= 14) {   // sparkr supported from 1.4.0
@@ -110,7 +110,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkTest() throws IOException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote();
+        Note note = ZeppelinServer.notebook.createNote(null);
         note.setName("note");
         int sparkVersion = getSparkVersionNumber(note);
 
@@ -133,7 +133,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkAutoConvertOptionTest() throws IOException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote();
+        Note note = ZeppelinServer.notebook.createNote(null);
         note.setName("note");
 
         int sparkVersion = getSparkVersionNumber(note);
@@ -158,7 +158,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void zRunTest() throws IOException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote();
+        Note note = ZeppelinServer.notebook.createNote(null);
         Paragraph p0 = note.addParagraph();
         Map config0 = p0.getConfig();
         config0.put("enabled", true);
@@ -190,7 +190,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkDepLoaderTest() throws IOException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote();
+        Note note = ZeppelinServer.notebook.createNote(null);
 
         if (isPyspark() && getSparkVersionNumber(note) >= 14) {
             // restart spark interpreter

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -80,7 +80,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p);
         assertEquals(Status.FINISHED, p.getStatus());
         assertEquals("55", p.getResult().message());
-        ZeppelinServer.notebook.removeNote(note.id());
+        ZeppelinServer.notebook.removeNote(note.id(), null);
     }
 
     @Test
@@ -104,7 +104,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         assertEquals(Status.FINISHED, p.getStatus());
         assertEquals("[1] 3", p.getResult().message());
       }
-      ZeppelinServer.notebook.removeNote(note.id());
+      ZeppelinServer.notebook.removeNote(note.id(), null);
     }
 
     @Test
@@ -127,7 +127,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             assertEquals(Status.FINISHED, p.getStatus());
             assertEquals("55\n", p.getResult().message());
         }
-        ZeppelinServer.notebook.removeNote(note.id());
+        ZeppelinServer.notebook.removeNote(note.id(), null);
     }
 
     @Test
@@ -152,7 +152,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             assertEquals(Status.FINISHED, p.getStatus());
             assertEquals("10\n", p.getResult().message());
         }
-        ZeppelinServer.notebook.removeNote(note.id());
+        ZeppelinServer.notebook.removeNote(note.id(), null);
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         assertEquals(Status.FINISHED, p2.getStatus());
         assertEquals("10", p2.getResult().message());
 
-        ZeppelinServer.notebook.removeNote(note.id());
+        ZeppelinServer.notebook.removeNote(note.id(), null);
     }
 
     @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -89,7 +89,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
   @Test
   public void testMakeSureNoAngularObjectBroadcastToWebsocketWhoFireTheEvent() throws IOException {
     // create a notebook
-    Note note1 = notebook.createNote();
+    Note note1 = notebook.createNote(null);
 
     // get reference to interpreterGroup
     InterpreterGroup interpreterGroup = null;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -139,7 +139,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     verify(sock1, times(0)).send(anyString());
     verify(sock2, times(1)).send(anyString());
 
-    notebook.removeNote(note1.getId());
+    notebook.removeNote(note1.getId(), null);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     assertNotEquals(null, notebook.getNote(note.getId()));
     assertEquals("Test Zeppelin notebook import", notebook.getNote(note.getId()).getName());
     assertEquals("Test paragraphs import", notebook.getNote(note.getId()).getParagraphs().get(0).getText());
-    notebook.removeNote(note.getId());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -494,8 +494,8 @@ public class Note implements Serializable, JobListener {
     startDelayedPersistTimer(maxDelaySec, subject);
   }
 
-  public void unpersist() throws IOException {
-    repo.remove(id());
+  public void unpersist(AuthenticationInfo subject) throws IOException {
+    repo.remove(id(), subject);
   }
 
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -479,19 +479,19 @@ public class Note implements Serializable, JobListener {
     }
   }
 
-  public void persist() throws IOException {
+  public void persist(AuthenticationInfo subject) throws IOException {
     stopDelayedPersistTimer();
     snapshotAngularObjectRegistry();
     index.updateIndexDoc(this);
-    repo.save(this);
+    repo.save(this, subject);
   }
 
   /**
    * Persist this note with maximum delay.
    * @param maxDelaySec
    */
-  public void persist(int maxDelaySec) {
-    startDelayedPersistTimer(maxDelaySec);
+  public void persist(int maxDelaySec, AuthenticationInfo subject) {
+    startDelayedPersistTimer(maxDelaySec, subject);
   }
 
   public void unpersist() throws IOException {
@@ -499,7 +499,7 @@ public class Note implements Serializable, JobListener {
   }
 
 
-  private void startDelayedPersistTimer(int maxDelaySec) {
+  private void startDelayedPersistTimer(int maxDelaySec, final AuthenticationInfo subject) {
     synchronized (this) {
       if (delayedPersist != null) {
         return;
@@ -510,7 +510,7 @@ public class Note implements Serializable, JobListener {
         @Override
         public void run() {
           try {
-            persist();
+            persist(subject);
           } catch (IOException e) {
             logger.error(e.getMessage(), e);
           }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -43,6 +43,7 @@ import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.resource.ResourcePoolUtils;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
@@ -403,7 +404,7 @@ public class Notebook {
   }
 
   private void loadAllNotes() throws IOException {
-    List<NoteInfo> noteInfos = notebookRepo.list();
+    List<NoteInfo> noteInfos = notebookRepo.list(null);
 
     for (NoteInfo info : noteInfos) {
       loadNoteFromRepo(info.getId());
@@ -417,7 +418,7 @@ public class Notebook {
    * @return
    * @throws IOException
    */
-  public void reloadAllNotes() throws IOException {
+  public void reloadAllNotes(AuthenticationInfo subject) throws IOException {
     synchronized (notes) {
       notes.clear();
     }
@@ -429,7 +430,7 @@ public class Notebook {
       }
     }
 
-    List<NoteInfo> noteInfos = notebookRepo.list();
+    List<NoteInfo> noteInfos = notebookRepo.list(subject);
     for (NoteInfo info : noteInfos) {
       loadNoteFromRepo(info.getId());
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -327,10 +327,10 @@ public class Notebook {
   }
 
   @SuppressWarnings("rawtypes")
-  private Note loadNoteFromRepo(String id) {
+  private Note loadNoteFromRepo(String id, AuthenticationInfo subject) {
     Note note = null;
     try {
-      note = notebookRepo.get(id);
+      note = notebookRepo.get(id, subject);
     } catch (IOException e) {
       logger.error("Failed to load " + id, e);
     }
@@ -407,7 +407,7 @@ public class Notebook {
     List<NoteInfo> noteInfos = notebookRepo.list(null);
 
     for (NoteInfo info : noteInfos) {
-      loadNoteFromRepo(info.getId());
+      loadNoteFromRepo(info.getId(), null);
     }
   }
 
@@ -432,7 +432,7 @@ public class Notebook {
 
     List<NoteInfo> noteInfos = notebookRepo.list(subject);
     for (NoteInfo info : noteInfos) {
-      loadNoteFromRepo(info.getId());
+      loadNoteFromRepo(info.getId(), subject);
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -324,8 +324,9 @@ public class Notebook {
     }
   }
 
-  public void checkpointNote(String noteId, String checkpointMessage) throws IOException {
-    notebookRepo.checkpoint(noteId, checkpointMessage);
+  public void checkpointNote(String noteId, String checkpointMessage, AuthenticationInfo subject)
+      throws IOException {
+    notebookRepo.checkpoint(noteId, checkpointMessage, subject);
   }
 
   @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -285,7 +285,7 @@ public class Notebook {
     }
   }
 
-  public void removeNote(String id) {
+  public void removeNote(String id, AuthenticationInfo subject) {
     Note note;
 
     synchronized (notes) {
@@ -318,7 +318,7 @@ public class Notebook {
     ResourcePoolUtils.removeResourcesBelongsToNote(id);
 
     try {
-      note.unpersist();
+      note.unpersist(subject);
     } catch (IOException e) {
       logger.error(e.toString(), e);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -543,12 +543,12 @@ public class Notebook {
   }
 
   public List<Map<String, Object>> getJobListforNotebook(boolean needsReload,
-      long lastUpdateServerUnixTime) {
+      long lastUpdateServerUnixTime, AuthenticationInfo subject) {
     final String CRON_TYPE_NOTEBOOK_KEYWORD = "cron";
 
     if (needsReload) {
       try {
-        reloadAllNotes();
+        reloadAllNotes(subject);
       } catch (IOException e) {
         logger.error("Fail to reload notes from repository");
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -140,7 +140,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void save(Note note) throws IOException {
+  public void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     Gson gson = gsonBuilder.create();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -187,7 +187,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void remove(String noteId) throws IOException {
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
     try {
       CloudFileDirectory dir = rootDir.getDirectoryReference(noteId);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -29,6 +29,7 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.scheduler.Job;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.*;
@@ -70,7 +71,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NoteInfo> list() throws IOException {
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
     List<NoteInfo> infos = new LinkedList<NoteInfo>();
     NoteInfo info = null;
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -135,7 +135,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId) throws IOException {
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
     return getNote(noteId);
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -214,13 +214,13 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -206,7 +206,8 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
     // no-op
     LOG.info("Checkpoint feature isn't supported in {}", this.getClass().toString());
     return null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -206,7 +206,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
     // no-op
     LOG.info("Checkpoint feature isn't supported in {}", this.getClass().toString());
     return null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
@@ -96,9 +97,9 @@ public class GitNotebookRepo extends VFSNotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, String rev, AuthenticationInfo subject) throws IOException {
     //TODO(bzz): something like 'git checkout rev', that will not change-the-world though
-    return super.get(noteId);
+    return super.get(noteId, subject);
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -66,8 +66,8 @@ public class GitNotebookRepo extends VFSNotebookRepo {
   }
 
   @Override
-  public synchronized void save(Note note) throws IOException {
-    super.save(note);
+  public synchronized void save(Note note, AuthenticationInfo subject) throws IOException {
+    super.save(note, subject);
   }
 
   /* implemented as git add+commit

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -97,13 +97,13 @@ public class GitNotebookRepo extends VFSNotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, String rev, AuthenticationInfo subject) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     //TODO(bzz): something like 'git checkout rev', that will not change-the-world though
     return super.get(noteId, subject);
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     List<Revision> history = Lists.newArrayList();
     LOG.debug("Listing history for {}:", noteId);
     try {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -77,7 +77,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
    * @see org.apache.zeppelin.notebook.repo.VFSNotebookRepo#checkpoint(String, String)
    */
   @Override
-  public Revision checkpoint(String pattern, String commitMessage) {
+  public Revision checkpoint(String pattern, String commitMessage, AuthenticationInfo subject) {
     Revision revision = null;
     try {
       List<DiffEntry> gitDiff = git.diff().call();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -32,7 +32,7 @@ public interface NotebookRepo {
   @ZeppelinApi public List<NoteInfo> list(AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public Note get(String noteId, AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public void save(Note note, AuthenticationInfo subject) throws IOException;
-  @ZeppelinApi public void remove(String noteId) throws IOException;
+  @ZeppelinApi public void remove(String noteId, AuthenticationInfo subject) throws IOException;
 
   /**
    * Release any underlying resources

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -30,7 +30,7 @@ import org.apache.zeppelin.user.AuthenticationInfo;
  */
 public interface NotebookRepo {
   @ZeppelinApi public List<NoteInfo> list(AuthenticationInfo subject) throws IOException;
-  @ZeppelinApi public Note get(String noteId) throws IOException;
+  @ZeppelinApi public Note get(String noteId, AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public void save(Note note) throws IOException;
   @ZeppelinApi public void remove(String noteId) throws IOException;
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -31,7 +31,7 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 public interface NotebookRepo {
   @ZeppelinApi public List<NoteInfo> list(AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public Note get(String noteId, AuthenticationInfo subject) throws IOException;
-  @ZeppelinApi public void save(Note note) throws IOException;
+  @ZeppelinApi public void save(Note note, AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public void remove(String noteId) throws IOException;
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -23,12 +23,13 @@ import java.util.List;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.user.AuthenticationInfo;
 
 /**
  * Notebook repository (persistence layer) abstraction
  */
 public interface NotebookRepo {
-  @ZeppelinApi public List<NoteInfo> list() throws IOException;
+  @ZeppelinApi public List<NoteInfo> list(AuthenticationInfo subject) throws IOException;
   @ZeppelinApi public Note get(String noteId) throws IOException;
   @ZeppelinApi public void save(Note note) throws IOException;
   @ZeppelinApi public void remove(String noteId) throws IOException;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -29,9 +29,37 @@ import org.apache.zeppelin.user.AuthenticationInfo;
  * Notebook repository (persistence layer) abstraction
  */
 public interface NotebookRepo {
+  /**
+   * Lists notebook information about all notebooks in storage.
+   * @param subject contains user information.
+   * @return
+   * @throws IOException
+   */
   @ZeppelinApi public List<NoteInfo> list(AuthenticationInfo subject) throws IOException;
+
+  /**
+   * Get the notebook with the given id.
+   * @param noteId is notebook id.
+   * @param subject contains user information.
+   * @return
+   * @throws IOException
+   */
   @ZeppelinApi public Note get(String noteId, AuthenticationInfo subject) throws IOException;
+
+  /**
+   * Save given note in storage
+   * @param note is the note itself.
+   * @param subject contains user information.
+   * @throws IOException
+   */
   @ZeppelinApi public void save(Note note, AuthenticationInfo subject) throws IOException;
+
+  /**
+   * Remove note with given id.
+   * @param noteId is the note id.
+   * @param subject contains user information.
+   * @throws IOException
+   */
   @ZeppelinApi public void remove(String noteId, AuthenticationInfo subject) throws IOException;
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -42,6 +42,7 @@ public interface NotebookRepo {
   /**
    * Versioning API
    */
+
   /**
    * chekpoint (set revision) for notebook.
    * @param noteId Id of the Notebook
@@ -49,7 +50,9 @@ public interface NotebookRepo {
    * @return Rev
    * @throws IOException
    */
-  @ZeppelinApi public Revision checkpoint(String noteId, String checkpointMsg) throws IOException;
+  @ZeppelinApi
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException;
 
   /**
    * Get particular revision of the Notebook.
@@ -82,4 +85,5 @@ public interface NotebookRepo {
     public String message;
     public int time;
   }
+
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -68,7 +68,7 @@ public interface NotebookRepo {
   @ZeppelinApi public void close();
 
   /**
-   * Versioning API
+   * Versioning API (optional, preferred to have).
    */
 
   /**
@@ -78,9 +78,8 @@ public interface NotebookRepo {
    * @return Rev
    * @throws IOException
    */
-  @ZeppelinApi
-  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
-      throws IOException;
+  @ZeppelinApi public Revision checkpoint(String noteId, String checkpointMsg, 
+      AuthenticationInfo subject) throws IOException;
 
   /**
    * Get particular revision of the Notebook.
@@ -90,7 +89,8 @@ public interface NotebookRepo {
    * @return a Notebook
    * @throws IOException
    */
-  @ZeppelinApi public Note get(String noteId, Revision rev) throws IOException;
+  @ZeppelinApi public Note get(String noteId, Revision rev, AuthenticationInfo subject)
+      throws IOException;
 
   /**
    * List of revisions of the given Notebook.
@@ -98,7 +98,7 @@ public interface NotebookRepo {
    * @param noteId id of the Notebook
    * @return list of revisions
    */
-  @ZeppelinApi public List<Revision> revisionHistory(String noteId);
+  @ZeppelinApi public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject);
 
   /**
    * Represents the 'Revision' a point in life of the notebook

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -159,9 +159,9 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   @Override
-  public void remove(String noteId) throws IOException {
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
     for (NotebookRepo repo : repos) {
-      repo.remove(noteId);
+      repo.remove(noteId, subject);
     }
     /* TODO(khalid): handle case when removing from secondary storage fails */
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -31,6 +31,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,13 +115,13 @@ public class NotebookRepoSync implements NotebookRepo {
    *  Lists Notebooks from the first repository
    */
   @Override
-  public List<NoteInfo> list() throws IOException {
-    return getRepo(0).list();
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
+    return getRepo(0).list(subject);
   }
 
   /* list from specific repo (for tests) */
-  List<NoteInfo> list(int repoIndex) throws IOException {
-    return getRepo(repoIndex).list();
+  List<NoteInfo> list(int repoIndex, AuthenticationInfo subject) throws IOException {
+    return getRepo(repoIndex).list(subject);
   }
 
   /**
@@ -174,8 +175,8 @@ public class NotebookRepoSync implements NotebookRepo {
     LOG.info("Sync started");
     NotebookRepo srcRepo = getRepo(sourceRepoIndex);
     NotebookRepo dstRepo = getRepo(destRepoIndex);
-    List <NoteInfo> srcNotes = srcRepo.list();
-    List <NoteInfo> dstNotes = dstRepo.list();
+    List <NoteInfo> srcNotes = srcRepo.list(null);
+    List <NoteInfo> dstNotes = dstRepo.list(null);
 
     Map<String, List<String>> noteIDs = notesCheckDiff(srcNotes, srcRepo, dstNotes, dstRepo);
     List<String> pushNoteIDs = noteIDs.get(pushKey);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -128,13 +128,13 @@ public class NotebookRepoSync implements NotebookRepo {
    *  Returns from Notebook from the first repository
    */
   @Override
-  public Note get(String noteId) throws IOException {
-    return getRepo(0).get(noteId);
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
+    return getRepo(0).get(noteId, subject);
   }
 
   /* get note from specific repo (for tests) */
-  Note get(int repoIndex, String noteId) throws IOException {
-    return getRepo(repoIndex).get(noteId);
+  Note get(int repoIndex, String noteId, AuthenticationInfo subject) throws IOException {
+    return getRepo(repoIndex).get(noteId, subject);
   }
 
   /**
@@ -211,7 +211,7 @@ public class NotebookRepoSync implements NotebookRepo {
   private void pushNotes(List<String> ids, NotebookRepo localRepo,
       NotebookRepo remoteRepo) throws IOException {
     for (String id : ids) {
-      remoteRepo.save(localRepo.get(id));
+      remoteRepo.save(localRepo.get(id, null));
     }
   }
 
@@ -243,8 +243,8 @@ public class NotebookRepoSync implements NotebookRepo {
       dnote = containsID(destNotes, snote.getId());
       if (dnote != null) {
         /* note exists in source and destination storage systems */
-        sdate = lastModificationDate(sourceRepo.get(snote.getId()));
-        ddate = lastModificationDate(destRepo.get(dnote.getId()));
+        sdate = lastModificationDate(sourceRepo.get(snote.getId(), null));
+        ddate = lastModificationDate(destRepo.get(dnote.getId(), null));
         if (sdate.after(ddate)) {
           /* source contains more up to date note - push */
           pushIDs.add(snote.getId());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -141,11 +141,11 @@ public class NotebookRepoSync implements NotebookRepo {
    *  Saves to all repositories
    */
   @Override
-  public void save(Note note) throws IOException {
-    getRepo(0).save(note);
+  public void save(Note note, AuthenticationInfo subject) throws IOException {
+    getRepo(0).save(note, subject);
     if (getRepoCount() > 1) {
       try {
-        getRepo(1).save(note);
+        getRepo(1).save(note, subject);
       }
       catch (IOException e) {
         LOG.info(e.getMessage() + ": Failed to write to secondary storage");
@@ -154,8 +154,8 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   /* save note to specific repo (for tests) */
-  void save(int repoIndex, Note note) throws IOException {
-    getRepo(repoIndex).save(note);
+  void save(int repoIndex, Note note, AuthenticationInfo subject) throws IOException {
+    getRepo(repoIndex).save(note, subject);
   }
 
   @Override
@@ -211,7 +211,7 @@ public class NotebookRepoSync implements NotebookRepo {
   private void pushNotes(List<String> ids, NotebookRepo localRepo,
       NotebookRepo remoteRepo) throws IOException {
     for (String id : ids) {
-      remoteRepo.save(localRepo.get(id, null));
+      remoteRepo.save(localRepo.get(id, null), null);
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -355,7 +355,7 @@ public class NotebookRepoSync implements NotebookRepo {
 
   //checkpoint to all available storages
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
     int repoCount = getRepoCount();
     int repoBound = Math.min(repoCount, getMaxRepoNum());
     int errorCount = 0;
@@ -364,7 +364,7 @@ public class NotebookRepoSync implements NotebookRepo {
     Revision rev = null;
     for (int i = 0; i < repoBound; i++) {
       try {
-        allRepoCheckpoints.add(getRepo(i).checkpoint(noteId, checkpointMsg));
+        allRepoCheckpoints.add(getRepo(i).checkpoint(noteId, checkpointMsg, subject));
       } catch (IOException e) {
         LOG.warn("Couldn't checkpoint in {} storage with index {} for note {}", 
           getRepo(i).getClass().toString(), i, noteId);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -355,7 +355,8 @@ public class NotebookRepoSync implements NotebookRepo {
 
   //checkpoint to all available storages
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
     int repoCount = getRepoCount();
     int repoBound = Math.min(repoCount, getMaxRepoNum());
     int errorCount = 0;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -389,13 +389,13 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -225,7 +225,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void remove(String noteId) throws IOException {
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
     String key = user + "/" + "notebook" + "/" + noteId;
     final ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
         .withBucketName(bucketName).withPrefix(key);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -197,7 +197,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId) throws IOException {
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
     return getNote(user + "/" + "notebook" + "/" + noteId + "/" + "note.json");
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -38,6 +38,7 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +137,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NoteInfo> list() throws IOException {
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
     List<NoteInfo> infos = new LinkedList<>();
     NoteInfo info;
     try {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -202,7 +202,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void save(Note note) throws IOException {
+  public void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     Gson gson = gsonBuilder.create();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -257,13 +257,13 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -250,7 +250,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -250,7 +250,8 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -205,7 +205,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public synchronized void save(Note note) throws IOException {
+  public synchronized void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     Gson gson = gsonBuilder.create();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -40,6 +40,7 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +108,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NoteInfo> list() throws IOException {
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
     FileObject rootDir = getRootDir();
 
     FileObject[] children = rootDir.getChildren();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -183,7 +183,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId) throws IOException {
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
     FileObject rootDir = fsManager.resolveFile(getPath("/"));
     FileObject noteDir = rootDir.resolveFile(noteId, NameScope.CHILD);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -231,7 +231,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void remove(String noteId) throws IOException {
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
     FileObject rootDir = fsManager.resolveFile(getPath("/"));
     FileObject noteDir = rootDir.resolveFile(noteId, NameScope.CHILD);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -254,7 +254,8 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -261,13 +261,13 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -168,7 +168,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public void save(Note note) throws IOException {
+  public void save(Note note, AuthenticationInfo subject) throws IOException {
     if (note == null) {
       throw new IOException("Zeppelinhub failed to save empty note");
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -29,6 +29,7 @@ import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.rest.ZeppelinhubRestApiHandler;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.Client;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +142,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NoteInfo> list() throws IOException {
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
     String response = restApiClient.asyncGet("");
     List<NoteInfo> notes = GSON.fromJson(response, new TypeToken<List<NoteInfo>>() {}.getType());
     if (notes == null) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -153,7 +153,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId) throws IOException {
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
     if (StringUtils.isBlank(noteId)) {
       return EMPTY_NOTE;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -178,7 +178,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public void remove(String noteId) throws IOException {
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
     restApiClient.asyncDel(noteId);
     LOG.info("ZeppelinHub REST API removing note {} ", noteId);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -196,13 +196,13 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev) throws IOException {
+  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }
 
   @Override
-  public List<Revision> revisionHistory(String noteId) {
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -189,7 +189,8 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public Revision checkpoint(String noteId, String checkpointMsg) throws IOException {
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -109,7 +109,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testSelectingReplImplementation() throws IOException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     // run with defatul repl
@@ -171,7 +171,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testPersist() throws IOException, SchedulerException, RepositoryException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
 
     // run with default repl
     Paragraph p1 = note.addParagraph();
@@ -179,7 +179,7 @@ public class NotebookTest implements JobListenerFactory{
     config.put("enabled", true);
     p1.setConfig(config);
     p1.setText("hello world");
-    note.persist();
+    note.persist(null);
 
     Notebook notebook2 = new Notebook(
         conf, notebookRepo, schedulerFactory,
@@ -189,7 +189,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException{
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     Paragraph p1 = note.addParagraph();
     Map config = p1.getConfig();
     config.put("enabled", true);
@@ -207,7 +207,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testRunAll() throws IOException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     // p1
@@ -246,7 +246,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testSchedule() throws InterruptedException, IOException{
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     Paragraph p = note.addParagraph();
@@ -278,7 +278,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException{
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
     
     Paragraph p = note.addParagraph();
@@ -319,7 +319,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testCloneNote() throws IOException, CloneNotSupportedException,
       InterruptedException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -328,7 +328,7 @@ public class NotebookTest implements JobListenerFactory{
     while(p.isTerminated()==false || p.getResult()==null) Thread.yield();
 
     p.setStatus(Status.RUNNING);
-    Note cloneNote = notebook.cloneNote(note.getId(), "clone note");
+    Note cloneNote = notebook.cloneNote(note.getId(), "clone note", null);
     Paragraph cp = cloneNote.paragraphs.get(0);
     assertEquals(cp.getStatus(), Status.READY);
 
@@ -340,7 +340,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testResourceRemovealOnParagraphNoteRemove() throws IOException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
     for (InterpreterGroup intpGroup : InterpreterGroup.getAll()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
@@ -369,7 +369,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnNotebookRemove() throws InterruptedException,
       IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = note.getNoteReplLoader()
@@ -402,7 +402,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnParagraphRemove() throws InterruptedException,
       IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = note.getNoteReplLoader()
@@ -435,7 +435,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnInterpreterRestart() throws InterruptedException,
       IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = note.getNoteReplLoader()
@@ -462,7 +462,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPermissions() throws IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
     // empty owners, readers and writers means note is public
     assertEquals(notebookAuthorization.isOwner(note.id(),
@@ -507,7 +507,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws InterruptedException,
       IOException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     ArrayList<Paragraph> paragraphs = new ArrayList<>();
@@ -544,7 +544,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException {
     // create a notes
-    Note note1  = notebook.createNote();
+    Note note1  = notebook.createNote(null);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -560,7 +560,7 @@ public class NotebookTest implements JobListenerFactory{
 
     // remove note and recreate
     notebook.removeNote(note1.getId());
-    note1 = notebook.createNote();
+    note1 = notebook.createNote(null);
     p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -574,10 +574,10 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPerSessionInterpreter() throws IOException {
     // create two notes
-    Note note1  = notebook.createNote();
+    Note note1  = notebook.createNote(null);
     Paragraph p1 = note1.addParagraph();
 
-    Note note2  = notebook.createNote();
+    Note note2  = notebook.createNote(null);
     Paragraph p2 = note2.addParagraph();
 
     p1.setText("getId");
@@ -615,7 +615,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException {
     // create a notes
-    Note note1  = notebook.createNote();
+    Note note1  = notebook.createNote(null);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -149,7 +149,7 @@ public class NotebookTest implements JobListenerFactory{
 
     // load copied notebook on memory when reloadAllNotes() is called
     Note copiedNote = notebookRepo.get("2A94M5J1Z");
-    notebook.reloadAllNotes();
+    notebook.reloadAllNotes(null);
     notes = notebook.getAllNotes();
     assertEquals(notes.size(), 1);
     assertEquals(notes.get(0).id(), copiedNote.id());
@@ -164,7 +164,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notes.size(), 1);
 
     // delete notebook from notebook list when reloadAllNotes() is called
-    notebook.reloadAllNotes();
+    notebook.reloadAllNotes(null);
     notes = notebook.getAllNotes();
     assertEquals(notes.size(), 0);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -240,7 +240,7 @@ public class NotebookTest implements JobListenerFactory{
     assertNull(p2.getResult());
     assertEquals("repl1: p3", p3.getResult().message());
 
-    notebook.removeNote(note.getId());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -361,7 +361,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(1, ResourcePoolUtils.getAllResources().size());
 
     // remove note
-    notebook.removeNote(note.id());
+    notebook.removeNote(note.id(), null);
     assertEquals(0, ResourcePoolUtils.getAllResources().size());
   }
 
@@ -388,7 +388,7 @@ public class NotebookTest implements JobListenerFactory{
     registry.add("o3", "object3", null, null);
 
     // remove notebook
-    notebook.removeNote(note.id());
+    notebook.removeNote(note.id(), null);
 
     // notebook scope or paragraph scope object should be removed
     assertNull(registry.get("o1", note.id(), null));
@@ -456,7 +456,7 @@ public class NotebookTest implements JobListenerFactory{
     // local and global scope object should be removed
     assertNull(registry.get("o1", note.id(), null));
     assertNull(registry.get("o2", null, null));
-    notebook.removeNote(note.id());
+    notebook.removeNote(note.id(), null);
   }
 
   @Test
@@ -501,7 +501,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notebookAuthorization.isReader(note.id(),
             new HashSet<String>(Arrays.asList("user3"))), true);
 
-    notebook.removeNote(note.id());
+    notebook.removeNote(note.id(), null);
   }
 
   @Test
@@ -559,7 +559,7 @@ public class NotebookTest implements JobListenerFactory{
     InterpreterResult result = p1.getResult();
 
     // remove note and recreate
-    notebook.removeNote(note1.getId());
+    notebook.removeNote(note1.getId(), null);
     note1 = notebook.createNote(null);
     p1 = note1.addParagraph();
     p1.setText("getId");
@@ -568,7 +568,7 @@ public class NotebookTest implements JobListenerFactory{
     while (p1.getStatus() != Status.FINISHED) Thread.yield();
     assertNotEquals(p1.getResult().message(), result.message());
 
-    notebook.removeNote(note1.getId());
+    notebook.removeNote(note1.getId(), null);
   }
 
   @Test
@@ -608,8 +608,8 @@ public class NotebookTest implements JobListenerFactory{
 
     assertNotEquals(p1.getResult().message(), p2.getResult().message());
 
-    notebook.removeNote(note1.getId());
-    notebook.removeNote(note2.getId());
+    notebook.removeNote(note1.getId(), null);
+    notebook.removeNote(note2.getId(), null);
   }
 
   @Test
@@ -640,7 +640,7 @@ public class NotebookTest implements JobListenerFactory{
 
     assertNotEquals(result.message(), p1.getResult().message());
 
-    notebook.removeNote(note1.getId());
+    notebook.removeNote(note1.getId(), null);
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -148,7 +148,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notes.size(), 0);
 
     // load copied notebook on memory when reloadAllNotes() is called
-    Note copiedNote = notebookRepo.get("2A94M5J1Z");
+    Note copiedNote = notebookRepo.get("2A94M5J1Z", null);
     notebook.reloadAllNotes(null);
     notes = notebook.getAllNotes();
     assertEquals(notes.size(), 1);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -646,7 +646,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testNormalizeNoteName() throws IOException {
     // create a notes
-    Note note1  = notebook.createNote();
+    Note note1  = notebook.createNote(null);
 
     note1.setName("MyNote");
     assertEquals(note1.getName(), "MyNote");
@@ -666,7 +666,7 @@ public class NotebookTest implements JobListenerFactory{
     note1.setName("\\\\\\MyNote///sub");
     assertEquals(note1.getName(), "/MyNote/sub");
 
-    notebook.removeNote(note1.getId());
+    notebook.removeNote(note1.getId(), null);
   }
 
   private void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -140,7 +140,7 @@ public class GitNotebookRepoTest {
     p.setText("%md checkpoint test text");
     
     // save and checkpoint note
-    notebookRepo.save(note);
+    notebookRepo.save(note, null);
     notebookRepo.checkpoint(TEST_NOTE_ID, "second commit");
     
     // see if commit is added

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -132,7 +132,7 @@ public class GitNotebookRepoTest {
     int initialCount = notebookHistoryBefore.size();
     
     // add changes to note
-    Note note = notebookRepo.get(TEST_NOTE_ID);
+    Note note = notebookRepo.get(TEST_NOTE_ID, null);
     Paragraph p = note.addParagraph();
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -97,7 +97,7 @@ public class GitNotebookRepoTest {
     assertThat(git).isNotNull();
 
     assertThat(dotGit.exists()).isEqualTo(true);
-    assertThat(notebookRepo.list()).isNotEmpty();
+    assertThat(notebookRepo.list(null)).isNotEmpty();
 
     List<DiffEntry> diff = git.diff().call();
     // no commit, diff isn't empty
@@ -108,7 +108,7 @@ public class GitNotebookRepoTest {
   public void showNotebookHistory() throws GitAPIException, IOException {
     //given
     notebookRepo = new GitNotebookRepo(conf);
-    assertThat(notebookRepo.list()).isNotEmpty();
+    assertThat(notebookRepo.list(null)).isNotEmpty();
 
     //when
     List<Revision> testNotebookHistory = notebookRepo.revisionHistory(TEST_NOTE_ID);
@@ -122,9 +122,9 @@ public class GitNotebookRepoTest {
   public void addCheckpoint() throws IOException {
     // initial checks
     notebookRepo = new GitNotebookRepo(conf);
-    assertThat(notebookRepo.list()).isNotEmpty();
-    assertThat(containsNote(notebookRepo.list(), TEST_NOTE_ID)).isTrue();
-    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID)).isEmpty();
+    assertThat(notebookRepo.list(null)).isNotEmpty();
+    assertThat(containsNote(notebookRepo.list(null), TEST_NOTE_ID)).isTrue();
+    assertThat(notebookRepo.history(TEST_NOTE_ID)).isEmpty();
 
     notebookRepo.checkpoint(TEST_NOTE_ID, "first commit");
     List<Revision> notebookHistoryBefore = notebookRepo.revisionHistory(TEST_NOTE_ID);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -126,7 +126,7 @@ public class GitNotebookRepoTest {
     assertThat(containsNote(notebookRepo.list(null), TEST_NOTE_ID)).isTrue();
     assertThat(notebookRepo.history(TEST_NOTE_ID)).isEmpty();
 
-    notebookRepo.checkpoint(TEST_NOTE_ID, "first commit");
+    notebookRepo.checkpoint(TEST_NOTE_ID, "first commit", null);
     List<Revision> notebookHistoryBefore = notebookRepo.revisionHistory(TEST_NOTE_ID);
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID)).isNotEmpty();
     int initialCount = notebookHistoryBefore.size();
@@ -141,7 +141,7 @@ public class GitNotebookRepoTest {
     
     // save and checkpoint note
     notebookRepo.save(note, null);
-    notebookRepo.checkpoint(TEST_NOTE_ID, "second commit");
+    notebookRepo.checkpoint(TEST_NOTE_ID, "second commit", null);
     
     // see if commit is added
     List<Revision> notebookHistoryAfter = notebookRepo.revisionHistory(TEST_NOTE_ID);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -111,7 +111,7 @@ public class GitNotebookRepoTest {
     assertThat(notebookRepo.list(null)).isNotEmpty();
 
     //when
-    List<Revision> testNotebookHistory = notebookRepo.revisionHistory(TEST_NOTE_ID);
+    List<Revision> testNotebookHistory = notebookRepo.revisionHistory(TEST_NOTE_ID, null);
 
     //then
     //no initial commit, empty history
@@ -124,11 +124,11 @@ public class GitNotebookRepoTest {
     notebookRepo = new GitNotebookRepo(conf);
     assertThat(notebookRepo.list(null)).isNotEmpty();
     assertThat(containsNote(notebookRepo.list(null), TEST_NOTE_ID)).isTrue();
-    assertThat(notebookRepo.history(TEST_NOTE_ID)).isEmpty();
+    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null)).isEmpty();
 
     notebookRepo.checkpoint(TEST_NOTE_ID, "first commit", null);
-    List<Revision> notebookHistoryBefore = notebookRepo.revisionHistory(TEST_NOTE_ID);
-    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID)).isNotEmpty();
+    List<Revision> notebookHistoryBefore = notebookRepo.revisionHistory(TEST_NOTE_ID, null);
+    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null)).isNotEmpty();
     int initialCount = notebookHistoryBefore.size();
     
     // add changes to note
@@ -144,7 +144,7 @@ public class GitNotebookRepoTest {
     notebookRepo.checkpoint(TEST_NOTE_ID, "second commit", null);
     
     // see if commit is added
-    List<Revision> notebookHistoryAfter = notebookRepo.revisionHistory(TEST_NOTE_ID);
+    List<Revision> notebookHistoryAfter = notebookRepo.revisionHistory(TEST_NOTE_ID, null);
     assertThat(notebookHistoryAfter.size()).isEqualTo(initialCount + 1);
   }
   

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -146,7 +146,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(notebookRepoSync.list(0, null).get(0).getId(),notebookRepoSync.list(1, null).get(0).getId());
     
     /* remove Note */
-    notebookSync.removeNote(notebookRepoSync.list(0, null).get(0).getId());
+    notebookSync.removeNote(notebookRepoSync.list(0, null).get(0).getId(), null);
     
     /* check that deleted in both storages */
     assertEquals(0, notebookRepoSync.list(0, null).size());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -170,29 +170,29 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     /* new paragraph not yet saved into storages */
     assertEquals(0, notebookRepoSync.get(0,
-        notebookRepoSync.list(0, null).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(0, null).get(0).getId(), null).getParagraphs().size());
     assertEquals(0, notebookRepoSync.get(1,
-        notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(1, null).get(0).getId(), null).getParagraphs().size());
     
     /* save to storage under index 0 (first storage) */ 
     notebookRepoSync.save(0, note);
     
     /* check paragraph saved to first storage */
     assertEquals(1, notebookRepoSync.get(0,
-        notebookRepoSync.list(0, null).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(0, null).get(0).getId(), null).getParagraphs().size());
     /* check paragraph isn't saved to second storage */
     assertEquals(0, notebookRepoSync.get(1,
-        notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(1, null).get(0).getId(), null).getParagraphs().size());
     /* apply sync */
     notebookRepoSync.sync();
     /* check whether added to second storage */
     assertEquals(1, notebookRepoSync.get(1,
-    notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
+    notebookRepoSync.list(1, null).get(0).getId(), null).getParagraphs().size());
     /* check whether same paragraph id */
     assertEquals(p1.getId(), notebookRepoSync.get(0,
-        notebookRepoSync.list(0, null).get(0).getId()).getLastParagraph().getId());
+        notebookRepoSync.list(0, null).get(0).getId(), null).getLastParagraph().getId());
     assertEquals(p1.getId(), notebookRepoSync.get(1,
-        notebookRepoSync.list(1, null).get(0).getId()).getLastParagraph().getId());
+        notebookRepoSync.list(1, null).get(0).getId(), null).getLastParagraph().getId());
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -244,7 +244,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     String noteId = vRepoSync.list(null).get(0).getId();
     // first checkpoint
     vRepoSync.checkpoint(noteId, "checkpoint message", null);
-    int vCount = gitRepo.revisionHistory(noteId).size();
+    int vCount = gitRepo.revisionHistory(noteId, null).size();
     assertThat(vCount).isEqualTo(1);
     
     Paragraph p = note.addParagraph();
@@ -256,7 +256,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     // save and checkpoint again
     vRepoSync.save(note, null);
     vRepoSync.checkpoint(noteId, "checkpoint message 2", null);
-    assertThat(gitRepo.revisionHistory(noteId).size()).isEqualTo(vCount + 1);
+    assertThat(gitRepo.revisionHistory(noteId, null).size()).isEqualTo(vCount + 1);
   }
   
   static void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -118,16 +118,16 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
   public void testSyncOnCreate() throws IOException {
     /* check that both storage systems are empty */
     assertTrue(notebookRepoSync.getRepoCount() > 1);
-    assertEquals(0, notebookRepoSync.list(0).size());
-    assertEquals(0, notebookRepoSync.list(1).size());
+    assertEquals(0, notebookRepoSync.list(0, null).size());
+    assertEquals(0, notebookRepoSync.list(1, null).size());
     
     /* create note */
     Note note = notebookSync.createNote();
 
     // check that automatically saved on both storages
-    assertEquals(1, notebookRepoSync.list(0).size());
-    assertEquals(1, notebookRepoSync.list(1).size());
-    assertEquals(notebookRepoSync.list(0).get(0).getId(),notebookRepoSync.list(1).get(0).getId());
+    assertEquals(1, notebookRepoSync.list(0, null).size());
+    assertEquals(1, notebookRepoSync.list(1, null).size());
+    assertEquals(notebookRepoSync.list(0, null).get(0).getId(),notebookRepoSync.list(1, null).get(0).getId());
     
   }
 
@@ -135,22 +135,22 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
   public void testSyncOnDelete() throws IOException {
     /* create note */
     assertTrue(notebookRepoSync.getRepoCount() > 1);
-    assertEquals(0, notebookRepoSync.list(0).size());
-    assertEquals(0, notebookRepoSync.list(1).size());
+    assertEquals(0, notebookRepoSync.list(0, null).size());
+    assertEquals(0, notebookRepoSync.list(1, null).size());
     
     Note note = notebookSync.createNote();
 
     /* check that created in both storage systems */
-    assertEquals(1, notebookRepoSync.list(0).size());
-    assertEquals(1, notebookRepoSync.list(1).size());
-    assertEquals(notebookRepoSync.list(0).get(0).getId(),notebookRepoSync.list(1).get(0).getId());
+    assertEquals(1, notebookRepoSync.list(0, null).size());
+    assertEquals(1, notebookRepoSync.list(1, null).size());
+    assertEquals(notebookRepoSync.list(0, null).get(0).getId(),notebookRepoSync.list(1, null).get(0).getId());
     
     /* remove Note */
-    notebookSync.removeNote(notebookRepoSync.list(0).get(0).getId());
+    notebookSync.removeNote(notebookRepoSync.list(0, null).get(0).getId());
     
     /* check that deleted in both storages */
-    assertEquals(0, notebookRepoSync.list(0).size());
-    assertEquals(0, notebookRepoSync.list(1).size());
+    assertEquals(0, notebookRepoSync.list(0, null).size());
+    assertEquals(0, notebookRepoSync.list(1, null).size());
     
   }
   
@@ -170,37 +170,37 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     /* new paragraph not yet saved into storages */
     assertEquals(0, notebookRepoSync.get(0,
-        notebookRepoSync.list(0).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(0, null).get(0).getId()).getParagraphs().size());
     assertEquals(0, notebookRepoSync.get(1,
-        notebookRepoSync.list(1).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
     
     /* save to storage under index 0 (first storage) */ 
     notebookRepoSync.save(0, note);
     
     /* check paragraph saved to first storage */
     assertEquals(1, notebookRepoSync.get(0,
-        notebookRepoSync.list(0).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(0, null).get(0).getId()).getParagraphs().size());
     /* check paragraph isn't saved to second storage */
     assertEquals(0, notebookRepoSync.get(1,
-        notebookRepoSync.list(1).get(0).getId()).getParagraphs().size());
+        notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
     /* apply sync */
     notebookRepoSync.sync();
     /* check whether added to second storage */
     assertEquals(1, notebookRepoSync.get(1,
-    notebookRepoSync.list(1).get(0).getId()).getParagraphs().size());
+    notebookRepoSync.list(1, null).get(0).getId()).getParagraphs().size());
     /* check whether same paragraph id */
     assertEquals(p1.getId(), notebookRepoSync.get(0,
-        notebookRepoSync.list(0).get(0).getId()).getLastParagraph().getId());
+        notebookRepoSync.list(0, null).get(0).getId()).getLastParagraph().getId());
     assertEquals(p1.getId(), notebookRepoSync.get(1,
-        notebookRepoSync.list(1).get(0).getId()).getLastParagraph().getId());
+        notebookRepoSync.list(1, null).get(0).getId()).getLastParagraph().getId());
   }
 
   @Test
   public void testSyncOnReloadedList() throws IOException {
     /* check that both storage repos are empty */
     assertTrue(notebookRepoSync.getRepoCount() > 1);
-    assertEquals(0, notebookRepoSync.list(0).size());
-    assertEquals(0, notebookRepoSync.list(1).size());
+    assertEquals(0, notebookRepoSync.list(0, null).size());
+    assertEquals(0, notebookRepoSync.list(1, null).size());
 
     File srcDir = new File("src/test/resources/2A94M5J1Z");
     File destDir = new File(secNotebookDir + "/2A94M5J1Z");
@@ -211,13 +211,13 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     } catch (IOException e) {
       LOG.error(e.toString(), e);
     }
-    assertEquals(0, notebookRepoSync.list(0).size());
-    assertEquals(1, notebookRepoSync.list(1).size());
+    assertEquals(0, notebookRepoSync.list(0, null).size());
+    assertEquals(1, notebookRepoSync.list(1, null).size());
 
     // After reloading notebooks repos should be synchronized
-    notebookSync.reloadAllNotes();
-    assertEquals(1, notebookRepoSync.list(0).size());
-    assertEquals(1, notebookRepoSync.list(1).size());
+    notebookSync.reloadAllNotes(null);
+    assertEquals(1, notebookRepoSync.list(0, null).size());
+    assertEquals(1, notebookRepoSync.list(1, null).size());
   }
 
   @Test
@@ -236,12 +236,12 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     GitNotebookRepo gitRepo = (GitNotebookRepo) vRepoSync.getRepo(0);
     
     // no notes
-    assertThat(vRepoSync.list().size()).isEqualTo(0);
+    assertThat(vRepoSync.list(null).size()).isEqualTo(0);
     // create note
     Note note = vNotebookSync.createNote();
-    assertThat(vRepoSync.list().size()).isEqualTo(1);
+    assertThat(vRepoSync.list(null).size()).isEqualTo(1);
     
-    String noteId = vRepoSync.list().get(0).getId();
+    String noteId = vRepoSync.list(null).get(0).getId();
     // first checkpoint
     vRepoSync.checkpoint(noteId, "checkpoint message");
     int vCount = gitRepo.revisionHistory(noteId).size();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -243,7 +243,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     String noteId = vRepoSync.list(null).get(0).getId();
     // first checkpoint
-    vRepoSync.checkpoint(noteId, "checkpoint message");
+    vRepoSync.checkpoint(noteId, "checkpoint message", null);
     int vCount = gitRepo.revisionHistory(noteId).size();
     assertThat(vCount).isEqualTo(1);
     
@@ -255,7 +255,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     // save and checkpoint again
     vRepoSync.save(note, null);
-    vRepoSync.checkpoint(noteId, "checkpoint message 2");
+    vRepoSync.checkpoint(noteId, "checkpoint message 2", null);
     assertThat(gitRepo.revisionHistory(noteId).size()).isEqualTo(vCount + 1);
   }
   

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -122,7 +122,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(0, notebookRepoSync.list(1, null).size());
     
     /* create note */
-    Note note = notebookSync.createNote();
+    Note note = notebookSync.createNote(null);
 
     // check that automatically saved on both storages
     assertEquals(1, notebookRepoSync.list(0, null).size());
@@ -138,7 +138,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(0, notebookRepoSync.list(0, null).size());
     assertEquals(0, notebookRepoSync.list(1, null).size());
     
-    Note note = notebookSync.createNote();
+    Note note = notebookSync.createNote(null);
 
     /* check that created in both storage systems */
     assertEquals(1, notebookRepoSync.list(0, null).size());
@@ -158,7 +158,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
   public void testSyncUpdateMain() throws IOException {
     
     /* create note */
-    Note note = notebookSync.createNote();
+    Note note = notebookSync.createNote(null);
     Paragraph p1 = note.addParagraph();
     Map config = p1.getConfig();
     config.put("enabled", true);
@@ -175,7 +175,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
         notebookRepoSync.list(1, null).get(0).getId(), null).getParagraphs().size());
     
     /* save to storage under index 0 (first storage) */ 
-    notebookRepoSync.save(0, note);
+    notebookRepoSync.save(0, note, null);
     
     /* check paragraph saved to first storage */
     assertEquals(1, notebookRepoSync.get(0,
@@ -238,7 +238,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     // no notes
     assertThat(vRepoSync.list(null).size()).isEqualTo(0);
     // create note
-    Note note = vNotebookSync.createNote();
+    Note note = vNotebookSync.createNote(null);
     assertThat(vRepoSync.list(null).size()).isEqualTo(1);
     
     String noteId = vRepoSync.list(null).get(0).getId();
@@ -254,7 +254,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     p.setText("%md checkpoint test");
     
     // save and checkpoint again
-    vRepoSync.save(note);
+    vRepoSync.save(note, null);
     vRepoSync.checkpoint(noteId, "checkpoint message 2");
     assertThat(gitRepo.revisionHistory(noteId).size()).isEqualTo(vCount + 1);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -93,7 +93,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
   @Test
   public void testInvalidJsonFile() throws IOException {
     // given
-    int numNotes = notebookRepo.list().size();
+    int numNotes = notebookRepo.list(null).size();
 
     // when create invalid json file
     File testNoteDir = new File(mainNotebookDir, "test");
@@ -101,7 +101,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     FileUtils.writeStringToFile(new File(testNoteDir, "note.json"), "");
 
     // then
-    assertEquals(numNotes, notebookRepo.list().size());
+    assertEquals(numNotes, notebookRepo.list(null).size());
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -106,7 +106,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
 
   @Test
   public void testSaveNotebook() throws IOException, InterruptedException {
-    Note note = notebook.createNote();
+    Note note = notebook.createNote(null);
     note.getNoteReplLoader().setInterpreters(factory.getDefaultInterpreterSettingList());
 
     Paragraph p1 = note.addParagraph();
@@ -133,7 +133,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     }
 
     note.setName("SaveTest");
-    notebookRepo.save(note);
+    notebookRepo.save(note, null);
     assertEquals(note.getName(), "SaveTest");
   }
 
@@ -146,7 +146,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     @Override
     public void run() {
       try {
-        notebookRepo.save(note);
+        notebookRepo.save(note, null);
       } catch (IOException e) {
         LOG.error(e.toString(), e);
       }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
@@ -130,7 +130,7 @@ public class ZeppelinHubRepoTest {
   
   @Test
   public void testGetNote() throws IOException {
-    Note notebook = repo.get("AAAAA");
+    Note notebook = repo.get("AAAAA", null);
     assertThat(notebook).isNotNull();
     assertThat(notebook.id()).isEqualTo("2A94M5J1Z");
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
@@ -138,13 +138,13 @@ public class ZeppelinHubRepoTest {
   @Test
   public void testRemoveNote() throws IOException {
     // not suppose to throw
-    repo.remove("AAAAA");
+    repo.remove("AAAAA", null);
   }
   
   @Test
   public void testRemoveNoteError() throws IOException {
     // not suppose to throw
-    repo.remove("BBBBB");
+    repo.remove("BBBBB", null);
   }
 
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
@@ -123,7 +123,7 @@ public class ZeppelinHubRepoTest {
 
   @Test
   public void testGetAllNotes() throws IOException {
-    List<NoteInfo> notebooks = repo.list();
+    List<NoteInfo> notebooks = repo.list(null);
     assertThat(notebooks).isNotEmpty();
     assertThat(notebooks.size()).isEqualTo(3);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -204,7 +204,7 @@ public class LuceneSearchTest {
     //when
     Paragraph p1 = note1.getLastParagraph();
     p1.setText("no no no");
-    note1.persist();
+    note1.persist(null);
 
     //then
     assertThat(resultForQuery("Notebook1").size()).isEqualTo(1);
@@ -228,7 +228,7 @@ public class LuceneSearchTest {
 
     //when
     note1.setName("NotebookN");
-    note1.persist();
+    note1.persist(null);
 
     //then
     assertThat(resultForQuery("Notebook1")).isEmpty();


### PR DESCRIPTION
### What is this PR for?
This PR is to make available information on the currently authenticated user(subject) in the Notebook storage level. It can be used for multiple purposes (ACL, login to third parties, etc.) once storage layer is user aware. It basically updates NotebookRepo api with additional user info

### What type of PR is it?
Improvement

### Todos
* [x] - add authInfo(subject) to list()
* [x] - add authInfo(subject) to get()
* [x] - add authInfo(subject) to save()
* [x] - add authInfo(subject) to remove()

### What is the Jira issue?


### How should this be tested?
storage layer should be working as before with and without authenticated user, green CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? not breaking, but some api changes
* Does this needs documentation? No
