### PR TITLE
[HOTFIX] Fix NullPointerException	at org.apache.zeppelin.notebook.Paragraph.getRepl(Paragraph.java:204)

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -160,6 +160,11 @@ public class Note implements Serializable, ParagraphJobListener {
 
   public void setInterpreterFactory(InterpreterFactory factory) {
     this.factory = factory;
+    synchronized (paragraphs) {
+      for (Paragraph p : paragraphs) {
+        p.setInterpreterFactory(factory);
+      }
+    }
   }
 
   public JobListenerFactory getJobListenerFactory() {
@@ -447,7 +452,6 @@ public class Note implements Serializable, ParagraphJobListener {
         authenticationInfo.setUser(cronExecutingUser);
         p.setAuthenticationInfo(authenticationInfo);
 
-        p.setInterpreterFactory(factory);
         p.setListener(jobListenerFactory.getParagraphJobListener(this));
         Interpreter intp = factory.getInterpreter(getId(), p.getRequiredReplName());
 
@@ -463,7 +467,6 @@ public class Note implements Serializable, ParagraphJobListener {
    */
   public void run(String paragraphId) {
     Paragraph p = getParagraph(paragraphId);
-    p.setInterpreterFactory(factory);
     p.setListener(jobListenerFactory.getParagraphJobListener(this));
     String requiredReplName = p.getRequiredReplName();
     Interpreter intp = factory.getInterpreter(getId(), requiredReplName);
@@ -501,7 +504,6 @@ public class Note implements Serializable, ParagraphJobListener {
 
   public List<InterpreterCompletion> completion(String paragraphId, String buffer, int cursor) {
     Paragraph p = getParagraph(paragraphId);
-    p.setInterpreterFactory(factory);
     p.setListener(jobListenerFactory.getParagraphJobListener(this));
     List completion = p.completion(buffer, cursor);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -143,7 +143,7 @@ public class NotebookTest implements JobListenerFactory{
     assertNull(note.getParagraphs().get(0).getRepl(null));
   }
 
-    @Test
+  @Test
   public void testReloadAllNotes() throws IOException {
     File srcDir = new File("src/test/resources/2A94M5J1Z");
     File destDir = new File(notebookDir.getAbsolutePath() + "/2A94M5J1Z");

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -128,6 +128,22 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
+  public void testReloadAndSetInterpreter() throws IOException {
+    // given a notebook
+    File srcDir = new File("src/test/resources/2A94M5J1Z");
+    File destDir = new File(notebookDir.getAbsolutePath() + "/2A94M5J1Z");
+    FileUtils.copyDirectory(srcDir, destDir);
+
+    // when load
+    notebook.reloadAllNotes(null);
+    assertEquals(1, notebook.getAllNotes().size());
+
+    // then interpreter factory should be injected into all the paragraphs
+    Note note = notebook.getAllNotes().get(0);
+    assertNull(note.getParagraphs().get(0).getRepl(null));
+  }
+
+    @Test
   public void testReloadAllNotes() throws IOException {
     File srcDir = new File("src/test/resources/2A94M5J1Z");
     File destDir = new File(notebookDir.getAbsolutePath() + "/2A94M5J1Z");


### PR DESCRIPTION
### What is this PR for?
When notebook is being loaded, following error is raised after #836 

```
Caused by: java.lang.NullPointerException
	at org.apache.zeppelin.notebook.Paragraph.getRepl(Paragraph.java:204)
	at org.apache.zeppelin.notebook.Paragraph.getCurrentRepl(Paragraph.java:208)
	at org.apache.zeppelin.helium.Helium.suggestApp(Helium.java:138)
	at org.apache.zeppelin.rest.HeliumRestApi.suggest(HeliumRestApi.java:83)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:180)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96)
	... 50 more
```

### What type of PR is it?
Hotfix

### Todos
* [x] - Fix

### What is the Jira issue?
ZEPPELIN-732, ZEPPELIN-1075

### How should this be tested?
Run Zeppelin and load any notebook. And see if there're unexpected exception raised.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

