### PR TITLE
[ZEPPELIN-1314] dump out the R command in debug mode

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinR.java
@@ -141,6 +141,9 @@ public class ZeppelinR implements ExecuteResultHandler {
     cmd.addArgument(Integer.toString(port));
     cmd.addArgument(libPath);
     cmd.addArgument(Integer.toString(sparkVersion.toNumber()));
+    
+    // dump out the R command to facilitate manually running it, e.g. for fault diagnosis purposes
+    logger.debug(cmd)
 
     executor = new DefaultExecutor();
     outputStream = new SparkOutputStream(logger);


### PR DESCRIPTION
### What is this PR for?

When diagnosing issues executing R, it would be useful to view the command that is being run so that command can be manually executed and debugged.
### What type of PR is it?

Improvement
### Todos
- [ ] - Task
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-1314
### How should this be tested?

N/A
### Screenshots (if appropriate)

N/A
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
