### PR TITLE
[ZEPPELIN-1245] Focus first paragraph after notebook creation

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -95,10 +95,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     $scope.chart = {};
     $scope.colWidthOption = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     $scope.showTitleEditor = false;
-    $scope.paragraphFocused = false;
-    if (newParagraph.focus) {
-      $scope.paragraphFocused = true;
-    }
+    $scope.paragraphFocused = true;
 
     if (!$scope.paragraph.config) {
       $scope.paragraph.config = {};


### PR DESCRIPTION
### What is this PR for?
Once the notebook is created, cursor should focus on the first paragraph


### What type of PR is it?
Bug Fix 

### Todos
* [ ] - None

### What is the Jira issue?
 https://issues.apache.org/jira/browse/ZEPPELIN-1245

### How should this be tested?
Once the Zeppelin server is started , Create a new notebook
check if cursor blinks on the first paragraph of the notebook

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

