### PR TITLE
[ZEPPELIN-1069]Ignore implicit interpreter when user enter wrong interpreter name

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -266,7 +266,8 @@ public class Note implements Serializable, JobListener {
    */
   private void addLastReplNameIfEmptyText(Paragraph p) {
     String replName = lastReplName.get();
-    if (StringUtils.isEmpty(p.getText()) && StringUtils.isNotEmpty(replName)) {
+    if (StringUtils.isEmpty(p.getText()) && StringUtils.isNotEmpty(replName)
+            && replLoader.isBinding(replName)) {
       p.setText(getInterpreterName(replName) + " ");
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteInterpreterLoader.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteInterpreterLoader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.Constants;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.RegisteredInterpreter;
@@ -203,5 +204,18 @@ public class NoteInterpreterLoader {
 
   Optional<InterpreterSetting> getDefaultInterpreterSetting() {
     return getDefaultInterpreterSetting(getInterpreterSettings());
+  }
+
+  boolean isBinding(String replName) {
+    if (StringUtils.isBlank(replName) || StringUtils.isEmpty(noteId)) {
+      return false;
+    }
+    List<InterpreterSetting> interpreterSettings = getInterpreterSettings();
+    for (InterpreterSetting interpreterSetting : interpreterSettings) {
+      if (interpreterSetting.getGroup().equals(replName)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteInterpreterLoaderTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteInterpreterLoaderTest.java
@@ -169,6 +169,23 @@ public class NoteInterpreterLoaderTest {
     assertNull(loaderB.getInterpreterSettings().get(0).getInterpreterGroup("noteB").get("noteB"));
   }
 
+  @Test
+  public void testIsBinding() throws Exception {
+//    noteId: null
+    NoteInterpreterLoader loaderA = new NoteInterpreterLoader(factory);
+    assertFalse(loaderA.isBinding("hello"));
+
+//    noteId: not null
+//    interpreter group: group1, group2
+    loaderA.setNoteId("noteHello");
+    loaderA.setInterpreters(factory.getDefaultInterpreterSettingList());
+    assertFalse(loaderA.isBinding(""));
+    assertFalse(loaderA.isBinding("  "));
+
+    assertTrue(loaderA.isBinding("group1"));
+    assertTrue(loaderA.isBinding("group2"));
+  }
+
 
   private void delete(File file){
     if(file.isFile()) file.delete();


### PR DESCRIPTION
### What is this PR for?
Ignore implicit interpreter when user enter wrong interpreter name
linked to https://github.com/apache/zeppelin/pull/806#issuecomment-227041293

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1069

### How should this be tested?
unit test
Run-time checking

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no