### PR TITLE
[ZEPPELIN-708]shift<enter> positions automatically to the next cell

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1130,18 +1130,16 @@ public class NotebookServer extends WebSocketServlet implements
       p.setAuthenticationInfo(new AuthenticationInfo());
     }
 
-    Map<String, Object> params = (Map<String, Object>) fromMessage
-       .get("params");
+    Map<String, Object> params = (Map<String, Object>) fromMessage.get("params");
     p.settings.setParams(params);
-    Map<String, Object> config = (Map<String, Object>) fromMessage
-       .get("config");
+    Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
     p.setConfig(config);
-    // if it's the last paragraph, let's add a new one
-    boolean isTheLastParagraph = note.isLastParagraph(p.getId());
-    if (!(text.trim().equals(p.getMagic()) || Strings.isNullOrEmpty(text)) &&
-        isTheLastParagraph) {
-      note.addParagraph();
+    Map<String, Object> requestParam = (Map<String, Object>) fromMessage.get("requestParam");
+    Paragraph newParagraph = null;
+    if (isAddNewParagraph(note, p, requestParam)) {
+      newParagraph = note.addParagraph();
     }
+    setFocusedParagraphId(note, paragraphId, requestParam, newParagraph);
 
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
     note.persist(subject);
@@ -1157,6 +1155,56 @@ public class NotebookServer extends WebSocketServlet implements
         broadcast(note.getId(), new Message(OP.PARAGRAPH).put("paragraph", p));
       }
     }
+  }
+
+  /**
+   * set focused paragraph id
+   *
+   * @param note         note
+   * @param paragraphId  current paragraph id
+   * @param requestParam request parameter
+   * @param newParagraph it is a new one (when new one is added)
+   */
+  void setFocusedParagraphId(Note note, String paragraphId, Map<String, Object> requestParam,
+      Paragraph newParagraph) {
+    //if note has new one, the new one is focused
+    if (newParagraph != null) {
+      note.getConfig().put("focusedParagraphId", newParagraph.getId());
+      return;
+    }
+    //if user want to move focus to next, I figure next paragraph id out.
+    if (requestParam.containsKey("moveFocusToNextParagraph") && (boolean) requestParam
+        .get("moveFocusToNextParagraph")) {
+      Iterator<Paragraph> noteParagraphs = note.getParagraphs().iterator();
+      while (noteParagraphs.hasNext()) {
+        if (paragraphId.equals(noteParagraphs.next().getId())) {
+          note.getConfig().put("focusedParagraphId", noteParagraphs.next().getId());
+          note.getConfig().put("previousFocusedParagraphId", paragraphId);
+          return;
+        }
+      }
+    }
+    //set current paragraph id
+    note.getConfig().put("focusedParagraphId", paragraphId);
+  }
+
+  /**
+   * checking add new paragraph
+   *
+   * @param note         note
+   * @param p            Paragraph
+   * @param requestParam request parameter
+   * @return if return is {@code true}, add new paragraph
+   */
+  boolean isAddNewParagraph(Note note, Paragraph p, Map<String, Object> requestParam) {
+    return
+        //if user want to move next
+        requestParam.containsKey("moveFocusToNextParagraph") && (boolean) requestParam
+            .get("moveFocusToNextParagraph")
+            //if text in paragraph is empty
+            && (!(p.getText().trim().equals(p.getMagic())) || Strings.isNullOrEmpty(p.getText()))
+            //if is last paragraph
+            && note.isLastParagraph(p.getId());
   }
 
   private void sendAllConfigurations(NotebookSocket conn, HashSet<String> userAndRoles,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -274,7 +274,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       collector.checkThat("Before Run Output field contains ",
           driver.findElement(By.xpath(xpathToOutputField)).getText(),
           CoreMatchers.equalTo(""));
-      driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@ng-click='runParagraph(getEditorValue())']")).click();
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@ng-click='runParagraphAndMoveFocusToNext(getEditorValue())']")).click();
       waitForParagraph(1, "FINISHED");
       collector.checkThat("After Run Output field contains  ",
           driver.findElement(By.xpath(xpathToOutputField)).getText(),

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -374,13 +374,14 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl', function($scope, $ro
     var numOldParagraphs = oldParagraphIds.length;
 
     var paragraphToBeFocused;
-    var focusedParagraph;
-    for (var i = 0; i < $scope.note.paragraphs.length; i++) {
-      var paragraphId = $scope.note.paragraphs[i].id;
-      if (angular.element('#' + paragraphId + '_paragraphColumn_main').scope().paragraphFocused) {
-        focusedParagraph = paragraphId;
-        break;
-      }
+    var focusedParagraph = $scope.note.config.focusedParagraphId;
+    if ($scope.note.config.previousFocusedParagraphId) {
+      angular.element('#' + $scope.note.config.previousFocusedParagraphId + '_paragraphColumn_main')
+        .scope().paragraphFocused = false;
+    }
+    if (angular.element('#' + focusedParagraph + '_paragraphColumn_main').scope()) {
+      angular.element('#' + focusedParagraph + '_paragraphColumn_main').scope().paragraphFocused = true;
+      angular.element('#' + focusedParagraph + '_paragraphColumn_main').scope().editor.focus();
     }
 
     /** add a new paragraph */

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -24,7 +24,7 @@ limitations under the License.
 
   <!-- Run / Cancel button -->
   <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
-        ng-click="runParagraph(getEditorValue())"
+        ng-click="runParagraphAndMoveFocusToNext(getEditorValue())"
         ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
   <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top" tooltip="Cancel"
         ng-click="cancelParagraph()"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -37,7 +37,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         if (filtered.length === 1) {
           var paragraph = filtered[0];
           websocketMsgSrv.runParagraph(paragraph.id, paragraph.title, paragraph.text,
-              paragraph.config, paragraph.settings.params);
+              paragraph.config, paragraph.settings.params, paragraph.requestParam);
         } else {
           ngToast.danger({content: 'Cannot find a paragraph with id \'' + paragraphId + '\'',
             verticalPosition: 'top', dismissOnTimeout: false});
@@ -207,6 +207,8 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
   };
 
   var initializeDefault = function() {
+    $scope.paragraph.requestParam = {};
+
     var config = $scope.paragraph.config;
 
     if (!config.colWidth) {
@@ -303,9 +305,15 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
 
   $scope.runParagraph = function(data) {
     websocketMsgSrv.runParagraph($scope.paragraph.id, $scope.paragraph.title,
-                                 data, $scope.paragraph.config, $scope.paragraph.settings.params);
+                                 data, $scope.paragraph.config, $scope.paragraph.settings.params,
+                                 $scope.paragraph.requestParam);
     $scope.originalText = angular.copy(data);
     $scope.dirtyText = undefined;
+  };
+
+  $scope.runParagraphAndMoveFocusToNext = function(data) {
+    $scope.paragraph.requestParam.moveFocusToNextParagraph = true;
+    $scope.runParagraph(data);
   };
 
   $scope.saveParagraph = function() {
@@ -2638,7 +2646,10 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       } else if (editorHide && (keyCode === 40 || (keyCode === 78 && keyEvent.ctrlKey && !keyEvent.altKey))) { // down
         // move focus to next paragraph
         $scope.$emit('moveFocusToNextParagraph', paragraphId);
+      } else if (keyEvent.ctrlKey && keyCode === 13) { // Ctrl + Enter
+        $scope.run();
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
+        $scope.paragraph.requestParam.moveFocusToNextParagraph = true;
         $scope.run();
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c
         $scope.cancelParagraph();

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -30,7 +30,18 @@ limitations under the License.
             </div>
           </div>
           <div class="col-md-8">
-            Run paragraph
+            Run paragraph, move focus to next
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Enter</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Run paragraph, focus stays
           </div>
         </div>
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -97,7 +97,7 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       websocketEvents.sendNewEvent({op: 'CANCEL_PARAGRAPH', data: {id: paragraphId}});
     },
 
-    runParagraph: function(paragraphId, paragraphTitle, paragraphData, paragraphConfig, paragraphParams) {
+    runParagraph: function(paragraphId, paragraphTitle, paragraphData, paragraphConfig, paragraphParams, requestParam) {
       websocketEvents.sendNewEvent({
         op: 'RUN_PARAGRAPH',
         data: {
@@ -105,7 +105,8 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
           title: paragraphTitle,
           paragraph: paragraphData,
           config: paragraphConfig,
-          params: paragraphParams
+          params: paragraphParams,
+          requestParam: requestParam
         }
       });
     },


### PR DESCRIPTION
### What is this PR for?
* Add and modify shortcut function
  * Shift + Enter: Run paragraph, move focus to next
  * Ctrl + Enter: Run paragraph, focus stays
* Moves the cursor to the end of the paragraph, When new paragraph is added

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-708

### How should this be tested?
* unit test
* online test

### Screenshots (if appropriate)
![zeppelin-708](https://cloud.githubusercontent.com/assets/10624086/17442234/c578d26e-5b6f-11e6-930c-0c4fd53a4505.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
