### PR TITLE
ZEPPELIN-1328 - z.show in python interpreter does not display PNG images in python 3

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -20,11 +20,7 @@
 import sys
 import signal
 import base64
-
-try:
-    import StringIO as io
-except ImportError:
-    import io as io
+import io
 
 def intHandler(signum, frame):  # Set the signal handler
     print ("Paragraph interrupted")
@@ -117,6 +113,7 @@ class PyZeppelinContext(object):
     
     def __init__(self):
         self.max_result = 1000
+        self.py3 = bool(sys.version_info >= (3,))
     
     def input(self, name, defaultValue=""):
         print(self.errorMsg)
@@ -168,13 +165,23 @@ class PyZeppelinContext(object):
                         fmt='png', **kwargs):
         """Matplotlib show function
         """
-        img = io.StringIO()
         if fmt == 'png':
+            img = io.BytesIO()
             p.savefig(img, format=fmt)
             html = "%html <img src={img} width={width}, height={height}>"
-            img_str = "data:image/png;base64,"
+            img_str = b"data:image/png;base64,"
             img_str += base64.b64encode(img.getvalue().strip())
+            # Need to do this for python3 compatibility
+            if self.py3:
+                img_str = img_str.decode('ascii')
+                
         elif fmt == 'svg':
+            # Another python3 compatability check
+            if self.py3:
+                img = io.StringIO()
+            else:
+                img = io.BytesIO()
+                
             p.savefig(img, format=fmt)
             html = "%html <div style='width:{width};height:{height}'>{img}<div>"
             img_str = img.getvalue()

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -20,7 +20,11 @@
 import sys
 import signal
 import base64
-import io
+from io import BytesIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 def intHandler(signum, frame):  # Set the signal handler
     print ("Paragraph interrupted")
@@ -138,14 +142,14 @@ class PyZeppelinContext(object):
         """Pretty prints DF using Table Display System
         """
         limit = len(df) > self.max_result
-        header_buf = io.StringIO("")
+        header_buf = StringIO("")
         header_buf.write(str(df.columns[0]))
         for col in df.columns[1:]:
             header_buf.write("\t")
             header_buf.write(str(col))
         header_buf.write("\n")
         
-        body_buf = io.StringIO("")
+        body_buf = StringIO("")
         rows = df.head(self.max_result).values if limit else df.values
         for row in rows:
             body_buf.write(str(row[0]))
@@ -166,7 +170,7 @@ class PyZeppelinContext(object):
         """Matplotlib show function
         """
         if fmt == 'png':
-            img = io.BytesIO()
+            img = BytesIO()
             p.savefig(img, format=fmt)
             html = "%html <img src={img} width={width}, height={height}>"
             img_str = b"data:image/png;base64,"
@@ -176,12 +180,7 @@ class PyZeppelinContext(object):
                 img_str = img_str.decode('ascii')
                 
         elif fmt == 'svg':
-            # Another python3 compatability check
-            if self.py3:
-                img = io.StringIO()
-            else:
-                img = io.BytesIO()
-                
+            img = StringIO()
             p.savefig(img, format=fmt)
             html = "%html <div style='width:{width};height:{height}'>{img}<div>"
             img_str = img.getvalue()


### PR DESCRIPTION
### What is this PR for?
Support for plotting PNG images via matplotlib inline for the python interpreter was recently added (#1329). However, these changes did not work for python3 since it handles strings differently. This PR aims to make the inline plotting compatible with both python 2 and 3. 


### What type of PR is it?
Bug Fix

### What is the Jira issue?
* [ZEPPELIN-1328](https://issues.apache.org/jira/browse/ZEPPELIN-1328)

### How should this be tested?
In a python interpreteter cell, make sure the following produce an image:
```python
%python
import matplotlib.pyplot as plt
import numpy as np

x = np.arange(5)
plt.plot(x)
z.show(plt, fmt='png') # Repeat for fmt='svg'
```
This should be tested for both python2 and 3 interpreters (via the interpreter settings page). 

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

