### PR TITLE
[MINOR] Blocking the minus cursor value.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -208,7 +208,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
 
   public List<InterpreterCompletion> completion(String buffer, int cursor) {
     String replName = getRequiredReplName(buffer);
-    if (replName != null) {
+    if (replName != null && cursor > replName.length()) {
       cursor -= replName.length() + 1;
     }
     String body = getScriptBody(buffer);


### PR DESCRIPTION
### What is this PR for?
This PR is for blocking minus cursor value on the paragraph.
If we put the ```ctrl+.``` for auto completion on the interpreter name, the cursor value to be minus so it occurs ```java.lang.StringIndexOutOfBoundsException```.

### What type of PR is it?
Improvement | Refactoring


### Screenshots (if appropriate)
![cursor](https://cloud.githubusercontent.com/assets/3348133/16369544/7a347148-3c73-11e6-8d6c-032af0b7520f.gif)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

