### PR TITLE
ZEPPELIN-1168 Add http header X-Requested-By in post request to Livy for CSRF protection

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -348,6 +348,7 @@ public class LivyHelper {
     RestTemplate restTemplate = getRestTemplate();
     HttpHeaders headers = new HttpHeaders();
     headers.add("Content-Type", "application/json");
+    headers.add("X-Requested-By", "zeppelin");
     ResponseEntity<String> response = null;
     if (method.equals("POST")) {
       HttpEntity<String> entity = new HttpEntity<String>(jsonData, headers);


### PR DESCRIPTION
### What is this PR for?
Add http header X-Requested-By in post request to Livy for CSRF protection

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1168

### How should this be tested?
enable csrf_protection on livy and check for "CSRF protection is enabled" message in the Livy logs. If this header is missing Livy server will send the following error message "Missing Required Header for CSRF protection."

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
