### PR TITLE
[ZEPPELIN-1191] Supported legacy way to run paragraph with group name only

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -96,13 +96,13 @@ public class InterpreterFactory implements InterpreterGroupFactory {
    * This is only references with default settings, name and properties
    * key: InterpreterSetting.name
    */
-  private Map<String, InterpreterSetting> interpreterSettingsRef = new HashMap<>();
+  private final Map<String, InterpreterSetting> interpreterSettingsRef = new HashMap<>();
 
   /**
    * This is used by creating and running Interpreters
    * key: InterpreterSetting.id <- This is becuase backward compatibility
    */
-  private Map<String, InterpreterSetting> interpreterSettings = new HashMap<>();
+  private final Map<String, InterpreterSetting> interpreterSettings = new HashMap<>();
 
   private Map<String, List<String>> interpreterBindings = new HashMap<>();
   private List<RemoteRepository> interpreterRepositories;
@@ -174,7 +174,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
         registerInterpreterFromResource(cl, interpreterDirString, interpreterJson);
 
-        /**
+        /*
          * TODO(jongyoul)
          * - Remove these codes below because of legacy code
          * - Support ThreadInterpreter
@@ -460,8 +460,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
    * Return ordered interpreter setting list.
    * The list does not contain more than one setting from the same interpreter class.
    * Order by InterpreterClass (order defined by ZEPPELIN_INTERPRETERS), Interpreter setting name
-   *
-   * @return
    */
   public List<String> getDefaultInterpreterSettingList() {
     // this list will contain default interpreter setting list
@@ -521,8 +519,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   }
 
   /**
-   * @param group    InterpreterSetting reference name
-   * @param properties
+   * @param group InterpreterSetting reference name
    * @return
    */
   public InterpreterSetting add(String group, ArrayList<InterpreterInfo> interpreterInfos,
@@ -571,8 +568,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
       } else {
         interpreterSetting =
-            new InterpreterSetting(group, null, interpreterInfos, properties, dependencies,
-                option, path);
+            new InterpreterSetting(group, null, interpreterInfos, properties, dependencies, option,
+                path);
         interpreterSettingsRef.put(group, interpreterSetting);
       }
     }
@@ -1166,6 +1163,16 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         List<Interpreter> interpreters = createOrGetInterpreterList(noteId, setting);
         if (null != interpreters) {
           return interpreters.get(0);
+        }
+      }
+
+      // Support the legacy way to use it
+      for (InterpreterSetting s : settings) {
+        if (s.getGroup().equals(replName)) {
+          List<Interpreter> interpreters = createOrGetInterpreterList(noteId, s);
+          if (null != interpreters) {
+            return interpreters.get(0);
+          }
         }
       }
     }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -155,5 +155,6 @@ public class InterpreterFactoryTest {
     }});
 
     assertEquals("className1", factory.getInterpreter("note", "test-group1").getClassName());
+    assertEquals("className1", factory.getInterpreter("note", "group1").getClassName());
   }
 }


### PR DESCRIPTION
### What is this PR for?
Preserving legacy way to run paragraph when users use group name only

### What type of PR is it?
[Improvement]

### Todos
* [x] - Added the way to find a interpreter with group name at last

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1191

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

