### PR TITLE
[ZEPPELIN-1094] Run all paragraphs keeps appending empty paragraphs

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1075,7 +1075,8 @@ public class NotebookServer extends WebSocketServlet implements
     boolean isTheLastParagraph = note.getLastParagraph().getId()
         .equals(p.getId());
     note.setLastReplName(paragraphId);
-    if (!Strings.isNullOrEmpty(text) && isTheLastParagraph) {
+    if (!(text.equals(note.getLastInterpreterName() + " ") || Strings.isNullOrEmpty(text)) &&
+        isTheLastParagraph) {
       note.addParagraph();
     }
 


### PR DESCRIPTION
### What is this PR for?
Every time user clicks on "Run all paragraphs" button system keeps appending an empty paragraph. Ideally content of paragraph should be checked before adding any empty paragraph.
This started happening after [ZEPPELIN-707](https://issues.apache.org/jira/browse/ZEPPELIN-707) was merged.

### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [x] - add more condition before calling note.addParagraph()

### What is the Jira issue?
* [ZEPPELIN-1094](https://issues.apache.org/jira/browse/ZEPPELIN-1094)



### Screenshots (if appropriate)

Before
![before](https://cloud.githubusercontent.com/assets/674497/16512206/5d9b91b4-3f76-11e6-991f-560817efb331.gif)

After
![after](https://cloud.githubusercontent.com/assets/674497/16512205/5d993bbc-3f76-11e6-916a-2924a17bd6a1.gif)


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

