### PR TITLE
ZEPPELIN-1403. Should maintain the using port list

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -153,13 +153,14 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
   public void onProcessComplete(int exitValue) {
     logger.info("Interpreter process exited {}", exitValue);
     running = false;
-
+    RemoteInterpreterUtils.releasePort(port);
   }
 
   @Override
   public void onProcessFailed(ExecuteException e) {
     logger.info("Interpreter process failed {}", e);
     running = false;
+    RemoteInterpreterUtils.releasePort(port);
   }
 
   public boolean isRunning() {


### PR DESCRIPTION
### What is this PR for?

For now, in RemoteInterpreterManagedProcess we will first find one available port (By using ServerSocket) and then use this port in the interpreter process. But it is possible that 2 interpreters use the same port. Here's the scenarios.
1. Thread1 (Interpreter A) find available port 3000 
2. Thread2 (Interpreter B) find available port 3000 
3. Process for Interpreter A starts
4. Process for Interpreter B starts
### What type of PR is it?

[Bug Fix]
### Todos
- [ ] - Task
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-1403
### How should this be tested?

No test added
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
