### PR TITLE
[ZEPPELIN-1255] Add cast to string in z.show() for Pandas DataFrame

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -140,19 +140,19 @@ class PyZeppelinContext(object):
         """
         limit = len(df) > self.max_result
         header_buf = io.StringIO("")
-        header_buf.write(df.columns[0])
+        header_buf.write(str(df.columns[0]))
         for col in df.columns[1:]:
             header_buf.write("\t")
-            header_buf.write(col)
+            header_buf.write(str(col))
         header_buf.write("\n")
         
         body_buf = io.StringIO("")
         rows = df.head(self.max_result).values if limit else df.values
         for row in rows:
-            body_buf.write(row[0])
+            body_buf.write(str(row[0]))
             for cell in row[1:]:
                 body_buf.write("\t")
-                body_buf.write(cell)
+                body_buf.write(str(cell))
             body_buf.write("\n")
         body_buf.seek(0); header_buf.seek(0)
         #TODO(bzz): fix it, so it shows red notice, as in Spark

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -153,4 +153,24 @@ public class PythonInterpreterPandasSqlTest {
     assertTrue(ret.message().length() > 0);
   }
 
+  @Test
+  public void showDataFrame() {
+    InterpreterResult ret;
+    ret = python.interpret("import pandas as pd", context);
+    ret = python.interpret("import numpy as np", context);
+
+    // given a Pandas DataFrame with non-text data
+    ret = python.interpret("d1 = {1 : [np.nan, 1, 2, 3], 'two' : [3., 4., 5., 6.7]}", context);
+    ret = python.interpret("df1 = pd.DataFrame(d1)", context);
+    assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());
+
+    // when
+    ret = python.interpret("z.show(df1)", context);
+
+    // then
+    assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(ret.message(), Type.TABLE, ret.type());
+    assertTrue(ret.message().indexOf("nan") > 0);
+    assertTrue(ret.message().indexOf("6.7") > 0);
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Casting data types in Pandas DataFrame to string in z.show()

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1255](https://issues.apache.org/jira/browse/ZEPPELIN-1255)

### How should this be tested?
```
%python

import pandas as pd

df = pd.read_csv('https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data', header=None)
df.columns=[1, 2, 3, 'PetalWidth', 'Name']
z.show(df)

%python.sql

SELECT * FROM df  LIMIT 10
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

