### PR TITLE
ZEPPELIN-1318 - Add support for matplotlib displaying png images in python interpreter

### DIFF
--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -87,7 +87,7 @@ print("".join(z.checkbox("f3", [("o1","1"), ("o2","2")],["1"])))
 
 ## Matplotlib integration
  The python interpreter can display matplotlib graph with the function `z.show()`.
- You need to have matplotlib module installed and a XServer running to use this functionality !
+ You need to have matplotlib module installed and a XServer running to use this functionality!
  
  ```python
 %python
@@ -97,12 +97,12 @@ plt.figure()
 z.show(plt)
 plt.close()
 ```
-z.show function can take optional parameters to adapt graph width and height
+The `z.show()` function can take optional parameters to adapt graph dimensions (width and height) as well as output format (png or optionally svg).
 
  ```python
 %python
 z.show(plt, width='50px')
-z.show(plt, height='150px')
+z.show(plt, height='150px', fmt='svg')
 ```
 <img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/pythonMatplotlib.png" />
 

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -19,6 +19,7 @@
 # Remove interactive mode displayhook
 import sys
 import signal
+import base64
 
 try:
     import StringIO as io
@@ -69,10 +70,10 @@ def help():
  plt.close()
  </pre>
  <div><br/> z.show function can take optional parameters
- to adapt graph width and height</div>
+ to adapt graph dimensions (width and height) and format (png or svg)</div>
  <div><b>example </b>:
  <pre>z.show(plt,width='50px
- z.show(plt,height='150px') </pre></div>
+ z.show(plt,height='150px', fmt='svg') </pre></div>
 
  <h3>Pandas DataFrame</h3>
  <div> You need to have Pandas module installed
@@ -163,13 +164,24 @@ class PyZeppelinContext(object):
         #)
         body_buf.close(); header_buf.close()
     
-    def show_matplotlib(self, p, width="100%", height="100%", **kwargs):
+    def show_matplotlib(self, p, width="100%", height="100%",
+                        fmt='png', **kwargs):
         """Matplotlib show function
         """
         img = io.StringIO()
-        p.savefig(img, format="svg")
-        html = "%html <div style='width:{width};height:{height}'>{image}<div>"
-        print(html.format(width=width, height=height, image=img.getvalue()))
+        if fmt == 'png':
+            p.savefig(img, format=fmt)
+            html = "%html <img src={img} width={width}, height={height}>"
+            img_str = "data:image/png;base64,"
+            img_str += base64.b64encode(img.getvalue().strip())
+        elif fmt == 'svg':
+            p.savefig(img, format=fmt)
+            html = "%html <div style='width:{width};height:{height}'>{img}<div>"
+            img_str = img.getvalue()
+        else:
+            raise ValueError("fmt must be 'png' or 'svg'")
+        
+        print(html.format(width=width, height=height, img=img_str))
         img.close()
 
 


### PR DESCRIPTION
### What is this PR for?
This PR adds support for plotting png images using the matplotlib helper function within a python interpreter (eg `z.show()`). The primary motivation for this is due to the overhead incurred from svg images, which can lag the notebooks if multiple, complicated images are generated (for example, multiple filled contour plots). png images are more lightweight, but of course come at a cost of image quality due to them being raster rather than vector like svg. The support for png images is incorporated through the use of a new optional argument to `z.show` called `fmt` which can be one of `'svg'` or `'png'`. The same code that is currently used in show is used for svg images while the code for png images relies on converting the image directly to a byte array and then entering the decoded byte string directly into an HTML image tag. Currently `fmt` defaults to `'png'` but I think we should consider discussing the pros and cons of each option in this PR. 

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1318](https://issues.apache.org/jira/browse/ZEPPELIN-1318)

### How should this be tested?
In a notebook cell, enter:
```python
%python
import matplotlib.pyplot as plt
import numpy as np

plt.figure()
plt.plot(np.arange(10))
z.show(plt, fmt=fmt)
```
Where `fmt` may be one of `'svg'` or `'png'`, and any other input should result in a `ValueError`. I would also recommend testing the example in the screenshot below. 

### Screenshots (if appropriate)
![zeppelin plot](https://puu.sh/qzc4t/b8fcfe856e.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes (if the changes to the `help()` docstring are not sufficient)

