### PR TITLE
[ZEPPELIN-1059] Fix the Print CSS file

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -150,8 +150,10 @@ public class WebDriverManager {
       firebugUrlString = "http://getfirebug.com/releases/firebug/1.11/firebug-1.11.4.xpi";
     else if (firefoxVersion >= 23 && firefoxVersion < 30)
       firebugUrlString = "http://getfirebug.com/releases/firebug/1.12/firebug-1.12.8.xpi";
-    else if (firefoxVersion >= 30)
+    else if (firefoxVersion >= 30 && firefoxVersion < 33)
       firebugUrlString = "http://getfirebug.com/releases/firebug/2.0/firebug-2.0.7.xpi";
+    else if (firefoxVersion >= 33)
+      firebugUrlString = "http://getfirebug.com/releases/firebug/2.0/firebug-2.0.17.xpi";
 
 
     LOG.info("firebug version: " + firefoxVersion + ", will be downloaded to " + tempPath);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/ZeppelinITUtils.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/ZeppelinITUtils.java
@@ -20,6 +20,8 @@ package org.apache.zeppelin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.openqa.selenium.WebDriver;
+import java.util.concurrent.TimeUnit;
 
 public class ZeppelinITUtils {
 
@@ -45,5 +47,14 @@ public class ZeppelinITUtils {
         false, ProcessData.Types_Of_Data.OUTPUT);
     //wait for server to start.
     sleep(5000, false);
+  }
+
+  public static void turnOffImplicitWaits(WebDriver driver) {
+    driver.manage().timeouts().implicitlyWait(0, TimeUnit.SECONDS);
+  }
+
+  public static void turnOnImplicitWaits(WebDriver driver) {
+    driver.manage().timeouts().implicitlyWait(AbstractZeppelinIT.MAX_IMPLICIT_WAIT,
+        TimeUnit.SECONDS);
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -343,9 +343,12 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       String xpathToShowTitle = getParagraphXPath(1) + "//ul/li/a[@ng-click='showTitle()']";
       String xpathToHideTitle = getParagraphXPath(1) + "//ul/li/a[@ng-click='hideTitle()']";
 
-      collector.checkThat("Before Show Title : The title field contains",
-          driver.findElement(By.xpath(xpathToTitle)).getText(),
-          CoreMatchers.equalTo(""));
+      ZeppelinITUtils.turnOffImplicitWaits(driver);
+      Integer titleElems = driver.findElements(By.xpath(xpathToTitle)).size();
+      collector.checkThat("Before Show Title : The title doesn't exist",
+          titleElems,
+          CoreMatchers.equalTo(0));
+      ZeppelinITUtils.turnOnImplicitWaits(driver);
 
       clickAndWait(By.xpath(xpathToSettingIcon));
       collector.checkThat("Before Show Title : The title option in option panel of paragraph is labeled as  ",
@@ -363,9 +366,13 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           CoreMatchers.equalTo("Hide title"));
 
       clickAndWait(By.xpath(xpathToHideTitle));
+      ZeppelinITUtils.turnOffImplicitWaits(driver);
+      titleElems = driver.findElements(By.xpath(xpathToTitle)).size();
       collector.checkThat("After Hide Title : The title field contains",
-          driver.findElement(By.xpath(xpathToTitle)).getText(),
-          CoreMatchers.equalTo(""));
+          titleElems,
+          CoreMatchers.equalTo(0));
+      ZeppelinITUtils.turnOnImplicitWaits(driver);
+
       driver.findElement(By.xpath(xpathToSettingIcon)).click();
       driver.findElement(By.xpath(xpathToShowTitle)).click();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -368,7 +368,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       clickAndWait(By.xpath(xpathToHideTitle));
       ZeppelinITUtils.turnOffImplicitWaits(driver);
       titleElems = driver.findElements(By.xpath(xpathToTitle)).size();
-      collector.checkThat("After Hide Title : The title field contains",
+      collector.checkThat("After Hide Title : The title field is hidden",
           titleElems,
           CoreMatchers.equalTo(0));
       ZeppelinITUtils.turnOnImplicitWaits(driver);

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -15,7 +15,7 @@ limitations under the License.
   <h3>
     <div style="float: left; width: auto; max-width: 40%">
       <input type="text" pu-elastic-input class="form-control2" placeholder="{{noteName(note)}}" style="min-width: 0px; max-width: 95%;"
-           ng-show="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" />
+           ng-if="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" />
       <p class="form-control-static2" ng-click="showEditor = true; oldName = note.name" ng-show="!showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -12,6 +12,10 @@
  * limitations under the License.
  */
 
+.notebookContent {
+  padding-top: 36px;
+}
+
 .paragraph-col {
   margin: 0;
   padding: 0;

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -13,7 +13,7 @@ limitations under the License.
 -->
 <!-- Here the controller <NotebookCtrl> is not needed because explicitly set in the app.js (route) -->
 <div ng-include src="'app/notebook/notebook-actionBar.html'"></div>
-<div style="padding-top: 36px;">
+<div class="notebookContent">
   <!-- settings -->
   <div ng-if="showSetting" class="setting">
     <div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -15,7 +15,7 @@ limitations under the License.
 <div id="{{paragraph.id}}_container"
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
-  <div ng-if="paragraph.config.title"
+  <div ng-show="paragraph.config.title"
        id="{{paragraph.id}}_title"
        class="title">
     <input type="text"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -15,7 +15,7 @@ limitations under the License.
 <div id="{{paragraph.id}}_container"
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
-  <div ng-show="paragraph.config.title"
+  <div ng-if="paragraph.config.title"
        id="{{paragraph.id}}_title"
        class="title">
     <input type="text"
@@ -23,7 +23,7 @@ limitations under the License.
            style="min-width: 400px; max-width: 80%;"
            placeholder="Untitled"
            ng-model="paragraph.title"
-           ng-show="showTitleEditor"
+           ng-if="showTitleEditor"
            ng-escape="showTitleEditor = false; paragraph.title = oldTitle;"
            ng-blur="setTitle(); showTitleEditor = false"
            ng-enter="setTitle(); showTitleEditor = false"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -15,7 +15,7 @@ limitations under the License.
 <div id="{{paragraph.id}}_container"
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
-  <div ng-show="paragraph.config.title"
+  <div ng-if="paragraph.config.title"
        id="{{paragraph.id}}_title"
        class="title">
     <input type="text"
@@ -23,7 +23,7 @@ limitations under the License.
            style="min-width: 400px; max-width: 80%;"
            placeholder="Untitled"
            ng-model="paragraph.title"
-           ng-if="showTitleEditor"
+           ng-show="showTitleEditor"
            ng-escape="showTitleEditor = false; paragraph.title = oldTitle;"
            ng-blur="setTitle(); showTitleEditor = false"
            ng-enter="setTitle(); showTitleEditor = false"

--- a/zeppelin-web/src/assets/styles/printMode.css
+++ b/zeppelin-web/src/assets/styles/printMode.css
@@ -12,49 +12,36 @@
  * limitations under the License.
  */
 
-body {
-  background: white;
-}
+ @media print {
 
-.labelBtn {
-  display: none;
-}
+   body {
+     padding-top: 0px;
+   }
 
-.new_h3 {
-  margin-left: 220px;
-  top: 0;
-  position: fixed;
-}
+   .navbar-fixed-top {
+      display: none !important;
+   }
 
-.noteAction {
-  border: 1px solid #3071a9;
-  box-shadow: none;
-}
+   .noteAction {
+      position: initial;
+   }
 
-.control {
-  display: none;
-}
+   .noteAction .btn-group,
+   .noteAction .labelBtn,
+   .noteAction .pull-right {
+      display: none !important;
+   }
 
-.editor {
-  display: none;
-}
+   .control span[class^="icon-"] {
+      display: none;
+   }
 
-.form-horizontal {
-  display: none;
-}
+   .notebookContent {
+     padding-top: 0px;
+   }
 
-.btn-group {
-  display: none;
-}
+   .new-paragraph {
+      display: none;
+   }
 
-.box {
-  border: none;
-}
-
-svg {
-  margin-left: -20px;
-}
-
-.btn-link {
-  display: none;
-}
+ }

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -66,9 +66,9 @@ limitations under the License.
     <link rel="stylesheet" href="fonts/Patua-One.css" />
     <link rel="stylesheet" href="fonts/Source-Code-Pro.css" />
     <link rel="stylesheet" href="fonts/Roboto.css" />
-    <link rel="stylesheet" href="assets/styles/printMode.css" />
     <!-- endbuild -->
     <link rel="stylesheet" ng-href="assets/styles/looknfeel/{{looknfeel}}.css" />
+    <link rel="stylesheet" href="assets/styles/printMode.css" />
   </head>
   <body ng-class="{'bodyAsIframe': asIframe}">
     <!--[if lt IE 7]>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -66,6 +66,7 @@ limitations under the License.
     <link rel="stylesheet" href="fonts/Patua-One.css" />
     <link rel="stylesheet" href="fonts/Source-Code-Pro.css" />
     <link rel="stylesheet" href="fonts/Roboto.css" />
+    <link rel="stylesheet" href="assets/styles/printMode.css" />
     <!-- endbuild -->
     <link rel="stylesheet" ng-href="assets/styles/looknfeel/{{looknfeel}}.css" />
   </head>


### PR DESCRIPTION
### What is this PR for?
While investigating the original issue, I discovered that the `printMode.css` file was never used before.
I changed it so it is taken into account when printing, and added some CSS to remove unnecessary components in the printing page.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1059

### How should this be tested?
Try to print a Note with your web-browser and look at the preview.
There shouldn't be the Zeppelin Navbar or a weird Title hiding the content.

### Screenshots (if appropriate)
After this PR:
![screen shot 2016-07-13 at 7 16 50 pm](https://cloud.githubusercontent.com/assets/710411/16800158/d275a8dc-492e-11e6-9230-bc56e7d029c1.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

