### PR TITLE
Update AWS S3 library to avoid old Jackson

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -42,9 +42,15 @@
     </dependency>
 
     <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20160212</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.10.62</version>
+      <version>1.11.24</version>
     </dependency>
 
     <dependency>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
@@ -43,9 +43,9 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amazonaws.util.json.JSONArray;
-import com.amazonaws.util.json.JSONException;
-import com.amazonaws.util.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;


### PR DESCRIPTION
### What is this PR for?
Spark 2.0 remote requires Jackson 2.6 or later while Zeppelin uses
Jackson 2.5 from AWS S3 library. In order to resolve this, update AWS
S3 library to 1.11 which depends on Jackson 2.6.

### What type of PR is it?
Improvement

### Todos
* [ ] - Apply Patch

### What is the Jira issue?
No JIRA issue

### How should this be tested?
 * Set Spark Interpreter not to use local.
 * Run a simple Hello World notebook.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO