### PR TITLE
[ZEPPELIN-1257] storage - fix get note revision api

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1201,12 +1201,12 @@ public class NotebookServer extends WebSocketServlet implements
   private void getNoteRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)
       throws IOException {
     String noteId = (String) fromMessage.get("noteId");
-    Revision revision = (Revision) fromMessage.get("revision");
+    String revisionId = (String) fromMessage.get("revisionId");
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-    Note revisionNote = notebook.getNoteRevision(noteId, revision, subject);
+    Note revisionNote = notebook.getNoteRevision(noteId, revisionId, subject);
     conn.send(serializeMessage(new Message(OP.NOTE_REVISION)
         .put("noteId", noteId)
-        .put("revisionId", revision)
+        .put("revisionId", revisionId)
         .put("data", revisionNote)));
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1202,7 +1202,7 @@ public class NotebookServer extends WebSocketServlet implements
     String noteId = (String) fromMessage.get("noteId");
     String revisionId = (String) fromMessage.get("revisionId");
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-    Note revisionNote = notebook.getNoteRevision(noteId, revisionId, subject);
+    Note revisionNote = notebook.getNoteByRevision(noteId, revisionId, subject);
     conn.send(serializeMessage(new Message(OP.NOTE_REVISION)
         .put("noteId", noteId)
         .put("revisionId", revisionId)

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -37,7 +37,6 @@ import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.notebook.*;
-import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.Message.OP;
@@ -1182,7 +1181,7 @@ public class NotebookServer extends WebSocketServlet implements
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
     Revision revision = notebook.checkpointNote(noteId, commitMessage, subject);
     if (revision != null) {
-      List<NotebookRepo.Revision> revisions = notebook.listRevisionHistory(noteId, subject);
+      List<Revision> revisions = notebook.listRevisionHistory(noteId, subject);
       conn.send(serializeMessage(new Message(OP.LIST_REVISION_HISTORY)
         .put("revisionList", revisions)));
     }
@@ -1192,7 +1191,7 @@ public class NotebookServer extends WebSocketServlet implements
       Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("noteId");
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-    List<NotebookRepo.Revision> revisions = notebook.listRevisionHistory(noteId, subject);
+    List<Revision> revisions = notebook.listRevisionHistory(noteId, subject);
 
     conn.send(serializeMessage(new Message(OP.LIST_REVISION_HISTORY)
       .put("revisionList", revisions)));

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -236,7 +236,7 @@ public class NotebookServer extends WebSocketServlet implements
             listRevisionHistory(conn, notebook, messagereceived);
             break;
           case NOTE_REVISION:
-            getNoteRevision(conn, notebook, messagereceived);
+            getNoteByRevision(conn, notebook, messagereceived);
             break;
           case LIST_NOTEBOOK_JOBS:
             unicastNotebookJobInfo(conn, messagereceived);
@@ -1197,7 +1197,7 @@ public class NotebookServer extends WebSocketServlet implements
       .put("revisionList", revisions)));
   }
 
-  private void getNoteRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)
+  private void getNoteByRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)
       throws IOException {
     String noteId = (String) fromMessage.get("noteId");
     String revisionId = (String) fromMessage.get("revisionId");

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -170,7 +170,7 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    getNoteRevision: function(noteId, revisionId) {
+    getNoteByRevision: function(noteId, revisionId) {
       websocketEvents.sendNewEvent({
         op: 'NOTE_REVISION',
         data: {

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -170,12 +170,12 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    getNoteRevision: function(noteId, revision) {
+    getNoteRevision: function(noteId, revisionId) {
       websocketEvents.sendNewEvent({
         op: 'NOTE_REVISION',
         data: {
           noteId: noteId,
-          revision: revision
+          revisionId: revisionId
         }
       });
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -363,7 +363,7 @@ public class Notebook implements NoteEventListener {
     return notebookRepo.revisionHistory(noteId, subject);
   }
 
-  public Note getNoteRevision(String noteId, String revisionId, AuthenticationInfo subject)
+  public Note getNoteByRevision(String noteId, String revisionId, AuthenticationInfo subject)
       throws IOException {
     return notebookRepo.get(noteId, revisionId, subject);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -358,7 +358,7 @@ public class Notebook implements NoteEventListener {
     return notebookRepo.checkpoint(noteId, checkpointMessage, subject);
   }
 
-  public List<NotebookRepo.Revision> listRevisionHistory(String noteId,
+  public List<Revision> listRevisionHistory(String noteId,
       AuthenticationInfo subject) {
     return notebookRepo.revisionHistory(noteId, subject);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -363,9 +363,9 @@ public class Notebook implements NoteEventListener {
     return notebookRepo.revisionHistory(noteId, subject);
   }
 
-  public Note getNoteRevision(String noteId, Revision revision, AuthenticationInfo subject)
+  public Note getNoteRevision(String noteId, String revisionId, AuthenticationInfo subject)
       throws IOException {
-    return notebookRepo.get(noteId, revision, subject);
+    return notebookRepo.get(noteId, revisionId, subject);
   }
 
   @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -217,7 +217,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
+  public Note get(String noteId, String revId, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -108,7 +108,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
    * 4. apply stash on top and remove it
    */
   @Override
-  public synchronized Note get(String noteId, Revision rev, AuthenticationInfo subject)
+  public synchronized Note get(String noteId, String revId, AuthenticationInfo subject)
       throws IOException {
     Note note = null;
     RevCommit stash = null;
@@ -123,7 +123,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
       }
       ObjectId head = git.getRepository().resolve(Constants.HEAD);
       // checkout to target revision
-      git.checkout().setStartPoint(rev.id).addPath(noteId).call();
+      git.checkout().setStartPoint(revId).addPath(noteId).call();
       // get the note
       note = super.get(noteId, subject);
       // checkout back to head
@@ -137,7 +137,7 @@ public class GitNotebookRepo extends VFSNotebookRepo {
             stashes.size());
       }
     } catch (GitAPIException e) {
-      LOG.error("Failed to return note from revision \"{}\"", rev.message, e);
+      LOG.error("Failed to return note from revision \"{}\"", revId, e);
     }
     return note;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -89,7 +89,7 @@ public interface NotebookRepo {
    * @return a Notebook
    * @throws IOException
    */
-  @ZeppelinApi public Note get(String noteId, Revision rev, AuthenticationInfo subject)
+  @ZeppelinApi public Note get(String noteId, String revId, AuthenticationInfo subject)
       throws IOException;
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -355,12 +355,12 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev, AuthenticationInfo subject) {
+  public Note get(String noteId, String revId, AuthenticationInfo subject) {
     Note revisionNote = null;
     try {
-      revisionNote = getRepo(0).get(noteId, rev, subject);
+      revisionNote = getRepo(0).get(noteId, revId, subject);
     } catch (IOException e) {
-      LOG.error("Failed to get revision {} of note {}", rev.id, noteId, e);
+      LOG.error("Failed to get revision {} of note {}", revId, noteId, e);
     }
     return revisionNote;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -260,7 +260,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
+  public Note get(String noteId, String revId, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -274,7 +274,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
+  public Note get(String noteId, String revId, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -196,7 +196,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public Note get(String noteId, Revision rev, AuthenticationInfo subject) throws IOException {
+  public Note get(String noteId, String revId, AuthenticationInfo subject) throws IOException {
     // Auto-generated method stub
     return null;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -234,7 +234,7 @@ public class GitNotebookRepoTest {
     assertThat(paragraphCount_2).isEqualTo(paragraphCount_1 + 1);
 
     // get note from revision 1
-    Note noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1, null);
+    Note noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1.id, null);
     assertThat(noteRevision_1.getParagraphs().size()).isEqualTo(paragraphCount_1);
 
     // get current note
@@ -252,7 +252,7 @@ public class GitNotebookRepoTest {
     assertThat(paragraphCount_3).isEqualTo(paragraphCount_2 + 1);
 
     // get revision 1 again
-    noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1, null);
+    noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1.id, null);
     assertThat(noteRevision_1.getParagraphs().size()).isEqualTo(paragraphCount_1);
 
     // check that note is unchanged
@@ -287,7 +287,7 @@ public class GitNotebookRepoTest {
     int paragraphCount_2 = note.getParagraphs().size();
 
     // get note from revision 1
-    Note noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1, null);
+    Note noteRevision_1 = notebookRepo.get(TEST_NOTE_ID, revision_1.id, null);
     assertThat(noteRevision_1.getParagraphs().size()).isEqualTo(paragraphCount_1);
 
     // get current note
@@ -296,7 +296,7 @@ public class GitNotebookRepoTest {
 
     // test for absent revision
     Revision absentRevision = new Revision("absentId", StringUtils.EMPTY, 0);
-    note = notebookRepo.get(TEST_NOTE_ID, absentRevision, null);
+    note = notebookRepo.get(TEST_NOTE_ID, absentRevision.id, null);
     assertThat(note).isNull();
   }
 


### PR DESCRIPTION
### What is this PR for?
Getting revision of note requires only unique revision id and the whole revision object isn't required. This PR is to fix the issue.


### What type of PR is it?
Bug Fix | Improvement

### Todos
* [x] - change storage api
* [x] - modify notebook server

### What is the Jira issue?
[ZEPPELIN-1257](https://issues.apache.org/jira/browse/ZEPPELIN-1257)

### How should this be tested?
Storage layer tests should pass, green CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
