### PR TITLE
BugFix-blocking of blank values insertion on the Credential page.

### DIFF
--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -24,11 +24,10 @@ angular.module('zeppelinWebApp').controller('CredentialCtrl', function($scope, $
 
   $scope.updateCredentials = function() {
     if (_.isEmpty($scope.credentialEntity.trim()) ||
-        _.isEmpty($scope.credentialUsername.trim()) ||
-        _.isEmpty($scope.credentialPassword.trim())) {
+        _.isEmpty($scope.credentialUsername.trim())) {
       BootstrapDialog.alert({
         closable: true,
-        message: 'The values must be filled.'
+        message: 'Username \\ Entity can not be empty.'
       });
       return;
     }

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -21,15 +21,28 @@ angular.module('zeppelinWebApp').controller('CredentialCtrl', function($scope, $
   $scope.credentialEntity = '';
   $scope.credentialUsername = '';
   $scope.credentialPassword = '';
-  
+
   $scope.updateCredentials = function() {
+    if (_.isEmpty($scope.credentialEntity.trim()) ||
+        _.isEmpty($scope.credentialUsername.trim()) ||
+        _.isEmpty($scope.credentialPassword.trim())) {
+      BootstrapDialog.alert({
+        closable: true,
+        message: 'The values must be filled.'
+      });
+      return;
+    }
+
     $http.put(baseUrlSrv.getRestApiBase() + '/credential',
       { 'entity': $scope.credentialEntity,
         'username': $scope.credentialUsername,
         'password': $scope.credentialPassword
       } ).
     success(function (data, status, headers, config) {
-      alert('Successfully saved credentials');
+      BootstrapDialog.alert({
+        closable: true,
+        message: 'Successfully saved credentials.'
+      });
       $scope.credentialEntity = '';
       $scope.credentialUsername = '';
       $scope.credentialPassword = '';


### PR DESCRIPTION
### What is this PR for?
This PR blocks the blank values insertion on the Credential page and 
changes the success message box to zeppelin's dialog box.


### What type of PR is it?
Bug Fix


### How should this be tested?
Try to save with blank values on the Credential page.

### Screenshots (if appropriate)
  - before 
![out](https://cloud.githubusercontent.com/assets/3348133/16255783/c5d19378-3887-11e6-9eec-5fcac42ee276.gif)


  - after
![image](https://cloud.githubusercontent.com/assets/3348133/16255706/18967912-3887-11e6-8823-21683c17082d.png)


![image](https://cloud.githubusercontent.com/assets/3348133/16255722/55c9f494-3887-11e6-84f8-857a7f5380d6.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

