### PR TITLE
ZEPPELIN-1115: add correct %python.sql interpreter name to configuration

### DIFF
--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -21,7 +21,7 @@
   {
     "group": "python",
     "name": "sql",
-    "className": "org.apache.zeppelin.python.PythonPandasSqlInterpreter",
+    "className": "org.apache.zeppelin.python.PythonInterpreterPandasSql",
     "properties": { }
   }
 ]

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -508,7 +508,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         + "org.apache.zeppelin.postgresql.PostgreSqlInterpreter,"
         + "org.apache.zeppelin.flink.FlinkInterpreter,"
         + "org.apache.zeppelin.python.PythonInterpreter,"
-        + "org.apache.zeppelin.python.PythonPandasSqlInterpreter,"
+        + "org.apache.zeppelin.python.PythonInterpreterPandasSql,"
         + "org.apache.zeppelin.ignite.IgniteInterpreter,"
         + "org.apache.zeppelin.ignite.IgniteSqlInterpreter,"
         + "org.apache.zeppelin.lens.LensInterpreter,"


### PR DESCRIPTION
### What is this PR for?
Hotfix for [ZEPPELIN-1244](https://issues.apache.org/jira/browse/ZEPPELIN-1244)

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1244](https://issues.apache.org/jira/browse/ZEPPELIN-1244)

### How should this be tested?
Remove interpreter configuration and try `%python.sql` i.e over [bank.csv](http://mlr.cs.umass.edu/ml/datasets/Bank+Marketing) read as `pandas.dataframe`
```
#stop zeppelin
rm conf/interpreter-setting.json
#start zeppelin


%python
import pandas as pd
rates = pd.read_csv("http://www3.dsi.uminho.pt/pcortez/data/bank.csv", sep=";")

%python.sql
SELECT * FROM rates LIMIT 10
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

