### PR TITLE
Prevent menubar hide notebook title and control buttons depending on screen size

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -62,7 +62,7 @@ limitations under the License.
             <div class="input-group">
               <input
                 type="text"
-                style="min-width:300px;"
+                style="min-width:200px;"
                 ng-model="searchForm.searchTerm"
                 id="searchTermId"
                 ng-disabled="!navbar.connected"


### PR DESCRIPTION
### What is this PR for?
Prevent menubar hide notebook title and control buttons, depending on screen size

### What type of PR is it?
Bug Fix

### Todos
* [x] - Make search input box smaller

### How should this be tested?
Resize your browser

### Screenshots (if appropriate)
before
![menubar_before](https://cloud.githubusercontent.com/assets/1540981/16331737/0ea27b88-39a7-11e6-8db5-e14326aecbaf.gif)
after
![menubar_after](https://cloud.githubusercontent.com/assets/1540981/16331742/19ea0cc2-39a7-11e6-9535-16c5d7926694.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

