### PR TITLE
[ZEPPELIN-1072] Saving Interpreter Setting dosen't notify when its finished

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -105,20 +105,12 @@ abstract public class AbstractZeppelinIT {
   }
 
   protected void createNewNote() {
-    List<WebElement> notebookLinks = driver.findElements(By
-        .xpath("//div[contains(@class, \"col-md-4\")]/div/ul/li"));
-    List<String> notebookTitles = new LinkedList<String>();
-    for (WebElement el : notebookLinks) {
-      notebookTitles.add(el.getText());
-    }
-
-    WebElement createNoteLink = driver.findElement(By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new note')]"));
-    createNoteLink.click();
+    clickAndWait(By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new" +
+        " note')]"));
 
     WebDriverWait block = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
-    WebElement modal = block.until(ExpectedConditions.visibilityOfElementLocated(By.id("noteNameModal")));
-    WebElement createNoteButton = modal.findElement(By.id("createNoteButton"));
-    createNoteButton.click();
+    block.until(ExpectedConditions.visibilityOfElementLocated(By.id("noteNameModal")));
+    clickAndWait(By.id("createNoteButton"));
 
     try {
       Thread.sleep(500); // wait for notebook list updated
@@ -136,7 +128,7 @@ abstract public class AbstractZeppelinIT {
   }
 
   protected void clickAndWait(final By locator) {
-    driver.findElement(locator).click();
+    pollingWait(locator, MAX_IMPLICIT_WAIT).click();
     ZeppelinITUtils.sleep(1000, true);
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -213,9 +214,14 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]"));
 
-      clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this " +
-          "interpreter and restart with new settings?')]//" +
-          "div[@class='bootstrap-dialog-close-button']/button"));
+      try {
+        clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to " +
+            "update this interpreter and restart with new settings?')]//" +
+            "div[@class='bootstrap-dialog-close-button']/button"));
+      } catch (TimeoutException e) {
+        //Modal dialog got closed earlier than expected nothing to worry.
+      }
+
       driver.navigate().back();
       createNewNote();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -210,9 +210,12 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       String artifact = "org.apache.commons:commons-csv:1.1";
       depArtifact.sendKeys(artifact);
       driver.findElement(By.xpath("//div[@id='spark']//form//button[1]")).click();
-      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
-          "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+      clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this interpreter and restart with new settings?')]" +
+          "//div[@class='modal-footer']//button[contains(.,'OK')]"));
 
+      clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to update this " +
+          "interpreter and restart with new settings?')]//" +
+          "div[@class='bootstrap-dialog-close-button']/button"));
       driver.navigate().back();
       createNewNote();
 

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -102,7 +102,7 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
   };
 
   $scope.updateInterpreterSetting = function(form, settingId) {
-    BootstrapDialog.confirm({
+    var thisConfirm = BootstrapDialog.confirm({
       closable: true,
       title: '',
       message: 'Do you want to update this interpreter and restart with new settings?',
@@ -133,16 +133,23 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl', function($scope, 
             dependencies: angular.copy(setting.dependencies)
           };
 
-          $http.put(baseUrlSrv.getRestApiBase() + '/interpreter/setting/' + settingId, request).
-            success(function (data, status, headers, config) {
+          thisConfirm.$modalFooter.find('button').addClass('disabled');
+          thisConfirm.$modalFooter.find('button:contains("OK")')
+            .html('<i class="fa fa-circle-o-notch fa-spin"></i> Saving Setting');
+
+          $http.put(baseUrlSrv.getRestApiBase() + '/interpreter/setting/' + settingId, request)
+            .success(function(data, status, headers, config) {
               $scope.interpreterSettings[index] = data.body;
               removeTMPSettings(index);
-            }).
-            error(function (data, status, headers, config) {
+              thisConfirm.close();
+            })
+            .error(function(data, status, headers, config) {
               console.log('Error %o %o', status, data.message);
               ngToast.danger({content: data.message, verticalPosition: 'bottom'});
               form.$show();
+              thisConfirm.close();
             });
+          return false;
         }
       }
     });


### PR DESCRIPTION
### What is this PR for?
When user tries to save Interpreter Setting, it does not notify user when its done.
In cases where saving setting includes adding dependencies, it can take longer than 10 seconds, depending on number of dependencies added.

### What type of PR is it?
[Improvement]

### Todos
* [x] - add fa-spin with OK button

### What is the Jira issue?
* [ZEPPELIN-1072](https://issues.apache.org/jira/browse/ZEPPELIN-1072)

### How should this be tested?
Try loading a dependency in any of the interpreter, you will notice "OK" button is replaced by loading icon.

### Screenshots (if appropriate)
![zeppelin-1072](https://cloud.githubusercontent.com/assets/674497/16409449/3df5fb34-3d3b-11e6-8d3e-457022e7269e.gif)


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

