### PR TITLE
[HOTFIX] build fail after merge #1151

### DIFF
--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -20,7 +20,7 @@ angular.module('zeppelinWebApp').service('SaveAsService', function(browserDetect
     if (browserDetectService.detectIE()) {
       angular.element('body').append('<iframe id="SaveAsId" style="display: none"></iframe>');
       var frameSaveAs = angular.element('body > iframe#SaveAsId')[0].contentWindow;
-      content= BOM + content;
+      content = BOM + content;
       frameSaveAs.document.open('text/json', 'replace');
       frameSaveAs.document.write(content);
       frameSaveAs.document.close();


### PR DESCRIPTION
### What is this PR for?
#1151 has been created created before #1139 merge.
#1151 was passing CI but it's failing in master with #1139 merged.

```
[INFO] --- frontend-maven-plugin:0.0.25:grunt (grunt build) @ zeppelin-web ---
[INFO] Running 'grunt build --no-color' in /Users/moon/Projects/zeppelin/zeppelin-web
[INFO] Running "jscs:all" (jscs) task
[INFO] requireSpaceBeforeBinaryOperators: Operator = should not stick to preceding expression at src/components/saveAs/saveAs.service.js :
[INFO]     21 |      angular.element('body').append('<iframe id="SaveAsId" style="display: none"></iframe>');
[INFO]     22 |      var frameSaveAs = angular.element('body > iframe#SaveAsId')[0].contentWindow;
[INFO]     23 |      content= BOM + content;
[INFO] ---------------------^
[INFO]     24 |      frameSaveAs.document.open('text/json', 'replace');
[INFO]     25 |      frameSaveAs.document.write(content);
[INFO] >> 1 code style errors found!
[INFO] Warning: Task "jscs:all" failed. Use --force to continue.
[INFO] 
[INFO] Aborted due to warnings.
```

### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix problem

### What is the Jira issue?
ZEPPELIN-1138,  ZEPPELIN-235

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

