### PR TITLE
[ZEPPELIN-1015] Cron job fails to run a paragraph when multiple type of interpreter is being used

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -428,6 +428,22 @@ public class Note implements Serializable, JobListener {
     }
   }
 
+  /**
+   * Check whether all paragraphs belongs to this note has terminated
+   * @return
+   */
+  public boolean isTerminated() {
+    synchronized (paragraphs) {
+      for (Paragraph p : paragraphs) {
+        if (!p.isTerminated()) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
   public List<InterpreterCompletion> completion(String paragraphId, String buffer, int cursor) {
     Paragraph p = getParagraph(paragraphId);
     p.setNoteReplLoader(replLoader);
@@ -561,5 +577,4 @@ public class Note implements Serializable, JobListener {
 
   @Override
   public void onProgressUpdate(Job job, int progress) {}
-
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -634,7 +634,7 @@ public class Notebook {
       Note note = notebook.getNote(noteId);
       note.runAll();
     
-      while (!note.getLastParagraph().isTerminated()) {
+      while (!note.isTerminated()) {
         try {
           Thread.sleep(1000);
         } catch (InterruptedException e) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter1.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter1.java
@@ -35,13 +35,22 @@ public class MockInterpreter1 extends Interpreter{
 	public MockInterpreter1(Properties property) {
 		super(property);
 	}
+	boolean open;
+
 
 	@Override
 	public void open() {
+		open = true;
 	}
 
 	@Override
 	public void close() {
+		open = false;
+	}
+
+
+	public boolean isOpen() {
+		return open;
 	}
 
 	@Override
@@ -51,6 +60,13 @@ public class MockInterpreter1 extends Interpreter{
 		if ("getId".equals(st)) {
 			// get unique id of this interpreter instance
 			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "" + this.hashCode());
+		} else if (st.startsWith("sleep")) {
+			try {
+				Thread.sleep(Integer.parseInt(st.split(" ")[1]));
+			} catch (InterruptedException e) {
+				// nothing to do
+			}
+			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "repl1: " + st);
 		} else {
 			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "repl1: " + st);
 		}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter2.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter2.java
@@ -36,13 +36,22 @@ public class MockInterpreter2 extends Interpreter{
 		super(property);
 	}
 
+	boolean open;
+
 	@Override
 	public void open() {
+		open = true;
 	}
 
 	@Override
 	public void close() {
+		open = false;
 	}
+
+	public boolean isOpen() {
+		return open;
+	}
+
 
 	@Override
 	public InterpreterResult interpret(String st, InterpreterContext context) {
@@ -51,6 +60,13 @@ public class MockInterpreter2 extends Interpreter{
 		if ("getId".equals(st)) {
 			// get unique id of this interpreter instance
 			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "" + this.hashCode());
+		} else if (st.startsWith("sleep")) {
+			try {
+				Thread.sleep(Integer.parseInt(st.split(" ")[1]));
+			} catch (InterruptedException e) {
+				// nothing to do
+			}
+			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "repl2: " + st);
 		} else {
 			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "repl2: " + st);
 		}


### PR DESCRIPTION
### What is this PR for?
Cron job can fail when notebook uses multiple types of paragraphs.
Problem reported here http://apache-zeppelin-users-incubating-mailing-list.75479.x6.nabble.com/Cron-job-fails-to-run-a-paragraph-that-runs-correctly-manually-tt2265.html

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix
* [x] - Unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1015

### How should this be tested?
Create two paragraphs in the notebook
First takes longer than second (last) paragraph.
First paragraph and second paragraph should use different interpreter.

If cron schedule the notebook with 'auto-restart interpreter on cron execution' checked.
Then interpreters will be restarted when second paragraph finished, but first paragraph is still running.
That may cause abort of first paragraph run.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
