### PR TITLE
[ZEPPELIN-1310] [WIP] Deactivate angular debugging classes

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -199,7 +199,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
     try {
       // navigate to interpreter page
-      WebElement settingButton = driver.findElement(By.xpath("//button[@class='nav-btn dropdown-toggle ng-scope']"));
+      WebElement settingButton = driver.findElement(By.xpath("//button[@class='nav-btn dropdown-toggle']"));
       settingButton.click();
       WebElement interpreterLink = driver.findElement(By.xpath("//a[@href='#/interpreter']"));
       interpreterLink.click();
@@ -289,7 +289,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       // Get 2nd paragraph id
       final String secondParagraphId = driver.findElement(By.xpath(getParagraphXPath(2)
-              + "//div[@class=\"control ng-scope\"]//ul[@class=\"dropdown-menu\"]/li[1]"))
+              + "//div[@class=\"control\"]//ul[@class=\"dropdown-menu\"]/li[1]"))
               .getAttribute("textContent");
 
       assertTrue("Cannot find paragraph id for the 2nd paragraph", isNotBlank(secondParagraphId));

--- a/zeppelin-web/CONTRIBUTING.md
+++ b/zeppelin-web/CONTRIBUTING.md
@@ -7,13 +7,19 @@ For that, start Zeppelin server normally, then use ``./grunt serve`` in _zeppeli
 
 This will launch a Zeppelin WebApplication on port **9000** that will update on code changes.
 
+## Debugging
+It is recommended to use your Web Browser's console (with deactivated cache) to debug.
+
+If you are using plugins such as **Batarang**, you will need to activate angular's debug system through your console
+by typing: `angular.reloadWithDebugInfo();`
+
 ## Technologies
 
 Zeppelin WebApplication is using **AngularJS** as main Framework, and **Grunt** and **Bower** as helpers.
 
 So you might want to get familiar with it.
 [Here is a good start](http://www.sitepoint.com/kickstart-your-angularjs-development-with-yeoman-grunt-and-bower/)
-(There is obviously plenty more ressources to learn)
+(There is obviously plenty more resources to learn)
 
 ## Coding style
 

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -42,9 +42,10 @@
             }
           };
         })
-        .config(function($httpProvider, $routeProvider, ngToastProvider) {
+        .config(function($httpProvider, $routeProvider, ngToastProvider, $compileProvider) {
           // withCredentials when running locally via grunt
           $httpProvider.defaults.withCredentials = true;
+          $compileProvider.debugInfoEnabled(false);
 
           $routeProvider
             .when('/', {


### PR DESCRIPTION
### What is this PR for?
This PR removes the angular debug classes added to HTML elements (that plugins like batarang are using), it follows advices from the angular [documentation](https://code.angularjs.org/1.5.5/docs/guide/production) and should improve performances.


### What type of PR is it?
Improvement

### Todos
* [x] - Add documentation on how to easily activate it for people wanted to debug
* [ ] - Have the `angular.element().scope().controllerCall()` refactored
* [ ] - Fix Selenium tests

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1310

### How should this be tested?
Do a `./grunt build` or launch Zeppelin normally
Check in the console there should not be any `ng-scope` or such in the html classes

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes

