### PR TITLE
ZEPPELIN-1305. Fix bug of ZEPPELIN-1215

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -533,8 +533,8 @@ public class SparkInterpreter extends Interpreter {
     if (getProperty("master").equals("yarn-client")) {
       System.setProperty("SPARK_YARN_MODE", "true");
     }
-    if (getProperty().contains("spark.yarn.keytab") &&
-            getProperty().contains("spark.yarn.principal")) {
+    if (getProperty().containsKey("spark.yarn.keytab") &&
+            getProperty().containsKey("spark.yarn.principal")) {
       try {
         String keytab = getProperty().getProperty("spark.yarn.keytab");
         String principal = getProperty().getProperty("spark.yarn.principal");


### PR DESCRIPTION
### What is this PR for?
It is my bad, Before commit ZEPPELIN-1215, I change `getProperty().getProperty(key) != null` to `getProperty().contains(key)`. But it should be `getProperty().containsKey(key)`.



### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1305

### How should this be tested?
Tested manually in a secured cluster

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

