### PR TITLE
ZEPPELIN-1342. Adding dependencies via SPARK_SUBMIT_OPTIONS doesn't work on Spark 2.0.0

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -594,7 +594,7 @@ public class SparkInterpreter extends Interpreter {
       argList.add("-Yrepl-class-based");
       argList.add("-Yrepl-outdir");
       argList.add(outputDir.getAbsolutePath());
-      if (conf.get("spark.jars") != null) {
+      if (conf.contains("spark.jars")) {
         String jars = StringUtils.join(conf.get("spark.jars").split(","), File.separator);
         argList.add("-classpath");
         argList.add(jars);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.base.Joiner;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -593,7 +594,11 @@ public class SparkInterpreter extends Interpreter {
       argList.add("-Yrepl-class-based");
       argList.add("-Yrepl-outdir");
       argList.add(outputDir.getAbsolutePath());
-
+      if (conf.get("spark.jars") != null) {
+        String jars = StringUtils.join(conf.get("spark.jars").split(","), File.separator);
+        argList.add("-classpath");
+        argList.add(jars);
+      }
 
       scala.collection.immutable.List<String> list =
           JavaConversions.asScalaBuffer(argList).toList();


### PR DESCRIPTION
### What is this PR for?

The root cause is due to the change of repl of scala-2.11. User needs to specify the jars in the repl setting explicitly.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1342

### How should this be tested?
Tested manually as shown in the screenshot. 

### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/164491/17997416/f26c262c-6ba0-11e6-8586-22a6a633b21b.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

