### PR TITLE
[ZEPPELIN-1081] Extract spark.r setting from interpreter-setting.json on Spark interpreter mudule

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -437,6 +437,19 @@
     <!-- to deactivate 'exclude-sparkr' automatically when 'spark' is activated -->
     <profile>
       <id>sparkr</id>
+      <build>
+        <resources>
+          <resource>
+            <directory>src/main/resources</directory>
+            <excludes>
+              <exclude>interpreter-setting.json</exclude>
+            </excludes>
+          </resource>
+          <resource>
+            <directory>src/main/sparkr-resources</directory>
+          </resource>
+        </resources>
+      </build>
     </profile>
 
     <profile>

--- a/spark/src/main/sparkr-resources/interpreter-setting.json
+++ b/spark/src/main/sparkr-resources/interpreter-setting.json
@@ -118,5 +118,36 @@
         "description": "Python command to run pyspark with"
       }
     }
+  },
+  {
+    "group": "spark",
+    "name": "r",
+    "className": "org.apache.zeppelin.spark.SparkRInterpreter",
+    "properties": {
+      "zeppelin.R.knitr": {
+        "envName": "ZEPPELIN_R_KNITR",
+        "propertyName": "zeppelin.R.knitr",
+        "defaultValue": "true",
+        "description": "whether use knitr or not"
+      },
+      "zeppelin.R.cmd": {
+        "envName": "ZEPPELIN_R_CMD",
+        "propertyName": "zeppelin.R.cmd",
+        "defaultValue": "R",
+        "description": "R repl path"
+      },
+      "zeppelin.R.image.width": {
+        "envName": "ZEPPELIN_R_IMAGE_WIDTH",
+        "propertyName": "zeppelin.R.image.width",
+        "defaultValue": "100%",
+        "description": ""
+      },
+      "zeppelin.R.render.options": {
+        "envName": "ZEPPELIN_R_RENDER_OPTIONS",
+        "propertyName": "zeppelin.R.render.options",
+        "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F",
+        "description": ""
+      }
+    }
   }
 ]


### PR DESCRIPTION
### What is this PR for?
Avoid setting `spark.r` without `-Psparkr`. This enables to use `-Pr` correctly.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Separate settings with profile

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1081

### How should this be tested?
1. Build Zeppelin with `-Pr`
1. Run codes with R

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

