### PR TITLE
[ZEPPELIN-1144]Zeppelin home page should only list notebooks with read or write permission

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -467,8 +467,7 @@ public class NotebookServer extends WebSocketServlet implements
         LOG.error("Fail to reload notes from repository", e);
       }
     }
-
-    List<Note> notes = notebook.getAllNotes();
+    List<Note> notes = notebook.getAllNotes(subject);
     List<Map<String, String>> notesInfo = new LinkedList<>();
     for (Note note : notes) {
       Map<String, String> info = new HashMap<>();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -28,8 +28,12 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonReader;
@@ -520,6 +524,35 @@ public class Notebook implements NoteEventListener {
         }
       });
       return noteList;
+    }
+  }
+
+  public List<Note> getAllNotes(AuthenticationInfo subject) {
+    final Set<String> entities = Sets.newHashSet();
+    if (subject != null) {
+      entities.add(subject.getUser());
+    }
+
+    synchronized (notes) {
+      return FluentIterable.from(notes.values()).filter(new Predicate<Note>() {
+        @Override
+        public boolean apply(Note input) {
+          return input != null && notebookAuthorization.isReader(input.getId(), entities);
+        }
+      }).toSortedList(new Comparator<Note>() {
+        @Override
+        public int compare(Note note1, Note note2) {
+          String name1 = note1.id();
+          if (note1.getName() != null) {
+            name1 = note1.getName();
+          }
+          String name2 = note2.id();
+          if (note2.getName() != null) {
+            name2 = note2.getName();
+          }
+          return name1.compareTo(name2);
+        }
+      });
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -42,6 +42,7 @@ import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
 import org.junit.Before;
@@ -810,6 +811,26 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(note1.getName(), "/MyNote/sub");
 
     notebook.removeNote(note1.getId(), null);
+  }
+
+  @Test
+  public void testGetAllNotes() throws Exception {
+    Note note1 = notebook.createNote(null);
+    Note note2 = notebook.createNote(null);
+    assertEquals(2, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
+
+    notebook.getNotebookAuthorization().setOwners(note1.getId(), Sets.newHashSet("user1"));
+    notebook.getNotebookAuthorization().setWriters(note1.getId(), Sets.newHashSet("user1"));
+    notebook.getNotebookAuthorization().setReaders(note1.getId(), Sets.newHashSet("user1"));
+    assertEquals(1, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
+    assertEquals(2, notebook.getAllNotes(new AuthenticationInfo("user1")).size());
+
+    notebook.getNotebookAuthorization().setOwners(note2.getId(), Sets.newHashSet("user2"));
+    notebook.getNotebookAuthorization().setWriters(note2.getId(), Sets.newHashSet("user2"));
+    notebook.getNotebookAuthorization().setReaders(note2.getId(), Sets.newHashSet("user2"));
+    assertEquals(0, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
+    assertEquals(1, notebook.getAllNotes(new AuthenticationInfo("user1")).size());
+    assertEquals(1, notebook.getAllNotes(new AuthenticationInfo("user2")).size());
   }
 
   private void delete(File file){


### PR DESCRIPTION
### What is this PR for?
If logged in user does not have Read and Write permission for a notebook, user should not see the notebook in the zeppelin home page.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1144

### How should this be tested?
* unit test
* online test

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

