### PR TITLE
[ZEPPELIN-1159] Livy interpreter gets "404 not found" error

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -33,6 +33,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.kerberos.client.KerberosRestTemplate;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.Charset;
@@ -349,17 +350,24 @@ public class LivyHelper {
     HttpHeaders headers = new HttpHeaders();
     headers.add("Content-Type", "application/json");
     ResponseEntity<String> response = null;
-    if (method.equals("POST")) {
-      HttpEntity<String> entity = new HttpEntity<String>(jsonData, headers);
-      response = restTemplate.exchange(targetURL, HttpMethod.POST, entity, String.class);
-      paragraphHttpMap.put(paragraphId, response);
-    } else if (method.equals("GET")) {
-      HttpEntity<String> entity = new HttpEntity<String>(headers);
-      response = restTemplate.exchange(targetURL, HttpMethod.GET, entity, String.class);
-      paragraphHttpMap.put(paragraphId, response);
-    } else if (method.equals("DELETE")) {
-      HttpEntity<String> entity = new HttpEntity<String>(headers);
-      response = restTemplate.exchange(targetURL, HttpMethod.DELETE, entity, String.class);
+    try {
+      if (method.equals("POST")) {
+        HttpEntity<String> entity = new HttpEntity<String>(jsonData, headers);
+
+        response = restTemplate.exchange(targetURL, HttpMethod.POST, entity, String.class);
+        paragraphHttpMap.put(paragraphId, response);
+      } else if (method.equals("GET")) {
+        HttpEntity<String> entity = new HttpEntity<String>(headers);
+        response = restTemplate.exchange(targetURL, HttpMethod.GET, entity, String.class);
+        paragraphHttpMap.put(paragraphId, response);
+      } else if (method.equals("DELETE")) {
+        HttpEntity<String> entity = new HttpEntity<String>(headers);
+        response = restTemplate.exchange(targetURL, HttpMethod.DELETE, entity, String.class);
+      }
+    } catch (HttpClientErrorException e) {
+      response = new ResponseEntity(e.getResponseBodyAsString(), e.getStatusCode());
+      LOGGER.error(String.format("Error with %s StatusCode: %s",
+          response.getStatusCode().value(), e.getResponseBodyAsString()));
     }
     if (response == null) {
       return null;


### PR DESCRIPTION
### What is this PR for?
RestTemplate throws HttpClientErrorException, exception thrown when an HTTP 4xx is received.
http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/HttpClientErrorException.html


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-1159](https://issues.apache.org/jira/browse/ZEPPELIN-1159)

### How should this be tested?
Run a paragraph using livy interpreter (say sc.version), now let this session expire (or just restart livy server), then try running the same paragraph, this should result in proper error message.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

