### PR TITLE
[ZEPPELIN-910] New interpreter registration mechanism to HDFSFileInterpreter

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -37,17 +37,6 @@ public class HDFSFileInterpreter extends FileInterpreter {
   static final String HDFS_USER = "hdfs.user";
   static final String HDFS_MAXLENGTH = "hdfs.maxlength";
 
-  static {
-    Interpreter.register(
-        "hdfs",
-        "file",
-        HDFSFileInterpreter.class.getName(),
-        new InterpreterPropertyBuilder()
-            .add(HDFS_URL, "http://localhost:50070/webhdfs/v1/", "The URL for WebHDFS")
-            .add(HDFS_USER, "hdfs", "The WebHDFS user")
-            .add(HDFS_MAXLENGTH, "1000", "Maximum number of lines of results fetched").build());
-  }
-
   Exception exceptionOnConnect = null;
   HDFSCommand cmd = null;
   Gson gson = null;

--- a/file/src/main/resources/interpreter-setting.json
+++ b/file/src/main/resources/interpreter-setting.json
@@ -1,0 +1,27 @@
+[
+  {
+    "group": "file",
+    "name": "hdfs",
+    "className": "org.apache.zeppelin.file.HDFSFileInterpreter",
+    "properties": {
+      "hdfs.url": {
+        "envName": null,
+        "propertyName": "hdfs.url",
+        "defaultValue": "http://localhost:50070/webhdfs/v1/",
+        "description": "The URL for WebHDFS"
+      },
+      "hdfs.user": {
+        "envName": null,
+        "propertyName": "hdfs.user",
+        "defaultValue": "hdfs",
+        "description": "The WebHDFS user"
+      },
+      "hdfs.maxlength": {
+        "envName": null,
+        "propertyName": "hdfs.maxlength",
+        "defaultValue": "1000",
+        "description": "Maximum number of lines of results fetched"
+      }
+    }
+  }
+]


### PR DESCRIPTION
### What is this PR for?
This PR applies the new interpreter registration mechanism to HDFSFileInterpreter

### What type of PR is it?
Improvement

### Todos
Move interpreter registration properties from a static block to interpreter-setting.json

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-910

### How should this be tested?
 1. apply patch
 2. rm conf/interpreter.json
 3. mvn clean package -DskipTests
 4. bin/zeppelin-daemon.sh start
 5. Configure %file interpreter setting according to your HDFS setup
 6. run some paragraph with HDFS file access

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No