### PR TITLE
[ZEPPELIN-1031] Update Elasticsearch to release 2.3.3

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -34,7 +34,7 @@
   <url>http://www.apache.org</url>
 
   <properties>
-    <elasticsearch.version>2.1.0</elasticsearch.version>
+    <elasticsearch.version>2.3.3</elasticsearch.version>
     <guava.version>18.0</guava.version>
     <json-flattener.version>0.1.6</json-flattener.version>
   </properties>


### PR DESCRIPTION
### What is this PR for?
Update ElasticSearch interpreter to use ElasticSearch 2.3.3

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-1031](https://issues.apache.org/jira/browse/ZEPPELIN-1031)