### PR TITLE
[ZEPPELIN-1065] Flaky Test - ParagraphActionsIT.testRemoveButton

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -38,9 +38,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.openqa.selenium.Keys.ENTER;
-import static org.openqa.selenium.Keys.SHIFT;
-
 abstract public class AbstractZeppelinIT {
   protected static WebDriver driver;
 
@@ -48,21 +45,6 @@ abstract public class AbstractZeppelinIT {
   protected static final long MAX_IMPLICIT_WAIT = 30;
   protected static final long MAX_BROWSER_TIMEOUT_SEC = 30;
   protected static final long MAX_PARAGRAPH_TIMEOUT_SEC = 60;
-
-  protected void sleep(long millis, boolean logOutput) {
-    if (logOutput) {
-      LOG.info("Starting sleeping for " + (millis / 1000) + " seconds...");
-      LOG.info("Caller: " + Thread.currentThread().getStackTrace()[2]);
-    }
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-    if (logOutput) {
-      LOG.info("Finished.");
-    }
-  }
 
   protected void setTextOfParagraph(int paragraphNo, String text) {
     String editorId = driver.findElement(By.xpath(getParagraphXPath(paragraphNo) + "//div[contains(@class, 'editor')]")).getAttribute("id");
@@ -147,10 +129,15 @@ abstract public class AbstractZeppelinIT {
   protected void deleteTestNotebook(final WebDriver driver) {
     driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']"))
         .sendKeys(Keys.ENTER);
-    sleep(1000, true);
+    ZeppelinITUtils.sleep(1000, true);
     driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this notebook')]" +
         "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
-    sleep(100, true);
+    ZeppelinITUtils.sleep(100, true);
+  }
+
+  protected void clickAndWait(final By locator) {
+    driver.findElement(locator).click();
+    ZeppelinITUtils.sleep(1000, true);
   }
 
   protected void handleException(String message, Exception e) throws Exception {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -109,22 +109,22 @@ public class AuthenticationIT extends AbstractZeppelinIT {
     pollingWait(By.xpath(
         "//div[contains(@class, 'navbar-collapse')]//li//button[contains(.,'Login')]"),
         MAX_BROWSER_TIMEOUT_SEC).click();
-    sleep(1000, false);
+    ZeppelinITUtils.sleep(1000, false);
     pollingWait(By.xpath("//*[@id='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(userName);
     pollingWait(By.xpath("//*[@id='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(password);
     pollingWait(By.xpath("//*[@id='NoteImportCtrl']//button[contains(.,'Login')]"),
         MAX_BROWSER_TIMEOUT_SEC).click();
-    sleep(1000, false);
+    ZeppelinITUtils.sleep(1000, false);
   }
 
   private void logoutUser(String userName) {
-    sleep(500, false);
+    ZeppelinITUtils.sleep(500, false);
     driver.findElement(By.xpath("//div[contains(@class, 'navbar-collapse')]//li[contains(.,'" +
         userName + "')]")).click();
-    sleep(500, false);
+    ZeppelinITUtils.sleep(500, false);
     driver.findElement(By.xpath("//div[contains(@class, 'navbar-collapse')]//li[contains(.,'" +
         userName + "')]//a[@ng-click='logout()']")).click();
-    sleep(5000, false);
+    ZeppelinITUtils.sleep(5000, false);
   }
 
   //  @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -157,10 +157,11 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       sleep(1000, true);
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this paragraph')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+      sleep(1000, true);
       Integer newNosOfParas = driver.findElements(By.xpath("//div[@ng-controller=\"ParagraphCtrl\"]")).size();
       collector.checkThat("After Remove : Number of paragraphs are",
-          oldNosOfParas-1,
-          CoreMatchers.equalTo(newNosOfParas));
+          newNosOfParas,
+          CoreMatchers.equalTo(oldNosOfParas - 1));
       ZeppelinITUtils.sleep(1000, false);
       deleteTestNotebook(driver);
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -28,7 +28,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.Select;
 import org.slf4j.Logger;
@@ -57,6 +59,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
     driver.quit();
   }
+
   @Test
   public void testCreateNewButton() throws Exception {
     if (!endToEndTestEnabled()) {
@@ -146,19 +149,23 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       waitForParagraph(1, "READY");
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
-      driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click='insertNew()']")).click();
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click='insertNew()']"))
+          .click();
       waitForParagraph(2, "READY");
-      Integer oldNosOfParas = driver.findElements(By.xpath("//div[@ng-controller=\"ParagraphCtrl\"]")).size();
+      Integer oldNosOfParas = driver.findElements(By.xpath
+          ("//div[@ng-controller=\"ParagraphCtrl\"]")).size();
       collector.checkThat("Before Remove : Number of paragraphs are ",
           oldNosOfParas,
           CoreMatchers.equalTo(2));
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
-      driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click='removeParagraph()']")).click();
-      sleep(1000, true);
-      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this paragraph')]" +
-          "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
-      sleep(1000, true);
-      Integer newNosOfParas = driver.findElements(By.xpath("//div[@ng-controller=\"ParagraphCtrl\"]")).size();
+
+      clickAndWait(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click='removeParagraph()']"));
+
+      clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this paragraph')" +
+          "]//div[@class='modal-footer']//button[contains(.,'OK')]"));
+
+      Integer newNosOfParas = driver.findElements(By.xpath
+          ("//div[@ng-controller=\"ParagraphCtrl\"]")).size();
       collector.checkThat("After Remove : Number of paragraphs are",
           newNosOfParas,
           CoreMatchers.equalTo(oldNosOfParas - 1));
@@ -199,7 +206,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click='moveDown()']")).click();
 
-      ZeppelinITUtils.sleep(1000,false);
+      ZeppelinITUtils.sleep(1000, false);
 
       collector.checkThat("The paragraph1 value contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'editor')]")).getText(),
@@ -211,7 +218,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       driver.findElement(By.xpath(getParagraphXPath(2) + "//span[@class='icon-settings']")).click();
       driver.findElement(By.xpath(getParagraphXPath(2) + "//ul/li/a[@ng-click='moveUp()']")).click();
 
-      ZeppelinITUtils.sleep(1000,false);
+      ZeppelinITUtils.sleep(1000, false);
 
       collector.checkThat("The paragraph1 value contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'editor')]")).getText(),
@@ -219,7 +226,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       collector.checkThat("The paragraph1 value contains",
           driver.findElement(By.xpath(getParagraphXPath(2) + "//div[contains(@class, 'editor')]")).getText(),
           CoreMatchers.equalTo("2"));
-      ZeppelinITUtils.sleep(1000,false);
+      ZeppelinITUtils.sleep(1000, false);
       deleteTestNotebook(driver);
 
     } catch (Exception e) {
@@ -246,10 +253,10 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       );
 
       driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='runNote()']")).sendKeys(Keys.ENTER);
-      sleep(1000, true);
+      ZeppelinITUtils.sleep(1000, true);
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Run all paragraphs?')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
-      sleep(2000, false);
+      ZeppelinITUtils.sleep(2000, false);
 
       collector.checkThat("Paragraph status is ",
           getParagraphStatus(1), CoreMatchers.equalTo("READY")
@@ -273,7 +280,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       createNewNote();
 
       waitForParagraph(1, "READY");
-      String xpathToOutputField=getParagraphXPath(1) + "//div[contains(@ng-if,'getResultType()')]";
+      String xpathToOutputField = getParagraphXPath(1) + "//div[contains(@ng-if,'getResultType()')]";
       setTextOfParagraph(1, "println (\"abcd\")");
       collector.checkThat("Before Run Output field contains ",
           driver.findElement(By.xpath(xpathToOutputField)).getText(),
@@ -292,7 +299,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       deleteTestNotebook(driver);
 
     } catch (Exception e) {
-      handleException("Exception in ParagraphActionsIT while testClearOutputButton ",e);
+      handleException("Exception in ParagraphActionsIT while testClearOutputButton ", e);
     }
 
   }
@@ -336,8 +343,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       String xpathToTitle = getParagraphXPath(1) + "//div[contains(@class, 'title')]/div";
       String xpathToSettingIcon = getParagraphXPath(1) + "//span[@class='icon-settings']";
-      String xpathToShowTitle=getParagraphXPath(1) + "//ul/li/a[@ng-click='showTitle()']";
-      String xpathToHideTitle=getParagraphXPath(1) + "//ul/li/a[@ng-click='hideTitle()']";
+      String xpathToShowTitle = getParagraphXPath(1) + "//ul/li/a[@ng-click='showTitle()']";
+      String xpathToHideTitle = getParagraphXPath(1) + "//ul/li/a[@ng-click='hideTitle()']";
 
       collector.checkThat("Before Show Title : The title field contains",
           driver.findElement(By.xpath(xpathToTitle)).getText(),
@@ -392,9 +399,9 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       createNewNote();
 
       waitForParagraph(1, "READY");
-      String xpathToLineNumberField=getParagraphXPath(1) + "//div[contains(@class, 'ace_gutter-layer')]";
-      String xpathToShowLineNumberButton=getParagraphXPath(1) + "//ul/li/a[@ng-click='showLineNumbers()']";
-      String xpathToHideLineNumberButton=getParagraphXPath(1) + "//ul/li/a[@ng-click='hideLineNumbers()']";
+      String xpathToLineNumberField = getParagraphXPath(1) + "//div[contains(@class, 'ace_gutter-layer')]";
+      String xpathToShowLineNumberButton = getParagraphXPath(1) + "//ul/li/a[@ng-click='showLineNumbers()']";
+      String xpathToHideLineNumberButton = getParagraphXPath(1) + "//ul/li/a[@ng-click='hideLineNumbers()']";
 
       collector.checkThat("Before \"Show line number\" the Line Number is Enabled ",
           driver.findElement(By.xpath(xpathToLineNumberField)).isDisplayed(),

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.integration;
 
 import org.apache.zeppelin.AbstractZeppelinIT;
 import org.apache.zeppelin.WebDriverManager;
+import org.apache.zeppelin.ZeppelinITUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -178,10 +179,10 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']"))
           .sendKeys(Keys.ENTER);
-      sleep(1000, true);
+      ZeppelinITUtils.sleep(1000, true);
       driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this notebook')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
-      sleep(100, true);
+      ZeppelinITUtils.sleep(100, true);
 
       LOG.info("testCreateNotebook Test executed");
     } catch (Exception e) {
@@ -234,7 +235,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       //delete created notebook for cleanup.
       deleteTestNotebook(driver);
-      sleep(1000, false);
+      ZeppelinITUtils.sleep(1000, false);
 
       // reset dependency
       settingButton.click();
@@ -306,7 +307,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       //delete created notebook for cleanup.
       deleteTestNotebook(driver);
-      sleep(1000, true);
+      ZeppelinITUtils.sleep(1000, true);
 
       LOG.info("testAngularRunParagraph Test executed");
     }  catch (Exception e) {


### PR DESCRIPTION
### What is this PR for?
This is fix for fixing flaky CI failing test

```
testRemoveButton(org.apache.zeppelin.integration.ParagraphActionsIT)  Time elapsed: 9.641 sec  <<< FAILURE!
java.lang.AssertionError: After Remove : Number of paragraphs are
Expected: <2>
     but: was <1>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.rules.ErrorCollector$1.call(ErrorCollector.java:65)
	at org.junit.rules.ErrorCollector.checkSucceeds(ErrorCollector.java:78)
	at org.junit.rules.ErrorCollector.checkThat(ErrorCollector.java:63)
	at org.apache.zeppelin.integration.ParagraphActionsIT.testRemoveButton(ParagraphActionsIT.java:161)
```

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Add delay after paragraph delete.

### What is the Jira issue?
* [ZEPPELIN-1065](https://issues.apache.org/jira/browse/ZEPPELIN-1065)

### How should this be tested?
CI should be green


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

