### PR TITLE
[ZEPPELIN-1395] Local or Remote Interpreter by Configuration

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -121,7 +121,7 @@ public class SparkInterpreter extends Interpreter {
 
 
   public SparkInterpreter(Properties property) {
-    super(property);
+   super(property);
     out = new SparkOutputStream(logger);
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -254,11 +254,6 @@ public abstract class Interpreter {
     private String path;
 
     public RegisteredInterpreter(String name, String group, String className,
-        Map<String, InterpreterProperty> properties) {
-      this(name, group, className, false, properties);
-    }
-
-    public RegisteredInterpreter(String name, String group, String className,
         boolean defaultInterpreter, Map<String, InterpreterProperty> properties) {
       super();
       this.name = name;

--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -73,6 +73,13 @@ limitations under the License.
         <div class="col-md-12" style="padding-left:0px">
           <div class="checkbox">
             <span class="input-group" style="line-height:30px;">
+              <label><input type="checkbox" style="width:20px" ng-model="newInterpreterSetting.option.remote"/> Remote Interpreter </label>
+            </span>
+          </div>
+        </div>
+        <div class="col-md-12" style="padding-left:0px">
+          <div class="checkbox">
+            <span class="input-group" style="line-height:30px;">
               <label><input type="checkbox" style="width:20px" ng-model="newInterpreterSetting.option.isExistingProcess"/> Connect to existing process </label>
             </span>
           </div>

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -205,6 +205,9 @@ angular.module('zeppelinWebApp').controller('InterpreterCtrl',
             if (!setting.option) {
               setting.option = {};
             }
+            if (setting.option.remote === undefined) {
+              setting.option.remote = true;
+            }
             if (setting.option.isExistingProcess === undefined) {
               setting.option.isExistingProcess = false;
             }

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -175,8 +175,18 @@ limitations under the License.
       <div class="col-md-12">
         <div class="checkbox">
           <span class="input-group" style="line-height:30px;">
+            <label><input type="checkbox" style="width:20px" id="isRemote" ng-model="setting.option.remote" ng-disabled="!valueform.$visible"/>
+              Remote Interpreter </label>
+          </span>
+        </div>
+      </div>
+
+      <br />
+      <div class="col-md-12">
+        <div class="checkbox">
+          <span class="input-group" style="line-height:30px;">
             <label><input type="checkbox" style="width:20px" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
-            Connect to existing process </label>
+              Connect to existing process </label>
           </span>
         </div>
       </div>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -386,6 +386,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getRelativeDir(String.format("%s/shiro.ini", getConfDir()));
   }
 
+  public boolean getInterpreterRemote() {
+    return getBoolean(ConfVars.ZEPPELIN_INTERPRETER_REMOTE);
+  }
+
   public String getInterpreterRemoteRunnerPath() {
     return getRelativeDir(ConfVars.ZEPPELIN_INTERPRETER_REMOTE_RUNNER);
   }
@@ -544,6 +548,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC("zeppelin.notebook.one.way.sync", false),
+    ZEPPELIN_INTERPRETER_REMOTE("zeppelin.interpreter.remote", true),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner",
         System.getProperty("os.name")
                 .startsWith("Windows") ? "bin/interpreter.cmd" : "bin/interpreter.sh"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -157,10 +158,12 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   }
 
   private void init() throws InterpreterException, IOException, RepositoryException {
+
     String interpreterJson = conf.getInterpreterJson();
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
 
     Path interpretersDir = Paths.get(conf.getInterpreterDir());
+
     if (Files.exists(interpretersDir)) {
       for (Path interpreterDir : Files
           .newDirectoryStream(interpretersDir, new DirectoryStream.Filter<Path>() {
@@ -169,18 +172,22 @@ public class InterpreterFactory implements InterpreterGroupFactory {
               return Files.exists(entry) && Files.isDirectory(entry);
             }
           })) {
+
         String interpreterDirString = interpreterDir.toString();
 
-        registerInterpreterFromPath(interpreterDirString, interpreterJson);
+        URL[] urls = recursiveBuildLibList(new File(interpreterDirString));
+        URLClassLoader urlClassLoader = new URLClassLoader(urls, cl);
 
-        registerInterpreterFromResource(cl, interpreterDirString, interpreterJson);
+        registerInterpreterFromPath(urlClassLoader, interpreterDir, interpreterJson);
+
+        registerInterpreterFromResource(urlClassLoader, interpreterDir, interpreterJson);
 
         /*
          * TODO(jongyoul)
          * - Remove these codes below because of legacy code
          * - Support ThreadInterpreter
-         */
-        URLClassLoader ccl = new URLClassLoader(recursiveBuildLibList(interpreterDir.toFile()), cl);
+        URL[] urls = recursiveBuildLibList(interpreterDir.toFile());
+        URLClassLoader ccl = new URLClassLoader(urls, cl);
         for (String className : interpreterClassList) {
           try {
             // Load classes
@@ -192,13 +199,14 @@ public class InterpreterFactory implements InterpreterGroupFactory {
                 Interpreter.registeredInterpreters.get(interpreterKey)
                     .setPath(interpreterDirString);
                 logger.info("Interpreter " + interpreterKey + " found. class=" + className);
-                cleanCl.put(interpreterDirString, ccl);
               }
             }
+          cleanCl.put(interpreterDirString, ccl);
           } catch (Throwable t) {
             // nothing to do
           }
         }
+         */
       }
     }
 
@@ -264,7 +272,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   private InterpreterSetting createFromInterpreterSettingRef(InterpreterSetting o) {
     InterpreterSetting setting =
         new InterpreterSetting(o.getName(), o.getName(), o.getInterpreterInfos(), o.getProperties(),
-            o.getDependencies(), o.getOption(), o.getPath());
+            o.getDependencies(), o.getOption(), o.getPath(), conf);
     setting.setInterpreterGroupFactory(this);
     return setting;
   }
@@ -277,31 +285,32 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     return properties;
   }
 
-  private void registerInterpreterFromResource(ClassLoader cl, String interpreterDir,
+  private void registerInterpreterFromResource(URLClassLoader cl, Path interpreterDir,
       String interpreterJson) throws IOException, RepositoryException {
-    URL[] urls = recursiveBuildLibList(new File(interpreterDir));
-    ClassLoader tempClassLoader = new URLClassLoader(urls, cl);
 
-    InputStream inputStream = tempClassLoader.getResourceAsStream(interpreterJson);
+    InputStream inputStream = cl.getResourceAsStream(interpreterJson);
 
     if (null != inputStream) {
       logger.debug("Reading {} from resources in {}", interpreterJson, interpreterDir);
       List<RegisteredInterpreter> registeredInterpreterList =
           getInterpreterListFromJson(inputStream);
-      registerInterpreters(registeredInterpreterList, interpreterDir);
+      registerInterpreters(cl, registeredInterpreterList, interpreterDir);
     }
+
   }
 
-  private void registerInterpreterFromPath(String interpreterDir, String interpreterJson)
+  private void registerInterpreterFromPath(URLClassLoader cl, Path interpreterDir, String interpreterJson)
       throws IOException, RepositoryException {
 
-    Path interpreterJsonPath = Paths.get(interpreterDir, interpreterJson);
+    Path interpreterJsonPath = Paths.get(interpreterDir.toString(), interpreterJson);
+
     if (Files.exists(interpreterJsonPath)) {
       logger.debug("Reading {}", interpreterJsonPath);
       List<RegisteredInterpreter> registeredInterpreterList =
           getInterpreterListFromJson(interpreterJsonPath);
-      registerInterpreters(registeredInterpreterList, interpreterDir);
+      registerInterpreters(cl, registeredInterpreterList, interpreterDir);
     }
+
   }
 
   private List<RegisteredInterpreter> getInterpreterListFromJson(Path filename)
@@ -315,10 +324,12 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     return gson.fromJson(new InputStreamReader(stream), registeredInterpreterListType);
   }
 
-  private void registerInterpreters(List<RegisteredInterpreter> registeredInterpreters,
-      String absolutePath) throws IOException, RepositoryException {
+  private void registerInterpreters(URLClassLoader cl, List<RegisteredInterpreter> registeredInterpreters,
+       Path interpreterDir) throws IOException, RepositoryException {
 
-    for (RegisteredInterpreter registeredInterpreter : registeredInterpreters) {
+      cleanCl.put(interpreterDir.toFile().getAbsolutePath(), cl);
+
+      for (RegisteredInterpreter registeredInterpreter : registeredInterpreters) {
       InterpreterInfo interpreterInfo =
           new InterpreterInfo(registeredInterpreter.getClassName(), registeredInterpreter.getName(),
               registeredInterpreter.isDefaultInterpreter());
@@ -331,7 +342,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         }
       }
 
-      add(registeredInterpreter.getGroup(), interpreterInfo, properties, absolutePath);
+      add(registeredInterpreter.getGroup(), interpreterInfo, properties, interpreterDir.toFile().getAbsolutePath());
     }
 
   }
@@ -360,12 +371,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
     for (String k : info.interpreterSettings.keySet()) {
       InterpreterSetting setting = info.interpreterSettings.get(k);
-
-      // Always use separate interpreter process
-      // While we decided to turn this feature on always (without providing
-      // enable/disable option on GUI).
-      // previously created setting should turn this feature on here.
-      setting.getOption().setRemote(true);
 
       // Update transient information from InterpreterSettingRef
       interpreterSettingObject = interpreterSettingsRef.get(setting.getGroup());
@@ -577,7 +582,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       } else {
         interpreterSetting =
             new InterpreterSetting(group, null, interpreterInfos, properties, dependencies, option,
-                path);
+                path, conf);
         interpreterSettingsRef.put(group, interpreterSetting);
       }
     }
@@ -915,9 +920,11 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   private Interpreter createRepl(String dirName, String className, Properties property)
       throws InterpreterException {
+
     logger.info("Create repl {} from {}", className, dirName);
 
     ClassLoader oldcl = Thread.currentThread().getContextClassLoader();
+
     try {
 
       URLClassLoader ccl = cleanCl.get(dirName);
@@ -926,32 +933,17 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         ccl = URLClassLoader.newInstance(new URL[] {}, oldcl);
       }
 
-      boolean separateCL = true;
-      try { // check if server's classloader has driver already.
-        Class cls = this.getClass().forName(className);
-        if (cls != null) {
-          separateCL = false;
-        }
-      } catch (Exception e) {
-        logger.error("exception checking server classloader driver", e);
-      }
+      Thread.currentThread().setContextClassLoader(ccl);
 
-      URLClassLoader cl;
-
-      if (separateCL == true) {
-        cl = URLClassLoader.newInstance(new URL[] {}, ccl);
-      } else {
-        cl = ccl;
-      }
-      Thread.currentThread().setContextClassLoader(cl);
-
-      Class<Interpreter> replClass = (Class<Interpreter>) cl.loadClass(className);
+      Class<Interpreter> replClass = (Class<Interpreter>) ccl.loadClass(className);
       Constructor<Interpreter> constructor =
           replClass.getConstructor(new Class[] {Properties.class});
       Interpreter repl = constructor.newInstance(property);
       repl.setClassloaderUrls(ccl.getURLs());
-      LazyOpenInterpreter intp = new LazyOpenInterpreter(new ClassloaderInterpreter(repl, cl));
+      LazyOpenInterpreter intp = new LazyOpenInterpreter(new ClassloaderInterpreter(repl, ccl));
+
       return intp;
+
     } catch (SecurityException e) {
       throw new InterpreterException(e);
     } catch (NoSuchMethodException e) {
@@ -1015,14 +1007,18 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     List<String> interpreterSettingIds = getNoteInterpreterSettingBinding(noteId);
     LinkedList<InterpreterSetting> settings = new LinkedList<>();
     synchronized (interpreterSettingIds) {
+      List<String> idsToBeRemoved = Lists.newArrayList();
       for (String id : interpreterSettingIds) {
         InterpreterSetting setting = get(id);
         if (setting == null) {
           // interpreter setting is removed from factory. remove id from here, too
-          interpreterSettingIds.remove(id);
+          idsToBeRemoved.add(id);
         } else {
           settings.add(setting);
         }
+      }
+      for (String id: idsToBeRemoved) {
+        interpreterSettingIds.remove(id);
       }
     }
     return settings;
@@ -1242,8 +1238,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   private Interpreter getDevInterpreter() {
     if (devInterpreter == null) {
-      InterpreterOption option = new InterpreterOption();
-      option.setRemote(true);
+      InterpreterOption option = new InterpreterOption(conf.getInterpreterRemote());
 
       InterpreterGroup interpreterGroup = createInterpreterGroup("dev", option);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
@@ -21,7 +21,7 @@ import com.google.gson.annotations.SerializedName;
 
 /**
  * Information of interpreters in this interpreter setting.
- * this will be serialized for conf/interpreter.json and REST api response.
+ * this will be serialized for conf/interpreter-setting.json and REST api response.
  */
 public class InterpreterInfo {
   private String name;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
@@ -33,6 +33,12 @@ public class InterpreterOption {
   boolean setPermission;
   List<String> users;
 
+  private InterpreterOption() {}
+
+  public InterpreterOption(boolean remote) {
+    this.remote = remote;
+  }
+
   public boolean isExistingProcess() {
     return isExistingProcess;
   }
@@ -59,14 +65,6 @@ public class InterpreterOption {
 
   public List<String> getUsers() {
     return users;
-  }
-
-  public InterpreterOption() {
-    remote = false;
-  }
-
-  public InterpreterOption(boolean remote) {
-    this.remote = remote;
   }
 
   public boolean isRemote() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 
 import static org.apache.zeppelin.notebook.utility.IdHashes.generateId;
@@ -48,6 +49,7 @@ public class InterpreterSetting {
   private List<Dependency> dependencies;
   private InterpreterOption option;
   private transient String path;
+  private transient ZeppelinConfiguration conf;
 
   @Deprecated private transient InterpreterGroupFactory interpreterGroupFactory;
 
@@ -57,7 +59,7 @@ public class InterpreterSetting {
 
   public InterpreterSetting(String id, String name, String group,
       List<InterpreterInfo> interpreterInfos, Properties properties, List<Dependency> dependencies,
-      InterpreterOption option, String path) {
+      InterpreterOption option, String path, ZeppelinConfiguration conf) {
     this.id = id;
     this.name = name;
     this.group = group;
@@ -67,11 +69,12 @@ public class InterpreterSetting {
     this.option = option;
     this.path = path;
     this.status = Status.READY;
+    this.conf = conf;
   }
 
   public InterpreterSetting(String name, String group, List<InterpreterInfo> interpreterInfos,
-      Properties properties, List<Dependency> dependencies, InterpreterOption option, String path) {
-    this(generateId(), name, group, interpreterInfos, properties, dependencies, option, path);
+      Properties properties, List<Dependency> dependencies, InterpreterOption option, String path, ZeppelinConfiguration conf) {
+    this(generateId(), name, group, interpreterInfos, properties, dependencies, option, path, conf);
   }
 
   /**
@@ -79,9 +82,9 @@ public class InterpreterSetting {
    *
    * @param o interpreterSetting from interpreterSettingRef
    */
-  public InterpreterSetting(InterpreterSetting o) {
+  public InterpreterSetting(InterpreterSetting o, ZeppelinConfiguration conf) {
     this(generateId(), o.getName(), o.getGroup(), o.getInterpreterInfos(), o.getProperties(),
-        o.getDependencies(), o.getOption(), o.getPath());
+        o.getDependencies(), o.getOption(), o.getPath(), conf);
   }
 
   public String getId() {
@@ -164,7 +167,7 @@ public class InterpreterSetting {
 
   public InterpreterOption getOption() {
     if (option == null) {
-      option = new InterpreterOption();
+      option = new InterpreterOption(conf.getInterpreterRemote());
     }
 
     return option;


### PR DESCRIPTION
### What is this PR for?
The current remote interpreter (launched via shell) is scalable and open but suffers from 2 limitations:
- It does not allow to easily debug in the IDE.
- It does not allow to embedd Zeppelin (for small deployements) in a single jar.

A configuration per interpreter "Remote Interpreter" (true/false, true by default) is proposed.
An additional property `zeppeline.interpreter.remote' in zeppelin-site.xml is also proposed (a new interpreter will be created with that value for it `option.remote` attribute).

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Value defined in zeppelin-site.xml is not honored when creating a new interepreter
* [ ] - Unit Test
* [ ] - Documentatoin

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1395

### How should this be tested?
Load Zeppelin source in your IDE and start ZeppelinServer in debug mode
Put breakpoints in the interpreter sources, Set / Uset the "Remote Interpeter (see screeenshot).

### Screenshots (if appropriate)
![animated-gif](https://cloud.githubusercontent.com/assets/226720/18076557/5098c4d6-6e7f-11e6-9309-b93463738957.gif)

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? Y

