### PR TITLE
[Bugfix] init RepoSetting values

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -389,11 +389,11 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
 
   $scope.resetNewRepositorySetting = function() {
     $scope.newRepoSetting = {
-      id: undefined,
-      url: undefined,
+      id: '',
+      url: '',
       snapshot: false,
-      username: undefined,
-      password: undefined
+      username: '',
+      password: ''
     };
   };
 


### PR DESCRIPTION
### What is this PR for?
This PR fixes initialize value bug of ```Add New Repository```.


### What type of PR is it?
Bug Fix


### How should this be tested?
1. launch the ```Add New Repository``` modal window.
2. put URL value 
3. hit Cancel button
4. launch the ```Add New Repository``` modal window again.


### Screenshots (if appropriate)
  - before
![bb](https://cloud.githubusercontent.com/assets/3348133/16388909/5fbddd00-3cd6-11e6-9e46-1afbb8a37356.gif)


  - after
![after](https://cloud.githubusercontent.com/assets/3348133/16388911/6294390c-3cd6-11e6-92ae-01a8730e3c25.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

