### PR TITLE
ZEPPELIN-1374. Should prevent use dot in interpreter name

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -325,6 +325,15 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl',
         return;
       }
 
+      if (!$scope.newInterpreterSetting.name.indexOf('.') >= 0) {
+        BootstrapDialog.alert({
+          closable: true,
+          title: 'Add interpreter',
+          message: '\'.\' is invalid for interpreter name'
+        });
+        return;
+      }
+
       if (_.findIndex($scope.interpreterSettings, {'name': $scope.newInterpreterSetting.name}) >= 0) {
         BootstrapDialog.alert({
           closable: true,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -506,6 +506,9 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   public InterpreterSetting createNewSetting(String name, String group,
       List<Dependency> dependencies, InterpreterOption option, Properties p) throws IOException {
+    if (name.indexOf(".") >= 0) {
+      throw new IOException("'.' is invalid for InterpreterSetting name.");
+    }
     InterpreterSetting setting = createFromInterpreterSettingRef(group);
     setting.setName(name);
     setting.setGroup(group);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -157,4 +157,14 @@ public class InterpreterFactoryTest {
     assertEquals("className1", factory.getInterpreter("note", "test-group1").getClassName());
     assertEquals("className1", factory.getInterpreter("note", "group1").getClassName());
   }
+
+  @Test
+  public void testInvalidInterpreterSettingName() {
+    try {
+      factory.createNewSetting("new.mock1", "mock1", new LinkedList<Dependency>(), new InterpreterOption(false), new Properties());
+      fail("expect fail because of invalid InterpreterSetting Name");
+    } catch (IOException e) {
+      assertEquals("'.' is invalid for InterpreterSetting name.", e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
### What is this PR for?
dot is invalid for interpreter name as it is used as the separator of interpreter group name and interpreter name.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1374

### How should this be tested?
Tested it manually as shown in the screenshot. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/17995181/3047152e-6b92-11e6-9fbf-c683330359a9.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

