### PR TITLE
zeppelin-display dependency version built only for Scala binary version 2.11

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -53,7 +53,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-display_${scala.binary.version}</artifactId>
+      <artifactId>zeppelin-display_2.10</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
### What is this PR for?
Makes the project build again when selecting Scala version 2.11

As per the comment to the @Leemoonsoo 's commit:
https://github.com/apache/zeppelin/commit/0c5a03e6be20a13eee60e84b75cdf2a9dd64d3f4#diff-4ce8d865f6ee3c2eea04aa4e650c38b9R56

It seems it needs to be changed explicitly to _zeppelin-display_2.10_ due to https://issues.apache.org/jira/browse/ZEPPELIN-1179 and https://github.com/apache/zeppelin/commit/6bb4b5ba8e7ecd6274dd437c6ec5c4a9b178e4d1 as then when building with
```
mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests
```
doesn't work:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Zeppelin ........................................... SUCCESS [01:34 min]
[INFO] Zeppelin: Interpreter .............................. SUCCESS [ 27.248 s]
[INFO] Zeppelin: Zengine .................................. SUCCESS [ 37.027 s]
[INFO] Zeppelin: Display system apis ...................... SUCCESS [ 33.301 s]
[INFO] Zeppelin: Spark dependencies ....................... SUCCESS [10:01 min]
[INFO] Zeppelin: Spark .................................... FAILURE [01:58 min]
[INFO] Zeppelin: Markdown interpreter ..................... SKIPPED
[INFO] Zeppelin: Angular interpreter ...................... SKIPPED
[INFO] Zeppelin: Shell interpreter ........................ SKIPPED
[INFO] Zeppelin: Livy interpreter ......................... SKIPPED
[INFO] Zeppelin: HBase interpreter ........................ SKIPPED
[INFO] Zeppelin: PostgreSQL interpreter ................... SKIPPED
[INFO] Zeppelin: JDBC interpreter ......................... SKIPPED
[INFO] Zeppelin: File System Interpreters ................. SKIPPED
[INFO] Zeppelin: Flink .................................... SKIPPED
[INFO] Zeppelin: Apache Ignite interpreter ................ SKIPPED
[INFO] Zeppelin: Kylin interpreter ........................ SKIPPED
[INFO] Zeppelin: Python interpreter ....................... SKIPPED
[INFO] Zeppelin: Lens interpreter ......................... SKIPPED
[INFO] Zeppelin: Apache Cassandra interpreter ............. SKIPPED
[INFO] Zeppelin: Elasticsearch interpreter ................ SKIPPED
[INFO] Zeppelin: BigQuery interpreter ..................... SKIPPED
[INFO] Zeppelin: Alluxio interpreter ...................... SKIPPED
[INFO] Zeppelin: web Application .......................... SKIPPED
[INFO] Zeppelin: Server ................................... SKIPPED
[INFO] Zeppelin: Packaging distribution ................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 15:14 min
[INFO] Finished at: 2016-08-26T11:22:35+00:00
[INFO] Final Memory: 52M/234M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project zeppelin-spark_2.10: Could not resolve dependencies for project org.apache.zeppelin:zeppelin-spark_2.10:jar:0.7.0-SNAPSHOT: Could not find artifact org.apache.zeppelin:zeppelin-display_2.11:jar:0.7.0-SNAPSHOT in apache.snapshots (http://repository.apache.org/snapshots) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :zeppelin-spark_2.10
The command '/bin/sh -c mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests' returned a non-zero code: 1
```
e.g. as in:
https://github.com/conker84/docker-zeppelin/blob/master/Dockerfile
and hence also this https://travis-ci.org/apache/zeppelin/jobs/155291535 failure

### What type of PR is it?
Bug Fix

### Todos
none

### What is the Jira issue?
* ZEPPELIN-1179 - might need to be reopened

### How should this be tested?
Build the project with mvn clean package -Pscala-2.11 -DskipTests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
