### PR TITLE
[ZEPPELIN-1076] Set hbase.client.retries.number for JDBC

### DIFF
--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -94,6 +94,12 @@
         "defaultValue": "org.apache.phoenix.jdbc.PhoenixDriver",
         "description": ""
       },
+      "phoenix.hbase.client.retries.number": {
+        "envName": null,
+        "propertyName": "phoenix.hbase.client.retries.number",
+        "defaultValue": "1",
+        "description": "Maximum retries.  Used as maximum for all retryable operations such as the getting of a cell's value, starting a row update, etc."
+      },
       "tajo.url": {
         "envName": null,
         "propertyName": "tajo.url",


### PR DESCRIPTION
### What is this PR for?
If a user has "org.apache.phoenix:phoenix-core:4.x.x" jar added as a dependency in JDBC interpreter, and for some reason phoenix was not accessible or not properly configured; then the phoenix tries to for 35 times (which is default for hbase.client.retries.number) and each retires is 8 second apart, before it finally fails.


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Set phoenix.hbase.client.retries.number for JDBC

### What is the Jira issue?
* [ZEPPELIN-1076](https://issues.apache.org/jira/browse/ZEPPELIN-1076)

### How should this be tested?
In JDBC interpreter add `org.apache.phoenix:phoenix-core:4.4.0-HBase-1.0` as dependency, but don't configure phoenix setting.
Then try to run any sql query with any of the configured JDBC driver (like `show tables`)

 - Without this it will take slightly more than about 5 mins
 - With this it should fetch result sooner (in less than a minute)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

