### PR TITLE
ZEPPELIN-1319 Use absolute path for ssl truststore and keystore when available

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -273,7 +273,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
   public String getKeyStorePath() {
     String path = getString(ConfVars.ZEPPELIN_SSL_KEYSTORE_PATH);
-    if (path != null && path.startsWith("/")) {
+    if (path != null && path.startsWith("/") || isWindowsPath(path)) {
       return path;
     } else {
       return getRelativeDir(
@@ -302,7 +302,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
   public String getTrustStorePath() {
     String path = getString(ConfVars.ZEPPELIN_SSL_TRUSTSTORE_PATH);
-    if (path != null && path.startsWith("/")) {
+    if (path != null && path.startsWith("/") || isWindowsPath(path)) {
       return path;
     } else {
       return getRelativeDir(

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -272,10 +272,15 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
   public String getKeyStorePath() {
-    return getRelativeDir(
-            String.format("%s/%s",
-                    getConfDir(),
-                    getString(ConfVars.ZEPPELIN_SSL_KEYSTORE_PATH)));
+    String path = getString(ConfVars.ZEPPELIN_SSL_KEYSTORE_PATH);
+    if (path != null && path.startsWith("/")) {
+      return path;
+    } else {
+      return getRelativeDir(
+          String.format("%s/%s",
+              getConfDir(),
+              getString(path)));
+    }
   }
 
   public String getKeyStoreType() {
@@ -297,10 +302,13 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
   public String getTrustStorePath() {
     String path = getString(ConfVars.ZEPPELIN_SSL_TRUSTSTORE_PATH);
-    if (path == null) {
-      return getKeyStorePath();
+    if (path != null && path.startsWith("/")) {
+      return path;
     } else {
-      return getRelativeDir(path);
+      return getRelativeDir(
+          String.format("%s/%s",
+              getConfDir(),
+              getString(path)));
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Use absolute path for ssl truststore and keystore when available

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1319

### How should this be tested?
Config `zeppelin.ssl.truststore.path`, `zeppelin.ssl.keystore.path` and verify whether the absolute path or the path relative to conf is used.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
