### PR TITLE
[MINOR] Enable pyspark test in local mode

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -168,6 +168,8 @@ public abstract class AbstractTestRestApi {
 
         String sparkHome = getSparkHome();
         if (sparkHome != null) {
+          sparkIntpSetting.getProperties().setProperty("master", "spark://" + getHostname() + ":7071");
+          sparkIntpSetting.getProperties().setProperty("spark.cores.max", "2");
           // set spark home for pyspark
           sparkIntpSetting.getProperties().setProperty("spark.home", sparkHome);
           pySpark = true;
@@ -189,7 +191,7 @@ public abstract class AbstractTestRestApi {
   }
 
   private static String getSparkHome() {
-    String sparkHome = getSparkHomeRecursively(new File(System.getProperty("user.dir")));
+    String sparkHome = getSparkHomeRecursively(new File(System.getProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName())));
     System.out.println("SPARK HOME detected " + sparkHome);
     return sparkHome;
   }


### PR DESCRIPTION
### What is this PR for?
Enabling test for pyspark in local mode

### What type of PR is it?
[Improvement]

### Todos
* [x] - Add spark configuration and
* [x] - Edit a logic for finding spark home 

### What is the Jira issue?
N/A

### How should this be tested?
1. Download spark under {ZEPPELIN_HOME}
1. run `testing/startSparkCluster.sh`
1. `mvn clean package -Pspark-1.6 -Ppyspark -Pyarn -DskipTests`
1. Run `ZeppelinSparkClusterTest`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

