### PR TITLE
[ZEPPELIN-1178] Tooltip: Show chart type when hovering over chart icon

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -20,37 +20,44 @@ limitations under the License.
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('table')}"
-          ng-click="setGraphMode('table', true)" ><i class="fa fa-table"></i>
+          ng-click="setGraphMode('table', true)" 
+          tooltip="Table" tooltip-placement="bottom"><i class="fa fa-table"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('multiBarChart')}"
-          ng-click="setGraphMode('multiBarChart', true)"><i class="fa fa-bar-chart"></i>
+          ng-click="setGraphMode('multiBarChart', true)"
+          tooltip="Multi Bar Chart" tooltip-placement="bottom"><i class="fa fa-bar-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('pieChart')}"
-          ng-click="setGraphMode('pieChart', true)"><i class="fa fa-pie-chart"></i>
+          ng-click="setGraphMode('pieChart', true)"
+          tooltip="Pie Chart" tooltip-placement="bottom"><i class="fa fa-pie-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('stackedAreaChart')}"
-          ng-click="setGraphMode('stackedAreaChart', true)"><i class="fa fa-area-chart"></i>
+          ng-click="setGraphMode('stackedAreaChart', true)"
+          tooltip="Stacked Area Chart" tooltip-placement="bottom"><i class="fa fa-area-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('lineChart') || isGraphMode('lineWithFocusChart')}"
-          ng-click="paragraph.config.graph.lineWithFocus ? setGraphMode('lineWithFocusChart', true) : setGraphMode('lineChart', true)"><i class="fa fa-line-chart"></i>
+          ng-click="paragraph.config.graph.lineWithFocus ? setGraphMode('lineWithFocusChart', true) : setGraphMode('lineChart', true)"
+          tooltip="Line With Focus Chart" tooltip-placement="bottom"><i class="fa fa-line-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('scatterChart')}"
-          ng-click="setGraphMode('scatterChart', true)"><i class="cf cf-scatter-chart"></i>
+          ng-click="setGraphMode('scatterChart', true)"
+          tooltip="Scatter Chart" tooltip-placement="bottom"><i class="cf cf-scatter-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('map')}"
-          ng-click="setGraphMode('map', true)"><i class="fa fa-map-marker"></i>
+          ng-click="setGraphMode('map', true)"
+          tooltip="Map" tooltip-placement="bottom"><i class="fa fa-map-marker"></i>
   </button>
 
   <button type="button"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-chart-selector.html
@@ -27,7 +27,7 @@ limitations under the License.
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('multiBarChart')}"
           ng-click="setGraphMode('multiBarChart', true)"
-          tooltip="Multi Bar Chart" tooltip-placement="bottom"><i class="fa fa-bar-chart"></i>
+          tooltip="Bar Chart" tooltip-placement="bottom"><i class="fa fa-bar-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
@@ -39,13 +39,13 @@ limitations under the License.
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('stackedAreaChart')}"
           ng-click="setGraphMode('stackedAreaChart', true)"
-          tooltip="Stacked Area Chart" tooltip-placement="bottom"><i class="fa fa-area-chart"></i>
+          tooltip="Area Chart" tooltip-placement="bottom"><i class="fa fa-area-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"
           ng-class="{'active': isGraphMode('lineChart') || isGraphMode('lineWithFocusChart')}"
           ng-click="paragraph.config.graph.lineWithFocus ? setGraphMode('lineWithFocusChart', true) : setGraphMode('lineChart', true)"
-          tooltip="Line With Focus Chart" tooltip-placement="bottom"><i class="fa fa-line-chart"></i>
+          tooltip="Line Chart" tooltip-placement="bottom"><i class="fa fa-line-chart"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm"
           ng-if="paragraph.result.type == 'TABLE'"


### PR DESCRIPTION
### What is this PR for?
A usability improvement: Added tooltips for the chart icons in Zeppelin paragraphs, showing the chart types when hovering over the chart icons.


### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1178

### How should this be tested?
1. Deploy Zeppelin and navigate to zeppelin tutorial
2. Run a paragraph and hover over the chart icon buttons to see the tooltip getting displayed.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
