### PR TITLE
[ZEPPELIN-1136] NPE in Zeppelin Logs

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -57,10 +57,12 @@ public class GetUserList {
   public List<String> getUserList(IniRealm r) {
     List<String> userList = new ArrayList<>();
     Map getIniUser = r.getIni().get("users");
-    Iterator it = getIniUser.entrySet().iterator();
-    while (it.hasNext()) {
-      Map.Entry pair = (Map.Entry) it.next();
-      userList.add(pair.getKey().toString().trim());
+    if (getIniUser != null) {
+      Iterator it = getIniUser.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry pair = (Map.Entry) it.next();
+        userList.add(pair.getKey().toString().trim());
+      }
     }
     return userList;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
@@ -101,21 +101,22 @@ public class SecurityRestApi {
     try {
       GetUserList getUserListObj = new GetUserList();
       Collection realmsList = SecurityUtils.getRealmsList();
-      for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
-        Realm realm = iterator.next();
-        String name = realm.getName();
-        if (name.equals("iniRealm")) {
-          usersList.addAll(getUserListObj.getUserList((IniRealm) realm));
-        } else if (name.equals("ldapRealm")) {
-          usersList.addAll(getUserListObj.getUserList((JndiLdapRealm) realm, searchText));
-        } else if (name.equals("activeDirectoryRealm")) {
-          usersList.addAll(getUserListObj.getUserList((ActiveDirectoryGroupRealm) realm,
-              searchText));
-        } else if (name.equals("jdbcRealm")) {
-          usersList.addAll(getUserListObj.getUserList((JdbcRealm) realm));
+      if (realmsList != null) {
+        for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
+          Realm realm = iterator.next();
+          String name = realm.getName();
+          if (name.equals("iniRealm")) {
+            usersList.addAll(getUserListObj.getUserList((IniRealm) realm));
+          } else if (name.equals("ldapRealm")) {
+            usersList.addAll(getUserListObj.getUserList((JndiLdapRealm) realm, searchText));
+          } else if (name.equals("activeDirectoryRealm")) {
+            usersList.addAll(getUserListObj.getUserList((ActiveDirectoryGroupRealm) realm,
+                searchText));
+          } else if (name.equals("jdbcRealm")) {
+            usersList.addAll(getUserListObj.getUserList((JdbcRealm) realm));
+          }
         }
       }
-
     } catch (Exception e) {
       LOG.error("Exception in retrieving Users from realms ", e);
     }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
@@ -20,17 +20,24 @@ package org.apache.zeppelin.rest;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ErrorCollector;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
 
 public class SecurityRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
+
+  @Rule
+  public ErrorCollector collector = new ErrorCollector();
 
   @BeforeClass
   public static void init() throws Exception {
@@ -49,9 +56,35 @@ public class SecurityRestApiTest extends AbstractTestRestApi {
     Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
         new TypeToken<Map<String, Object>>(){}.getType());
     Map<String, String> body = (Map<String, String>) resp.get("body");
-    assertEquals("anonymous", body.get("principal"));
-    assertEquals("anonymous", body.get("ticket"));
+    collector.checkThat("Paramater principal", body.get("principal"),
+        CoreMatchers.equalTo("anonymous"));
+    collector.checkThat("Paramater ticket", body.get("ticket"),
+        CoreMatchers.equalTo("anonymous"));
     get.releaseConnection();
+  }
+
+  @Test
+  public void testGetUserList() throws IOException {
+    GetMethod get = httpGet("/security/userlist/admi");
+    get.addRequestHeader("Origin", "http://localhost");
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+        new TypeToken<Map<String, Object>>(){}.getType());
+    List<String> userList = (List<String>)  resp.get("body");
+    collector.checkThat("Search result size", userList.size(),
+        CoreMatchers.equalTo(1));
+    collector.checkThat("Search result contains admin", userList.contains("admin"),
+        CoreMatchers.equalTo(true));
+    get.releaseConnection();
+
+    GetMethod notUser = httpGet("/security/userlist/randomString");
+    notUser.addRequestHeader("Origin", "http://localhost");
+    Map<String, Object> notUserResp = gson.fromJson(notUser.getResponseBodyAsString(),
+        new TypeToken<Map<String, Object>>(){}.getType());
+    List<String> emptyUserList = (List<String>)  notUserResp.get("body");
+    collector.checkThat("Search result size", emptyUserList.size(),
+        CoreMatchers.equalTo(0));
+
+    notUser.releaseConnection();
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
Access Zeppelin without configuring any security, Zeppelin shows anoymous user and notice the NPE in Zeppelin logs.

```
ERROR [2016-07-08 17:45:17,879] ({qtp1800659519-45} SecurityRestApi.java[getUserList]:120) - Exception in retrieving Users from realms 
java.lang.NullPointerException
	at org.apache.zeppelin.rest.GetUserList.getUserList(GetUserList.java:60)
	at org.apache.zeppelin.rest.SecurityRestApi.getUserList(SecurityRestApi.java:108)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:180)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96)
```

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-1136](https://issues.apache.org/jira/browse/ZEPPELIN-1136)

### How should this be tested?
Have shiro.ini with just following (minimal) content

```
[urls]
/api/version = anon
/** = anon
#/** = authc
```

and observe in logs, there should be no error logs.


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

