### PR TITLE
[ZEPPELIN-1365] Error of Zeppelin Application in development mode.

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -34,6 +34,7 @@ import org.apache.zeppelin.display.*;
 import org.apache.zeppelin.helium.*;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.dev.ZeppelinDevServer;
 import org.apache.zeppelin.interpreter.thrift.*;
 import org.apache.zeppelin.resource.*;
 import org.apache.zeppelin.scheduler.Job;
@@ -133,7 +134,11 @@ public class RemoteInterpreterServer
 
   public static void main(String[] args)
       throws TTransportException, InterruptedException {
-    int port = Integer.parseInt(args[0]);
+
+    int port = ZeppelinDevServer.DEFAULT_TEST_INTERPRETER_PORT;
+    if (args.length > 0) {
+      port = Integer.parseInt(args[0]);
+    }
     RemoteInterpreterServer remoteInterpreterServer = new RemoteInterpreterServer(port);
     remoteInterpreterServer.start();
     remoteInterpreterServer.join();


### PR DESCRIPTION
### What is this PR for?
This PR fixes the bug of running application in development mode.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1365


### How should this be tested?
1. run zeppelin
2. run org.apache.zeppelin.interpreter.dev.ZeppelinApplicationDevServer in development mode.
(http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/development/writingzeppelinapplication.html)
3. and run paragraph like screenshot.

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/3348133/17935588/d95ec2de-6a56-11e6-84d9-19030984411d.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

