### PR TITLE
Prevent NullPointerException if "gatewayServer" does not exist

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -83,7 +83,7 @@ if [[ ! -d "${ZEPPELIN_PID_DIR}" ]]; then
 fi
 
 if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
-  echo "Pid dir doesn't exist, create ${ZEPPELIN_NOTEBOOK_DIR}"
+  echo "Notebook dir doesn't exist, create ${ZEPPELIN_NOTEBOOK_DIR}"
   $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
 fi
 

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -125,8 +125,10 @@ public class PythonInterpreter extends Interpreter {
 
     logger.info("closing Python interpreter .....");
     try {
-      process.close();
-      gatewayServer.shutdown();
+      if (process != null)
+        process.close();
+      if (gatewayServer != null)
+        gatewayServer.shutdown();
     } catch (IOException e) {
       logger.error("Can't close the interpreter", e);
     }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -125,10 +125,12 @@ public class PythonInterpreter extends Interpreter {
 
     logger.info("closing Python interpreter .....");
     try {
-      if (process != null)
+      if (process != null) {
         process.close();
-      if (gatewayServer != null)
+      }
+      if (gatewayServer != null) {
         gatewayServer.shutdown();
+      }
     } catch (IOException e) {
       logger.error("Can't close the interpreter", e);
     }


### PR DESCRIPTION
### What is this PR for?
Avoiding and preventing undesired NullPointerException during re-loading python interpreter
Since py4j is optional when PythonInterpreter starts, it should be optional too while it close.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* N/A

### How should this be tested?

Reload PythongInterpreter on Zeppelin web "Interpreter" menu and check the log message if it complains NullPointerException

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

