### PR TITLE
ZEPPELIN-1108 ] Doesn't work autocompletion for Postgresql interpreter

### DIFF
--- a/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
+++ b/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
@@ -114,10 +114,10 @@ public class PostgreSqlInterpreter extends Interpreter {
 
   private SqlCompleter sqlCompleter;
 
-  private static final Function<CharSequence, String> sequenceToStringTransformer =
-      new Function<CharSequence, String>() {
-        public String apply(CharSequence seq) {
-          return seq.toString();
+  private static final Function<CharSequence, InterpreterCompletion> sequenceToStringTransformer =
+      new Function<CharSequence, InterpreterCompletion>() {
+        public InterpreterCompletion apply(CharSequence seq) {
+          return new InterpreterCompletion(seq.toString(), seq.toString());
         }
       };
 

--- a/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
+++ b/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -254,7 +255,8 @@ public class PostgreSqlInterpreterTest extends BasicJDBCTestCaseAdapter {
   public void testAutoCompletion() throws SQLException {
     psqlInterpreter.open();
     assertEquals(1, psqlInterpreter.completion("SEL", 0).size());
-    assertEquals("SELECT ", psqlInterpreter.completion("SEL", 0).iterator().next());
+    InterpreterCompletion selectCompletion = new InterpreterCompletion("SELECT ", "SELECT ");
+    assertEquals(selectCompletion, psqlInterpreter.completion("SEL", 0).iterator().next());
     assertEquals(0, psqlInterpreter.completion("SEL", 100).size());
   }
 }


### PR DESCRIPTION
### What is this PR for?
Doesn't work autocompletion for postgresql interpreter
'Completion' There is a problem with the return type of implementation.

```
org.apache.zeppelin.interpreter.InterpreterException: org.apache.thrift.transport.TTransportException
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.completion(RemoteInterpreter.java:396)
	at org.apache.zeppelin.interpreter.LazyOpenInterpreter.completion(LazyOpenInterpreter.java:122)
	at org.apache.zeppelin.notebook.Paragraph.completion(Paragraph.java:216)
	at org.apache.zeppelin.notebook.Note.completion(Note.java:488)
	at org.apache.zeppelin.socket.NotebookServer.completion(NotebookServer.java:729)
	at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:202)
	at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:56)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:128)
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:65)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:122)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:161)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:309)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:214)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220)
	at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:258)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:632)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:480)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.thrift.transport.TTransportException
	at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:132)
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
	at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
	at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
	at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
	at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.recv_completion(RemoteInterpreterService.java:346)
	at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.completion(RemoteInterpreterService.java:330)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.completion(RemoteInterpreter.java:392)

```

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1108

### How should this be tested?
try to completion for Postgresql interpreter paragraph.

```
%psql 
SELET * F (ctrl + shift + space)
```

### Screenshots (if appropriate)
![psql](https://cloud.githubusercontent.com/assets/10525473/16565072/ead568f8-4245-11e6-857a-c440d14e6f6f.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

