### PR TITLE
Add spark dependency jars in driver classpath also in spark-submit mode

### DIFF
--- a/bin/interpreter.cmd
+++ b/bin/interpreter.cmd
@@ -68,6 +68,8 @@ if not exist "%ZEPPELIN_LOG_DIR%" (
 )
 
 if /I "%INTERPRETER_ID%"=="spark" (
+    call "%bin%\functions.cmd" ADDJARINDIR "%INTERPRETER_DIR%\dep"
+
     if defined SPARK_HOME (
         set SPARK_SUBMIT=%SPARK_HOME%\bin\spark-submit.cmd
         for %%d in ("%ZEPPELIN_HOME%\interpreter\spark\zeppelin-spark*.jar") do (
@@ -91,8 +93,6 @@ if /I "%INTERPRETER_ID%"=="spark" (
             )
             set ZEPPELIN_CLASSPATH=!LOCAL_HADOOP_CLASSPATH!;%ZEPPELIN_CLASSPATH%
         )
-        
-        call "%bin%\functions.cmd" ADDJARINDIR "%INTERPRETER_DIR%\dep"
         
         for %%d in ("%ZEPPELIN_HOME%\interpreter\spark\pyspark\py4j-*-src.zip") do (
             set py4j=%%d

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -90,6 +90,8 @@ fi
 
 # set spark related env variables
 if [[ "${INTERPRETER_ID}" == "spark" ]]; then
+  addJarInDirForIntp "${INTERPRETER_DIR}/dep"
+  
   if [[ -n "${SPARK_HOME}" ]]; then
     export SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
     SPARK_APP_JAR="$(ls ${ZEPPELIN_HOME}/interpreter/spark/zeppelin-spark*.jar)"
@@ -111,8 +113,6 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
       addJarInDirForIntp "${HADOOP_HOME}"
       addJarInDirForIntp "${HADOOP_HOME}/lib"
     fi
-
-    addJarInDirForIntp "${INTERPRETER_DIR}/dep"
 
     pattern="${ZEPPELIN_HOME}/interpreter/spark/pyspark/py4j-*-src.zip"
     py4j=($pattern)


### PR DESCRIPTION
### What is this PR for?
This commit adds spark dependency jars into the driver classpath of spark-submit. It is needed to let driver app find classes distributed along with spark, such as classes required for hive support.


### What type of PR is it?
[Bug Fix]

### How should this be tested?
When SPARK_HOME is set, zeppelin.spark.useHiveContext is set to true (default), and hive-site.xml is present in the conf dir Spark is expected to use the hive catalog as described in the hive-site.xml.
Without this commit spark is configured to use always the in-memory catalog, because it does not find hive support classes so it defaults to in memory embedded hive catalog.


