### PR TITLE
[ZEPPELIN-1131] Does not initialize login page values.

### DIFF
--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -65,7 +65,7 @@ angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, noteboo
     node.hidden = !node.hidden;
   };
 
-  angular.element('#loginModal').on("hidden.bs.modal", function () {
+  angular.element('#loginModal').on('hidden.bs.modal', function (e) {
     $rootScope.$broadcast('initLoginValues');
   });
 

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -65,7 +65,7 @@ angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, noteboo
     node.hidden = !node.hidden;
   };
 
-  angular.element('#loginModal').on('hidden.bs.modal', function (e) {
+  angular.element('#loginModal').on('hidden.bs.modal', function(e) {
     $rootScope.$broadcast('initLoginValues');
   });
 

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -65,4 +65,8 @@ angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, noteboo
     node.hidden = !node.hidden;
   };
 
+  angular.element('#loginModal').on("hidden.bs.modal", function () {
+    $rootScope.$broadcast('initLoginValues');
+  });
+
 });

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -39,5 +39,15 @@ angular.module('zeppelinWebApp').controller('LoginCtrl',
       });
 
     };
+
+    $rootScope.$on('initLoginValues', function() {
+      initLoginValues();
+    });
+    var initLoginValues = function() {
+      $scope.loginParams = {
+        userName: '',
+        password: ''
+      };
+    };
   }
 );

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -40,7 +40,7 @@ angular.module('zeppelinWebApp').controller('LoginCtrl',
 
     };
 
-    $rootScope.$on('initLoginValues', function() {
+    $scope.$on('initLoginValues', function() {
       initValues();
     });
     var initValues = function() {

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -41,9 +41,9 @@ angular.module('zeppelinWebApp').controller('LoginCtrl',
     };
 
     $rootScope.$on('initLoginValues', function() {
-      initLoginValues();
+      initValues();
     });
-    var initLoginValues = function() {
+    var initValues = function() {
       $scope.loginParams = {
         userName: '',
         password: ''


### PR DESCRIPTION
### What is this PR for?
This PR is for initialization of login page values(id, password).
The login id and password does not initialize even if login page closed.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1131


### How should this be tested?
1. click login.
2. put id and password.
3. just close the modal window.
4. reopen login modal.
5. id and password should be initialized.

### Screenshots (if appropriate)
- before
![before](https://cloud.githubusercontent.com/assets/3348133/16708435/b3ce4e32-462e-11e6-8065-f4e57e1c91f0.gif)


- after
![after](https://cloud.githubusercontent.com/assets/3348133/16708433/9f70238e-462e-11e6-9735-5801bd7bc856.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

