### PR TITLE
[ZEPPELIN-1261] Bug fix in z.show() for matplotlib graphs

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -166,16 +166,9 @@ class PyZeppelinContext(object):
         """Matplotlib show function
         """
         img = io.StringIO()
-        p.savefig(img, format='svg')
-        img.seek(0)
-        style = ""
-        if (width != "0"):
-            style += 'width:' + width
-        if (height != "0"):
-            if (len(style) != 0):
-                style += ","
-                style += 'height:' + height
-        print("%html <div style='" + style + "'>" + img.read() + "<div>")
+        p.savefig(img, format="svg")
+        html = "%html <div style='width:{width};height:{height}'>{image}<div>"
+        print(html.format(width=width, height=height, image=img.getvalue()))
         img.close()
 
 

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -162,7 +162,7 @@ class PyZeppelinContext(object):
         #)
         body_buf.close(); header_buf.close()
     
-    def show_matplotlib(self, p, width="0", height="0", **kwargs):
+    def show_matplotlib(self, p, width="100%", height="100%", **kwargs):
         """Matplotlib show function
         """
         img = io.StringIO()


### PR DESCRIPTION
### What is this PR for?
Bug fix in z.show() for matplotlib graphs and code refactoring

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1261](https://issues.apache.org/jira/browse/ZEPPELIN-1261)

### How should this be tested?
```
%python
import matplotlib.pyplot as plt

x = [1,2,3,4,5]
y = [6,7,8,9,0]

plt.plot(x, y, marker="o")
z.show(plt, height="20em")
plt.close()
```
```
%python
import matplotlib.pyplot as plt

x = [1,2,3,4,5]
y = [6,7,8,9,0]

plt.plot(x, y, marker="o")
z.show(plt, height="300px")
plt.close()
```

### Screenshots (if appropriate)
![plot](https://dl.dropboxusercontent.com/u/20947972/z.show.height.example.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

