### PR TITLE
 [ZEPPELIN-1040] Show the time when the result is updated

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -820,7 +820,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     }
     var user = (pdata.user === undefined || pdata.user === null) ? 'anonymous' : pdata.user;
     var desc = 'Took ' + moment.duration((timeMs / 1000), 'seconds').format('h [hrs] m [min] s [sec]') +
-      '. Last updated by ' + user + ' at ' + moment(pdata.dateUpdated).format('MMMM DD YYYY, h:mm:ss A') + '.';
+      '. Last updated by ' + user + ' at ' + moment(pdata.dateFinished).format('MMMM DD YYYY, h:mm:ss A') + '.';
     if ($scope.isResultOutdated()) {
       desc += ' (outdated)';
     }


### PR DESCRIPTION
### What is this PR for?
As per existing usage, the time shown in end of each paragraph is the time the paragraph is updated not when the paragraph is actually executed/run.

_" Took 10 sec. Last updated by anonymous at **August 26 2016, 1:52:01 PM.** "_

PR is aimed at changing the existing usage to show when the paragraph is last executed as this gives  clarification to users about the executed time of paragraph


### What type of PR is it?
 Improvement 

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1040

### How should this be tested?
1. Start the server and create a new note book
2. create a new paragraph and execute the paragraph
3. Now rerun the paragraph, the time should get updated now inline with execution of the paragraph

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

