### PR TITLE
[ZEPPELIN-936] Fix flaky test SparkRTest

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -129,6 +129,7 @@ public abstract class AbstractTestRestApi {
 
         // set spark master
         sparkIntpSetting.getProperties().setProperty("master", "spark://" + getHostname() + ":7071");
+        sparkIntpSetting.getProperties().setProperty("spark.cores.max", "2");
 
         // set spark home for pyspark
         sparkIntpSetting.getProperties().setProperty("spark.home", getSparkHome());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -127,7 +127,7 @@ public abstract class AbstractTestRestApi {
           }
         }
 
-        // set spark master
+        // set spark master and other properties
         sparkIntpSetting.getProperties().setProperty("master", "spark://" + getHostname() + ":7071");
         sparkIntpSetting.getProperties().setProperty("spark.cores.max", "2");
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -127,7 +127,7 @@ public abstract class AbstractTestRestApi {
           }
         }
 
-        // set spark master and other properties
+        // set spark master and other properties.
         sparkIntpSetting.getProperties().setProperty("master", "spark://" + getHostname() + ":7071");
         sparkIntpSetting.getProperties().setProperty("spark.cores.max", "2");
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -127,7 +127,7 @@ public abstract class AbstractTestRestApi {
           }
         }
 
-        // set spark master and other properties.
+        // set spark master and other properties
         sparkIntpSetting.getProperties().setProperty("master", "spark://" + getHostname() + ":7071");
         sparkIntpSetting.getProperties().setProperty("spark.cores.max", "2");
 


### PR DESCRIPTION
### What is this PR for?
This PR fixes test failure described in ZEPPELIN-936,
or hanging on SparkRTest

```
Spark version detected 1.6.1
23:52:30,005  INFO org.apache.zeppelin.notebook.Paragraph:252 - run paragraph 20160623-235230_1368989448 using r org.apache.zeppelin.interpreter.LazyOpenInterpreter@5221ff81


No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself.

The build has been terminated
```


### What type of PR is it?
Hot Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-936


