### PR TITLE
[ZEPPELIN-1002] Move configuration menus under dropdown

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -125,9 +125,7 @@ public class WebDriverManager {
         (new WebDriverWait(driver, 5)).until(new ExpectedCondition<Boolean>() {
           @Override
           public Boolean apply(WebDriver d) {
-            return d.findElement(By.xpath(
-                "//button[contains(@class,'username')]" +
-                "/span[contains(.,'Connected')]"))
+            return d.findElement(By.xpath("//i[@tooltip='WebSocket Connected']"))
                 .isDisplayed();
           }
         });

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -126,7 +126,8 @@ public class WebDriverManager {
           @Override
           public Boolean apply(WebDriver d) {
             return d.findElement(By.xpath(
-                "//div[contains(@class, 'navbar-collapse')]//li//a[contains(.,'Connected')]"))
+                "//button[@class='btn dropdown-toggle nav-status-btn']" +
+                "/span[contains(.,'Connected')]"))
                 .isDisplayed();
           }
         });

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -126,7 +126,7 @@ public class WebDriverManager {
           @Override
           public Boolean apply(WebDriver d) {
             return d.findElement(By.xpath(
-                "//button[@class='btn dropdown-toggle nav-status-btn']" +
+                "//button[contains(@class,'username')]" +
                 "/span[contains(.,'Connected')]"))
                 .isDisplayed();
           }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -158,8 +158,8 @@ public class AuthenticationIT extends AbstractZeppelinIT {
 
       String noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
 
-      pollingWait(By.xpath("//button[@tooltip='Note permissions']"),
-          MAX_BROWSER_TIMEOUT_SEC).sendKeys(Keys.ENTER);
+      pollingWait(By.xpath("//span[@tooltip='Note permissions']"),
+          MAX_BROWSER_TIMEOUT_SEC).click();
       pollingWait(By.xpath("//input[@ng-model='permissions.owners']"), MAX_BROWSER_TIMEOUT_SEC)
           .sendKeys("finance");
       pollingWait(By.xpath("//input[@ng-model='permissions.readers']"), MAX_BROWSER_TIMEOUT_SEC)

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -196,7 +196,9 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
     try {
       // navigate to interpreter page
-      WebElement interpreterLink = driver.findElement(By.xpath("//a[contains(.,'Interpreter')]"));
+      WebElement configButton = driver.findElement(By.xpath("//button[contains(.,'Connected')]"));
+      configButton.click();
+      WebElement interpreterLink = driver.findElement(By.xpath("//a[@href='#/interpreter']"));
       interpreterLink.click();
 
       // add new dependency to spark interpreter
@@ -235,6 +237,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       sleep(1000, false);
 
       // reset dependency
+      configButton.click();
       interpreterLink.click();
       driver.findElement(By.xpath("//div[@id='spark']//button[contains(.,'edit')]")).sendKeys(Keys.ENTER);
       WebElement testDepRemoveBtn = pollingWait(By.xpath("//tr[descendant::text()[contains(.,'" +

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -196,7 +196,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
     try {
       // navigate to interpreter page
-      WebElement settingButton = driver.findElement(By.xpath("//button[@class='btn nav-btn dropdown-toggle']"));
+      WebElement settingButton = driver.findElement(By.xpath("//button[@class='nav-btn dropdown-toggle ng-scope']"));
       settingButton.click();
       WebElement interpreterLink = driver.findElement(By.xpath("//a[@href='#/interpreter']"));
       interpreterLink.click();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -196,8 +196,8 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
     try {
       // navigate to interpreter page
-      WebElement configButton = driver.findElement(By.xpath("//button[contains(.,'Connected')]"));
-      configButton.click();
+      WebElement settingButton = driver.findElement(By.xpath("//button[@class='btn nav-btn dropdown-toggle']"));
+      settingButton.click();
       WebElement interpreterLink = driver.findElement(By.xpath("//a[@href='#/interpreter']"));
       interpreterLink.click();
 
@@ -237,7 +237,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       sleep(1000, false);
 
       // reset dependency
-      configButton.click();
+      settingButton.click();
       interpreterLink.click();
       driver.findElement(By.xpath("//div[@id='spark']//button[contains(.,'edit')]")).sendKeys(Keys.ENTER);
       WebElement testDepRemoveBtn = pollingWait(By.xpath("//tr[descendant::text()[contains(.,'" +

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -274,25 +274,9 @@ a.navbar-brand:hover {
 
 .nav-btn {
   color: #fff;
-  background-color: #3071a9;
-  border-color: #3071a9;
-}
-
-.nav-btn:hover,
-.nav-btn:focus,
-.nav-btn:active, .open > .dropdown-toggle.nav-btn {
-  color: #fff;
-  background-color: #428bca;
-  border-color: #357ebd;
-}
-
-.nav-status-btn,
-.nav-status-btn:hover,
-.nav-status-btn:focus {
-  color: #fff;
-  background-color: #3071a9;
-  border-color: #3071a9;
-  cursor: default;
+  background-color: transparent;
+  border-color: transparent;
+  font-size: 14px;
 }
 
 .nav-login-btn,
@@ -307,15 +291,18 @@ a.navbar-brand:hover {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 180px;
+  max-width: 120px;
+  display: inline-block;
 }
 
 .server-connected {
+  padding-top: 12px;
   color: #00CC00;
   font-size: 12px !important;
 }
 
 .server-disconnected {
+  padding-top: 12px;
   color: rgba(240, 48, 0, 1);
   font-size: 12px !important;
 }

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -272,18 +272,27 @@ a.navbar-brand:hover {
   margin-top: 8px;
 }
 
-.nav-config-btn {
+.nav-btn {
   color: #fff;
   background-color: #3071a9;
   border-color: #3071a9;
 }
 
-.nav-config-btn:hover,
-.nav-config-btn:focus,
-.nav-config-btn:active, .open > .dropdown-toggle.nav-config-btn {
+.nav-btn:hover,
+.nav-btn:focus,
+.nav-btn:active, .open > .dropdown-toggle.nav-btn {
   color: #fff;
   background-color: #428bca;
   border-color: #357ebd;
+}
+
+.nav-status-btn,
+.nav-status-btn:hover,
+.nav-status-btn:focus {
+  color: #fff;
+  background-color: #3071a9;
+  border-color: #3071a9;
+  cursor: default;
 }
 
 .nav-login-btn,

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -303,6 +303,13 @@ a.navbar-brand:hover {
   border-color: #357ebd;
 }
 
+.username {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
 .server-connected {
   color: #00CC00;
   font-size: 12px !important;

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -242,10 +242,6 @@ a.navbar-brand:hover {
     background: #080808;
   }
 
-  .server-status {
-    float: right;
-  }
-
   .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
     background: #3071A9;
   }
@@ -272,20 +268,40 @@ a.navbar-brand:hover {
   }
 }
 
-i.server-status {
-  font-size: 12px;
-  top: -2px;
-  position: relative;
+.nav-component {
+  margin-top: 8px;
+}
+
+.nav-config-btn {
+  color: #fff;
+  background-color: #3071a9;
+  border-color: #3071a9;
+}
+
+.nav-config-btn:hover,
+.nav-config-btn:focus,
+.nav-config-btn:active, .open > .dropdown-toggle.nav-config-btn {
+  color: #fff;
+  background-color: #428bca;
+  border-color: #357ebd;
+}
+
+.nav-login-btn,
+.nav-login-btn:hover,
+.nav-login-btn:focus {
+  color: #fff;
+  background-color: #428bca;
+  border-color: #357ebd;
 }
 
 .server-connected {
   color: #00CC00;
+  font-size: 12px !important;
 }
 
 .server-disconnected {
   color: rgba(240, 48, 0, 1);
   font-size: 12px !important;
-  font-weight: bold !important;
 }
 
 .box {

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -153,26 +153,24 @@ limitations under the License.
     </span>
 
     <div class="pull-right" style="margin-top:15px; margin-right:15px; font-size:15px;">
-      <span>
-        <button type="button"
-            class="btn btn-default btn-xs"
+      <span class="setting-btn"
+            type="button"
             data-toggle="modal"
             data-target="#shortcutModal"
             tooltip-placement="bottom" tooltip="List of shortcut">
-          <i class="fa fa-keyboard-o"></i>
-        </button>
-        <button type="button"
-            class="btn btn-default btn-xs"
+        <i class="fa fa-keyboard-o"></i>
+      </span>
+      <span class="setting-btn"
+            type="button"
             ng-click="toggleSetting()"
             tooltip-placement="bottom" tooltip="Interpreter binding">
-          <i class="fa fa-cog" ng-style="{color: showSetting ? '#3071A9' : 'black' }"></i>
-        </button>
-        <button type="button"
-            class="btn btn-default btn-xs"
+        <i class="fa fa-cog" ng-style="{color: showSetting ? '#3071A9' : 'black' }"></i>
+      </span>
+      <span class="setting-btn"
+            type="button"
             ng-click="togglePermissions()"
             tooltip-placement="bottom" tooltip="Note permissions">
-          <i class="fa fa-lock" ng-style="{color: showPermissions ? '#3071A9' : 'black' }"></i>
-        </button>
+        <i class="fa fa-lock" ng-style="{color: showPermissions ? '#3071A9' : 'black' }"></i>
       </span>
 
       <span class="btn-group">

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -223,6 +223,13 @@
   padding-left: 5px;
 }
 
+.setting-btn {
+  position: relative;
+  top: 2px;
+  margin-right: 4px;
+  cursor: pointer;
+}
+
 .cron-preset-container {
   padding: 10px 20px 0 20px;
   font-weight: normal;

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -76,7 +76,7 @@ angular.module('zeppelinWebApp')
     $rootScope.truncatedUsername = $rootScope.ticket.principal;
   }
 
-  var MAX_USERNAME_LENGTH=20;
+  var MAX_USERNAME_LENGTH=16;
 
   angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
@@ -92,8 +92,7 @@ angular.module('zeppelinWebApp')
     if ($rootScope.ticket) {
       if ($rootScope.ticket.principal.length <= MAX_USERNAME_LENGTH) {
         $rootScope.truncatedUsername = $rootScope.ticket.principal;
-      }
-      else {
+      } else {
         $rootScope.truncatedUsername = $rootScope.ticket.principal.substr(0, MAX_USERNAME_LENGTH) + '..';
       }
     }
@@ -146,7 +145,6 @@ angular.module('zeppelinWebApp')
   };
 
   function getZeppelinVersion() {
-    console.log('version');
     $http.get(baseUrlSrv.getRestApiBase() + '/version').success(
       function(data, status, headers, config) {
         $rootScope.zeppelinVersion = data.body;

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -63,20 +63,12 @@ angular.module('zeppelinWebApp')
     }, 500);
   };
 
-
   var vm = this;
   vm.notes = notebookListDataFactory;
   vm.connected = websocketMsgSrv.isConnected();
   vm.websocketMsgSrv = websocketMsgSrv;
   vm.arrayOrderingSrv = arrayOrderingSrv;
   $scope.searchForm = searchService;
-
-  if ($rootScope.ticket) {
-    $rootScope.fullUsername = $rootScope.ticket.principal;
-    $rootScope.truncatedUsername = $rootScope.ticket.principal;
-  }
-
-  var MAX_USERNAME_LENGTH=16;
 
   angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
@@ -88,21 +80,7 @@ angular.module('zeppelinWebApp')
     vm.connected = param;
   });
 
-  $scope.checkUsername = function () {
-    if ($rootScope.ticket) {
-      if ($rootScope.ticket.principal.length <= MAX_USERNAME_LENGTH) {
-        $rootScope.truncatedUsername = $rootScope.ticket.principal;
-      } else {
-        $rootScope.truncatedUsername = $rootScope.ticket.principal.substr(0, MAX_USERNAME_LENGTH) + '..';
-      }
-    }
-    if (_.isEmpty($rootScope.truncatedUsername)) {
-      $rootScope.truncatedUsername = 'Connected';
-    }
-  };
-
   $scope.$on('loginSuccess', function(event, param) {
-    $scope.checkUsername();
     loadNotes();
   });
 
@@ -159,6 +137,5 @@ angular.module('zeppelinWebApp')
 
   getZeppelinVersion();
   vm.loadNotes();
-  $scope.checkUsername();
 
 });

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -76,7 +76,7 @@ angular.module('zeppelinWebApp')
     $rootScope.truncatedUsername = $rootScope.ticket.principal;
   }
 
-  var MAX_USERNAME_LENGTH=16;
+  var MAX_USERNAME_LENGTH=20;
 
   angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -81,18 +81,26 @@ limitations under the License.
             </div>
           </form>
         <li class="nav-component">
+          <i ng-if="navbar.connected" class="fa fa-circle server-connected"
+             tooltip="WebSocket Connected" tooltip-placement="bottom"></i>
+          <i ng-if="!navbar.connected" class="fa fa-circle server-disconnected"
+             tooltip="WebSocket Disconnected" tooltip-placement="bottom"></i>
+        </li>
+        <li>
           <div class="dropdown">
-            <button class="btn dropdown-toggle username" type="button" data-toggle="dropdown" style="margin-right: 5px;"
-                    ng-class="{'nav-status-btn': !ticket.principal || ticket.principal === 'anonymous',
-                             'nav-btn': ticket.principal && ticket.principal !== 'anonymous'}">
-              <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-              <span ng-show="navbar.connected" ng-if="!ticket.principal || ticket.principal === 'anonymous'">Connected</span>
-              <span ng-show="navbar.connected" ng-if="ticket.principal && ticket.principal !== 'anonymous'">{{ticket.principal}}</span>
-              <span ng-show="!navbar.connected">Disconnected</span>
-              <span class="caret" ng-if="ticket.principal && ticket.principal !== 'anonymous'"></span>
+            <button ng-if="ticket" class="nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin:11px 5px 0 0;">
+              <span class="username">{{ticket.principal}}</span>
+              <span class="caret" style="margin-bottom: 8px"></span>
             </button>
-            <ul class="dropdown-menu" ng-if="ticket.principal && ticket.principal !== 'anonymous'">
-              <li><a ng-click="logout()">Logout</a></li>
+            <span ng-if="!ticket" style="margin: 5px;"></span>
+            <ul class="dropdown-menu">
+              <li><a href="" data-toggle="modal" data-target="#aboutModal">About Zeppelin</a>
+              <li role="separator" style="margin: 5px 0;" class="divider"></li>
+              <li><a href="#/interpreter">Interpreter</a></li>
+              <li><a href="#/credential">Credential</a></li>
+              <li><a href="#/configuration">Configuration</a></li>
+              <li ng-if="ticket.principal && ticket.principal !== 'anonymous'" role="separator" style="margin: 5px 0;" class="divider"></li>
+              <li ng-if="ticket.principal && ticket.principal !== 'anonymous'"><a ng-click="logout()">Logout</a></li>
             </ul>
           </div>
         </li>
@@ -100,20 +108,6 @@ limitations under the License.
           <button class="btn nav-login-btn" data-toggle="modal" data-target="#loginModal"
                   ng-click="showLoginWindow()">Login
           </button>
-        </li>
-        <li class="nav-component" ng-if="ticket">
-          <div class="dropdown">
-            <button class="btn nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;">
-              <i class="fa fa-cog"></i>
-            </button>
-            <ul class="dropdown-menu">
-              <li><a href="#/interpreter">Interpreter</a></li>
-              <li><a href="#/credential">Credential</a></li>
-              <li><a href="#/configuration">Configuration</a></li>
-              <li role="separator" class="divider"></li>
-              <li><a href="" data-toggle="modal" data-target="#aboutModal">About</a>
-            </ul>
-          </div>
         </li>
       </ul>
     </div>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -86,16 +86,12 @@ limitations under the License.
                     ng-class="{'nav-status-btn': !ticket.principal || ticket.principal === 'anonymous',
                              'nav-btn': ticket.principal && ticket.principal !== 'anonymous'}">
               <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-              <span ng-show="navbar.connected" ng-if="ticket.principal === 'anonymous'">Connected</span>
-              <span ng-show="navbar.connected" ng-if="ticket.principal !== 'anonymous'">{{truncatedUsername}}</span>
+              <span ng-show="navbar.connected" ng-if="!ticket.principal || ticket.principal === 'anonymous'">Connected</span>
+              <span ng-show="navbar.connected" ng-if="ticket.principal && ticket.principal !== 'anonymous'">{{ticket.principal}}</span>
               <span ng-show="!navbar.connected">Disconnected</span>
               <span class="caret" ng-if="ticket.principal && ticket.principal !== 'anonymous'"></span>
             </button>
             <ul class="dropdown-menu" ng-if="ticket.principal && ticket.principal !== 'anonymous'">
-              <li class="dropdown-header">
-                <strong>{{ticket.principal}}</strong>
-              </li>
-              <li role="separator" class="divider"></li>
               <li><a ng-click="logout()">Logout</a></li>
             </ul>
           </div>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -82,29 +82,21 @@ limitations under the License.
           </form>
         <li class="nav-component">
           <div class="dropdown">
-            <button class="btn nav-config-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;">
+            <button class="btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;"
+                    ng-class="{'nav-status-btn': !ticket.principal || ticket.principal === 'anonymous',
+                             'nav-btn': ticket.principal && ticket.principal !== 'anonymous'}">
               <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
               <span ng-show="navbar.connected" ng-if="ticket.principal === 'anonymous'">Connected</span>
               <span ng-show="navbar.connected" ng-if="ticket.principal !== 'anonymous'">{{truncatedUsername}}</span>
               <span ng-show="!navbar.connected">Disconnected</span>
-              <span class="caret"></span>
+              <span class="caret" ng-if="ticket.principal && ticket.principal !== 'anonymous'"></span>
             </button>
-            <ul class="dropdown-menu">
-              <li><a href="" data-toggle="modal" data-target="#aboutModal">
-                <i class="fa fa-info"></i>&nbsp;&nbsp;About</a>
+            <ul class="dropdown-menu" ng-if="ticket.principal && ticket.principal !== 'anonymous'">
+              <li class="dropdown-header">
+                <strong>{{ticket.principal}}</strong>
               </li>
-              <li ng-if="ticket">
-                <a href="#/interpreter">Interpreter</a>
-              </li>
-              <li ng-if="ticket">
-                <a href="#/credential">Credential</a>
-              </li>
-              <li ng-if="ticket">
-                <a href="#/configuration">Configuration</a>
-              </li>
-              <li ng-show="ticket.principal && ticket.principal!='anonymous'">
-                <a ng-click="logout()">Logout</a>
-              </li>
+              <li role="separator" class="divider"></li>
+              <li><a ng-click="logout()">Logout</a></li>
             </ul>
           </div>
         </li>
@@ -112,6 +104,20 @@ limitations under the License.
           <button class="btn nav-login-btn" data-toggle="modal" data-target="#loginModal"
                   ng-click="showLoginWindow()">Login
           </button>
+        </li>
+        <li class="nav-component" ng-if="ticket">
+          <div class="dropdown">
+            <button class="btn nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;">
+              <i class="fa fa-cog"></i>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="#/interpreter">Interpreter</a></li>
+              <li><a href="#/credential">Credential</a></li>
+              <li><a href="#/configuration">Configuration</a></li>
+              <li role="separator" class="divider"></li>
+              <li><a href="" data-toggle="modal" data-target="#aboutModal">About</a>
+            </ul>
+          </div>
         </li>
       </ul>
     </div>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -82,7 +82,7 @@ limitations under the License.
           </form>
         <li class="nav-component">
           <div class="dropdown">
-            <button class="btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;"
+            <button class="btn dropdown-toggle username" type="button" data-toggle="dropdown" style="margin-right: 5px;"
                     ng-class="{'nav-status-btn': !ticket.principal || ticket.principal === 'anonymous',
                              'nav-btn': ticket.principal && ticket.principal !== 'anonymous'}">
               <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -44,24 +44,15 @@ limitations under the License.
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
-              <li ng-repeat="note in navbar.notes.root.children |notebookFilter:query track by $index" ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'notebook_list_renderer.html'"></li>
+              <li ng-repeat="note in navbar.notes.root.children |notebookFilter:query track by $index"
+                  ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'notebook_list_renderer.html'"></li>
             </div>
           </ul>
         </li>
-        <li>
-          <a href="#/interpreter">Interpreter</a>
-        </li>
-        <li>
-          <a href="#/credential">Credential</a>
-        </li>
-        <li>
-          <a href="#/configuration">Configuration</a>
-        </li>
       </ul>
 
-
       <ul class="nav navbar-nav navbar-right" style="margin-right:5px;">
-        <li ng-if="ticket" style="margin-top:10px;">
+        <li class="nav-component" ng-if="ticket">
         <!--TODO(bzz): move to Typeahead https://angular-ui.github.io/bootstrap  -->
 
           <form role="search" data-ng-model="searchForm"
@@ -89,43 +80,39 @@ limitations under the License.
               </span>
             </div>
           </form>
+        <li class="nav-component">
+          <div class="dropdown">
+            <button class="btn nav-config-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin-right: 5px;">
+              <i class="fa fa-circle" ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
+              <span ng-show="navbar.connected" ng-if="ticket.principal === 'anonymous'">Connected</span>
+              <span ng-show="navbar.connected" ng-if="ticket.principal !== 'anonymous'">{{truncatedUsername}}</span>
+              <span ng-show="!navbar.connected">Disconnected</span>
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <li><a href="" data-toggle="modal" data-target="#aboutModal">
+                <i class="fa fa-info"></i>&nbsp;&nbsp;About</a>
+              </li>
+              <li ng-if="ticket">
+                <a href="#/interpreter">Interpreter</a>
+              </li>
+              <li ng-if="ticket">
+                <a href="#/credential">Credential</a>
+              </li>
+              <li ng-if="ticket">
+                <a href="#/configuration">Configuration</a>
+              </li>
+              <li ng-show="ticket.principal && ticket.principal!='anonymous'">
+                <a ng-click="logout()">Logout</a>
+              </li>
+            </ul>
+          </div>
         </li>
-        <li class="dropdown " dropdown="">
-          <a class="dropdown-toggle" type="button" data-toggle="dropdown" href="#"
-             ng-show="navbar.connected" ng-if="ticket.principal == 'anonymous' ">
-            <i class="fa fa-circle server-status"
-               ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-            Connected
-            <span class="caret"></span>
-          </a>
-          <a class="dropdown-toggle" type="button" data-toggle="dropdown" href="#"
-             ng-show="navbar.connected" ng-if="ticket.principal != 'anonymous' "
-             tooltip-placement="bottom" tooltip="{{fullUsername}}">
-            <i class="fa fa-circle server-status"
-               ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-            {{truncatedUsername}}
-            <span class="caret"></span></a>
-          <a class="dropdown-toggle" type="button" data-toggle="dropdown" href="#"
-             ng-show="!navbar.connected">
-            <i class="fa fa-circle server-status"
-               ng-class="{'server-connected':navbar.connected, 'server-disconnected':!navbar.connected}"></i>
-            Disconnected
-            <span class="caret"></span></a>
-
-          <ul class="dropdown-menu">
-            <li><a href="" data-toggle="modal" data-target="#aboutModal">
-              <i style="font-size: 15px;" class="fa fa-info"></i> About</a></li>
-            <li ng-show="ticket.principal && ticket.principal!='anonymous'" style="left: 5px;">
-              <a ng-click="logout()">Logout</a>
-            </li>
-          </ul>
-        </li>
-        <li ng-if="!ticket">
-          <button class="btn btn-default" data-toggle="modal" data-target="#loginModal"
-                  ng-click="showLoginWindow()" style="margin-top: 8px">Login
+        <li class="nav-component" ng-if="!ticket">
+          <button class="btn nav-login-btn" data-toggle="modal" data-target="#loginModal"
+                  ng-click="showLoginWindow()">Login
           </button>
         </li>
-
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## What is this PR for?
- Move configuration menus under dropdown menu
- Change dropdown menu style
- Change `Login` button style

### What type of PR is it?
Improvement

### Todos
- [x] Fix selenium test

### What is the Jira issue?
[ZEPPELIN-1002](https://issues.apache.org/jira/browse/ZEPPELIN-1002)

### Screenshots (if appropriate)
#### As anonymous
Before
<img width="1280" alt="screen shot 2016-06-14 at 9 43 35 pm" src="https://cloud.githubusercontent.com/assets/8503346/16068223/19a73576-3279-11e6-81bd-04b4277ccc50.png">

After
<img width="1280" alt="screen shot 2016-06-16 at 10 15 21 am" src="https://cloud.githubusercontent.com/assets/8503346/16126059/57461b94-33ab-11e6-937e-b6195839c8fa.png">

#### With shiro authc
Before
<img width="1280" alt="screen shot 2016-06-16 at 10 18 45 am" src="https://cloud.githubusercontent.com/assets/8503346/16126145/c6a2f49e-33ab-11e6-83a8-3ee4bb62be56.png">
<img width="1280" alt="screen shot 2016-06-16 at 10 21 52 am" src="https://cloud.githubusercontent.com/assets/8503346/16126253/2d90387e-33ac-11e6-9fa4-93aac98c6a76.png">

After
<img width="1280" alt="screen shot 2016-06-16 at 10 17 46 am" src="https://cloud.githubusercontent.com/assets/8503346/16126120/ac8c5866-33ab-11e6-8e43-47a69b0587ef.png">
<img width="1280" alt="screen shot 2016-06-20 at 11 30 04 am" src="https://cloud.githubusercontent.com/assets/8503346/16205804/6afd3474-36da-11e6-8b2e-bd2b22a5c7c9.png">

<img width="1280" alt="screen shot 2016-06-16 at 10 20 15 am" src="https://cloud.githubusercontent.com/assets/8503346/16126258/34bec64c-33ac-11e6-8392-c16c3380bac0.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? It needs image updates
