### PR TITLE
[ZEPPELIN-1127] Show error message in case of exception with JDBC

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -364,7 +364,9 @@ public class JDBCInterpreter extends Interpreter {
 
     } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
-      StringBuilder stringBuilder = new StringBuilder(e.getClass().toString()).append("\n");
+      StringBuilder stringBuilder = new StringBuilder();
+      stringBuilder.append(e.getMessage()).append("\n");
+      stringBuilder.append(e.getClass().toString()).append("\n");
       stringBuilder.append(StringUtils.join(e.getStackTrace(), "\n"));
       return new InterpreterResult(Code.ERROR, stringBuilder.toString());
     }


### PR DESCRIPTION
### What is this PR for?
When there is exception while executeSql in JDBC interpreter, only stack trace is sent back to UI, it should include e.getMessage() as well.



### What type of PR is it?
[Improvement]


### What is the Jira issue?
* [ZEPPELIN-1127](https://issues.apache.org/jira/browse/ZEPPELIN-1127)

### How should this be tested?
Create a paragraph, and write following and try to run

```
%phoenix
select * from a_table_not_there
```

You should see below, followed by stack trace 
```
ERROR 1012 (42M03): Table undefined. tableName=A_TABLE_NOT_THERE
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

