### PR TITLE
[ZEPPELIN-1336] hadoop library for spark interpreter is not match.

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -954,6 +954,18 @@
           <version>${yarn.version}</version>
         </dependency>
 
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-common</artifactId>
+          <version>${yarn.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+          <version>${yarn.version}</version>
+        </dependency>
+
 	<dependency>
 	  <groupId>org.apache.hadoop</groupId>
 	  <artifactId>hadoop-common</artifactId>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-spark_2.11</artifactId>
+  <artifactId>zeppelin-spark_2.10</artifactId>
   <packaging>jar</packaging>
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Spark</name>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-spark_2.10</artifactId>
+  <artifactId>zeppelin-spark_2.11</artifactId>
   <packaging>jar</packaging>
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Spark</name>
@@ -941,6 +941,36 @@
           <artifactId>hadoop-yarn-api</artifactId>
           <version>${yarn.version}</version>
         </dependency>
+
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-client</artifactId>
+          <version>${yarn.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-yarn-common</artifactId>
+          <version>${yarn.version}</version>
+        </dependency>
+
+	<dependency>
+	  <groupId>org.apache.hadoop</groupId>
+	  <artifactId>hadoop-common</artifactId>
+          <version>${yarn.version}</version>
+	</dependency>
+
+	<dependency>
+	  <groupId>org.apache.hadoop</groupId>
+	  <artifactId>hadoop-hdfs</artifactId>
+          <version>${yarn.version}</version>
+	</dependency>
+
+	<dependency>
+	  <groupId>org.apache.hadoop</groupId>
+	  <artifactId>hadoop-client</artifactId>
+          <version>${yarn.version}</version>
+	</dependency>
       </dependencies>
     </profile>
     


### PR DESCRIPTION
### What is this PR for?
This PR is for download hadoop libraries for yarn cluster.
This issue comes from https://github.com/apache/zeppelin/pull/1318.

### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1336


### How should this be tested?
1 build zeppelin for `spark2.0&hadoop2.7`
```
mvn clean package -Pspark-2.0 -Phadoop-2.7 -Dhadoop.version=2.7.2 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests 
```


2 verify hadoop library version for spark.
```
ls -al $ZEPPELIN_HOME/spark/target/lib/
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

