### PR TITLE
[ZEPPELIN/1356] The graph legend truncates at the nearest period (.) in its grouping

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1835,7 +1835,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       if (groups.length === 1 && values.length === 1) {
         for (d3gIndex = 0; d3gIndex < d3g.length; d3gIndex++) {
           colName = d3g[d3gIndex].key;
-          colName = colName.split('.').slice(0, -1).join('.'); // [ZEPPELIN-1356]: in case the column contains period
+          colName = colName.split('.').slice(0, -1).join('.');
           d3g[d3gIndex].key = colName;
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1835,7 +1835,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       if (groups.length === 1 && values.length === 1) {
         for (d3gIndex = 0; d3gIndex < d3g.length; d3gIndex++) {
           colName = d3g[d3gIndex].key;
-          colName = colName.split('.')[0];
+          colName = colName.split('.').slice(0, -1).join('.'); // [ZEPPELIN-1356]: in case the column contains period
           d3g[d3gIndex].key = colName;
         }
       }


### PR DESCRIPTION
### What is this PR for?
Fix the issue: in line graph if user uses the numbers that contains period(.), e.g. 3.14 in the groups the legend will only show 3 instead of 3.14.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1356

### How should this be tested?
Localhost test with screenshot

### Screenshots (if appropriate)
Before
<img width="1251" alt="screen shot 2016-08-25 at 6 51 36 pm" src="https://cloud.githubusercontent.com/assets/3334391/17991618/10e38f20-6af5-11e6-9399-196f7c3a325a.png">
After
<img width="1249" alt="screen shot 2016-08-25 at 6 45 19 pm" src="https://cloud.githubusercontent.com/assets/3334391/17991506/3225d5e0-6af4-11e6-8090-5ea2319444d3.png">


### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.

