### PR TITLE
[DOC][ZEPPELIN-1209] Remove a useless sentence about default interpreter in docs

### DIFF
--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -156,7 +156,6 @@ println(a)
 
 ### 0.6.0 and later
 Inside of a notebook, `%[INTERPRETER_GROUP].[INTERPRETER_NAME]` directive will call your interpreter.
-Note that the first interpreter configuration in zeppelin.interpreters will be the default one.
 
 You can omit either [INTERPRETER\_GROUP] or [INTERPRETER\_NAME]. If you omit [INTERPRETER\_NAME], then first available interpreter will be selected in the [INTERPRETER\_GROUP].
 Likewise, if you skip [INTERPRETER\_GROUP], then [INTERPRETER\_NAME] will be chosen from default interpreter group.

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -377,7 +377,7 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class] <br /> The first interpreter will be a default value. <br /> It means only the first interpreter in this list can be available without <code>%interpreter_name</code> annotation in notebook paragraph. </td>
+    <td>Comma separated interpreter configurations [Class]</td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -377,7 +377,10 @@ You can configure Apache Zeppelin with both **environment variables** in `conf/z
     <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
     ...
     </td>
-    <td>Comma separated interpreter configurations [Class]</td>
+    <td>
+      Comma separated interpreter configurations [Class] <br/>
+      <span style="font-style:italic">NOTE: This property is deprecated since Zeppelin-0.6.0 and will not be supported from Zeppelin-0.7.0</span>
+    </td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETER_DIR</td>


### PR DESCRIPTION
### What is this PR for?
As new interpreter registration mechanism which was started in [ZEPPELIN-804](https://issues.apache.org/jira/browse/ZEPPELIN-804), we can't set default interpreter anymore using `zeppelin-site.xml` as described in [https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/install.html#apache-zeppelin-configuration](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/install.html#apache-zeppelin-configuration) (see `zeppelin.interpreters` property description in the configuration table). So we need to remove the related contents in Zeppelin docs site.

Below pages will be updated: 
 - [https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/install.html#apache-zeppelin-configuration](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/install.html#apache-zeppelin-configuration)
 - [https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/development/writingzeppelininterpreter.html#060-and-later](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/development/writingzeppelininterpreter.html#060-and-later)

### What type of PR is it?
Documentation

### What is the Jira issue?
[ZEPPELIN-1209](https://issues.apache.org/jira/browse/ZEPPELIN-1209)

### How should this be tested?
No need to test. Just removed two sentences about the default interpreter setting.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

