### PR TITLE
[HOTFIX] Master branch build fail after merge ca4e587f11a90169b7ae95fe53ce909b5226cf1a

### DIFF
--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -54,8 +54,8 @@ limitations under the License.
     <link rel="stylesheet" href="app/search/search.css" />
     <link rel="stylesheet" href="app/notebook/notebook.css" />
     <link rel="stylesheet" href="app/notebook/paragraph/paragraph.css" />
-    <link rel="stylesheet" href="app/jobmanager/jobmanager.css">
-    <link rel="stylesheet" href="app/jobmanager/jobs/job.css">
+    <link rel="stylesheet" href="app/jobmanager/jobmanager.css" />
+    <link rel="stylesheet" href="app/jobmanager/jobs/job.css" />
     <link rel="stylesheet" href="app/interpreter/interpreter.css" />
     <link rel="stylesheet" href="app/credential/credential.css" />
     <link rel="stylesheet" href="app/configuration/configuration.css" />


### PR DESCRIPTION
### What is this PR for?
Fixes master branch build fail with error

```
[INFO] --- frontend-maven-plugin:0.0.25:grunt (grunt build) @ zeppelin-web ---
[INFO] Running 'grunt build --no-color' in /Users/moon/Projects/zeppelin/zeppelin-web
[INFO] Running "jshint:all" (jshint) task
[INFO] 
[INFO] ✔ No problems
[INFO] 
[INFO] 
[INFO] Running "htmlhint:src" (htmlhint) task
[INFO]    src/index.html
[INFO]       L57 |    <link rel="stylesheet" href="app/jobmanager/jobmanager.css">
[INFO]                ^ The empty tag : [ link ] must be self closed. (tag-self-close)
[INFO]       L58 |    <link rel="stylesheet" href="app/jobmanager/jobs/job.css">
[INFO]                ^ The empty tag : [ link ] must be self closed. (tag-self-close)
[INFO] 
[INFO] >> 2 errors in 1 files
[INFO] Warning: Task "htmlhint:src" failed. Use --force to continue.
[INFO] 
[INFO] Aborted due to warnings.
```

### What type of PR is it?
Hot Fix

### Todos
* [x] - close tag

### What is the Jira issue?
ZEPPELIN-964, ZEPPELIN-1088

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no

