### PR TITLE
ZEPPELIN-1197. Should print output directly without invoking function print in pyspark interpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/LogOutputStream.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/LogOutputStream.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.spark;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Minor modification of LogOutputStream of apache commons exec.
+ * LogOutputStream of apache commons exec has one issue that method flush doesn't throw IOException,
+ * so that SparkOutputStream can not extend it correctly.
+ */
+public abstract class LogOutputStream extends OutputStream {
+  private static final int INTIAL_SIZE = 132;
+  private static final int CR = 13;
+  private static final int LF = 10;
+  private final ByteArrayOutputStream buffer;
+  private boolean skip;
+  private final int level;
+
+  public LogOutputStream() {
+    this(999);
+  }
+
+  public LogOutputStream(int level) {
+    this.buffer = new ByteArrayOutputStream(132);
+    this.skip = false;
+    this.level = level;
+  }
+
+  @Override
+  public void write(int cc) throws IOException {
+    byte c = (byte) cc;
+    if (c != 10 && c != 13) {
+      this.buffer.write(cc);
+    } else if (!this.skip) {
+      this.processBuffer();
+    }
+
+    this.skip = c == 13;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (this.buffer.size() > 0) {
+      this.processBuffer();
+    }
+
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (this.buffer.size() > 0) {
+      this.processBuffer();
+    }
+
+    super.close();
+  }
+
+  public int getMessageLevel() {
+    return this.level;
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    int offset = off;
+    int blockStartOffset = off;
+
+    for (int remaining = len; remaining > 0; blockStartOffset = offset) {
+      while (remaining > 0 && b[offset] != 10 && b[offset] != 13) {
+        ++offset;
+        --remaining;
+      }
+
+      int blockLength = offset - blockStartOffset;
+      if (blockLength > 0) {
+        this.buffer.write(b, blockStartOffset, blockLength);
+      }
+
+      while (remaining > 0 && (b[offset] == 10 || b[offset] == 13)) {
+        this.write(b[offset]);
+        ++offset;
+        --remaining;
+      }
+    }
+
+  }
+
+  protected void processBuffer() {
+    this.processLine(this.buffer.toString());
+    this.buffer.reset();
+  }
+
+  protected void processLine(String line) {
+    this.processLine(line, this.level);
+  }
+
+  protected abstract void processLine(String var1, int var2);
+}

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -179,7 +179,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     cmd.addArgument(Integer.toString(port), false);
     cmd.addArgument(Integer.toString(getSparkInterpreter().getSparkVersion().toNumber()), false);
     executor = new DefaultExecutor();
-    outputStream = new SparkOutputStream();
+    outputStream = new SparkOutputStream(logger);
     PipedOutputStream ps = new PipedOutputStream();
     in = null;
     try {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -122,7 +122,7 @@ public class SparkInterpreter extends Interpreter {
 
   public SparkInterpreter(Properties property) {
     super(property);
-    out = new SparkOutputStream();
+    out = new SparkOutputStream(logger);
   }
 
   public SparkInterpreter(Properties property, SparkContext sc) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkOutputStream.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkOutputStream.java
@@ -17,17 +17,20 @@
 package org.apache.zeppelin.spark;
 
 import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * InterpreterOutput can be attached / detached.
  */
-public class SparkOutputStream extends OutputStream {
+public class SparkOutputStream extends LogOutputStream {
+
+  public static Logger logger;
   InterpreterOutput interpreterOutput;
 
-  public SparkOutputStream() {
+  public SparkOutputStream(Logger logger) {
+    this.logger = logger;
   }
 
   public InterpreterOutput getInterpreterOutput() {
@@ -40,6 +43,7 @@ public class SparkOutputStream extends OutputStream {
 
   @Override
   public void write(int b) throws IOException {
+    super.write(b);
     if (interpreterOutput != null) {
       interpreterOutput.write(b);
     }
@@ -47,6 +51,7 @@ public class SparkOutputStream extends OutputStream {
 
   @Override
   public void write(byte [] b) throws IOException {
+    super.write(b);
     if (interpreterOutput != null) {
       interpreterOutput.write(b);
     }
@@ -54,13 +59,20 @@ public class SparkOutputStream extends OutputStream {
 
   @Override
   public void write(byte [] b, int offset, int len) throws IOException {
+    super.write(b, offset, len);
     if (interpreterOutput != null) {
       interpreterOutput.write(b, offset, len);
     }
   }
 
   @Override
+  protected void processLine(String s, int i) {
+    logger.debug("Interpreter output:" + s);
+  }
+
+  @Override
   public void close() throws IOException {
+    super.close();
     if (interpreterOutput != null) {
       interpreterOutput.close();
     }
@@ -68,6 +80,7 @@ public class SparkOutputStream extends OutputStream {
 
   @Override
   public void flush() throws IOException {
+    super.flush();
     if (interpreterOutput != null) {
       interpreterOutput.flush();
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
@@ -139,7 +139,7 @@ public class ZeppelinR implements ExecuteResultHandler {
     cmd.addArgument(libPath);
 
     executor = new DefaultExecutor();
-    outputStream = new SparkOutputStream();
+    outputStream = new SparkOutputStream(logger);
 
     input = new PipedOutputStream();
     PipedInputStream in = new PipedInputStream(input);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -140,6 +140,25 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
           paragraph1Result.getText().toString(), CoreMatchers.equalTo("test loop 0\ntest loop 1\ntest loop 2")
       );
 
+      // the last statement's evaluation result is printed
+      setTextOfParagraph(2, "%pyspark\\n" +
+              "sc.version\\n" +
+              "1+1");
+      runParagraph(2);
+      try {
+        waitForParagraph(2, "FINISHED");
+      } catch (TimeoutException e) {
+        waitForParagraph(2, "ERROR");
+        collector.checkThat("Paragraph from SparkParagraphIT of testPySpark status: ",
+                "ERROR", CoreMatchers.equalTo("FINISHED")
+        );
+      }
+      WebElement paragraph2Result = driver.findElement(By.xpath(
+              getParagraphXPath(2) + "//div[@class=\"tableDisplay\"]"));
+      collector.checkThat("Paragraph from SparkParagraphIT of testPySpark result: ",
+              paragraph2Result.getText().toString(), CoreMatchers.equalTo("2")
+      );
+
     } catch (Exception e) {
       handleException("Exception in SparkParagraphIT while testPySpark", e);
     }


### PR DESCRIPTION
### What is this PR for?
For now, user need to invoke print to make the output displayed on the notebook. This behavior is not natural and consistent with other notebooks. This PR is to make the pyspark interpreter in zeppelin behave the same as other notebook. 2 main changes 
* use single mode to compile the last statement, so that the evaluation result of the last statement will be printed to stdout, this is consistent with other notebooks (like jupyter)
* Make SparkOutputStream extends LogOutputStream so that we can see the output of inner process (Python/R), it is helpful for diagnosing. 

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1197

### How should this be tested?
Tested it manually. Input the following text in pyspark paragraph,
```
1+1
sc.version
```
And get the following output
```
u'1.6.1'
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? User don't need to call print explicitly. 
* Does this needs documentation? Yes

