### PR TITLE
[ZEPPELIN-1026] set syntax highlight based on default bound interpreter

### DIFF
--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -71,7 +71,7 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
       },...
     },
     "editor": {
-      "mode": "your-syntax-highlight-language"
+      "language": "your-syntax-highlight-language"
     }
   },
   {
@@ -110,7 +110,7 @@ If you want to add a new set of syntax highlighting,
 
   ```
   "editor": {
-      "mode": "java"
+      "language": "java"
   }
   ```
 

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -42,7 +42,7 @@ In 'Separate Interpreter(scoped / isolated) for each note' mode which you can se
 Creating a new interpreter is quite simple. Just extend [org.apache.zeppelin.interpreter](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java) abstract class and implement some methods.
 You can include `org.apache.zeppelin:zeppelin-interpreter:[VERSION]` artifact in your build system. And you should put your jars under your interpreter directory with a specific directory name. Zeppelin server reads interpreter directories recursively and initializes interpreters including your own interpreter.
 
-There are three locations where you can store your interpreter group, name and other information. Zeppelin server tries to find the location below. Next, Zeppelin tries to find `interpreter-setting.json` in your interpreter jar. 
+There are three locations where you can store your interpreter group, name and other information. Zeppelin server tries to find the location below. Next, Zeppelin tries to find `interpreter-setting.json` in your interpreter jar.
 
 ```
 {ZEPPELIN_INTERPRETER_DIR}/{YOUR_OWN_INTERPRETER_DIR}/interpreter-setting.json
@@ -68,12 +68,15 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
         "propertyName": null,
         "defaultValue": "property2DefaultValue",
         "description": "Property 2 description"
-      }, ...
+      },...
+    },
+    "editor": {
+      "mode": "your-syntax-highlight-language"
     }
   },
   {
     ...
-  } 
+  }
 ]
 ```
 
@@ -96,15 +99,20 @@ some interpreter specific code...
 ```
 
 ## Programming Languages for Interpreter
-If the interpreter uses a specific programming language ( like Scala, Python, SQL ), it is generally recommended to add a syntax highlighting supported for that to the notebook paragraph editor.  
+If the interpreter uses a specific programming language (like Scala, Python, SQL), it is generally recommended to add a syntax highlighting supported for that to the notebook paragraph editor.  
 
 To check out the list of languages supported, see the `mode-*.js` files under `zeppelin-web/bower_components/ace-builds/src-noconflict` or from [github.com/ajaxorg/ace-builds](https://github.com/ajaxorg/ace-builds/tree/master/src-noconflict).  
 
 If you want to add a new set of syntax highlighting,  
 
 1. Add the `mode-*.js` file to <code>[zeppelin-web/bower.json](https://github.com/apache/zeppelin/blob/master/zeppelin-web/bower.json)</code> ( when built, <code>[zeppelin-web/src/index.html](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/index.html)</code> will be changed automatically. ).  
-2. Add to the list of `editorMode` in <code>[zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js)</code> - it follows the pattern 'ace/mode/x' where x is the name.  
-3. Add to the code that checks for `%` prefix and calls `session.setMode(editorMode.x)` in `setParagraphMode` located in <code>[zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js)</code>.  
+2. Add `editor` object to `interpreter-setting.json` file. If you want to set your language to java, add:
+
+  ```
+  "editor": {
+      "mode": "java"
+  }
+  ```
 
 ## Install your interpreter binary
 
@@ -216,4 +224,3 @@ We welcome contribution to a new interpreter. Please follow these few steps:
  - Add documentation on how to use your interpreter under `docs/interpreter/`. Follow the Markdown style as this [example](https://github.com/apache/zeppelin/blob/master/docs/interpreter/elasticsearch.md). Make sure you list config settings and provide working examples on using your interpreter in code boxes in Markdown. Link to images as appropriate (images should go to `docs/assets/themes/zeppelin/img/docs-img/`). And add a link to your documentation in the navigation menu (`docs/_includes/themes/zeppelin/_navigation.html`).
  - Most importantly, ensure licenses of the transitive closure of all dependencies are list in [license file](https://github.com/apache/zeppelin/blob/master/zeppelin-distribution/src/bin_license/LICENSE).
  - Commit your changes and open a [Pull Request](https://github.com/apache/zeppelin/pulls) on the project [Mirror on GitHub](https://github.com/apache/zeppelin); check to make sure Travis CI build is passing.
- 

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -18,7 +18,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   }
 ]

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -16,6 +16,9 @@
         "defaultValue": "6123",
         "description": "port of running JobManager."
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   }
 ]

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -154,6 +154,9 @@
         "defaultValue": "org.postgresql.Driver",
         "description": ""
       }
+    },
+    "editor": {
+      "mode": "sql"
     }
   }
 ]

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -156,7 +156,7 @@
       }
     },
     "editor": {
-      "mode": "sql"
+      "language": "sql"
     }
   }
 ]

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -82,6 +82,9 @@
         "defaultValue": "",
         "description": "Kerberos keytab to authenticate livy"
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   },
   {
@@ -100,6 +103,9 @@
         "defaultValue": "false",
         "description": "Execute multiple SQL concurrently if set true."
       }
+    },
+    "editor": {
+      "mode": "sql"
     }
   },
   {
@@ -107,6 +113,9 @@
     "name": "pyspark",
     "className": "org.apache.zeppelin.livy.LivyPySparkInterpreter",
     "properties": {
+    },
+    "editor": {
+      "mode": "python"
     }
   },
   {
@@ -114,6 +123,9 @@
     "name": "sparkr",
     "className": "org.apache.zeppelin.livy.LivySparkRInterpreter",
     "properties": {
+    },
+    "editor": {
+      "mode": "r"
     }
   }
 ]

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -84,7 +84,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   },
   {
@@ -105,7 +105,7 @@
       }
     },
     "editor": {
-      "mode": "sql"
+      "language": "sql"
     }
   },
   {
@@ -115,7 +115,7 @@
     "properties": {
     },
     "editor": {
-      "mode": "python"
+      "language": "python"
     }
   },
   {
@@ -125,7 +125,7 @@
     "properties": {
     },
     "editor": {
-      "mode": "r"
+      "language": "r"
     }
   }
 ]

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -16,6 +16,9 @@
         "defaultValue": "1000",
         "description": "Max number of dataframe rows to display."
       }
+    },
+    "editor": {
+      "mode": "python"
     }
   },
   {

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -18,7 +18,7 @@
       }
     },
     "editor": {
-      "mode": "python"
+      "language": "python"
     }
   },
   {

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -12,7 +12,7 @@
       }
     },
     "editor": {
-      "mode": "sh"
+      "language": "sh"
     }
   }
 ]

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -10,6 +10,9 @@
         "defaultValue": "60000",
         "description": "Shell command time out in millisecs. Default = 60000"
       }
+    },
+    "editor": {
+      "mode": "sh"
     }
   }
 ]

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -54,6 +54,9 @@
         "defaultValue": "local[*]",
         "description": "Spark master uri. ex) spark://masterhost:7077"
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   },
   {
@@ -85,6 +88,9 @@
         "defaultValue": "true",
         "description": "Import implicits, UDF collection, and sql if set true. true by default."
       }
+    },
+    "editor": {
+      "mode": "sql"
     }
   },
   {
@@ -104,6 +110,9 @@
         "defaultValue": "spark-packages,http://dl.bintray.com/spark-packages/maven,false;",
         "description": "A list of 'id,remote-repository-URL,is-snapshot;' for each remote repository."
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   },
   {
@@ -117,6 +126,9 @@
         "defaultValue": "python",
         "description": "Python command to run pyspark with"
       }
+    },
+    "editor": {
+      "mode": "python"
     }
   }
 ]

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -56,7 +56,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   },
   {
@@ -90,7 +90,7 @@
       }
     },
     "editor": {
-      "mode": "sql"
+      "language": "sql"
     }
   },
   {
@@ -112,7 +112,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   },
   {
@@ -128,7 +128,7 @@
       }
     },
     "editor": {
-      "mode": "python"
+      "language": "python"
     }
   }
 ]

--- a/spark/src/main/sparkr-resources/interpreter-setting.json
+++ b/spark/src/main/sparkr-resources/interpreter-setting.json
@@ -56,7 +56,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   },
   {
@@ -90,7 +90,7 @@
       }
     },
     "editor": {
-      "mode": "sql"
+      "language": "sql"
     }
   },
   {
@@ -112,7 +112,7 @@
       }
     },
     "editor": {
-      "mode": "scala"
+      "language": "scala"
     }
   },
   {
@@ -128,7 +128,7 @@
       }
     },
     "editor": {
-      "mode": "python"
+      "language": "python"
     }
   },
   {
@@ -162,7 +162,7 @@
       }
     },
     "editor": {
-      "mode": "r"
+      "language": "r"
     }
   }
 ]

--- a/spark/src/main/sparkr-resources/interpreter-setting.json
+++ b/spark/src/main/sparkr-resources/interpreter-setting.json
@@ -54,6 +54,9 @@
         "defaultValue": "local[*]",
         "description": "Spark master uri. ex) spark://masterhost:7077"
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   },
   {
@@ -85,6 +88,9 @@
         "defaultValue": "true",
         "description": "Import implicits, UDF collection, and sql if set true. true by default."
       }
+    },
+    "editor": {
+      "mode": "sql"
     }
   },
   {
@@ -104,6 +110,9 @@
         "defaultValue": "spark-packages,http://dl.bintray.com/spark-packages/maven,false;",
         "description": "A list of 'id,remote-repository-URL,is-snapshot;' for each remote repository."
       }
+    },
+    "editor": {
+      "mode": "scala"
     }
   },
   {
@@ -117,6 +126,9 @@
         "defaultValue": "python",
         "description": "Python command to run pyspark with"
       }
+    },
+    "editor": {
+      "mode": "python"
     }
   },
   {
@@ -148,6 +160,9 @@
         "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F",
         "description": ""
       }
+    },
+    "editor": {
+      "mode": "r"
     }
   }
 ]

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -251,6 +251,7 @@ public abstract class Interpreter {
     private String className;
     private boolean defaultInterpreter;
     private Map<String, InterpreterProperty> properties;
+    private Map<String, Object> editor;
     private String path;
 
     public RegisteredInterpreter(String name, String group, String className,
@@ -266,6 +267,7 @@ public abstract class Interpreter {
       this.className = className;
       this.defaultInterpreter = defaultInterpreter;
       this.properties = properties;
+      this.editor = new HashMap<>();
     }
 
     public String getName() {
@@ -290,6 +292,10 @@ public abstract class Interpreter {
 
     public Map<String, InterpreterProperty> getProperties() {
       return properties;
+    }
+
+    public Map<String, Object> getEditor() {
+      return editor;
     }
 
     public void setPath(String path) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -226,6 +226,9 @@ public class NotebookServer extends WebSocketServlet implements
           case LIST_UPDATE_NOTEBOOK_JOBS:
             unicastUpdateNotebookJobInfo(conn, messagereceived);
             break;
+          case EDITOR_SETTING:
+            getEditorSetting(conn, notebook, messagereceived);
+            break;
           default:
             break;
       }
@@ -1259,7 +1262,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     /**
-     * This callback is for praragraph that runs on RemoteInterpreterProcess
+     * This callback is for paragraph that runs on RemoteInterpreterProcess
      * @param paragraph
      * @param out
      * @param output
@@ -1367,11 +1370,24 @@ public class NotebookServer extends WebSocketServlet implements
         if (id.equals(interpreterGroupId)) {
           broadcast(
               note.id(),
-              new Message(OP.ANGULAR_OBJECT_REMOVE).put("name", name).put(
-                      "noteId", noteId).put("paragraphId", paragraphId));
+              new Message(OP.ANGULAR_OBJECT_REMOVE)
+                  .put("name", name)
+                  .put("noteId", noteId)
+                  .put("paragraphId", paragraphId));
         }
       }
     }
+  }
+
+  private void getEditorSetting(NotebookSocket conn, Notebook notebook, Message fromMessage)
+      throws IOException {
+    String replName = (String) fromMessage.get("magic");
+    String noteId = getOpenNoteId(conn);
+    Note note = notebook.getNote(noteId);
+    Message resp = new Message(OP.EDITOR_SETTING);
+    resp.put("editor", note.getEditorSetting(replName));
+    conn.send(serializeMessage(resp));
+    return;
   }
 }
 

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -24,7 +24,7 @@
     "angular-elastic": "~2.4.2",
     "angular-elastic-input": "~2.2.0",
     "angular-xeditable": "0.1.12",
-    "highlightjs": "^9.2.0",
+    "highlightjs": "^9.4.0",
     "lodash": "~3.9.3",
     "angular-filter": "~0.5.4",
     "ngtoast": "~2.0.0",
@@ -59,7 +59,7 @@
         "highlight.pack.js",
         "styles/github.css"
       ],
-      "version": "8.4.0",
+      "version": "9.4.0",
       "name": "highlightjs"
     }
   }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -560,7 +560,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       }
 
       var remoteCompleter = {
-        getCompletions : function(editor, session, pos, prefix, callback) {
+        getCompletions: function(editor, session, pos, prefix, callback) {
           if (!$scope.editor.isFocused()) {
             return;
           }
@@ -715,7 +715,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
           var promise = getEditorSetting(magic);
           promise.then(function(editorSetting) {
             if (!_.isEmpty(editorSetting.editor)) {
-              var mode = 'ace/mode/' + editorSetting.editor.mode;
+              var mode = 'ace/mode/' + editorSetting.editor.language;
               $scope.paragraph.config.editorMode = mode;
               session.setMode(mode);
             }
@@ -727,7 +727,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
               if (!editorModes[oldMode] || !editorModes[oldMode].test(paragraphText)) {
                 for (var key in editorModes) {
                   if (key !== oldMode) {
-                    if (editorModes[key].test(paragraphText)){
+                    if (editorModes[key].test(paragraphText)) {
                       $scope.paragraph.config.editorMode = key;
                       session.setMode(key);
                       return true;

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -76,8 +76,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
           action: function(dialog) {
             dialog.close();
             angular.element('#loginModal').modal({
-                    show: 'true'
-                  });
+              show: 'true'
+            });
           }
         }, {
           label: 'Cancel',
@@ -97,6 +97,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('updateProgress', data);
     } else if (op === 'COMPLETION_LIST') {
       $rootScope.$broadcast('completionList', data);
+    } else if (op === 'EDITOR_SETTING') {
+      $rootScope.$broadcast('editorSetting', data);
     } else if (op === 'ANGULAR_OBJECT_UPDATE') {
       $rootScope.$broadcast('angularObjectUpdate', data);
     } else if (op === 'ANGULAR_OBJECT_REMOVE') {

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -161,6 +161,15 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
+    getEditorSetting: function(replName) {
+      websocketEvents.sendNewEvent({
+        op: 'EDITOR_SETTING',
+        data: {
+          magic: replName
+        }
+      });
+    },
+
     isConnected: function() {
       return websocketEvents.isConnected();
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -660,7 +660,7 @@ public class Note implements Serializable, ParagraphJobListener {
     try {
       editor = intp.findRegisteredInterpreterByClassName(intp.getClassName()).getEditor();
     } catch (NullPointerException e) {
-      editor.put("mode", "text");
+      editor.put("language", "text");
     }
     return editor;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -650,6 +650,21 @@ public class Note implements Serializable, ParagraphJobListener {
     return getInterpreterName(getLastReplName());
   }
 
+  public Interpreter getRepl(String name) {
+    return factory.getInterpreter(id(), name);
+  }
+
+  public Map<String, Object> getEditorSetting(String replName) {
+    Interpreter intp = getRepl(replName);
+    Map<String, Object> editor = new HashMap<>();
+    try {
+      editor = intp.findRegisteredInterpreterByClassName(intp.getClassName()).getEditor();
+    } catch (NullPointerException e) {
+      editor.put("mode", "text");
+    }
+    return editor;
+  }
+
   @Override
   public void beforeStatusChange(Job job, Status before, Status after) {
     if (jobListenerFactory != null) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -202,7 +202,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
   }
 
   public Interpreter getRepl(String name) {
-    return factory.getInterpreter(note.getId(), name);
+    return note.getRepl(name);
   }
 
   public Interpreter getCurrentRepl() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -76,6 +76,10 @@ public class Message {
     INSERT_PARAGRAPH, // [c-s] create new paragraph below current paragraph
                       // @param target index
 
+    EDITOR_SETTING,   // [c-s] ask paragraph editor setting
+                      // @param magic magic keyword written in paragraph
+                      // ex) spark.spark or spark
+
     COMPLETION,       // [c-s] ask completion candidates
                       // @param id
                       // @param buf current code

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -21,43 +21,43 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Zeppelin websocker massage template class.
+ * Zeppelin websocket massage template class.
  */
 public class Message {
   /**
    * Representation of event type.
    */
   public static enum OP {
-    GET_HOME_NOTE, // [c-s] load note for home screen
+    GET_HOME_NOTE,    // [c-s] load note for home screen
 
-    GET_NOTE, // [c-s] client load note
-              // @param id note id
+    GET_NOTE,         // [c-s] client load note
+                      // @param id note id
 
-    NOTE, // [s-c] note info
-          // @param note serlialized Note object
+    NOTE,             // [s-c] note info
+                      // @param note serlialized Note object
 
-    PARAGRAPH, // [s-c] paragraph info
-               // @param paragraph serialized paragraph object
+    PARAGRAPH,        // [s-c] paragraph info
+                      // @param paragraph serialized paragraph object
 
-    PROGRESS, // [s-c] progress update
-              // @param id paragraph id
-              // @param progress percentage progress
+    PROGRESS,         // [s-c] progress update
+                      // @param id paragraph id
+                      // @param progress percentage progress
 
-    NEW_NOTE, // [c-s] create new notebook
-    DEL_NOTE, // [c-s] delete notebook
-              // @param id note id
-    CLONE_NOTE, // [c-s] clone new notebook
-                // @param id id of note to clone
-                // @param name name fpor the cloned note
-    IMPORT_NOTE,  // [c-s] import notebook
-                  // @param object notebook
+    NEW_NOTE,         // [c-s] create new notebook
+    DEL_NOTE,         // [c-s] delete notebook
+                      // @param id note id
+    CLONE_NOTE,       // [c-s] clone new notebook
+                      // @param id id of note to clone
+                      // @param name name fpor the cloned note
+    IMPORT_NOTE,      // [c-s] import notebook
+                      // @param object notebook
     NOTE_UPDATE,
 
-    RUN_PARAGRAPH, // [c-s] run paragraph
-                   // @param id paragraph id
-                  // @param paragraph paragraph content.ie. script
-                  // @param config paragraph config
-                  // @param params paragraph params
+    RUN_PARAGRAPH,    // [c-s] run paragraph
+                      // @param id paragraph id
+                      // @param paragraph paragraph content.ie. script
+                      // @param config paragraph config
+                      // @param params paragraph params
 
     COMMIT_PARAGRAPH, // [c-s] commit paragraph
                       // @param id paragraph id
@@ -69,60 +69,60 @@ public class Message {
     CANCEL_PARAGRAPH, // [c-s] cancel paragraph run
                       // @param id paragraph id
 
-    MOVE_PARAGRAPH, // [c-s] move paragraph order
-                    // @param id paragraph id
-                    // @param index index the paragraph want to go
+    MOVE_PARAGRAPH,   // [c-s] move paragraph order
+                      // @param id paragraph id
+                      // @param index index the paragraph want to go
 
     INSERT_PARAGRAPH, // [c-s] create new paragraph below current paragraph
                       // @param target index
 
-    COMPLETION, // [c-s] ask completion candidates
-                // @param id
-                // @param buf current code
-                // @param cursor cursor position in code
+    COMPLETION,       // [c-s] ask completion candidates
+                      // @param id
+                      // @param buf current code
+                      // @param cursor cursor position in code
 
-    COMPLETION_LIST, // [s-c] send back completion candidates list
-                     // @param id
-                     // @param completions list of string
+    COMPLETION_LIST,  // [s-c] send back completion candidates list
+                      // @param id
+                      // @param completions list of string
 
-    LIST_NOTES, // [c-s] ask list of note
-    RELOAD_NOTES_FROM_REPO, // [c-s] reload notes from repo
+    LIST_NOTES,                   // [c-s] ask list of note
+    RELOAD_NOTES_FROM_REPO,       // [c-s] reload notes from repo
 
-    NOTES_INFO, // [s-c] list of note infos
-                // @param notes serialized List<NoteInfo> object
+    NOTES_INFO,                   // [s-c] list of note infos
+                                  // @param notes serialized List<NoteInfo> object
 
     PARAGRAPH_REMOVE,
     PARAGRAPH_CLEAR_OUTPUT,
-    PARAGRAPH_APPEND_OUTPUT,  // [s-c] append output
-    PARAGRAPH_UPDATE_OUTPUT,  // [s-c] update (replace) output
+    PARAGRAPH_APPEND_OUTPUT,      // [s-c] append output
+    PARAGRAPH_UPDATE_OUTPUT,      // [s-c] update (replace) output
     PING,
     AUTH_INFO,
 
-    ANGULAR_OBJECT_UPDATE,  // [s-c] add/update angular object
-    ANGULAR_OBJECT_REMOVE,  // [s-c] add angular object del
+    ANGULAR_OBJECT_UPDATE,        // [s-c] add/update angular object
+    ANGULAR_OBJECT_REMOVE,        // [s-c] add angular object del
     
-    ANGULAR_OBJECT_UPDATED,  // [c-s] angular object value updated,
+    ANGULAR_OBJECT_UPDATED,       // [c-s] angular object value updated,
 
-    ANGULAR_OBJECT_CLIENT_BIND,  // [c-s] angular object updated from AngularJS z object
+    ANGULAR_OBJECT_CLIENT_BIND,   // [c-s] angular object updated from AngularJS z object
 
-    ANGULAR_OBJECT_CLIENT_UNBIND,  // [c-s] angular object unbind from AngularJS z object
+    ANGULAR_OBJECT_CLIENT_UNBIND, // [c-s] angular object unbind from AngularJS z object
 
-    LIST_CONFIGURATIONS, // [c-s] ask all key/value pairs of configurations
-    CONFIGURATIONS_INFO, // [s-c] all key/value pairs of configurations
-                  // @param settings serialized Map<String, String> object
+    LIST_CONFIGURATIONS,          // [c-s] ask all key/value pairs of configurations
+    CONFIGURATIONS_INFO,          // [s-c] all key/value pairs of configurations
+                                  // @param settings serialized Map<String, String> object
 
-    CHECKPOINT_NOTEBOOK,    // [c-s] checkpoint notebook to storage repository
-                            // @param noteId
-                            // @param checkpointName
+    CHECKPOINT_NOTEBOOK,          // [c-s] checkpoint notebook to storage repository
+                                  // @param noteId
+                                  // @param checkpointName
 
-    APP_APPEND_OUTPUT,      // [s-c] append output
-    APP_UPDATE_OUTPUT,      // [s-c] update (replace) output
-    APP_LOAD,               // [s-c] on app load
-    APP_STATUS_CHANGE,      // [s-c] on app status change
+    APP_APPEND_OUTPUT,            // [s-c] append output
+    APP_UPDATE_OUTPUT,            // [s-c] update (replace) output
+    APP_LOAD,                     // [s-c] on app load
+    APP_STATUS_CHANGE,            // [s-c] on app status change
 
-    LIST_NOTEBOOK_JOBS,     // [c-s] get notebook job management infomations
-    LIST_UPDATE_NOTEBOOK_JOBS // [c-s] get job management informations for until unixtime
-                               // @param unixTime
+    LIST_NOTEBOOK_JOBS,           // [c-s] get notebook job management information
+    LIST_UPDATE_NOTEBOOK_JOBS     // [c-s] get job management information for until unixtime
+                                  // @param unixTime
   }
 
   public OP op;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.zeppelin.notebook;
 
-import com.google.common.base.Optional;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
@@ -106,7 +104,7 @@ public class NoteTest {
   @Test
   public void putDefaultReplNameIfInterpreterSettingAbsent() {
     when(interpreterFactory.getDefaultInterpreterSetting(anyString()))
-            .thenReturn(null);
+        .thenReturn(null);
 
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
     note.putDefaultReplName();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -841,16 +841,16 @@ public class NotebookTest implements JobListenerFactory{
 
     // get editor setting from interpreter-setting.json
     Map<String, Object> editor = note.getEditorSetting("mock11");
-    assertEquals("java", editor.get("mode"));
+    assertEquals("java", editor.get("language"));
 
     // when interpreter is not loaded via interpreter-setting.json
     // or editor setting doesn't exit
     editor = note.getEditorSetting("mock1");
-    assertEquals(null, editor.get("mode"));
+    assertEquals(null, editor.get("language"));
 
     // when interpreter is not bound to note
     editor = note.getEditorSetting("mock2");
-    assertEquals("text", editor.get("mode"));
+    assertEquals("text", editor.get("language"));
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -85,7 +85,7 @@ public class ParagraphTest {
     assertEquals("Get right replName", "jdbc", p.getRequiredReplName());
     assertEquals("Get right scriptBody", "(h2) show databases", p.getScriptBody());
 
-    when(interpreterFactory.getInterpreter(anyString(), eq("jdbc"))).thenReturn(interpreter);
+    when(note.getRepl(eq("jdbc"))).thenReturn(interpreter);
     when(interpreter.getFormType()).thenReturn(Interpreter.FormType.NATIVE);
     when(note.getId()).thenReturn("noteId");
 

--- a/zeppelin-zengine/src/test/resources/interpreter/mock/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/mock/interpreter-setting.json
@@ -1,0 +1,12 @@
+[
+  {
+    "group": "mock11",
+    "name": "mock11",
+    "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter11",
+    "properties": {
+    },
+    "editor": {
+      "mode": "java"
+    }
+  }
+]

--- a/zeppelin-zengine/src/test/resources/interpreter/mock/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/mock/interpreter-setting.json
@@ -6,7 +6,7 @@
     "properties": {
     },
     "editor": {
-      "mode": "java"
+      "language": "java"
     }
   }
 ]


### PR DESCRIPTION
### What is this PR for?
- Set syntax highlight based on default interpreter if %magic is not set
- Get syntax highlight mode from backend

### What type of PR is it?
Improvement

### Todos
* [x] Add test
* [x] Update [writingzeppelininterpreter.md](https://github.com/apache/zeppelin/blob/master/docs/development/writingzeppelininterpreter.md)
* [ ] Fix test
* [ ] Test after #1145 merged, modify if necessary

### What is the Jira issue?
[ZEPPELIN-1026](https://issues.apache.org/jira/browse/ZEPPELIN-1026)

### Screenshots (if appropriate)
This is screenshot when the default interpreter set to python interpreter.
**Before**
Has `scala` as syntax highlight language when %python is not set.
<img width="665" alt="screen shot 2016-07-07 at 10 46 20 pm" src="https://cloud.githubusercontent.com/assets/8503346/16655312/af67a302-4494-11e6-949e-793ad0515d7a.png">


**After**
Has `python` as syntax highlight language even when %python is not set.
<img width="666" alt="screen shot 2016-07-07 at 10 44 39 pm" src="https://cloud.githubusercontent.com/assets/8503346/16655248/769d8ba4-4494-11e6-9b3c-dc5e026e9c53.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes
