### PR TITLE
[ZEPPELIN-1391][Interpreters] print error while existing registedInterpreter with the same key but different settings

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -345,10 +345,14 @@ public abstract class Interpreter {
   }
 
   public static void register(RegisteredInterpreter registeredInterpreter) {
-    // TODO(jongyoul): Error should occur when two same interpreter key with different settings
     String interpreterKey = registeredInterpreter.getInterpreterKey();
     if (!registeredInterpreters.containsKey(interpreterKey)) {
       registeredInterpreters.put(interpreterKey, registeredInterpreter);
+    } else {
+      RegisteredInterpreter existInterpreter = registeredInterpreters.get(interpreterKey);
+      if (!existInterpreter.getProperties().equals(registeredInterpreter.getProperties())) {
+        logger.error("exist registeredInterpreter with the same key but has different settings.");
+      }
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
@@ -70,6 +70,14 @@ public class InterpreterProperty {
     this.description = description;
   }
 
+  public int hashCode() {
+    return this.toString().hashCode();
+  }
+
+  public boolean equals(Object o) {
+    return this.toString().equals(o.toString());
+  }
+
   public String getValue() {
     //TODO(jongyoul): Remove SparkInterpreter's getSystemDefault method
     if (envName != null && !envName.isEmpty()) {
@@ -90,7 +98,7 @@ public class InterpreterProperty {
 
   @Override
   public String toString() {
-    return String.format("{envName=%s, propertyName=%s, defaultValue=%s, description=%20s", envName,
-        propertyName, defaultValue, description);
+    return String.format("{envName=%s, propertyName=%s, defaultValue=%s, description=%20s}",
+            envName, propertyName, defaultValue, description);
   }
 }


### PR DESCRIPTION
### What is this PR for?
print error while existing registedInterpreter with the same key but different settings.
In order to compare the property Map in the Interpreter easily,
I override the `equals` method in `InterpreterProperty` class. (and `hashCode` at the same time)

and I fix a small error in  `InterpreterProperty.toString()`, its result forgot `}` in the end. 


### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1391

### How should this be tested?
Existing tests.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
