### PR TITLE
[BugFix] Show checkbox for "Connect to existing process" on interpreter menu.

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -72,8 +72,8 @@ limitations under the License.
 
         <div class="col-md-12" style="padding-left:0px">
           <div class="checkbox">
-            <span class="input-group">
-              <label><input type="checkbox" style="width:0%;height:0%" ng-model="newInterpreterSetting.option.isExistingProcess"/> Connect to existing process </label>
+            <span class="input-group" style="line-height:30px;">
+              <label><input type="checkbox" style="width:20px" ng-model="newInterpreterSetting.option.isExistingProcess"/> Connect to existing process </label>
             </span>
           </div>
         </div>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -173,8 +173,8 @@ limitations under the License.
       <br />
       <div class="col-md-12">
         <div class="checkbox">
-          <span class="input-group">
-            <label><input type="checkbox" style="width:0%;height:0%" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
+          <span class="input-group" style="line-height:30px;">
+            <label><input type="checkbox" style="width:10%;height:70%" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
             Connect to existing process </label>
           </span>
         </div>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -174,7 +174,7 @@ limitations under the License.
       <div class="col-md-12">
         <div class="checkbox">
           <span class="input-group" style="line-height:30px;">
-            <label><input type="checkbox" style="width:10%" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
+            <label><input type="checkbox" style="width:20px" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
             Connect to existing process </label>
           </span>
         </div>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -174,7 +174,7 @@ limitations under the License.
       <div class="col-md-12">
         <div class="checkbox">
           <span class="input-group" style="line-height:30px;">
-            <label><input type="checkbox" style="width:10%;height:70%" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
+            <label><input type="checkbox" style="width:10%" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
             Connect to existing process </label>
           </span>
         </div>


### PR DESCRIPTION
### What is this PR for?
This PR fixes a bug of showing checkbox for "Connect to existing process" on interpreter menu.


### What type of PR is it?
Bug Fix


### How should this be tested?
Go to interpreter menu and check if checkbox for "Connect to existing process" exists.

### Screenshots (if appropriate)
- before
![image](https://cloud.githubusercontent.com/assets/3348133/17141824/aa316672-5388-11e6-952d-50a3769a01a5.png)

- after
![image](https://cloud.githubusercontent.com/assets/3348133/17141840/babfad8c-5388-11e6-9209-e37e252e95b4.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

