### PR TITLE
[HOTFIX] Add logins authentication for hdfs file interpreter

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/HDFSCommand.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSCommand.java
@@ -23,6 +23,8 @@ import java.net.HttpURLConnection;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import javax.ws.rs.core.UriBuilder;
+
+import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 
 /**
@@ -128,6 +130,12 @@ public class HDFSCommand {
     // Connect and get response string
     URL hdfsUrl = uri.toURL();
     HttpURLConnection con = (HttpURLConnection) hdfsUrl.openConnection();
+
+    if (hdfsUrl.getUserInfo() != null) {
+      String basicAuth = "Basic " + new String(new Base64()
+        .encode(hdfsUrl.getUserInfo().getBytes()));
+      con.setRequestProperty("Authorization", basicAuth);
+    }
 
     if (op.cmd == HttpType.GET) {
       con.setRequestMethod("GET");


### PR DESCRIPTION
### What is this PR for?

When attempting to login to a webhdfs file system with credentials as in:
`https://<username>:<password>@<host>:<port>`

We get a `ava.io.IOException: Server returned HTTP response code: 401 for URL: ....`

This has to do with how Java authorizes a URL.  A simple fix is applied to handle this. 
### What type of PR is it?

Improvement
### Todos
- [x] - Apply Patch
### What is the Jira issue?

No JIRA issue, this was required functionality for a use case. I expect others will require this too.
### How should this be tested?

Login to a webhdfs that requires authentication.  It works. 
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update?
  No
- Is there breaking changes for older versions?
  No
- Does this needs documentation?
  I don't think so- the intuitive way to pass username/login is https://`user`:`password`@host.  This makes that work. 
