### PR TITLE
[ZEPPELIN-1077] remove filter query on link change

### DIFF
--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -59,7 +59,7 @@ limitations under the License.
               <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
             <ul id="notebook-names">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
-              <li ng-repeat="note in home.notes.list | filter:query | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">
+              <li ng-repeat="note in home.notes.list | filter:query.q | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">
                 <i style="font-size: 10px;" class="icon-doc"></i>
                 <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
               </li>
@@ -67,7 +67,7 @@ limitations under the License.
                 <li ng-repeat="node in home.notes.root.children | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index" ng-include="'notebook_folder_renderer.html'" />
               </div>
               <div ng-if="query && query.name !== ''">
-                <li ng-repeat="note in home.notes.flatList | filter:query | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">
+                <li ng-repeat="note in home.notes.flatList | filter:query.q | orderBy:home.arrayOrderingSrv.notebookListOrdering track by $index">
                   <i style="font-size: 10px;" class="icon-doc"></i>
                   <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
                 </li>

--- a/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
+++ b/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
@@ -11,4 +11,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()" placeholder="&#xf002 Filter" ng-model="$parent.query" />
+<input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()" placeholder="&#xf002 Filter" ng-model="$parent.query.q" />

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -18,6 +18,7 @@ angular.module('zeppelinWebApp')
 .controller('NavCtrl', function($scope, $rootScope, $http, $routeParams,
     $location, notebookListDataFactory, baseUrlSrv, websocketMsgSrv, arrayOrderingSrv, searchService) {
 
+  $scope.query = {q : '' };
   /** Current list of notes (ids) */
 
   $scope.showLoginWindow = function() {
@@ -34,6 +35,10 @@ angular.module('zeppelinWebApp')
   $scope.searchForm = searchService;
 
   angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
+
+  angular.element(document).click(function(){
+    $scope.query.q = '';
+  });
 
   $scope.$on('setNoteMenu', function(event, notes) {
     notebookListDataFactory.setNotes(notes);

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -32,7 +32,7 @@ limitations under the License.
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
-              <li ng-repeat="note in navbar.notes.root.children | filter:query | orderBy:navbar.arrayOrderingSrv.notebookListOrdering track by $index"
+              <li ng-repeat="note in navbar.notes.root.children | filter:query.q | orderBy:navbar.arrayOrderingSrv.notebookListOrdering track by $index"
                   ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'components/navbar/navbar-notebookList-elem.html'">
               </li>
             </div>


### PR DESCRIPTION
### What is this PR for?
When filtering a note-name under notebook menu through navbar, the note-name query remains as it is , when clicked on any other link.


### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
[[ZEPPELIN-1077]](https://issues.apache.org/jira/browse/ZEPPELIN-1077)

### How should this be tested?
1. Open the notebook menu under navbar and search for any notebook.
2. Refer to any other page like interpreter,credentials .
3. The filter query under notebook menu resets on click of any other link.

### Screenshots (if appropriate)

**BEFORE:**
http://g.recordit.co/4tuS8yAAPR.gif

**AFTER:**
http://g.recordit.co/IZUR8mBUFs.gif



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

