### PR TITLE
[ZEPPELIN-1220] Add geographical map as visualization option

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -116,8 +116,6 @@ The following components are provided under Apache License.
     (Apache 2.0) Google HTTP Client Library for Java (com.google.http-client:google-http-client-jackson2:1.21.0 - https://github.com/google/google-http-java-client/tree/dev/google-http-client-jackson2)
     (Apache 2.0) angular-esri-map (https://github.com/Esri/angular-esri-map)
 
->>>>>>> Add angular-esri-map to license document
-
 ========================================================================
 MIT licenses
 ========================================================================

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -114,6 +114,9 @@ The following components are provided under Apache License.
     (Apache 2.0) Utility classes for Jetty (org.mortbay.jetty:jetty-util:6.1.26 - http://javadox.com/org.mortbay.jetty/jetty/6.1.26/overview-tree.html)
     (Apache 2.0) Servlet API (org.mortbay.jetty:servlet-api:2.5-20081211 - https://en.wikipedia.org/wiki/Jetty_(web_server))
     (Apache 2.0) Google HTTP Client Library for Java (com.google.http-client:google-http-client-jackson2:1.21.0 - https://github.com/google/google-http-java-client/tree/dev/google-http-client-jackson2)
+    (Apache 2.0) angular-esri-map (https://github.com/Esri/angular-esri-map)
+
+>>>>>>> Add angular-esri-map to license document
 
 ========================================================================
 MIT licenses

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -32,7 +32,8 @@
     "bootstrap3-dialog": "bootstrap-dialog#~1.34.7",
     "handsontable": "~0.24.2",
     "moment-duration-format": "^1.3.0",
-    "select2": "^4.0.3"
+    "select2": "^4.0.3",
+    "angular-esri-map": "~2.0.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.0"

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -33,7 +33,8 @@
           'xeditable',
           'ngToast',
           'focus-if',
-          'ngResource'
+          'ngResource',
+          'esri.map'
       ])
         .filter('breakFilter', function() {
           return function(text) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -47,6 +47,11 @@ limitations under the License.
           ng-class="{'active': isGraphMode('scatterChart')}"
           ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
   </button>
+  <button type="button" class="btn btn-default btn-sm"
+          ng-if="paragraph.result.type == 'TABLE'"
+          ng-class="{'active': isGraphMode('map')}"
+          ng-click="setGraphMode('map', true)"><i class="fa fa-map-marker"></i>
+  </button>
 
   <button type="button"
           ng-if="paragraph.result.type != 'TABLE'"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
@@ -52,8 +52,11 @@ limitations under the License.
     <svg></svg>
   </div>
 
-  <div ng-if="getGraphMode()=='map'"
-       id="p{{paragraph.id}}_map">
-    <div></div>
+  <div ng-if="getGraphMode()=='map'" id="p{{paragraph.id}}_map"
+       ng-switch="paragraph.config.graph.map.isOnline">
+    <div ng-switch-when="true"></div>
+    <span class="map-offline-text" ng-switch-default>
+      <span>Maps require internet connectivity.</span>
+    </span>
   </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-graph.html
@@ -51,4 +51,9 @@ limitations under the License.
        id="p{{paragraph.id}}_scatterChart">
     <svg></svg>
   </div>
+
+  <div ng-if="getGraphMode()=='map'"
+       id="p{{paragraph.id}}_map">
+    <div></div>
+  </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-graphOptions.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-graphOptions.html
@@ -28,7 +28,7 @@ limitations under the License.
       show line chart with focus
     </label>
   </div>
-  <div class="ng-if=isGraphMode('map')">
+  <div ng-if="isGraphMode('map')">
     <label>Basemap</label>
     <span class="dropdown">
       <button type="button" class="btn btn-default btn-sm dropdown-toggle" style="min-width: 0px;" data-toggle="dropdown">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-graphOptions.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-graphOptions.html
@@ -28,4 +28,19 @@ limitations under the License.
       show line chart with focus
     </label>
   </div>
+  <div class="ng-if=isGraphMode('map')">
+    <label>Basemap</label>
+    <span class="dropdown">
+      <button type="button" class="btn btn-default btn-sm dropdown-toggle" style="min-width: 0px;" data-toggle="dropdown">
+        <span ng-bind="paragraph.config.graph.map.baseMapType"></span>
+        <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" style="min-width: 70px;">
+        <li ng-repeat="opt in baseMapOption">
+          <a ng-click="setMapBaseMap(opt)">{{opt}}</a>
+        </li>
+      </ul>
+    </span>
+    <br/>
+  </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
@@ -154,7 +154,8 @@ limitations under the License.
         <ul data-drop="true"
             ng-model="paragraph.config.graph.scatter.size"
             jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
-            class="list-unstyled">
+            class="list-unstyled"
+            style="height:36px">
           <li ng-if="paragraph.config.graph.scatter.size">
             <div class="btn btn-xs" style="color:white" ng-class="{'btn-warning': isValidSizeOption(paragraph.config.graph.scatter, paragraph.result.rows)}">
               {{paragraph.config.graph.scatter.size.name}} <span class="fa fa-close" ng-click="removeScatterOptionSize($index)"></span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
@@ -154,8 +154,7 @@ limitations under the License.
         <ul data-drop="true"
             ng-model="paragraph.config.graph.scatter.size"
             jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
-            class="list-unstyled"
-            style="height:36px">
+            class="list-unstyled">
           <li ng-if="paragraph.config.graph.scatter.size">
             <div class="btn btn-xs" style="color:white" ng-class="{'btn-warning': isValidSizeOption(paragraph.config.graph.scatter, paragraph.result.rows)}">
               {{paragraph.config.graph.scatter.size.name}} <span class="fa fa-close" ng-click="removeScatterOptionSize($index)"></span>
@@ -173,8 +172,7 @@ limitations under the License.
         <ul data-drop="true"
             ng-model="paragraph.config.graph.map.lat"
             jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
-            class="list-unstyled"
-            style="height:36px">
+            class="list-unstyled">
           <li ng-if="paragraph.config.graph.map.lat">
             <div class="btn btn-primary btn-xs">
               {{paragraph.config.graph.map.lat.name}} <span class="fa fa-close" ng-click="removeMapOptionLat($index)"></span>
@@ -189,8 +187,7 @@ limitations under the License.
         <ul data-drop="true"
             ng-model="paragraph.config.graph.map.lng"
             jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
-            class="list-unstyled"
-            style="height:36px">
+            class="list-unstyled">
           <li ng-if="paragraph.config.graph.map.lng">
             <div class="btn btn-primary btn-xs">
               {{paragraph.config.graph.map.lng.name}} <span class="fa fa-close" ng-click="removeMapOptionLng($index)"></span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
@@ -32,7 +32,7 @@ limitations under the License.
     </ul>
   </div>
 
-  <div class="row" ng-if="getGraphMode()!='scatterChart'">
+  <div class="row" ng-if="getGraphMode()!='scatterChart' && getGraphMode()!='map'">
     <div class="col-md-4">
       <span class="columns lightBold">
         Keys
@@ -159,6 +159,56 @@ limitations under the License.
           <li ng-if="paragraph.config.graph.scatter.size">
             <div class="btn btn-xs" style="color:white" ng-class="{'btn-warning': isValidSizeOption(paragraph.config.graph.scatter, paragraph.result.rows)}">
               {{paragraph.config.graph.scatter.size.name}} <span class="fa fa-close" ng-click="removeScatterOptionSize($index)"></span>
+            </div>
+          </li>
+        </ul>
+      </span>
+    </div>
+  </div>
+
+  <div class="row" ng-if="getGraphMode()=='map'">
+    <div class="col-md-4">
+      <span class="columns lightBold">
+        Latitude
+        <ul data-drop="true"
+            ng-model="paragraph.config.graph.map.lat"
+            jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+            class="list-unstyled"
+            style="height:36px">
+          <li ng-if="paragraph.config.graph.map.lat">
+            <div class="btn btn-primary btn-xs">
+              {{paragraph.config.graph.map.lat.name}} <span class="fa fa-close" ng-click="removeMapOptionLat($index)"></span>
+            </div>
+          </li>
+        </ul>
+      </span>
+    </div>
+    <div class="col-md-4">
+      <span class="columns lightBold">
+        Longitude
+        <ul data-drop="true"
+            ng-model="paragraph.config.graph.map.lng"
+            jqyoui-droppable="{onDrop:'onGraphOptionChange()'}"
+            class="list-unstyled"
+            style="height:36px">
+          <li ng-if="paragraph.config.graph.map.lng">
+            <div class="btn btn-primary btn-xs">
+              {{paragraph.config.graph.map.lng.name}} <span class="fa fa-close" ng-click="removeMapOptionLng($index)"></span>
+            </div>
+          </li>
+        </ul>
+      </span>
+    </div>
+    <div class="col-md-4">
+      <span class="columns lightBold">
+        Pin contents
+        <ul data-drop="true"
+            ng-model="paragraph.config.graph.map.pin"
+            jqyoui-droppable="{multiple:true, onDrop:'onGraphOptionChange()'}"
+            class="list-unstyled">
+          <li ng-repeat="item in paragraph.config.graph.map.pin">
+            <div class="btn btn-primary btn-xs">
+              {{item.name}} <span class="fa fa-close" ng-click="removeMapOptionPinInfo($index)"></span>
             </div>
           </li>
         </ul>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-pivot.html
@@ -203,12 +203,12 @@ limitations under the License.
       <span class="columns lightBold">
         Pin contents
         <ul data-drop="true"
-            ng-model="paragraph.config.graph.map.pin"
+            ng-model="paragraph.config.graph.map.pinCols"
             jqyoui-droppable="{multiple:true, onDrop:'onGraphOptionChange()'}"
             class="list-unstyled">
-          <li ng-repeat="item in paragraph.config.graph.map.pin">
+          <li ng-repeat="col in paragraph.config.graph.map.pinCols">
             <div class="btn btn-primary btn-xs">
-              {{item.name}} <span class="fa fa-close" ng-click="removeMapOptionPinInfo($index)"></span>
+              {{col.name}} <span class="fa fa-close" ng-click="removeMapOptionPinInfo($index)"></span>
             </div>
           </li>
         </ul>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1219,7 +1219,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       getMapPins(function(pins) {
         createPinMapLayer(pins, function(pinLayer) {
           $scope.map.map.add(pinLayer);
-          if (pins.length > 0) {
+          if (pinLayer.source.length > 0) {
             $scope.map.goTo(pinLayer.source);
           }
         });
@@ -1241,7 +1241,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
             basemap: 'streets'
           }),
           center: [-75.7325985, 45.4041593],  // Apption (lng, lat)
-          zoom: 16,
+          zoom: 14,
           pinRenderer: new SimpleRenderer({
             symbol: new SimpleMarkerSymbol({
               'color': [255, 0, 0, 0.5],
@@ -1258,7 +1258,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
             })
           })
         });
-        updateMapPins();
+        $scope.map.then(updateMapPins);
       });
     };
 
@@ -1461,10 +1461,27 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       }
     }
 
-    if (!$scope.paragraph.config.graph.map.lat && !$scope.paragraph.config.graph.map.lng &&
-            $scope.paragraph.result.columnNames.length > 1) {
-      $scope.paragraph.config.graph.map.lat = $scope.paragraph.result.columnNames[0];
-      $scope.paragraph.config.graph.map.lng = $scope.paragraph.result.columnNames[1];
+    /* try to find columns for the map logitude and latitude */
+    var i;
+    var col;
+    if (!$scope.paragraph.config.graph.map.lat) {
+      for (i = 0; i < $scope.paragraph.result.columnNames.length; ++i) {
+        col = $scope.paragraph.result.columnNames[i];
+        if (col.name.toUpperCase().indexOf('LAT') !== -1) {
+          $scope.paragraph.config.graph.map.lat = col;
+          break;
+        }
+      }
+    }
+
+    if (!$scope.paragraph.config.graph.map.lng) {
+      for (i = 0; i < $scope.paragraph.result.columnNames.length; ++i) {
+        col = $scope.paragraph.result.columnNames[i];
+        if (col.name.toUpperCase().indexOf('LONG') !== -1) {
+          $scope.paragraph.config.graph.map.lng = col;
+          break;
+        }
+      }
     }
   };
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -245,6 +245,12 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       config.graph.scatter = {};
     }
 
+    if (!config.graph.map) {
+      config.graph.map = {
+        pin: []
+      };
+    }
+
     if (config.enabled === undefined) {
       config.enabled = true;
     }
@@ -907,6 +913,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
 
       if (!type || type === 'table') {
         setTable($scope.paragraph.result, refresh);
+      } else if (type === 'map') {
+        setMap($scope.paragraph.result, refresh);
       } else {
         setD3Chart(type, $scope.paragraph.result, refresh);
       }
@@ -1131,6 +1139,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     $timeout(retryRenderer);
   };
 
+  var setMap = function(data, refresh) {
+  };
+
   $scope.isGraphMode = function(graphName) {
     var activeAppId = _.get($scope.paragraph.config, 'helium.activeApp');
     if ($scope.getResultType() === 'TABLE' && $scope.getGraphMode() === graphName && !activeAppId) {
@@ -1193,6 +1204,24 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
   };
 
+  $scope.removeMapOptionLat = function(idx) {
+    $scope.paragraph.config.graph.map.lat = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeMapOptionLng = function(idx) {
+    $scope.paragraph.config.graph.map.lng = null;
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
+  $scope.removeMapOptionPinInfo = function(idx) {
+    $scope.paragraph.config.graph.map.pin.splice(idx, 1);
+    clearUnknownColsFromGraphOption();
+    $scope.setGraphMode($scope.paragraph.config.graph.mode, true, false);
+  };
+
   /* Clear unknown columns from graph option */
   var clearUnknownColsFromGraphOption = function() {
     var unique = function(list) {
@@ -1223,7 +1252,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       }
     };
 
-    var removeUnknownFromScatterSetting = function(fields) {
+    var removeUnknownFromFields = function(fields) {
       for (var f in fields) {
         if (fields[f]) {
           var found = false;
@@ -1235,7 +1264,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
               break;
             }
           }
-          if (!found) {
+          if (!found && !(fields[f] instanceof Array)) {
             fields[f] = null;
           }
         }
@@ -1250,7 +1279,10 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     unique($scope.paragraph.config.graph.groups);
     removeUnknown($scope.paragraph.config.graph.groups);
 
-    removeUnknownFromScatterSetting($scope.paragraph.config.graph.scatter);
+    removeUnknownFromFields($scope.paragraph.config.graph.scatter);
+
+    removeUnknownFromFields($scope.paragraph.config.graph.map);
+    removeUnknown($scope.paragraph.config.graph.map.pin);
   };
 
   /* select default key and value if there're none selected */
@@ -1270,6 +1302,12 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       } else if ($scope.paragraph.result.columnNames.length === 1) {
         $scope.paragraph.config.graph.scatter.xAxis = $scope.paragraph.result.columnNames[0];
       }
+    }
+
+    if (!$scope.paragraph.config.graph.map.lat && !$scope.paragraph.config.graph.map.lng &&
+            $scope.paragraph.result.columnNames.length > 1) {
+      $scope.paragraph.config.graph.map.lat = $scope.paragraph.result.columnNames[0];
+      $scope.paragraph.config.graph.map.lng = $scope.paragraph.result.columnNames[1];
     }
   };
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1295,7 +1295,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
 
     var renderMap = function() {
       var mapdiv = angular.element('#p' + $scope.paragraph.id + '_map')
-      .css('height', $scope.paragraph.config.graph.height).children('div').get(0);
+                          .css('height', $scope.paragraph.config.graph.height)
+                          .children('div').get(0);
 
       // on chart type change, destroy map to force reinitialization.
       if ($scope.map && !refresh) {
@@ -1505,27 +1506,21 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     }
 
     /* try to find columns for the map logitude and latitude */
-    var i;
-    var col;
-    if (!$scope.paragraph.config.graph.map.lat) {
-      for (i = 0; i < $scope.paragraph.result.columnNames.length; ++i) {
-        col = $scope.paragraph.result.columnNames[i];
-        if (col.name.toUpperCase().indexOf('LAT') !== -1) {
-          $scope.paragraph.config.graph.map.lat = col;
-          break;
+    var findDefaultMapCol = function(settingName, keyword) {
+      var col;
+      if (!$scope.paragraph.config.graph.map[settingName]) {
+        for (var i = 0; i < $scope.paragraph.result.columnNames.length; ++i) {
+          col = $scope.paragraph.result.columnNames[i];
+          if (col.name.toUpperCase().indexOf(keyword) !== -1) {
+            $scope.paragraph.config.graph.map[settingName] = col;
+            break;
+          }
         }
       }
-    }
+    };
 
-    if (!$scope.paragraph.config.graph.map.lng) {
-      for (i = 0; i < $scope.paragraph.result.columnNames.length; ++i) {
-        col = $scope.paragraph.result.columnNames[i];
-        if (col.name.toUpperCase().indexOf('LONG') !== -1) {
-          $scope.paragraph.config.graph.map.lng = col;
-          break;
-        }
-      }
-    }
+    findDefaultMapCol('lat', 'LAT');
+    findDefaultMapCol('lng', 'LONG');
   };
 
   var pivot = function(data) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1237,6 +1237,20 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       var mapdiv = angular.element('#p' + $scope.paragraph.id + '_map div')
       .css('height', $scope.paragraph.config.graph.height).get(0);
 
+      // prevent zooming with the scroll wheel
+      var disableZoom = function(e) {
+        var evt = e || window.event;
+        evt.cancelBubble = true;
+        evt.returnValue = false;
+        if (evt.stopPropagation) {
+          evt.stopPropagation();
+        }
+      };
+      var eName = window.WheelEvent ? 'wheel' :  // Modern browsers
+                  window.MouseWheelEvent ? 'mousewheel' :  // WebKit and IE
+                  'DOMMouseScroll';  // Old Firefox
+      mapdiv.addEventListener(eName, disableZoom, true);
+
       esriLoader.require(['esri/views/MapView',
                           'esri/Map',
                           'esri/renderers/SimpleRenderer',
@@ -1247,8 +1261,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
           map: new Map({
             basemap: $scope.paragraph.config.graph.map.baseMapType.toLowerCase()
           }),
-          center: [-75.7325985, 45.4041593],  // Apption (lng, lat)
-          zoom: 14,
+          center: [-106.3468, 56.1304],  // Canada (lng, lat)
+          zoom: 2,
           pinRenderer: new SimpleRenderer({
             symbol: new SimpleMarkerSymbol({
               'color': [255, 0, 0, 0.5],

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1233,10 +1233,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       });
     };
 
-    var createMap = function() {
-      var mapdiv = angular.element('#p' + $scope.paragraph.id + '_map div')
-      .css('height', $scope.paragraph.config.graph.height).get(0);
-
+    var createMap = function(mapdiv) {
       // prevent zooming with the scroll wheel
       var disableZoom = function(e) {
         var evt = e || window.event;
@@ -1284,6 +1281,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     };
 
     var renderMap = function() {
+      var mapdiv = angular.element('#p' + $scope.paragraph.id + '_map')
+      .css('height', $scope.paragraph.config.graph.height).children('div').get(0);
+
       // on chart type change, destroy map to force reinitialization.
       if ($scope.map && !refresh) {
         $scope.map.map.destroy();
@@ -1296,9 +1296,11 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         if (!esriLoader.isLoaded()) {
           esriLoader.bootstrap({
             url: '//js.arcgis.com/4.0'
-          }).then(createMap);
+          }).then(function() {
+            createMap(mapdiv);
+          });
         } else {
-          createMap();
+          createMap(mapdiv);
         }
       } else {
         updateMapPins();

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1193,8 +1193,9 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
             var lat = row[latCol.index];
             var pin = {
               geometry: new Point({
-                x: lng,
-                y: lat
+                longitude: lng,
+                latitude: lat,
+                spatialReference: $scope.map.spatialReference
               }),
               attributes: {
                 _ObjectID: i,
@@ -1275,6 +1276,18 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
                       '16,7.416S19.584,9.021,19.584,11S17.979,14.584,16,14.584z'
             })
           })
+        });
+
+        $scope.map.on('click', function() {
+          // ArcGIS JS API 4.0 does not account for scrolling or position
+          // changes by default (this is a bug, to be fixed in the upcoming
+          // version 4.1; see https://geonet.esri.com/thread/177238#comment-609681).
+          // This results in a misaligned popup.
+
+          // Workaround: manually set popup position to match position of selected pin
+          if ($scope.map.popup.selectedFeature) {
+            $scope.map.popup.location = $scope.map.popup.selectedFeature.geometry;
+          }
         });
         $scope.map.then(updateMapPins);
       });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1302,7 +1302,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       var callback = function(res) {
         var online = (res.status > 0);
         $scope.paragraph.config.graph.map.isOnline = online;
-        cb(res.status > 0);
+        cb(online);
       };
       $http.head('//services.arcgisonline.com/arcgis/', {
         timeout: 5000,

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1305,17 +1305,33 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         $scope.map = null;
       }
 
-      // create map if not exists.
-      if (!$scope.map) {
+      var requireMapCSS = function() {
+        var url = '//js.arcgis.com/4.0/esri/css/main.css';
+        if (!angular.element('link[href="' + url + '"]').length) {
+          var link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.type = 'text/css';
+          link.href = url;
+          angular.element('head').append(link);
+        }
+      };
+
+      var requireMapJS = function(cb) {
         if (!esriLoader.isLoaded()) {
           esriLoader.bootstrap({
             url: '//js.arcgis.com/4.0'
-          }).then(function() {
-            createMap(mapdiv);
-          });
+          }).then(cb);
         } else {
-          createMap(mapdiv);
+          cb();
         }
+      };
+
+      // create map if not exists.
+      if (!$scope.map) {
+        requireMapCSS();
+        requireMapJS(function() {
+          createMap(mapdiv);
+        });
       } else {
         updateMapPins();
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -337,6 +337,10 @@ table.dataTable.table-condensed .sorting_desc:after {
   overflow: visible;
 }
 
+.esri-docked.esri-dock-to-bottom {
+  padding: 8px;
+}
+
 .tableDisplay .btn-group span {
   margin: 10px 0 0 10px;
   font-size: 12px;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -327,20 +327,10 @@ table.dataTable.table-condensed .sorting_desc:after {
 .tableDisplay div {
 }
 
-.tableDisplay img {
+.tableDisplay img:not(.esri-bitmap) {
   display: block;
   max-width: 100%;
   height: auto;
-}
-
-/*
-  Above, the max-width property of img tags inside tableDisplay divs was just
-  set to a percentage (max-width is relative to the parent element). However, the
-  parent elements of Esri map tiles don't have a width, resulting in an invisible
-  map (100% of 0px is 0px)! The below rule corrects for this.
-*/
-.tableDisplay .esri-display-object {
-	width: 100%;
 }
 
 .tableDisplay .btn-group span {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -345,6 +345,22 @@ table.dataTable.table-condensed .sorting_desc:after {
   max-height: 100%;
 }
 
+span.map-offline-text {
+  display: table;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+}
+
+span.map-offline-text > span {
+  display: table-cell;
+  vertical-align: middle;
+  font-size: 18px;
+  font-weight: 700;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #212121;
+}
+
 .tableDisplay .btn-group span {
   margin: 10px 0 0 10px;
   font-size: 12px;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -337,8 +337,9 @@ table.dataTable.table-condensed .sorting_desc:after {
   overflow: visible;
 }
 
-.esri-docked.esri-dock-to-bottom {
+.esri-popup > .esri-docked.esri-dock-to-bottom {
   padding: 8px;
+  margin-top: 0px;
 }
 
 .esri-popup-main {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -341,6 +341,10 @@ table.dataTable.table-condensed .sorting_desc:after {
   padding: 8px;
 }
 
+.esri-popup-main {
+  max-height: 100%;
+}
+
 .tableDisplay .btn-group span {
   margin: 10px 0 0 10px;
   font-size: 12px;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -354,7 +354,8 @@ table.dataTable.table-condensed .sorting_desc:after {
 
 }
 
-.tableDisplay .option .columns {
+.tableDisplay .option .columns,
+div.esri-view {
   height: 100%;
 }
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -333,6 +333,10 @@ table.dataTable.table-condensed .sorting_desc:after {
   height: auto;
 }
 
+.esri-display-object > svg {
+  overflow: visible;
+}
+
 .tableDisplay .btn-group span {
   margin: 10px 0 0 10px;
   font-size: 12px;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -333,6 +333,16 @@ table.dataTable.table-condensed .sorting_desc:after {
   height: auto;
 }
 
+/*
+  Above, the max-width property of img tags inside tableDisplay divs was just
+  set to a percentage (max-width is relative to the parent element). However, the
+  parent elements of Esri map tiles don't have a width, resulting in an invisible
+  map (100% of 0px is 0px)! The below rule corrects for this.
+*/
+.tableDisplay .esri-display-object {
+	width: 100%;
+}
+
 .tableDisplay .btn-group span {
   margin: 10px 0 0 10px;
   font-size: 12px;

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -70,7 +70,6 @@ limitations under the License.
     <!-- endbuild -->
     <link rel="stylesheet" ng-href="assets/styles/looknfeel/{{looknfeel}}.css" />
     <link rel="stylesheet" href="assets/styles/printMode.css" />
-    <link rel="stylesheet" href="//js.arcgis.com/4.0/esri/css/main.css" />
   </head>
   <body ng-class="{'bodyAsIframe': asIframe}">
     <!--[if lt IE 7]>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -70,6 +70,7 @@ limitations under the License.
     <!-- endbuild -->
     <link rel="stylesheet" ng-href="assets/styles/looknfeel/{{looknfeel}}.css" />
     <link rel="stylesheet" href="assets/styles/printMode.css" />
+    <link rel="stylesheet" href="//js.arcgis.com/4.0/esri/css/main.css" />
   </head>
   <body ng-class="{'bodyAsIframe': asIframe}">
     <!--[if lt IE 7]>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -147,6 +147,7 @@ limitations under the License.
     <script src="bower_components/handsontable/dist/handsontable.js"></script>
     <script src="bower_components/moment-duration-format/lib/moment-duration-format.js"></script>
     <script src="bower_components/select2/dist/js/select2.js"></script>
+    <script src="bower_components/angular-esri-map/dist/angular-esri-map.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:js({.tmp,src}) scripts/scripts.js -->

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -66,6 +66,7 @@ module.exports = function(config) {
       'bower_components/moment-duration-format/lib/moment-duration-format.js',
       'bower_components/select2/dist/js/select2.js',
       'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/angular-esri-map/dist/angular-esri-map.js'
       // endbower
       'src/app/app.js',
       'src/app/app.controller.js',

--- a/zeppelin-web/test/spec/controllers/paragraph.js
+++ b/zeppelin-web/test/spec/controllers/paragraph.js
@@ -39,7 +39,7 @@ describe('Controller: ParagraphCtrl', function() {
     'getResultType', 'loadTableData', 'setGraphMode', 'isGraphMode', 'onGraphOptionChange',
     'removeGraphOptionKeys', 'removeGraphOptionValues', 'removeGraphOptionGroups', 'setGraphOptionValueAggr',
     'removeScatterOptionXaxis', 'removeScatterOptionYaxis', 'removeScatterOptionGroup',
-    'removeScatterOptionSize'];
+    'removeScatterOptionSize', 'removeMapOptionLat', 'removeMapOptionLng', 'removeMapOptionPinInfo'];
 
   functions.forEach(function(fn) {
     it('check for scope functions to be defined : ' + fn, function() {


### PR DESCRIPTION
### What is this PR for?
Added a 2D [Esri map](https://developers.arcgis.com/javascript/) as a graph option for paragraphs. This makes it easier to visualize relations in geographical data.
Pins are plotted at points in specified longitude/latitude columns and customizable column values are shown when pins are clicked. Is this of interest?

The angular-esri-map module is used, which is released under the Apache 2.0 license, and the JavaScript API is free to use (see [https://developers.arcgis.com/terms/](https://developers.arcgis.com/terms/)).

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-1220](https://issues.apache.org/jira/browse/ZEPPELIN-1220)

### How should this be tested?
Execute a query in a paragraph and select the map pin from the chart type selector.
Set the longitude/latitude (and optionally, pin info) columns, then interact with the map.

### Screenshot
![screenshot](https://cloud.githubusercontent.com/assets/9356790/16997359/1262d786-4e83-11e6-8230-a906fe1da2e9.png)

### Questions:
* Does the licenses files need update? __yes.__ For angular-esri-map.
* Is there breaking changes for older versions? __no__
* Does this needs documentation? __potentially.__ This feature follows the same layout as the other visualization modes, so users will likely be able to use it easily. However, screenshots of some supported visualizations modes are present in the current documentation. If this PR is merged, it may be desirable to display the map option as well. Interestingly the scatter chart is not included in screenshots in the documentation.