### PR TITLE
[Zeppelin - 1152] Listing note revision history

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -45,6 +45,7 @@ import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.notebook.*;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.Message.OP;
 import org.apache.zeppelin.scheduler.Job;
@@ -219,6 +220,9 @@ public class NotebookServer extends WebSocketServlet implements
             break;
           case CHECKPOINT_NOTEBOOK:
             checkpointNotebook(conn, notebook, messagereceived);
+            break;
+          case LIST_REVISION_HISTORY:
+            listRevisionHistory(conn, notebook, messagereceived);
             break;
           case LIST_NOTEBOOK_JOBS:
             unicastNotebookJobInfo(conn, messagereceived);
@@ -1127,6 +1131,16 @@ public class NotebookServer extends WebSocketServlet implements
     String commitMessage = (String) fromMessage.get("commitMessage");
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
     notebook.checkpointNote(noteId, commitMessage, subject);
+  }
+
+  private void listRevisionHistory(NotebookSocket conn, Notebook notebook,
+      Message fromMessage) throws IOException {
+    String noteId = (String) fromMessage.get("noteId");
+    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+    List<NotebookRepo.Revision> revisions = notebook.listRevisionHistory(noteId, subject);
+
+    conn.send(serializeMessage(new Message(OP.LIST_REVISION_HISTORY)
+      .put("revisionList", revisions)));
   }
 
   /**

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -64,40 +64,56 @@ limitations under the License.
               tooltip-placement="bottom" tooltip="Export the notebook">
         <i class="fa fa-download"></i>
       </button>
-      <button type="button"
-              class="btn btn-default btn-xs dropdown-toggle"
-              ng-hide="viewOnly"
-              data-toggle="dropdown"
-              tooltip-placement="bottom" tooltip="Version control">
-        <i class="fa fa-file-code-o"></i>
-      </button>
-      <ul class="dropdown-menu" role="menu" style="width:250px">
-        <li>
-          <div class="commit-container">
-            <div>
-              <input type="text"
-                     dropdown-input
-                     placeholder="commit message"
-                     id="note.checkpoint.message"
-                     style="width: 145px;"
-                     ng-model="note.checkpoint.message"/>
-              <button type="button"
-                      class="btn btn-default btn-xs"
-                      ng-hide="viewOnly"
-                      ng-click="checkpointNotebook(note.checkpoint.message)"
-                      style="margin-left: 4px;"
-                      tooltip-placement="bottom" tooltip="Commit the notebook">Commit
-              </button>
+    </span>
+
+    <span class="labelBtn btn-group" role="group">
+      <div class="btn-group" role="group">
+        <button type="button"
+                class="btn btn-default btn-xs dropdown-toggle"
+                id="versionControlDropdown"
+                ng-hide="viewOnly"
+                data-toggle="dropdown"
+                tooltip-placement="bottom" tooltip="Version control">
+          <i class="fa fa-file-code-o"></i>
+        </button>
+        <ul class="dropdown-menu" style="width:250px"
+          aria-labelledby="versionControlDropdown">
+          <li>
+            <div class="commit-container">
+              <div>
+                <input type="text"
+                       dropdown-input
+                       placeholder="commit message"
+                       id="note.checkpoint.message"
+                       style="width: 145px;"
+                       ng-model="note.checkpoint.message"/>
+                <button type="button"
+                        class="btn btn-default btn-xs"
+                        ng-hide="viewOnly"
+                        ng-click="checkpointNotebook(note.checkpoint.message)"
+                        style="margin-left: 4px;"
+                        tooltip-placement="bottom" tooltip="Commit the notebook">Commit
+                </button>
+              </div>
             </div>
-          </div>
-        </li>
-        <li ng-repeat="revision in ::noteRevisions">
-          <div>
-            message: {{revision[$index].message}}
-            time: {{revision[$index].time}}
-          </div>
-        </li>
-      </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default btn-xs revisionName">
+          Head
+        </button>
+        <button type="button" ng-if="noteRevisions.length > 0"
+          class="btn btn-default dropdown-toggle caretSeparator"
+          data-toggle="dropdown" id="revisionsDropdown">
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
+          <li ng-repeat="revision in noteRevisions | orderBy:'time'" class="revision">
+            <a style="cursor:pointer"><strong>{{moment.unix(revision.time).format("YY/MM/DD")}}</strong> - {{revision.message}}</a>
+          </li>
+        </ul>
+      </div>
     </span>
 
 <!-- put the delete action by itself for your protection -->

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -91,16 +91,10 @@ limitations under the License.
             </div>
           </div>
         </li>
-        <li>
+        <li ng-repeat="revision in ::noteRevisions">
           <div>
-            <button type="button"
-                    class="btn btn-default btn-xs"
-                    ng-hide="viewOnly"
-                    ng-click="listRevisionHistory()"
-                    style="margin-left: 4px;"
-                    tooltip-placement="bottom" tooltip="List revision history">List
-            </button>
-            table
+            message: {{revision[$index].message}}
+            time: {{revision[$index].time}}
           </div>
         </li>
       </ul>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -110,7 +110,7 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer"><strong>{{moment.unix(revision.time).format("YY/MM/DD")}}</strong> - {{revision.message}}</a>
+            <a style="cursor:pointer"><strong>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm:ss a')}}</strong> - {{revision.message}}</a>
           </li>
         </ul>
       </div>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -110,7 +110,10 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer; line-height:120%"><strong>{{revision.message}}</strong> <br/>
+            <a style="cursor:pointer">
+              <span style="display: block;">
+                <strong>{{revision.message}}</strong>
+              </span>
               <span class="revisionDate">
                 <em>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm a')}}</em>
               </span>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -91,6 +91,18 @@ limitations under the License.
             </div>
           </div>
         </li>
+        <li>
+          <div>
+            <button type="button"
+                    class="btn btn-default btn-xs"
+                    ng-hide="viewOnly"
+                    ng-click="listRevisionHistory()"
+                    style="margin-left: 4px;"
+                    tooltip-placement="bottom" tooltip="List revision history">List
+            </button>
+            table
+          </div>
+        </li>
       </ul>
     </span>
 

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -110,7 +110,11 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer"><strong>{{revision.message}}</strong> - <em>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm a')}}</em></a>
+            <a style="cursor:pointer"><strong>{{revision.message}}</strong> -
+              <span class="revisionDate">
+                <em>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm a')}}</em>
+              </span>
+            </a>
           </li>
         </ul>
       </div>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -109,7 +109,7 @@ limitations under the License.
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
-          <li ng-repeat="revision in noteRevisions | orderBy:'time'" class="revision">
+          <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
             <a style="cursor:pointer"><strong>{{moment.unix(revision.time).format("YY/MM/DD")}}</strong> - {{revision.message}}</a>
           </li>
         </ul>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -110,7 +110,7 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer"><strong>{{revision.message}}</strong> -
+            <a style="cursor:pointer; line-height:120%"><strong>{{revision.message}}</strong> <br/>
               <span class="revisionDate">
                 <em>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm a')}}</em>
               </span>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -110,7 +110,7 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer"><strong>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm:ss a')}}</strong> - {{revision.message}}</a>
+            <a style="cursor:pointer"><strong>{{revision.message}}</strong> - <em>{{moment.unix(revision.time).format('MMMM Do YYYY, h:mm a')}}</em></a>
           </li>
         </ul>
       </div>

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -55,6 +55,16 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   var searchText = [];
   $scope.role = '';
 
+  $scope.noteRevisions = websocketMsgSrv.listRevisionHistory($routeParams.noteId);
+
+
+  $scope.$on('setConnectedStatus', function(event, param) {
+    if (connectedOnce && param) {
+      initNotebook();
+    }
+    connectedOnce = true;
+  });
+
   $scope.getCronOptionNameFromValue = function(value) {
     if (!value) {
       return '';
@@ -175,15 +185,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     document.getElementById('note.checkpoint.message').value = '';
   };
 
-  $scope.listRevisionHistory = function() {
-    websocketMsgSrv.listRevisionHistory($routeParams.noteId);
-  };
-
   $scope.$on('listRevisionHistory', function(event, data) {
     console.log(data);
-    if (data === '{}') {
-      console.log('empty data');
-    }
+    $scope.noteRevisions = data;
   });
 
   $scope.runNote = function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -19,6 +19,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
                                                                      $rootScope, $http, websocketMsgSrv,
                                                                      baseUrlSrv, $timeout, SaveAsService) {
   $scope.note = null;
+  $scope.moment = moment;
   $scope.showEditor = false;
   $scope.editorToggled = false;
   $scope.tableToggled = false;
@@ -54,8 +55,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   var previousSelectedListWriters = [];
   var searchText = [];
   $scope.role = '';
-
-  $scope.noteRevisions = websocketMsgSrv.listRevisionHistory($routeParams.noteId);
+  $scope.noteRevisions = [];
 
   $scope.$on('setConnectedStatus', function(event, param) {
     if (connectedOnce && param) {
@@ -80,6 +80,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   /** Init the new controller */
   var initNotebook = function() {
     websocketMsgSrv.getNotebook($routeParams.noteId);
+    websocketMsgSrv.listRevisionHistory($routeParams.noteId);
 
     var currentRoute = $route.current;
     if (currentRoute) {
@@ -185,8 +186,8 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   };
 
   $scope.$on('listRevisionHistory', function(event, data) {
-    console.log(data);
-    $scope.noteRevisions = data;
+    console.log("We got the revisions yeahh %o", data);
+    $scope.noteRevisions = data.revisionList;
   });
 
   $scope.runNote = function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -57,7 +57,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   $scope.noteRevisions = websocketMsgSrv.listRevisionHistory($routeParams.noteId);
 
-
   $scope.$on('setConnectedStatus', function(event, param) {
     if (connectedOnce && param) {
       initNotebook();

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -175,6 +175,17 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     document.getElementById('note.checkpoint.message').value = '';
   };
 
+  $scope.listRevisionHistory = function() {
+    websocketMsgSrv.listRevisionHistory($routeParams.noteId);
+  };
+
+  $scope.$on('listRevisionHistory', function(event, data) {
+    console.log(data);
+    if (data === '{}') {
+      console.log('empty data');
+    }
+  });
+
   $scope.runNote = function() {
     BootstrapDialog.confirm({
       closable: true,

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -186,7 +186,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   };
 
   $scope.$on('listRevisionHistory', function(event, data) {
-    console.log("We got the revisions yeahh %o", data);
+    console.log('We got the revisions %o', data);
     $scope.noteRevisions = data.revisionList;
   });
 

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -21,12 +21,15 @@
   margin-bottom: 0 !important;
 }
 
-.revision a  {
+.revision a {
+  padding: 2px 10px !important;
+}
+
+.revision a span {
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 2px 10px !important;
 }
 
 .revisionName {
@@ -36,8 +39,9 @@
 }
 
 .revisionDate {
-  font-size:70%;
+  font-size: 8px;
   color: DarkGrey;
+  display: block;
 }
 
 .revisionName:hover,

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -14,6 +14,7 @@
 
 .notebookContent {
   padding-top: 36px;
+}
 
 .revision  {
   max-width: 250px;

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -14,6 +14,38 @@
 
 .notebookContent {
   padding-top: 36px;
+
+.revision  {
+  max-width: 250px;
+  margin-bottom: 0 !important;
+}
+
+.revision a  {
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 2px 10px !important;
+}
+
+.revisionName {
+  cursor: default;
+  padding: 1px 10px !important;
+  max-width: 150px;
+}
+
+.revisionName:hover,
+.revisionName:focus,
+.revisionName:active {
+  background: transparent;
+  border-color: #ccc;
+}
+
+.caretSeparator {
+  height: 22px;
+  line-height: 9px;
+  width: 16px;
+  padding-left: 3px !important;
 }
 
 .paragraph-col {

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -36,7 +36,8 @@
 }
 
 .revisionDate {
-  font-size:80%;
+  font-size:70%;
+  color: DarkGrey;
 }
 
 .revisionName:hover,

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -35,6 +35,10 @@
   max-width: 150px;
 }
 
+.revisionDate {
+  font-size:80%;
+}
+
 .revisionName:hover,
 .revisionName:focus,
 .revisionName:active {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -109,6 +109,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('appLoad', data);
     } else if (op === 'APP_STATUS_CHANGE') {
       $rootScope.$broadcast('appStatusChange', data);
+    } else if (op === 'LIST_REVISION_HISTORY') {
+      $rootScope.$broadcast('listRevisionHistory', data);
     }
   });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -170,7 +170,7 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    isConnected: function(){
+    isConnected: function() {
       return websocketEvents.isConnected();
     },
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -161,7 +161,16 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    isConnected: function() {
+    listRevisionHistory: function(noteId) {
+      websocketEvents.sendNewEvent({
+        op: 'LIST_REVISION_HISTORY',
+        data: {
+          noteId: noteId
+        }
+      });
+    },
+
+    isConnected: function(){
       return websocketEvents.isConnected();
     },
 

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -7,7 +7,8 @@ describe('Controller: NotebookCtrl', function() {
   var scope;
 
   var websocketMsgSrvMock = {
-    getNotebook: function() {}
+    getNotebook: function() {},
+    listRevisionHistory: function() {}
   };
 
   var baseUrlSrvMock = {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -55,6 +55,7 @@ import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.resource.ResourcePoolUtils;
 import org.apache.zeppelin.scheduler.Job;
@@ -352,9 +353,9 @@ public class Notebook implements NoteEventListener {
     }
   }
 
-  public void checkpointNote(String noteId, String checkpointMessage, AuthenticationInfo subject)
-      throws IOException {
-    notebookRepo.checkpoint(noteId, checkpointMessage, subject);
+  public Revision checkpointNote(String noteId, String checkpointMessage,
+      AuthenticationInfo subject) throws IOException {
+    return notebookRepo.checkpoint(noteId, checkpointMessage, subject);
   }
 
   public List<NotebookRepo.Revision> listRevisionHistory(String noteId,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -357,6 +357,11 @@ public class Notebook implements NoteEventListener {
     notebookRepo.checkpoint(noteId, checkpointMessage, subject);
   }
 
+  public List<NotebookRepo.Revision> listRevisionHistory(String noteId,
+      AuthenticationInfo subject) {
+    return notebookRepo.revisionHistory(noteId, subject);
+  }
+
   @SuppressWarnings("rawtypes")
   private Note loadNoteFromRepo(String id, AuthenticationInfo subject) {
     Note note = null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -361,7 +362,12 @@ public class NotebookRepoSync implements NotebookRepo {
 
   @Override
   public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
-    // Auto-generated method stub
-    return null;
+    List<Revision> revisions = Collections.emptyList();
+    try {
+      revisions = getRepo(0).revisionHistory(noteId, subject);
+    } catch (IOException e) {
+      LOG.error("Failed to list revision history", e);
+    }
+    return revisions;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -114,6 +114,8 @@ public class Message {
     CHECKPOINT_NOTEBOOK,    // [c-s] checkpoint notebook to storage repository
                             // @param noteId
                             // @param checkpointName
+    LIST_REVISION_HISTORY,  // [c-s] list revision history of the notebook
+                            // @param noteId
 
     APP_APPEND_OUTPUT,      // [s-c] append output
     APP_UPDATE_OUTPUT,      // [s-c] update (replace) output

--- a/zeppelin-zengine/src/test/resources/2A94M5J2Z/note.json
+++ b/zeppelin-zengine/src/test/resources/2A94M5J2Z/note.json
@@ -1,0 +1,87 @@
+{
+  "paragraphs": [
+    {
+      "text": "%md\n## Congratulations, it\u0027s done.\n##### You can create your own notebook in \u0027Notebook\u0027 menu. Good luck!",
+      "config": {
+        "colWidth": 12.0,
+        "graph": {
+          "mode": "table",
+          "height": 300.0,
+          "optionOpen": false,
+          "keys": [],
+          "values": [],
+          "groups": [],
+          "scatter": {}
+        },
+        "editorHide": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph_1423836268492_216498320",
+      "id": "20150213-230428_1231780373",
+      "result": {
+        "code": "SUCCESS",
+        "type": "HTML",
+        "msg": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+      },
+      "dateCreated": "Feb 13, 2015 11:04:28 PM",
+      "dateStarted": "Apr 1, 2015 9:12:18 PM",
+      "dateFinished": "Apr 1, 2015 9:12:18 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "text": "%md\n\nAbout bank data\n\n```\nCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n```",
+      "config": {
+        "colWidth": 12.0,
+        "graph": {
+          "mode": "table",
+          "height": 300.0,
+          "optionOpen": false,
+          "keys": [],
+          "values": [],
+          "groups": [],
+          "scatter": {}
+        },
+        "editorHide": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph_1427420818407_872443482",
+      "id": "20150326-214658_12335843",
+      "result": {
+        "code": "SUCCESS",
+        "type": "HTML",
+        "msg": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+      },
+      "dateCreated": "Mar 26, 2015 9:46:58 PM",
+      "dateStarted": "Jul 3, 2015 1:44:56 PM",
+      "dateFinished": "Jul 3, 2015 1:44:56 PM",
+      "status": "FINISHED",
+      "progressUpdateIntervalMs": 500
+    },
+    {
+      "config": {},
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph_1435955447812_-158639899",
+      "id": "20150703-133047_853701097",
+      "dateCreated": "Jul 3, 2015 1:30:47 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "Sample note - excerpt from Zeppelin Tutorial",
+  "id": "2A94M5J2Z",
+  "angularObjects": {},
+  "config": {
+    "looknfeel": "default"
+  },
+  "info": {}
+}


### PR DESCRIPTION
### What is this PR for?
This PR addresses ability to view the history of note revisions from the `version control` menu

### What type of PR is it?
Improvement

### Todos
* [x] - backend changes
* [x] - tests
* [x] - propagation to frontend
* [x] -  rendering list

### What is the Jira issue?
[Zeppelin - 1152](https://issues.apache.org/jira/browse/ZEPPELIN-1152)

### How should this be tested?
1. Select Git notebook storage layer as primary (e.g. in `conf/zeppelin-env.sh` add 
``` 
export ZEPPELIN_NOTEBOOK_STORAGE="org.apache.zeppelin.notebook.repo.GitNotebookRepo"
```
2. Select any note in Zeppelin and `commit` it in `version control` menu
3. The list with new commit should be shown in the same menu

### Screenshots (if appropriate)
<img width="782" alt="screen shot 2016-07-21 at 11 35 21 am" src="https://cloud.githubusercontent.com/assets/1642088/17009639/c8bcbd58-4f37-11e6-92cd-88147b7419e6.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
