### PR TITLE
[ZEPPELIN- 1298] Log instead of throwing trace for ping messages

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -20,6 +20,8 @@ import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
@@ -132,9 +134,14 @@ public class NotebookServer extends WebSocketServlet implements
       
       String ticket = TicketContainer.instance.getTicket(messagereceived.principal);
       if (ticket != null && !ticket.equals(messagereceived.ticket)){
-        /* not to pollute logs, log in debug instead of exception */
-        LOG.debug("{} message: invalid ticket {} != {}", messagereceived.op,
-            messagereceived.ticket, ticket);
+        /* not to pollute logs, log instead of exception */
+        if (StringUtils.isEmpty(messagereceived.ticket)) {
+          LOG.debug("{} message: invalid ticket {} != {}", messagereceived.op,
+              messagereceived.ticket, ticket);
+        } else {
+          LOG.warn("{} message: invalid ticket {} != {}", messagereceived.op,
+              messagereceived.ticket, ticket);
+        }
         return;
       }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -131,8 +131,14 @@ public class NotebookServer extends WebSocketServlet implements
       }
       
       String ticket = TicketContainer.instance.getTicket(messagereceived.principal);
-      if (ticket != null && !ticket.equals(messagereceived.ticket))
+      if (ticket != null && !ticket.equals(messagereceived.ticket)){
+        if (messagereceived.op == OP.PING) {
+          /* not to pollute logs with exception trace */
+          LOG.info("Received PING with invalid ticket {}", messagereceived.ticket);
+          return;
+        }
         throw new Exception("Invalid ticket " + messagereceived.ticket + " != " + ticket);
+      }
 
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
       boolean allowAnonymous = conf.

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -132,12 +132,10 @@ public class NotebookServer extends WebSocketServlet implements
       
       String ticket = TicketContainer.instance.getTicket(messagereceived.principal);
       if (ticket != null && !ticket.equals(messagereceived.ticket)){
-        if (messagereceived.op == OP.PING) {
-          /* not to pollute logs with exception trace */
-          LOG.info("Received PING with invalid ticket {}", messagereceived.ticket);
-          return;
-        }
-        throw new Exception("Invalid ticket " + messagereceived.ticket + " != " + ticket);
+        /* not to pollute logs, log in debug instead of exception */
+        LOG.debug("{} message: invalid ticket {} != {}", messagereceived.op,
+            messagereceived.ticket, ticket);
+        return;
       }
 
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();


### PR DESCRIPTION
### What is this PR for?
When non authenticated user in non-anonymous mode tries to send any websocket api message it results in throwing a traceback. However on PING message we don't need to show the whole traceback and we can just log in order not to pollute the logs file.


### What type of PR is it?
Hot Fix

### Todos
* [x] - log and return on PING

### What is the Jira issue?
[Zeppelin-1298](https://issues.apache.org/jira/browse/ZEPPELIN-1298)

### How should this be tested?
Follow the steps in issue and shouldn't get repeating traceback.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

