### PR TITLE
BugFix of Automatically adds %.* of previous paragraph's typing.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -113,7 +113,7 @@ public class Note implements Serializable, JobListener {
 
   private String getDefaultInterpreterName() {
     Optional<InterpreterSetting> settingOptional = replLoader.getDefaultInterpreterSetting();
-    return settingOptional.isPresent() ? settingOptional.get().getName() : StringUtils.EMPTY;
+    return settingOptional.isPresent() ? settingOptional.get().getGroup() : StringUtils.EMPTY;
   }
 
   void putDefaultReplName() {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -112,7 +112,7 @@ public class NoteTest {
   @Test
   public void putDefaultReplNameIfInterpreterSettingPresent() {
     InterpreterSetting interpreterSetting = Mockito.mock(InterpreterSetting.class);
-    when(interpreterSetting.getName()).thenReturn("spark");
+    when(interpreterSetting.getGroup()).thenReturn("spark");
     when(replLoader.getDefaultInterpreterSetting())
             .thenReturn(Optional.of(interpreterSetting));
 
@@ -126,7 +126,7 @@ public class NoteTest {
   @Test
   public void addParagraphWithLastReplName() {
     InterpreterSetting interpreterSetting = Mockito.mock(InterpreterSetting.class);
-    when(interpreterSetting.getName()).thenReturn("spark");
+    when(interpreterSetting.getGroup()).thenReturn("spark");
     when(replLoader.getDefaultInterpreterSetting())
             .thenReturn(Optional.of(interpreterSetting));
 
@@ -141,7 +141,7 @@ public class NoteTest {
   @Test
   public void insertParagraphWithLastReplName() {
     InterpreterSetting interpreterSetting = Mockito.mock(InterpreterSetting.class);
-    when(interpreterSetting.getName()).thenReturn("spark");
+    when(interpreterSetting.getGroup()).thenReturn("spark");
     when(replLoader.getDefaultInterpreterSetting())
             .thenReturn(Optional.of(interpreterSetting));
 


### PR DESCRIPTION
### What is this PR for?
This PR is to fix bug from https://github.com/apache/zeppelin/pull/806.
The default interpreter name that automatically adds should be interpreter group name. 

### What type of PR is it?
Bug Fix


### Screenshots (if appropriate)
  - before 
![b](https://cloud.githubusercontent.com/assets/3348133/16221424/99cab6b6-37cd-11e6-8074-93fd9db53b45.gif)

  - after
![a](https://cloud.githubusercontent.com/assets/3348133/16221623/d2c36e94-37ce-11e6-957f-fea2e67dd55d.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

