### PR TITLE
[ZEPPELIN-449] Enhance log messages when interpreter is initializing

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -124,14 +124,20 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
 
     long startTime = System.currentTimeMillis();
     while (System.currentTimeMillis() - startTime < getConnectTimeout()) {
-      if (RemoteInterpreterUtils.checkIfRemoteEndpointAccessible("localhost", port)) {
-        break;
-      } else {
-        try {
-          Thread.sleep(500);
-        } catch (InterruptedException e) {
-          logger.error("Exception in RemoteInterpreterProcess while synchronized reference " +
-              "Thread.sleep", e);
+      try {
+        if (RemoteInterpreterUtils.checkIfRemoteEndpointAccessible("localhost", port)) {
+          break;
+        } else {
+          try {
+            Thread.sleep(500);
+          } catch (InterruptedException e) {
+            logger.error("Exception in RemoteInterpreterProcess while synchronized reference " +
+                    "Thread.sleep", e);
+          }
+        }
+      } catch (Exception e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Remote interpreter not yet accessible at localhost:" + port);
         }
       }
     }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -46,9 +47,19 @@ public class RemoteInterpreterUtils {
       discover.connect(new InetSocketAddress(host, port), 1000);
       discover.close();
       return true;
-    } catch (IOException e) {
+    } catch (ConnectException cne) {
       // end point is not accessible
-      LOGGER.debug(e.getMessage(), e);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Remote endpoint '" + host + ":" + port + "' is not accessible " +
+                "(might be initializing): " + cne.getMessage());
+      }
+      return false;
+    } catch (IOException ioe) {
+      // end point is not accessible
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Remote endpoint '" + host + ":" + port + "' is not accessible " +
+                "(might be initializing): " + ioe.getMessage());
+      }
       return false;
     }
   }


### PR DESCRIPTION
### What is this PR for?

Enhance log messages when interpreter is initializing to avoid user confusion.
### What type of PR is it?

[Bug Fix]
### What is the Jira issue?
- [ZEPPELIN-449](https://issues.apache.org/jira/browse/ZEPPELIN-449)
