### PR TITLE
[ZEPPELIN-1034] Add Spark Interpreter option to not import implicits

### DIFF
--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -55,12 +55,13 @@ REM set HADOOP_CONF_DIR         		REM yarn-site.xml is located in configuration 
 REM Pyspark (supported with Spark 1.2.1 and above)
 REM To configure pyspark, you need to set spark distribution's path to 'spark.home' property in Interpreter setting screen in Zeppelin GUI
 REM set PYSPARK_PYTHON          		REM path to the python command. must be the same path on the driver(Zeppelin) and all workers.
-REM set PYTHONPATH  
+REM set PYTHONPATH
 
 REM Spark interpreter options
 REM
 REM set ZEPPELIN_SPARK_USEHIVECONTEXT  REM Use HiveContext instead of SQLContext if set true. true by default.
 REM set ZEPPELIN_SPARK_CONCURRENTSQL   REM Execute multiple SQL concurrently if set true. false by default.
+REM set ZEPPELIN_SPARK_IMPORTIMPLICIT  REM Import implicits, UDF collection, and sql if set true. true by default.
 REM set ZEPPELIN_SPARK_MAXRESULT       REM Max number of SparkSQL result to display. 1000 by default.
 
 REM ZeppelinHub connection configuration

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -55,14 +55,16 @@
 # Pyspark (supported with Spark 1.2.1 and above)
 # To configure pyspark, you need to set spark distribution's path to 'spark.home' property in Interpreter setting screen in Zeppelin GUI
 # export PYSPARK_PYTHON          		# path to the python command. must be the same path on the driver(Zeppelin) and all workers.
-# export PYTHONPATH  
+# export PYTHONPATH
 
 ## Spark interpreter options ##
 ##
 # export ZEPPELIN_SPARK_USEHIVECONTEXT  # Use HiveContext instead of SQLContext if set true. true by default.
 # export ZEPPELIN_SPARK_CONCURRENTSQL   # Execute multiple SQL concurrently if set true. false by default.
+# export ZEPPELIN_SPARK_IMPORTIMPLICIT  # Import implicits, UDF collection, and sql if set true. true by default.
 # export ZEPPELIN_SPARK_MAXRESULT       # Max number of SparkSQL result to display. 1000 by default.
 # export ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE       # Size in characters of the maximum text message to be received by websocket. Defaults to 1024000
+
 
 #### HBase interpreter configuration ####
 
@@ -75,4 +77,3 @@
 # export ZEPPELINHUB_API_ADDRESS		# Refers to the address of the ZeppelinHub service in use
 # export ZEPPELINHUB_API_TOKEN			# Refers to the Zeppelin instance token of the user
 # export ZEPPELINHUB_USER_KEY			# Optional, when using Zeppelin with authentication.
-

--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -45,7 +45,7 @@ Spark Interpreter group, which consists of five interpreters.
 </table>
 
 ## Configuration
-The Spark interpreter can be configured with properties provided by Zeppelin. 
+The Spark interpreter can be configured with properties provided by Zeppelin.
 You can also set other Spark properties which are not listed in the table. For a list of additional properties, refer to [Spark Available Properties](http://spark.apache.org/docs/latest/configuration.html#available-properties).
 <table class="table-configuration">
   <tr>
@@ -110,6 +110,11 @@ You can also set other Spark properties which are not listed in the table. For a
     <td>zeppelin.spark.useHiveContext</td>
     <td>true</td>
     <td>Use HiveContext instead of SQLContext if it is true.</td>
+  </tr>
+  <tr>
+    <td>zeppelin.spark.importImplicit</td>
+    <td>true</td>
+    <td>Import implicits, UDF collection, and sql if set true.</td>
   </tr>
 </table>
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -176,6 +176,10 @@ public class SparkInterpreter extends Interpreter {
     return java.lang.Boolean.parseBoolean(getProperty("zeppelin.spark.useHiveContext"));
   }
 
+  private boolean importImplicit() {
+    return java.lang.Boolean.parseBoolean(getProperty("zeppelin.spark.importImplicit"));
+  }
+
   public SQLContext getSQLContext() {
     synchronized (sharedInterpreterLock) {
       if (sqlc == null) {
@@ -250,7 +254,7 @@ public class SparkInterpreter extends Interpreter {
           | IllegalArgumentException | InvocationTargetException e) {
         // continue instead of: throw new InterpreterException(e);
         // Newer Spark versions (like the patched CDH5.7.0 one) don't contain this method
-        logger.warn(String.format("Spark method classServerUri not available due to: [%s]", 
+        logger.warn(String.format("Spark method classServerUri not available due to: [%s]",
           e.getMessage()));
       }
     }
@@ -540,12 +544,14 @@ public class SparkInterpreter extends Interpreter {
               + "_binder.get(\"sqlc\").asInstanceOf[org.apache.spark.sql.SQLContext]");
       intp.interpret("import org.apache.spark.SparkContext._");
 
-      if (sparkVersion.oldSqlContextImplicits()) {
-        intp.interpret("import sqlContext._");
-      } else {
-        intp.interpret("import sqlContext.implicits._");
-        intp.interpret("import sqlContext.sql");
-        intp.interpret("import org.apache.spark.sql.functions._");
+      if (importImplicit()) {
+        if (sparkVersion.oldSqlContextImplicits()) {
+          intp.interpret("import sqlContext._");
+        } else {
+          intp.interpret("import sqlContext.implicits._");
+          intp.interpret("import sqlContext.sql");
+          intp.interpret("import org.apache.spark.sql.functions._");
+        }
       }
     }
 

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -77,6 +77,12 @@
         "propertyName": "zeppelin.spark.maxResult",
         "defaultValue": "1000",
         "description": "Max number of SparkSQL result to display."
+      },
+      "zeppelin.spark.importImplicit": {
+        "envName": "ZEPPELIN_SPARK_IMPORTIMPLICIT",
+        "propertyName": "zeppelin.spark.importImplicit",
+        "defaultValue": "true",
+        "description": "Import implicits, UDF collection, and sql if set true. true by default."
       }
     }
   },

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -69,6 +69,7 @@ public class SparkInterpreterTest {
     p.setProperty("spark.app.name", "Zeppelin Test");
     p.setProperty("zeppelin.spark.useHiveContext", "true");
     p.setProperty("zeppelin.spark.maxResult", "1000");
+    p.setProperty("zeppelin.spark.importImplicit", "true");
 
     return p;
   }
@@ -226,6 +227,30 @@ public class SparkInterpreterTest {
     assertEquals(Code.SUCCESS,
         repl2.interpret("print(sc.parallelize(1 to 10).count())", context).code());
 
+    repl2.close();
+  }
+
+  @Test
+  public void testEnableImplicitImport() {
+    Properties p = new Properties();
+    p.setProperty("zeppelin.spark.importImplicit", "true");
+    SparkInterpreter repl2 = new SparkInterpreter(p);
+
+    repl2.open();
+    String ddl = "val df = Seq((1, true), (2, false)).toDF(\"num\", \"bool\")";
+    assertEquals(Code.SUCCESS, repl2.interpret(ddl, context).code());
+    repl2.close();
+  }
+
+  @Test
+  public void testDisableImplicitImport() {
+    Properties p = new Properties();
+    p.setProperty("zeppelin.spark.importImplicit", "false");
+    SparkInterpreter repl2 = new SparkInterpreter(p);
+
+    repl2.open();
+    String ddl = "val df = Seq((1, true), (2, false)).toDF(\"num\", \"bool\")";
+    assertEquals(Code.ERROR, repl2.interpret(ddl, context).code());
     repl2.close();
   }
 }

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -232,9 +232,12 @@ public class SparkInterpreterTest {
 
   @Test
   public void testEnableImplicitImport() {
-    Properties p = new Properties();
+    // Set option of importing implicits to "true", and initialize new Spark repl
+    Properties p = getSparkTestProperties();
     p.setProperty("zeppelin.spark.importImplicit", "true");
     SparkInterpreter repl2 = new SparkInterpreter(p);
+    repl2.setInterpreterGroup(intpGroup);
+    intpGroup.get("note").add(repl2);
 
     repl2.open();
     String ddl = "val df = Seq((1, true), (2, false)).toDF(\"num\", \"bool\")";
@@ -244,9 +247,13 @@ public class SparkInterpreterTest {
 
   @Test
   public void testDisableImplicitImport() {
-    Properties p = new Properties();
+    // Set option of importing implicits to "false", and initialize new Spark repl
+    // this test should return error status when creating DataFrame from sequence
+    Properties p = getSparkTestProperties();
     p.setProperty("zeppelin.spark.importImplicit", "false");
     SparkInterpreter repl2 = new SparkInterpreter(p);
+    repl2.setInterpreterGroup(intpGroup);
+    intpGroup.get("note").add(repl2);
 
     repl2.open();
     String ddl = "val df = Seq((1, true), (2, false)).toDF(\"num\", \"bool\")";


### PR DESCRIPTION
### What is this PR for?
This PR adds option `zeppelin.spark.importImplicit` to not import `SQLContext` implicits, UDF collections. It is `true`, which means importing implicit functions and has been the default behaviour.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1034

### How should this be tested?
Added unit-tests, also manual testing using similar to unit-tests scenario.

### Screenshots (if appropriate)

### Questions:
* Does this needs documentation?

Documentation is updated to include description for new option.
