### PR TITLE
[ZEPPELIN-385] Notebook offline view mode

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -62,6 +62,10 @@
               templateUrl: 'app/notebook/notebook.html',
               controller: 'NotebookCtrl'
             })
+            .when('/notebook/:noteId/offlineView', {
+                templateUrl: 'app/notebook/notebook.html',
+                controller: 'NotebookCtrl'
+            })
             .when('/jobmanager', {
               templateUrl: 'app/jobmanager/jobmanager.html',
               controller: 'JobmanagerCtrl'

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -15,8 +15,8 @@ limitations under the License.
   <h3>
     <div style="float: left; width: auto; max-width: 40%">
       <input type="text" pu-elastic-input class="form-control2" placeholder="{{noteName(note)}}" style="min-width: 0px; max-width: 95%;"
-           ng-show="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" />
-      <p class="form-control-static2" ng-click="showEditor = true; oldName = note.name" ng-show="!showEditor">{{noteName(note)}}</p>
+           ng-show="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" ng-disabled="{{offlineView}}"/>
+      <p class="form-control-static2" ng-click="showEditor = !offlineView; oldName = note.name" ng-show="!showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">
@@ -24,20 +24,23 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-click="runNote()"
               ng-class="{'disabled':isNoteRunning()}"
-              tooltip-placement="bottom" tooltip="Run all paragraphs">
+              tooltip-placement="bottom" tooltip="Run all paragraphs"
+              ng-disabled="{{offlineView}}">
         <i class="icon-control-play"></i>
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="toggleAllEditor()"
               ng-hide="viewOnly"
-              tooltip-placement="bottom" tooltip="Show/hide the code">
+              tooltip-placement="bottom" tooltip="Show/hide the code"
+              ng-disabled="{{offlineView}}">
         <i ng-class="editorToggled ?  'fa icon-size-fullscreen' :'fa icon-size-actual'"></i></button>
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="toggleAllTable()"
               ng-hide="viewOnly"
-              tooltip-placement="bottom" tooltip="Show/hide the output">
+              tooltip-placement="bottom" tooltip="Show/hide the output"
+              ng-disabled="{{offlineView}}">
         <i ng-class="tableToggled ? 'fa icon-notebook' : 'fa icon-book-open'"></i>
       </button>
       <button type="button"
@@ -45,7 +48,8 @@ limitations under the License.
               ng-click="clearAllParagraphOutput()"
               ng-hide="viewOnly"
               ng-class="{'disabled':isNoteRunning()}"
-              tooltip-placement="bottom" tooltip="Clear output">
+              tooltip-placement="bottom" tooltip="Clear output"
+              ng-disabled="{{offlineView}}">
         <i class="fa fa-eraser"></i>
       </button>
 
@@ -54,21 +58,23 @@ limitations under the License.
               ng-hide="viewOnly"
               tooltip-placement="bottom" tooltip="Clone the notebook"
               data-toggle="modal" data-target="#noteNameModal" data-clone="true"
-              >
+              ng-disabled="{{offlineView}}">
         <i class="fa fa-copy"></i>
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
               ng-hide="viewOnly"
               ng-click="exportNotebook()"
-              tooltip-placement="bottom" tooltip="Export the notebook">
+              tooltip-placement="bottom" tooltip="Export the notebook"
+              ng-disabled="{{offlineView}}">
         <i class="fa fa-download"></i>
       </button>
       <button type="button"
               class="btn btn-default btn-xs dropdown-toggle"
               ng-hide="viewOnly"
               data-toggle="dropdown"
-              tooltip-placement="bottom" tooltip="Version control">
+              tooltip-placement="bottom" tooltip="Version control"
+              ng-disabled="{{offlineView}}">
         <i class="fa fa-file-code-o"></i>
       </button>
       <ul class="dropdown-menu" role="menu" style="width:250px">
@@ -100,7 +106,8 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
                 ng-hide="viewOnly"
-                tooltip-placement="bottom" tooltip="Remove the notebook">
+                tooltip-placement="bottom" tooltip="Remove the notebook"
+                ng-disabled="{{offlineView}}">
           <i class="icon-trash"></i>
         </button>
       </span>
@@ -111,7 +118,8 @@ limitations under the License.
              type="button"
              data-toggle="dropdown"
              ng-class="{ 'btn-info' : note.config.cron, 'btn-danger' : note.info.cron, 'btn-default' : !note.config.cron}"
-             tooltip-placement="bottom" tooltip="Run scheduler">
+             tooltip-placement="bottom" tooltip="Run scheduler"
+             ng-disabled="{{offlineView}}">
           <span class="fa fa-clock-o"></span> {{getCronOptionNameFromValue(note.config.cron)}}
         </div>
         <ul class="dropdown-menu" role="menu" style="width:300px">
@@ -157,20 +165,20 @@ limitations under the License.
     </div>
 
     <div class="pull-right" style="margin-top:15px; margin-right:15px; margin-left: 15px; margin-bottom: 13px; font-size:15px;">
-      <span class="setting-btn"
+      <span class="setting-btn {{offlineView ? 'disable' : ''}}"
             type="button"
             data-toggle="modal"
             data-target="#shortcutModal"
             tooltip-placement="bottom" tooltip="List of shortcut">
         <i class="fa fa-keyboard-o"></i>
       </span>
-      <span class="setting-btn"
+      <span class="setting-btn {{offlineView ? 'disable' : ''}}"
             type="button"
             ng-click="toggleSetting()"
             tooltip-placement="bottom" tooltip="Interpreter binding">
         <i class="fa fa-cog" ng-style="{color: showSetting ? '#3071A9' : 'black' }"></i>
       </span>
-      <span class="setting-btn"
+      <span class="setting-btn {{offlineView ? 'disable' : ''}}"
             type="button"
             ng-click="togglePermissions()"
             tooltip-placement="bottom" tooltip="Note permissions">
@@ -179,12 +187,16 @@ limitations under the License.
 
       <span class="btn-group">
         <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                data-toggle="dropdown">
+                data-toggle="dropdown" ng-disabled="{{offlineView}}">
           {{note.config.looknfeel}} <span class="caret"></span>
         </button>
         <ul class="dropdown-menu pull-right" role="menu">
           <li ng-repeat="looknfeel in looknfeelOption">
             <a style="cursor:pointer" ng-click="setLookAndFeel(looknfeel)">{{looknfeel}}</a>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a style="cursor:pointer" ng-href="{{offlineViewPath}}" target="_blank">offline view</a>
           </li>
         </ul>
       </span>

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -40,8 +40,20 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   $scope.interpreterBindings = [];
   $scope.isNoteDirty = null;
   $scope.saveTimer = null;
-
   var connectedOnce = false;
+
+
+  // offline view mode
+  var pattern = new RegExp('^.*\/notebook\/[a-zA-Z0-9_]*\/offlineView$');
+  $scope.offlineView = pattern.test($location.path());
+  var path = '';
+  if ($scope.offlineView) {
+    path = '/#' + $location.path();
+  } else {
+    path = '/#' + $location.path() + '/offlineView';
+  }
+  $scope.offlineViewPath = path;
+  $scope.offlineViewLoaded = false;
 
   // user auto complete related
   $scope.suggestions = [];
@@ -338,6 +350,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   /** update the current note */
   $scope.$on('setNoteContent', function(event, note) {
+    if ($scope.offlineView && $scope.offlineViewLoaded) {
+      return;
+    }
     $scope.paragraphUrl = $routeParams.paragraphId;
     $scope.asIframe = $routeParams.asIframe;
     if ($scope.paragraphUrl) {
@@ -353,6 +368,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     initializeLookAndFeel();
     //open interpreter binding setting when there're none selected
     getInterpreterBindings(getInterpreterBindingsCallBack);
+    //note loaded for viewOnly mode
+    $scope.offlineViewLoaded = true;
   });
 
   var initializeLookAndFeel = function() {

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -139,7 +139,7 @@ limitations under the License.
        ng-init="init(currentParagraph, note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
        class="paragraph-col">
-    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe">
+    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe || offlineView">
       <h4 class="plus-sign">&#43;</h4>
     </div>
     <div id="{{currentParagraph.id}}_paragraphColumn"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -34,6 +34,7 @@ limitations under the License.
   <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" style="cursor:pointer;" tooltip-placement="top" tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide') + ' output'}}"
         ng-click="toggleOutput()"></span>
   <span class="dropdown navbar-right">
+    <span ng-if="!offlineView">
     <span class="icon-settings" style="cursor:pointer"
           data-toggle="dropdown"
           type="button">
@@ -90,5 +91,6 @@ limitations under the License.
         <a ng-click="removeParagraph()" ng-hide="$last"><span class="fa fa-times"></span> Remove</a>
       </li>
     </ul>
+  </span>
   </span>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -385,6 +385,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
 
   // TODO: this may have impact on performance when there are many paragraphs in a note.
   $scope.$on('updateParagraph', function(event, data) {
+    if ($scope.offlineView) {
+      return;
+    }
     if (data.paragraph.id === $scope.paragraph.id &&
         (data.paragraph.dateCreated !== $scope.paragraph.dateCreated ||
          data.paragraph.dateFinished !== $scope.paragraph.dateFinished ||
@@ -528,6 +531,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
   };
 
   $scope.runParagraph = function(data) {
+    if ($scope.offlineView) {
+      return;
+    }
     websocketMsgSrv.runParagraph($scope.paragraph.id, $scope.paragraph.title,
                                  data, $scope.paragraph.config, $scope.paragraph.settings.params);
     $scope.originalText = angular.copy(data);
@@ -599,6 +605,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
   };
 
   $scope.toggleEditor = function() {
+    if ($scope.offlineView) {
+      return;
+    }
     if ($scope.paragraph.config.editorHide) {
       $scope.openEditor();
     } else {
@@ -720,6 +729,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
   };
 
   $scope.toggleOutput = function() {
+    if ($scope.offlineView) {
+      return;
+    }
     var newConfig = angular.copy($scope.paragraph.config);
     newConfig.tableHide = !newConfig.tableHide;
     var newParams = angular.copy($scope.paragraph.settings.params);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -28,7 +28,7 @@ limitations under the License.
            ng-blur="setTitle(); showTitleEditor = false"
            ng-enter="setTitle(); showTitleEditor = false"
            focus-if="showTitleEditor" />
-    <div ng-click="showTitleEditor = !asIframe && !viewOnly; oldTitle = paragraph.title;"
+    <div ng-click="showTitleEditor = !asIframe && !viewOnly  && !offlineView; oldTitle = paragraph.title;"
          ng-show="!showTitleEditor"
          ng-bind-html="paragraph.title || 'Untitled'">
     </div>
@@ -45,7 +45,7 @@ limitations under the License.
                      require : ['ace/ext/language_tools']
                    }"
            ng-model="paragraph.text"
-           ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING',
+           ng-class="{'disable': {{offlineView}} || paragraph.status == 'RUNNING' || paragraph.status == 'PENDING',
              'paragraph-text--dirty' : dirtyText !== originalText && dirtyText !== undefined}">
       </div>
     </div>


### PR DESCRIPTION
### What is this PR for?
This PR is to address so called `offline view` (view only + offline) mode. In this mode you open notebook in `only view` mode meaning can't do any editions + notebook and paragraph bars are disabled. Further, it's called `offline`, in case someone else does any changes in the notebook while you have it open, the changes will not be rendered in your screen until you reload it. There was initial work under #389, however some notable differences exist. For example, same functionality here available from frontend menu without need to restart Zeppelin. Also it provides `offline` view which was absent in initial PR.

### What type of PR is it?
Feature

### Todos
* [x] - basic frontend implementation
* [ ] - address comments + green CI


### What is the Jira issue?
related to [ZEPPELIN-385](https://issues.apache.org/jira/browse/ZEPPELIN-385)

### How should this be tested?
1. open any notebook
2. click `offline view` from the dropdown menu of notebook `looknfeel` bar on the  top right
3. try to edit note or do any changes

### Screenshots (if appropriate)
view only
![offlineview](https://cloud.githubusercontent.com/assets/1642088/16442880/489470f8-3d8a-11e6-9edb-4677230a6a44.gif)

offline view
![offline4](https://cloud.githubusercontent.com/assets/1642088/16543563/f5ae83a4-4114-11e6-9ada-80afef7666e8.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Possibly

