### PR TITLE
[ZEPPELIN-1128] add try-catch in close() method.

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -259,7 +259,6 @@ public class JDBCInterpreter extends Interpreter {
 
   @Override
   public void close() {
-
     try {
       for (List<Connection> connectionList : propertyKeyUnusedConnectionListMap.values()) {
         for (Connection c : connectionList) {
@@ -288,7 +287,6 @@ public class JDBCInterpreter extends Interpreter {
         }
       }
       paragraphIdConnectionMap.clear();
-
     } catch (Exception e) {
       logger.error("Error while closing...", e);
     }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -264,7 +264,7 @@ public class JDBCInterpreter extends Interpreter {
         for (Connection c : connectionList) {
           try {
             c.close();
-          } catch (SQLException e) {
+          } catch (Exception e) {
             logger.error("Error while closing propertyKeyUnusedConnectionListMap connection...", e);
           }
         }
@@ -273,7 +273,7 @@ public class JDBCInterpreter extends Interpreter {
       for (Statement statement : paragraphIdStatementMap.values()) {
         try {
           statement.close();
-        } catch (SQLException e) {
+        } catch (Exception e) {
           logger.error("Error while closing paragraphIdStatementMap statement...", e);
         }
       }
@@ -282,7 +282,7 @@ public class JDBCInterpreter extends Interpreter {
       for (Connection connection : paragraphIdConnectionMap.values()) {
         try {
           connection.close();
-        } catch (SQLException e) {
+        } catch (Exception e) {
           logger.error("Error while closing paragraphIdConnectionMap connection...", e);
         }
       }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -263,17 +263,29 @@ public class JDBCInterpreter extends Interpreter {
     try {
       for (List<Connection> connectionList : propertyKeyUnusedConnectionListMap.values()) {
         for (Connection c : connectionList) {
-          c.close();
+          try {
+            c.close();
+          } catch (SQLException e) {
+            logger.error("Error while closing propertyKeyUnusedConnectionListMap connection...", e);
+          }
         }
       }
 
       for (Statement statement : paragraphIdStatementMap.values()) {
-        statement.close();
+        try {
+          statement.close();
+        } catch (SQLException e) {
+          logger.error("Error while closing paragraphIdStatementMap statement...", e);
+        }
       }
       paragraphIdStatementMap.clear();
 
       for (Connection connection : paragraphIdConnectionMap.values()) {
-        connection.close();
+        try {
+          connection.close();
+        } catch (SQLException e) {
+          logger.error("Error while closing paragraphIdConnectionMap connection...", e);
+        }
       }
       paragraphIdConnectionMap.clear();
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -289,7 +289,7 @@ public class JDBCInterpreter extends Interpreter {
       }
       paragraphIdConnectionMap.clear();
 
-    } catch (SQLException e) {
+    } catch (Exception e) {
       logger.error("Error while closing...", e);
     }
   }


### PR DESCRIPTION
### What is this PR for?
Fix bug on JdbcInterpreter when hive server restarted.
each connection.close() should be wraped by try-catch.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1128

### How should this be tested?
Restart hive while zeppelin still alive.

After that, Zeppelin notebook's hive query execution will be fail
![error](https://cloud.githubusercontent.com/assets/366810/16649904/3071ec56-4476-11e6-9d13-75d4fa0f8f4f.PNG)

Stacktrace is like this. 
It was HiveInterpreter because i use zeppelin by yum install on centos(some old version).
But JdbcInterpreter & HiveInterpreter's close() method is same.

> ERROR [2016-07-07 18:23:46,676] ({pool-1-thread-2} HiveInterpreter.java[close]:166) - Error while closing...
java.sql.SQLException: Error while cleaning up the server resources
        at org.apache.hive.jdbc.HiveConnection.close(HiveConnection.java:721)
        at org.apache.zeppelin.hive.HiveInterpreter.close(HiveInterpreter.java:151)
        at org.apache.zeppelin.interpreter.ClassloaderInterpreter.close(ClassloaderInterpreter.java:88)
        at org.apache.zeppelin.interpreter.LazyOpenInterpreter.close(LazyOpenInterpreter.java:78)
        at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer.close(RemoteInterpreterServer.java:232)
        at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Processor$close.getResult(RemoteInterpreterService.java:1432)
        at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Processor$close.getResult(RemoteInterpreterService.java:1417)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:285)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.thrift.transport.TTransportException: java.net.SocketException: Broken pipe
        at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:161)
        at org.apache.thrift.transport.TSaslTransport.flush(TSaslTransport.java:501)
        at org.apache.thrift.transport.TSaslClientTransport.flush(TSaslClientTransport.java:37)
        at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:65)
        at org.apache.hive.service.cli.thrift.TCLIService$Client.send_CloseSession(TCLIService.java:177)
        at org.apache.hive.service.cli.thrift.TCLIService$Client.CloseSession(TCLIService.java:169)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.apache.hive.jdbc.HiveConnection$SynchronizedHandler.invoke(HiveConnection.java:1380)
        at com.sun.proxy.$Proxy0.CloseSession(Unknown Source)
        at org.apache.hive.jdbc.HiveConnection.close(HiveConnection.java:719)
        ... 12 more
Caused by: java.net.SocketException: Broken pipe
        at java.net.SocketOutputStream.socketWrite0(Native Method)
        at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:109)
        at java.net.SocketOutputStream.write(SocketOutputStream.java:153)
        at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
        at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
        at org.apache.thrift.transport.TIOStreamTransport.flush(TIOStreamTransport.java:159)
        ... 24 more


### Screenshots (if appropriate)
![error](https://cloud.githubusercontent.com/assets/366810/16649904/3071ec56-4476-11e6-9d13-75d4fa0f8f4f.PNG)
