### PR TITLE
[ZEPPELIN-1110] Catch Exception in ZeppelinIT. testSparkInterpreterDependencyLoading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ before_script:
 script:
   - mvn $TEST_FLAG $PROFILE -B $TEST_PROJECTS
 
-
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ before_script:
 script:
   - mvn $TEST_FLAG $PROFILE -B $TEST_PROJECTS
 
+
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
@@ -218,7 +219,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
         clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to " +
             "update this interpreter and restart with new settings?')]//" +
             "div[@class='bootstrap-dialog-close-button']/button"));
-      } catch (TimeoutException e) {
+      } catch (TimeoutException | StaleElementReferenceException e) {
         //Modal dialog got closed earlier than expected nothing to worry.
       }
 


### PR DESCRIPTION
### What is this PR for?
Catch Exception in case dialog is removed from dom to fix flaky test of `ZeppelinIT. testSparkInterpreterDependencyLoading`

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1110](https://issues.apache.org/jira/browse/ZEPPELIN-1110)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

