### PR TITLE
[ZEPPELIN-1302] fix rinterpreter default prop values init error

### DIFF
--- a/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
+++ b/r/src/main/scala/org/apache/zeppelin/rinterpreter/RInterpreter.scala
@@ -110,10 +110,10 @@ object RInterpreter {
 
   // These are the additional properties we need on top of the ones provided by the spark interpreters
   lazy val props: Map[String, InterpreterProperty] = new InterpreterPropertyBuilder()
-    .add("rhadoop.cmd",           SparkInterpreter.getSystemDefault("rhadoop.cmd", "HADOOP_CMD", ""), "Usually /usr/bin/hadoop")
-    .add("rhadooop.streamingjar", SparkInterpreter.getSystemDefault("rhadoop.cmd", "HADOOP_STREAMING", ""), "Usually /usr/lib/hadoop/contrib/streaming/hadoop-streaming-<version>.jar")
-    .add("rscala.debug",          SparkInterpreter.getSystemDefault("rscala.debug","RSCALA_DEBUG", "false"), "Whether to turn on rScala debugging") // TEST:  Implemented but not tested
-    .add("rscala.timeout",        SparkInterpreter.getSystemDefault("rscala.timeout","RSCALA_TIMEOUT", "60"), "Timeout for rScala") // TEST:  Implemented but not tested
+    .add("rhadoop.cmd",           SparkInterpreter.getSystemDefault("HADOOP_CMD", "rhadoop.cmd", ""), "Usually /usr/bin/hadoop")
+    .add("rhadooop.streamingjar", SparkInterpreter.getSystemDefault("HADOOP_STREAMING", "rhadooop.streamingjar", ""), "Usually /usr/lib/hadoop/contrib/streaming/hadoop-streaming-<version>.jar")
+    .add("rscala.debug",          SparkInterpreter.getSystemDefault("RSCALA_DEBUG", "rscala.debug","false"), "Whether to turn on rScala debugging") // TEST:  Implemented but not tested
+    .add("rscala.timeout",        SparkInterpreter.getSystemDefault("RSCALA_TIMEOUT", "rscala.timeout","60"), "Timeout for rScala") // TEST:  Implemented but not tested
     .build
 
   def getProps() = {


### PR DESCRIPTION
### What is this PR for?
1.
Correct the calling to `SparkInterpreter.getSystemDefault`
from
`SparkInterpreter.getSystemDefault(propName, envName, defaultValue) `
to
`SparkInterpreter.getSystemDefault(envName, propName, defaultValue) `
2.
correct the `propName` parameter for `rhadoop.sparkstreamingjar` here.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1302

### How should this be tested?
Existing tests.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

