### PR TITLE
Added another location of metastore_db in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ zeppelin-web/bower_components
 # project level
 /logs/
 /run/
-/metastore_db/
+**/metastore_db/
 /*.log
 /jobs/
 /zan-repo/


### PR DESCRIPTION
### What is this PR for?
Avoiding tracking metastore_db from git when you run ZeppelinServer in you IDE

### What type of PR is it?
[Improvement]

### Todos
* [x] - Add recursive directory of metastore_db in .gitignore

### What is the Jira issue?
N/A

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No