### PR TITLE
[ZEPPELIN-998] Extend install.md -> Quick Start

### DIFF
--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -433,6 +433,8 @@ a.anchor {
   word-break: keep-all;
   -webkit-overflow-scrolling: touch;
   font-size: 90%;
+  margin-top: 16px;
+  margin-bottom: 16px;
 }
 .content table th {
   font-weight: bold;

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,9 +124,9 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
 ####Quick Start
 
 * Getting Started
-  * [Quick Start](./install/install.html) for basic instructions on installing Zeppelin
-  * [Configuration](./install/install.html#zeppelin-configuration) lists for Zeppelin
-  * [Explore Apache Zeppelin UI](./quickstart/explorezeppelinui.html): basic components of Zeppelin home
+  * [Quick Start](./install/install.html) for basic instructions on installing Apache Zeppelin
+  * [Configuration](./install/install.html#apache-zeppelin-configuration) lists for Apache Zeppelin
+  * [Explore Apache Zeppelin UI](./quickstart/explorezeppelinui.html): basic components of Apache Zeppelin home
   * [Tutorial](./quickstart/tutorial.html): a short walk-through tutorial that uses Apache Spark backend
 * Basic Feature Guide
   * [Dynamic Form](./manual/dynamicform.html): a step by step guide for creating dynamic forms

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -19,38 +19,117 @@ limitations under the License.
 -->
 {% include JB/setup %}
 
-## Zeppelin Installation
-Welcome to your first trial to explore Zeppelin!
+# Quick Start
+Welcome to your first trial to explore Apache Zeppelin! 
+This page will help you to get started with Zeppelin. Here is the list of this page. 
 
-In this documentation, we will explain how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can see all of Zeppelin's configurations in the [Zeppelin Configuration](install.html#zeppelin-configuration) section below.
+* [Installation](#installation)
+  * [Downloading Binary Package](#downloading-binary-package)
+  * [Building from Source](#building-from-source)
+* [Starting Zeppelin with Command Line](#starting-zeppelin-with-command-line)
+  * [Start Zeppelin](#start-zeppelin)
+  * [Stop Zeppelin](#stop-zeppelin)
+  * [(Optional) Start Zeppelin with a service manager](#optional-start-zeppelin-with-a-service-manager)
+* [What is the next?](#what-is-the-next)
+* [Zeppelin Configuration](#zeppelin-configuration)
 
-### Install with Binary Package
+## Installation
 
-If you want to install Zeppelin with latest binary package, please visit [this page](http://zeppelin.apache.org/download.html).
+Apache Zeppelin officially tested on the below environment. 
 
-### Build from Zeppelin Source
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Value</th>
+  </tr>
+  <tr>
+    <td>Oracle JDK</td>
+    <td>1.7 <br /> (set <code>JAVA_HOME</code>)</td>
+  </tr>
+  <tr>
+    <td>OS</td>
+    <td>Mac OSX <br /> Ubuntu 14.X <br /> CentOS 6.X <br /> Windows 7 Pro SP1</td>
+  </tr>
+</table>
 
-You can also build Zeppelin from the source.
+There are two options to install Zeppelin on your machine. One is [downloading prebuild binary package](#downloading-binary-package) from the archive. 
+You can download not only the latest stable version but also the older one if you need. 
+The other option is [building from the source](#building-from-source).
+Although it can be unstable somehow since it is on development status, you can explore newly added feature and change it as you want.
 
-#### Prerequisites for build
- * Java 1.7
- * Git
- * Maven(3.1.x or higher)
- * Node.js Package Manager
+### Downloading Binary Package
 
-If you don't have requirements prepared, please check instructions in [README.md](https://github.com/apache/zeppelin/blob/master/README.md) for the details.
+If you want to install Zeppelin with a stable binary package, please visit [Zeppelin download Page](http://zeppelin.apache.org/download.html). 
+After unpacking, jump to [Starting Zeppelin with Command Line](#starting-zeppelin-with-command-line) section.
 
+### Building from Source
+If you want to build from the source, there are more requirements. 
 
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Value</th>
+  </tr>
+  <tr>
+    <td>Git</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Maven</td>
+    <td>3.1.x or higher</td>
+  </tr>
+  <tr>
+    <td>Node.js Package Manager(npm)</td>
+    <td></td>
+  </tr>
+</table>
 
-Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.
-[Spark Interpreter for Apache Zeppelin](../interpreter/spark.html) will be a good example.
+If you don't have the above requirements yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step.
 
-## Zeppelin Start / Stop
+####1. Clone Zeppelin repository
+
+```
+git clone https://github.com/apache/zeppelin.git
+```
+
+####2. Build source with options 
+Each interpreters requires different build options. For the further information about options, please see [Build](https://github.com/apache/zeppelin#build) section.
+
+```
+mvn clean package -DskipTests [Options]
+```
+
+Here are some examples with several options
+
+```
+# basic build
+mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark
+
+# spark-cassandra integration
+mvn clean package -Pcassandra-spark-1.5 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+
+# with CDH
+mvn clean package -Pspark-1.5 -Dhadoop.version=2.6.0-cdh5.5.0 -Phadoop-2.6 -Pvendor-repo -DskipTests
+
+# with MapR
+mvn clean package -Pspark-1.5 -Pmapr50 -DskipTests
+```
+
+For the further information about building with source, please see [README.md](https://github.com/apache/zeppelin/blob/master/README.md) in Zeppelin repository.
+
+## Starting Zeppelin with Command Line
 #### Start Zeppelin
 
 ```
 bin/zeppelin-daemon.sh start
 ```
+
+If you are using Windows 
+
+```
+bin\zeppelin.cmd
+```
+
 After successful start, visit [http://localhost:8080](http://localhost:8080) with your web browser.
 
 #### Stop Zeppelin
@@ -59,21 +138,28 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 bin/zeppelin-daemon.sh stop
 ```
 
-#### Start Zeppelin with a service manager such as upstart
+#### (Optional) Start Zeppelin with a service manager
 
-Zeppelin can auto start as a service with an init script, such as services managed by upstart.
+> **Note :** The below description was written based on Ubuntu Linux.
 
-The following is an example upstart script to be saved as `/etc/init/zeppelin.conf`
-This example has been tested with Ubuntu Linux.
+Zeppelin can be auto started as a service with an init script, such as services managed by **upstart**.
+
+The following is an example of upstart script to be saved as `/etc/init/zeppelin.conf`
 This also allows the service to be managed with commands such as
 
-`sudo service zeppelin start`  
-`sudo service zeppelin stop`  
-`sudo service zeppelin restart`
+```
+sudo service zeppelin start  
+sudo service zeppelin stop  
+sudo service zeppelin restart
+```
 
-Other service managers could use a similar approach with the `upstart` argument passed to the zeppelin-daemon.sh script:  `bin/zeppelin-daemon.sh upstart`
+Other service managers could use a similar approach with the `upstart` argument passed to the `zeppelin-daemon.sh` script.
 
-##### zeppelin.conf
+```
+bin/zeppelin-daemon.sh upstart
+```
+
+**zeppelin.conf**
 
 ```
 description "zeppelin"
@@ -93,11 +179,12 @@ chdir /usr/share/zeppelin
 exec bin/zeppelin-daemon.sh upstart
 ```
 
-#### Running on Windows
+## What is the next?
+Congratulation to your successful Zeppelin installation! Here are two next steps you might need.
 
-```
-bin\zeppelin.cmd
-```
+ * For an in-depth overview of Zeppelin UI, head to [Explore Zeppelin UI](../quickstart/explorezeppelinui.html)
+ * After getting familiar with Zeppelin UI, have fun with a short walk-through [Tutorial](../quickstart/tutorial.html) that uses Apache Spark backend
+ * If you need more configuration setting for Zeppelin, jump to the next section: [Zeppelin Configuration](#zeppelin-configuration)
 
 ## Zeppelin Configuration
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -21,17 +21,17 @@ limitations under the License.
 
 # Quick Start
 Welcome to your first trial to explore Apache Zeppelin! 
-This page will help you to get started with Zeppelin. Here is the list of this page. 
+This page will help you to get started with Apache Zeppelin. Here is the list of this page. 
 
 * [Installation](#installation)
   * [Downloading Binary Package](#downloading-binary-package)
   * [Building from Source](#building-from-source)
-* [Starting Zeppelin with Command Line](#starting-zeppelin-with-command-line)
+* [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line)
   * [Start Zeppelin](#start-zeppelin)
   * [Stop Zeppelin](#stop-zeppelin)
-  * [(Optional) Start Zeppelin with a service manager](#optional-start-zeppelin-with-a-service-manager)
+  * [(Optional) Start Apache Zeppelin with a service manager](#optional-start-apache-zeppelin-with-a-service-manager)
 * [What is the next?](#what-is-the-next)
-* [Zeppelin Configuration](#zeppelin-configuration)
+* [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
 
 ## Installation
 
@@ -52,15 +52,15 @@ Apache Zeppelin officially tested on the below environment.
   </tr>
 </table>
 
-There are two options to install Zeppelin on your machine. One is [downloading prebuild binary package](#downloading-binary-package) from the archive. 
+There are two options to install Apache Zeppelin on your machine. One is [downloading prebuild binary package](#downloading-binary-package) from the archive. 
 You can download not only the latest stable version but also the older one if you need. 
 The other option is [building from the source](#building-from-source).
 Although it can be unstable somehow since it is on development status, you can explore newly added feature and change it as you want.
 
 ### Downloading Binary Package
 
-If you want to install Zeppelin with a stable binary package, please visit [Zeppelin download Page](http://zeppelin.apache.org/download.html). 
-After unpacking, jump to [Starting Zeppelin with Command Line](#starting-zeppelin-with-command-line) section.
+If you want to install Apache Zeppelin with a stable binary package, please visit [Apache Zeppelin download Page](http://zeppelin.apache.org/download.html). 
+After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
 
 ### Building from Source
 If you want to build from the source, there are more requirements. 
@@ -78,15 +78,11 @@ If you want to build from the source, there are more requirements.
     <td>Maven</td>
     <td>3.1.x or higher</td>
   </tr>
-  <tr>
-    <td>Node.js Package Manager(npm)</td>
-    <td></td>
-  </tr>
 </table>
 
 If you don't have the above requirements yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step.
 
-####1. Clone Zeppelin repository
+####1. Clone Apache Zeppelin repository
 
 ```
 git clone https://github.com/apache/zeppelin.git
@@ -117,7 +113,7 @@ mvn clean package -Pspark-1.5 -Pmapr50 -DskipTests
 
 For the further information about building with source, please see [README.md](https://github.com/apache/zeppelin/blob/master/README.md) in Zeppelin repository.
 
-## Starting Zeppelin with Command Line
+## Starting Apache Zeppelin with Command Line
 #### Start Zeppelin
 
 ```
@@ -138,11 +134,11 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 bin/zeppelin-daemon.sh stop
 ```
 
-#### (Optional) Start Zeppelin with a service manager
+#### (Optional) Start Apache Zeppelin with a service manager
 
 > **Note :** The below description was written based on Ubuntu Linux.
 
-Zeppelin can be auto started as a service with an init script, such as services managed by **upstart**.
+Apache Zeppelin can be auto started as a service with an init script, such as services managed by **upstart**.
 
 The following is an example of upstart script to be saved as `/etc/init/zeppelin.conf`
 This also allows the service to be managed with commands such as
@@ -180,15 +176,15 @@ exec bin/zeppelin-daemon.sh upstart
 ```
 
 ## What is the next?
-Congratulation to your successful Zeppelin installation! Here are two next steps you might need.
+Congratulation on your successful Apache Zeppelin installation! Here are two next steps you might need.
 
- * For an in-depth overview of Zeppelin UI, head to [Explore Zeppelin UI](../quickstart/explorezeppelinui.html)
- * After getting familiar with Zeppelin UI, have fun with a short walk-through [Tutorial](../quickstart/tutorial.html) that uses Apache Spark backend
- * If you need more configuration setting for Zeppelin, jump to the next section: [Zeppelin Configuration](#zeppelin-configuration)
+ * For an in-depth overview of Apache Zeppelin UI, head to [Explore Apache Zeppelin UI](../quickstart/explorezeppelinui.html)
+ * After getting familiar with Apache Zeppelin UI, have fun with a short walk-through [Tutorial](../quickstart/tutorial.html) that uses Apache Spark backend
+ * If you need more configuration setting for Apache Zeppelin, jump to the next section: [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
 
-## Zeppelin Configuration
+## Apache Zeppelin Configuration
 
-You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
+You can configure Apache Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
 
 <table class="table-configuration">
   <tr>
@@ -297,13 +293,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
     <td>zeppelin.notebook.homescreen</td>
     <td></td>
-    <td>A notebook id displayed in Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
+    <td>A notebook id displayed in Apache Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
     <td>zeppelin.notebook.homescreen.hide</td>
     <td>false</td>
-    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
+    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Apache Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WAR_TEMPDIR</td>
@@ -315,13 +311,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_DIR</td>
     <td>zeppelin.notebook.dir</td>
     <td>notebook</td>
-    <td>The root directory where Zeppelin notebook directories are saved</td>
+    <td>The root directory where notebook directories are saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
     <td>zeppelin.notebook.s3.bucket</td>
     <td>zeppelin</td>
-    <td>S3 Bucket where Zeppelin notebook files will be saved</td>
+    <td>S3 Bucket where notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
@@ -357,7 +353,7 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_AZURE_SHARE</td>
     <td>zeppelin.notebook.azure.share</td>
     <td>zeppelin</td>
-    <td>Share where the Zeppelin notebook files will be saved</td>
+    <td>Share where the notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_AZURE_USER</td>
@@ -378,13 +374,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in Zeppelin notebook paragraph. </td>
+    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in notebook paragraph. </td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>
     <td>zeppelin.interpreter.dir</td>
     <td>interpreter</td>
-    <td>Zeppelin interpreter directory</td>
+    <td>Interpreter directory</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 # Quick Start
 Welcome to your first trial to explore Apache Zeppelin! 
-This page will help you to get started with Apache Zeppelin. Here is the list of this page. 
+This page will help you to get started and here is the list of topics covered.
 
 * [Installation](#installation)
   * [Downloading Binary Package](#downloading-binary-package)
@@ -35,7 +35,7 @@ This page will help you to get started with Apache Zeppelin. Here is the list of
 
 ## Installation
 
-Apache Zeppelin officially tested on the below environment. 
+Apache Zeppelin officially supports and is tested on next environments.
 
 <table class="table-configuration">
   <tr>
@@ -63,7 +63,7 @@ If you want to install Apache Zeppelin with a stable binary package, please visi
 After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
 
 ### Building from Source
-If you want to build from the source, there are more requirements. 
+If you want to build from the source, the software below needs to be installed on your system.
 
 <table class="table-configuration">
   <tr>
@@ -80,7 +80,7 @@ If you want to build from the source, there are more requirements.
   </tr>
 </table>
 
-If you don't have the above requirements yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step.
+If you don't have it installed yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step instructions from there.
 
 ####1. Clone Apache Zeppelin repository
 


### PR DESCRIPTION
### What is this PR for?
Most of other projects have **Quick Start** or **Getting Started** page for the beginner. Currently, Zeppelin also has [Zeppelin Install](https://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/install/install.html) which is similar with those kind of instruction page. But it has only contents that explain just installation and configuration. So I updated this page to **Quick Start** so that it can include step by step guide for the beginners.

### What type of PR is it?
Improvement & Documentation 

### Todos
* [x] - Add each title link to the head of documentation 
* [x] - Add more information about Zeppelin installation
* [x] - Reorder contents 

### What is the Jira issue?
[ZEPPELIN-998](https://issues.apache.org/jira/browse/ZEPPELIN-998)

### How should this be tested?
See the attached screenshot images

### Screenshots (if appropriate)
<img width="809" alt="screen shot 2016-06-14 at 2 59 47 pm" src="https://cloud.githubusercontent.com/assets/10060731/16061227/d88abe56-3240-11e6-845c-e37a9975aceb.png">
<img width="796" alt="screen shot 2016-06-14 at 3 00 01 pm" src="https://cloud.githubusercontent.com/assets/10060731/16061229/daca8b06-3240-11e6-821b-7d118b7b3e09.png">
<img width="789" alt="screen shot 2016-06-14 at 3 00 15 pm" src="https://cloud.githubusercontent.com/assets/10060731/16061234/dd12072c-3240-11e6-9a0a-cf1e320fd879.png">
<img width="785" alt="screen shot 2016-06-14 at 3 00 27 pm" src="https://cloud.githubusercontent.com/assets/10060731/16061238/df7f904c-3240-11e6-83e0-73f3688c0815.png">
<img width="789" alt="screen shot 2016-06-14 at 3 00 38 pm" src="https://cloud.githubusercontent.com/assets/10060731/16061242/e1ad1402-3240-11e6-81ba-2e7125cec98e.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

