### PR TITLE
[ZEPPELIN-1333] Fix Double Run when Shift + Enter on display form

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -22,7 +22,6 @@ limitations under the License.
 
       <input class="form-control input-sm"
              ng-if="!paragraph.settings.forms[formulaire.name].options"
-             ng-enter="runParagraph(getEditorValue())"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
              name="{{formulaire.name}}" />


### PR DESCRIPTION
### What is this PR for?
Display form input has a `ng-enter` catcher, so if you use SHIFT + ENTER, the run function will be called twice.
This PR is resolving the issue by removing the `ng-enter`, making the display form input react to SHIT + ENTER only.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1333

### How should this be tested?
I used 3 different paragraphs:
```
%spark 
var counter=0;
def myTestFunc(testVal:Int) = {
    counter+=testVal;
    println(s"$counter");
}
```

```
%spark 
myTestFunc(1);
```

```
%spark 
myTestFunc(z.input("testvalue").toString().toInt);
```

Both paragraph 2 and 3 should increment of 1 (type 1 in the input).
The input in Paragraph 3 should be ran only with SHIFT + ENTER

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? In a way yes
* Does this needs documentation? Good question
