### PR TITLE
[ZEPPELIN-530] Added changes for Credential Provider, using hadoop commons Credential apis

### DIFF
--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -28,7 +28,10 @@ user3 = password4, role2
 ### A sample for configuring Active Directory Realm
 #activeDirectoryRealm = org.apache.zeppelin.server.ActiveDirectoryGroupRealm
 #activeDirectoryRealm.systemUsername = userNameA
+
+#use either systemPassword or hadoopSecurityCredentialPath, more details in http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html
 #activeDirectoryRealm.systemPassword = passwordA
+#activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/zeppelin.jceks
 #activeDirectoryRealm.searchBase = CN=Users,DC=SOME_GROUP,DC=COMPANY,DC=COM
 #activeDirectoryRealm.url = ldap://ldap.test.com:389
 #activeDirectoryRealm.groupRolesMap = "CN=admin,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"admin","CN=finance,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"finance","CN=hr,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"hr"

--- a/conf/shiro.ini
+++ b/conf/shiro.ini
@@ -29,7 +29,7 @@ user3 = password4, role2
 #activeDirectoryRealm = org.apache.zeppelin.server.ActiveDirectoryGroupRealm
 #activeDirectoryRealm.systemUsername = userNameA
 
-#use either systemPassword or hadoopSecurityCredentialPath, more details in http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html
+#use either systemPassword or hadoopSecurityCredentialPath, more details in http://zeppelin.apache.org/docs/latest/security/shiroauthentication.html
 #activeDirectoryRealm.systemPassword = passwordA
 #activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/zeppelin.jceks
 #activeDirectoryRealm.searchBase = CN=Users,DC=SOME_GROUP,DC=COMPANY,DC=COM

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -1,3 +1,4 @@
+
 ---
 layout: page
 title: "Apache Shiro Authentication for Apache Zeppelin"
@@ -112,10 +113,36 @@ To learn more about Apache Shiro Realm, please check [this documentation](http:/
 We also provide community custom Realms.
 
 ### Active Directory
-TBD
+
+```
+activeDirectoryRealm = org.apache.zeppelin.server.ActiveDirectoryGroupRealm
+activeDirectoryRealm.systemUsername = userNameA
+activeDirectoryRealm.systemPassword = passwordA
+activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/conf/zeppelin.jceks
+activeDirectoryRealm.searchBase = CN=Users,DC=SOME_GROUP,DC=COMPANY,DC=COM
+activeDirectoryRealm.url = ldap://ldap.test.com:389
+activeDirectoryRealm.groupRolesMap = "CN=aGroupName,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"group1"
+activeDirectoryRealm.authorizationCachingEnabled = false
+```
+
+
+Also instead of specifying systemPassword in clear text in shiro.ini administrator can choose to specify the same in "hadoop credential".
+Create a keystore file using the hadoop credential commandline, for this the hadoop commons should be in the classpath
+`hadoop credential create activeDirectoryRealm.systempassword -provider jceks://file/user/zeppelin/conf/zeppelin.jceks`
+
+Change the following values in the Shiro.ini file, and uncomment the line:
+`activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/conf/zeppelin.jceks`
 
 ### LDAP
-TBD
+
+```
+ldapRealm = org.apache.zeppelin.server.LdapGroupRealm
+# search base for ldap groups (only relevant for LdapGroupRealm):
+ldapRealm.contextFactory.environment[ldap.searchBase] = dc=COMPANY,dc=COM
+ldapRealm.contextFactory.url = ldap://ldap.test.com:389
+ldapRealm.userDnTemplate = uid={0},ou=Users,dc=COMPANY,dc=COM
+ldapRealm.contextFactory.authenticationMechanism = SIMPLE
+```
 
 ### ZeppelinHub
 [ZeppelinHub](https://www.zeppelinhub.com) is a service that synchronize your Apache Zeppelin notebooks and enables you to collaborate easily.

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -1,4 +1,3 @@
-
 ---
 layout: page
 title: "Apache Shiro Authentication for Apache Zeppelin"

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <cxf.version>2.7.7</cxf.version>
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
+    <hadoop-common.version>2.6.0</hadoop-common.version>
   </properties>
 
   <dependencyManagement>
@@ -203,6 +204,61 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>${hadoop-common.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-server</artifactId>
+        </exclusion>
+
+
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jackrabbit</groupId>
+          <artifactId>jackrabbit-webdav</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jgit</groupId>
+          <artifactId>org.eclipse.jgit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch</artifactId>
+        </exclusion>
+
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
This is the first step in order to ensure clear text passwords are not stored in the configuration files. To start with this PR will take care of getting AD system password from the .jceks file, configured by the user specified in the shiro.ini file. Going forward the same keystore can be used to read passwords for other systems as well. 

If the hadoopSecurityCredentialPath path is present and not empty in the shiro.ini, then the password is read from the keystore file and it need not be stored inside the shiro.ini file. 


### What type of PR is it?
[ Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-530


### How should this be tested?
Create a keystore file using the hadoop credential commandline, for this the hadoop commons should be in the classpath

`hadoop credential create activeDirectoryRealm.systempassword -provider jceks://file/user/zeppelin/conf/zeppelin.jceks`

Change the following values in the Shiro.ini file, and uncomment the line:

`activeDirectoryRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/conf/zeppelin.jceks`

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No. This is an additional option. 
* Does this needs documentation?
Yes

### Tasks
* Documentation

