### PR TITLE
[ZEPPELIN-1228] Make z.show() work with Dataset

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -163,8 +163,15 @@ public class ZeppelinContext {
   public void show(Object o, int maxResult) {
     Class cls = null;
     try {
-      cls = this.getClass().forName("org.apache.spark.sql.DataFrame");
+      cls = this.getClass().forName("org.apache.spark.sql.Dataset");
     } catch (ClassNotFoundException e) {
+    }
+
+    if (cls == null) {
+      try {
+        cls = this.getClass().forName("org.apache.spark.sql.DataFrame");
+      } catch (ClassNotFoundException e) {
+      }
     }
 
     if (cls == null) {
@@ -175,7 +182,7 @@ public class ZeppelinContext {
     }
 
     if (cls == null) {
-      throw new InterpreterException("Can not road DataFrame/SchemaRDD class");
+      throw new InterpreterException("Can not road Dataset/DataFrame/SchemaRDD class");
     }
 
 

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -189,6 +189,13 @@ public class SparkInterpreterTest {
   }
 
   @Test
+  public void testZShow() {
+    repl.interpret("case class Person(name:String, age:Int)\n", context);
+    repl.interpret("val people = sc.parallelize(Seq(Person(\"moon\", 33), Person(\"jobs\", 51), Person(\"gates\", 51), Person(\"park\", 34)))\n", context);
+    assertEquals(Code.SUCCESS, repl.interpret("z.show(people.toDF)", context).code());
+  }
+
+  @Test
   public void testSparkSql(){
     repl.interpret("case class Person(name:String, age:Int)\n", context);
     repl.interpret("val people = sc.parallelize(Seq(Person(\"moon\", 33), Person(\"jobs\", 51), Person(\"gates\", 51), Person(\"park\", 34)))\n", context);


### PR DESCRIPTION
### What is this PR for?
z.show() does not work in spark 2.0


### What type of PR is it?
Bug Fix

### Todos
* [x] - Make z.show() work with dataset
* [x] - add a unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1228

### How should this be tested?
```
case class Data(n:Int)
val data = sc.parallelize(1 to 10).map(i=>Data(i)).toDF
data.registerTempTable("data")
z.show(spark.sql("select * from data"))
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

