### PR TITLE
[ZEPPELIN-1062] Get original InterpreterSetting when there is no change

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -150,6 +150,8 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
               thisConfirm.close();
             });
           return false;
+        } else {
+          getInterpreterSettings();
         }
       }
     });

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -103,7 +103,9 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
 
   $scope.updateInterpreterSetting = function(form, settingId) {
     var thisConfirm = BootstrapDialog.confirm({
-      closable: true,
+      closable: false,
+      closeByBackdrop: false,
+      closeByKeyboard: false,
       title: '',
       message: 'Do you want to update this interpreter and restart with new settings?',
       callback: function (result) {
@@ -151,7 +153,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
             });
           return false;
         } else {
-          getInterpreterSettings();
+          form.$show();
         }
       }
     });


### PR DESCRIPTION
### What is this PR for?
When we update interpreter property values, we edit some values and click "save" button. Then a bootstrap dialog is show up. In this step, if we click "cancel", the updated value is still existed in the table. This new value is not stored actually. After refresh, the original value will be shown. 

I just get original InterpreterSetting(`getInterpreterSettings()`) when there is no change(`result`) for fixing this bug.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-1062](https://issues.apache.org/jira/browse/ZEPPELIN-1062)

### How should this be tested?
It's really simple. Just see the below attached screenshots. 

### Screenshots (if appropriate)
 - Before
![interpreter_setting](https://cloud.githubusercontent.com/assets/10060731/16358958/461a1d32-3ad8-11e6-849f-5010caed4e4d.gif)

- After
![after](https://cloud.githubusercontent.com/assets/10060731/16580420/57126fc2-42df-11e6-9a39-110326beafd8.gif)




### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

