### PR TITLE
ZEPPELIN-1287. No need to call print to display output in PythonInterpreter

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -134,10 +134,11 @@ public class PythonInterpreter extends Interpreter {
 
     InterpreterResult result;
     if (pythonErrorIn(output)) {
-      result = new InterpreterResult(Code.ERROR, output.replaceAll(">>> ", "").trim());
+      result = new InterpreterResult(Code.ERROR, output);
     } else {
-      result = new InterpreterResult(Code.SUCCESS, output.replaceAll(">>> ", "")
-          .replaceAll("\\.\\.\\.", "").trim());
+      // TODO(zjffdu), we should not do string replacement operation in the result, as it is
+      // possible that the output contains the kind of pattern itself, e.g. print("...")
+      result = new InterpreterResult(Code.SUCCESS, output.replaceAll("\\.\\.\\.", ""));
     }
     return result;
   }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -134,9 +134,9 @@ public class PythonInterpreter extends Interpreter {
 
     InterpreterResult result;
     if (pythonErrorIn(output)) {
-      result = new InterpreterResult(Code.ERROR, output.replaceAll(">>>", "").trim());
+      result = new InterpreterResult(Code.ERROR, output.replaceAll(">>> ", "").trim());
     } else {
-      result = new InterpreterResult(Code.SUCCESS, output.replaceAll(">>>", "")
+      result = new InterpreterResult(Code.SUCCESS, output.replaceAll(">>> ", "")
           .replaceAll("\\.\\.\\.", "").trim());
     }
     return result;
@@ -265,4 +265,5 @@ public class PythonInterpreter extends Interpreter {
   public int getMaxResult() {
     return maxResult;
   }
+  
 }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
@@ -20,7 +20,12 @@ package org.apache.zeppelin.python;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 
 /**

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -30,6 +30,8 @@ def intHandler(signum, frame):  # Set the signal handler
     raise KeyboardInterrupt()
 
 signal.signal(signal.SIGINT, intHandler)
+# set prompt as empty string so that java side don't need to remove the prompt.
+sys.ps1=""
 
 def help():
     print("""%html

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -25,8 +25,6 @@ try:
 except ImportError:
     import io as io
 
-sys.displayhook = lambda x: None
-
 def intHandler(signum, frame):  # Set the signal handler
     print ("Paragraph interrupted")
     raise KeyboardInterrupt()

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -115,7 +115,7 @@ public class PythonInterpreterTest {
    */
   @Test
   public void testPy4jInstalled() throws IOException, InterruptedException {
-    when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn(">>>");
+    when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn("");
 
     pythonInterpreter.open();
     Integer py4jPort = pythonInterpreter.getPy4jPort();
@@ -137,7 +137,7 @@ public class PythonInterpreterTest {
   @Test
   public void testClose() throws IOException, InterruptedException {
     //given: py4j is installed
-    when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn(">>>");
+    when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn("");
 
     pythonInterpreter.open();
     Integer py4jPort = pythonInterpreter.getPy4jPort();
@@ -210,11 +210,11 @@ public class PythonInterpreterTest {
       String output = "";
 
       for (int i = 0; i < lines.length; i++) {
-        output += ">>>" + lines[i];
+        output += lines[i];
       }
       return output;
     } else {
-      return ">>>";
+      return "";
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
It is not necessary to call print to display output in PythonInterpreter. 2 main changes:
* the root cause is the displayhook in bootstrap.py
* also did some code refactoring on PythonInterpreter


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1287

### How should this be tested?
Verify it manually

### Screenshots (if appropriate)
![2016-08-04_1404](https://cloud.githubusercontent.com/assets/164491/17392006/090279d2-5a4d-11e6-840b-4cddb595a42e.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
