### PR TITLE
ZEPPELIN-1030 Added example for various jdbc-like interpreters

### DIFF
--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -45,6 +45,90 @@
         "propertyName": "zeppelin.jdbc.concurrent.max_connection",
         "defaultValue": "10",
         "description": "Number of concurrent execution"
+      },
+      "hive.url": {
+        "envName": null,
+        "propertyName": "hive.url",
+        "defaultValue": "jdbc:hive2://localhost:10000",
+        "description": ""
+      },
+      "hive.user": {
+        "envName": null,
+        "propertyName": "hive.user",
+        "defaultValue": "hive",
+        "description": ""
+      },
+      "hive.password": {
+        "envName": null,
+        "propertyName": "hive.password",
+        "defaultValue": "",
+        "description": ""
+      },
+      "hive.driver": {
+        "envName": null,
+        "propertyName": "hive.driver",
+        "defaultValue": "org.apache.hive.jdbc.HiveDriver",
+        "description": ""
+      },
+      "phoenix.url": {
+        "envName": null,
+        "propertyName": "phoenix.url",
+        "defaultValue": "jdbc:phoenix:localhost:2181:/hbase-unsecure",
+        "description": ""
+      },
+      "phoenix.user": {
+        "envName": null,
+        "propertyName": "phoenix.user",
+        "defaultValue": "phoenixuser",
+        "description": ""
+      },
+      "phoenix.password": {
+        "envName": null,
+        "propertyName": "phoenix.password",
+        "defaultValue": "",
+        "description": ""
+      },
+      "phoenix.driver": {
+        "envName": null,
+        "propertyName": "phoenix.driver",
+        "defaultValue": "org.apache.phoenix.jdbc.PhoenixDriver",
+        "description": ""
+      },
+      "tajo.url": {
+        "envName": null,
+        "propertyName": "tajo.url",
+        "defaultValue": "jdbc:tajo://localhost:26002/default",
+        "description": ""
+      },
+      "tajo.driver": {
+        "envName": null,
+        "propertyName": "tajo.driver",
+        "defaultValue": "org.apache.tajo.jdbc.TajoDriver",
+        "description": ""
+      },
+      "psql.url": {
+        "envName": null,
+        "propertyName": "psql.url",
+        "defaultValue": "jdbc:postgresql://localhost:5432/",
+        "description": ""
+      },
+      "psql.user": {
+        "envName": null,
+        "propertyName": "psql.user",
+        "defaultValue": "phoenixuser",
+        "description": ""
+      },
+      "psql.password": {
+        "envName": null,
+        "propertyName": "psql.password",
+        "defaultValue": "",
+        "description": ""
+      },
+      "psql.driver": {
+        "envName": null,
+        "propertyName": "psql.driver",
+        "defaultValue": "org.postgresql.Driver",
+        "description": ""
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Adding examples settings for JdbcInterpreter to use jdbc drivers. This hasn't changed actual codes

### What type of PR is it?
[Documentation]

### Todos
* [x] - Add example

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1030

### How should this be tested?
1. mvn clean package -DskipTests -Pspark-1.6 -pl 'jdbc,zeppelin-interpreter,zeppelin-web,zeppelin-server,zeppelin-zengine,zeppelin-display'
2. Test it

### Screenshots (if appropriate)
<img width="744" alt="screen shot 2016-06-27 at 11 46 00 pm" src="https://cloud.githubusercontent.com/assets/3612566/16384014/6aef186a-3cc2-11e6-93e0-105fd9d29eff.png">
<img width="1579" alt="screen shot 2016-06-27 at 11 47 59 pm" src="https://cloud.githubusercontent.com/assets/3612566/16384015/6af3a7ea-3cc2-11e6-88f5-1dc6bc672079.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

