### PR TITLE
ZEPPELIN-1270. Remove getting SQLContext from SparkSession.wrapped()

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -238,10 +238,7 @@ public class SparkInterpreter extends Interpreter {
    */
   private SQLContext getSQLContext_2() {
     if (sqlc == null) {
-      sqlc = (SQLContext) Utils.invokeMethod(sparkSession, "wrapped");
-      if (sqlc == null) {
-        sqlc = (SQLContext) Utils.invokeMethod(sparkSession, "sqlContext");
-      }
+      sqlc = (SQLContext) Utils.invokeMethod(sparkSession, "sqlContext");
     }
     return sqlc;
   }


### PR DESCRIPTION
### What is this PR for?
SparkSession.wrapped is only for spark 2.0 preview, it is not supported in spark 2.0 release. So I think we can remove that piece of code. Otherwise we will get the following error in log which might be a little confusing.
```
08:05:44,946 - Thread(pool-2-thread-3) - (Utils.java:40) - org.apache.spark.sql.SparkSession.wrapped()
java.lang.NoSuchMethodException: org.apache.spark.sql.SparkSession.wrapped()
    at java.lang.Class.getMethod(Class.java:1786)
    at org.apache.zeppelin.spark.Utils.invokeMethod(Utils.java:38)
    at org.apache.zeppelin.spark.Utils.invokeMethod(Utils.java:33)
```


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1270

### How should this be tested?
Check the log and the above error is gone. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

