### PR TITLE
[ZEPPELIN-1312] Hotfix - consistent getNoteRevision in websocket call

### DIFF
--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -170,12 +170,12 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    getNoteRevision: function(noteId, revisionId) {
+    getNoteRevision: function(noteId, revision) {
       websocketEvents.sendNewEvent({
         op: 'NOTE_REVISION',
         data: {
           noteId: noteId,
-          revisionId: revisionId
+          revision: revision
         }
       });
     },


### PR DESCRIPTION
### What is this PR for?
This pr fixes inconsistency on websocket call of getNoteRevision method on frontend, since backend waits for `Revision` but front sends `RevisionId`.  This is the simplest fix without api change.


### What type of PR is it?
Hot Fix

### Todos
* [x] - `RevisionId` -> `Revision`

### What is the Jira issue?
[Zeppelin-1312](https://issues.apache.org/jira/browse/ZEPPELIN-1312)

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

