### PR TITLE
[MINOR] Changed guava version to 19.0 for selenium test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <log4j.version>1.2.17</log4j.version>
     <libthrift.version>0.9.2</libthrift.version>
     <gson.version>2.2</gson.version>
-    <guava.version>15.0</guava.version>
+    <guava.version>19.0</guava.version>
     <jetty.version>9.2.15.v20160210</jetty.version>
 
     <PermGen>64m</PermGen>


### PR DESCRIPTION
### What is this PR for?
Enable selenium test with SafariDriver.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Upgrade guava version

### What is the Jira issue?
N/A

### How should this be tested?
1. Install selenium driver for Safari
1. Make sure that you don't have firefox installed
1. Start Zeppelin without this patch
1. run a selenium test. `TEST_SELENIUM="true" mvn package -DfailIfNoTests=false -pl 'zeppelin-interpreter,zeppelin-zengine,zeppelin-server' -Dtest=ParagraphActionsIT`
1. Got error
1. Repeat after patch
1. Success

### Screenshots (if appropriate)
Got error like:
```
java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;
	at org.openqa.selenium.safari.WebSocketConnection.send(WebSocketConnection.java:139)
	at org.openqa.selenium.safari.SafariDriverCommandExecutor.execute(SafariDriverCommandExecutor.java:188)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:620)
	at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:247)
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:129)
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:142)
	at org.openqa.selenium.safari.SafariDriver.<init>(SafariDriver.java:62)
	at org.openqa.selenium.safari.SafariDriver.<init>(SafariDriver.java:42)
	at org.apache.zeppelin.WebDriverManager.getWebDriver(WebDriverManager.java:103)
	at org.apache.zeppelin.integration.ParagraphActionsIT.startUp(ParagraphActionsIT.java:51)
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

