### PR TITLE
[ZEPPELIN-1406] modify to load method artifact local path in Helium application json

### DIFF
--- a/zeppelin-examples/zeppelin-example-clock/zeppelin-example-clock.json
+++ b/zeppelin-examples/zeppelin-example-clock/zeppelin-example-clock.json
@@ -18,7 +18,7 @@
   "type" : "APPLICATION",
   "name" : "zeppelin.clock",
   "description" : "Clock (example)",
-  "artifact" : "zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
+  "artifact" : "../zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
   "className" : "org.apache.zeppelin.example.app.clock.Clock",
   "resources" : [[":java.util.Date"]],
   "icon" : '<i class="fa fa-clock-o"></i>'

--- a/zeppelin-examples/zeppelin-example-horizontalbar/zeppelin-example-horizontalbar.json
+++ b/zeppelin-examples/zeppelin-example-horizontalbar/zeppelin-example-horizontalbar.json
@@ -18,7 +18,7 @@
   "type" : "APPLICATION",
   "name" : "zeppelin.horizontalbar",
   "description" : "Horizontal Bar chart (example)",
-  "artifact" : "zeppelin-examples/zeppelin-example-horizontalbar/target/zeppelin-example-horizontalbar-0.7.0-SNAPSHOT.jar",
+  "artifact" : "../zeppelin-examples/zeppelin-example-horizontalbar/target/zeppelin-example-horizontalbar-0.7.0-SNAPSHOT.jar",
   "className" : "org.apache.zeppelin.example.app.horizontalbar.HorizontalBar",
   "resources" : [[":org.apache.zeppelin.interpreter.InterpreterResult"]],
   "icon" : '<i class="fa fa-bar-chart" style="-webkit-transform: rotate(90deg) scaleX(-1);-moz-transform: rotate(90deg) scaleX(-1);-ms-transform: rotate(90deg) scaleX(-1);"></i>'

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
@@ -85,6 +85,10 @@ public class HeliumPackage {
     return artifact;
   }
 
+  public void setArtifact(String newArtifact) {
+    this.artifact = newArtifact;
+  }
+
   public String getClassName() {
     return className;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -86,7 +86,8 @@ public class ZeppelinServer extends Application {
         conf.getString(ConfVars.ZEPPELIN_INTERPRETER_LOCALREPO));
 
     this.helium = new Helium(conf.getHeliumConfPath(), conf.getHeliumDefaultLocalRegistryPath());
-    this.heliumApplicationFactory = new HeliumApplicationFactory();
+    this.heliumApplicationFactory = new HeliumApplicationFactory(
+        conf.getHeliumDefaultLocalRegistryPath());
     this.schedulerFactory = new SchedulerFactory();
     this.replFactory = new InterpreterFactory(conf, notebookWsServer,
         notebookWsServer, heliumApplicationFactory, depResolver);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -125,7 +125,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, Noteb
           appStatusChange(paragraph, appState.getId(), ApplicationState.Status.LOADING);
 
           if (pkg != null && pkg.getArtifact().trim().charAt(0) != '/') {
-            String absolutAppPath = String.format("%s/%s", heliumLocalPath, pkg.getArtifact())ex;
+            String absolutAppPath = String.format("%s/%s", heliumLocalPath, pkg.getArtifact());
             pkg.setArtifact(absolutAppPath);
           }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.helium;
 
 import com.google.gson.Gson;
 import org.apache.thrift.TException;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.*;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterInfo;
@@ -44,8 +45,10 @@ public class HeliumApplicationFactory implements ApplicationEventListener, Noteb
   private final Gson gson = new Gson();
   private Notebook notebook;
   private ApplicationEventListener applicationEventListener;
+  private String heliumLocalPath;
 
-  public HeliumApplicationFactory() {
+  public HeliumApplicationFactory(String heliumLocalPath) {
+    this.heliumLocalPath = heliumLocalPath;
     executor = ExecutorFactory.singleton().createOrGet(
         HeliumApplicationFactory.class.getName(), 10);
   }
@@ -120,6 +123,12 @@ public class HeliumApplicationFactory implements ApplicationEventListener, Noteb
 
         try {
           appStatusChange(paragraph, appState.getId(), ApplicationState.Status.LOADING);
+
+          if (pkg != null && pkg.getArtifact().trim().charAt(0) != '/') {
+            String absolutAppPath = String.format("%s/%s", heliumLocalPath, pkg.getArtifact())ex;
+            pkg.setArtifact(absolutAppPath);
+          }
+
           String pkgInfo = gson.toJson(pkg);
           String appId = appState.getId();
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -79,7 +79,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     MockInterpreter2.register("mock2", "org.apache.zeppelin.interpreter.mock.MockInterpreter2");
 
 
-    heliumAppFactory = new HeliumApplicationFactory();
+    heliumAppFactory = new HeliumApplicationFactory(home.getAbsolutePath() + "/helium");
     depResolver = new DependencyResolver(tmpDir.getAbsolutePath() + "/local-repo");
     factory = new InterpreterFactory(conf,
         new InterpreterOption(true), null, null, heliumAppFactory, depResolver);


### PR DESCRIPTION
### What is this PR for?

Currently contained in the Zeppelin Helium application does not work.
The relative value of the configuration file path does incurring call normally.
Therefore, it sets the Helium directory you specified in the application default directory.
An example of the application was to modify the path of helium.
### What type of PR is it?

Bug Fix, Improvement
### Todos
- [x] added setter method for artifact in Helium Packakge class
- [x] if not absolute path for artifact then replace to absolute path for helium artifact local path
- [x] replace helium example artifact path for json
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1406
### How should this be tested?

step 1. 
build

```
mvn clean package -Pbuild-distr -Pexamples -DskipTests
```

step 2.
go to web ui and create a new notebook.
write paragraph.
here.

```
%spark 
import java.util.Date
new Date();
```

step 3.
choice. 
helium application clock.

working well.
### Screenshots (if appropriate)
#### before

does not working.
![noshow](https://cloud.githubusercontent.com/assets/10525473/18199308/afbb3a3a-713a-11e6-926e-c4089874ae5b.png)
#### after

![clock](https://cloud.githubusercontent.com/assets/10525473/18199270/83483df4-713a-11e6-9ced-de9b37974f19.png)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? no
