### PR TITLE
[MINOR] Update outdated contents in zeppelin-distribution/*.md files

### DIFF
--- a/zeppelin-distribution/README.md
+++ b/zeppelin-distribution/README.md
@@ -15,17 +15,19 @@
  limitations under the License.
 -->
 
-# Distribution archive of Zeppelin project #
+# Distribution archive of Apache Zeppelin
 
-Zeppelin is distributed as a single gzip archive with the following structure:
+Apache Zeppelin is distributed as a single gzip archive with the following structure:
 
 ```
-zeppelin
+Zeppelin
  ├── bin
  │   ├── zeppelin.sh
  │   └── seppelin-deamon.sh
- ├── lib
  ├── conf
+ ├── interpreter
+ ├── lib
+ ├── licenses
  ├── zan-repo
  │    ├── txt.wordcount
  │    ├── vis.bubble
@@ -33,12 +35,11 @@ zeppelin
  │    ├── ml.something
  │    └── ...
  ├── zeppelin-server-<verion>.jar
- ├── zeppelin-web-<verion>.war
- └── zeppelin-cli-<verion>.jar
+ └── zeppelin-web-<verion>.war
  
 ```
 
-We use maven-assembly-pugin to build it, see distribution.xml for details
+We use `maven-assembly-plugin` to build it, see `zeppelin-distribution/src/assemble/distribution.xml ` for details.
 
-**IMPORTANT:** _/lib_ subdirectory contains all transitive dependencies of the zeppelin-distribution module,
-automatically resolved by maven, except for explicitly excluded _server_, _web_ and _cli_ zeppelin sub-modules.
+>**IMPORTANT:** `_/lib_` subdirectory contains all transitive dependencies of the `zeppelin-distribution` module,
+automatically resolved by maven, except for explicitly excluded `_server_` and `_web_`  Zeppelin sub-modules.

--- a/zeppelin-distribution/build-infrastructure.md
+++ b/zeppelin-distribution/build-infrastructure.md
@@ -15,38 +15,41 @@
  limitations under the License.
 -->
 
-Zeppelin dependency graph:
---------------
-                     hive, hadoop, ...
+# Apache Zeppelin Build Infrastructure
+
+## Dependency graph
+
+```
+                     e.g. hive, hadoop, ...
                        | | |
                        v v v
-  Zeppelin Server  <- Zengine -> Zeppelin CLI
+  Zeppelin Server  <- Zengine
          +               |
     zeppeli web          v
                         ZAN
+```
+
+
+## Artifacts
+
+ - Zeppelin Server  : Web UI, server to host it  / executable
+ - Zeppelin Web     : Web UI, clint-side JS app  / HTML+JavaScript; war
+ - Zeppelin Zengine : Main library               / java library
+ - ZAN              
 
 
 
-Zeppelin artifacts:
-------------------
-Zeppelin CLI    - Commandline UI             - executable
-Zeppelin Server - Web UI, server to host it  - executable
-Zwppwlin Web    - Web UI, clint-side JS app  - HTML+JavaScript; war
-Zengine         - Main library               - java library
-ZAN             - 
+## Build process
+
+ - compile                => *.class, minify *.js
+ - build modules          => *.jar, war
+ - test                   => UnitTest reports
+ - package -P build-distr => final .zip
+ - integration-test       => selenium over running zeppelin-server (from package)
 
 
+## Verify
 
-Build process:
--------------
-compile                => *.class, minify *.js
-build modules          => *.jar, war
-test                   => UnitTest reports
-package -P build-distr => final .zip
-integration-test       => selenium over running zeppelin-server (from package)
-
-
-verify:
- pre-inegration-test   => start Zeppelin
- integration-test
- post-inegration-test  => stop Zeppelin
+ - pre-inegration-test   => start Zeppelin
+ - integration-test
+ - post-inegration-test  => stop Zeppelin


### PR DESCRIPTION
### What is this PR for?
It seems some outdated contents are remained in `zeppelin-distribution/*.md` files. 
e.g. `Zeppelin CLI`, `Zeppelin project(old name of Apache Zeppelin)`

If there are more contents which need to be updated(removed or put it back), please let me know.


### What type of PR is it?
Documentation

### What is the Jira issue?
Since it's so minor update, I didn't create Jira issue for this :)

### How should this be tested?
no need to be tested i think

### Screenshots (if appropriate)
 - `zeppelin-distribution/build-infrastructure.md`
  - Before
<img width="935" alt="screen shot 2016-08-10 at 10 10 01 pm" src="https://cloud.githubusercontent.com/assets/10060731/17554895/1c56a0ee-5f48-11e6-96ce-28070635b4f2.png">

  - After
<img width="704" alt="screen shot 2016-08-10 at 10 06 38 pm" src="https://cloud.githubusercontent.com/assets/10060731/17554893/16cd2fc6-5f48-11e6-8194-cc8011b0ddb8.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

