### PR TITLE
[MINOR] [ZEPPELIN-1043] Blocked in inaccessible notebook with blank page

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -742,7 +742,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
               label: 'Cancel',
               action: function (dialog) {
                 dialog.close();
-                $window.history.back();
+                $window.location.replace('/');
               }
             }
           ]

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -16,7 +16,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('NotebookCtrl',
-  function($scope, $route, $routeParams, $location, $rootScope, $http,
+  function($scope, $route, $routeParams, $location, $rootScope, $http, $window,
     websocketMsgSrv, baseUrlSrv, $timeout, SaveAsService) {
   $scope.note = null;
   $scope.showEditor = false;
@@ -723,7 +723,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
       error(function (data, status, headers, config) {
         console.log('Error %o %o', status, data.message);
         BootstrapDialog.show({
-          closable: true,
+          closable: false,
+          closeByBackdrop: false,
+          closeByKeyboard: false,
           title: 'Insufficient privileges',
           message: data.message,
           buttons: [
@@ -740,6 +742,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
               label: 'Cancel',
               action: function (dialog) {
                 dialog.close();
+                $window.history.back();
               }
             }
           ]

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -13,7 +13,7 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope, $websocket, $location, baseUrlSrv) {
+angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope, $websocket, $location, $window, baseUrlSrv) {
   var websocketCalls = {};
 
   websocketCalls.ws = $websocket(baseUrlSrv.getWebsocketUrl());
@@ -74,8 +74,9 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
               }
           }, {
               label: 'Cancel',
-              action: function(dialog){
-                 dialog.close();
+              action: function(dialog) {
+                  dialog.close();
+                  $window.history.back();
               }
           }]
       });

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -61,7 +61,9 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'AUTH_INFO') {
       BootstrapDialog.show({
-          closable: true,
+          closable: false,
+          closeByBackdrop: false,
+          closeByKeyboard: false,
           title: 'Insufficient privileges', 
           message: data.info.toString(),
           buttons: [{

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -78,7 +78,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents', function($rootScope,
               label: 'Cancel',
               action: function(dialog) {
                   dialog.close();
-                  $window.history.back();
+                  $window.location.replace('/');
               }
           }]
       });


### PR DESCRIPTION
### What is this PR for?
Currently, when a user who doesn't have a permission for a notebook is trying to access to the notebook, a dialog is shown up. The user can login in this dialog or close it.
But if the user is trying to just close this dialog, the location is not changed and still stay `/notebook/NOTE_ID` with blank page. So the user have to click somewhere manually. 

So I just added `$window.history.back()` so that it can go back to previous page.
See the attached gif image :)

### What type of PR is it?
Bug Fix

### Todos
- [x] - Disable backdrop, ESC drop and close icon

### What is the Jira issue?
[ZEPPELIN-1043](https://issues.apache.org/jira/browse/ZEPPELIN-1043)

### How should this be tested?
1. Apply this patch and activate shiro -> login with `admin`
2. Create a notebook and set a note permission (just fill  all 3 fields with `admin`)
3. Logout with `admin` and login with `user1` 
4. Try to access to the notebook -> a popup will be shown
5. Click `Cancel` -> Page will redirect to your previous location (home or the previous notebook page)

### Screenshots (if appropriate)
- Before
![before](https://cloud.githubusercontent.com/assets/10060731/16245851/96bd5674-37b7-11e6-9f9e-c69b74b0e6cc.gif)

- After
When you were in home
![after1](https://cloud.githubusercontent.com/assets/10060731/16245854/9a16fc30-37b7-11e6-80d3-b7bae18c78b2.gif)
When you were in the other notebook 
![after2](https://cloud.githubusercontent.com/assets/10060731/16245855/9c0da7a0-37b7-11e6-8e07-470be0d18fa2.gif)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

