### PR TITLE
[HOTFIX] change 1.5-SNAPSHOT to 1.5-20160502.230123-45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,17 +341,16 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
         <executions>
           <execution>
+            <id>process-remote-resources</id>
             <goals>
               <goal>process</goal>
             </goals>
             <configuration>
               <resourceBundles>
-                <!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
                 <resourceBundle>org.apache:apache-jar-resource-bundle:1.0</resourceBundle>
               </resourceBundles>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
             <configuration>
               <resourceBundles>
                 <!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
-                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-20160502.230123-45</resourceBundle>
+                <resourceBundle>org.apache:apache-jar-resource-bundle:1.0</resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
             <configuration>
               <resourceBundles>
                 <!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
-                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
+                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-20160502.230123-45</resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>


### PR DESCRIPTION
### What is this PR for?
This is to fix CI which is mostly failing for resource org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT, until the resource is generated in https://repository.apache.org/content/groups/snapshots/org/apache/apache/resources/apache-jar-resource-bundle/1.5-SNAPSHOT/


### What type of PR is it?
[Hot Fix]


### How should this be tested?
CI should be green



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

