### PR TITLE
ZEPPELIN-1105: Python - add paragraph ERROR status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
   include:
     # Test all modules
     - jdk: "oraclejdk7"
-      env: SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS="-Dpython.test.exclude=''"
 
     # Test spark module for 1.5.2
     - jdk: "oraclejdk7"

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -35,6 +35,7 @@
 
   <properties>
     <py4j.version>0.9.2</py4j.version>
+    <python.test.exclude>**/PythonInterpreterWithPythonInstalledTest.java</python.test.exclude>
   </properties>
 
   <dependencies>
@@ -67,7 +68,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -89,13 +90,23 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
-          <execution> 
-            <id>enforce</id> 
-            <phase>none</phase> 
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>none</phase>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${python.test.exclude}</exclude>
+          </excludes>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -135,11 +146,12 @@
                   <version>${project.version}</version>
                   <type>${project.packaging}</type>
                 </artifactItem>
-              </artifactItems>              
+              </artifactItems>
             </configuration>
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -54,7 +54,7 @@ public class PythonInterpreter extends Interpreter {
 
   private Integer port;
   private GatewayServer gatewayServer;
-  private Boolean py4J = false;
+  private Boolean py4JisInstalled = false;
   private InterpreterContext context;
   private int maxResult;
 
@@ -91,7 +91,8 @@ public class PythonInterpreter extends Interpreter {
       LOG.error("Can't execute " + BOOTSTRAP_PY + " to initiate python process", e);
     }
 
-    if (py4J = isPy4jInstalled()) {
+    py4JisInstalled = isPy4jInstalled();
+    if (py4JisInstalled) {
       port = findRandomOpenPortOnAllLocalInterfaces();
       LOG.info("Py4j gateway port : " + port);
       try {
@@ -205,7 +206,7 @@ public class PythonInterpreter extends Interpreter {
     while ((line = bootstrapReader.readLine()) != null) {
       bootstrapCode += line + "\n";
     }
-    if (py4J && port != null && port != -1) {
+    if (py4JisInstalled && port != null && port != -1) {
       bootstrapCode = bootstrapCode.replaceAll("\\%PORT\\%", port.toString());
     }
     LOG.info("Bootstrap python interpreter with code from \n " + file);

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.zeppelin.python;
 
-import static org.apache.zeppelin.python.PythonInterpreter.*;
+import static org.apache.zeppelin.python.PythonInterpreter.DEFAULT_ZEPPELIN_PYTHON;
+import static org.apache.zeppelin.python.PythonInterpreter.MAX_RESULT;
+import static org.apache.zeppelin.python.PythonInterpreter.ZEPPELIN_PYTHON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -45,8 +47,12 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Python interpreter unit test
+ *
+ * Important: ALL tests here DO NOT REQUIRE Python to be installed
+ * If Python dependency is required, please look at PythonInterpreterWithPythonInstalledTest
  */
 public class PythonInterpreterTest {
   private static final Logger LOG = LoggerFactory.getLogger(PythonProcess.class);
@@ -91,7 +97,8 @@ public class PythonInterpreterTest {
    * If Py4J is not installed, bootstrap_input.py
    * is not sent to Python process and py4j JavaGateway is not running
    */
-  @Test public void testPy4jIsNotInstalled() {
+  @Test
+  public void testPy4jIsNotInstalled() {
     pythonInterpreter.open();
     assertNull(pythonInterpreter.getPy4jPort());
     assertTrue(cmdHistory.contains("def help()"));
@@ -108,7 +115,8 @@ public class PythonInterpreterTest {
    *
    * @throws IOException
    */
-  @Test public void testPy4jInstalled() throws IOException {
+  @Test
+  public void testPy4jInstalled() throws IOException {
     when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn(">>>");
 
     pythonInterpreter.open();

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
@@ -1,0 +1,44 @@
+package org.apache.zeppelin.python;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.junit.Test;
+
+/**
+ * Python interpreter unit test that user real Python
+ *
+ * Important: ALL tests here REQUIRE Python to be installed
+ * They are excluded from default build, to run them manually do:
+ *
+ * <code>
+ * mvn "-Dtest=org.apache.zeppelin.python.PythonInterpreterWithPythonInstalledTest" test -pl python
+ * </code>
+ *
+ * or
+ * <code>
+ * mvn -Dpython.test.exclude='' test -pl python
+ * </code>
+ */
+public class PythonInterpreterWithPythonInstalledTest {
+
+  @Test
+  public void badSqlSyntaxFails() {
+    //given
+    PythonInterpreter realPython = new PythonInterpreter(
+        PythonInterpreterTest.getPythonTestProperties());
+    realPython.open();
+
+    //when
+    InterpreterResult ret = realPython.interpret("select wrong syntax", null);
+
+    //then
+    assertNotNull("Interpreter returned 'null'", ret);
+    //System.out.println("\nInterpreter response: \n" + ret.message());
+    assertEquals(InterpreterResult.Code.ERROR, ret.code());
+    assertTrue(ret.message().length() > 0);
+  }
+
+}

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
@@ -1,3 +1,20 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 package org.apache.zeppelin.python;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
### What is this PR for?
Implement paragraph ERROR status for Python interpreter in case of Error or Exception in the output.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1105](https://issues.apache.org/jira/browse/ZEPPELIN-1105)

### How should this be tested?
CI should pass, or

```
mvn "-Dtest=org.apache.zeppelin.python.PythonInterpreterWithPythonInstalledTest" test -pl python
```

should pass, or paragraph status should be ERROR for something like

```
import some-thing
```

### Screenshots (if appropriate)
![screen shot 2016-07-04 at 21 30 23](https://cloud.githubusercontent.com/assets/5582506/16560453/8fd0dddc-422e-11e6-9977-c3aea052db39.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
