### PR TITLE
Updated path to point to latest Maven binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ _Notes:_
  
 #### Install maven
 ```
-wget http://www.eu.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
-sudo tar -zxf apache-maven-3.3.3-bin.tar.gz -C /usr/local/
-sudo ln -s /usr/local/apache-maven-3.3.3/bin/mvn /usr/local/bin/mvn
+wget http://www.eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+sudo tar -zxf apache-maven-3.3.9-bin.tar.gz -C /usr/local/
+sudo ln -s /usr/local/apache-maven-3.3.9/bin/mvn /usr/local/bin/mvn
 ```
 
 _Notes:_


### PR DESCRIPTION
### What is this PR for?
To update link of Maven binary provided in the installation steps.

### What type of PR is it?
[Documentation]

### Todos
NA

### What is the Jira issue?
NA

### How should this be tested?
By running the following commands
```
wget http://www.eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
sudo tar -zxf apache-maven-3.3.9-bin.tar.gz -C /usr/local/
sudo ln -s /usr/local/apache-maven-3.3.9/bin/mvn /usr/local/bin/mvn

# Build using latest mvn
mvn clean package -Pspark-1.6 -Phadoop-2.4 -Pyarn -Ppyspark -DskipTests
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

