### PR TITLE
[ZEPPELIN-1186] Prevent NPE when unbind interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -445,7 +445,8 @@ public class HeliumApplicationFactory implements ApplicationEventListener, Noteb
       Interpreter currentInterpreter = p.getCurrentRepl();
       List<InterpreterInfo> infos = setting.getInterpreterInfos();
       for (InterpreterInfo info : infos) {
-        if (info.getClassName().equals(currentInterpreter.getClassName())) {
+        if (currentInterpreter != null &&
+            info.getClassName().equals(currentInterpreter.getClassName())) {
           onParagraphRemove(p);
           break;
         }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -240,6 +240,27 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     notebook.removeNote(note1.getId(), null);
   }
 
+  @Test
+  public void testInterpreterUnbindOfNullReplParagraph() throws IOException {
+    // create note
+    Note note1 = notebook.createNote(null);
+
+    // add paragraph with invalid magic
+    Paragraph p1 = note1.addParagraph();
+    p1.setText("%fake ");
+
+    // make sure that p1's repl is null
+    Interpreter intp = p1.getCurrentRepl();
+    assertEquals(intp, null);
+
+    // Unbind all interpreter from note
+    // NullPointerException shouldn't occur here
+    notebook.bindInterpretersToNote(note1.id(), new LinkedList<String>());
+
+    // remove note
+    notebook.removeNote(note1.getId(), null);
+  }
+
 
   @Test
   public void testUnloadOnInterpreterRestart() throws IOException {


### PR DESCRIPTION
### What is this PR for?
Unbinding interpreter from note throws NPE when paragraph repl is not set.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1186](https://issues.apache.org/jira/browse/ZEPPELIN-1186)

### How should this be tested?
1. Create notebook
2. type '%fake ' including space at the end
3. Unbind spark interpreter from note binding and hit save
4. Unbind all interpreter and hit save
5. See if you can save the interpreter bind without error

### Screenshots (if appropriate)
**Before**
![before](https://cloud.githubusercontent.com/assets/8503346/16870039/9d44b918-4aba-11e6-9640-63c8d9e116ad.gif)

**After**
![after](https://cloud.githubusercontent.com/assets/8503346/16870050/a3cdae84-4aba-11e6-91a8-f1996436fc6c.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

