### PR TITLE
[ZEPPELIN-1301] fix potential encoding problem in RInterpreter processHTML DataURI conversion

### DIFF
--- a/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
+++ b/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
@@ -145,7 +145,11 @@ object RInterpreter {
     val fp = new File(file)
     val fdata = new Array[Byte](fp.length().toInt)
     val fin = new BufferedInputStream(new FileInputStream(fp))
-    try { fin.read(fdata) } finally { fin.close() }
+    try {
+      fin.read(fdata)
+    } finally {
+      fin.close()
+    }
     s"""data:${mime};base64,""" + StringUtils.newStringUtf8(Base64.encodeBase64(fdata, false))
   }
 

--- a/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
+++ b/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.rinterpreter
 
+import java.io.{BufferedInputStream, File, FileInputStream}
 import java.nio.file.{Files, Paths}
 import java.util._
 
@@ -141,8 +142,11 @@ object RInterpreter {
   }
 
   def dataURI(file : String, mime : String) : String = {
-    val data: String = Source.fromFile(file).getLines().mkString("\n")
-    s"""data:${mime};base64,""" + StringUtils.newStringUtf8(Base64.encodeBase64(data.getBytes(), false))
+    val fp = new File(file)
+    val fdata = new Array[Byte](fp.length().toInt)
+    val fin = new BufferedInputStream(new FileInputStream(fp))
+    try { fin.read(fdata) } finally { fin.close() }
+    s"""data:${mime};base64,""" + StringUtils.newStringUtf8(Base64.encodeBase64(fdata, false))
   }
 
   // The purpose here is to deal with knitr producing HTML with script and css tags outside the <body>


### PR DESCRIPTION
### What is this PR for?
fix potential encoding problem in RInterpreter processHTML DataURI conversion.
Read binary content from local file and turn into Base64 format directly.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1301

### How should this be tested?
Existing tests.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

