### PR TITLE
[Zeppelin-1161] Revert precise execution time

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -136,6 +136,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) slf4j-log4j12 v1.7.10 (org.slf4j:slf4j-log4j12:jar:1.7.10 - http://www.slf4j.org) - http://www.slf4j.org/license.html
     (The MIT License) bcprov-jdk15on v1.51 (org.bouncycastle:bcprov-jdk15on:jar:1.51 - http://www.bouncycastle.org/java.html) - http://www.bouncycastle.org/licence.html
     (The MIT License) AnchorJS (https://github.com/bryanbraun/anchorjs) - https://github.com/bryanbraun/anchorjs/blob/master/README.md#license
+    (The MIT License) moment-duration-format v1.3.0 (https://github.com/jsmreese/moment-duration-format) - https://github.com/jsmreese/moment-duration-format/blob/master/LICENSE
 
 The following components are provided under the MIT License.
 
@@ -144,7 +145,6 @@ The following components are provided under the MIT License.
     (The MIT License) JUL to SLF4J bridge (org.slf4j:jul-to-slf4j:1.7.5 - http://www.slf4j.org)
     (The MIT License) angular-resource (angular-resource - https://github.com/angular/angular.js/tree/master/src/ngResource)
     (The MIT License) minimal-json (com.eclipsesource.minimal-json:minimal-json:0.9.4 - https://github.com/ralfstx/minimal-json)
-
 
 ========================================================================
 BSD-style licenses

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -30,7 +30,8 @@
     "ngtoast": "~2.0.0",
     "ng-focus-if": "~1.0.2",
     "bootstrap3-dialog": "bootstrap-dialog#~1.34.7",
-    "handsontable": "~0.24.2"
+    "handsontable": "~0.24.2",
+    "moment-duration-format": "^1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.0"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1036,8 +1036,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       return '';
     }
     var user = (pdata.user === undefined || pdata.user === null) ? 'anonymous' : pdata.user;
-    var desc = 'Took ' + (timeMs / 1000) + ' seconds. Last updated by ' + user +
-      ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
+    var desc = 'Took ' + moment.duration((timeMs / 1000), "seconds").format("h [hrs] m [min] s [sec]")
+      + '. Last updated by ' + user + ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
     if ($scope.isResultOutdated()) {
       desc += ' (outdated)';
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1036,7 +1036,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       return '';
     }
     var user = (pdata.user === undefined || pdata.user === null) ? 'anonymous' : pdata.user;
-    var desc = 'Took ' + (timeMs/1000) + ' seconds. Last updated by ' + user +
+    var desc = 'Took ' + (timeMs / 1000) + ' seconds. Last updated by ' + user +
       ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
     if ($scope.isResultOutdated()) {
       desc += ' (outdated)';

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1036,8 +1036,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       return '';
     }
     var user = (pdata.user === undefined || pdata.user === null) ? 'anonymous' : pdata.user;
-    var desc = 'Took ' + moment.duration((timeMs / 1000), "seconds").format("h [hrs] m [min] s [sec]")
-      + '. Last updated by ' + user + ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
+    var desc = 'Took ' + moment.duration((timeMs / 1000), 'seconds').format('h [hrs] m [min] s [sec]') +
+      '. Last updated by ' + user + ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
     if ($scope.isResultOutdated()) {
       desc += ' (outdated)';
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1036,9 +1036,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       return '';
     }
     var user = (pdata.user === undefined || pdata.user === null) ? 'anonymous' : pdata.user;
-    var desc = 'Took ' +
-      moment.duration(moment(pdata.dateFinished).diff(moment(pdata.dateStarted))).humanize() +
-      '. Last updated by ' + user + ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
+    var desc = 'Took ' + (timeMs/1000) + ' seconds. Last updated by ' + user +
+      ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
     if ($scope.isResultOutdated()) {
       desc += ' (outdated)';
     }
@@ -2413,4 +2412,3 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     }
   });
 });
-

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -143,6 +143,7 @@ limitations under the License.
     <script src="bower_components/moment/moment.js"></script>
     <script src="bower_components/pikaday/pikaday.js"></script>
     <script src="bower_components/handsontable/dist/handsontable.js"></script>
+    <script src="bower_components/moment-duration-format/lib/moment-duration-format.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:js({.tmp,src}) scripts/scripts.js -->

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -63,6 +63,7 @@ module.exports = function(config) {
       'bower_components/moment/moment.js',
       'bower_components/pikaday/pikaday.js',
       'bower_components/handsontable/dist/handsontable.js',
+      'bower_components/moment-duration-format/lib/moment-duration-format.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
       'src/app/app.js',


### PR DESCRIPTION
### What is this PR for?
It had been pointed out in the mailing list that after https://github.com/apache/zeppelin/pull/862, the execution time was changed to humanized fashion, while we would want to keep something more precise in that case.

This PR is rolling back to the old precise time for execution time.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1161

### How should this be tested?
Run a paragraph, after it is finished, it should show: `Took x seconds.` instead of `Took a few seconds` (or Hours, Minutes, Sec)

### Screenshot
![screen shot 2016-07-13 at 2 19 45 pm](https://cloud.githubusercontent.com/assets/710411/16792626/0ff3ccb8-4905-11e6-89b6-a202944d66b8.png)

### Questions:
* Does the licenses files need update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? No
