### PR TITLE
[Zeppelin-1276] Fix Notebook Title Input

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -13,10 +13,11 @@ limitations under the License.
 -->
 <div class="noteAction" ng-show="note.id && !paragraphUrl">
   <h3>
-    <div style="float: left; width: auto; max-width: 40%">
+    <div style="float: left; width: auto; max-width: 40%"
+      ng-controller="ElasticInputCtrl as input">
       <input type="text" pu-elastic-input class="form-control2" placeholder="{{noteName(note)}}" style="min-width: 0px; max-width: 95%;"
-           ng-if="showEditor" ng-model="note.name" ng-blur="sendNewName();showEditor = false;" ng-enter="sendNewName();showEditor = false;" ng-escape="note.name = oldName; showEditor = false" focus-if="showEditor" />
-      <p class="form-control-static2" ng-click="showEditor = true; oldName = note.name" ng-show="!showEditor">{{noteName(note)}}</p>
+           ng-if="input.showEditor" ng-model="note.name" ng-blur="sendNewName();input.showEditor = false;" ng-enter="sendNewName();input.showEditor = false;" ng-escape="note.name = oldName; input.showEditor = false" focus-if="input.showEditor" />
+      <p class="form-control-static2" ng-click="input.showEditor = true; oldName = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -18,7 +18,6 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
                                                                      baseUrlSrv, $timeout, saveAsService) {
   $scope.note = null;
   $scope.moment = moment;
-  $scope.showEditor = false;
   $scope.editorToggled = false;
   $scope.tableToggled = false;
   $scope.viewOnly = false;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -94,7 +94,6 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     $scope.originalText = angular.copy(newParagraph.text);
     $scope.chart = {};
     $scope.colWidthOption = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    $scope.showTitleEditor = false;
     $scope.paragraphFocused = false;
     if (newParagraph.focus) {
       $scope.paragraphFocused = true;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -17,19 +17,20 @@ limitations under the License.
 
   <div ng-if="paragraph.config.title"
        id="{{paragraph.id}}_title"
+       ng-controller="ElasticInputCtrl as input"
        class="title">
     <input type="text"
            pu-elastic-input
            style="min-width: 400px; max-width: 80%;"
            placeholder="Untitled"
            ng-model="paragraph.title"
-           ng-show="showTitleEditor"
-           ng-escape="showTitleEditor = false; paragraph.title = oldTitle;"
-           ng-blur="setTitle(); showTitleEditor = false"
-           ng-enter="setTitle(); showTitleEditor = false"
-           focus-if="showTitleEditor" />
-    <div ng-click="showTitleEditor = !asIframe && !viewOnly; oldTitle = paragraph.title;"
-         ng-show="!showTitleEditor"
+           ng-if="input.showEditor"
+           ng-escape="input.showEditor = false; paragraph.title = oldTitle;"
+           ng-blur="setTitle(); input.showEditor = false"
+           ng-enter="setTitle(); input.showEditor = false"
+           focus-if="input.showEditor" />
+    <div ng-click="input.showEditor = !asIframe && !viewOnly; oldTitle = paragraph.title;"
+         ng-show="!input.showEditor"
          ng-bind-html="paragraph.title || 'Untitled'">
     </div>
   </div>

--- a/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
+++ b/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+angular.module('zeppelinWebApp')
+.controller('ElasticInputCtrl', function() {
+  var vm = this;
+  this.showEditor = false;
+});

--- a/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
+++ b/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
 angular.module('zeppelinWebApp')
 .controller('ElasticInputCtrl', function() {
   var vm = this;
-  this.showEditor = false;
+  vm.showEditor = false;
 });

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -178,6 +178,7 @@ limitations under the License.
     <script src="components/saveAs/saveAs.service.js"></script>
     <script src="components/searchService/search.service.js"></script>
     <script src="components/login/login.controller.js"></script>
+    <script src="components/elasticInputCtrl/elasticInput.controller.js"></script>
     <!-- endbuild -->
   </body>
 </html>

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -46,10 +46,6 @@ describe('Controller: NotebookCtrl', function() {
     });
   });
 
-  it('should set default value of "showEditor" to false', function() {
-    expect(scope.showEditor).toEqual(false);
-  });
-
   it('should set default value of "editorToggled" to false', function() {
     expect(scope.editorToggled).toEqual(false);
   });


### PR DESCRIPTION
### What is this PR for?
The Notebook Title Input would not disappear after being edited.
This is a problem made by its plugin elastic-input.
We originally used ng-if instead of ng-show so it doesn't break the Page Print, however that change made the scope value to toggle unusable.
So we added a trustworthy small controller on top of the component.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1276

### How should this be tested?
* Click on the Notebook title
* Try to do: Enter or Esc or Click somewhere else
* The Input border should not be there anymore
* Do the same for the Paragraph
* If you do Print Page there shouldn't any titles duplicated at the top

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
