### PR TITLE
[ZEPPELIN-1206] fix "name 'z' is not defined" with python3

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -74,7 +74,7 @@ z.show(plt,height='150px') </pre></div>''')
     print ('<h3>Pandas DataFrame</h3>')
     print ('<div> You need to have Pandas module installed ')
     print ('to use this functionality (pip install pandas) !</div><br/>')
-    print """
+    print ("""
 <div>The interpreter can visualize Pandas DataFrame
 with the function z.show()
 <pre>
@@ -82,11 +82,11 @@ import pandas as pd
 df = pd.read_csv("bank.csv", sep=";")
 z.show(df)
 </pre></div>
-"""
+""")
     print ('<h3>SQL over Pandas DataFrame</h3>')
     print ('<div> You need to have Pandas&Pandasql modules installed ')
     print ('to use this functionality (pip install pandas pandasql) !</div><br/>')
-    print """
+    print ("""
 <div>Python interpreter group includes %sql interpreter that can query
 Pandas DataFrames using SQL and visualize results using Zeppelin Table Display System
 
@@ -102,7 +102,7 @@ df = pd.read_csv("bank.csv", sep=";")
 %sql
 SELECT * from df LIMIT 5
 </pre></div>
-"""
+""")
 
 
 class PyZeppelinContext(object):


### PR DESCRIPTION
### What is this PR for?
PythonInterpreter can not use dynamic form with python3.
Fix this problem.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1206

### How should this be tested?
```
%python
print(z.input("test"))
```

Make a note above, and run it.

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
