### PR TITLE
Python: fix for 'run all' paragraphs

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -161,8 +161,8 @@ public class PythonInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetParallelScheduler(
-        PythonInterpreter.class.getName() + this.hashCode(), 10);
+    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
+        PythonInterpreter.class.getName() + this.hashCode());
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
Switch to FIFO scheduler as in current implementation `.interpret()` is not thread-safe and so in parallel one 'Run All' fails some paragraphs with NPE in logs

### What type of PR is it?
Bug Fix | Improvement

### How should this be tested?
'Run All' passes without NPE in logs i.e on this [Zeppelin notebook for python](https://www.zeppelinhub.com/viewer/notebooks/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL2J6ei9pbmN1YmF0b3ItemVwcGVsaW4vMTkyZjU3YjZjMGZkMjc4NzgwZDI3NDAzMGY1YmJlOTZlZThkNzdiYi9ub3RlYm9vay8yQlFBMzVDSlovbm90ZS5qc29u)
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

