### PR TITLE
[HOTFIX] After hotfix #1292, build fails with -Pyarn

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -926,6 +926,9 @@
 
     <profile>
       <id>yarn</id>
+      <properties>
+        <yarn.version>${hadoop.version}</yarn.version>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What is this PR for?
#1292 fixed CI problem. However, build command fails with -Pyarn 

```
[ERROR] 'dependencies.dependency.version' for org.apache.hadoop:hadoop-yarn-api:jar must be a valid version but is '${yarn.version}'. @ line 939, column 20
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-dependency-plugin @ line 341, column 15
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.apache.zeppelin:zeppelin-spark_2.10:0.7.0-SNAPSHOT (/Users/moon/Projects/zeppelin/spark/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for org.apache.hadoop:hadoop-yarn-api:jar must be a valid version but is '${yarn.version}'. @ line 939, column 20
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
```


### What type of PR is it?
Hot Fix

### Todos
* [x] - set yarn.version property when -Pyarn is activated

### How should this be tested?
Build zeppelin with -Pyarn activated
