### PR TITLE
[ZEPPELIN-1020] Remove suggestion list on click

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -879,7 +879,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
 
   // function to find suggestion list on change
   $scope.search = function(role) {
-    $('.userlist').show();
+    angular.element('.userlist').show();
     convertToArray(role);
     checkPreviousRole(role);
     getChangedIndex();
@@ -952,7 +952,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
   };
 
 angular.element(document).click(function(){
-     $('.userlist').hide();
+     angular.element('.userlist').hide();
 });
 
 });

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -951,7 +951,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     $scope.suggestions = [];
   };
 
-$(document).click(function(){
+angular.element(document).click(function(){
      $('.userlist').hide();
 });
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -879,6 +879,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
 
   // function to find suggestion list on change
   $scope.search = function(role) {
+    $('.userlist').show();
     convertToArray(role);
     checkPreviousRole(role);
     getChangedIndex();
@@ -950,5 +951,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     $scope.suggestions = [];
   };
 
+$(document).click(function(){
+     $('.userlist').hide();
+});
 
 });


### PR DESCRIPTION
### What is this PR for?
The suggestion list under note permissions for readers, writers & owners should hide on-click anywhere on the notebook.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[ZEPPELIN-1020](https://issues.apache.org/jira/browse/ZEPPELIN-1020)

### How should this be tested?
1.Click on any field for setting permission for owners, readers & writers.
2.The suggestion list is displayed.
3.Now, click on any part of the notebook the suggestion list hides.

### Screenshots (if appropriate)

**BEFORE:**
http://g.recordit.co/7Esaq245Tp.gif

**AFTER**
http://g.recordit.co/Rfgn5dONPz.gif


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

