### PR TITLE
[ZEPPELIN-1304] Show popup when interpreter name is empty

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -249,8 +249,8 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl',
 
     $scope.addNewInterpreterSetting = function() {
       //user input validation on interpreter creation
-      if ($scope.newInterpreterSetting.name &&
-        !$scope.newInterpreterSetting.name.trim() || !$scope.newInterpreterSetting.group) {
+      if (!$scope.newInterpreterSetting.name ||
+          !$scope.newInterpreterSetting.name.trim() || !$scope.newInterpreterSetting.group) {
         BootstrapDialog.alert({
           closable: true,
           title: 'Add interpreter',


### PR DESCRIPTION
### What is this PR for?
Prevent creating interpreter with empty name.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1304](https://issues.apache.org/jira/browse/ZEPPELIN-1304)

### How should this be tested?
Try to create interpreter name with empty string or white spaces.

### Screenshots (if appropriate)
**Before**
![aug-07-2016 17-21-45](https://cloud.githubusercontent.com/assets/8503346/17461324/8a087ac2-5cc3-11e6-8a3e-244e87d4cf55.gif)


**After**
![aug-07-2016 17-19-43](https://cloud.githubusercontent.com/assets/8503346/17461326/8eeddae6-5cc3-11e6-9c26-61c1bf651c0b.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

