### PR TITLE
[ZEPPELIN-1125] Application does not logout user when authcBasic and `./grunt serve` is used

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -17,7 +17,6 @@
 package org.apache.zeppelin.rest;
 
 import org.apache.shiro.authc.*;
-import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.server.JsonResponse;
@@ -26,7 +25,10 @@ import org.apache.zeppelin.utils.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -109,23 +111,15 @@ public class LoginRestApi {
     LOG.warn(response.toString());
     return response.build();
   }
-  
-  @GET
+
+  @POST
   @Path("logout")
   @ZeppelinApi
   public Response logout() {
     JsonResponse response;
-    
     Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
     currentUser.logout();
-
-    Map<String, String> data = new HashMap<>();
-    data.put("principal", "anonymous");
-    data.put("roles", "");
-    data.put("ticket", "anonymous");
-    data.put("WWW-Authenticate", "Basic realm=\"Login required\"");
-   
-    response = new JsonResponse(Response.Status.UNAUTHORIZED, "", data);
+    response = new JsonResponse(Response.Status.UNAUTHORIZED, "", "");
     LOG.warn(response.toString());
     return response.build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -26,10 +26,7 @@ import org.apache.zeppelin.utils.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -113,7 +110,7 @@ public class LoginRestApi {
     return response.build();
   }
   
-  @POST
+  @GET
   @Path("logout")
   @ZeppelinApi
   public Response logout() {
@@ -126,8 +123,9 @@ public class LoginRestApi {
     data.put("principal", "anonymous");
     data.put("roles", "");
     data.put("ticket", "anonymous");
+    data.put("WWW-Authenticate", "Basic realm=\"Login required\"");
    
-    response = new JsonResponse(Response.Status.OK, "", data);
+    response = new JsonResponse(Response.Status.UNAUTHORIZED, "", data);
     LOG.warn(response.toString());
     return response.build();
   }

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -55,9 +55,11 @@ angular.module('zeppelinWebApp')
   $scope.logout = function() {
     var logoutURL = baseUrlSrv.getRestApiBase() + '/login/logout';
 
-    $http.get(logoutURL).error(function() {
+    //for firefox and safari
+    logoutURL = logoutURL.replace('//', '//false:false@');
+    $http.post(logoutURL).error(function() {
       //force authcBasic (if configured) to logout
-      $http.get(logoutURL).error(function() {
+      $http.post(logoutURL).error(function() {
         $rootScope.userName = '';
         $rootScope.ticket.principal = '';
         $rootScope.ticket.ticket = '';
@@ -69,7 +71,7 @@ angular.module('zeppelinWebApp')
           window.location.replace('/');
         }, 1000);
       });
-      });
+    });
   };
 
   $scope.search = function(searchTerm) {

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -54,30 +54,22 @@ angular.module('zeppelinWebApp')
 
   $scope.logout = function() {
     var logoutURL = baseUrlSrv.getRestApiBase() + '/login/logout';
-    var request = new XMLHttpRequest();
 
-    //force authcBasic (if configured) to logout by setting credentials as false:false
-    request.open('post', logoutURL, true, 'false', 'false');
-    request.onreadystatechange = function() {
-      if (request.readyState === 4) {
-        if (request.status === 401 || request.status === 405 || request.status === 500) {
-          $rootScope.userName = '';
-          $rootScope.ticket.principal = '';
-          $rootScope.ticket.ticket = '';
-          $rootScope.ticket.roles = '';
-          BootstrapDialog.show({
-            message: 'Logout Success'
-          });
-          setTimeout(function() {
-            window.location.replace('/');
-          }, 1000);
-        } else {
-          request.open('post', logoutURL, true, 'false', 'false');
-          request.send();
-        }
-      }
-    };
-    request.send();
+    $http.get(logoutURL).error(function() {
+      //force authcBasic (if configured) to logout
+      $http.get(logoutURL).error(function() {
+        $rootScope.userName = '';
+        $rootScope.ticket.principal = '';
+        $rootScope.ticket.ticket = '';
+        $rootScope.ticket.roles = '';
+        BootstrapDialog.show({
+          message: 'Logout Success'
+        });
+        setTimeout(function() {
+          window.location.replace('/');
+        }, 1000);
+      });
+      });
   };
 
   $scope.search = function(searchTerm) {


### PR DESCRIPTION
### What is this PR for?
Creating this issue from [this](https://github.com/apache/zeppelin/pull/1071#issuecomment-230720461) comment, Application does not logout user when authcBasic is used and process was running with `grunt serve`


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-1125](https://issues.apache.org/jira/browse/ZEPPELIN-1125)

### How should this be tested?
Run web-app as `grunt serve` and configure shiro auth to use `authcBasic`, and then try to logout.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
