### PR TITLE
[ZEPPELIN-1385] Avoid NPE when create SparkSession

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -300,7 +300,9 @@ public class SparkInterpreter extends Interpreter {
     String execUri = System.getenv("SPARK_EXECUTOR_URI");
     conf.setAppName(getProperty("spark.app.name"));
 
-    conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath());
+    if (outputDir != null) {
+      conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath());
+    }
 
     if (execUri != null) {
       conf.set("spark.executor.uri", execUri);


### PR DESCRIPTION
### What is this PR for?
Avoid NPE when create SparkSession is outputDir has not been set yet


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-1385](https://issues.apache.org/jira/browse/ZEPPELIN-1385)
