### PR TITLE
ZEPPELIN-1130 Make Livy create session retries configurable

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -48,7 +48,6 @@ public class LivyHelper {
   Gson gson = new GsonBuilder().setPrettyPrinting().create();
   HashMap<String, Object> paragraphHttpMap = new HashMap<>();
   Properties property;
-  Integer MAX_NOS_RETRY = 60;
 
   LivyHelper(Properties property) {
     this.property = property;
@@ -83,9 +82,16 @@ public class LivyHelper {
           }.getType());
       Integer sessionId = ((Double) jsonMap.get("id")).intValue();
       if (!jsonMap.get("state").equals("idle")) {
-        Integer nosRetry = MAX_NOS_RETRY;
+        Integer retryCount = 120;
 
-        while (nosRetry >= 0) {
+        try {
+          retryCount = Integer.valueOf(
+              property.getProperty("zeppelin.livy.create.session.retries"));
+        } catch (Exception e) {
+          //nothing to do
+        }
+
+        while (retryCount >= 0) {
           LOGGER.error(String.format("sessionId:%s state is %s",
               jsonMap.get("id"), jsonMap.get("state")));
           Thread.sleep(1000);
@@ -108,9 +114,9 @@ public class LivyHelper {
             LOGGER.error(String.format("Cannot start  %s.\n%s", kind, logs));
             throw new Exception(String.format("Cannot start  %s.\n%s", kind, logs));
           }
-          nosRetry--;
+          retryCount--;
         }
-        if (nosRetry <= 0) {
+        if (retryCount <= 0) {
           LOGGER.error("Error getting session for user within 60Sec.");
           throw new Exception(String.format("Cannot start  %s.", kind));
         }

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -82,7 +82,7 @@ public class LivyHelper {
           }.getType());
       Integer sessionId = ((Double) jsonMap.get("id")).intValue();
       if (!jsonMap.get("state").equals("idle")) {
-        Integer retryCount = 120;
+        Integer retryCount = 60;
 
         try {
           retryCount = Integer.valueOf(

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -88,7 +88,8 @@ public class LivyHelper {
           retryCount = Integer.valueOf(
               property.getProperty("zeppelin.livy.create.session.retries"));
         } catch (Exception e) {
-          //nothing to do
+          LOGGER.info("zeppelin.livy.create.session.retries property is not configured." +
+              " Using default retry count.");
         }
 
         while (retryCount >= 0) {
@@ -117,7 +118,7 @@ public class LivyHelper {
           retryCount--;
         }
         if (retryCount <= 0) {
-          LOGGER.error("Error getting session for user within 60Sec.");
+          LOGGER.error("Error getting session for user within the given number of retries.");
           throw new Exception(String.format("Cannot start  %s.", kind));
         }
       }

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -118,7 +118,7 @@ public class LivyHelper {
           retryCount--;
         }
         if (retryCount <= 0) {
-          LOGGER.error("Error getting session for user within the given number of retries.");
+          LOGGER.error("Error getting session for user within the configured number of retries.");
           throw new Exception(String.format("Cannot start  %s.", kind));
         }
       }

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -11,6 +11,12 @@
         "defaultValue": "http://localhost:8998",
         "description": "The URL for Livy Server."
       },
+      "zeppelin.livy.create.session.retries": {
+        "envName": "ZEPPELIN_LIVY_CREATE_SESSION_RETRIES",
+        "propertyName": "zeppelin.livy.create.session.retries",
+        "defaultValue": "120",
+        "description": "Livy Server create session retry count."
+      },
       "livy.spark.master": {
         "propertyName": "livy.spark.master",
         "defaultValue": "local[*]",


### PR DESCRIPTION
### What is this PR for?
Make Livy create session retires configurable

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1130

### How should this be tested?
- Add/Edit `zeppelin.livy.create.session.retries` property in Livy interpreter settings
- Run a paragraph with `%livy sc.version`
- Verify the retries count in logs

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

