### PR TITLE
[ZEPPELIN-1116]send out more exception msg

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -16,6 +16,7 @@ package org.apache.zeppelin.jdbc;
 
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -15,7 +15,7 @@
 package org.apache.zeppelin.jdbc;
 
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
-
+import java.io.*;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -421,11 +421,11 @@ public class JDBCInterpreter extends Interpreter {
 
     } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
-      StringBuilder stringBuilder = new StringBuilder();
-      stringBuilder.append(e.getMessage()).append("\n");
-      stringBuilder.append(e.getClass().toString()).append("\n");
-      stringBuilder.append(StringUtils.join(e.getStackTrace(), "\n"));
-      return new InterpreterResult(Code.ERROR, stringBuilder.toString());
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      PrintStream ps = new PrintStream(baos);
+      e.printStackTrace(ps);
+      String errorMsg = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+      return new InterpreterResult(Code.ERROR, errorMsg);
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
better jdbc error msg make people know the true error clearly.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1116

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/168310/18045048/68e41d14-6e03-11e6-9a8b-25acd00f6684.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

in sql case, the real error exception stack is hide in e.getCause.getCause. use printStackTrace to receive all the stack trace make people know true reason.