### PR TITLE
Blocking the zeppelin-web build error.

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -36,9 +36,6 @@
     "angular-mocks": "1.5.0"
   },
   "appPath": "src",
-  "resolutions": {
-    "perfect-scrollbar": "~0.5.4"
-  },
   "overrides": {
     "ace-builds": {
       "main": [

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "zeppelin-web",
+  "license": "Apache-2.0",
   "version": "0.0.0",
   "dependencies": {
     "grunt-angular-templates": "^0.5.7",


### PR DESCRIPTION
### What is this PR for?
This PR is for blocking unnecessary zeppelin-web build errors.
```
[ERROR] npm WARN package.json zeppelin-web@0.0.0 No license field.
[ERROR] bower perfect-scrollbar extra-resolution Unnecessary resolution: perfect-scrollbar#~0.5.4
```

### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1014


### How should this be tested?
You can run ```mvn clean package -DskipTests``` in the zeppelin-web folder.


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

