### PR TITLE
[ZEPPELIN-1109] Remove bootstrap dialog fade-in/out animation

### DIFF
--- a/zeppelin-web/src/app/app.controller.js
+++ b/zeppelin-web/src/app/app.controller.js
@@ -44,4 +44,7 @@ angular.module('zeppelinWebApp').controller('MainCtrl', function($scope, $rootSc
   BootstrapDialog.defaultOptions.onshown = function() {
     angular.element('#' + this.id).find('.btn:last').focus();
   };
+  
+  // Remove BootstrapDialog animation
+  BootstrapDialog.configDefaultOptions({animate: false});
 });

--- a/zeppelin-web/src/app/app.controller.js
+++ b/zeppelin-web/src/app/app.controller.js
@@ -44,7 +44,7 @@ angular.module('zeppelinWebApp').controller('MainCtrl', function($scope, $rootSc
   BootstrapDialog.defaultOptions.onshown = function() {
     angular.element('#' + this.id).find('.btn:last').focus();
   };
-  
+
   // Remove BootstrapDialog animation
   BootstrapDialog.configDefaultOptions({animate: false});
 });


### PR DESCRIPTION
### What is this PR for?
This PR will fix [ZEPPELIN-1109](https://issues.apache.org/jira/browse/ZEPPELIN-1109). 
I'm not sure this approach can be the best way for fixing this issue since I would prefer to have the fade-in/out animation for bootstrap dialog. So if anyone has better idea for this, please let me know. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1109](https://issues.apache.org/jira/browse/ZEPPELIN-1109)

### How should this be tested?
1. Press `Enter` button right after clicking any bootstrap dialog (i.e. trash can icon in the notebook) 
-> Bootstrap dialog will be shown up multiple times
2. Apply this patch and [build `zeppelin-web`](https://github.com/apache/zeppelin/tree/master/zeppelin-web#configured-environment)
3. Try number 1 again -> you can see there is no fade animation so you don't have time interval to generate multi dialogs

### Screenshots (if appropriate)
 - Before 
![multiple_dialog](https://cloud.githubusercontent.com/assets/10060731/16799515/25973fb0-492c-11e6-981e-19d46db31520.gif)

 - After
![remove_animation](https://cloud.githubusercontent.com/assets/10060731/16799517/2980f6d4-492c-11e6-8a5a-905800665e9f.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

