### PR TITLE
ZEPPELIN-992 Move some tests from InterpreterFactoryTest to LazyOpenInterpreterTest

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/LazyOpenInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/LazyOpenInterpreterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by jl on 6/13/16.
+ */
+public class LazyOpenInterpreterTest {
+  Interpreter interpreter = mock(Interpreter.class);
+
+  @Test
+  public void isOpenTest() {
+    InterpreterResult interpreterResult = new InterpreterResult(InterpreterResult.Code.SUCCESS, "");
+    when(interpreter.interpret(any(String.class), any(InterpreterContext.class))).thenReturn(interpreterResult);
+
+    LazyOpenInterpreter lazyOpenInterpreter = new LazyOpenInterpreter(interpreter);
+
+    assertFalse("Interpreter is not open", lazyOpenInterpreter.isOpen());
+    InterpreterContext interpreterContext =
+        new InterpreterContext("note", "id", "title", "text", null, null, null, null, null, null, null);
+    lazyOpenInterpreter.interpret("intp 1", interpreterContext);
+    assertTrue("Interpeter is open", lazyOpenInterpreter.isOpen());
+  }
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/LazyOpenInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/LazyOpenInterpreterTest.java
@@ -24,9 +24,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by jl on 6/13/16.
- */
 public class LazyOpenInterpreterTest {
   Interpreter interpreter = mock(Interpreter.class);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.zeppelin.interpreter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.*;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +33,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.sonatype.aether.RepositoryException;
+
+import static org.junit.Assert.*;
 
 public class InterpreterFactoryTest {
 
@@ -91,10 +88,7 @@ public class InterpreterFactoryTest {
     factory.createInterpretersForNote(setting, "sharedProcess", "session");
 
     // get interpreter
-    Interpreter repl1 = interpreterGroup.get("session").get(0);
-    assertFalse(((LazyOpenInterpreter) repl1).isOpen());
-    repl1.interpret("repl1", context);
-    assertTrue(((LazyOpenInterpreter) repl1).isOpen());
+    assertNotNull("get Interpreter", interpreterGroup.get("session").get(0));
 
     // try to get unavailable interpreter
     assertNull(factory.get("unknown"));


### PR DESCRIPTION
### What is this PR for?
Moving Interpreter.interpret into LazyOpenInterpreterTest in oder to divide test scope between InterpreterFactoryTest and LazyOpenInterpreter. This is related to #987 a little bit.

### What type of PR is it?
[Refactoring]

### Todos
* [x] - Divide tests

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-992

### How should this be tested?
Changed only test case

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

