### PR TITLE
[ZEPPELIN-1333] prevent calling runParagraph() on shift-enter event

### DIFF
--- a/zeppelin-web/src/components/ngenter/ngenter.directive.js
+++ b/zeppelin-web/src/components/ngenter/ngenter.directive.js
@@ -17,9 +17,11 @@ angular.module('zeppelinWebApp').directive('ngEnter', function() {
   return function(scope, element, attrs) {
     element.bind('keydown keypress', function(event) {
       if (event.which === 13) {
-        scope.$apply(function() {
-          scope.$eval(attrs.ngEnter);
-        });
+        if (!event.shiftKey) {
+          scope.$apply(function() {
+            scope.$eval(attrs.ngEnter);
+          });
+        }
         event.preventDefault();
       }
     });


### PR DESCRIPTION
### What is this PR for?
when shift-enter is pressed in text box of dynamic form, the paragraph runs twice.
1) ng-enter event handler
2) global event handler

blocking shift-enter in ng-enter event handler, this issue could be resolved.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1333

### How should this be tested?
![image](https://cloud.githubusercontent.com/assets/6119284/17725846/af8775b4-6489-11e6-912f-99dbc8a050bb.png)
the test case above should return 1 with enter event and shift-enter event.
