### PR TITLE
[ZEPPELIN-1327] Fix bug in z.show for Python interpreter

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -173,7 +173,9 @@ class PyZeppelinContext(object):
             p.savefig(img, format=fmt)
             img_str = b"data:image/png;base64,"
             img_str += base64.b64encode(img.getvalue().strip())
-            img_str = "<img src={img}>".format(img=img_str.decode("ascii"))
+            # Decoding img_str is necessary for Python 3 compability
+            img_str = img_str.decode("ascii")
+            img_str = "<img src={img}>".format(img=img_str)
         elif fmt == "svg":
             img = StringIO()
             p.savefig(img, format=fmt)

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -117,7 +117,6 @@ class PyZeppelinContext(object):
     
     def __init__(self):
         self.max_result = 1000
-        self.py3 = bool(sys.version_info >= (3,))
     
     def input(self, name, defaultValue=""):
         print(self.errorMsg)
@@ -165,28 +164,24 @@ class PyZeppelinContext(object):
         #)
         body_buf.close(); header_buf.close()
     
-    def show_matplotlib(self, p, width="100%", height="100%",
-                        fmt='png', **kwargs):
+    def show_matplotlib(self, p, fmt="png", width="100%", height="100%", 
+                        **kwargs):
         """Matplotlib show function
         """
-        if fmt == 'png':
+        if fmt == "png":
             img = BytesIO()
             p.savefig(img, format=fmt)
-            html = "%html <img src={img} width={width}, height={height}>"
             img_str = b"data:image/png;base64,"
             img_str += base64.b64encode(img.getvalue().strip())
-            # Need to do this for python3 compatibility
-            if self.py3:
-                img_str = img_str.decode('ascii')
-                
-        elif fmt == 'svg':
+            img_str = "<img src={img}>".format(img=img_str.decode("ascii"))
+        elif fmt == "svg":
             img = StringIO()
             p.savefig(img, format=fmt)
-            html = "%html <div style='width:{width};height:{height}'>{img}<div>"
             img_str = img.getvalue()
         else:
             raise ValueError("fmt must be 'png' or 'svg'")
         
+        html = "%html <div style='width:{width};height:{height}'>{img}<div>"
         print(html.format(width=width, height=height, img=img_str))
         img.close()
 

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -164,7 +164,7 @@ class PyZeppelinContext(object):
         #)
         body_buf.close(); header_buf.close()
     
-    def show_matplotlib(self, p, fmt="png", width="100%", height="100%", 
+    def show_matplotlib(self, p, fmt="png", width="auto", height="auto", 
                         **kwargs):
         """Matplotlib show function
         """
@@ -173,9 +173,10 @@ class PyZeppelinContext(object):
             p.savefig(img, format=fmt)
             img_str = b"data:image/png;base64,"
             img_str += base64.b64encode(img.getvalue().strip())
-            # Decoding img_str is necessary for Python 3 compability
+            img_tag = "<img src={img} style='width={width};height:{height}'>"
+            # Decoding is necessary for Python 3 compability
             img_str = img_str.decode("ascii")
-            img_str = "<img src={img}>".format(img=img_str)
+            img_str = img_tag.format(img=img_str, width=width, height=height)
         elif fmt == "svg":
             img = StringIO()
             p.savefig(img, format=fmt)


### PR DESCRIPTION
### What is this PR for?
Currently, height parameter for z.show implementation to display PNG images in Python interpreter is not working. This PR fix that bug.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1327](https://issues.apache.org/jira/browse/ZEPPELIN-1327)

### How should this be tested?
```python
import matplotlib.pyplot as plt

x = [1,2,3,4,5]
y = [6,7,8,9,0]

plt.plot(x, y, marker="o")
z.show(plt, height="200px")
plt.close()
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

