### PR TITLE
ZEPPELIN-1224: Fix typo in method name

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/DepInterpreter.java
@@ -76,9 +76,9 @@ public class DepInterpreter extends Interpreter {
   private ByteArrayOutputStream out;
   private SparkDependencyContext depc;
   /**
-   * completor - org.apache.spark.repl.SparkJLineCompletion (scala 2.10)
+   * completer - org.apache.spark.repl.SparkJLineCompletion (scala 2.10)
    */
-  private Object completor;
+  private Object completer;
   private SparkILoop interpreter;
   static final Logger LOGGER = LoggerFactory.getLogger(DepInterpreter.class);
 
@@ -176,7 +176,7 @@ public class DepInterpreter extends Interpreter {
     depc = new SparkDependencyContext(getProperty("zeppelin.dep.localrepo"),
                                  getProperty("zeppelin.dep.additionalRemoteRepository"));
     if (Utils.isScala2_10()) {
-      completor = Utils.instantiateClass(
+      completer = Utils.instantiateClass(
           "org.apache.spark.repl.SparkJLineCompletion",
           new Class[]{Utils.findClass("org.apache.spark.repl.SparkIMain")},
           new Object[]{intp});
@@ -286,7 +286,7 @@ public class DepInterpreter extends Interpreter {
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor) {
     if (Utils.isScala2_10()) {
-      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completor, "completer");
+      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completer, "completer");
       Candidates ret = c.complete(buf, cursor);
 
       List<String> candidates = WrapAsJava$.MODULE$.seqAsJavaList(ret.candidates());

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -111,9 +111,9 @@ public class SparkInterpreter extends Interpreter {
   private SparkDependencyResolver dep;
 
   /**
-   * completor - org.apache.spark.repl.SparkJLineCompletion (scala 2.10)
+   * completer - org.apache.spark.repl.SparkJLineCompletion (scala 2.10)
    */
-  private Object completor;
+  private Object completer;
 
   private Map<String, Object> binder;
   private SparkVersion sparkVersion;
@@ -576,7 +576,7 @@ public class SparkInterpreter extends Interpreter {
           }
         }
 
-        completor = Utils.instantiateClass(
+        completer = Utils.instantiateClass(
             "org.apache.spark.repl.SparkJLineCompletion",
             new Class[]{Utils.findClass("org.apache.spark.repl.SparkIMain")},
             new Object[]{intp});
@@ -748,7 +748,7 @@ public class SparkInterpreter extends Interpreter {
       cursor = completionText.length();
     }
     if (Utils.isScala2_10()) {
-      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completor, "completer");
+      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completer, "completer");
       Candidates ret = c.complete(completionText, cursor);
 
       List<String> candidates = WrapAsJava$.MODULE$.seqAsJavaList(ret.candidates());

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -748,7 +748,7 @@ public class SparkInterpreter extends Interpreter {
       cursor = completionText.length();
     }
     if (Utils.isScala2_10()) {
-      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completor, "completor");
+      ScalaCompleter c = (ScalaCompleter) Utils.invokeMethod(completor, "completer");
       Candidates ret = c.complete(completionText, cursor);
 
       List<String> candidates = WrapAsJava$.MODULE$.seqAsJavaList(ret.candidates());


### PR DESCRIPTION
### What is this PR for?
Get  the correct method to invoke, for autocompletion

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1224

### How should this be tested?
Try to get the auto complete suggestion.(`cmd + .`)
We should not get `NoSuchMethodError` and suggestions should be listed rightly

### Screenshots (if appropriate)
NA

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

