### PR TITLE
[ZEPPELIN-1103] Fix "stackedAreaChart", "lineWithFocusChart" graph when dataset contains "NULL" value.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1769,7 +1769,7 @@ angular.module('zeppelinWebApp')
     var colNameIndex = {};
     var colIdx = 0;
     var rowIndexValue = {};
-    var maxRowValue = Math.max(Object.keys(schema).size(), Math.max.apply(null, Object.keys(schema).filter(function(obj){return !isNaN(obj)}).map(parseFloat)));
+    var maxRowValue = Math.max(Object.keys(schema).length, Math.max.apply(null, Object.keys(schema).filter(function(obj){return !isNaN(obj)}).map(parseFloat)));
 
     for (var k in rows) {
       traverse(sKey, schema[sKey], k, rows[k], function(rowName, rowValue, colName, value) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1769,13 +1769,20 @@ angular.module('zeppelinWebApp')
     var colNameIndex = {};
     var colIdx = 0;
     var rowIndexValue = {};
+    var maxRowValue = Math.max(Object.keys(schema).size(), Math.max.apply(null, Object.keys(schema).filter(function(obj){return !isNaN(obj)}).map(parseFloat)));
 
     for (var k in rows) {
       traverse(sKey, schema[sKey], k, rows[k], function(rowName, rowValue, colName, value) {
         //console.log("RowName=%o, row=%o, col=%o, value=%o", rowName, rowValue, colName, value);
         if (rowNameIndex[rowValue] === undefined) {
-          rowIndexValue[rowIdx] = rowValue;
-          rowNameIndex[rowValue] = rowIdx++;
+          if (!allowTextXAxis && isNaN(rowValue)) {
+            rowIndexValue[maxRowValue + 1] = rowValue; // rowIndexValue[53] : "NULL"
+            rowNameIndex[rowValue] = maxRowValue + 1; // rowNameIndex["NULL"] : 53
+            rowIdx++;
+          } else {
+            rowIndexValue[rowIdx] = rowValue;
+            rowNameIndex[rowValue] = rowIdx++;
+          }
         }
 
         if (colNameIndex[colName] === undefined) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1769,7 +1769,7 @@ angular.module('zeppelinWebApp')
     var colNameIndex = {};
     var colIdx = 0;
     var rowIndexValue = {};
-    var maxRowValue = Math.max(Object.keys(schema).length, Math.max.apply(null, Object.keys(schema).filter(function(obj){return !isNaN(obj)}).map(parseFloat)));
+    var maxRowValue = Math.max(Object.keys(schema).length, Math.max.apply(null, Object.keys(schema).filter(function(obj){return !isNaN(obj);}).map(parseFloat)));
 
     for (var k in rows) {
       traverse(sKey, schema[sKey], k, rows[k], function(rowName, rowValue, colName, value) {


### PR DESCRIPTION
### What is this PR for?

Fix "stackedAreaChart", "lineWithFocusChart" graph when dataset contains "NULL" value.
- wired graph with "NULL" value
  ![asis1](https://cloud.githubusercontent.com/assets/366810/16553574/4e3b34b4-4204-11e6-96bc-2624619bd82e.PNG)
  ![asis2](https://cloud.githubusercontent.com/assets/366810/16553575/50a26358-4204-11e6-9356-e54ac3c93274.PNG)
- fixed graph with "NULL" value
  ![tobe1](https://cloud.githubusercontent.com/assets/366810/16553578/5236f904-4204-11e6-87e2-289e85914381.PNG)
  ![tobe2](https://cloud.githubusercontent.com/assets/366810/16553580/551e5fae-4204-11e6-8a6f-6292e652023c.PNG)
### What type of PR is it?

Bug Fix
### Todos
- [x] - Check side effect.
- [x] - Need fix when maxRowValue == rowIdx
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-1103
### How should this be tested?
- This problem can regenerate under dataset like this.
  ![image](https://cloud.githubusercontent.com/assets/366810/16553605/83210050-4204-11e6-8c77-4e1c441f7d93.png)
- rowIndexValue variable is like this on 1777 line.
  rowIndexValue : Object {0: "0", 1: "1", 2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9", 10: "10", 11: "11", 12: "12", 13: "13", 14: "14", 15: "15", 16: "16", 17: "17", 18: "18", 19: "19", 20: "20", 21: "21", 22: "22", 23: "23", 24: "24", 25: "25", 26: "26", 27: "27", 28: "28", 29: "29", 30: "30", 31: "31", 32: "32", 33: "33", 34: "34", 35: "35", 36: "36", 37: "37", 38: "38", 39: "39", 40: "40", 41: "41", 42: "42", 43: "43", 44: "52"}
  rowNameIndex : Object {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15, 16: 16, 17: 17, 18: 18, 19: 19, 20: 20, 21: 21, 22: 22, 23: 23, 24: 24, 25: 25, 26: 26, 27: 27, 28: 28, 29: 29, 30: 30, 31: 31, 32: 32, 33: 33, 34: 34, 35: 35, 36: 36, 37: 37, 38: 38, 39: 39, 40: 40, 41: 41, 42: 42, 43: 43, 52: 44}
