### PR TITLE
ZEPPELIN-995 Change scheduler for JDBC interpreter to use concurrent execution

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -98,6 +98,9 @@ public class JDBCInterpreter extends Interpreter {
 
   static final String EMPTY_COLUMN_VALUE = "";
 
+  private final String CONCURRENT_EXECUTION_KEY = "zeppelin.jdbc.concurrent.use";
+  private final String CONCURRENT_EXECUTION_COUNT = "zeppelin.jdbc.concurrent.max_connection";
+
   private final HashMap<String, Properties> propertiesMap;
   private final Map<String, Statement> paragraphIdStatementMap;
 
@@ -433,8 +436,10 @@ public class JDBCInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetParallelScheduler(
-        JDBCInterpreter.class.getName() + this.hashCode(), 10);
+    String schedulerName = JDBCInterpreter.class.getName() + this.hashCode();
+    return isConcurrentExecution() ?
+            SchedulerFactory.singleton().createOrGetParallelScheduler(schedulerName, 10)
+            : SchedulerFactory.singleton().createOrGetFIFOScheduler(schedulerName);
   }
 
   @Override
@@ -451,6 +456,18 @@ public class JDBCInterpreter extends Interpreter {
   public int getMaxResult() {
     return Integer.valueOf(
         propertiesMap.get(COMMON_KEY).getProperty(MAX_LINE_KEY, MAX_LINE_DEFAULT));
+  }
+
+  boolean isConcurrentExecution() {
+    return Boolean.valueOf(getProperty(CONCURRENT_EXECUTION_KEY));
+  }
+
+  int getMaxConcurrentConnection() {
+    try {
+      return Integer.valueOf(getProperty(CONCURRENT_EXECUTION_COUNT));
+    } catch (Exception e) {
+      return 10;
+    }
   }
 }
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -433,8 +433,8 @@ public class JDBCInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
-        JDBCInterpreter.class.getName() + this.hashCode());
+    return SchedulerFactory.singleton().createOrGetParallelScheduler(
+        JDBCInterpreter.class.getName() + this.hashCode(), 10);
   }
 
   @Override

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -33,6 +33,18 @@
         "propertyName": "common.max_count",
         "defaultValue": "1000",
         "description": "Max number of SQL result to display."
+      },
+      "zeppelin.jdbc.concurrent.use": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.concurrent.use",
+        "defaultValue": "true",
+        "description": "Use parallel scheduler"
+      },
+      "zeppelin.jdbc.concurrent.max_connection": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.concurrent.max_connection",
+        "defaultValue": "10",
+        "description": "Number of concurrent execution"
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Changed scheduler from FIFO to Parallels in JdbcInterpreter. This is a default behaviour of HiveInterpreter. When we merge all JDBC-like interpreter into JDBC, we need to change default behaviour of JdbcInterpreter.

### What type of PR is it?
[Feature]

### Todos
* [x] - Changed scheduler

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-995

### How should this be tested?
You can run multiple queries simultaneously.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

