### PR TITLE
increase more logs, and return appropriate error to front-end

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -361,11 +362,11 @@ public class JDBCInterpreter extends Interpreter {
 
       return new InterpreterResult(Code.SUCCESS, msg.toString());
 
-    } catch (SQLException ex) {
-      logger.error("Cannot run " + sql, ex);
-      return new InterpreterResult(Code.ERROR, ex.getMessage());
-    } catch (ClassNotFoundException e) {
+    } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
+      if (e.getMessage() == null) {
+        return new InterpreterResult(Code.ERROR, StringUtils.join(e.getStackTrace(), "\n"));
+      }
       return new InterpreterResult(Code.ERROR, e.getMessage());
     }
   }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -364,10 +364,9 @@ public class JDBCInterpreter extends Interpreter {
 
     } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
-      if (e.getMessage() == null) {
-        return new InterpreterResult(Code.ERROR, StringUtils.join(e.getStackTrace(), "\n"));
-      }
-      return new InterpreterResult(Code.ERROR, e.getMessage());
+      StringBuilder stringBuilder = new StringBuilder(e.getClass().toString()).append("\n");
+      stringBuilder.append(StringUtils.join(e.getStackTrace(), "\n"));
+      return new InterpreterResult(Code.ERROR, stringBuilder.toString());
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
In the current implementation JDBC interpret only catches SQLException and ClassNotFoundException. However, there can be a case for example NullPointerException or for that matter anything else can be thrown.



### What type of PR is it?
[Improvement]

### Todos
* [x] - increase more logs, and return appropriate error to front-end

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
As an example for hive2.

#### Properties

|name|	value|
| ------------- |:-------------:|
|default.driver|	org.apache.hive.jdbc.HiveDriver|
|default.url	|jdbc:hive2://hive-machine:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2|

#### Dependencies

|artifact	|exclude|
| ------------- |:-------------:|
|org.apache.hive:hive-jdbc:1.2.1	||
|org.apache.hadoop:hadoop-common:2.7.2||


With the above setting used on an older driver for hive2 it shows exception in log, but on the front-end paragraph shows error, and no logs.

```
ERROR [2016-06-19 14:47:46,186] ({pool-2-thread-2} Job.java[run]:182) - Job failed
java.lang.NullPointerException
        at org.apache.thrift.transport.TSocket.open(TSocket.java:168)
        at org.apache.thrift.transport.TSaslTransport.open(TSaslTransport.java:248)
        at org.apache.thrift.transport.TSaslClientTransport.open(TSaslClientTransport.java:37)
        at org.apache.hive.jdbc.HiveConnection.openTransport(HiveConnection.java:190)
        at org.apache.hive.jdbc.HiveConnection.<init>(HiveConnection.java:163)
        at org.apache.hive.jdbc.HiveDriver.connect(HiveDriver.java:105)
        at java.sql.DriverManager.getConnection(DriverManager.java:571)
        at java.sql.DriverManager.getConnection(DriverManager.java:187)
        at org.apache.zeppelin.jdbc.JDBCInterpreter.getConnection(JDBCInterpreter.java:218)
        at org.apache.zeppelin.jdbc.JDBCInterpreter.getStatement(JDBCInterpreter.java:229)
        at org.apache.zeppelin.jdbc.JDBCInterpreter.executeSql(JDBCInterpreter.java:288)
        at org.apache.zeppelin.jdbc.JDBCInterpreter.interpret(JDBCInterpreter.java:393)
        at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:94)
        at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer$InterpretJob.jobRun(RemoteInterpreterServer.java:341)
        at org.apache.zeppelin.scheduler.Job.run(Job.java:176)
        at org.apache.zeppelin.scheduler.FIFOScheduler$1.run(FIFOScheduler.java:139)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
```

### Screenshots (if appropriate)

Before:
<img width="1436" alt="screen shot 2016-06-20 at 5 11 59 pm" src="https://cloud.githubusercontent.com/assets/674497/16192988/20ce0312-370a-11e6-967e-281e99dbb18f.png">


After:
<img width="1435" alt="screen shot 2016-06-20 at 5 10 26 pm" src="https://cloud.githubusercontent.com/assets/674497/16192984/1121d222-370a-11e6-8da9-43adc80c9c15.png">



### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no

