### PR TITLE
[HOTFIX] Bring zeppelin-display back to dependency of spark interpreter module

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -51,11 +51,11 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
-    <!-- dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-display_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-    </dependency -->
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -989,5 +989,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
### What is this PR for?
problem reported http://apache-zeppelin-dev-mailing-list.75694.x6.nabble.com/Angular-Display-System-tp13740.html


### What type of PR is it?
Hot Fix

### Todos
* [x] - Bring zeppelin-display back to dependency of spark interpreter module

### What is the Jira issue?

### How should this be tested?
Try import in the spark interpreter
```
import org.apache.zeppelin.display.angular.notebookscope._ 
import AngularElem._ 
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

