### PR TITLE
[ZEPPELIN-1289] Update the default value of 'spark.executor.memory' property

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -79,7 +79,7 @@ You can also set other Spark properties which are not listed in the table. For a
   </tr>
   <tr>
     <td>spark.executor.memory </td>
-    <td>512m</td>
+    <td>1g</td>
     <td>Executor memory per worker instance. <br/> ex) 512m, 32g</td>
   </tr>
   <tr>

--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -75,7 +75,7 @@ The role of registered interpreters, settings and interpreters group are describ
       "className": "org.apache.zeppelin.spark.SparkInterpreter",
       "properties": {
         "spark.executor.memory": {
-          "defaultValue": "512m",
+          "defaultValue": "1g",
           "description": "Executor memory per worker instance. ex) 512m, 32g"
         },
         "spark.cores.max": {
@@ -154,7 +154,7 @@ The role of registered interpreters, settings and interpreters group are describ
       "group": "spark",
       "properties": {
         "spark.cores.max": "",
-        "spark.executor.memory": "512m",
+        "spark.executor.memory": "1g",
       },
       "interpreterGroup": [
         {


### PR DESCRIPTION
### What is this PR for?
As of Spark 1.5.0, the default value of 'spark.executor.memory' is 1g, not 512m so let's follow the change.

### What type of PR is it?
Improvement

### Todos
* [x] - Replaced all of the occurrences of the default value of spark.executor.memory with '1g'

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1289

### How should this be tested?
Should be checked by some people's eyes.

### Questions:
* Does the licenses files need update?: no
* Is there breaking changes for older versions?: no
* Does this needs documentation?: no

