### PR TITLE
ZEPPELIN-1071 ] Ace-editor hidden auto-complete additional events.

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -975,10 +975,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
   };
 
   angular.element(document).click(function(){
-       angular.element('.userlist').hide();
-  });
-
-  angular.element(document).click(function(){
+    angular.element('.userlist').hide();
     angular.element('.ace_autocomplete').hide();
   });
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -956,8 +956,12 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     $scope.suggestions = [];
   };
 
-angular.element(document).click(function(){
-     angular.element('.userlist').hide();
-});
+  angular.element(document).click(function(){
+       angular.element('.userlist').hide();
+  });
+
+  angular.element(document).click(function(){
+    angular.element('.ace_autocomplete').hide();
+  });
 
 });


### PR DESCRIPTION
### What is this PR for?
Does not hide popup for Ace editor-autocomplete
If the page move or click on an event occurs, the auto-completion should be hidden.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1071

### How should this be tested?
1. Call the auto-complete in the code window (ctrl + shift + space)
2. Click anywhere without closing the pop-up.

### Screenshots (if appropriate)

#### Before
![ace_ok](https://cloud.githubusercontent.com/assets/10525473/16407960/56d71fe6-3d51-11e6-8a39-5938388de8a4.gif)
#### After
![ace_ok2](https://cloud.githubusercontent.com/assets/10525473/16407961/593ae7f4-3d51-11e6-8deb-6c7106b060c8.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

