### PR TITLE
[ZEPPELIN-1039] updated CreateNewButton Testcase in ParagraphAction 

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -92,20 +92,27 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       ZeppelinITUtils.sleep(1000, false);
       waitForParagraph(1, "READY");
 
+      String oldIntpTag = driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'editor')]")).getText();
+
       collector.checkThat("Paragraph is created above",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'editor')]")).getText(),
-          CoreMatchers.equalTo(StringUtils.EMPTY));
+          CoreMatchers.not(StringUtils.EMPTY));
       setTextOfParagraph(1, " this is above ");
+
 
       newPara = driver.findElement(By.xpath(getParagraphXPath(2) + "//div[contains(@class,'new-paragraph')][2]"));
       action.moveToElement(newPara).click().build().perform();
 
       waitForParagraph(3, "READY");
 
+      String lastIntpTag = driver.findElement(By.xpath(getParagraphXPath(3) + "//div[contains(@class, 'editor')]")).getText();
+
       collector.checkThat("Paragraph is created below",
           driver.findElement(By.xpath(getParagraphXPath(3) + "//div[contains(@class, 'editor')]")).getText(),
-          CoreMatchers.equalTo(StringUtils.EMPTY));
+          CoreMatchers.not(StringUtils.EMPTY));
       setTextOfParagraph(3, " this is below ");
+
+      collector.checkThat("Compare interpreter name tag", oldIntpTag, CoreMatchers.equalTo(lastIntpTag));
 
       collector.checkThat("The output field of paragraph1 contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'editor')]")).getText(),


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/zeppelin/commit/dec31d69efc3d167bb1f5ac91b26478f307414fb
After updating the code, and test cases fail.
The code was modified to add code to the test.

The interpreter automatically name is added, and therefore empty para graph is not generated.
```
testCreateNewButton(org.apache.zeppelin.integration.ParagraphActionsIT)  Time elapsed: 11.069 sec  <<< FAILURE!
java.lang.AssertionError: Paragraph is created above
Expected: ""
     but: was "%spark "
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.rules.ErrorCollector$1.call(ErrorCollector.java:65)
	at org.junit.rules.ErrorCollector.checkSucceeds(ErrorCollector.java:78)
	at org.junit.rules.ErrorCollector.checkThat(ErrorCollector.java:63)
	at org.apache.zeppelin.integration.ParagraphActionsIT.testCreateNewButton(ParagraphActionsIT.java:95)

testCreateNewButton(org.apache.zeppelin.integration.ParagraphActionsIT)  Time elapsed: 11.069 sec  <<< FAILURE!
java.lang.AssertionError: Paragraph is created below
Expected: ""
     but: was "%spark "
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.rules.ErrorCollector$1.call(ErrorCollector.java:65)
	at org.junit.rules.ErrorCollector.checkSucceeds(ErrorCollector.java:78)
	at org.junit.rules.ErrorCollector.checkThat(ErrorCollector.java:63)
	at org.apache.zeppelin.integration.ParagraphActionsIT.testCreateNewButton(ParagraphActionsIT.java:105)
```
### What type of PR is it?
Bug Fix

### Todos
* [x] - Updated Test case (createNewButton - ParagraphActionsIT.java)

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1039

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

