### PR TITLE
ZEPPELIN-1187. Redirect output of the process running interpreter.sh to log4j

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -59,6 +60,7 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
     this.env = env;
     this.interpreterDir = intpDir;
     this.localRepoDir = localRepoDir;
+
   }
 
   RemoteInterpreterManagedProcess(String intpRunner,
@@ -103,7 +105,7 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
     cmdLine.addArgument(localRepoDir, false);
 
     executor = new DefaultExecutor();
-
+    executor.setStreamHandler(new PumpStreamHandler(new ProcessLogOutputStream(logger)));
     watchdog = new ExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT);
     executor.setWatchdog(watchdog);
 
@@ -162,5 +164,19 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
 
   public boolean isRunning() {
     return running;
+  }
+
+  private static class ProcessLogOutputStream extends LogOutputStream {
+
+    private Logger logger;
+
+    public ProcessLogOutputStream(Logger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    protected void processLine(String s, int i) {
+      this.logger.debug(s);
+    }
   }
 }


### PR DESCRIPTION
### What is this PR for?
For now the output of process running interpter.sh is lost, it would be nice to redirect it to log4j for debugging, especially debugging related with interpreter.sh

### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1187

### How should this be tested?
Tested manully, here's the output in the log file of the process running interpreter.sh

```
INFO [2016-07-15 15:30:10,537] ({Exec Stream Pumper} RemoteInterpreterManagedProcess.java[processLine]:179) - Spark Command: /Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/bin/java -cp /Users/jzhang/github/zeppelin/interpreter/spark/*:/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/lib/*:/Users/jzhang/github/zeppelin/conf/:/Users/jzhang/github/zeppelin/conf/:/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/classes/Users/jzhang/github/zeppelin/interpreter/spark/zeppelin-spark-0.7.0-SNAPSHOT.jar:/Users/jzhang/Java/lib/spark-1.6.1/conf/:/Users/jzhang/Java/lib/spark-1.6.1/assembly/target/scala-2.10/spark-assembly-1.6.1-hadoop2.6.0.jar:/Users/jzhang/Java/lib/spark-1.6.1/lib_managed/jars/datanucleus-api-jdo-3.2.6.jar:/Users/jzhang/Java/lib/spark-1.6.1/lib_managed/jars/datanucleus-core-3.2.10.jar:/Users/jzhang/Java/lib/spark-1.6.1/lib_managed/jars/datanucleus-rdbms-3.2.9.jar:/Users/jzhang/Java/lib/hadoop-2.7.2/etc/hadoop/ -Xms1g -Xmx1g -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///Users/jzhang/github/zeppelin/conf/log4j.properties -Dzeppelin.log.file=/Users/jzhang/github/zeppelin/logs/zeppelin-interpreter-spark-jzhang-jzhangMBPr.local.log org.apache.spark.deploy.SparkSubmit --conf spark.driver.extraClassPath=::/Users/jzhang/github/zeppelin/interpreter/spark/*:/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/lib/*::/Users/jzhang/github/zeppelin/conf:/Users/jzhang/github/zeppelin/conf:/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/classes/Users/jzhang/github/zeppelin/interpreter/spark/zeppelin-spark-0.7.0-SNAPSHOT.jar --conf spark.driver.extraJavaOptions= -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///Users/jzhang/github/zeppelin/conf/log4j.properties -Dzeppelin.log.file=/Users/jzhang/github/zeppelin/logs/zeppelin-interpreter-spark-jzhang-jzhangMBPr.local.log --class org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer /Users/jzhang/github/zeppelin/interpreter/spark/zeppelin-spark-0.7.0-SNAPSHOT.jar 55592
 INFO [2016-07-15 15:30:10,537] ({Exec Stream Pumper} RemoteInterpreterManagedProcess.java[processLine]:179) - ========================================
 INFO [2016-07-15 15:30:11,058] ({Exec Stream Pumper} RemoteInterpreterManagedProcess.java[processLine]:179) - SLF4J: Class path contains multiple SLF4J bindings.
```
