### PR TITLE
[ZEPPELIN-954] Fix table cell selection problem on second run by properly destroying hot.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1226,7 +1226,7 @@ angular.module('zeppelinWebApp')
       var height = $scope.paragraph.config.graph.height;
       var container = angular.element('#p' + $scope.paragraph.id + '_table').css('height', height).get(0);
       var resultRows = data.rows;
-      var columnNames = _.pluck($scope.paragraph.result.columnNames, 'name');
+      var columnNames = _.pluck(data.columnNames, 'name');
 
       // on chart type change, destroy table to force reinitialization.
       if ($scope.hot && !refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1224,12 +1224,16 @@ angular.module('zeppelinWebApp')
   var setTable = function(type, data, refresh) {
     var renderTable = function() {
       var height = $scope.paragraph.config.graph.height;
-      angular.element('#p' + $scope.paragraph.id + '_table').css('height', height);
+      var container = angular.element('#p' + $scope.paragraph.id + '_table').css('height', height).get(0);
       var resultRows = $scope.paragraph.result.rows;
       var columnNames = _.pluck($scope.paragraph.result.columnNames, 'name');
-      var container = document.getElementById('p' + $scope.paragraph.id + '_table');
 
-      var handsontable = new Handsontable(container, {
+      if ($scope.hot) {
+        // properly destroy old table. otherwise leftover event handlers can cause problems.
+        $scope.hot.destroy();
+      }
+
+      $scope.hot = new Handsontable(container, {
         data: resultRows,
         colHeaders: columnNames,
         rowHeaders: false,
@@ -1239,7 +1243,8 @@ angular.module('zeppelinWebApp')
         contextMenu: false,
         manualColumnResize: true,
         manualRowResize: true,
-        editor: false,
+        readOnly: true,
+        readOnlyCellClassName: '',  // don't apply any special class so we can retain current styling
         fillHandle: false,
         fragmentSelection: true,
         disableVisualSelection: true,


### PR DESCRIPTION
### What is this PR for?
* Fix table cell selection problem on second run by properly destroying hot.
* Also make cells readonly. Previously one were able to paste into them.

### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
* [ZEPPELIN-954]


### How should this be tested?
Execute the following paragraph multiple times, and verify the table cells are still selectable.
```
%sh
echo %table
echo -e "col1\tcol2\tcol3"
echo -e "1\t2.1\tabcdefg"
```
Also try to paste anything into a cell to no avail.


### Screenshots (if appropriate)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No