### PR TITLE
[ZEPPELIN-921] Apply new mechanism to KnitR and RRepl

### DIFF
--- a/r/pom.xml
+++ b/r/pom.xml
@@ -200,6 +200,7 @@
             <exclude>**/derby.log</exclude>
             <exclude>**/metastore_db/</exclude>
             <exclude>**/README.md</exclude>
+            <exclude>**/interpreter-setting.json</exclude>
             <exclude>**/dependency-reduced-pom.xml</exclude>
           </excludes>
         </configuration>

--- a/r/src/main/java/org/apache/zeppelin/rinterpreter/KnitR.java
+++ b/r/src/main/java/org/apache/zeppelin/rinterpreter/KnitR.java
@@ -34,12 +34,6 @@ import java.util.Properties;
 public class KnitR extends Interpreter implements WrappedInterpreter {
   KnitRInterpreter intp;
 
-  static {
-    Interpreter.register("knitr", "spark", KnitR.class.getName(),
-        RInterpreter.getProps()
-    );
-  }
-
   public KnitR(Properties property, Boolean startSpark) {
     super(property);
     intp = new KnitRInterpreter(property, startSpark);

--- a/r/src/main/java/org/apache/zeppelin/rinterpreter/RRepl.java
+++ b/r/src/main/java/org/apache/zeppelin/rinterpreter/RRepl.java
@@ -34,12 +34,6 @@ import java.util.Properties;
 public class RRepl extends Interpreter implements WrappedInterpreter {
   RReplInterpreter intp;
 
-  static {
-    Interpreter.register("r", "spark", RRepl.class.getName(),
-            RInterpreter.getProps()
-    );
-  }
-
   public RRepl(Properties property, Boolean startSpark) {
     super(property);
     intp = new RReplInterpreter(property, startSpark);

--- a/r/src/main/resources/interpreter-setting.json
+++ b/r/src/main/resources/interpreter-setting.json
@@ -1,0 +1,14 @@
+[
+  {
+    "group": "spark",
+    "name": "knitr",
+    "className": "org.apache.zeppelin.rinterpreter.KnitR",
+    "properties": null
+  },
+  {
+    "group": "spark",
+    "name": "r",
+    "className": "org.apache.zeppelin.rinterpreter.RRepl",
+    "properties": null
+  }
+]


### PR DESCRIPTION
### What is this PR for?
This PR applies the new interpreter registration mechanism to KnitR and RRepl.

### What type of PR is it?
Improvement

### Todos
- Move interpreter registration properties from static block to interpreter-setting.json

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-921

### How should this be tested?
1. apply patch
2. rm -r interpreter/r
3. rm conf/interpreter.json
4. mvn clean package -DskipTests -Pspark-1.6 -Psparkr
5. bin/zeppelin-daemon.sh start
6. run some paragraph with simple R queries

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No