### PR TITLE
ZEPPELIN-1284. Unable to run paragraph with default interpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -300,7 +300,9 @@ public class SparkInterpreter extends Interpreter {
     String execUri = System.getenv("SPARK_EXECUTOR_URI");
     conf.setAppName(getProperty("spark.app.name"));
 
-    conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath());
+    if (outputDir != null) {
+      conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath());
+    }
 
     if (execUri != null) {
       conf.set("spark.executor.uri", execUri);


### PR DESCRIPTION
### What is this PR for?
This issue happens when SPARK_HOME is not defined. In this case, you are using spark 2.0 and scala-2.10


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1284

### How should this be tested?
Run the following command, and then run the tutorial note in local mode
```
mvn package -DskipTests -Ppyspark -Psparkr -Pyarn -Phadoop-2.7 -Pspark-2.0
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

