### PR TITLE
[HOTFIX][ZEPPELIN-1240] Removed interpreter properties are restored

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -912,8 +912,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       throws InterpreterException {
     logger.info("Create repl {} from {}", className, dirName);
 
-    updatePropertiesFromRegisteredInterpreter(property, className);
-
     ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
     try {
 
@@ -984,9 +982,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     String localRepoPath = conf.getInterpreterLocalRepoPath() + "/" + interpreterSettingId;
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
 
-    updatePropertiesFromRegisteredInterpreter(property, className);
-
-
     RemoteInterpreter remoteInterpreter =
         new RemoteInterpreter(property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
             interpreterPath, localRepoPath, connectTimeout, maxPoolSize,
@@ -994,22 +989,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     remoteInterpreter.setEnv(env);
 
     return new LazyOpenInterpreter(remoteInterpreter);
-  }
-
-  private Properties updatePropertiesFromRegisteredInterpreter(Properties properties,
-      String className) {
-    RegisteredInterpreter registeredInterpreter =
-        Interpreter.findRegisteredInterpreterByClassName(className);
-    if (null != registeredInterpreter) {
-      Map<String, InterpreterProperty> defaultProperties = registeredInterpreter.getProperties();
-      for (String key : defaultProperties.keySet()) {
-        if (!properties.containsKey(key) && null != defaultProperties.get(key).getValue()) {
-          properties.setProperty(key, defaultProperties.get(key).getValue());
-        }
-      }
-    }
-
-    return properties;
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -505,7 +505,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     setting.setGroup(group);
     setting.appendDependencies(dependencies);
     setting.setInterpreterOption(option);
-    setting.updateProperties(p);
+    setting.setProperties(p);
     setting.setInterpreterGroupFactory(this);
     interpreterSettings.put(setting.getId(), setting);
     saveToFile();
@@ -837,7 +837,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         intpsetting.closeAndRmoveAllInterpreterGroups();
 
         intpsetting.setOption(option);
-        intpsetting.updateProperties(properties);
+        intpsetting.setProperties(properties);
         intpsetting.setDependencies(dependencies);
 
         loadInterpreterDependencies(intpsetting);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -206,6 +206,10 @@ public class InterpreterSetting {
     this.properties.putAll(p);
   }
 
+  void setProperties(Properties p) {
+    this.properties = p;
+  }
+
   void setGroup(String group) {
     this.group = group;
   }


### PR DESCRIPTION
### What is this PR for?
Fixing the bug that users cannot delete some interpreter settings from interpreter tab.

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos
* [x] - Changed `update` to `set`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1240

### How should this be tested?
1. Make new interpreter via interpreter tab
1. remove some properties

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

