### PR TITLE
[Zeppelin - 1104] ZeppelinHub storage max note size to 64Mb

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/Client.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/Client.java
@@ -32,6 +32,9 @@ public class Client {
   private final ZeppelinClient zeppelinClient;
   private static Client instance = null;
 
+  private static final int MB = 1048576;
+  private static final int MAXIMUM_NOTE_SIZE = 64 * MB;
+
   public static Client initialize(String zeppelinUri, String zeppelinhubUri, String token, 
       ZeppelinConfiguration conf) {
     if (instance == null) {
@@ -75,5 +78,9 @@ public class Client {
 
   public void relayToZeppelin(Message message, String noteId) {
     zeppelinClient.send(message, noteId);
+  }
+
+  public static int getMaxNoteSize() {
+    return MAXIMUM_NOTE_SIZE;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -90,6 +90,8 @@ public class ZeppelinClient {
     SslContextFactory sslContextFactory = new SslContextFactory();
     WebSocketClient client = new WebSocketClient(sslContextFactory);
     client.setMaxIdleTimeout(5 * min * 1000);
+    client.setMaxTextMessageBufferSize(Client.getMaxNoteSize());
+    client.getPolicy().setMaxTextMessageSize(Client.getMaxNoteSize());
     //TODO(khalid): other client settings
     return client;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
@@ -60,9 +60,7 @@ public class ZeppelinhubClient {
   private final URI zeppelinhubWebsocketUrl;
   private final ClientUpgradeRequest conectionRequest;
   private final String zeppelinhubToken;
-  
-  private static final int MB = 1048576;
-  private static final int MAXIMUN_TEXT_SIZE = 64 * MB;
+
   private static final long CONNECTION_IDLE_TIME = TimeUnit.SECONDS.toMillis(30);
   private static ZeppelinhubClient instance = null;
   private static Gson gson;
@@ -155,7 +153,8 @@ public class ZeppelinhubClient {
   private WebSocketClient createNewWebsocketClient() {
     SslContextFactory sslContextFactory = new SslContextFactory();
     WebSocketClient client = new WebSocketClient(sslContextFactory);
-    client.setMaxTextMessageBufferSize(MAXIMUN_TEXT_SIZE);
+    client.setMaxTextMessageBufferSize(Client.getMaxNoteSize());
+    client.getPolicy().setMaxTextMessageSize(Client.getMaxNoteSize());
     client.setMaxIdleTimeout(CONNECTION_IDLE_TIME);
     return client;
   }


### PR DESCRIPTION
### What is this PR for?
This is to increase default note (text message) size used in ZeppelinHub storage layer from 64Kb to 64Mb. 

### What type of PR is it?
Improvement

### Todos
* [x] - change ws client configuration

### What is the Jira issue?
[ZEPPELIN-1104](https://issues.apache.org/jira/browse/ZEPPELIN-1104) 

### How should this be tested?
1. configure to use ZeppelinHub storage
2. create any note larger than 64Kb
3. edit note
4. shouldn't receive the exception traceback reported in the issue

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

