### PR TITLE
[ZEPPELIN-1208] fixed invaild position user config button in navbar

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -71,15 +71,13 @@ limitations under the License.
             </div>
           </form>
         </li>
-        <li class="nav-component">
-          <i ng-if="navbar.connected" class="fa fa-circle server-connected"
-             tooltip="WebSocket Connected" tooltip-placement="bottom"></i>
-          <i ng-if="!navbar.connected" class="fa fa-circle server-disconnected"
-             tooltip="WebSocket Disconnected" tooltip-placement="bottom"></i>
-        </li>
-        <li>
+        <li style="margin-left: 10px;">
           <div class="dropdown">
-            <button ng-if="ticket" class="nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin:11px 5px 0 0;">
+            <i ng-if="navbar.connected" class="fa fa-circle server-connected"
+               tooltip="WebSocket Connected" tooltip-placement="bottom" style="margin-top: 7px; margin-right: 0px; vertical-align: top"></i>
+            <i ng-if="!navbar.connected" class="fa fa-circle server-disconnected"
+               tooltip="WebSocket Disconnected" tooltip-placement="bottom" style="margin-top: 7px; vertical-align: top"></i>
+            <button ng-if="ticket" class="nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin:11px 5px 0 0; padding-left: 0px;">
               <span class="username">{{ticket.principal}}</span>
               <span class="caret" style="margin-bottom: 8px"></span>
             </button>
@@ -94,6 +92,9 @@ limitations under the License.
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'"><a ng-click="logout()">Logout</a></li>
             </ul>
           </div>
+        </li>
+        <li>
+
         </li>
         <li class="nav-component" ng-if="!ticket">
           <button class="btn nav-login-btn" data-toggle="modal" data-target="#loginModal"

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -93,9 +93,6 @@ limitations under the License.
             </ul>
           </div>
         </li>
-        <li>
-
-        </li>
         <li class="nav-component" ng-if="!ticket">
           <button class="btn nav-login-btn" data-toggle="modal" data-target="#loginModal"
                   ng-click="showLoginWindow()">Login


### PR DESCRIPTION
### What is this PR for?
icon for connect or disconnect
invalid align in the mobile screen.
See the screen shot.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1208

### How should this be tested?
Loading a web page from a mobile or Minimizing the width web browser.

### Screenshots (if appropriate)
#### before
![cap 2016-07-19 01-22-56-717](https://cloud.githubusercontent.com/assets/10525473/16922334/213b38ea-4d50-11e6-8b15-0564ab88c570.png)
![cap 2016-07-19 01-23-08-542](https://cloud.githubusercontent.com/assets/10525473/16922337/22449df8-4d50-11e6-9eb6-9ba24d2e712b.png)

#### after
![cap 2016-07-19 01-21-22-964](https://cloud.githubusercontent.com/assets/10525473/16922342/25b73e5a-4d50-11e6-87b1-005f00c79a5b.png)
![cap 2016-07-19 01-21-32-983](https://cloud.githubusercontent.com/assets/10525473/16922346/274d5ca4-4d50-11e6-8aed-0e1d3c4ebb5b.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

