### PR TITLE
[ZEPPELIN-1335] bug fixed y axis label for scatterChart and stackedAreaChart 

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1053,7 +1053,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       d3g = scatterData.d3g;
 
       $scope.chart[type].xAxis.tickFormat(function(d) {return xAxisTickFormat(d, xLabels);});
-      $scope.chart[type].yAxis.tickFormat(function(d) {return xAxisTickFormat(d, yLabels);});
+      $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d, yLabels);});
 
       // configure how the tooltip looks.
       $scope.chart[type].tooltipContent(function(key, x, y, graph, data) {
@@ -1095,7 +1095,11 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         xLabels = pivotdata.xLabels;
         d3g = pivotdata.d3g;
         $scope.chart[type].xAxis.tickFormat(function(d) {return xAxisTickFormat(d, xLabels);});
-        $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d);});
+        if (type === 'stackedAreaChart') {
+          $scope.chart[type].yAxisTickFormat(function(d) {return yAxisTickFormat(d);});
+        } else {
+          $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d, xLabels);});
+        }
         $scope.chart[type].yAxis.axisLabelDistance(50);
         if ($scope.chart[type].useInteractiveGuideline) { // lineWithFocusChart hasn't got useInteractiveGuideline
           $scope.chart[type].useInteractiveGuideline(true); // for better UX and performance issue. (https://github.com/novus/nvd3/issues/691)


### PR DESCRIPTION
### What is this PR for?
When Y Axis be large value, the format that is displayed is incorrect.
(case by scatterChart and stackedAreaChart )


### What type of PR is it?
Bug Fix

### Todos
- [x] - fixed scatterChart  y Axis
- [x] - fixed stackedAreaChart y Axis format function.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1335

### How should this be tested?
test paragraph context.
```
%spark 

case class DumyDataStruct(XAxis:Long, YAxis:Long)
var dumyDataRange = 1 to 1000

val dumyDataTable = dumyDataRange.map(data => {
            DumyDataStruct(data, data * 1000000000L)
        }
    )
dumyDataTable.toDF().registerTempTable("dumyGraph")
```

```
%sql
select * from dumyGraph
```
After running the Paragraphs, plase look at the Y-axis of the chart.

### Screenshots (if appropriate)
#### before
![incorrect](https://cloud.githubusercontent.com/assets/10525473/17779342/4ff192f0-65a2-11e6-9008-f89f28dd208c.gif)

#### after
![correct](https://cloud.githubusercontent.com/assets/10525473/17779339/4df4e3b2-65a2-11e6-90c8-6fee574aae12.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

