### PR TITLE
ZEPPELIN-1225. Errors before the last shell command are ignored

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -69,7 +69,6 @@ public class ShellInterpreter extends Interpreter {
   public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
     LOGGER.debug("Run shell command '" + cmd + "'");
     OutputStream outStream = new ByteArrayOutputStream();
-    OutputStream errStream = new ByteArrayOutputStream();
     
     CommandLine cmdLine = CommandLine.parse(shell);
     // the Windows CMD shell doesn't handle multiline statements,
@@ -82,7 +81,7 @@ public class ShellInterpreter extends Interpreter {
 
     try {
       DefaultExecutor executor = new DefaultExecutor();
-      executor.setStreamHandler(new PumpStreamHandler(outStream, errStream));
+      executor.setStreamHandler(new PumpStreamHandler(outStream, outStream));
       executor.setWatchdog(new ExecuteWatchdog(Long.valueOf(getProperty(TIMEOUT_PROPERTY))));
       executors.put(contextInterpreter.getParagraphId(), executor);
       int exitVal = executor.execute(cmdLine);
@@ -93,7 +92,7 @@ public class ShellInterpreter extends Interpreter {
       int exitValue = e.getExitValue();
       LOGGER.error("Can not run " + cmd, e);
       Code code = Code.ERROR;
-      String message = errStream.toString();
+      String message = outStream.toString();
       if (exitValue == 143) {
         code = Code.INCOMPLETE;
         message += "Paragraph received a SIGTERM.\n";

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.shell;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
@@ -55,5 +56,19 @@ public class ShellInterpreterTest {
     }
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
   }
-  
+
+  @Test
+  public void testInvalidCommand(){
+    shell.open();
+    InterpreterContext context = new InterpreterContext("","1","","",null,null,null,null,null,null,null);
+    InterpreterResult result = new InterpreterResult(Code.ERROR);
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      result = shell.interpret("invalid_command\ndir",context);
+    } else {
+      result = shell.interpret("invalid_command\nls",context);
+    }
+    assertEquals(InterpreterResult.Code.SUCCESS,result.code());
+    assertTrue(result.message().contains("invalid_command"));
+  }
+
 }

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -55,6 +55,10 @@ public class ShellInterpreterTest {
       result = shell.interpret("ls", context);
     }
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertTrue(shell.executors.isEmpty());
+    // it should be fine to cancel a statement that has been completed.
+    shell.cancel(context);
+    assertTrue(shell.executors.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
The problem is that command "bash -c <shell scripts>" will always return 0 as long as the last line of shell script run correctly. e.g the following command will run correctly without any error message.
```
hello
pwd
``` 
This PR will redirect stderr and stdout to the same place, and will display both the stderr and stdout to frontend just like what user see in the native shell terminal. So the output of above command will be as following
```
bash: hello: command not found
/Users/jzhang/github/zeppelin
```

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1225

### How should this be tested?
Unit test is added and also manually verify it on zeppelin notebook. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

