### PR TITLE
[ZEPPELIN-1183] Replace $window.location by $location

### DIFF
--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -13,8 +13,8 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').controller('ConfigurationCtrl', function($scope, $route, $routeParams, $location,
-                                                                          $rootScope, $http, baseUrlSrv, ngToast) {
+angular.module('zeppelinWebApp').controller('ConfigurationCtrl', function($scope, $rootScope, $http,
+                                                                          baseUrlSrv, ngToast) {
   $scope.configrations = [];
   $scope._ = _;
 

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -14,8 +14,7 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').controller('CredentialCtrl', function($scope, $route, $routeParams, $location,
-                                                                       $rootScope, $http, baseUrlSrv, ngToast) {
+angular.module('zeppelinWebApp').controller('CredentialCtrl', function($scope, $rootScope, $http, baseUrlSrv, ngToast) {
   $scope._ = _;
 
   $scope.credentialInfo = [];

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -14,7 +14,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('HomeCtrl', function($scope, notebookListDataFactory, websocketMsgSrv,
-                                                                 $rootScope, arrayOrderingSrv, $http, baseUrlSrv) {
+                                                                 $rootScope, arrayOrderingSrv) {
   var vm = this;
   vm.notes = notebookListDataFactory;
   vm.websocketMsgSrv = websocketMsgSrv;

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -15,7 +15,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('InterpreterCtrl',
-  function($scope, $route, $routeParams, $location, $rootScope, $http, baseUrlSrv, ngToast) {
+  function($scope, $http, baseUrlSrv, ngToast) {
     var interpreterSettingsTmp = [];
     $scope.interpreterSettings = [];
     $scope.availableInterpreters = {};

--- a/zeppelin-web/src/app/jobmanager/jobmanager.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobmanager.controller.js
@@ -16,8 +16,7 @@
 
 angular.module('zeppelinWebApp')
   .controller('JobmanagerCtrl',
-    function($scope, $route, $routeParams, $location, $rootScope, $http, $q,
-             websocketMsgSrv, baseUrlSrv, $interval, $timeout, SaveAsService) {
+    function($scope, websocketMsgSrv, $interval) {
 
       $scope.$on('setNotebookJobs', function(event, responseData) {
         $scope.lastJobServerUnixTime = responseData.lastResponseUnixTime;

--- a/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
@@ -15,7 +15,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp')
-  .controller('JobCtrl', function($scope, $rootScope, $http, baseUrlSrv) {
+  .controller('JobCtrl', function($scope) {
 
     $scope.init = function(jobInformation) {
       $scope.progressValue = 0;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -16,7 +16,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $route, $routeParams, $location,
-                                                                     $rootScope, $http, $window, websocketMsgSrv,
+                                                                     $rootScope, $http, websocketMsgSrv,
                                                                      baseUrlSrv, $timeout, SaveAsService) {
   $scope.note = null;
   $scope.showEditor = false;
@@ -746,7 +746,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
               label: 'Cancel',
               action: function(dialog) {
                 dialog.close();
-                $window.location.replace('/');
+                $location.path('/');
               }
             }
           ]
@@ -970,4 +970,3 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   });
 
 });
-

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -141,7 +141,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       callback: function(result) {
         if (result) {
           websocketMsgSrv.deleteNotebook(noteId);
-          $location.path('/#');
+          $location.path('/');
         }
       }
     });
@@ -162,7 +162,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       callback: function(result) {
         if (result) {
           websocketMsgSrv.cloneNotebook(noteId);
-          $location.path('/#');
+          $location.path('/');
         }
       }
     });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -14,7 +14,7 @@
  */
 'use strict';
 
-angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $rootScope, $route, $window, $element,
+angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $rootScope, $route, $window,
                                                                       $routeParams, $location, $timeout, $compile,
                                                                       $http, websocketMsgSrv, baseUrlSrv, ngToast,
                                                                       SaveAsService) {
@@ -2413,4 +2413,3 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     }
   });
 });
-

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -81,7 +81,7 @@ angular.module('zeppelinWebApp')
   };
 
   $scope.search = function(searchTerm) {
-    $location.url(/search/ + searchTerm);
+    $location.path('/search/' + searchTerm);
   };
 
   function loadNotes() {

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -15,7 +15,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, notebookListDataFactory,
-                                                             $rootScope, $routeParams, websocketMsgSrv) {
+                                                                      $routeParams, websocketMsgSrv) {
   var vm = this;
   vm.clone = false;
   vm.notes = notebookListDataFactory;

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -14,7 +14,7 @@
 'use strict';
 
 angular.module('zeppelinWebApp').factory('websocketEvents',
-  function($rootScope, $websocket, $location, $window, baseUrlSrv) {
+  function($rootScope, $websocket, $location, baseUrlSrv) {
   var websocketCalls = {};
 
   websocketCalls.ws = $websocket(baseUrlSrv.getWebsocketUrl());
@@ -83,7 +83,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
           label: 'Cancel',
           action: function(dialog) {
             dialog.close();
-            $window.location.replace('/');
+            $location.path('/');
           }
         }]
       });

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -57,7 +57,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NEW_NOTE') {
-      $location.path('notebook/' + data.note.id);
+      $location.path('/notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
     } else if (op === 'LIST_NOTEBOOK_JOBS') {


### PR DESCRIPTION
### What is this PR for?
There is a native service used across the app to take care of re-routing to different page: `$location`, however there has been a few times where `$window.location` is used instead, and people tend to do it in new PR too.

This convert the `$window.location` from the code to use `$location`.

Only one was kept in `app.controller.js` for Iframe, so it doesn't flicker.


### What type of PR is it?
Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1183

### How should this be tested?
You can try to reproduce the couple of cases that redirection is needed,
but overall there shouldn't be any issue from that change.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

