### PR TITLE
[HOTFIX][ZEPPELIN-1240] Part 2. Removed interpreter properties are restored

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -828,8 +828,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       throws InterpreterException {
     logger.info("Create repl {} from {}", className, dirName);
 
-    updatePropertiesFromRegisteredInterpreter(property, className);
-
     ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
     try {
 
@@ -892,31 +890,12 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     String localRepoPath = conf.getInterpreterLocalRepoPath() + "/" + interpreterSettingId;
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
 
-    updatePropertiesFromRegisteredInterpreter(property, className);
-
     LazyOpenInterpreter intp = new LazyOpenInterpreter(new RemoteInterpreter(
         property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
         interpreterPath, localRepoPath, connectTimeout,
         maxPoolSize, remoteInterpreterProcessListener));
     return intp;
   }
-
-  private Properties updatePropertiesFromRegisteredInterpreter(Properties properties,
-                                                                  String className) {
-    RegisteredInterpreter registeredInterpreter = Interpreter.findRegisteredInterpreterByClassName(
-        className);
-    if (null != registeredInterpreter) {
-      Map<String, InterpreterProperty> defaultProperties = registeredInterpreter.getProperties();
-      for (String key : defaultProperties.keySet()) {
-        if (!properties.containsKey(key) && null != defaultProperties.get(key).getValue()) {
-          properties.setProperty(key, defaultProperties.get(key).getValue());
-        }
-      }
-    }
-
-    return properties;
-  }
-
 
   private URL[] recursiveBuildLibList(File path) throws MalformedURLException {
     URL[] urls = new URL[0];


### PR DESCRIPTION
### What is this PR for?
Fixing the bug that users cannot delete some interpreter settings from interpreter tab. This is second part of ZEPPELIN-1240 for branch-0.6 only

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos
* [x] - Changed `update` to `set`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1240

### How should this be tested?
1. Make new interpreter via interpreter tab
1. remove some properties

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No