### PR TITLE
ZEPPELIN-1254 Make get and save Interpreter bindings calls via websocket

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -20,7 +20,6 @@ package org.apache.zeppelin.rest;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,18 +38,18 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.utils.InterpreterBindingUtils;
 import org.quartz.CronExpression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.zeppelin.annotation.ZeppelinApi;
-import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.rest.message.CronRequest;
-import org.apache.zeppelin.rest.message.InterpreterSettingListForNoteBind;
+import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.rest.message.NewNotebookRequest;
 import org.apache.zeppelin.rest.message.NewParagraphRequest;
 import org.apache.zeppelin.rest.message.RunParagraphWithParametersRequest;
@@ -186,29 +185,8 @@ public class NotebookRestApi {
   @Path("interpreter/bind/{noteId}")
   @ZeppelinApi
   public Response bind(@PathParam("noteId") String noteId) {
-    List<InterpreterSettingListForNoteBind> settingList = new LinkedList<>();
-
-    List<InterpreterSetting> selectedSettings = notebook.getBindedInterpreterSettings(noteId);
-    for (InterpreterSetting setting : selectedSettings) {
-      settingList.add(new InterpreterSettingListForNoteBind(setting.getId(), setting.getName(),
-          setting.getInterpreterInfos(), true));
-    }
-
-    List<InterpreterSetting> availableSettings = notebook.getInterpreterFactory().get();
-    for (InterpreterSetting setting : availableSettings) {
-      boolean selected = false;
-      for (InterpreterSetting selectedSetting : selectedSettings) {
-        if (selectedSetting.getId().equals(setting.getId())) {
-          selected = true;
-          break;
-        }
-      }
-
-      if (!selected) {
-        settingList.add(new InterpreterSettingListForNoteBind(setting.getId(), setting.getName(),
-            setting.getInterpreterInfos(), false));
-      }
-    }
+    List<InterpreterSettingsList> settingList =
+        InterpreterBindingUtils.getInterpreterBindings(notebook, noteId);
     return new JsonResponse<>(Status.OK, "", settingList).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -187,6 +187,7 @@ public class NotebookRestApi {
   public Response bind(@PathParam("noteId") String noteId) {
     List<InterpreterSettingsList> settingList =
         InterpreterBindingUtils.getInterpreterBindings(notebook, noteId);
+    notebookServer.broadcastInterpreterBindings(noteId, settingList);
     return new JsonResponse<>(Status.OK, "", settingList).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -436,7 +436,8 @@ public class NotebookServer extends WebSocketServlet implements
     String noteID = (String) fromMessage.data.get("noteID");
     List<InterpreterSettingsList> settingList =
         InterpreterBindingUtils.getInterpreterBindings(notebook(), noteID);
-    broadcastInterpreterBindings(noteID, settingList);
+    conn.send(serializeMessage(new Message(OP.INTERPRETER_BINDINGS)
+        .put("interpreterBindings", settingList)));
   }
 
   public List<Map<String, String>> generateNotebooksInfo(boolean needsReload,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/types/InterpreterSettingsList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/types/InterpreterSettingsList.java
@@ -31,7 +31,7 @@ public class InterpreterSettingsList {
   private List<InterpreterInfo> interpreters;
 
   public InterpreterSettingsList(String id, String name,
-                                 List<InterpreterInfo> interpreters, boolean selected) {
+      List<InterpreterInfo> interpreters, boolean selected) {
     this.id = id;
     this.name = name;
     this.interpreters = interpreters;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/types/InterpreterSettingsList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/types/InterpreterSettingsList.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.rest.message;
+package org.apache.zeppelin.types;
 
 import java.util.List;
 
@@ -24,14 +24,14 @@ import org.apache.zeppelin.interpreter.InterpreterInfo;
 /**
  * InterpreterSetting information for binding
  */
-public class InterpreterSettingListForNoteBind {
+public class InterpreterSettingsList {
   private String id;
   private String name;
   private boolean selected;
   private List<InterpreterInfo> interpreters;
 
-  public InterpreterSettingListForNoteBind(String id, String name,
-      List<InterpreterInfo> interpreters, boolean selected) {
+  public InterpreterSettingsList(String id, String name,
+                                 List<InterpreterInfo> interpreters, boolean selected) {
     this.id = id;
     this.name = name;
     this.interpreters = interpreters;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/InterpreterBindingUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/InterpreterBindingUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.utils;
+
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.types.InterpreterSettingsList;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Utils for interpreter bindings
+ */
+public class InterpreterBindingUtils {
+  public static List<InterpreterSettingsList> getInterpreterBindings(Notebook notebook,
+                                                                     String noteId) {
+    List<InterpreterSettingsList> settingList = new LinkedList<>();
+    List<InterpreterSetting> selectedSettings =
+        notebook.getBindedInterpreterSettings(noteId);
+    for (InterpreterSetting setting : selectedSettings) {
+      settingList.add(new InterpreterSettingsList(setting.getId(), setting.getName(),
+          setting.getInterpreterInfos(), true));
+    }
+
+    List<InterpreterSetting> availableSettings = notebook.getInterpreterFactory().get();
+    for (InterpreterSetting setting : availableSettings) {
+      boolean selected = false;
+      for (InterpreterSetting selectedSetting : selectedSettings) {
+        if (selectedSetting.getId().equals(setting.getId())) {
+          selected = true;
+          break;
+        }
+      }
+
+      if (!selected) {
+        settingList.add(new InterpreterSettingsList(setting.getId(), setting.getName(),
+            setting.getInterpreterInfos(), false));
+      }
+    }
+
+    return settingList;
+  }
+}

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -450,22 +450,13 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
   };
 
   var getInterpreterBindings = function(callback) {
-    $http.get(baseUrlSrv.getRestApiBase() + '/notebook/interpreter/bind/' + $scope.note.id).
-    success(function(data, status, headers, config) {
-      $scope.interpreterBindings = data.body;
-      $scope.interpreterBindingsOrig = angular.copy($scope.interpreterBindings); // to check dirty
-      if (callback) {
-        callback();
-      }
-    }).
-    error(function(data, status, headers, config) {
-      if (status !== 0) {
-        console.log('Error %o %o', status, data.message);
-      }
-    });
+    websocketMsgSrv.getInterpreterBindings($scope.note.id);
   };
 
-  var getInterpreterBindingsCallBack = function() {
+  $scope.$on('interpreterBindings', function(event, data) {
+    $scope.interpreterBindings = data.interpreterBindings;
+    $scope.interpreterBindingsOrig = angular.copy($scope.interpreterBindings); // to check dirty
+
     var selected = false;
     var key;
     var setting;
@@ -490,7 +481,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
       }
       $scope.showSetting = true;
     }
-  };
+  });
 
   $scope.interpreterSelectionListeners = {
     accept: function(sourceItemHandleScope, destSortableScope) {return true;},
@@ -530,16 +521,9 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
         selectedSettingIds.push(setting.id);
       }
     }
-
-    $http.put(baseUrlSrv.getRestApiBase() + '/notebook/interpreter/bind/' + $scope.note.id,
-              selectedSettingIds).
-    success(function(data, status, headers, config) {
-      console.log('Interpreter binding %o saved', selectedSettingIds);
-      $scope.showSetting = false;
-    }).
-    error(function(data, status, headers, config) {
-      console.log('Error %o %o', status, data.message);
-    });
+    websocketMsgSrv.saveInterpreterBindings($scope.note.id, selectedSettingIds);
+    console.log('Interpreter bindings %o saved', selectedSettingIds);
+    $scope.showSetting = false;
   };
 
   $scope.toggleSetting = function() {
@@ -983,7 +967,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
     initializeLookAndFeel();
     //open interpreter binding setting when there're none selected
-    getInterpreterBindings(getInterpreterBindingsCallBack);
+    getInterpreterBindings(); //getInterpreterBindings(getInterpreterBindingsCallBack);
   });
 
   $scope.$on('$destroy', function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -449,7 +449,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
   };
 
-  var getInterpreterBindings = function(callback) {
+  var getInterpreterBindings = function() {
     websocketMsgSrv.getInterpreterBindings($scope.note.id);
   };
 
@@ -967,7 +967,7 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     }
     initializeLookAndFeel();
     //open interpreter binding setting when there're none selected
-    getInterpreterBindings(); //getInterpreterBindings(getInterpreterBindingsCallBack);
+    getInterpreterBindings();
   });
 
   $scope.$on('$destroy', function() {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -113,6 +113,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('listRevisionHistory', data);
     } else if (op === 'NOTE_REVISION') {
       $rootScope.$broadcast('noteRevision', data);
+    } else if (op === 'INTERPRETER_BINDINGS') {
+      $rootScope.$broadcast('interpreterBindings', data);
     }
   });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -196,6 +196,15 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
 
     unsubscribeJobManager: function() {
       websocketEvents.sendNewEvent({op: 'UNSUBSCRIBE_JOBMANAGER'});
+    },
+
+    getInterpreterBindings: function(noteID) {
+      websocketEvents.sendNewEvent({op: 'GET_INTERPRETER_BINDINGS', data: {noteID: noteID}});
+    },
+
+    saveInterpreterBindings: function(noteID, selectedSettingIds) {
+      websocketEvents.sendNewEvent({op: 'SAVE_INTERPRETER_BINDINGS',
+        data: {noteID: noteID, selectedSettingIds: selectedSettingIds}});
     }
 
   };

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -7,7 +7,8 @@ describe('Controller: NotebookCtrl', function() {
 
   var websocketMsgSrvMock = {
     getNotebook: function() {},
-    listRevisionHistory: function() {}
+    listRevisionHistory: function() {},
+    getInterpreterBindings: function() {}
   };
 
   var baseUrlSrvMock = {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -127,8 +127,14 @@ public class Message {
     APP_STATUS_CHANGE,      // [s-c] on app status change
 
     LIST_NOTEBOOK_JOBS,     // [c-s] get notebook job management infomations
-    LIST_UPDATE_NOTEBOOK_JOBS // [c-s] get job management informations for until unixtime
+    LIST_UPDATE_NOTEBOOK_JOBS, // [c-s] get job management informations for until unixtime
                                // @param unixTime
+    GET_INTERPRETER_BINDINGS, // [c-s] get interpreter bindings
+                              // @param noteID
+    SAVE_INTERPRETER_BINDINGS, // [c-s] save interpreter bindings
+                               // @param noteID
+                               // @param selectedSettingIds
+    INTERPRETER_BINDINGS // [s-c] interpreter bindings
   }
 
   public OP op;


### PR DESCRIPTION
### What is this PR for?
This PR uses websocket to get and save interpreter bindings instead of rest api

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1254

### How should this be tested?
Go to interpreter binding settings on notebook page and enable/disable interpreter or reorder and save. Simultaneously verify the network calls on browser's console.

### Screenshots (if appropriate)
n/a
### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

