### PR TITLE
[ZEPPELIN-1082] Restore Interpreter page layout change

### DIFF
--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -29,7 +29,7 @@ limitations under the License.
   </div>
 </div>
 
-<div class="box width-full home">
+<div class="box width-full">
   <div>
     <div class="row configuration">
       <div class="col-md-12">

--- a/zeppelin-web/src/app/credential/credential.html
+++ b/zeppelin-web/src/app/credential/credential.html
@@ -28,7 +28,7 @@ limitations under the License.
   </div>
 </div>
 
-<div class="box width-full home"
+<div class="box width-full"
      >
   <div>
     <div class="row interpreter">

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -86,7 +86,7 @@ limitations under the License.
   <div ng-include src="'app/interpreter/interpreter-create/interpreter-create.html'"></div>
 </div>
 
-<div class="box width-full home"
+<div class="box width-full"
      ng-repeat="setting in interpreterSettings | orderBy: 'group' | filter: searchInterpreter">
   <div id="{{setting.name | lowercase}}">
     <div class="row interpreter">


### PR DESCRIPTION
### What is this PR for?
Apply margin-bottom: 20px on `box` class by removing `home` class

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1082](https://issues.apache.org/jira/browse/ZEPPELIN-1082)

### Screenshots (if appropriate)
**Before**
<img width="1280" alt="screen shot 2016-06-28 at 11 56 16 pm" src="https://cloud.githubusercontent.com/assets/8503346/16443219/554778b6-3d8c-11e6-884f-8a7024e5d3d1.png">


**After**
<img width="1280" alt="screen shot 2016-06-28 at 11 56 48 pm" src="https://cloud.githubusercontent.com/assets/8503346/16443239/6142ccc4-3d8c-11e6-914f-87f523bf8275.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

