### PR TITLE
[ZEPPELIN-1256][BUILD] Build distribution package with Spark 2.0 and Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,15 @@ matrix:
   include:
     # Test all modules with spark 2.0.0 and scala 2.11
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.0.0" HADOOP_VER="2.3" PROFILE="-Pspark-2.0 -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Dscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.11" SPARK_VER="2.0.0" HADOOP_VER="2.3" PROFILE="-Pspark-2.0 -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test all modules with scala 2.10
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.10" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.10" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.10" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test all modules with scala 2.11
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Dscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.11" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test spark module for 1.5.2
     - jdk: "oraclejdk7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,17 @@ addons:
 
 matrix:
   include:
-    # Test all modules with spark-2.0.0-preview and scala 2.11
+    # Test all modules with spark 2.0.0 and scala 2.11
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.0.0" HADOOP_VER="2.3" PROFILE="-Pspark-2.0 -Dspark.version=2.0.0-preview -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.11" SPARK_VER="2.0.0" HADOOP_VER="2.3" PROFILE="-Pspark-2.0 -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Dscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test all modules with scala 2.10
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.10" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.10" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.10" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test all modules with scala 2.11
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
+      env: SCALA_VER="2.11" SPARK_VER="1.6.1" HADOOP_VER="2.3" PROFILE="-Pspark-1.6 -Pr -Phadoop-2.3 -Ppyspark -Psparkr -Pscalding -Pexamples -Dscala-2.11" BUILD_FLAG="package -Pbuild-distr" TEST_FLAG="verify -Pusing-packaged-distr" TEST_PROJECTS=""
 
     # Test spark module for 1.5.2
     - jdk: "oraclejdk7"

--- a/README.md
+++ b/README.md
@@ -158,9 +158,15 @@ Available profiles are
 
 minor version can be adjusted by `-Dhadoop.version=x.x.x`
 
-##### `-Dscala-2.11 (optional)`
+##### `-Pscala-[version] (optional)`
 
-build with Scala 2.11. If you don't define this property, Zeppelin will be built with Scala 2.10.
+set scala version (default 2.10)
+Available profiles are
+
+```
+-Pscala-2.10
+-Pscala-2.11
+```
 
 ##### `-Pyarn` (optional)
 
@@ -212,7 +218,7 @@ Here're some examples:
 ```sh
 # build with spark-2.0, scala-2.11
 ./dev/change_scala_version.sh 2.11
-mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Dscala-2.11
+mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11
 
 # build with spark-1.6, scala-2.10
 mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr
@@ -298,11 +304,11 @@ For configuration details check __`./conf`__ subdirectory.
 
 ### Building for Scala 2.11
 
-To produce a Zeppelin package compiled with Scala 2.11, use the -Dscala-2.11 profile:
+To produce a Zeppelin package compiled with Scala 2.11, use the -Pscala-2.11 profile:
 
 ```
 ./dev/change_scala_version.sh 2.11
-mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Dscala-2.11 -DskipTests clean install
+mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests clean install
 ```
 
 ### Package

--- a/README.md
+++ b/README.md
@@ -158,15 +158,9 @@ Available profiles are
 
 minor version can be adjusted by `-Dhadoop.version=x.x.x`
 
-##### `-Pscala-[version] (optional)`
+##### `-Dscala-2.11 (optional)`
 
-set scala version (default 2.10)
-Available profiles are
-
-```
--Pscala-2.10
--Pscala-2.11
-```
+build with Scala 2.11. If you don't define this property, Zeppelin will be built with Scala 2.10.
 
 ##### `-Pyarn` (optional)
 
@@ -217,7 +211,8 @@ Here're some examples:
 
 ```sh
 # build with spark-2.0, scala-2.11
-mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11
+./dev/change_scala_version.sh 2.11
+mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Dscala-2.11
 
 # build with spark-1.6, scala-2.10
 mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr
@@ -303,10 +298,11 @@ For configuration details check __`./conf`__ subdirectory.
 
 ### Building for Scala 2.11
 
-To produce a Zeppelin package compiled with Scala 2.11, use the -Pscala-2.11 profile:
+To produce a Zeppelin package compiled with Scala 2.11, use the -Dscala-2.11 profile:
 
 ```
-mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests clean install
+./dev/change_scala_version.sh 2.11
+mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Dscala-2.11 -DskipTests clean install
 ```
 
 ### Package

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -103,8 +103,8 @@ function make_binary_release() {
 
 git_clone
 make_source_package
-make_binary_release all "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Dscala-2.11"
-make_binary_release netinst "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Dscala-2.11 -pl !alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
+make_binary_release all "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Pscala-2.11"
+make_binary_release netinst "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Pscala-2.11 -pl !alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -66,6 +66,7 @@ function make_binary_release() {
 
   cp -r "${WORKING_DIR}/zeppelin" "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
   cd "${WORKING_DIR}/zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
+  ./dev/change_scala_version.sh 2.11
   echo "mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}"
   mvn clean package -Pbuild-distr -DskipTests ${BUILD_FLAGS}
   if [[ $? -ne 0 ]]; then
@@ -102,8 +103,8 @@ function make_binary_release() {
 
 git_clone
 make_source_package
-make_binary_release all "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
-make_binary_release netinst "-Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -pl !alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
+make_binary_release all "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Dscala-2.11"
+make_binary_release netinst "-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr -Dscala-2.11 -pl !alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!markdown,!postgresql,!python,!shell"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -94,9 +94,9 @@ function publish_to_maven() {
 
   # build with scala-2.10
   echo "mvn clean install -Ppublish-distr \
-    -Dmaven.repo.local=${tmp_repo} -Pscala-2.10 \
+    -Dmaven.repo.local=${tmp_repo} \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.10 \
+  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.10 failed."
@@ -107,9 +107,9 @@ function publish_to_maven() {
   "${BASEDIR}/change_scala_version.sh" 2.11
 
   echo "mvn clean install -Ppublish-distr \
-    -Dmaven.repo.local=${tmp_repo} -Pscala-2.11 \
+    -Dmaven.repo.local=${tmp_repo} -Dscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.11 \
+  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Dscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.11 failed."

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -94,9 +94,9 @@ function publish_to_maven() {
 
   # build with scala-2.10
   echo "mvn clean install -Ppublish-distr \
-    -Dmaven.repo.local=${tmp_repo} \
+    -Dmaven.repo.local=${tmp_repo} -Pscala-2.10 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" \
+  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.10 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.10 failed."
@@ -107,9 +107,9 @@ function publish_to_maven() {
   "${BASEDIR}/change_scala_version.sh" 2.11
 
   echo "mvn clean install -Ppublish-distr \
-    -Dmaven.repo.local=${tmp_repo} -Dscala-2.11 \
+    -Dmaven.repo.local=${tmp_repo} -Pscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Dscala-2.11 \
+  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.11 failed."

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -94,7 +94,8 @@ Here are some examples with several options
 
 ```
 # build with spark-2.0, scala-2.11
-mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11
+./dev/change_scala_version.sh 2.11
+mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Dscala-2.11
 
 # build with spark-1.6, scala-2.10
 mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -95,7 +95,7 @@ Here are some examples with several options
 ```
 # build with spark-2.0, scala-2.11
 ./dev/change_scala_version.sh 2.11
-mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Dscala-2.11
+mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11
 
 # build with spark-1.6, scala-2.10
 mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr

--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -84,6 +84,15 @@ If you install one of these interpreters only with `--name` option, installer wi
 ./bin/install-interpreter.sh --name flink --artifact org.apache.zeppelin:zeppelin-flink_2.10:0.6.1
 ```
 
+#### Install Spark interpreter built with Scala 2.10
+Spark distribution package has been built with Scala 2.10 until 1.6.2. If you have `SPARK_HOME` set pointing to Spark version ealier than 2.0.0, you need to download Spark interpreter packaged with Scala 2.10. To do so, use follow command:
+
+```
+rm -rf ./interpreter/spark
+./bin/install-interpreter.sh --name spark --artifact org.apache.zeppelin:zeppelin-spark_2.10:0.6.1
+```
+
+<br />
 Once you have installed interpreters, you need to restart Zeppelin. And then [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -652,7 +652,7 @@
     <profile>
       <id>scala-2.10</id>
       <activation>
-        <property><name>!scala-2.11</name></property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
         <scala.version>2.10.5</scala.version>
@@ -662,9 +662,6 @@
 
     <profile>
       <id>scala-2.11</id>
-      <activation>
-        <property><name>scala-2.11</name></property>
-      </activation>
       <properties>
         <scala.version>2.11.7</scala.version>
         <scala.binary.version>2.11</scala.binary.version>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -380,7 +380,7 @@
     <profile>
       <id>scala-2.10</id>
       <activation>
-        <property><name>!scala-2.11</name></property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
         <extra.source.dir>src/main/scala-2.10</extra.source.dir>
@@ -390,9 +390,6 @@
 
     <profile>
       <id>scala-2.11</id>
-      <activation>
-        <property><name>scala-2.11</name></property>
-      </activation>
       <properties>
         <extra.source.dir>src/main/scala-2.11</extra.source.dir>
         <extra.testsource.dir>src/test/scala/scala-2.11</extra.testsource.dir>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -94,10 +94,6 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
-      <activation>
-        <property><name>scala-2.11</name></property>
-      </activation>
-
       <dependencies>
         <dependency>
           <groupId>org.scala-lang.modules</groupId>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -114,10 +114,6 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
-      <activation>
-        <property><name>scala-2.11</name></property>
-      </activation>
-
       <dependencyManagement>
         <dependencies>
           <dependency>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -413,10 +413,6 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
-      <activation>
-        <property><name>scala-2.11</name></property>
-      </activation>
-
       <dependencyManagement>
         <dependencies>
           <dependency>


### PR DESCRIPTION
### What is this PR for?
- build distribution package with Spark 2.0 and Scala 2.11
- change travis profile to use spark 2.0 instead of 2.0.0-preview by removing `-Dspark.version=2.0.0-preview` property
- Change profile activation rule 
  * current way of profile activation is not proper for supporting more than three scala version
  * -Pscala-2.11 activates both scala-2.10 and scala-2.11 profile without this patch

### What type of PR is it?
Build

### What is the Jira issue?
[ZEPPELIN-1256](https://issues.apache.org/jira/browse/ZEPPELIN-1256)

### How should this be tested?

**Before**
Run `mvn help:active-profiles -Pscala-2.11`:
   ```
Active Profiles for Project 'org.apache.zeppelin:zeppelin:pom:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-interpreter:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-zengine:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-display_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-display_2.11:0.7.0-SNAPSHOT)
 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-spark-dependencies_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - spark-2.0 (source: org.apache.zeppelin:zeppelin-spark-dependencies_2.11:0.7.0-SNAPSHOT)
 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-spark_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - exclude-sparkr (source: org.apache.zeppelin:zeppelin-spark_2.11:0.7.0-SNAPSHOT)
 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-markdown:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-angular:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-shell:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-livy:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-hbase:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-postgresql:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-jdbc:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-file:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-flink_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-ignite_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-kylin:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-python:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-lens:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-cassandra_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-elasticsearch:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-alluxio:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-web:war:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-server:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-server:0.7.0-SNAPSHOT)
 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-distribution:pom:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-distribution:0.7.0-SNAPSHOT)
 - scala-2.10 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
```

**After**
Run `mvn help:active-profiles -Dscala-2.11`:
   ```
Active Profiles for Project 'org.apache.zeppelin:zeppelin:pom:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-interpreter:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-zengine:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-display_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-display_2.11:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-spark-dependencies_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - spark-2.0 (source: org.apache.zeppelin:zeppelin-spark-dependencies_2.11:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-spark_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - exclude-sparkr (source: org.apache.zeppelin:zeppelin-spark_2.11:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-markdown:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-angular:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-shell:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-livy:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-hbase:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-postgresql:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-jdbc:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-file:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-flink_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-ignite_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-kylin:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-python:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-lens:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-cassandra_2.11:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-elasticsearch:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-alluxio:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-web:war:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-server:jar:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-server:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)



Active Profiles for Project 'org.apache.zeppelin:zeppelin-distribution:pom:0.7.0-SNAPSHOT':

The following profiles are active:

 - scala-2.11 (source: org.apache.zeppelin:zeppelin-distribution:0.7.0-SNAPSHOT)
 - scala-2.11 (source: org.apache.zeppelin:zeppelin:0.7.0-SNAPSHOT)
```


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes (for scala 2.11 build)

