### PR TITLE
[DOCS] Fix link to specific doc from release page

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -28,12 +28,12 @@
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Docs<b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <li><span><b>Release</b><span></li>
-                <li><a href="docs/0.5.6-incubating">0.5.6-incubating</a></li>
-                <li><a href="docs/0.5.5-incubating">0.5.5-incubating</a></li>
-                <li><a href="docs/0.5.0-incubating">0.5.0-incubating</a></li>
+                <li><a href="/docs/0.5.6-incubating">0.5.6-incubating</a></li>
+                <li><a href="/docs/0.5.5-incubating">0.5.5-incubating</a></li>
+                <li><a href="/docs/0.5.0-incubating">0.5.0-incubating</a></li>
                 <li role="separator" class="divider"></li>
                 <li><span><b>Snapshot</b>&nbsp;(development)<span></li>                
-                <li><a href="docs/0.6.0-SNAPSHOT">0.6.0-SNAPSHOT</a></li>
+                <li><a href="/docs/0.6.0-SNAPSHOT">0.6.0-SNAPSHOT</a></li>
               </ul>
             </li>
             


### PR DESCRIPTION
### What is this PR for?
Link to docs in [release note](http://zeppelin.apache.org/releases/zeppelin-release-0.5.6-incubating.html) page leads to http://zeppelin.apache.org/releases/docs/0.5.6-incubating instead of http://zeppelin.apache.org/docs/0.5.6-incubating

### What type of PR is it?
Documentation

### Screenshots (if appropriate)
**Before**
<img width="940" alt="screen shot 2016-06-13 at 12 08 29 am" src="https://cloud.githubusercontent.com/assets/8503346/15999615/cfabef62-30fb-11e6-92a4-488942f374b4.png">

**After**
<img width="937" alt="screen shot 2016-06-13 at 12 14 12 am" src="https://cloud.githubusercontent.com/assets/8503346/15999625/e12e6ef4-30fb-11e6-8c6c-8c07698d560b.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

