### PR TITLE
[ZEPPELIN-1379] Flink interpreter is missing scala libraries

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -120,21 +120,18 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
       <version>${scala.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
       <version>${scala.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -319,7 +316,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.4</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -339,10 +335,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
+            <id>copy-artifact</id>
             <phase>package</phase>
             <goals>
               <goal>copy</goal>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -116,8 +116,8 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>


### PR DESCRIPTION
### What is this PR for?
On Flink interpreter, remove provided scope from scala libraries to enable copying them to interpreter location.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-1379](https://issues.apache.org/jira/browse/ZEPPELIN-1379)
