### PR TITLE
[ZEPPELIN-1032] Update Apache Flink to 1.0.3 release

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -35,7 +35,7 @@
   <url>http://zeppelin.apache.org</url>
 
   <properties>
-    <flink.version>1.0.0</flink.version>
+    <flink.version>1.0.3</flink.version>
     <flink.akka.version>2.3.7</flink.akka.version>
     <flink.scala.binary.version>2.10</flink.scala.binary.version>
     <flink.scala.version>2.10.4</flink.scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,17 +19,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.maven-v4_0_0.xsd">
 
-  <!-- Licensed to the Apache Software Foundation (ASF) under one or more
-    contributor license agreements. See the NOTICE file distributed with this
-    work for additional information regarding copyright ownership. The ASF licenses
-    this file to You under the Apache License, Version 2.0 (the "License"); you
-    may not use this file except in compliance with the License. You may obtain
-    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless
-    required by applicable law or agreed to in writing, software distributed
-    under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
-    OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-    the specific language governing permissions and limitations under the License. -->
-
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.zeppelin</groupId>


### PR DESCRIPTION
### What is this PR for?
Update Flink interpreter to use most recent Apache Flink 1.0.3 release


### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-1032](https://issues.apache.org/jira/browse/ZEPPELIN-1032)