### PR TITLE
ZEPPELIN-1199. Need to login using keytab and principal before creating SparkContext in secured cluster

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -33,11 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.base.Joiner;
 
-import com.google.common.base.Preconditions;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.spark.HttpServer;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkEnv;
@@ -491,10 +487,10 @@ public class SparkInterpreter extends Interpreter {
       conf.set("spark.yarn.isPython", "true");
     }
 
-    String keytab = conf.get("spark.yarn.keytab");
-    String principal = conf.get("spark.yarn.principal");
-    if (keytab != null && principal != null) {
+    if (conf.contains("spark.yarn.keytab") && conf.contains("spark.yarn.principal")) {
       try {
+        String keytab = conf.get("spark.yarn.keytab");
+        String principal = conf.get("spark.yarn.principal");
         UserGroupInformation.loginUserFromKeytab(principal, keytab);
       } catch (IOException e) {
         throw new RuntimeException("Can not pass kerberos authentication", e);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.spark;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -32,6 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.base.Joiner;
 
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.spark.HttpServer;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkEnv;
@@ -485,6 +491,15 @@ public class SparkInterpreter extends Interpreter {
       conf.set("spark.yarn.isPython", "true");
     }
 
+    String keytab = conf.get("spark.yarn.keytab");
+    String principal = conf.get("spark.yarn.principal");
+    if (keytab != null && principal != null) {
+      try {
+        UserGroupInformation.loginUserFromKeytab(principal, keytab);
+      } catch (IOException e) {
+        throw new RuntimeException("Can not pass kerberos authentication", e);
+      }
+    }
     SparkContext sparkContext = new SparkContext(conf);
     return sparkContext;
   }


### PR DESCRIPTION
### What is this PR for?
Need to login using keytab and principal before creating SparkContext in secured cluster. 


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1199

### How should this be tested?
Manually verified in a secured cluster. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
