### PR TITLE
[ZEPPELIN-1142] Zeppelin allows two users to simultaneously edit the notebook permissions

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -719,7 +719,10 @@ public class NotebookServer extends WebSocketServlet implements
     if (fromMessage != null) {
       String noteName = (String) ((Map) fromMessage.get("notebook")).get("name");
       String noteJson = gson.toJson(fromMessage.get("notebook"));
-      AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+      AuthenticationInfo subject = null;
+      if (fromMessage.principal != null) {
+        subject = new AuthenticationInfo(fromMessage.principal);
+      }
       note = notebook.importNote(noteJson, noteName, subject);
       note.persist(subject);
       broadcastNote(note);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -24,10 +24,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.gson.Gson;
@@ -158,6 +160,11 @@ public class Notebook implements NoteEventListener {
       note.putDefaultReplName();
     }
 
+    if (subject != null && !"anonymous".equals(subject.getUser())) {
+      Set<String> owners = new HashSet<String>();
+      owners.add(subject.getUser());
+      notebookAuthorization.setOwners(note.getId(), owners);
+    }
     notebookIndex.addIndexDoc(note);
     note.persist(subject);
     fireNoteCreateEvent(note);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -42,6 +42,7 @@ import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
 import org.junit.Before;
@@ -210,6 +211,21 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
+  public void testCreateNoteWithSubject() throws IOException, SchedulerException, RepositoryException {
+    AuthenticationInfo subject = new AuthenticationInfo("user1");
+    Note note = notebook.createNote(subject);
+
+    Notebook notebook = new Notebook(
+        conf, notebookRepo, schedulerFactory,
+        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
+    assertNotNull(notebook.getNotebookAuthorization().getOwners(note.getId()));
+    assertEquals(1, notebook.getNotebookAuthorization().getOwners(note.getId()).size());
+    Set<String> owners = new HashSet<>();
+    owners.add("user1");
+    assertEquals(owners, notebook.getNotebookAuthorization().getOwners(note.getId()));
+  }
+
+  @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException{
     Note note = notebook.createNote(null);
     Paragraph p1 = note.addParagraph();
@@ -351,7 +367,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testExportAndImportNote() throws IOException, CloneNotSupportedException,
-          InterruptedException {
+          InterruptedException, InterpreterException, SchedulerException, RepositoryException {
     Note note = notebook.createNote(null);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
@@ -374,11 +390,23 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(p.getId(), p2.getId());
     assertEquals(p.text, p2.text);
     assertEquals(p.getResult().message(), p2.getResult().message());
+
+    // Verify import note with subject
+    AuthenticationInfo subject = new AuthenticationInfo("user1");
+    Note importedNote2 = notebook.importNote(exportedNoteJson, "Title2", subject);
+    Notebook notebook = new Notebook(
+        conf, notebookRepo, schedulerFactory,
+        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
+    assertNotNull(notebook.getNotebookAuthorization().getOwners(importedNote2.getId()));
+    assertEquals(1, notebook.getNotebookAuthorization().getOwners(importedNote2.getId()).size());
+    Set<String> owners = new HashSet<>();
+    owners.add("user1");
+    assertEquals(owners, notebook.getNotebookAuthorization().getOwners(importedNote2.getId()));
   }
 
   @Test
   public void testCloneNote() throws IOException, CloneNotSupportedException,
-      InterruptedException {
+      InterruptedException, InterpreterException, SchedulerException, RepositoryException {
     Note note = notebook.createNote(null);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
@@ -396,6 +424,18 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(cp.getId(), p.getId());
     assertEquals(cp.text, p.text);
     assertEquals(cp.getResult().message(), p.getResult().message());
+
+    // Verify clone note with subject
+    AuthenticationInfo subject = new AuthenticationInfo("user1");
+    Note cloneNote2 = notebook.cloneNote(note.getId(), "clone note2", subject);
+    Notebook notebook = new Notebook(
+        conf, notebookRepo, schedulerFactory,
+        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
+    assertNotNull(notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()));
+    assertEquals(1, notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()).size());
+    Set<String> owners = new HashSet<>();
+    owners.add("user1");
+    assertEquals(owners, notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()));
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -215,9 +215,6 @@ public class NotebookTest implements JobListenerFactory{
     AuthenticationInfo subject = new AuthenticationInfo("user1");
     Note note = notebook.createNote(subject);
 
-    Notebook notebook = new Notebook(
-        conf, notebookRepo, schedulerFactory,
-        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
     assertNotNull(notebook.getNotebookAuthorization().getOwners(note.getId()));
     assertEquals(1, notebook.getNotebookAuthorization().getOwners(note.getId()).size());
     Set<String> owners = new HashSet<>();
@@ -394,9 +391,6 @@ public class NotebookTest implements JobListenerFactory{
     // Verify import note with subject
     AuthenticationInfo subject = new AuthenticationInfo("user1");
     Note importedNote2 = notebook.importNote(exportedNoteJson, "Title2", subject);
-    Notebook notebook = new Notebook(
-        conf, notebookRepo, schedulerFactory,
-        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
     assertNotNull(notebook.getNotebookAuthorization().getOwners(importedNote2.getId()));
     assertEquals(1, notebook.getNotebookAuthorization().getOwners(importedNote2.getId()).size());
     Set<String> owners = new HashSet<>();
@@ -428,9 +422,6 @@ public class NotebookTest implements JobListenerFactory{
     // Verify clone note with subject
     AuthenticationInfo subject = new AuthenticationInfo("user1");
     Note cloneNote2 = notebook.cloneNote(note.getId(), "clone note2", subject);
-    Notebook notebook = new Notebook(
-        conf, notebookRepo, schedulerFactory,
-        new InterpreterFactory(conf, null, null, null, depResolver), this, null, notebookAuthorization, null);
     assertNotNull(notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()));
     assertEquals(1, notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()).size());
     Set<String> owners = new HashSet<>();


### PR DESCRIPTION
### What is this PR for?
This is about storing the owner information on creating a note so when the same user tries to edit the permissions of the note he could do it successfully.

### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1142

### How should this be tested?
Check the below cases via the web application or REST API calls and the owner information should be persisted properly.
* Create note
* Clone note
* Import note

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No