### PR TITLE
Change maven version from 3.3.3 to 3.3.9 at vagrant script and its documentation

### DIFF
--- a/docs/install/virtual_machine.md
+++ b/docs/install/virtual_machine.md
@@ -88,7 +88,7 @@ By default, Vagrant will share your project directory (the directory with the Va
 Running the following commands in the guest machine should display these expected versions:
 
 `node --version` should report *v0.12.7*
-`mvn --version` should report *Apache Maven 3.3.3* and *Java version: 1.7.0_85*
+`mvn --version` should report *Apache Maven 3.3.9* and *Java version: 1.7.0_85*
 
 The virtual machine consists of:
 

--- a/docs/install/virtual_machine.md
+++ b/docs/install/virtual_machine.md
@@ -96,7 +96,7 @@ The virtual machine consists of:
  - Node.js 0.12.7
  - npm 2.11.3
  - ruby 1.9.3 + rake, make and bundler (only required if building jekyll documentation)
- - Maven 3.3.3
+ - Maven 3.3.9
  - Git
  - Unzip
  - libfontconfig to avoid phatomJs missing dependency issues

--- a/scripts/vagrant/zeppelin-dev/roles/maven/tasks/main.yml
+++ b/scripts/vagrant/zeppelin-dev/roles/maven/tasks/main.yml
@@ -23,24 +23,24 @@
 
 
 - name: Call apache web service to find preferred maven download mirror
-  uri: url=http://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz&asjson=1 return_content=yes
+  uri: url=http://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz&asjson=1 return_content=yes
   register: webResponse
 
 #- debug: var=webResponse
 
 - name: download maven
   get_url: url="{{webResponse.json.preferred}}{{webResponse.json.path_info}}"
-           dest=/tmp/apache-maven-3.3.3-bin.tar.gz
+           dest=/tmp/apache-maven-3.3.9-bin.tar.gz
            mode=0440
            validate_certs=False
 
 - name: extract maven tgz
-  unarchive: src=/tmp/apache-maven-3.3.3-bin.tar.gz
+  unarchive: src=/tmp/apache-maven-3.3.9-bin.tar.gz
              dest=/usr/local/
              copy=no
-             creates=/usr/local/apache-maven-3.3.3
+             creates=/usr/local/apache-maven-3.3.9
 
 - name: create symlink to this maven version
-  file: src=/usr/local/apache-maven-3.3.3/bin/mvn
+  file: src=/usr/local/apache-maven-3.3.9/bin/mvn
         path=/usr/bin/mvn
         state=link


### PR DESCRIPTION
### What is this PR for?
Change maven version from 3.3.3 to 3.3.9 in vagrant script and its documentation due to path to 3.3.3 doesn't exist (return 404 from apache mirror)

### What type of PR is it?
Bug Fix | Documentation

### What is the Jira issue?
ZEPPELIN-1299

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

