### PR TITLE
ZEPPELIN-1107 ] Doesn't work autocompletion for jdbc interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -111,10 +111,10 @@ public class JDBCInterpreter extends Interpreter {
 
   private final Map<String, SqlCompleter> propertyKeySqlCompleterMap;
 
-  private static final Function<CharSequence, String> sequenceToStringTransformer =
-      new Function<CharSequence, String>() {
-        public String apply(CharSequence seq) {
-          return seq.toString();
+  private static final Function<CharSequence, InterpreterCompletion> sequenceToStringTransformer =
+      new Function<CharSequence, InterpreterCompletion>() {
+        public InterpreterCompletion apply(CharSequence seq) {
+          return new InterpreterCompletion(seq.toString(), seq.toString());
         }
       };
 
@@ -448,7 +448,9 @@ public class JDBCInterpreter extends Interpreter {
     List<CharSequence> candidates = new ArrayList<>();
     SqlCompleter sqlCompleter = propertyKeySqlCompleterMap.get(getPropertyKey(buf));
     if (sqlCompleter != null && sqlCompleter.complete(buf, cursor, candidates) >= 0) {
-      List completion = Lists.transform(candidates, sequenceToStringTransformer);
+      List<InterpreterCompletion> completion;
+      completion = Lists.transform(candidates, sequenceToStringTransformer);
+
       return completion;
     } else {
       return NO_COMPLETION;

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -29,10 +29,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.*;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.jdbc.JDBCInterpreter;
 import org.apache.zeppelin.scheduler.FIFOScheduler;
 import org.apache.zeppelin.scheduler.ParallelScheduler;
@@ -228,4 +230,23 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     scheduler = jdbcInterpreter.getScheduler();
     assertTrue(scheduler instanceof FIFOScheduler);
   }
+
+  @Test
+  public void testAutoCompletion() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
+    jdbcInterpreter.open();
+
+    List<InterpreterCompletion> completionList = jdbcInterpreter.completion("SEL", 0);
+    assertEquals(1, completionList.size());
+    assertEquals(true, completionList.contains("SELECT"));
+    assertEquals(0, jdbcInterpreter.completion("SEL", 100).size());
+  }
+
 }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -245,12 +245,11 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     jdbcInterpreter.open();
 
     List<InterpreterCompletion> completionList = jdbcInterpreter.completion("SEL", 0);
-    for (InterpreterCompletion intp : completionList) {
-      logger.info("completion result test - {} {}", intp.getName(), intp.getValue());
-    }
+    
+    InterpreterCompletion correctCompletionKeyword = new InterpreterCompletion("SELECT", "SELECT");
 
     assertEquals(2, completionList.size());
-    assertEquals(true, completionList.contains("SELECT"));
+    assertEquals(true, completionList.contains(correctCompletionKeyword));
     assertEquals(0, jdbcInterpreter.completion("SEL", 100).size());
   }
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -244,7 +244,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     jdbcInterpreter.open();
 
     List<InterpreterCompletion> completionList = jdbcInterpreter.completion("SEL", 0);
-    assertEquals(1, completionList.size());
+    assertEquals(2, completionList.size());
     assertEquals(true, completionList.contains("SELECT"));
     assertEquals(0, jdbcInterpreter.completion("SEL", 100).size());
   }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -15,6 +15,7 @@
 package org.apache.zeppelin.jdbc;
 
 import static java.lang.String.format;
+import static org.apache.zeppelin.interpreter.Interpreter.logger;
 import static org.junit.Assert.assertEquals;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_KEY;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_DRIVER;
@@ -244,6 +245,10 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     jdbcInterpreter.open();
 
     List<InterpreterCompletion> completionList = jdbcInterpreter.completion("SEL", 0);
+    for (InterpreterCompletion intp : completionList) {
+      logger.info("completion result test - {} {}", intp.getName(), intp.getValue());
+    }
+
     assertEquals(2, completionList.size());
     assertEquals(true, completionList.contains("SELECT"));
     assertEquals(0, jdbcInterpreter.completion("SEL", 100).size());


### PR DESCRIPTION
### What is this PR for?
Doesn't work autocompletion for jdbc interpreter
'Completion' There is a problem with the return type of implementation.

```
org.apache.zeppelin.interpreter.InterpreterException: org.apache.thrift.transport.TTransportException
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.completion(RemoteInterpreter.java:396)
	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.completion(LazyOpenInterpreter.java:122)
	at org.apache.zeppelin.notebook.Paragraph.completion(Paragraph.java:216)
	at org.apache.zeppelin.notebook.Note.completion(Note.java:488)
	at org.apache.zeppelin.socket.NotebookServer.completion(NotebookServer.java:729)
	at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:202)
	at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:56)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:128)
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:65)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:122)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:161)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:309)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:214)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220)
	at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:258)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:632)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:480)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.thrift.transport.TTransportException
	at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:132)
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
	at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
	at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
	at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
	at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.recv_completion(RemoteInterpreterService.java:346)
	at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.completion(RemoteInterpreterService.java:330)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.completion(RemoteInterpreter.java:392)

```

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1107

### How should this be tested?
try to completion for jdbc interpreter paragraph.

### Screenshots (if appropriate)
![jdbc](https://cloud.githubusercontent.com/assets/10525473/16565048/c9a74124-4245-11e6-8b6f-b78c3a038e9e.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

