### PR TITLE
[ZEPPELIN-1149] %sh interpreter kerberos support

### DIFF
--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -30,6 +30,21 @@ At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property v
     <td>60000</td>
     <td>Shell command time out in millisecs</td>
   </tr>
+  <tr>
+    <td>zeppelin.shell.auth.type</td>
+    <td></td>
+    <td>Types of authentications' methods supported are SIMPLE, and KERBEROS</td>
+  </tr>
+  <tr>
+    <td>zeppelin.shell.principal</td>
+    <td></td>
+    <td>The principal name to load from the keytab</td>
+  </tr>
+  <tr>
+    <td>zeppelin.shell.keytab.location</td>
+    <td></td>
+    <td>The path to the keytab file</td>
+  </tr>
 </table>
 
 ## Example

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -14,6 +14,29 @@ Shell interpreter uses [Apache Commons Exec](https://commons.apache.org/proper/c
 In Zeppelin notebook, you can use ` %sh ` in the beginning of a paragraph to invoke system shell and run commands.
 Note: Currently each command runs as Zeppelin user.
 
+
+## Properties
+You can modify the interpreter configuration in the `Interpreter` section. The most common properties are as follows, but you can specify other properties that need to be connected.
+
+<table class="table-configuration">
+  <tr>
+    <td>shell.command.timeout.millisecs</td>
+    <td>Shell command time out in millisecs. Default = 60000</td>
+  </tr>
+  <tr>
+   <td>shell.auth.type</td>
+   <td>Types of authentications' methods supported are SIMPLE, and KERBEROS</td>
+  </tr>
+  <tr>
+   <td>shell.principal</td>
+   <td>The principal name to load from the keytab</td>
+  </tr>
+  <tr>
+   <td>shell.keytab.location</td>
+   <td>The path to the keytab file</td>
+  </tr>
+</table>
+
 ### Example
 The following example demonstrates the basic usage of Shell in a Zeppelin notebook.
 

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -24,15 +24,15 @@ You can modify the interpreter configuration in the `Interpreter` section. The m
     <td>Shell command time out in millisecs. Default = 60000</td>
   </tr>
   <tr>
-   <td>shell.auth.type</td>
+   <td>zeppelin.shell.auth.type</td>
    <td>Types of authentications' methods supported are SIMPLE, and KERBEROS</td>
   </tr>
   <tr>
-   <td>shell.principal</td>
+   <td>zeppelin.shell.principal</td>
    <td>The principal name to load from the keytab</td>
   </tr>
   <tr>
-   <td>shell.keytab.location</td>
+   <td>zeppelin.shell.keytab.location</td>
    <td>The path to the keytab file</td>
   </tr>
 </table>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -62,6 +62,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.7.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -62,12 +62,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>2.7.0</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -60,7 +60,7 @@ public class ShellInterpreter extends Interpreter {
   public void open() {
     LOGGER.info("Command timeout property: {}", getProperty(TIMEOUT_PROPERTY));
     executors = new HashMap<String, DefaultExecutor>();
-    if (!StringUtils.isAnyEmpty(getProperty("shell.auth.type"))) {
+    if (!StringUtils.isAnyEmpty(getProperty("zeppelin.shell.auth.type"))) {
       ShellSecurityImpl.createSecureCinfiguration(getProperty(), shell);
     }
   }

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -61,7 +61,7 @@ public class ShellInterpreter extends Interpreter {
     LOGGER.info("Command timeout property: {}", getProperty(TIMEOUT_PROPERTY));
     executors = new HashMap<String, DefaultExecutor>();
     if (!StringUtils.isAnyEmpty(getProperty("zeppelin.shell.auth.type"))) {
-      ShellSecurityImpl.createSecureCinfiguration(getProperty(), shell);
+      ShellSecurityImpl.createSecureConfiguration(getProperty(), shell);
     }
   }
 

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -38,6 +38,7 @@ import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
+import org.apache.zeppelin.shell.security.ShellSecurityImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,8 +58,11 @@ public class ShellInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    LOGGER.info("Command timeout property: {}", TIMEOUT_PROPERTY);
+    LOGGER.info("Command timeout property: {}", getProperty(TIMEOUT_PROPERTY));
     executors = new HashMap<String, DefaultExecutor>();
+    if (!StringUtils.isAnyEmpty(getProperty("shell.auth.type"))) {
+      ShellSecurityImpl.createSecureCinfiguration(getProperty(), shell);
+    }
   }
 
   @Override

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -41,11 +41,11 @@ public class ShellSecurityImpl {
     UserGroupInformation.AuthenticationMethod authType;
     try {
       authType = UserGroupInformation
-        .AuthenticationMethod.valueOf(properties.getProperty("shell.auth.type")
+        .AuthenticationMethod.valueOf(properties.getProperty("zeppelin.shell.auth.type")
           .trim().toUpperCase());
     } catch (Exception e) {
       LOGGER.error(String.format("Invalid auth.type detected with value %s, defaulting " +
-        "auth.type to SIMPLE", properties.getProperty("shell.auth.type").trim()));
+        "auth.type to SIMPLE", properties.getProperty("zeppelin.shell.auth.type").trim()));
       authType = SIMPLE;
     }
 
@@ -55,8 +55,8 @@ public class ShellSecurityImpl {
           CommandLine cmdLine = CommandLine.parse(shell);
           cmdLine.addArgument("-c", false);
           String kinitCommand = String.format("kinit -k -t %s %s",
-            properties.getProperty("shell.keytab.location"),
-            properties.getProperty("shell.principal"));
+            properties.getProperty("zeppelin.shell.keytab.location"),
+            properties.getProperty("zeppelin.shell.principal"));
           cmdLine.addArgument(kinitCommand, false);
           DefaultExecutor executor = new DefaultExecutor();
 

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -63,6 +63,7 @@ public class ShellSecurityImpl {
           try {
             int exitVal = executor.execute(cmdLine);
           } catch (Exception e) {
+            LOGGER.error("Unable to run kinit for zeppelin user " + kinitCommand, e);
             throw new InterpreterException(e);
           }
     }

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -33,7 +33,7 @@ public class ShellSecurityImpl {
 
   private static Logger LOGGER = LoggerFactory.getLogger(ShellSecurityImpl.class);
 
-  public static void createSecureCinfiguration(Properties properties, String shell) {
+  public static void createSecureConfiguration(Properties properties, String shell) {
 
     String authType = properties.getProperty("zeppelin.shell.auth.type")
       .trim().toUpperCase();

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -19,15 +19,11 @@ package org.apache.zeppelin.shell.security;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
-
-import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
-import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.SIMPLE;
 
 
 /***
@@ -38,34 +34,26 @@ public class ShellSecurityImpl {
   private static Logger LOGGER = LoggerFactory.getLogger(ShellSecurityImpl.class);
 
   public static void createSecureCinfiguration(Properties properties, String shell) {
-    UserGroupInformation.AuthenticationMethod authType;
-    try {
-      authType = UserGroupInformation
-        .AuthenticationMethod.valueOf(properties.getProperty("zeppelin.shell.auth.type")
-          .trim().toUpperCase());
-    } catch (Exception e) {
-      LOGGER.error(String.format("Invalid auth.type detected with value %s, defaulting " +
-        "auth.type to SIMPLE", properties.getProperty("zeppelin.shell.auth.type").trim()));
-      authType = SIMPLE;
-    }
 
+    String authType = properties.getProperty("zeppelin.shell.auth.type")
+      .trim().toUpperCase();
 
     switch (authType) {
-        case KERBEROS:
-          CommandLine cmdLine = CommandLine.parse(shell);
-          cmdLine.addArgument("-c", false);
-          String kinitCommand = String.format("kinit -k -t %s %s",
-            properties.getProperty("zeppelin.shell.keytab.location"),
-            properties.getProperty("zeppelin.shell.principal"));
-          cmdLine.addArgument(kinitCommand, false);
-          DefaultExecutor executor = new DefaultExecutor();
+      case "KERBEROS":
+        CommandLine cmdLine = CommandLine.parse(shell);
+        cmdLine.addArgument("-c", false);
+        String kinitCommand = String.format("kinit -k -t %s %s",
+          properties.getProperty("zeppelin.shell.keytab.location"),
+          properties.getProperty("zeppelin.shell.principal"));
+        cmdLine.addArgument(kinitCommand, false);
+        DefaultExecutor executor = new DefaultExecutor();
 
-          try {
-            int exitVal = executor.execute(cmdLine);
-          } catch (Exception e) {
-            LOGGER.error("Unable to run kinit for zeppelin user " + kinitCommand, e);
-            throw new InterpreterException(e);
-          }
+        try {
+          int exitVal = executor.execute(cmdLine);
+        } catch (Exception e) {
+          LOGGER.error("Unable to run kinit for zeppelin user " + kinitCommand, e);
+          throw new InterpreterException(e);
+        }
     }
   }
 }

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.shell.security;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.SIMPLE;
+
+
+/***
+ * Shell security helper
+ */
+public class ShellSecurityImpl {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(ShellSecurityImpl.class);
+
+  public static void createSecureCinfiguration(Properties properties, String shell) {
+    UserGroupInformation.AuthenticationMethod authType;
+    try {
+      authType = UserGroupInformation
+        .AuthenticationMethod.valueOf(properties.getProperty("shell.auth.type")
+          .trim().toUpperCase());
+    } catch (Exception e) {
+      LOGGER.error(String.format("Invalid auth.type detected with value %s, defaulting " +
+        "auth.type to SIMPLE", properties.getProperty("shell.auth.type").trim()));
+      authType = SIMPLE;
+    }
+
+
+    switch (authType) {
+        case KERBEROS:
+          CommandLine cmdLine = CommandLine.parse(shell);
+          cmdLine.addArgument("-c", false);
+          String kinitCommand = String.format("kinit -k -t %s %s",
+            properties.getProperty("shell.keytab.location"),
+            properties.getProperty("shell.principal"));
+          cmdLine.addArgument(kinitCommand, false);
+          DefaultExecutor executor = new DefaultExecutor();
+
+          try {
+            int exitVal = executor.execute(cmdLine);
+          } catch (Exception e) {
+            throw new InterpreterException(e);
+          }
+    }
+  }
+}

--- a/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/security/ShellSecurityImpl.java
@@ -39,21 +39,21 @@ public class ShellSecurityImpl {
       .trim().toUpperCase();
 
     switch (authType) {
-      case "KERBEROS":
-        CommandLine cmdLine = CommandLine.parse(shell);
-        cmdLine.addArgument("-c", false);
-        String kinitCommand = String.format("kinit -k -t %s %s",
-          properties.getProperty("zeppelin.shell.keytab.location"),
-          properties.getProperty("zeppelin.shell.principal"));
-        cmdLine.addArgument(kinitCommand, false);
-        DefaultExecutor executor = new DefaultExecutor();
+        case "KERBEROS":
+          CommandLine cmdLine = CommandLine.parse(shell);
+          cmdLine.addArgument("-c", false);
+          String kinitCommand = String.format("kinit -k -t %s %s",
+            properties.getProperty("zeppelin.shell.keytab.location"),
+            properties.getProperty("zeppelin.shell.principal"));
+          cmdLine.addArgument(kinitCommand, false);
+          DefaultExecutor executor = new DefaultExecutor();
 
-        try {
-          int exitVal = executor.execute(cmdLine);
-        } catch (Exception e) {
-          LOGGER.error("Unable to run kinit for zeppelin user " + kinitCommand, e);
-          throw new InterpreterException(e);
-        }
+          try {
+            int exitVal = executor.execute(cmdLine);
+          } catch (Exception e) {
+            LOGGER.error("Unable to run kinit for zeppelin user " + kinitCommand, e);
+            throw new InterpreterException(e);
+          }
     }
   }
 }

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -10,21 +10,21 @@
         "defaultValue": "60000",
         "description": "Shell command time out in millisecs. Default = 60000"
       },
-      "shell.auth.type": {
+      "zeppelin.shell.auth.type": {
         "envName": null,
-        "propertyName": "shell.auth.type",
+        "propertyName": "zeppelin.shell.auth.type",
         "defaultValue": "",
         "description": "If auth type is needed, Example: KERBEROS"
       },
-      "shell.keytab.location": {
+      "zeppelin.shell.keytab.location": {
         "envName": null,
-        "propertyName": "shell.keytab.location",
+        "propertyName": "zeppelin.shell.keytab.location",
         "defaultValue": "",
         "description": "Kerberos keytab location"
       },
-      "shell.principal": {
+      "zeppelin.shell.principal": {
         "envName": null,
-        "propertyName": "shell.principal",
+        "propertyName": "zeppelin.shell.principal",
         "defaultValue": "",
         "description": "Kerberos principal"
       }

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -9,6 +9,24 @@
         "propertyName": "shell.command.timeout.millisecs",
         "defaultValue": "60000",
         "description": "Shell command time out in millisecs. Default = 60000"
+      },
+      "shell.auth.type": {
+        "envName": null,
+        "propertyName": "shell.auth.type",
+        "defaultValue": "",
+        "description": "If auth type is needed, Example: KERBEROS"
+      },
+      "shell.keytab.location": {
+        "envName": null,
+        "propertyName": "shell.keytab.location",
+        "defaultValue": "",
+        "description": "Kerberos keytab location"
+      },
+      "shell.principal": {
+        "envName": null,
+        "propertyName": "shell.principal",
+        "defaultValue": "",
+        "description": "Kerberos principal"
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Zeppelin Shell interpreter should work in a Kerberos environment


### What type of PR is it?
[Feature]


### What is the Jira issue?
* [ZEPPELIN-1149](https://issues.apache.org/jira/browse/ZEPPELIN-1149)

### How should this be tested?
In JDBC interpreter setting add following properties

 - shell.auth.type = KERBEROS
 - shell.principal = principal value
 - shell.keytab.location = keytab location

Now try and run any shell command (example: hdfs dfs -ls) it should return with valid results.


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes

