### PR TITLE
Block all routes except Home when user isn't logged

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -110,8 +110,7 @@
   function bootstrapApplication() {
     zeppelinWebApp.run(function($rootScope, $location) {
       $rootScope.$on('$routeChangeStart', function(event, next, current) {
-        if (!$rootScope.ticket && !next.$$route.publicAccess) {
-          event.preventDefault();
+        if (!$rootScope.ticket && next.$$route && !next.$$route.publicAccess) {
           $location.path('/');
         }
       });

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -98,7 +98,6 @@
     var baseUrlSrv = angular.injector(['zeppelinWebApp']).get('baseUrlSrv');
     // withCredentials when running locally via grunt
     $http.defaults.withCredentials = true;
-
     return $http.get(baseUrlSrv.getRestApiBase() + '/security/ticket').then(function(response) {
       zeppelinWebApp.run(function($rootScope) {
         $rootScope.ticket = angular.fromJson(response.data).body;
@@ -109,11 +108,18 @@
   }
 
   function bootstrapApplication() {
+    zeppelinWebApp.run(function($rootScope, $location) {
+      $rootScope.$on('$routeChangeStart', function(event, next, current) {
+        if (!$rootScope.ticket && !next.$$route.publicAccess) {
+          event.preventDefault();
+          $location.path('/');
+        }
+      });
+    });
     angular.bootstrap(document, ['zeppelinWebApp']);
   }
 
   angular.element(document).ready(function() {
     auth().then(bootstrapApplication);
   });
-
 }());


### PR DESCRIPTION
### What is this PR for?
When user isn't logged while the auth is activated, we are hiding the notebooks and most of the menus.
However you can still access them using the url routes.
This PR is blocking the url routes except the home route ('/') in that case.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1123

### How should this be tested?
* Activate the auth in shiro.ini
* Launch Zeppelin, and try to visit `localhost:8080/#/interpreter` by typing it in your browser
* You should be redirected to '/'

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

