### PR TITLE
[Zeppelin-1090][Hot Fix] LivySparkSQLInterpreter doesn't work in FIFO.

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -96,7 +96,7 @@ public class LivyHelper {
               }.getType());
           if (jsonMap.get("state").equals("idle")) {
             break;
-          } else if (jsonMap.get("state").equals("error")) {
+          } else if (jsonMap.get("state").equals("error") || jsonMap.get("state").equals("dead")) {
             json = executeHTTP(property.getProperty("zeppelin.livy.url") + "/sessions/" +
                     sessionId + "/log",
                 "GET", null,
@@ -124,7 +124,7 @@ public class LivyHelper {
 
   protected void initializeSpark(final InterpreterContext context,
                                  final Map<String, Integer> userSessionMap) throws Exception {
-    interpret("val sqlContext= new org.apache.spark.sql.SQLContext(sc)\n" +
+    interpret("val sqlContext = new org.apache.spark.sql.SQLContext(sc)\n" +
         "import sqlContext.implicits._", context, userSessionMap);
   }
 

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -88,6 +88,11 @@
         "propertyName": "zeppelin.livy.spark.sql.maxResult",
         "defaultValue": "1000",
         "description": "Max number of SparkSQL result to display."
+      },
+      "zeppelin.livy.concurrentSQL": {
+        "propertyName": "zeppelin.livy.concurrentSQL",
+        "defaultValue": "false",
+        "description": "Execute multiple SQL concurrently if set true."
       }
     }
   },


### PR DESCRIPTION
### What is this PR for?
LivySparkSQLInterpreter should work in FIFO with LivySparkInterpreter just like SparkSqlInterpreter works with SparkInterpreter


### What type of PR is it?
[Hot Fix]

### Todos
* [x] - LivySparkSQLInterpreter should work in FIFO just like SparkSqlInterpreter
* [x] - add in property file zeppelin.livy.concurrentSQL

### What is the Jira issue?
* [Zeppelin-1090](https://issues.apache.org/jira/browse/ZEPPELIN-1090)

### How should this be tested?
In a notebook create 2 paragraph make content of first as 

```
%livy
Thread.sleep(10000)
```

and other as 

```
%livy.sql
show tables
```

The second paragraph should not get executed before first.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
