### PR TITLE
Cache zeppelin-web/node_modules on travis ci and see if it reduces CI failure on npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
 
 before_install:
   - "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin"
-  - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || "node_modules are not cached"
+  - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || echo "node_modules are not cached"
   - mkdir -p ~/R
   - echo 'R_LIBS=~/R' > ~/.Renviron
   - R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org', lib='~/R')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
   directories:
     - .spark-dist
     - ${HOME}/.m2/repository/.cache/maven-download-plugin
+    - .node_modules
 
 addons:
   apt:
@@ -71,6 +72,7 @@ matrix:
 
 before_install:
   - "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin"
+  - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || "node_modules are not cached"
   - mkdir -p ~/R
   - echo 'R_LIBS=~/R' > ~/.Renviron
   - R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org', lib='~/R')"
@@ -91,6 +93,7 @@ script:
   - mvn $TEST_FLAG $PROFILE -B $TEST_PROJECTS
 
 after_success:
+  - rm -rf .node_modules; cp -r zeppelin-web/node_modules .node_modules
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,4 +107,3 @@ after_failure:
 
 after_script:
   - ./testing/stopSparkCluster.sh $SPARK_VER $HADOOP_VER
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,3 +107,4 @@ after_failure:
 
 after_script:
   - ./testing/stopSparkCluster.sh $SPARK_VER $HADOOP_VER
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,9 @@ before_script:
 
 script:
   - mvn $TEST_FLAG $PROFILE -B $TEST_PROJECTS
+  - rm -rf .node_modules; cp -r zeppelin-web/node_modules .node_modules
 
 after_success:
-  - rm -rf .node_modules; cp -r zeppelin-web/node_modules .node_modules
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
 
 after_failure:


### PR DESCRIPTION
### What is this PR for?
Recently CI build fails a lot on npm install on building zeppelin-web module with network issues.
This PR tries to cache zeppelin-web/node_modules on travis and see it it helps reducing network issues.

### What type of PR is it?
Improvement

### Todos
* [x] - Cache zeppelin-web/node_modules

