### PR TITLE
ZEPPELIN-1222. ClassNotFoundException of SparkJLineCompletion in Spark Interpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -260,7 +260,7 @@ public class SparkInterpreter extends Interpreter {
       jars = (String[]) Utils.invokeStaticMethod(SparkILoop.class, "getAddedJars");
     } else {
       jars = (String[]) Utils.invokeStaticMethod(
-              findClass("org.apache.spark.repl.Main"), "getAddedJars");
+              Utils.findClass("org.apache.spark.repl.Main"), "getAddedJars");
     }
 
     String classServerUri = null;
@@ -577,8 +577,8 @@ public class SparkInterpreter extends Interpreter {
         }
 
         completor = Utils.instantiateClass(
-            "SparkJLineCompletion",
-            new Class[]{findClass("org.apache.spark.repl.SparkIMain")},
+            "org.apache.spark.repl.SparkJLineCompletion",
+            new Class[]{Utils.findClass("org.apache.spark.repl.SparkIMain")},
             new Object[]{intp});
       }
 
@@ -1129,17 +1129,6 @@ public class SparkInterpreter extends Interpreter {
 
   public SparkVersion getSparkVersion() {
     return sparkVersion;
-  }
-
-
-
-  private Class findClass(String name) {
-    try {
-      return this.getClass().forName(name);
-    } catch (ClassNotFoundException e) {
-      logger.error(e.getMessage(), e);
-      return null;
-    }
   }
 
   private File createTempDir(String dir) {


### PR DESCRIPTION
### What is this PR for?

ClassNotFoundException happens because not fully qualified class name is specified. Specify the fully qualified class name in this PR, and remove method findClass in SparkInterpter, use findClass in Utils instead. 

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1222

### How should this be tested?
Manually verified, restart zeppelin server and spark interpreter, this issue is gone. 

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

