### PR TITLE
Update Utils.java

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/Utils.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/Utils.java
@@ -89,6 +89,8 @@ class Utils {
       return true;
     } catch (ClassNotFoundException e) {
       return false;
+    } catch (IncompatibleClassChangeError e) {
+      return false;
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://github.com/apache/zeppelin/blob/master/CONTRIBUTING.md

I was extract tarball build 0.6.1.
and modify configuration for my environment.
And I had completed the setting up and running the Zeppelin, then I connect "Zeppelin Tutorial" Notebook.
At this time, I meeted an error when running the "Load data into table" section in the "Zeppelin tutorial notebook".

Then, I had success in modifying the code in this way in order to succeed Zeppelin notebook, I create a PR

Here are some more details.

1. Setting up Zeppelin
  1-1. zeppelin-env.sh
  1-2. zeppelin-site.xml
  1-3. "hive-site" copy to "$ZEPPELIN_HOME/conf" dir. 

2. Start up Zeppelin

3. run paragraph "Load data into table" in Zeppelin Tutorial Notebook
  --> Meet the "java.lang.IncompatibleClassChangeError"

4. modify "Utils.java" source and apply "Utils.class" to "$ZEPPELIN_HOME/interpreter/spark/zeppelin-spark_2.11-0.6.1.jar"

5. Working Well !!

## My Environment]
- JDK : 1.8.0_60
- Scala : 2.11
- Apache Ambari - 2.2.2
  - Hortonwork - HDP-2.4.2.0-258
    - Hadoop 2.7.1.2.4.2.0-258
    - Tez : 0.7.x
    - Hive : 1.2.x
    - Spark : 1.6.2

### What type of PR is it?
Hot Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
First. Choose the "Zeppelin Tutorial" in Notebook.
Second. Run paragraph - "Load data into table".

Finished after Run
and
no error in "logs/zeppelin-interpreter-spark-root-${hostname}.log"

### Screenshots (if appropriate)
- logs/zeppelin-interpreter-spark-root-localhost.log

ERROR [2016-08-18 16:25:41,042] ({pool-2-thread-17} Job.java[run]:189) - Job failed
java.lang.IncompatibleClassChangeError: Implementing class
  at java.lang.ClassLoader.defineClass1(Native Method)
  at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
  at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
  at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
  at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
  at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
  at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
  at java.security.AccessController.doPrivileged(Native Method)
  at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
  at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:264)
  at org.apache.zeppelin.spark.Utils.isScala2_10(Utils.java:88)
  at org.apache.zeppelin.spark.SparkInterpreter.open(SparkInterpreter.java:570)
  at org.apache.zeppelin.interpreter.LazyOpenInterpreter.open(LazyOpenInterpreter.java:69)
  at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:93)
  at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer$InterpretJob.jobRun(RemoteInterpreterServer.java:341)
  at org.apache.zeppelin.scheduler.Job.run(Job.java:176)
  at org.apache.zeppelin.scheduler.FIFOScheduler$1.run(FIFOScheduler.java:139)
  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
  at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  at java.lang.Thread.run(Thread.java:745)
 INFO [2016-08-18 16:25:41,042] ({pool-2-thread-17} SchedulerFactory.java[jobFinished]:137) - Job remoteInterpretJob_1471505141040 finished by scheduler org.apache.zeppelin.spark.SparkInterpreter957201969


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

add catch clasuse : for scala-2.11.x 

//////////////////////////////////////////////////////////////////////
    } catch (IncompatibleClassChangeError e) {
      return false;
    }
//////////////////////////////////////////////////////////////////////