### PR TITLE
[BUILD][HOTFIX] Add -DskipTests property to reduce build time

### DIFF
--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
+PUBLISH_PROFILES="-Pbuild-distr -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"
@@ -93,10 +93,10 @@ function publish_to_maven() {
   tmp_repo="$(mktemp -d /tmp/zeppelin-repo-XXXXX)"
 
   # build with scala-2.10
-  echo "mvn clean install -Ppublish-distr \
+  echo "mvn clean install -DskipTests \
     -Dmaven.repo.local=${tmp_repo} -Pscala-2.10 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.10 \
+  mvn clean install -DskipTests -Dmaven.repo.local="${tmp_repo}" -Pscala-2.10 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.10 failed."
@@ -106,10 +106,10 @@ function publish_to_maven() {
   # build with scala-2.11
   "${BASEDIR}/change_scala_version.sh" 2.11
 
-  echo "mvn clean install -Ppublish-distr \
+  echo "mvn clean install -DskipTests \
     -Dmaven.repo.local=${tmp_repo} -Pscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}"
-  mvn clean install -Ppublish-distr -Dmaven.repo.local="${tmp_repo}" -Pscala-2.11 \
+  mvn clean install -DskipTests -Dmaven.repo.local="${tmp_repo}" -Pscala-2.11 \
     ${PUBLISH_PROFILES} ${PROJECT_OPTIONS}
   if [[ $? -ne 0 ]]; then
     echo "Build with scala 2.11 failed."


### PR DESCRIPTION
### What is this PR for?
In `dev/publish_release.sh` there are two mvn build. Second build fails with follow error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (start-zeppelin) on project zeppelin-server: An Ant BuildException has occured: The directory /private/tmp/zeppelin-release/zeppelin/zeppelin-server/${zeppelin.daemon.package.base} does not exist
[ERROR] around Ant part ...<exec spawn="true" dir="${zeppelin.daemon.package.base}" executable="./zeppelin-daemon.sh">... @ 4:94 in /private/tmp/zeppelin-release/zeppelin/zeppelin-server/target/antrun/build-main.xml
```

This PR skip tests to fix this issue as hotfix. In addition, it will reduce build time

### What type of PR is it?
Build

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

