### PR TITLE
[ZEPPELIN-1028] Fix exported notebook importing error

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -77,8 +77,7 @@ public class NotebookServer extends WebSocketServlet implements
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookServer.class);
-  Gson gson = new GsonBuilder()
-    .setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
+  Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final Queue<NotebookSocket> connectedSockets = new ConcurrentLinkedQueue<>();
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -77,8 +76,7 @@ public class NotebookServer extends WebSocketServlet implements
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookServer.class);
-  Gson gson = new GsonBuilder()
-          .setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
+  Gson gson = new Gson();
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final Queue<NotebookSocket> connectedSockets = new ConcurrentLinkedQueue<>();
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -76,7 +77,8 @@ public class NotebookServer extends WebSocketServlet implements
   }
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookServer.class);
-  Gson gson = new Gson();
+  Gson gson = new GsonBuilder()
+    .setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final Queue<NotebookSocket> connectedSockets = new ConcurrentLinkedQueue<>();
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -195,7 +195,7 @@ public class Notebook {
       throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.create();
+    Gson gson = gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
     JsonReader reader = new JsonReader(new StringReader(sourceJson));
     reader.setLenient(true);
     Note newNote;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -196,7 +196,7 @@ public class Notebook {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
 
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportSerializer())
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
       .create();
     JsonReader reader = new JsonReader(new StringReader(sourceJson));
     reader.setLenient(true);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -195,7 +195,9 @@ public class Notebook {
       throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.setDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").create();
+
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportSerializer())
+      .create();
     JsonReader reader = new JsonReader(new StringReader(sourceJson));
     reader.setLenient(true);
     Note newNote;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 /**
  *  Notebook Import serializer for gson
  */
-public class NotebookImportSerializer implements JsonDeserializer<Date> {
+public class NotebookImportDeserializer implements JsonDeserializer<Date> {
   private static final String[] DATE_FORMATS = new String[] {
     "yyyy-MM-dd'T'HH:mm:ssZ",
     "MMM dd, yyyy HH:mm:ss"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
@@ -30,7 +30,7 @@ import java.util.Date;
 import java.util.Locale;
 
 /**
- *  Notebook Import serializer for gson
+ *  importNote date format deserializer
  */
 public class NotebookImportDeserializer implements JsonDeserializer<Date> {
   private static final String[] DATE_FORMATS = new String[] {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportSerializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ *  Notebook Import serializer for gson
+ */
+public class NotebookImportSerializer implements JsonDeserializer<Date> {
+  private static final String[] DATE_FORMATS = new String[] {
+    "yyyy-MM-dd'T'HH:mm:ssZ",
+    "MMM dd, yyyy HH:mm:ss"
+  };
+
+  @Override
+  public Date deserialize(JsonElement jsonElement, Type typeOF,
+    JsonDeserializationContext context) throws JsonParseException {
+    for (String format : DATE_FORMATS) {
+      try {
+        return new SimpleDateFormat(format, Locale.US).parse(jsonElement.getAsString());
+      } catch (ParseException e) {
+      }
+    }
+    throw new JsonParseException("Unparsable date: \"" + jsonElement.getAsString()
+      + "\". Supported formats: " + Arrays.toString(DATE_FORMATS));
+  }
+}


### PR DESCRIPTION
### What is this PR for?

This bug seems to be produced by #862. Currently a exported notebook is not imported with below error message.

```
ERROR [2016-06-20 17:19:21,797] ({qtp559670971-14} NotebookServer.java[onMessage]:231) - Can't handle message
com.google.gson.JsonSyntaxException: 2016-06-20T14:33:31-0700
	at com.google.gson.internal.bind.DateTypeAdapter.deserializeToDate(DateTypeAdapter.java:81)
	at com.google.gson.internal.bind.DateTypeAdapter.read(DateTypeAdapter.java:66)
	at com.google.gson.internal.bind.DateTypeAdapter.read(DateTypeAdapter.java:41)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:93)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:172)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:81)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:60)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:93)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:172)
	at com.google.gson.Gson.fromJson(Gson.java:791)
	at org.apache.zeppelin.notebook.Notebook.importNote(Notebook.java:199)
	at org.apache.zeppelin.socket.NotebookServer.importNote(NotebookServer.java:656)
	at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:175)
	at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:56)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:128)
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:65)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:122)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:161)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:309)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:214)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220)
	at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:258)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:632)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:480)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.text.ParseException: Unparseable date: "2016-06-20T14:33:31-0700"
	at java.text.DateFormat.parse(DateFormat.java:366)
	at com.google.gson.internal.bind.DateTypeAdapter.deserializeToDate(DateTypeAdapter.java:79)
```


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-1028](https://issues.apache.org/jira/browse/ZEPPELIN-1028)

### How should this be tested?
1. Apply this patch (Build the source and restart Zeppelin)
2. Export a notebook and try to import it again
3. It should be imported as before

### Screenshots (if appropriate)
With this patch, we can import the below two types of date format notebooks. 
 -  Exported after #862 merged : `yyyy-MM-dd'T'HH:mm:ssZ`
<img width="289" alt="screen shot 2016-06-22 at 12 18 01 pm" src="https://cloud.githubusercontent.com/assets/10060731/16280468/6ebad710-3874-11e6-9ce6-b38e239649a2.png">

 - Exported before #862 merged : `MMM dd, yyyy HH:mm:ss`
<img width="288" alt="screen shot 2016-06-22 at 12 17 31 pm" src="https://cloud.githubusercontent.com/assets/10060731/16280459/6a4f256e-3874-11e6-848e-ec1ff6e9b441.png">



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

