### PR TITLE
[ZEPPELIN-1046] bin/install-interpreter.sh for netinst package

### DIFF
--- a/bin/install-interpreter.sh
+++ b/bin/install-interpreter.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Run Zeppelin 
+#
+
+bin=$(dirname "${BASH_SOURCE-$0}")
+bin=$(cd "${bin}">/dev/null; pwd)
+
+. "${bin}/common.sh"
+
+
+ZEPPELIN_INSTALL_INTERPRETER_MAIN=org.apache.zeppelin.interpreter.install.InstallInterpreter
+
+if [[ -d "${ZEPPELIN_HOME}/zeppelin-server/target/classes" ]]; then
+  ZEPPELIN_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-server/target/classes"
+fi
+addJarInDir "${ZEPPELIN_HOME}/zeppelin-server/target/lib"
+
+if [[ -d "${ZEPPELIN_HOME}/zeppelin-interpreter/target/classes" ]]; then
+  ZEPPELIN_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-interpreter/target/classes"
+fi
+addJarInDir "${ZEPPELIN_HOME}/zeppelin-interpreter/target/lib"
+
+addJarInDir "${ZEPPELIN_HOME}/lib"
+
+CLASSPATH+=":${ZEPPELIN_CLASSPATH}"
+$ZEPPELIN_RUNNER $JAVA_OPTS -cp $CLASSPATH $ZEPPELIN_INSTALL_INTERPRETER_MAIN ${@}

--- a/bin/install-interpreter.sh
+++ b/bin/install-interpreter.sh
@@ -26,9 +26,11 @@ bin=$(cd "${bin}">/dev/null; pwd)
 
 
 ZEPPELIN_INSTALL_INTERPRETER_MAIN=org.apache.zeppelin.interpreter.install.InstallInterpreter
+ZEPPELIN_LOGFILE="${ZEPPELIN_LOG_DIR}/install-interpreter.log"
+JAVA_OPTS+=" -Dzeppelin.log.file=${ZEPPELIN_LOGFILE}"
 
-if [[ -d "${ZEPPELIN_HOME}/zeppelin-server/target/classes" ]]; then
-  ZEPPELIN_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-server/target/classes"
+if [[ -d "${ZEPPELIN_HOME}/zeppelin-zengine/target/classes" ]]; then
+  ZEPPELIN_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-zengine/target/classes"
 fi
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-server/target/lib"
 

--- a/conf/interpreter-list
+++ b/conf/interpreter-list
@@ -17,10 +17,10 @@
 #
 # [name]  [maven artifact]  [description]
 
-alluxio         org.apache.zeppelin.zeppelin-alluxio:0.6.0              Alluxio interpreter
-angular         org.apache.zeppelin.zeppelin-angular:0.6.0              HTML and AngularJS view rendering
-cassandra       org.apache.zeppelin.zeppelin-cassandra:0.6.0            Cassandra interpreter
-elasticsearch   org.apache.zeppelin.zeppelin-elasticsearch:0.6.0        Elasticsearch interpreter
+alluxio         org.apache.zeppelin:zeppelin-alluxio:0.6.0              Alluxio interpreter
+angular         org.apache.zeppelin:zeppelin-angular:0.6.0              HTML and AngularJS view rendering
+cassandra       org.apache.zeppelin:zeppelin-cassandra:0.6.0            Cassandra interpreter
+elasticsearch   org.apache.zeppelin:zeppelin-elasticsearch:0.6.0        Elasticsearch interpreter
 file            org.apache.zeppelin:zeppelin-file:0.6.0                 HDFS file interpreter
 flink           org.apache.zeppelin:zeppelin-flink:0.6.0                Flink interpreter
 hbase           org.apache.zeppelin:zeppelin-hbase:0.6.0                Hbase interpreter

--- a/conf/interpreter-list
+++ b/conf/interpreter-list
@@ -20,7 +20,7 @@
 alluxio         org.apache.zeppelin.zeppelin-alluxio:0.6.0              Alluxio interpreter
 angular         org.apache.zeppelin.zeppelin-angular:0.6.0              HTML and AngularJS view rendering
 cassandra       org.apache.zeppelin.zeppelin-cassandra:0.6.0            Cassandra interpreter
-elasticsearch   org.apache.zeppelin.zeppelin-cassandra:0.6.0            Elasticsearch interpreter
+elasticsearch   org.apache.zeppelin.zeppelin-elasticsearch:0.6.0        Elasticsearch interpreter
 file            org.apache.zeppelin:zeppelin-file:0.6.0                 HDFS file interpreter
 flink           org.apache.zeppelin:zeppelin-flink:0.6.0                Flink interpreter
 hbase           org.apache.zeppelin:zeppelin-hbase:0.6.0                Hbase interpreter

--- a/conf/interpreter-list
+++ b/conf/interpreter-list
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# [name]  [maven artifact]  [description]
+
+alluxio         org.apache.zeppelin.zeppelin-alluxio:0.6.0              Alluxio interpreter
+angular         org.apache.zeppelin.zeppelin-angular:0.6.0              HTML and AngularJS view rendering
+cassandra       org.apache.zeppelin.zeppelin-cassandra:0.6.0            Cassandra interpreter
+elasticsearch   org.apache.zeppelin.zeppelin-cassandra:0.6.0            Elasticsearch interpreter
+file            org.apache.zeppelin:zeppelin-file:0.6.0                 HDFS file interpreter
+flink           org.apache.zeppelin:zeppelin-flink:0.6.0                Flink interpreter
+hbase           org.apache.zeppelin:zeppelin-hbase:0.6.0                Hbase interpreter
+ignite          org.apache.zeppelin:zeppelin-ignite:0.6.0               Ignite interpreter
+jdbc            org.apache.zeppelin:zeppelin-jdbc:0.6.0                 Jdbc interpreter
+kylin           org.apache.zeppelin:zeppelin-kylin:0.6.0                Kylin interpreter
+lens            org.apache.zeppelin:zeppelin-lens:0.6.0                 Lens interpreter
+livy            org.apache.zeppelin:zeppelin-livy:0.6.0                 Livy interpreter
+md              org.apache.zeppelin:zeppelin-markdown:0.6.0             Markdown support
+postgresql      org.apache.zeppelin:zeppelin-postgresql:0.6.0           Postgresql interpreter
+python          org.apache.zeppelin:zeppelin-python:0.6.0               Python interpreter
+shell           org.apache.zeppelin:zeppelin-shell:0.6.0                Shell command
+test1            org.apache.commons:commons-csv:1.1                     test
+test2           org.apache.commons:commons-csv:1.1                      test
+
+
+

--- a/conf/interpreter-list
+++ b/conf/interpreter-list
@@ -33,8 +33,3 @@ md              org.apache.zeppelin:zeppelin-markdown:0.6.0             Markdown
 postgresql      org.apache.zeppelin:zeppelin-postgresql:0.6.0           Postgresql interpreter
 python          org.apache.zeppelin:zeppelin-python:0.6.0               Python interpreter
 shell           org.apache.zeppelin:zeppelin-shell:0.6.0                Shell command
-test1            org.apache.commons:commons-csv:1.1                     test
-test2           org.apache.commons:commons-csv:1.1                      test
-
-
-

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -103,6 +103,7 @@ function make_binary_release() {
 git_clone
 make_source_package
 make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
+make_binary_release netinst "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -pl '!alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -103,7 +103,7 @@ function make_binary_release() {
 git_clone
 make_source_package
 make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
-make_binary_release netinst "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -pl '!alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
+make_binary_release netinst "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -pl !alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -42,6 +42,7 @@
                 <li><a href="{{BASE_PATH}}/manual/interpreters.html">Overview</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Usage</b><span></li>
+                <li><a href="{{BASE_PATH}}/manual/interpreterinstallation.html">Interpreter Installation</a></li>
                 <li><a href="{{BASE_PATH}}/manual/dynamicinterpreterload.html">Dynamic Interpreter Loading</a></li>
                 <li><a href="{{BASE_PATH}}/manual/dependencymanagement.html">Interpreter Dependency Management</a></li>
                 <li role="separator" class="divider"></li>

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -21,7 +21,7 @@
                 <li><a href="{{BASE_PATH}}/index.html">What is Apache Zeppelin ?</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Getting Started</b><span></li>
-                <li><a href="{{BASE_PATH}}/install/install.html">Quick Start</a></li>
+                <li><a href="{{BASE_PATH}}/install/install.html">Install</a></li>
                 <li><a href="{{BASE_PATH}}/install/install.html#zeppelin-configuration">Configuration</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/explorezeppelinui.html">Explore Zeppelin UI</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/tutorial.html">Tutorial</a></li>

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -22,7 +22,7 @@
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Getting Started</b><span></li>
                 <li><a href="{{BASE_PATH}}/install/install.html">Install</a></li>
-                <li><a href="{{BASE_PATH}}/install/install.html#zeppelin-configuration">Configuration</a></li>
+                <li><a href="{{BASE_PATH}}/install/install.html#apache-zeppelin-configuration">Configuration</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/explorezeppelinui.html">Explore Zeppelin UI</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/tutorial.html">Tutorial</a></li>
                 <li role="separator" class="divider"></li>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -19,40 +19,115 @@ limitations under the License.
 -->
 {% include JB/setup %}
 
-## Zeppelin Installation
-Welcome to your first trial to explore Zeppelin!
+# Quick Start
+Welcome to your first trial to explore Apache Zeppelin! 
+This page will help you to get started and here is the list of topics covered.
 
-In this documentation, we will explain how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can see all of Zeppelin's configurations in the [Zeppelin Configuration](install.html#zeppelin-configuration) section below.
+* [Installation](#installation)
+  * [Downloading Binary Package](#downloading-binary-package)
+  * [Building from Source](#building-from-source)
+* [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line)
+  * [Start Zeppelin](#start-zeppelin)
+  * [Stop Zeppelin](#stop-zeppelin)
+  * [(Optional) Start Apache Zeppelin with a service manager](#optional-start-apache-zeppelin-with-a-service-manager)
+* [What is the next?](#what-is-the-next)
+* [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
 
-### Install with Binary Package
+## Installation
 
-If you want to install Zeppelin with latest binary package, please visit [this page](http://zeppelin.apache.org/download.html).
+Apache Zeppelin officially supports and is tested on next environments.
 
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Value</th>
+  </tr>
+  <tr>
+    <td>Oracle JDK</td>
+    <td>1.7 <br /> (set <code>JAVA_HOME</code>)</td>
+  </tr>
+  <tr>
+    <td>OS</td>
+    <td>Mac OSX <br /> Ubuntu 14.X <br /> CentOS 6.X <br /> Windows 7 Pro SP1</td>
+  </tr>
+</table>
+
+There are two options to install Apache Zeppelin on your machine. One is [downloading prebuild binary package](#downloading-binary-package) from the archive. 
+You can download not only the latest stable version but also the older one if you need. 
+The other option is [building from the source](#building-from-source).
+Although it can be unstable somehow since it is on development status, you can explore newly added feature and change it as you want.
+
+### Downloading Binary Package
+
+If you want to install Apache Zeppelin with a stable binary package, please visit [Apache Zeppelin download Page](http://zeppelin.apache.org/download.html). 
 If you have downloaded `netinst` binary, [install additional interpreters](../manual/interpreterinstallation.html) before you start Zeppelin. Or simply run `./bin/install-interpreter.sh --all`.
 
-### Build from Zeppelin Source
+After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
 
-You can also build Zeppelin from the source.
+### Building from Source
+If you want to build from the source, the software below needs to be installed on your system.
 
-#### Prerequisites for build
- * Java 1.7
- * Git
- * Maven(3.1.x or higher)
- * Node.js Package Manager
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Value</th>
+  </tr>
+  <tr>
+    <td>Git</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Maven</td>
+    <td>3.1.x or higher</td>
+  </tr>
+</table>
 
-If you don't have requirements prepared, please check instructions in [README.md](https://github.com/apache/zeppelin/blob/master/README.md) for the details.
+If you don't have it installed yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step instructions from there.
 
+####1. Clone Apache Zeppelin repository
 
+```
+git clone https://github.com/apache/zeppelin.git
+```
 
-Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.
-[Spark Interpreter for Apache Zeppelin](../interpreter/spark.html) will be a good example.
+####2. Build source with options 
+Each interpreters requires different build options. For the further information about options, please see [Build](https://github.com/apache/zeppelin#build) section.
 
-## Zeppelin Start / Stop
+```
+mvn clean package -DskipTests [Options]
+```
+
+Here are some examples with several options
+
+```
+# basic build
+mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark
+
+# spark-cassandra integration
+mvn clean package -Pcassandra-spark-1.5 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
+
+# with CDH
+mvn clean package -Pspark-1.5 -Dhadoop.version=2.6.0-cdh5.5.0 -Phadoop-2.6 -Pvendor-repo -DskipTests
+
+# with MapR
+mvn clean package -Pspark-1.5 -Pmapr50 -DskipTests
+```
+
+For the further information about building with source, please see [README.md](https://github.com/apache/zeppelin/blob/master/README.md) in Zeppelin repository.
+
+## Starting Apache Zeppelin with Command Line
 #### Start Zeppelin
 
 ```
 bin/zeppelin-daemon.sh start
 ```
+
+If you are using Windows 
+
+```
+bin\zeppelin.cmd
+```
+
 After successful start, visit [http://localhost:8080](http://localhost:8080) with your web browser.
 
 #### Stop Zeppelin
@@ -61,21 +136,28 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 bin/zeppelin-daemon.sh stop
 ```
 
-#### Start Zeppelin with a service manager such as upstart
+#### (Optional) Start Apache Zeppelin with a service manager
 
-Zeppelin can auto start as a service with an init script, such as services managed by upstart.
+> **Note :** The below description was written based on Ubuntu Linux.
 
-The following is an example upstart script to be saved as `/etc/init/zeppelin.conf`
-This example has been tested with Ubuntu Linux.
+Apache Zeppelin can be auto started as a service with an init script, such as services managed by **upstart**.
+
+The following is an example of upstart script to be saved as `/etc/init/zeppelin.conf`
 This also allows the service to be managed with commands such as
 
-`sudo service zeppelin start`  
-`sudo service zeppelin stop`  
-`sudo service zeppelin restart`
+```
+sudo service zeppelin start  
+sudo service zeppelin stop  
+sudo service zeppelin restart
+```
 
-Other service managers could use a similar approach with the `upstart` argument passed to the zeppelin-daemon.sh script:  `bin/zeppelin-daemon.sh upstart`
+Other service managers could use a similar approach with the `upstart` argument passed to the `zeppelin-daemon.sh` script.
 
-##### zeppelin.conf
+```
+bin/zeppelin-daemon.sh upstart
+```
+
+**zeppelin.conf**
 
 ```
 description "zeppelin"
@@ -95,15 +177,16 @@ chdir /usr/share/zeppelin
 exec bin/zeppelin-daemon.sh upstart
 ```
 
-#### Running on Windows
+## What is the next?
+Congratulation on your successful Apache Zeppelin installation! Here are two next steps you might need.
 
-```
-bin\zeppelin.cmd
-```
+ * For an in-depth overview of Apache Zeppelin UI, head to [Explore Apache Zeppelin UI](../quickstart/explorezeppelinui.html)
+ * After getting familiar with Apache Zeppelin UI, have fun with a short walk-through [Tutorial](../quickstart/tutorial.html) that uses Apache Spark backend
+ * If you need more configuration setting for Apache Zeppelin, jump to the next section: [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
 
-## Zeppelin Configuration
+## Apache Zeppelin Configuration
 
-You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
+You can configure Apache Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
 
 <table class="table-configuration">
   <tr>
@@ -212,13 +295,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
     <td>zeppelin.notebook.homescreen</td>
     <td></td>
-    <td>A notebook id displayed in Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
+    <td>A notebook id displayed in Apache Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
     <td>zeppelin.notebook.homescreen.hide</td>
     <td>false</td>
-    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
+    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Apache Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WAR_TEMPDIR</td>
@@ -230,13 +313,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_DIR</td>
     <td>zeppelin.notebook.dir</td>
     <td>notebook</td>
-    <td>The root directory where Zeppelin notebook directories are saved</td>
+    <td>The root directory where notebook directories are saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
     <td>zeppelin.notebook.s3.bucket</td>
     <td>zeppelin</td>
-    <td>S3 Bucket where Zeppelin notebook files will be saved</td>
+    <td>S3 Bucket where notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
@@ -272,7 +355,7 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>ZEPPELIN_NOTEBOOK_AZURE_SHARE</td>
     <td>zeppelin.notebook.azure.share</td>
     <td>zeppelin</td>
-    <td>Share where the Zeppelin notebook files will be saved</td>
+    <td>Share where the notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_AZURE_USER</td>
@@ -293,13 +376,13 @@ You can configure Zeppelin with both **environment variables** in `conf/zeppelin
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in Zeppelin notebook paragraph. </td>
+    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in notebook paragraph. </td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>
     <td>zeppelin.interpreter.dir</td>
     <td>interpreter</td>
-    <td>Zeppelin interpreter directory</td>
+    <td>Interpreter directory</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -19,115 +19,40 @@ limitations under the License.
 -->
 {% include JB/setup %}
 
-# Quick Start
-Welcome to your first trial to explore Apache Zeppelin! 
-This page will help you to get started and here is the list of topics covered.
+## Zeppelin Installation
+Welcome to your first trial to explore Zeppelin!
 
-* [Installation](#installation)
-  * [Downloading Binary Package](#downloading-binary-package)
-  * [Building from Source](#building-from-source)
-* [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line)
-  * [Start Zeppelin](#start-zeppelin)
-  * [Stop Zeppelin](#stop-zeppelin)
-  * [(Optional) Start Apache Zeppelin with a service manager](#optional-start-apache-zeppelin-with-a-service-manager)
-* [What is the next?](#what-is-the-next)
-* [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
+In this documentation, we will explain how you can install Zeppelin from **Binary Package** or build from **Source** by yourself. Plus, you can see all of Zeppelin's configurations in the [Zeppelin Configuration](install.html#zeppelin-configuration) section below.
 
-## Installation
+### Install with Binary Package
 
-Apache Zeppelin officially supports and is tested on next environments.
+If you want to install Zeppelin with latest binary package, please visit [this page](http://zeppelin.apache.org/download.html).
 
-<table class="table-configuration">
-  <tr>
-    <th>Name</th>
-    <th>Value</th>
-  </tr>
-  <tr>
-    <td>Oracle JDK</td>
-    <td>1.7 <br /> (set <code>JAVA_HOME</code>)</td>
-  </tr>
-  <tr>
-    <td>OS</td>
-    <td>Mac OSX <br /> Ubuntu 14.X <br /> CentOS 6.X <br /> Windows 7 Pro SP1</td>
-  </tr>
-</table>
+If you have downloaded `netinst` binary, [install additional interpreters](../manual/interpreterinstallation.html) before you start Zeppelin. Or simply run `./bin/install-interpreter.sh --all`.
 
-There are two options to install Apache Zeppelin on your machine. One is [downloading prebuild binary package](#downloading-binary-package) from the archive. 
-You can download not only the latest stable version but also the older one if you need. 
-The other option is [building from the source](#building-from-source).
-Although it can be unstable somehow since it is on development status, you can explore newly added feature and change it as you want.
+### Build from Zeppelin Source
 
-### Downloading Binary Package
+You can also build Zeppelin from the source.
 
-If you want to install Apache Zeppelin with a stable binary package, please visit [Apache Zeppelin download Page](http://zeppelin.apache.org/download.html). 
-After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
+#### Prerequisites for build
+ * Java 1.7
+ * Git
+ * Maven(3.1.x or higher)
+ * Node.js Package Manager
 
-If you have downloaded `netinst` binary, [install additional interpreters](http://localhost:4000/install/install.html#install-interpreters) or simply run `./bin/install-interpreter.sh --all` before you jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
+If you don't have requirements prepared, please check instructions in [README.md](https://github.com/apache/zeppelin/blob/master/README.md) for the details.
 
-### Building from Source
-If you want to build from the source, the software below needs to be installed on your system.
 
-<table class="table-configuration">
-  <tr>
-    <th>Name</th>
-    <th>Value</th>
-  </tr>
-  <tr>
-    <td>Git</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Maven</td>
-    <td>3.1.x or higher</td>
-  </tr>
-</table>
 
-If you don't have it installed yet, please check [Before Build](https://github.com/apache/zeppelin/blob/master/README.md#before-build) section and follow step by step instructions from there.
+Maybe you need to configure individual interpreter. If so, please check **Interpreter** section in Zeppelin documentation.
+[Spark Interpreter for Apache Zeppelin](../interpreter/spark.html) will be a good example.
 
-####1. Clone Apache Zeppelin repository
-
-```
-git clone https://github.com/apache/zeppelin.git
-```
-
-####2. Build source with options 
-Each interpreters requires different build options. For the further information about options, please see [Build](https://github.com/apache/zeppelin#build) section.
-
-```
-mvn clean package -DskipTests [Options]
-```
-
-Here are some examples with several options
-
-```
-# basic build
-mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark
-
-# spark-cassandra integration
-mvn clean package -Pcassandra-spark-1.5 -Dhadoop.version=2.6.0 -Phadoop-2.6 -DskipTests
-
-# with CDH
-mvn clean package -Pspark-1.5 -Dhadoop.version=2.6.0-cdh5.5.0 -Phadoop-2.6 -Pvendor-repo -DskipTests
-
-# with MapR
-mvn clean package -Pspark-1.5 -Pmapr50 -DskipTests
-```
-
-For the further information about building with source, please see [README.md](https://github.com/apache/zeppelin/blob/master/README.md) in Zeppelin repository.
-
-## Starting Apache Zeppelin with Command Line
+## Zeppelin Start / Stop
 #### Start Zeppelin
 
 ```
 bin/zeppelin-daemon.sh start
 ```
-
-If you are using Windows 
-
-```
-bin\zeppelin.cmd
-```
-
 After successful start, visit [http://localhost:8080](http://localhost:8080) with your web browser.
 
 #### Stop Zeppelin
@@ -136,28 +61,21 @@ After successful start, visit [http://localhost:8080](http://localhost:8080) wit
 bin/zeppelin-daemon.sh stop
 ```
 
-#### (Optional) Start Apache Zeppelin with a service manager
+#### Start Zeppelin with a service manager such as upstart
 
-> **Note :** The below description was written based on Ubuntu Linux.
+Zeppelin can auto start as a service with an init script, such as services managed by upstart.
 
-Apache Zeppelin can be auto started as a service with an init script, such as services managed by **upstart**.
-
-The following is an example of upstart script to be saved as `/etc/init/zeppelin.conf`
+The following is an example upstart script to be saved as `/etc/init/zeppelin.conf`
+This example has been tested with Ubuntu Linux.
 This also allows the service to be managed with commands such as
 
-```
-sudo service zeppelin start  
-sudo service zeppelin stop  
-sudo service zeppelin restart
-```
+`sudo service zeppelin start`  
+`sudo service zeppelin stop`  
+`sudo service zeppelin restart`
 
-Other service managers could use a similar approach with the `upstart` argument passed to the `zeppelin-daemon.sh` script.
+Other service managers could use a similar approach with the `upstart` argument passed to the zeppelin-daemon.sh script:  `bin/zeppelin-daemon.sh upstart`
 
-```
-bin/zeppelin-daemon.sh upstart
-```
-
-**zeppelin.conf**
+##### zeppelin.conf
 
 ```
 description "zeppelin"
@@ -177,16 +95,15 @@ chdir /usr/share/zeppelin
 exec bin/zeppelin-daemon.sh upstart
 ```
 
-## What is the next?
-Congratulation on your successful Apache Zeppelin installation! Here are two next steps you might need.
+#### Running on Windows
 
- * For an in-depth overview of Apache Zeppelin UI, head to [Explore Apache Zeppelin UI](../quickstart/explorezeppelinui.html)
- * After getting familiar with Apache Zeppelin UI, have fun with a short walk-through [Tutorial](../quickstart/tutorial.html) that uses Apache Spark backend
- * If you need more configuration setting for Apache Zeppelin, jump to the next section: [Apache Zeppelin Configuration](#apache-zeppelin-configuration)
+```
+bin\zeppelin.cmd
+```
 
-## Apache Zeppelin Configuration
+## Zeppelin Configuration
 
-You can configure Apache Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
+You can configure Zeppelin with both **environment variables** in `conf/zeppelin-env.sh` (`conf\zeppelin-env.cmd` for Windows) and **Java properties** in `conf/zeppelin-site.xml`. If both are defined, then the **environment variables** will take priority.
 
 <table class="table-configuration">
   <tr>
@@ -295,13 +212,13 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN</td>
     <td>zeppelin.notebook.homescreen</td>
     <td></td>
-    <td>A notebook id displayed in Apache Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
+    <td>A notebook id displayed in Zeppelin homescreen <br />i.e. 2A94M5J1Z</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE</td>
     <td>zeppelin.notebook.homescreen.hide</td>
     <td>false</td>
-    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Apache Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
+    <td>This value can be "true" when to hide the notebook id set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Zeppelin homescreen. <br />For the further information, please read <a href="../manual/notebookashomepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WAR_TEMPDIR</td>
@@ -313,13 +230,13 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>ZEPPELIN_NOTEBOOK_DIR</td>
     <td>zeppelin.notebook.dir</td>
     <td>notebook</td>
-    <td>The root directory where notebook directories are saved</td>
+    <td>The root directory where Zeppelin notebook directories are saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_BUCKET</td>
     <td>zeppelin.notebook.s3.bucket</td>
     <td>zeppelin</td>
-    <td>S3 Bucket where notebook files will be saved</td>
+    <td>S3 Bucket where Zeppelin notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_S3_USER</td>
@@ -355,7 +272,7 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>ZEPPELIN_NOTEBOOK_AZURE_SHARE</td>
     <td>zeppelin.notebook.azure.share</td>
     <td>zeppelin</td>
-    <td>Share where the notebook files will be saved</td>
+    <td>Share where the Zeppelin notebook files will be saved</td>
   </tr>
   <tr>
     <td>ZEPPELIN_NOTEBOOK_AZURE_USER</td>
@@ -376,13 +293,13 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in notebook paragraph. </td>
+    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in Zeppelin notebook paragraph. </td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>
     <td>zeppelin.interpreter.dir</td>
     <td>interpreter</td>
-    <td>Interpreter directory</td>
+    <td>Zeppelin interpreter directory</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>
@@ -391,56 +308,3 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>Size in characters of the maximum text message to be received by websocket.</td>
   </tr>
 </table>
-
-## Install interpreters
-
-You can install additional [interpreters](../manual/interpreters.html) using `bin/install-interpreter.sh` command.
-
-### Community managed interpreters
-
-Informations of community managed interpreters are listed in `conf/interpreter-list` file. `bin/install-interpreter.sh` command will read this file to install interpreters.
-
-##### Install all community managed interpreters
-
-```
-./bin/install-interpreter.sh --all
-```
-
-##### Install specific interpreters
-
-```
-./bin/install-interpreter.sh --name md,shell,jdbc,python
-```
-
-You can get full list of community managed interpreters by running
-
-```
-./bin/install-interpreter.sh --list
-```
-
-Once you have installed interpreter, restart Zeppelin. And then you'll need [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [binding it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
-
-
-### 3rd party interpreters
-
-`./bin/install-interpreter.sh` command can install 3rd party interpreters available in maven repository.
-
-##### Install 3rd party interpreters
-
-```
-./bin/install-interpreter.sh --name interpreter1 --repository groupId1:artifact1:version1
-```
-
-The command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
-
-Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](install.html#zeppelin-configuration).
-And then restart Zeppelin, [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [binding it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
-
-
-##### Install multiple 3rd party interpreters at once
-
-`--name` and `--repository` argument receives comma separated list
-
-```
-./bin/install-interpreter.sh --name interpreter1,interpreter2 --repository groupId1:artifact1:version1,groupId2:artifact2:version2
-```

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -62,6 +62,8 @@ Although it can be unstable somehow since it is on development status, you can e
 If you want to install Apache Zeppelin with a stable binary package, please visit [Apache Zeppelin download Page](http://zeppelin.apache.org/download.html). 
 After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
 
+If you have downloaded `netinst` binary, [install additional interpreters](http://localhost:4000/install/install.html#install-interpreters) or simply run `./bin/install-interpreter.sh --all` before you jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.
+
 ### Building from Source
 If you want to build from the source, the software below needs to be installed on your system.
 
@@ -389,3 +391,56 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>Size in characters of the maximum text message to be received by websocket.</td>
   </tr>
 </table>
+
+## Install interpreters
+
+You can install additional [interpreters](../manual/interpreters.html) using `bin/install-interpreter.sh` command.
+
+### Community managed interpreters
+
+Informations of community managed interpreters are listed in `conf/interpreter-list` file. `bin/install-interpreter.sh` command will read this file to install interpreters.
+
+##### Install all community managed interpreters
+
+```
+./bin/install-interpreter.sh --all
+```
+
+##### Install specific interpreters
+
+```
+./bin/install-interpreter.sh --name md,shell,jdbc,python
+```
+
+You can get full list of community managed interpreters by running
+
+```
+./bin/install-interpreter.sh --list
+```
+
+Once you have installed interpreter, restart Zeppelin. And then you'll need [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [binding it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
+
+
+### 3rd party interpreters
+
+`./bin/install-interpreter.sh` command can install 3rd party interpreters available in maven repository.
+
+##### Install 3rd party interpreters
+
+```
+./bin/install-interpreter.sh --name interpreter1 --repository groupId1:artifact1:version1
+```
+
+The command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
+
+Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](install.html#zeppelin-configuration).
+And then restart Zeppelin, [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [binding it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
+
+
+##### Install multiple 3rd party interpreters at once
+
+`--name` and `--repository` argument receives comma separated list
+
+```
+./bin/install-interpreter.sh --name interpreter1,interpreter2 --repository groupId1:artifact1:version1,groupId2:artifact2:version2
+```

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -60,6 +60,7 @@ Although it can be unstable somehow since it is on development status, you can e
 ### Downloading Binary Package
 
 If you want to install Apache Zeppelin with a stable binary package, please visit [Apache Zeppelin download Page](http://zeppelin.apache.org/download.html). 
+
 If you have downloaded `netinst` binary, [install additional interpreters](../manual/interpreterinstallation.html) before you start Zeppelin. Or simply run `./bin/install-interpreter.sh --all`.
 
 After unpacking, jump to [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line) section.

--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -83,22 +83,22 @@ You can also find the below community managed interpreter list in `conf/interpre
   </tr>
   <tr>
     <td>alluxio</td>
-    <td>org.apache.zeppelin.zeppelin-alluxio:0.6.0</td>
+    <td>org.apache.zeppelin:zeppelin-alluxio:0.6.0</td>
     <td>Alluxio interpreter</td>
   </tr>
   <tr>
     <td>angular</td>
-    <td>org.apache.zeppelin.zeppelin-angular:0.6.0</td>
+    <td>org.apache.zeppelin:zeppelin-angular:0.6.0</td>
     <td>HTML and AngularJS view rendering</td>
   </tr>
   <tr>
     <td>cassandra</td>
-    <td>org.apache.zeppelin.zeppelin-cassandra:0.6.0</td>
+    <td>org.apache.zeppelin:zeppelin-cassandra:0.6.0</td>
     <td>Cassandra interpreter</td>
   </tr>
   <tr>
     <td>elasticsearch</td>
-    <td>org.apache.zeppelin.zeppelin-elasticsearch:0.6.0</td>
+    <td>org.apache.zeppelin:zeppelin-elasticsearch:0.6.0</td>
     <td>Elasticsearch interpreter</td>
   </tr>
   <tr>

--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -60,7 +60,7 @@ You can also install 3rd party interpreters located in the maven repository by u
 
 The above command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
 
-Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](../install/install.html#zeppelin-configuration).
+Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](../install/install.html#apache-zeppelin-configuration).
 And then restart Zeppelin, [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
 
 
@@ -94,7 +94,7 @@ You can also find the below community managed interpreter list in `conf/interpre
   <tr>
     <td>cassandra</td>
     <td>org.apache.zeppelin.zeppelin-cassandra:0.6.0</td>
-    <td>HTML and AngularJS view rendering</td>
+    <td>Cassandra interpreter</td>
   </tr>
   <tr>
     <td>elasticsearch</td>

--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -55,7 +55,7 @@ You can also install 3rd party interpreters located in the maven repository by u
 #### Install 3rd party interpreters
 
 ```
-./bin/install-interpreter.sh --name interpreter1 --repository groupId1:artifact1:version1
+./bin/install-interpreter.sh --name interpreter1 --artifact groupId1:artifact1:version1
 ```
 
 The above command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
@@ -67,10 +67,10 @@ And then restart Zeppelin, [create interpreter setting](../manual/interpreters.h
 #### Install multiple 3rd party interpreters at once
 
 ```
-./bin/install-interpreter.sh --name interpreter1,interpreter2 --repository groupId1:artifact1:version1,groupId2:artifact2:version2
+./bin/install-interpreter.sh --name interpreter1,interpreter2 --artifact groupId1:artifact1:version1,groupId2:artifact2:version2
 ```
 
-`--name` and `--repository` arguments will recieve comma separated list.
+`--name` and `--artifact` arguments will recieve comma separated list.
 
 ## Available community managed interpreters
 

--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -1,0 +1,164 @@
+---
+layout: page
+title: "Getting Started"
+description: ""
+group: install
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Interpreter Installation
+
+Apache Zeppelin provides **Interpreter Installation** mechanism for whom downloaded Zeppelin `netinst` binary package, or just want to install another 3rd party interpreters. 
+
+## Community managed interpreters
+Apache Zeppelin provides several interpreters as [community managed interpreters](#available-community-managed-interpreters). 
+If you downloaded `netinst` binary package, you need to install by using below commands.
+
+#### Install all community managed interpreters
+
+```
+./bin/install-interpreter.sh --all
+```
+
+#### Install specific interpreters
+
+```
+./bin/install-interpreter.sh --name md,shell,jdbc,python
+```
+
+You can get full list of community managed interpreters by running
+
+```
+./bin/install-interpreter.sh --list
+```
+
+Once you have installed interpreter, restart Zeppelin. And then you'll need to [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
+
+
+## 3rd party interpreters
+
+You can also install 3rd party interpreters located in the maven repository by using below commands.
+
+#### Install 3rd party interpreters
+
+```
+./bin/install-interpreter.sh --name interpreter1 --repository groupId1:artifact1:version1
+```
+
+The above command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
+
+Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](../install/install.html#zeppelin-configuration).
+And then restart Zeppelin, [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
+
+
+#### Install multiple 3rd party interpreters at once
+
+```
+./bin/install-interpreter.sh --name interpreter1,interpreter2 --repository groupId1:artifact1:version1,groupId2:artifact2:version2
+```
+
+`--name` and `--repository` argument will recieve comma separated list.
+
+## Available community managed interpreters
+
+You can also find the below community managed interpreter list in `conf/interpreter-list` file.
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Maven Artifact</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>alluxio</td>
+    <td>org.apache.zeppelin.zeppelin-alluxio:0.6.0</td>
+    <td>Alluxio interpreter</td>
+  </tr>
+  <tr>
+    <td>angular</td>
+    <td>org.apache.zeppelin.zeppelin-angular:0.6.0</td>
+    <td>HTML and AngularJS view rendering</td>
+  </tr>
+  <tr>
+    <td>cassandra</td>
+    <td>org.apache.zeppelin.zeppelin-cassandra:0.6.0</td>
+    <td>HTML and AngularJS view rendering</td>
+  </tr>
+  <tr>
+    <td>elasticsearch</td>
+    <td>org.apache.zeppelin.zeppelin-elasticsearch:0.6.0</td>
+    <td>Elasticsearch interpreter</td>
+  </tr>
+  <tr>
+    <td>file</td>
+    <td>org.apache.zeppelin:zeppelin-file:0.6.0</td>
+    <td>HDFS file interpreter</td>
+  </tr>
+  <tr>
+    <td>flink</td>
+    <td>org.apache.zeppelin:zeppelin-flink:0.6.0</td>
+    <td>Flink interpreter</td>
+  </tr>
+  <tr>
+    <td>hbase</td>
+    <td>org.apache.zeppelin:zeppelin-hbase:0.6.0</td>
+    <td>Hbase interpreter</td>
+  </tr>
+  <tr>
+    <td>ignite</td>
+    <td>org.apache.zeppelin:zeppelin-ignite:0.6.0</td>
+    <td>Ignite interpreter</td>
+  </tr>
+  <tr>
+    <td>jdbc</td>
+    <td>org.apache.zeppelin:zeppelin-jdbc:0.6.0</td>
+    <td>Jdbc interpreter</td>
+  </tr>
+  <tr>
+    <td>kylin</td>
+    <td>org.apache.zeppelin:zeppelin-kylin:0.6.0</td>
+    <td>Kylin interpreter</td>
+  </tr>
+  <tr>
+    <td>lens</td>
+    <td>org.apache.zeppelin:zeppelin-lens:0.6.0</td>
+    <td>Lens interpreter</td>
+  </tr>
+  <tr>
+    <td>livy</td>
+    <td>org.apache.zeppelin:zeppelin-livy:0.6.0</td>
+    <td>Livy interpreter</td>
+  </tr>
+  <tr>
+    <td>md</td>
+    <td>org.apache.zeppelin:zeppelin-markdown:0.6.0</td>
+    <td>Markdown support</td>
+  </tr>
+  <tr>
+    <td>postgresql</td>
+    <td>org.apache.zeppelin:zeppelin-postgresql:0.6.0</td>
+    <td>Postgresql interpreter</td>
+  </tr>
+  <tr>
+    <td>python</td>
+    <td>org.apache.zeppelin:zeppelin-python:0.6.0</td>
+    <td>Python interpreter</td>
+  </tr>
+  <tr>
+    <td>shell</td>
+    <td>org.apache.zeppelin:zeppelin-shell:0.6.0</td>
+    <td>Shell command</td>
+  </tr>
+</table>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/AbstractDependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/AbstractDependencyResolver.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.dep;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -25,6 +26,7 @@ import java.util.List;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.repository.Authentication;
+import org.sonatype.aether.repository.Proxy;
 import org.sonatype.aether.repository.RemoteRepository;
 import org.sonatype.aether.repository.RepositoryPolicy;
 import org.sonatype.aether.resolution.ArtifactResult;
@@ -42,6 +44,16 @@ public abstract class AbstractDependencyResolver {
     session = Booter.newRepositorySystemSession(system, localRepoPath);
     repos.add(Booter.newCentralRepository()); // add maven central
     repos.add(Booter.newLocalRepository());
+  }
+
+  public void setProxy(URL proxyUrl, String proxyUser, String proxyPassword) {
+    Authentication auth = new Authentication(proxyUser, proxyPassword);
+    Proxy proxy = new Proxy(proxyUrl.getProtocol(), proxyUrl.getHost(), proxyUrl.getPort(), auth);
+    synchronized (repos) {
+      for (RemoteRepository repo : repos) {
+        repo.setProxy(proxy);
+      }
+    }
   }
 
   public List<RemoteRepository> getRepos() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -63,11 +63,6 @@ public class DependencyResolver extends AbstractDependencyResolver {
     return load(artifact, new LinkedList<String>());
   }
   
-  public List<File> load(String artifact, String destPath)
-      throws RepositoryException, IOException {
-    return load(artifact, new LinkedList<String>(), destPath);
-  }
-
   public synchronized List<File> load(String artifact, Collection<String> excludes)
       throws RepositoryException, IOException {
     if (StringUtils.isBlank(artifact)) {
@@ -84,33 +79,6 @@ public class DependencyResolver extends AbstractDependencyResolver {
       libs.add(new File(artifact));
       return libs;
     }
-  }
-  
-  public List<File> load(String artifact, Collection<String> excludes, String destPath)
-      throws RepositoryException, IOException {
-    List<File> libs = new LinkedList<File>();
-
-    if (StringUtils.isNotBlank(artifact)) {
-      libs = load(artifact, excludes);
-
-      // find home dir
-      String home = System.getenv("ZEPPELIN_HOME");
-      if (home == null) {
-        home = System.getProperty("zeppelin.home");
-      }
-      if (home == null) {
-        home = "..";
-      }
-
-      for (File srcFile : libs) {
-        File destFile = new File(home + "/" + destPath, srcFile.getName());
-        if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
-          FileUtils.copyFile(srcFile, destFile);
-          logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
-        }
-      }
-    }
-    return libs;
   }
 
   public List<File> load(String artifact, File destPath) throws IOException, RepositoryException {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -113,6 +113,28 @@ public class DependencyResolver extends AbstractDependencyResolver {
     return libs;
   }
 
+  public List<File> load(String artifact, File destPath) throws IOException, RepositoryException {
+    return load(artifact, new LinkedList<String>(), destPath);
+  }
+
+  public List<File> load(String artifact, Collection<String> excludes, File destPath)
+      throws RepositoryException, IOException {
+    List<File> libs = new LinkedList<File>();
+
+    if (StringUtils.isNotBlank(artifact)) {
+      libs = load(artifact, excludes);
+
+      for (File srcFile : libs) {
+        File destFile = new File(destPath, srcFile.getName());
+        if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
+          FileUtils.copyFile(srcFile, destFile);
+          logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
+        }
+      }
+    }
+    return libs;
+  }
+
   private List<File> loadFromMvn(String artifact, Collection<String> excludes)
       throws RepositoryException {
     Collection<String> allExclusions = new LinkedList<String>();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.dep;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
@@ -33,27 +33,20 @@ import org.sonatype.aether.RepositoryException;
 public class DependencyResolverTest {
   private static DependencyResolver resolver;
   private static String testPath;
-  private static String testCopyPath;
-  private static String home;
-  
+  private static File testCopyPath;
+  private static File tmpDir;
+
   @BeforeClass
   public static void setUp() throws Exception {
-    testPath = "test-repo";
-    testCopyPath = "test-copy-repo";
+    tmpDir = new File(System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis());
+    testPath = tmpDir.getAbsolutePath() + "/test-repo";
+    testCopyPath = new File(tmpDir, "test-copy-repo");
     resolver = new DependencyResolver(testPath);
-    home = System.getenv("ZEPPELIN_HOME");
-    if (home == null) {
-      home = System.getProperty("zeppelin.home");
-    }
-    if (home == null) {
-      home = "..";
-    }
   }
   
   @AfterClass
   public static void tearDown() throws Exception {
-    FileUtils.deleteDirectory(new File(home + "/" + testPath));
-    FileUtils.deleteDirectory(new File(home + "/" + testCopyPath)); 
+    FileUtils.deleteDirectory(tmpDir);
   }
 
   @Rule
@@ -78,19 +71,19 @@ public class DependencyResolverTest {
   public void testLoad() throws Exception {
     // basic load
     resolver.load("com.databricks:spark-csv_2.10:1.3.0", testCopyPath);
-    assertEquals(new File(home + "/" + testCopyPath).list().length, 4);
-    FileUtils.cleanDirectory(new File(home + "/" + testCopyPath));
+    assertEquals(testCopyPath.list().length, 4);
+    FileUtils.cleanDirectory(testCopyPath);
 
     // load with exclusions parameter
     resolver.load("com.databricks:spark-csv_2.10:1.3.0",
         Collections.singletonList("org.scala-lang:scala-library"), testCopyPath);
-    assertEquals(new File(home + "/" + testCopyPath).list().length, 3);
-    FileUtils.cleanDirectory(new File(home + "/" + testCopyPath));
+    assertEquals(testCopyPath.list().length, 3);
+    FileUtils.cleanDirectory(testCopyPath);
 
     // load from added repository
     resolver.addRepo("sonatype", "https://oss.sonatype.org/content/repositories/agimatec-releases/", false);
     resolver.load("com.agimatec:agimatec-validation:0.9.3", testCopyPath);
-    assertEquals(new File(home + "/" + testCopyPath).list().length, 8);
+    assertEquals(testCopyPath.list().length, 8);
 
     // load invalid artifact
     resolver.delRepo("sonatype");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -346,6 +346,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_EMP);
   }
 
+  public String getInterpreterListPath() {
+    return getRelativeDir(String.format("%s/interpreter-list", getConfDir()));
+  }
+
   public String getInterpreterDir() {
     return getRelativeDir(ConfVars.ZEPPELIN_INTERPRETER_DIR);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -350,15 +350,17 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     List<Dependency> deps = intSetting.getDependencies();
     if (deps != null) {
       for (Dependency d: deps) {
+        File destDir = new File(conf.getRelativeDir(ConfVars.ZEPPELIN_DEP_LOCALREPO));
+
         if (d.getExclusions() != null) {
           depResolver.load(
               d.getGroupArtifactVersion(),
               d.getExclusions(),
-              conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO) + "/" + intSetting.id());
+              new File(destDir, intSetting.id()));
         } else {
           depResolver.load(
               d.getGroupArtifactVersion(),
-              conf.getString(ConfVars.ZEPPELIN_DEP_LOCALREPO) + "/" + intSetting.id());
+              new File(destDir, intSetting.id()));
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -175,7 +175,7 @@ public class InstallInterpreter {
     System.out.println("  -l, --list                  List available interpreters");
     System.out.println("  -a, --all                   Install all available interpreters");
     System.out.println("  -n, --name     [NAMES]      Install interpreters (comma separated list)" +
-        "e.g. spark,md,shell");
+        "e.g. md,shell,jdbc,python,angular");
     System.out.println("  -t, --artifact [ARTIFACTS]  (Optional with -n) custom artifact names. " +
         "(comma separated list correspond to --name) " +
         "e.g. customGroup:customArtifact:customVersion");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -54,6 +54,12 @@ public class InstallInterpreter {
     }
   }
 
+  public static void install(String [] names) {
+    for (String name : names) {
+      install(name);
+    }
+  }
+
   public static void install(String name) {
     // find artifact name
     for (int i = 0; i < availableInterpreters.length; i++) {
@@ -70,6 +76,17 @@ public class InstallInterpreter {
 
   private static String getArtifactName(String name) {
     return "org.apache.zeppelin:" + name + ":" + Util.getVersion();
+  }
+
+  public static void install(String [] names, String [] artifacts) {
+    if (names.length != artifacts.length) {
+      System.err.println("Length of given names and artifacts are different");
+      System.exit(1);
+    }
+
+    for (int i = 0; i < names.length; i++) {
+      install(names[i], artifacts[i]);
+    }
   }
 
   public static void install(String name, String artifact) {
@@ -101,8 +118,10 @@ public class InstallInterpreter {
     System.out.println("Options");
     System.out.println("  -l, --list                  List available interpreters");
     System.out.println("  -a, --all                   Install all available interpreters");
-    System.out.println("  -n, --name     [NAME]       Install an interpreter");
-    System.out.println("  -t, --artifact [ARTIFACT]   (Optional with -n) custom artifact name." +
+    System.out.println("  -n, --name     [NAMES]      Install interpreters (comma separated list)" +
+        "e.g. spark,md,shell");
+    System.out.println("  -t, --artifact [ARTIFACT]   (Optional with -n) custom artifact names. " +
+        "(comma separated list correspond to --name) " +
         "e.g. customGroup:customArtifact:customVersion");
   }
 
@@ -112,8 +131,8 @@ public class InstallInterpreter {
       return;
     }
 
-    String name = null;
-    String artifact = null;
+    String names = null;
+    String artifacts = null;
 
     for (int i = 0; i < args.length; i++) {
       String arg = args[i].toLowerCase(Locale.US);
@@ -130,11 +149,11 @@ public class InstallInterpreter {
             break;
           case "--name":
           case "-n":
-            name = args[++i];
+            names = args[++i];
             break;
           case "--artifact":
           case "-t":
-            artifact = args[++i];
+            artifacts = args[++i];
             break;
           case "--version":
           case "-v":
@@ -150,11 +169,11 @@ public class InstallInterpreter {
       }
     }
 
-    if (name != null) {
-      if (artifact != null) {
-        install(name, artifact);
+    if (names != null) {
+      if (artifacts != null) {
+        install(names.split(","), artifacts.split(","));
       } else {
-        install(name);
+        install(names.split(","));
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -107,7 +107,7 @@ public class InstallInterpreter {
 
   public List<AvailableInterpreterInfo> list() {
     for (AvailableInterpreterInfo info : availableInterpreters) {
-      System.out.println(info.name + "\t\t" + info.description);
+      System.out.println(info.name + "\t\t\t" + info.description);
     }
 
     return availableInterpreters;
@@ -162,7 +162,7 @@ public class InstallInterpreter {
     try {
       depResolver.load(artifact, installDir);
       System.out.println("Interpreter " + name + " installed under " +
-          installDir.getAbsolutePath());
+          installDir.getAbsolutePath() + ".");
     } catch (RepositoryException e) {
       e.printStackTrace();
     } catch (IOException e) {
@@ -176,7 +176,7 @@ public class InstallInterpreter {
     System.out.println("  -a, --all                   Install all available interpreters");
     System.out.println("  -n, --name     [NAMES]      Install interpreters (comma separated list)" +
         "e.g. spark,md,shell");
-    System.out.println("  -t, --artifact [ARTIFACT]   (Optional with -n) custom artifact names. " +
+    System.out.println("  -t, --artifact [ARTIFACTS]  (Optional with -n) custom artifact names. " +
         "(comma separated list correspond to --name) " +
         "e.g. customGroup:customArtifact:customVersion");
   }
@@ -234,13 +234,19 @@ public class InstallInterpreter {
     if (names != null) {
       if (artifacts != null) {
         installer.install(names.split(","), artifacts.split(","));
+        startTip();
         configurationTip();
         interpreterSettingTip();
       } else {
         installer.install(names.split(","));
+        startTip();
         interpreterSettingTip();
       }
     }
+  }
+
+  private static void startTip() {
+    System.out.println("");
   }
 
   private static void configurationTip() {
@@ -251,6 +257,6 @@ public class InstallInterpreter {
 
   private static void interpreterSettingTip() {
     System.out.println("Create interpreter setting in 'Interpreter' menu on GUI."
-        + "And then you can bind interpreter to your notebook to use");
+        + " And then you can bind interpreter on your notebook");
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.interpreter.install;
+
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Logger;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.dep.DependencyResolver;
+import org.apache.zeppelin.util.Util;
+import org.sonatype.aether.RepositoryException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Commandline utility to install interpreter from maven repository
+ */
+public class InstallInterpreter {
+  static ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+
+  static String [] availableInterpreters = {
+    "md",     "zeppelin-markdown",   "Markdown interpreter",
+    "sh",     "zeppelin-shell",      "Allows shell command",
+    "jdbc",   "zeppelin-jdbc",
+    "Generic JDBC interpreter for hive, phoenix, postsgresql, mysql, etc",
+  };
+
+  public static void list() {
+    for (int i = 0; i < availableInterpreters.length; i++) {
+      System.out.println(availableInterpreters[i] + "\t\t" + availableInterpreters[i + 2]);
+      i += 2;
+    }
+  }
+
+  public static void installAll() {
+    for (int i = 0; i < availableInterpreters.length; i++) {
+      install(availableInterpreters[i], getArtifactName(availableInterpreters[i + 1]));
+      i += 2;
+    }
+  }
+
+  public static void install(String name) {
+    // find artifact name
+    for (int i = 0; i < availableInterpreters.length; i++) {
+      if (name.equals(availableInterpreters[i])) {
+        install(name, getArtifactName(availableInterpreters[i + 1]));
+        return;
+      }
+      i += 2;
+    }
+
+    System.err.println("Can't find interpreter '" + name + "'");
+    System.exit(1);
+  }
+
+  private static String getArtifactName(String name) {
+    return "org.apache.zeppelin:" + name + ":" + Util.getVersion();
+  }
+
+  public static void install(String name, String artifact) {
+    DependencyResolver depResolver = new DependencyResolver(
+        conf.getInterpreterLocalRepoPath());
+
+    File interpreterBaseDir = new File(conf.getInterpreterDir());
+    File installDir = new File(interpreterBaseDir, name);
+    if (installDir.exists()) {
+      System.err.println("Directory " + installDir.getAbsolutePath() + " already exists. Skipping");
+      return;
+    }
+
+    System.out.println("Install " + name + "(" + artifact + ") to "
+        + installDir.getAbsolutePath() + " ... ");
+
+    try {
+      depResolver.load(artifact, installDir);
+      System.out.println("Interpreter " + name + " installed under " +
+          installDir.getAbsolutePath());
+    } catch (RepositoryException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void usage() {
+    System.out.println("Options");
+    System.out.println("  -l, --list                  List available interpreters");
+    System.out.println("  -a, --all                   Install all available interpreters");
+    System.out.println("  -n, --name     [NAME]       Install an interpreter");
+    System.out.println("  -t, --artifact [ARTIFACT]   (Optional with -n) custom artifact name." +
+        "e.g. customGroup:customArtifact:customVersion");
+  }
+
+  public static void main(String [] args) {
+    if (args.length == 0) {
+      usage();
+      return;
+    }
+
+    String name = null;
+    String artifact = null;
+
+    for (int i = 0; i < args.length; i++) {
+      String arg = args[i].toLowerCase(Locale.US);
+      switch (arg) {
+          case "--list":
+          case "-l":
+            list();
+            System.exit(0);
+            break;
+          case "--all":
+          case "-a":
+            installAll();
+            System.exit(0);
+            break;
+          case "--name":
+          case "-n":
+            name = args[++i];
+            break;
+          case "--artifact":
+          case "-t":
+            artifact = args[++i];
+            break;
+          case "--version":
+          case "-v":
+            Util.getVersion();
+            break;
+          case "--help":
+          case "-h":
+            usage();
+            System.exit(0);
+            break;
+          default:
+            System.out.println("Unknown option " + arg);
+      }
+    }
+
+    if (name != null) {
+      if (artifact != null) {
+        install(name, artifact);
+      } else {
+        install(name);
+      }
+    }
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -74,7 +74,7 @@ public class InstallInterpreter {
 
   private void readAvailableInterpreters() throws IOException {
     if (!interpreterListFile.isFile()) {
-      System.err.print("Can't find interpreter list " + interpreterListFile.getAbsolutePath());
+      System.err.println("Can't find interpreter list " + interpreterListFile.getAbsolutePath());
       return;
     }
     String text = FileUtils.readFileToString(interpreterListFile);
@@ -234,9 +234,23 @@ public class InstallInterpreter {
     if (names != null) {
       if (artifacts != null) {
         installer.install(names.split(","), artifacts.split(","));
+        configurationTip();
+        interpreterSettingTip();
       } else {
         installer.install(names.split(","));
+        interpreterSettingTip();
       }
     }
+  }
+
+  private static void configurationTip() {
+    System.out.println("Add interpreter class name to '"
+        + ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETERS.getVarName() + "' property "
+        + "in your conf/zeppelin-site.xml file");
+  }
+
+  private static void interpreterSettingTip() {
+    System.out.println("Create interpreter setting in 'Interpreter' menu on GUI."
+        + "And then you can bind interpreter to your notebook to use");
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/install/InstallInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/install/InstallInterpreterTest.java
@@ -1,0 +1,86 @@
+package org.apache.zeppelin.interpreter.install;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class InstallInterpreterTest {
+  private File tmpDir;
+  private InstallInterpreter installer;
+  private File interpreterBaseDir;
+
+  @Before
+  public void setUp() throws IOException {
+    tmpDir = new File(System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis());
+    new File(tmpDir, "conf").mkdirs();
+    interpreterBaseDir = new File(tmpDir, "interpreter");
+    File localRepoDir = new File(tmpDir, "local-repo");
+    interpreterBaseDir.mkdir();
+    localRepoDir.mkdir();
+
+    File interpreterListFile = new File(tmpDir, "conf/interpreter-list");
+
+
+    // create interpreter list file
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(), tmpDir.getAbsolutePath());
+
+    String interpreterList = "";
+    interpreterList += "intp1   org.apache.commons:commons-csv:1.1   test interpreter 1\n";
+    interpreterList += "intp2   org.apache.commons:commons-math3:3.6.1 test interpreter 2\n";
+
+    FileUtils.writeStringToFile(new File(tmpDir, "conf/interpreter-list"), interpreterList);
+
+    installer = new InstallInterpreter(interpreterListFile, interpreterBaseDir, localRepoDir
+        .getAbsolutePath());
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    FileUtils.deleteDirectory(tmpDir);
+  }
+
+
+  @Test
+  public void testList() {
+    assertEquals(2, installer.list().size());
+  }
+
+  @Test
+  public void install() {
+    assertEquals(0, interpreterBaseDir.listFiles().length);
+
+    installer.install("intp1");
+    assertTrue(new File(interpreterBaseDir, "intp1").isDirectory());
+  }
+
+  @Test
+  public void installAll() {
+    installer.installAll();
+    assertTrue(new File(interpreterBaseDir, "intp1").isDirectory());
+    assertTrue(new File(interpreterBaseDir, "intp2").isDirectory());
+  }
+}


### PR DESCRIPTION
### What is this PR for?
Implementation of bin/install-interpreter.sh for netinst package which suggested in the [discussion](http://apache-zeppelin-users-incubating-mailing-list.75479.x6.nabble.com/Ask-opinion-regarding-0-6-0-release-package-tp3298p3314.html).

Some usages will be

```
# download all interpreters provided by Apache Zeppelin project
bin/install-interpreter.sh --all

# download an interpreter with name (for example markdown interpreter)
bin/install-interpreter.sh --name md

# download an (3rd party) interpreter with specific maven artifact name
bin/install-interpreter.sh --name md -t org.apache.zeppelin:zeppelin-markdown:0.6.0-SNAPSHOT
```

If it looks fine, i'll continue the work (refactor code, and add test)

### What type of PR is it?
Feature

### Todos
* [x] - working implementation
* [x] - refactor
* [x] - add test

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

