### PR TITLE
change the jquery-ui css file name

### DIFF
--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -47,7 +47,7 @@ limitations under the License.
     <link rel="stylesheet" href="bower_components/pikaday/css/pikaday.css" />
     <link rel="stylesheet" href="bower_components/handsontable/dist/handsontable.css" />
     <!-- endbower -->
-    <link rel="stylesheet" href="bower_components/jquery-ui/themes/base/all.css" />
+    <link rel="stylesheet" href="bower_components/jquery-ui/themes/base/jquery-ui.css" />
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->
     <link rel="stylesheet" href="app/home/home.css" />


### PR DESCRIPTION
### What is this PR for?
The Jquery-ui css file name changed between version and is now missing
![screen shot 2016-07-13 at 3 37 02 pm](https://cloud.githubusercontent.com/assets/710411/16794236/707df05c-4911-11e6-8b11-e6bb385c23d0.png)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1166

### How should this be tested?
You can run in a paragraph and click inside the input:
```
%angular
<script>
  $( function() {
    $( "#datepicker" ).datepicker();
  } );
</script>
<p>Date: <input type="text" id="datepicker"></p>
```

### Screenshots (if appropriate)
Before:
![screen shot 2016-07-13 at 3 36 47 pm](https://cloud.githubusercontent.com/assets/710411/16794252/88cd44d2-4911-11e6-8a8c-465d44302475.png)

After:
![screen shot 2016-07-13 at 3 37 59 pm](https://cloud.githubusercontent.com/assets/710411/16794255/8b9a01fa-4911-11e6-802f-12868e48484b.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

