### PR TITLE
[ZEPPELIN-1007] Toggle only one of the interpreter/permission settings

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -612,7 +612,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
       BootstrapDialog.confirm({
         closable: true,
         title: '',
-        message: 'Changes will be discarded.',
+        message: 'Interpreter setting changes will be discarded.',
         callback: function(result) {
           if (result) {
             $scope.$apply(function() {
@@ -651,6 +651,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
       $scope.closeSetting();
     } else {
       $scope.openSetting();
+      $scope.closePermissions();
     }
   };
 
@@ -752,6 +753,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
       $scope.closePermissions();
     } else {
       $scope.openPermissions();
+      $scope.closeSetting();
     }
   };
 


### PR DESCRIPTION
### What is this PR for?
Prevent Interpreter binding and Note Permissions dialog opens at the same time.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1007](https://issues.apache.org/jira/browse/ZEPPELIN-1007)

### Screenshots (if appropriate)
Before
![jun-21-2016 17-55-31](https://cloud.githubusercontent.com/assets/8503346/16251286/90685022-37d9-11e6-972c-aedb4d48d983.gif)

After
![jun-21-2016 17-54-45](https://cloud.githubusercontent.com/assets/8503346/16251288/9594f9b0-37d9-11e6-9d84-8d96da221980.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

