### PR TITLE
[ZEPPELIN-1118] Migrate Zeppelin Live Demo feature from zeppelin-project.org to zeppelin.apache.org

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -64,7 +64,8 @@
     </p>
     <p><a href="http://youtu.be/_PQbVH_aO5E" target="_zeppelinVideo" class="btn btn-primary btn-lg bigFingerButton" role="button">Watch the video</a>
 
-       <a href="./download.html" class="btn btn-primary btn-lg bigFingerButton" role="button">Get Zeppelin</a></p>
+       <a href="./download.html" class="btn btn-primary btn-lg bigFingerButton" role="button">Get Zeppelin</a>
+       <a href="./demos.html" class="btn btn-primary btn-lg bigFingerButton" role="button">Live Demo</a></p>
   </div>
 </div>
 {% endif %}

--- a/demo/demo-aws-emr.html
+++ b/demo/demo-aws-emr.html
@@ -1,0 +1,15 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Zeppelin Live Demo</title>
+    </head>
+    <body style="margin:0px;padding:0px;overflow:hidden">
+        <div width="100%" style="padding:0 10px 0 10px">
+            <div style="float:left"><a href="/" style="color:#333333">Go back</a></div>
+            <div style="float:right">
+              Live demo powered by Apache Spark and Zeppelin on Amazon EMR              
+            </div>
+        </div>
+        <iframe src="http://showcase.zeppelinhub.io/#/" frameborder="0" style="overflow:hidden;height:99%;width:100%" height="99%" width="100%"></iframe>
+    </body>
+</html>

--- a/demos.md
+++ b/demos.md
@@ -23,6 +23,6 @@ List of live demo on behalf of Apache Zeppelin by 3rd parties.
 
 <ul>
   <li>
-    <a href="./demo/demo-aws-emr.html">Live demo</a> powered by Apache Spark and Apache Zeppelin on Amazon EMR.
+    <a href="./demo/demo-aws-emr.html">Live demo</a> powered by Apache Spark and Apache Zeppelin on <a href="https://aws.amazon.com/" target="_blank">Amazon EMR</a>.
   </li>
 </ul>

--- a/demos.md
+++ b/demos.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Demos
+tagline: Try live demo
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+{% include JB/setup %}
+
+List of live demo on behalf of Apache Zeppelin by 3rd parties.
+
+<ul>
+  <li>
+    <a href="./demo/demo-aws-emr.html">Live demo</a> powered by Apache Spark and Apache Zeppelin on Amazon EMR.
+  </li>
+</ul>


### PR DESCRIPTION
### What is this PR for?
Migrate Zeppelin Live Demo feature from zeppelin-project.org to zeppelin.apache.org
It adds

1) "Demo" button on main page to redirect demos.html
2) "demos.html" to list all the available 3rd party demos
3) Apache Zeppelin and Spark demo by Aws-emr.

Amazon EMR provided the demo instances and NFLabs helped configuring this demo.

### What type of PR is it?
Feature

### Todos
* [x] - migration of contents

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1118


### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/1540981/17559537/6ead70d6-5ed3-11e6-8e86-4f6c60ca55d8.png)

![image](https://cloud.githubusercontent.com/assets/1540981/17559525/61d02fa2-5ed3-11e6-950c-23ee573bc834.png)

![image](https://cloud.githubusercontent.com/assets/1540981/17559557/7e7478c0-5ed3-11e6-8437-9ed8c28fa205.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
