### PR TITLE
Add force layout visualization in paragraphs for SQL queries

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -165,10 +165,10 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
       }
 
       WebElement paragraph1Result = driver.findElement(By.xpath(
-          getParagraphXPath(1) + "//div[@class=\"tableDisplay\"]"));
+          getParagraphXPath(1) + "//div[@class=\"tableDisplay\"]//table"));
       collector.checkThat("Paragraph from SparkParagraphIT of testSqlSpark result: ",
-          paragraph1Result.getText().toString(), CoreMatchers.equalTo("age\njob\nmarital\neducation\nbalance\n30" +
-                      " unemployed married primary 1,787\nage\njob\nmarital\neducation\nbalance"));
+          paragraph1Result.getText().toString(), CoreMatchers.equalTo("age\njob\nmarital\neducation\nbalance\n" +
+          "30 unemployed married primary 1,787"));
     } catch (Exception e) {
       handleException("Exception in SparkParagraphIT while testSqlSpark", e);
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -40,6 +40,10 @@ limitations under the License.
             ng-class="{'active': isGraphMode('scatterChart')}"
             ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
     </button>
+    <button type="button" class="btn btn-default btn-sm"
+            ng-class="{'active': isGraphMode('forceLayout')}"
+            ng-click="setGraphMode('forceLayout', true)"><i class="fa fa-share-alt"></i>
+    </button>
   </div>
   <span class="btn-group">
     <button type="button" class="btn btn-default btn-sm"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -41,11 +41,22 @@ limitations under the License.
             ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
     </button>
   </div>
-  <span>
-    <button type="button" class="btn btn-default btn-sm" style="margin-left:10px"
-            tooltip="Download Data as TSV" tooltip-placement="bottom"
-            ng-click="exportToTSV()"><i class="fa fa-download"></i>
+  <span class="btn-group">
+    <button type="button" class="btn btn-default btn-sm"
+            style="margin-left:10px"
+            ng-click="exportToDSV(',')"
+            tooltip="Download Data as CSV" tooltip-placement="bottom">
+      <i class="fa fa-download"></i>
     </button>
+    <button type="button" class="btn btn-default btn-sm dropdown-toggle caretBtn"
+            data-toggle="dropdown">
+      <span class="caret" style="margin: 0px;"></span>
+      <span class="sr-only">Toggle Dropdown</span>
+    </button>
+    <ul class="dropdown-menu" role="menu" style="min-width: 70px;">
+      <li ng-click="exportToDSV(',')"><a>CSV</a></li>
+      <li ng-click="exportToDSV('\t')"><a>TSV</a></li>
+    </ul>
   </span>
   <span ng-if="getGraphMode()!='table'"
         style="margin-left:5px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
@@ -51,4 +51,10 @@ limitations under the License.
        id="p{{paragraph.id}}_scatterChart">
     <svg></svg>
   </div>
+
+  <div ng-if="getGraphMode()=='forceLayout'"
+       id="p{{paragraph.id}}_forceLayout"
+       class="forceLayout">
+    <svg></svg>
+  </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
@@ -32,7 +32,7 @@ limitations under the License.
     </ul>
   </div>
 
-  <div class="row" ng-if="getGraphMode()!='scatterChart'">
+  <div class="row" ng-if="getGraphMode()!='scatterChart' && getGraphMode()!='forceLayout'">
     <div class="col-md-4">
       <span class="columns lightBold">
         Keys
@@ -163,6 +163,73 @@ limitations under the License.
           </li>
         </ul>
       </span>
+    </div>
+  </div>
+
+  <div class="row" ng-if="getGraphMode()=='forceLayout'">
+    <div class="col-md-3">
+    <span class="columns lightBold">
+      Source
+      <ul data-drop="true"
+          ng-model="paragraph.config.graph.forceLayout.source"
+          jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+          class="list-unstyled"
+          style="height:36px">
+        <li ng-if="paragraph.config.graph.forceLayout.source">
+          <div class="btn btn-primary btn-xs">
+            {{paragraph.config.graph.forceLayout.source.name}} <span class="fa fa-close" ng-click="removeForceLayoutOptionSource($index)"></span>
+          </div>
+        </li>
+      </ul>
+    </span>
+    </div>
+    <div class="col-md-3">
+    <span class="columns lightBold">
+      Source Group
+      <ul data-drop="true"
+          ng-model="paragraph.config.graph.forceLayout.sourceGroup"
+          jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+          class="list-unstyled"
+          style="height:36px">
+        <li ng-if="paragraph.config.graph.forceLayout.sourceGroup">
+          <div class="btn btn-success btn-xs">
+            {{paragraph.config.graph.forceLayout.sourceGroup.name}} <span class="fa fa-close" ng-click="removeForceLayoutOptionSourceGroup($index)"></span>
+          </div>
+        </li>
+      </ul>
+    </span>
+    </div>
+    <div class="col-md-3">
+    <span class="columns lightBold">
+      Destination
+      <ul data-drop="true"
+          ng-model="paragraph.config.graph.forceLayout.dest"
+          jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+          class="list-unstyled"
+          style="height:36px">
+        <li ng-if="paragraph.config.graph.forceLayout.dest">
+          <div class="btn btn-info btn-xs">
+            {{paragraph.config.graph.forceLayout.dest.name}} <span class="fa fa-close" ng-click="removeForceLayoutOptionDest($index)"></span>
+          </div>
+        </li>
+      </ul>
+    </span>
+    </div>
+    <div class="col-md-3">
+    <span class="columns lightBold">
+      Destination Group
+      <ul data-drop="true"
+          ng-model="paragraph.config.graph.forceLayout.destGroup"
+          jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+          class="list-unstyled"
+          style="height:36px">
+        <li ng-if="paragraph.config.graph.forceLayout.destGroup">
+          <div class="btn btn-warning btn-xs">
+            {{paragraph.config.graph.forceLayout.destGroup.name}} <span class="fa fa-close" ng-click="removeForceLayoutOptionDestGroup($index)"></span>
+          </div>
+        </li>
+      </ul>
+    </span>
     </div>
   </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1313,7 +1313,7 @@ angular.module('zeppelinWebApp')
   };
 
   var setD3Chart = function(type, data, refresh) {
-    if (!$scope.chart[type]) {
+    if (!$scope.chart[type] && type !== 'forceLayout') {
       var chart = nv.models[type]();
       $scope.chart[type] = chart;
     }
@@ -1346,6 +1346,8 @@ angular.module('zeppelinWebApp')
       $scope.chart[type].showDistX(true)
         .showDistY(true);
       //handle the problem of tooltip not showing when muliple points have same value.
+    } else if (type === 'forceLayout') {
+      var forceLayoutData = setForceLayoutData(data, 1000);
     } else {
       var p = pivot(data);
       if (type === 'pieChart') {
@@ -1413,10 +1415,139 @@ angular.module('zeppelinWebApp')
       nv.utils.windowResize($scope.chart[type].update);
     };
 
+    var renderForceLayout = function() {
+      var color = d3.scale.category10();
+      var r = 5;
+      var margin = {top: -5, right: -5, bottom: -5, left: -5};
+      var height = $scope.paragraph.config.graph.height;
+      var width = angular.element('#p' + $scope.paragraph.id + '_' + 'resize').width();
+
+      function zoomed() {
+        container.attr('transform', 'translate(' + d3.event.translate + ')scale(' + d3.event.scale + ')');
+      }
+
+      function dragstarted(d) {
+        d3.event.sourceEvent.stopPropagation();
+        /*jshint validthis:true */
+        d3.select(this).classed('dragging', true);
+        force.start();
+      }
+
+      function dragged(d) {
+        /*jshint validthis:true */
+        d3.select(this).attr('cx', d.x = d3.event.x).attr('cy', d.y = d3.event.y);
+      }
+
+      function dragended(d) {
+        /*jshint validthis:true */
+        d3.select(this).classed('dragging', false);
+      }
+
+      d3.select('#p' + $scope.paragraph.id + '_' + type + ' svg g').remove();
+      d3.select('#p' + $scope.paragraph.id + '_' + type + ' div.tooltip').remove();
+
+      if (forceLayoutData) {
+        var force = d3.layout.force()
+          .charge(-120)
+          .linkDistance(30)
+          .size([width, height]);
+
+        var zoom = d3.behavior.zoom()
+          .scaleExtent([0, 10])
+          .on('zoom', zoomed);
+
+        var drag = d3.behavior.drag()
+          .origin(function(d) { return d; })
+          .on('dragstart', dragstarted)
+          .on('drag', dragged)
+          .on('dragend', dragended);
+
+        var svg = d3.select('#p' + $scope.paragraph.id + '_' + type + ' svg')
+          .attr('width', width)
+          .attr('height', height)
+          .append('g')
+          .attr('transform', 'translate(' + margin.left + ',' + margin.right + ')')
+          .call(zoom);
+
+        var tooltip = d3.select('#p' + $scope.paragraph.id + '_' + type).append('div')
+          .attr('class', 'tooltip')
+          .style('opacity', 0);
+
+        var rect = svg.append('rect')
+          .attr('width', width)
+          .attr('height', height)
+          .style('fill', 'none')
+          .style('pointer-events', 'all');
+
+        var container = svg.append('g')
+          .attr('class', 'container');
+
+        force.nodes(forceLayoutData.nodes)
+          .links(forceLayoutData.links)
+          .start();
+
+        var link = container.append('g')
+          .attr('class', 'links')
+          .selectAll('.link')
+          .data(forceLayoutData.links)
+          .enter().append('line')
+          .attr('class', 'link')
+          .style('stroke-width', function(d) { return Math.sqrt(d.value); });
+
+        var node = container.append('g')
+          .attr('class', 'nodes')
+          .selectAll('.node')
+          .data(forceLayoutData.nodes)
+          .enter().append('g')
+          .attr('class', 'node')
+          .attr('cx', function(d) { return d.x; })
+          .attr('cy', function(d) { return d.y; })
+          .call(drag);
+
+        node.append('circle')
+          .attr('r', r)
+          .style('fill', function(d) { return color(d.group); });
+
+        node.on('mouseover', function(d) {
+          console.log(d.group);
+          var offsetX = d3.transform(container.attr('transform')).translate[0];
+          var offsetY = d3.transform(container.attr('transform')).translate[1];
+          var scale = d3.transform(container.attr('transform')).scale[0];
+          tooltip.transition()
+            .duration(200)
+            .style('opacity', 0.9);
+          tooltip.html('<strong>name: <span class=\'tooltip-text\'>' + d.name + '</span><br>' +
+                       'group: <span class=\'tooltip-text\'>' + d.group + '</span></strong>')
+            .style('left', (d.px*scale + offsetX + 15) + 'px')
+            .style('top', (d.py*scale + offsetY - 18) + 'px');
+        })
+        .on('mouseout', function(d) {
+          tooltip.transition()
+            .duration(200)
+            .style('opacity', 0);
+        });
+
+        force.on('tick', function() {
+          link.attr('x1', function(d) { return d.source.x; })
+              .attr('y1', function(d) { return d.source.y; })
+              .attr('x2', function(d) { return d.target.x; })
+              .attr('y2', function(d) { return d.target.y; });
+
+          node.attr('transform', function(d) { return 'translate(' + d.x + ',' + d.y + ')'; });
+        });
+      } else {
+        throw new Error('No data available');
+      }
+    };
+
     var retryRenderer = function() {
       if (angular.element('#p' + $scope.paragraph.id + '_' + type + ' svg').length !== 0) {
         try {
-          renderChart();
+          if (type !== 'forceLayout') {
+            renderChart();
+          } else {
+            renderForceLayout();
+          }
         } catch(err) {
           console.log('Chart drawing error %o', err);
         }
@@ -1485,6 +1616,30 @@ angular.module('zeppelinWebApp')
 
   $scope.removeScatterOptionSize = function(idx) {
     $scope.paragraph.config.graph.scatter.size = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeForceLayoutOptionSource = function(idx) {
+    $scope.paragraph.config.graph.forceLayout.source = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeForceLayoutOptionSourceGroup = function(idx) {
+    $scope.paragraph.config.graph.forceLayout.sourceGroup = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeForceLayoutOptionDest = function(idx) {
+    $scope.paragraph.config.graph.forceLayout.dest = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeForceLayoutOptionDestGroup = function(idx) {
+    $scope.paragraph.config.graph.forceLayout.destGroup = null;
     clearUnknownColsFromGraphOption();
     $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
   };
@@ -2020,6 +2175,38 @@ angular.module('zeppelinWebApp')
       yLabels : colIndexValue,
       d3g : d3g
     };
+  };
+
+  var setForceLayoutData = function(data, limit) {
+    try {
+      var source = $scope.paragraph.config.graph.forceLayout.source;
+      var dest = $scope.paragraph.config.graph.forceLayout.dest;
+      var sourceGroup = $scope.paragraph.config.graph.forceLayout.sourceGroup;
+      var destGroup = $scope.paragraph.config.graph.forceLayout.destGroup;
+      var nodes = [];
+      var links = [];
+      var nodesMap = {};
+      angular.forEach(data.rows, function(row, index) {
+        if (index < limit) {
+          if (!(row[source.index] in nodesMap)) {
+            nodesMap[row[source.index]] = nodes.length;
+            nodes.push({ name: row[source.index], group: row[sourceGroup.index]});
+          }
+          if (!(row[dest.index] in nodesMap)) {
+            nodesMap[row[dest.index]] = nodes.length;
+            nodes.push({ name: row[dest.index], group: row[destGroup.index]});
+          }
+        }
+      });
+      angular.forEach(data.rows, function(row, index) {
+        if (index < limit) {
+          links.push({ source: nodesMap[row[source.index]], target: nodesMap[row[dest.index]], value: 1 });
+        }
+      });
+      return { nodes: nodes, links: links };
+    } catch(e) {
+      console.log(e.name + ': ' + e.message);
+    }
   };
 
   var isDiscrete = function(field) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2153,21 +2153,27 @@ angular.module('zeppelinWebApp')
     $scope.keepScrollDown = false;
   };
 
-  $scope.exportToTSV = function () {
+  $scope.exportToDSV = function (delimiter) {
     var data = $scope.paragraph.result;
-    var tsv = '';
+    var dsv = '';
     for (var titleIndex in $scope.paragraph.result.columnNames) {
-      tsv += $scope.paragraph.result.columnNames[titleIndex].name + '\t';
+      dsv += $scope.paragraph.result.columnNames[titleIndex].name + delimiter;
     }
-    tsv = tsv.substring(0, tsv.length - 1) + '\n';
+    dsv = dsv.substring(0, dsv.length - 1) + '\n';
     for (var r in $scope.paragraph.result.msgTable) {
       var row = $scope.paragraph.result.msgTable[r];
-      var tsvRow = '';
+      var dsvRow = '';
       for (var index in row) {
-        tsvRow += row[index].value + '\t';
+        dsvRow += row[index].value + delimiter;
       }
-      tsv += tsvRow.substring(0, tsvRow.length - 1) + '\n';
+      dsv += dsvRow.substring(0, dsvRow.length - 1) + '\n';
     }
-    SaveAsService.SaveAs(tsv, 'data', 'tsv');
+    var extension = '';
+    if (delimiter === '\t') {
+      extension = 'tsv';
+    } else if (delimiter === ',') {
+      extension = 'csv';
+    }
+    SaveAsService.SaveAs(dsv, 'data', extension);
   };
 });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -449,10 +449,6 @@ table.dataTable.table-condensed .sorting_desc:after {
   font-weight: 500;
 }
 
-.dropdown-menu > li:first-child > a:hover {
-  background-color: transparent;
-}
-
 table.table-striped {
   border-top: 1px solid #ddd;
   margin-top: 20px;
@@ -464,10 +460,16 @@ table.table-striped {
   cursor: pointer;
 }
 
-
 .scroll-paragraph-up {
   bottom: 5px;
   cursor: pointer;
   position: absolute;
   right: 15px;
+}
+
+/* DSV download toggle button */
+.caretBtn {
+  padding-right: 4px !important;
+  padding-left: 4px !important;
+  width: 20px;
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -473,3 +473,45 @@ table.table-striped {
   padding-left: 4px !important;
   width: 20px;
 }
+
+/*
+  Force Layout CSS
+*/
+
+.node {
+        stroke: #999;
+        stroke-width: 1.5px;
+    }
+
+.link {
+    stroke: #999;
+    stroke-opacity: .6;
+}
+
+.forceLayout div.tooltip {
+    position: absolute;
+    text-align: center;
+    width: auto;
+    padding: 4px 6px 4px 6px;
+    font: 12px sans-serif;
+    background: rgba(0, 0, 0, 0.75);
+    color: white;
+    border: 0px;
+    border-radius: 4px;
+    pointer-events: none;
+}
+
+.forceLayout div.tooltip:before {
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    border-right: 6px solid rgba(0, 0, 0, 0.75);
+    content: "";
+    position: absolute;
+    z-index: 99;
+    left: -6px;
+    top: 11px;
+}
+
+.forceLayout .tooltip-text {
+    color: orangered;
+}


### PR DESCRIPTION
### What is this PR for?
Add force layout (graph) visualization to the existing set of visualizations in Zeppelin Web notp. 

### What type of PR is it?
[Feature]

### What is the Jira issue?
[ZEPPELIN-1011]

### How should this be tested?
The testes are incorporated within the existing test suite. 

### Screenshots (if appropriate)
![eeffbb58-3238-11e6-92ea-148a4063d353](https://cloud.githubusercontent.com/assets/8441214/16072738/18feac4a-32eb-11e6-8e13-63ff04fa1df0.png)

### Questions:
* Does the licenses files need update?
No.
* Is there breaking changes for older versions?
No.
* Does this needs documentation?
We can add some documentation explaining about the different fields that need to be selected in order to generate the force layout component.