### PR TITLE
[ZEPPELIN-1316] Zeppelin can not start due to an incorrect Interpreter Setting	

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -370,7 +370,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       // Update transient information from InterpreterSettingRef
       interpreterSettingObject = interpreterSettingsRef.get(setting.getGroup());
       if (interpreterSettingObject == null) {
-        logger.info("can't get InterpreterSetting " +
+        logger.warn("can't get InterpreterSetting " +
           "Information From loaded Interpreter Setting Ref - {} ", setting.getGroup());
         continue;
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -55,6 +55,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.NullArgumentException;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositoryException;
@@ -345,6 +346,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     InputStreamReader isr = new InputStreamReader(fis);
     BufferedReader bufferedReader = new BufferedReader(isr);
     StringBuilder sb = new StringBuilder();
+    InterpreterSetting interpreterSettingObject;
+    String depClassPath = StringUtils.EMPTY;
     String line;
     while ((line = bufferedReader.readLine()) != null) {
       sb.append(line);
@@ -365,9 +368,14 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       setting.getOption().setRemote(true);
 
       // Update transient information from InterpreterSettingRef
-      // TODO(jl): Check if reference of setting is null
-
-      setting.setPath(interpreterSettingsRef.get(setting.getGroup()).getPath());
+      interpreterSettingObject = interpreterSettingsRef.get(setting.getGroup());
+      if (interpreterSettingObject == null) {
+        logger.info("can't get InterpreterSetting " +
+          "Information From loaded Interrpeter Setting Ref - {} ", setting.getGroup());
+        continue;
+      }
+      depClassPath = interpreterSettingObject.getPath();
+      setting.setPath(depClassPath);
 
       setting.setInterpreterGroupFactory(this);
       loadInterpreterDependencies(setting);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -371,7 +371,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       interpreterSettingObject = interpreterSettingsRef.get(setting.getGroup());
       if (interpreterSettingObject == null) {
         logger.info("can't get InterpreterSetting " +
-          "Information From loaded Interrpeter Setting Ref - {} ", setting.getGroup());
+          "Information From loaded Interpreter Setting Ref - {} ", setting.getGroup());
         continue;
       }
       depClassPath = interpreterSettingObject.getPath();


### PR DESCRIPTION
### What is this PR for?
If there are problems with the information defined in the Interpreter Setting (conf / interpreter.json), Interpreter Group during the defined file does not exist, can not run Zeppelin.
Thus, it was an exception handling for that part.

In order to address this issue in the current version it was restarted after deleting Interpreter.json.

### What type of PR is it?
Bug Fix

### Todos
- [x] - check to Interpreter Setting is null

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1316

### How should this be tested?

1. Modify the following part of the Interpreter.json file.
```json
{
      "interpreterGroup": [
        {    
          "name": "spark",
          "class": "fake and invalid class path more more...", // invalid value
          "defaultInterpreter": false
        }
}
```

2. 
After restarting the Zeppelin, Zeppelin Confirm that normally works.
Version of the PR is to be normally started up.
It should also be display all possible Interpreter Web UI.

### Screenshots (if appropriate)
#### before
<img width="618" alt="error" src="https://cloud.githubusercontent.com/assets/10525473/17543783/104363e4-5f0e-11e6-8279-e018a708ccb8.png">

#### after
<img width="1026" alt="correct" src="https://cloud.githubusercontent.com/assets/10525473/17543867/899da484-5f0e-11e6-9f8b-b1bac7cb2718.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
