### PR TITLE
[ZEPPELIN-728] Can't POST interpreter setting (CorsFilter?)

### DIFF
--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -219,7 +219,9 @@ The role of registered interpreters, settings and interpreters group are describ
   "dependencies": [
     {
       "groupArtifactVersion": "groupId:artifactId:version",
-      "exclusions": "groupId:artifactId"
+      "exclusions": [
+        "groupId:artifactId"
+      ]
     }
   ]
 }
@@ -249,7 +251,9 @@ The role of registered interpreters, settings and interpreters group are describ
     "dependencies": [
       {
         "groupArtifactVersion": "groupId:artifactId:version",
-        "exclusions": "groupId:artifactId"
+        "exclusions": [
+          "groupId:artifactId"
+        ]
       }
     ]
   }
@@ -298,7 +302,9 @@ The role of registered interpreters, settings and interpreters group are describ
   "dependencies": [
     {
       "groupArtifactVersion": "groupId:artifactId:version",
-      "exclusions": "groupId:artifactId"
+      "exclusions": [
+        "groupId:artifactId"
+      ]
     }
   ]
 }
@@ -328,7 +334,9 @@ The role of registered interpreters, settings and interpreters group are describ
     "dependencies": [
       {
         "groupArtifactVersion": "groupId:artifactId:version",
-        "exclusions": "groupId:artifactId"
+        "exclusions": [
+          "groupId:artifactId"
+        ]
       }
     ]
   }

--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -198,7 +198,10 @@ The role of registered interpreters, settings and interpreters group are describ
     </tr>
     <tr>
       <td>Fail code</td>
-      <td> 500 </td>
+      <td>
+          400 if the input json is empty <br/>
+          500 for any other errors
+      </td>
     </tr>
     <tr>
       <td>Sample JSON input</td>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -90,6 +90,9 @@ public class InterpreterRestApi {
     try {
       NewInterpreterSettingRequest request =
           gson.fromJson(message, NewInterpreterSettingRequest.class);
+      if (request == null) {
+        return new JsonResponse<>(Status.BAD_REQUEST).build();
+      }
       Properties p = new Properties();
       p.putAll(request.getProperties());
       InterpreterSetting interpreterSetting = interpreterFactory

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -120,6 +120,15 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  public void testSettingsCreateWithEmptyJson() throws IOException {
+    // Call Create Setting REST API
+    PostMethod post = httpPost("/interpreter/setting/", "");
+    LOG.info("testSettingCRUD create response\n" + post.getResponseBodyAsString());
+    assertThat("test create method:", post, isBadRequest());
+    post.releaseConnection();
+  }
+
+  @Test
   public void testInterpreterAutoBinding() throws IOException {
     // create note
     Note note = ZeppelinServer.notebook.createNote(null);


### PR DESCRIPTION
### What is this PR for?
This handles the NPE when the input json is empty for the interpreter setting POST request.

### What type of PR is it?
Bug Fix

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-728

### How should this be tested?
When empty json is sent for interpreter setting POST request, 400 status code should be returned.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No