### PR TITLE
[ZEPPELIN-1099] Build and run Spark without spark-dependencies

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -38,7 +38,7 @@
     <jsoup.version>1.8.2</jsoup.version>
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.4</powermock.version>
-    <spark.version>1.4.1</spark.version>
+    <spark.version>1.6.2</spark.version>
     <scala.version>2.10.4</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
   </properties>
@@ -67,9 +67,16 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-spark-dependencies</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -170,7 +170,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
                 cleanCl.put(interpreterDirString, ccl);
               }
             }
-          } catch (ClassNotFoundException e) {
+          } catch (Throwable t) {
             // nothing to do
           }
         }


### PR DESCRIPTION
### What is this PR for?
When users use SPARK_HOME, they won't want to include spark-dependencies. This PR makes it possible and results reducing whole size of package.

### What type of PR is it?
[Feature]

### Todos
* [x] - Remove dependencies of spark-dependencies

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1099

### How should this be tested?
* Run `mvn clean package -DskipTests -pl '!spark-dependencies'`
* Set SPARK_HOME in zeppelin-env.sh
* Start Zeppelin
* Run `sc.version` in a paragraph and check the version
* Stop Zeppelin
* Set SPARK_HOME in a different version
* Start, check and stop

I've tested it with 1.6.1 and 1.5.2.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No