### PR TITLE
[ZEPPELIN-1113] Don't save Paragraph ColWidth if not necessary

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -700,7 +700,7 @@ angular.module('zeppelinWebApp')
 
   $scope.changeColWidth = function(width) {
     angular.element('.navbar-right.open').removeClass('open');
-    if (width !== $scope.paragraph.config.colWidth) {
+    if (!width || width !== $scope.paragraph.config.colWidth) {
       $scope.paragraph.config.colWidth = width;
       var newParams = angular.copy($scope.paragraph.settings.params);
       var newConfig = angular.copy($scope.paragraph.config);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -701,7 +701,9 @@ angular.module('zeppelinWebApp')
   $scope.changeColWidth = function(width) {
     angular.element('.navbar-right.open').removeClass('open');
     if (!width || width !== $scope.paragraph.config.colWidth) {
-      $scope.paragraph.config.colWidth = width;
+      if (width) {
+        $scope.paragraph.config.colWidth = width;
+      }
       var newParams = angular.copy($scope.paragraph.settings.params);
       var newConfig = angular.copy($scope.paragraph.config);
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -698,12 +698,15 @@ angular.module('zeppelinWebApp')
     }
   };
 
-  $scope.changeColWidth = function() {
+  $scope.changeColWidth = function(width) {
     angular.element('.navbar-right.open').removeClass('open');
-    var newParams = angular.copy($scope.paragraph.settings.params);
-    var newConfig = angular.copy($scope.paragraph.config);
+    if (width !== $scope.paragraph.config.colWidth) {
+      $scope.paragraph.config.colWidth = width;
+      var newParams = angular.copy($scope.paragraph.settings.params);
+      var newConfig = angular.copy($scope.paragraph.config);
 
-    commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
+      commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
+    }
   };
 
   $scope.toggleGraphOption = function() {
@@ -1107,11 +1110,9 @@ angular.module('zeppelinWebApp')
           $scope.showLineNumbers();
         }
       } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 189) { // Ctrl + Shift + -
-        $scope.paragraph.config.colWidth = Math.max(1, $scope.paragraph.config.colWidth - 1);
-        $scope.changeColWidth();
+        $scope.changeColWidth(Math.max(1, $scope.paragraph.config.colWidth - 1));
       } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 187) { // Ctrl + Shift + =
-        $scope.paragraph.config.colWidth = Math.min(12, $scope.paragraph.config.colWidth + 1);
-        $scope.changeColWidth();
+        $scope.changeColWidth(Math.min(12, $scope.paragraph.config.colWidth + 1));
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 84) { // Ctrl + Alt + t
         if ($scope.paragraph.config.title) {
           $scope.hideTitle();
@@ -2152,18 +2153,11 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.resizeParagraph = function(width, height) {
-    if ($scope.paragraph.config.colWidth !== width) {
-
-        $scope.paragraph.config.colWidth = width;
-        $scope.changeColWidth();
-        $timeout(function() {
-          autoAdjustEditorHeight($scope.paragraph.id + '_editor');
-          $scope.changeHeight(height);
-        }, 200);
-
-    } else {
+    $scope.changeColWidth(width);
+    $timeout(function() {
+      autoAdjustEditorHeight($scope.paragraph.id + '_editor');
       $scope.changeHeight(height);
-    }
+    }, 200);
   };
 
   $scope.changeHeight = function(height) {


### PR DESCRIPTION
### What is this PR for?
We currently are saving the ColWidth changes all the time, while it is not necessary if the value is the same.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1113

### How should this be tested?
* Select a Col-12 Paragraph and use the shortcut Ctr+Shift+ = to make it bigger
* You shouldn't see any `Send >> "COMMIT_PARAGRAPH"` in your browser console


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

