### PR TITLE
[ZEPPELIN-1334] Environment variable defined in interpreter setting doesn't take effect

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -527,4 +527,11 @@ public class RemoteInterpreter extends Interpreter {
   public void setEnv(Map<String, String> env) {
     this.env = env;
   }
+
+  public void addEnv(Map<String, String> env) {
+    if (this.env == null) {
+      this.env = new HashMap<>();
+    }
+    this.env.putAll(env);
+  }
 }

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -258,5 +258,14 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.17</version>
+        <configuration combine.children="append">
+          <forkMode>always</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -994,7 +994,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         new RemoteInterpreter(property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
             interpreterPath, localRepoPath, connectTimeout, maxPoolSize,
             remoteInterpreterProcessListener, appEventListener);
-    remoteInterpreter.setEnv(env);
+    remoteInterpreter.addEnv(env);
 
     return new LazyOpenInterpreter(remoteInterpreter);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -18,10 +18,7 @@
 package org.apache.zeppelin.interpreter;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NullArgumentException;
@@ -31,6 +28,7 @@ import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +50,10 @@ public class InterpreterFactoryTest {
     tmpDir.mkdirs();
     new File(tmpDir, "conf").mkdirs();
 
-    MockInterpreter1.register("mock1", "org.apache.zeppelin.interpreter.mock.MockInterpreter1");
+    Map<String, InterpreterProperty> propertiesMockInterpreter1 = new HashMap<String, InterpreterProperty>();
+    propertiesMockInterpreter1.put("PROPERTY_1", new InterpreterProperty("PROPERTY_1", "", "VALUE_1", "desc"));
+    propertiesMockInterpreter1.put("property_2", new InterpreterProperty("", "property_2", "value_2", "desc"));
+    MockInterpreter1.register("mock1", "mock1", "org.apache.zeppelin.interpreter.mock.MockInterpreter1", propertiesMockInterpreter1);
     MockInterpreter2.register("mock2", "org.apache.zeppelin.interpreter.mock.MockInterpreter2");
 
     System.setProperty(ConfVars.ZEPPELIN_HOME.getVarName(), tmpDir.getAbsolutePath());
@@ -93,6 +94,29 @@ public class InterpreterFactoryTest {
     // restart interpreter
     factory.restart(mock1Setting.getId());
     assertNull(mock1Setting.getInterpreterGroup("sharedProcess").get("session"));
+  }
+
+  @Test
+  public void testRemoteRepl() throws Exception {
+    factory = new InterpreterFactory(conf, new InterpreterOption(true), null, null, null, depResolver);
+    List<InterpreterSetting> all = factory.get();
+    InterpreterSetting mock1Setting = null;
+    for (InterpreterSetting setting : all) {
+      if (setting.getName().equals("mock1")) {
+        mock1Setting = setting;
+        break;
+      }
+    }
+    InterpreterGroup interpreterGroup = mock1Setting.getInterpreterGroup("sharedProcess");
+    factory.createInterpretersForNote(mock1Setting, "sharedProcess", "session");
+    // get interpreter
+    assertNotNull("get Interpreter", interpreterGroup.get("session").get(0));
+    assertTrue(interpreterGroup.get("session").get(0) instanceof LazyOpenInterpreter);
+    LazyOpenInterpreter lazyInterpreter = (LazyOpenInterpreter)(interpreterGroup.get("session").get(0));
+    assertTrue(lazyInterpreter.getInnerInterpreter() instanceof RemoteInterpreter);
+    RemoteInterpreter remoteInterpreter = (RemoteInterpreter) lazyInterpreter.getInnerInterpreter();
+    assertEquals("VALUE_1", remoteInterpreter.getEnv().get("PROPERTY_1"));
+    assertEquals("value_2", remoteInterpreter.getProperty("property_2"));
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -18,7 +18,12 @@
 package org.apache.zeppelin.interpreter;
 
 import java.io.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NullArgumentException;


### PR DESCRIPTION
### What is this PR for?
I define SPAKR_HOME in interpreter setting, but it doesn't take effect. This PR is for bring back the environment variable defined in interpreter setting.  The root cause is that we reset the env after creating RemoteInterpreter.
```
         new RemoteInterpreter(property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
             interpreterPath, localRepoPath, connectTimeout, maxPoolSize,
             remoteInterpreterProcessListener, appEventListener);
    remoteInterpreter.setEnv(env);
```


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1334

### How should this be tested?
Tested manually.  Create 2 spark interpreter setting, one for spark1 another is for spark2. And define SPARK_HOME for each interpreter. Then I can run both spark1 and spark2 in one zeppelin instance. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/17696073/b64b1014-63de-11e6-88ab-d26b1c2fa75c.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

