### PR TITLE
fix typo the description of interpreter menu.

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -34,7 +34,7 @@ limitations under the License.
     </div>
     <div class="row">
       <div class="col-md-12">
-        Manage interpreters settings. You can create create / remove settings. Note can bind/unbind these interpreter settings.
+        Manage interpreters settings. You can create / edit / remove settings. Note can bind/unbind these interpreter settings.
       </div>
     </div>
 

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -34,7 +34,7 @@ limitations under the License.
     </div>
     <div class="row">
       <div class="col-md-12">
-        Manage interpreters settings. You can create / edit / remove settings. Note can bind/unbind these interpreter settings.
+        Manage interpreters settings. You can create / edit / remove settings. Note can bind / unbind these interpreter settings.
       </div>
     </div>
 


### PR DESCRIPTION
### What is this PR for?
This PR is for fixing typo of the interpreter menu description.


### What type of PR is it?
Bug Fix


### Screenshots (if appropriate)
  - before
 ![image](https://cloud.githubusercontent.com/assets/3348133/16156875/1dba142e-34f1-11e6-937b-c3d2c75a6c42.png)


  - after
![image](https://cloud.githubusercontent.com/assets/3348133/16156901/365979a2-34f1-11e6-91a7-4c99b78a1d86.png)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

