### PR TITLE
[HOTFIX][ZEPPELIN-1169] Fix wrong Guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <log4j.version>1.2.17</log4j.version>
     <libthrift.version>0.9.2</libthrift.version>
     <gson.version>2.2</gson.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>15.0</guava.version>
     <jetty.version>9.2.15.v20160210</jetty.version>
 
     <PermGen>64m</PermGen>


### PR DESCRIPTION
### What is this PR for?
Fixing the incompatible version for guava 

### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Revert guava.version for fitting in hadoop-2.6

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1169

### How should this be tested?
1. `mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -DskipTests`
1. Run spark interpreter with simple script

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

