### PR TITLE
[ZEPPELIN-1358] Add support to display Pandas DataFrame index using z.show()

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -142,17 +142,19 @@ class PyZeppelinContext(object):
         """
         limit = len(df) > self.max_result
         header_buf = StringIO("")
-        header_buf.write(str(df.columns[0]))
-        for col in df.columns[1:]:
+        idx_name = df.index.name if df.index.name is not None else ""
+        header_buf.write(idx_name)
+        for col in df.columns:
             header_buf.write("\t")
             header_buf.write(str(col))
         header_buf.write("\n")
         
         body_buf = StringIO("")
         rows = df.head(self.max_result).values if limit else df.values
-        for row in rows:
-            body_buf.write(str(row[0]))
-            for cell in row[1:]:
+        index = df.index.values
+        for idx, row in zip(index, rows):
+            body_buf.write("%html <strong>{}</strong>".format(str(idx)))
+            for cell in row:
                 body_buf.write("\t")
                 body_buf.write(str(cell))
             body_buf.write("\n")

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -137,14 +137,16 @@ class PyZeppelinContext(object):
         elif hasattr(p, '__call__'):
             p() #error reporting
     
-    def show_dataframe(self, df, **kwargs):
+    def show_dataframe(self, df, show_index=False, **kwargs):
         """Pretty prints DF using Table Display System
         """
         limit = len(df) > self.max_result
         header_buf = StringIO("")
-        idx_name = df.index.name if df.index.name is not None else ""
-        header_buf.write(idx_name)
-        for col in df.columns:
+        if show_index:
+            idx_name = str(df.index.name) if df.index.name is not None else ""
+            header_buf.write(idx_name + "\t")
+        header_buf.write(str(df.columns[0]))
+        for col in df.columns[1:]:
             header_buf.write("\t")
             header_buf.write(str(col))
         header_buf.write("\n")
@@ -153,8 +155,11 @@ class PyZeppelinContext(object):
         rows = df.head(self.max_result).values if limit else df.values
         index = df.index.values
         for idx, row in zip(index, rows):
-            body_buf.write("%html <strong>{}</strong>".format(str(idx)))
-            for cell in row:
+            if show_index:
+                body_buf.write("%html <strong>{}</strong>".format(idx))
+                body_buf.write("\t")
+            body_buf.write(str(row[0]))
+            for cell in row[1:]:
                 body_buf.write("\t")
                 body_buf.write(str(cell))
             body_buf.write("\n")

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -166,7 +166,7 @@ public class PythonInterpreterPandasSqlTest {
     assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());
 
     // when
-    ret = python.interpret("z.show(df1)", context);
+    ret = python.interpret("z.show(df1, show_index=True)", context);
 
     // then
     assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -159,9 +159,10 @@ public class PythonInterpreterPandasSqlTest {
     ret = python.interpret("import pandas as pd", context);
     ret = python.interpret("import numpy as np", context);
 
-    // given a Pandas DataFrame with non-text data
+    // given a Pandas DataFrame with an index and non-text data
+    ret = python.interpret("index = pd.Index([10, 11, 12, 13], name='index_name')", context);
     ret = python.interpret("d1 = {1 : [np.nan, 1, 2, 3], 'two' : [3., 4., 5., 6.7]}", context);
-    ret = python.interpret("df1 = pd.DataFrame(d1)", context);
+    ret = python.interpret("df1 = pd.DataFrame(d1, index=index)", context);
     assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());
 
     // when
@@ -170,6 +171,8 @@ public class PythonInterpreterPandasSqlTest {
     // then
     assertEquals(ret.message(), InterpreterResult.Code.SUCCESS, ret.code());
     assertEquals(ret.message(), Type.TABLE, ret.type());
+    assertTrue(ret.message().indexOf("index_name") == 0);
+    assertTrue(ret.message().indexOf("13") > 0);
     assertTrue(ret.message().indexOf("nan") > 0);
     assertTrue(ret.message().indexOf("6.7") > 0);
   }


### PR DESCRIPTION
### What is this PR for?

Add support to display optionally Pandas DataFrame index using z.show(show_index=True) in python interpreter. By default, DataFrame index will not be displayed.
### What type of PR is it?

Improvement
### What is the Jira issue?

[ZEPPELIN-1358](https://issues.apache.org/jira/browse/ZEPPELIN-1358)
### How should this be tested?

```
mvn -Dpython.test.exclude='' test -pl python -am
```
### Screenshots (if appropriate)

![screenshot from 2016-10-09 18-18-44](https://cloud.githubusercontent.com/assets/7907284/19223745/b88d07c6-8e4d-11e6-9592-c66f2e4a5ed2.png)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? no
