### PR TITLE
[ZEPPELIN-1250] remove 2.11 suffix from zeppelin-server

### DIFF
--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -75,7 +75,7 @@
 
   <dependencies>
     <dependency>
-      <artifactId>zeppelin-server_2.10</artifactId>
+      <artifactId>zeppelin-server</artifactId>
       <groupId>${project.groupId}</groupId>
       <version>${project.version}</version>
     </dependency>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-server_2.10</artifactId>
+  <artifactId>zeppelin-server</artifactId>
   <packaging>jar</packaging>
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Server</name>


### PR DESCRIPTION
### What is this PR for?
Remove 2.11 suffix from zeppelin-server since it uses scala dependencies only for test, so doesn't need to separate the artifact by scala version

### What type of PR is it?
Build

### What is the Jira issue?
[ZEPPELIN-1250](https://issues.apache.org/jira/browse/ZEPPELIN-1250)

### Screenshots (if appropriate)
Attaching result of compatibility between zeppelin-server_2.10, zeppelin-server_2.11.
![screen shot 2016-07-29 at 6 22 32 pm](https://cloud.githubusercontent.com/assets/8503346/17243801/87b2a90c-55b9-11e6-8fd3-d4ccd51a5e80.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

