### PR TITLE
Redirect home when requested a wrong notename path.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -494,6 +494,8 @@ public class NotebookServer extends WebSocketServlet implements
       addConnectionToNote(note.id(), conn);
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
       sendAllAngularObjects(note, conn);
+    } else {
+      conn.send(serializeMessage(new Message(OP.NOTE).put("note", null)));
     }
   }
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -338,7 +338,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   /** update the current note */
   $scope.$on('setNoteContent', function(event, note) {
     if (note === undefined) {
-      $location.path('/');
+      $location.path('/#');
     }
 
     $scope.paragraphUrl = $routeParams.paragraphId;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -338,7 +338,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   /** update the current note */
   $scope.$on('setNoteContent', function(event, note) {
     if (note === undefined) {
-      $window.location.href = '/';
+      $location.path('/');
     }
 
     $scope.paragraphUrl = $routeParams.paragraphId;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -80,7 +80,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     websocketMsgSrv.getNotebook($routeParams.noteId);
 
     var currentRoute = $route.current;
-
     if (currentRoute) {
       setTimeout(
         function() {
@@ -338,6 +337,10 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
 
   /** update the current note */
   $scope.$on('setNoteContent', function(event, note) {
+    if (note === undefined) {
+      $window.location.href = '/';
+    }
+
     $scope.paragraphUrl = $routeParams.paragraphId;
     $scope.asIframe = $routeParams.asIframe;
     if ($scope.paragraphUrl) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -338,7 +338,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   /** update the current note */
   $scope.$on('setNoteContent', function(event, note) {
     if (note === undefined) {
-      $location.path('/#');
+      $location.path('/');
     }
 
     $scope.paragraphUrl = $routeParams.paragraphId;


### PR DESCRIPTION
### What is this PR for?
This PR for redirecting to zeppelin home when requested wrong path.


### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1176


### How should this be tested?
put wrong path to your browser like screenshot.


### Screenshots (if appropriate)
- before
![b1](https://cloud.githubusercontent.com/assets/3348133/16835556/3b744224-49f4-11e6-84bf-6a22cc729a30.gif)

- after
![a](https://cloud.githubusercontent.com/assets/3348133/16835627/8cc590e2-49f4-11e6-878f-745ee026ef8e.gif)




### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

