### PR TITLE
[ZEPPELIN-1100] Auto completion of Alluxio interpreter doesn't work

### DIFF
--- a/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
+++ b/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
@@ -181,10 +181,11 @@ public class AlluxioInterpreter extends Interpreter {
     if (words.length > 0) {
       lastWord = words[ words.length - 1 ];
     }
-    ArrayList voices = new ArrayList<>();
+    
+    List<InterpreterCompletion>  voices = new LinkedList<>();
     for (String command : keywords) {
       if (command.startsWith(lastWord)) {
-        voices.add(command);
+        voices.add(new InterpreterCompletion(command, command));
       }
     }
     return voices;

--- a/alluxio/src/test/java/org/apache/zeppelin/alluxio/AlluxioInterpreterTest.java
+++ b/alluxio/src/test/java/org/apache/zeppelin/alluxio/AlluxioInterpreterTest.java
@@ -77,12 +77,22 @@ public class AlluxioInterpreterTest {
 
   @Test
   public void testCompletion() {
-    List expectedResultOne = Arrays.asList("cat", "chgrp",
-            "chmod", "chown", "copyFromLocal", "copyToLocal", "count",
-            "createLineage");
-    List expectedResultTwo = Arrays.asList("copyFromLocal",
-            "copyToLocal", "count");
-    List expectedResultThree = Arrays.asList("copyFromLocal", "copyToLocal");
+    List expectedResultOne = Arrays.asList(
+      new InterpreterCompletion("cat", "cat"),
+      new InterpreterCompletion("chgrp", "chgrp"),
+      new InterpreterCompletion("chmod", "chmod"),
+      new InterpreterCompletion("chown", "chown"),
+      new InterpreterCompletion("copyFromLocal", "copyFromLocal"),
+      new InterpreterCompletion("copyToLocal", "copyToLocal"),
+      new InterpreterCompletion("count", "count"),
+      new InterpreterCompletion("createLineage", "createLineage"));
+    List expectedResultTwo = Arrays.asList(
+      new InterpreterCompletion("copyFromLocal", "copyFromLocal"),
+      new InterpreterCompletion("copyToLocal", "copyToLocal"),
+      new InterpreterCompletion("count", "count"));
+    List expectedResultThree = Arrays.asList(
+      new InterpreterCompletion("copyFromLocal", "copyFromLocal"),
+      new InterpreterCompletion("copyToLocal", "copyToLocal"));
     List expectedResultNone = new ArrayList<String>();
 
     List<InterpreterCompletion> resultOne = alluxioInterpreter.completion("c", 0);
@@ -95,7 +105,12 @@ public class AlluxioInterpreterTest {
     Assert.assertEquals(expectedResultTwo, resultTwo);
     Assert.assertEquals(expectedResultThree, resultThree);
     Assert.assertEquals(expectedResultNone, resultNotMatch);
-    Assert.assertEquals(alluxioInterpreter.keywords, resultAll);
+
+    List allCompletionList = new ArrayList<>();
+    for (InterpreterCompletion ic : resultAll) {
+      allCompletionList.add(ic.getName());
+    }
+    Assert.assertEquals(alluxioInterpreter.keywords, allCompletionList);
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
This PR fixes auto competion of Alluxio interpreter


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1100


### How should this be tested?
Test auto completion of Alluxio, you can refer to http://zeppelin.incubator.apache.org/docs/0.6.0-SNAPSHOT/interpreter/alluxio.html#interpreter-commands.


### Screenshots (if appropriate)
 - before
![b](https://cloud.githubusercontent.com/assets/3348133/16546277/b085c3ca-4180-11e6-917c-53a8143c184b.gif)

 - after
![a](https://cloud.githubusercontent.com/assets/3348133/16546279/b752c7de-4180-11e6-863a-60743b0a9659.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
