### PR TITLE
[DOC][MINOR] Add shell interpreter docs to _navigation.html

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -64,7 +64,7 @@
                 <li><a href="{{BASE_PATH}}/interpreter/postgresql.html">Postgresql, HAWQ</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/r.html">R</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/scalding.html">Scalding</a></li>
-                <li><a href="{{BASE_PATH}}/pleasecontribute.html">Shell</a></li>
+                <li><a href="{{BASE_PATH}}/interpreter/shell.html">Shell</a></li>
                 <li><a href="{{BASE_PATH}}/interpreter/spark.html">Spark</a></li>
               </ul>
             </li>

--- a/docs/interpreter/alluxio.md
+++ b/docs/interpreter/alluxio.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Alluxio Interpreter"
 description: "Alluxio Interpreter"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Cassandra Interpreter"
 description: "Cassandra Interpreter"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/elasticsearch.md
+++ b/docs/interpreter/elasticsearch.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Elasticsearch Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Flink Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/geode.md
+++ b/docs/interpreter/geode.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Geode OQL Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -2,7 +2,7 @@
 layout: page
 title: "HBase Shell Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/hdfs.md
+++ b/docs/interpreter/hdfs.md
@@ -2,7 +2,7 @@
 layout: page
 title: "HDFS File System Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/hive.md
+++ b/docs/interpreter/hive.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Hive Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/ignite.md
+++ b/docs/interpreter/ignite.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Ignite Interpreter"
 description: "Ignite user guide"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Generic JDBC Interpreter"
 description: "JDBC user guide"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/lens.md
+++ b/docs/interpreter/lens.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Lens Interpreter"
 description: "Lens user guide"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Livy Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/markdown.md
+++ b/docs/interpreter/markdown.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Markdown Interpreter"
 description: "Markdown Interpreter"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/postgresql.md
+++ b/docs/interpreter/postgresql.md
@@ -2,7 +2,7 @@
 layout: page
 title: "PostgreSQL and HAWQ Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Python Interpreter"
 description: "Python Interpreter"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/r.md
+++ b/docs/interpreter/r.md
@@ -2,7 +2,7 @@
 layout: page
 title: "R Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/scalding.md
+++ b/docs/interpreter/scalding.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Scalding Interpreter"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -2,19 +2,39 @@
 layout: page
 title: "Shell Interpreter"
 description: "Shell Interpreter"
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 
-## Shell interpreter for Apache Zeppelin
+# Shell interpreter for Apache Zeppelin
 
-### Overview
+<div id="toc"></div>
+
+## Overview
 Shell interpreter uses [Apache Commons Exec](https://commons.apache.org/proper/commons-exec) to execute external processes. 
-
 In Zeppelin notebook, you can use ` %sh ` in the beginning of a paragraph to invoke system shell and run commands.
-Note: Currently each command runs as Zeppelin user.
 
-### Example
+> **Note :** Currently each command runs as Zeppelin user.
+
+## Configuration
+At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property value for Shell interpreter.
+
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Value</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>shell.command.timeout.millisecs</td>
+    <td>60000</td>
+    <td>Shell command time out in millisecs</td>
+  </tr>
+</table>
+
+## Example
 The following example demonstrates the basic usage of Shell in a Zeppelin notebook.
 
-<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-example.png" width="70%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-example.png" />
+
+If you need further information about **Zeppelin Interpreter Setting** for using Shell interpreter, please read [What is interpreter setting?](../manual/interpreters.html#what-is-interpreter-setting) section first.

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -14,7 +14,7 @@ group: interpreter
 Shell interpreter uses [Apache Commons Exec](https://commons.apache.org/proper/commons-exec) to execute external processes. 
 In Zeppelin notebook, you can use ` %sh ` in the beginning of a paragraph to invoke system shell and run commands.
 
-> **Note :** Currently each command runs as Zeppelin user.
+> **Note :** Currently each command runs as the user Zeppelin server is running as.
 
 ## Configuration
 At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property value for Shell interpreter.

--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Spark Interpreter Group"
 description: ""
-group: manual
+group: interpreter
 ---
 {% include JB/setup %}
 

--- a/docs/rest-api/rest-credential.md
+++ b/docs/rest-api/rest-credential.md
@@ -19,14 +19,18 @@ limitations under the License.
 -->
 {% include JB/setup %}
 
-## Zeppelin REST API
- Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
+# Apache Zeppelin Credential REST API
 
- All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. Note that zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
+<div id="toc"></div>
 
- If you work with Zeppelin and find a need for an additional REST API, please [file an issue or send us mail](http://zeppelin.apache.org/community.html).
+## Overview
+Apache Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
+All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. 
+Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
 
- <br />
+If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
+
+<br />
 ## Credential REST API List
 
 ### List Credential information
@@ -34,7 +38,7 @@ limitations under the License.
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```GET``` method returns all key/value pairs of credential information on the server.</td>
+      <td>This ```GET``` method returns all key/value pairs of the credential information on the server.</td>
     </tr>
     <tr>
       <td>URL</td>
@@ -78,7 +82,7 @@ limitations under the License.
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```PUT``` method creates an credential information with new properties.</td>
+      <td>This ```PUT``` method creates the credential information with new properties.</td>
     </tr>
     <tr>
       <td>URL</td>
@@ -124,7 +128,7 @@ limitations under the License.
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```DELETE``` method deletes credential information.</td>
+      <td>This ```DELETE``` method deletes the credential information.</td>
     </tr>
     <tr>
       <td>URL</td>
@@ -154,7 +158,7 @@ limitations under the License.
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```DELETE``` method deletes an given credential entity.</td>
+      <td>This ```DELETE``` method deletes a given credential entity.</td>
     </tr>
     <tr>
       <td>URL</td>


### PR DESCRIPTION
### What is this PR for?
After #1087 merged, a new docs `shell.md` was added. But in the docs website, still Shell interpreter link points to `pleasecontribute.html`. So I changed this link, applied TOC and added more descriptions. 


### What type of PR is it?
Documentation

### Todos
* [x] - Change `pleasecontribute.html` -> `shell.html`
* [x] - Apply TOC(table of contents)
* [x] - Add more description to `shell.md`

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? no
