### PR TITLE
ZEPPELIN-1170 Handsontable fails to display data on second run

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1282,49 +1282,40 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       var resultRows = data.rows;
       var columnNames = _.pluck(data.columnNames, 'name');
 
-      // on chart type change, destroy table to force reinitialization.
-      if ($scope.hot && !refresh) {
+      if ($scope.hot) {
         $scope.hot.destroy();
-        $scope.hot = null;
       }
 
-      // create table if not exists.
-      if (!$scope.hot) {
-        $scope.hot = new Handsontable(container, {
-          rowHeaders: false,
-          stretchH: 'all',
-          sortIndicator: true,
-          columnSorting: true,
-          contextMenu: false,
-          manualColumnResize: true,
-          manualRowResize: true,
-          readOnly: true,
-          readOnlyCellClassName: '',  // don't apply any special class so we can retain current styling
-          fillHandle: false,
-          fragmentSelection: true,
-          disableVisualSelection: true,
-          cells: function(row, col, prop) {
-            var cellProperties = {};
-            cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {
-              if (!isNaN(value)) {
-                cellProperties.format = '0,0.[00000]';
-                td.style.textAlign = 'left';
-                Handsontable.renderers.NumericRenderer.apply(this, arguments);
-              } else if (value.length > '%html'.length && '%html ' === value.substring(0, '%html '.length)) {
-                td.innerHTML = value.substring('%html'.length);
-              } else {
-                Handsontable.renderers.TextRenderer.apply(this, arguments);
-              }
-            };
-            return cellProperties;
-          }
-        });
-      }
-
-      // load data into table.
-      $scope.hot.updateSettings({
+      $scope.hot = new Handsontable(container, {
         colHeaders: columnNames,
-        data: resultRows
+        data: resultRows,
+        rowHeaders: false,
+        stretchH: 'all',
+        sortIndicator: true,
+        columnSorting: true,
+        contextMenu: false,
+        manualColumnResize: true,
+        manualRowResize: true,
+        readOnly: true,
+        readOnlyCellClassName: '',  // don't apply any special class so we can retain current styling
+        fillHandle: false,
+        fragmentSelection: true,
+        disableVisualSelection: true,
+        cells: function(row, col, prop) {
+          var cellProperties = {};
+          cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {
+            if (!isNaN(value)) {
+              cellProperties.format = '0,0.[00000]';
+              td.style.textAlign = 'left';
+              Handsontable.renderers.NumericRenderer.apply(this, arguments);
+            } else if (value.length > '%html'.length && '%html ' === value.substring(0, '%html '.length)) {
+              td.innerHTML = value.substring('%html'.length);
+            } else {
+              Handsontable.renderers.TextRenderer.apply(this, arguments);
+            }
+          };
+          return cellProperties;
+        }
       });
     };
 


### PR DESCRIPTION
### What is this PR for?
Handsontable fails to display data on second run if first run did not render table due to an error in the query.
Fix for a render issue caused by #1059

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1170

### How should this be tested?
Please ref the screenshots

### Screenshots (if appropriate)
**Before**
![old](https://cloud.githubusercontent.com/assets/2031306/16809245/35f0ced8-493d-11e6-8e1a-74c24100487a.gif)

**After**
![new](https://cloud.githubusercontent.com/assets/2031306/16809256/41a4de22-493d-11e6-9a4f-31c6ae654ceb.gif)



### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

