### PR TITLE
[Zeppelin-1229] Add cache buster for zeppelin-web build

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -68,6 +68,17 @@ module.exports = function(grunt) {
       src: ['src/**/*.html']
     },
 
+    cacheBust: {
+      taskName: {
+        options: {
+          baseDir: '<%= yeoman.dist %>',
+          assets: ['scripts/**.js', 'styles/**.css'],
+          deleteOriginals: true
+        },
+        src: ['<%= yeoman.dist %>/index.html']
+      }
+    },
+
     'goog-webfont-dl': {
       patuaOne: {
         options: {
@@ -534,7 +545,8 @@ module.exports = function(grunt) {
     'cssmin',
     'uglify',
     'usemin',
-    'htmlmin'
+    'htmlmin',
+    'cacheBust'
   ]);
 
   grunt.registerTask('default', [

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -10,6 +10,7 @@
     "autoprefixer": "^6.1.0",
     "bower": "1.7.2",
     "grunt": "^0.4.1",
+    "grunt-cache-bust": "^1.3.0",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
### What is this PR for?
In order to bust the cache when there is changes to the code of zeppelin-web after build, we are adding hashes at the end of the imported .js and .css files we use.
Every time there is changes in one of those file, the hash will change and the browser will use new file instead of cached one.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1229

### How should this be tested?
* Build zeppelin-web once and write down the HASH in `dist/scripts/scripts.HASH.js`
* After making a change inside a .js file of the application and building again, the hash in `dist/scripts/scripts.HASH.js` should be changed.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No