### PR TITLE
[ZEPPELIN-1171] Only retrieve resources if client is set

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourcePoolUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourcePoolUtils.java
@@ -55,10 +55,12 @@ public class ResourcePoolUtils {
         boolean broken = false;
         try {
           client = remoteInterpreterProcess.getClient();
-          List<String> resourceList = client.resourcePoolGetAll();
-          Gson gson = new Gson();
-          for (String res : resourceList) {
-            resourceSet.add(gson.fromJson(res, Resource.class));
+          if (client != null) {
+            List<String> resourceList = client.resourcePoolGetAll();
+            Gson gson = new Gson();
+            for (String res : resourceList) {
+              resourceSet.add(gson.fromJson(res, Resource.class));
+            }
           }
         } catch (Exception e) {
           logger.error(e.getMessage(), e);


### PR DESCRIPTION
### What is this PR for?

Fix NullPointerException when trying to retrieve resources and the client is not set
### What type of PR is it?

[Bug Fix]
### What is the Jira issue?
- [ZEPPELIN-1171](https://issues.apache.org/jira/browse/ZEPPELIN-1171)
