### PR TITLE
ZEPPELIN-1225. Errors before the last shell command are ignored

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -79,8 +79,8 @@ public class ShellInterpreter extends Interpreter {
     }
     cmdLine.addArgument(cmd, false);
     DefaultExecutor executor = new DefaultExecutor();
-    ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
-    executor.setStreamHandler(new PumpStreamHandler(contextInterpreter.out, errorStream));
+    executor.setStreamHandler(new PumpStreamHandler(contextInterpreter.out,
+            contextInterpreter.out));
     executor.setWatchdog(new ExecuteWatchdog(commandTimeOut));
 
     Job runningJob = getRunningJob(contextInterpreter.getParagraphId());
@@ -95,7 +95,14 @@ public class ShellInterpreter extends Interpreter {
       int exitValue = e.getExitValue();
       logger.error("Can not run " + cmd, e);
       Code code = Code.ERROR;
-      String msg = errorStream.toString();
+      String msg = null;
+      try {
+        contextInterpreter.out.flush();
+        msg = new String(contextInterpreter.out.toByteArray());
+      } catch (IOException e1) {
+        logger.error(e1.getMessage());
+        msg = e1.getMessage();
+      }
       if (exitValue == 143) {
         code = Code.INCOMPLETE;
         msg = msg + "Paragraph received a SIGTERM.\n";


### PR DESCRIPTION
What is this PR for?

The problem is that command "bash -c " will always return 0 as long as the last line of shell script run correctly. e.g the following command will run correctly without any error message.

hello
pwd
This PR will redirect stderr and stdout to the same place, and will display both the stderr and stdout to frontend just like what user see in the native shell terminal. So the output of above command will be as following

bash: hello: command not found
/Users/jzhang/github/zeppelin
What type of PR is it?

[Bug Fix]

What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1225
How should this be tested?

Unit test is added and also manually verify it on zeppelin notebook.

Screenshots (if appropriate)

Questions:

Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? No