### PR TITLE
[HOTFIX] add scala version to spark-dependencies artifact suffix

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-spark-dependencies</artifactId>
+      <artifactId>zeppelin-spark-dependencies_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
### What is this PR for?
After merging #1186, branch-0.6 build fails on travis because one dependency in `spark/pom.xml`  doesn't have valid artifact name which is `zeppelin-spark-dependencies`.(It should be `zeppelin-spark-dependencies_{scala.binary.version}`)
This dependency only exists in branch-0.6 not master after #1115.

### What type of PR is it?
Hot Fix 

### How should this be tested?
Build and see if error occurs

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

