### PR TITLE
[ZEPPELIN-813] Update safe_yaml version 0.9.7 -> 1.0.4

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       maruku (~> 0.6.0)
       pygments.rb (~> 0.5.0)
       redcarpet (~> 2.3.0)
-      safe_yaml (~> 0.9.7)
+      safe_yaml (~> 1.0.4)
     kramdown (1.2.0)
     liquid (2.5.4)
     listen (1.3.1)
@@ -47,7 +47,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.1.7)
     redcarpet (2.3.0)
-    safe_yaml (0.9.7)
+    safe_yaml (1.0.4)
     syntax (1.0.0)
     yajl-ruby (1.1.0)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-## Zeppelin documentation
+## Apache Zeppelin documentation
 
 This readme will walk you through building the Zeppelin documentation, which is included here with the Zeppelin source code.
 
@@ -6,15 +6,16 @@ This readme will walk you through building the Zeppelin documentation, which is 
 ## Build documentation
 See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 
-**tl;dr version:**
+**Requirements**
 
 ```
-    ruby --version >= 1.9.3
+    ruby --version >= 2.0.0
     gem install bundler
     # go to /docs under your Zeppelin source
     bundle install
 ```
 
+For the further information about requirements, please see [here](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#requirements). 
 *On OS X 10.9 you may need to do "xcode-select --install"*
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 ```
 
 For the further information about requirements, please see [here](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#requirements). 
+
 *On OS X 10.9 you may need to do "xcode-select --install"*
 
 


### PR DESCRIPTION
### What is this PR for?
This PR will fix [ZEPPELIN-813](https://issues.apache.org/jira/browse/ZEPPELIN-813).
I'm not sure what environment exactly generate this errors. I saw the below error in OS X 10.11.3 
and ruby 2.3.0.

```
$ bundle exec jekyll serve --watch
/Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/user_interaction.rb:328: warning: constant ::TimeoutError is deprecated
/Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:365:in `block in require_program': program version required (Commander::Runner::CommandError)
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `each'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `require_program'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:52:in `run!'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/delegates.rb:7:in `run!'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/commander-4.1.5/lib/commander/import.rb:10:in `block in <top (required)>'
/Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml/syck_node_monkeypatch.rb:42:in `<top (required)>': uninitialized constant Syck (NameError)
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:200:in `require'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:200:in `<module:YAML>'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:132:in `<top (required)>'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jekyll-1.3.0/lib/jekyll.rb:21:in `require'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jekyll-1.3.0/lib/jekyll.rb:21:in `<top (required)>'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jekyll-1.3.0/bin/jekyll:7:in `require'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jekyll-1.3.0/bin/jekyll:7:in `<top (required)>'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/bin/jekyll:23:in `load'
	from /Users/cyhsutw/.rbenv/versions/2.3.0/bin/jekyll:23:in `<main>'
```

Maybe this error will be gone with `bundle update`. But it would be better we set `safe_yaml` version for the other users. So I just updated `safe_yaml` version from `0.9.7` to `1.0.4` in `Gemfile.lock` manually. And confirmed that there are no compatibility issues with ruby version `2.3.0`(latest stable version), `2.2.1`, `2.1.1` and `2.0.0`(this version is no longer maintained by ruby). 

I also updated `docs/README.md` since we need ruby version higher than `2.0.0` not `1.9.3`. Please see [here](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#requirements).

### What type of PR is it?
Bug Fix & Documentation

### What is the Jira issue?
[ZEPPELIN-813](https://issues.apache.org/jira/browse/ZEPPELIN-813)

### How should this be tested?

###### 1. Apply this patch

```
$ cd docs
$ bundle install
```
If you already installed dependencies before, you need 

```
$ bundle update safe_yaml
```

###### 2. Check what version of `safe_yaml` is installed -> `1.0.4` should be installed. Then

```
$ bundle exec jekyll serve --watch
```
It should be run with no issues.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
