### PR TITLE
[HOTFIX] Remove duplicate closing brace in publish_release script

### DIFF
--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -129,7 +129,7 @@ function publish_to_maven() {
   repo_request="<promoteRequest><data><stagedRepositoryId>${staged_repo_id}</stagedRepositoryId><description>Apache Zeppelin ${RELEASE_VERSION}</description></data></promoteRequest>"
   out="$(curl -X POST -d "${repo_request}" -u "${ASF_USERID}:${ASF_PASSWORD}" \
     -H 'Content-Type:application/xml' -v \
-    "${NEXUS_STAGING}}/profiles/${NEXUS_PROFILE}/finish")"
+    "${NEXUS_STAGING}/profiles/${NEXUS_PROFILE}/finish")"
   close_ret=$?
   curl_error $close_ret
   echo "Closed Nexus staging repository: ${staged_repo_id}"


### PR DESCRIPTION
### What is this PR for?
Maven artifact publish script fails to close staging repository programmatically because of the duplicate closing braces. 

### What type of PR is it?
Bug Fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

