### PR TITLE
[ZEPPELIN-1182] Zeppelin should have Startup and Shutdown message

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -161,6 +161,8 @@ function upstart() {
   # where the service manager starts and stops the process
   initialize_default_directories
 
+  echo "ZEPPELIN_CLASSPATH: ${ZEPPELIN_CLASSPATH_OVERRIDES}:${CLASSPATH}" >> "${ZEPPELIN_OUTFILE}"
+
   $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_MAIN >> "${ZEPPELIN_OUTFILE}"
 }
 
@@ -177,6 +179,8 @@ function start() {
 
   initialize_default_directories
 
+  echo "ZEPPELIN_CLASSPATH: ${ZEPPELIN_CLASSPATH_OVERRIDES}:${CLASSPATH}" >> "${ZEPPELIN_OUTFILE}"
+
   nohup nice -n $ZEPPELIN_NICENESS $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_MAIN >> "${ZEPPELIN_OUTFILE}" 2>&1 < /dev/null &
   pid=$!
   if [[ -z "${pid}" ]]; then
@@ -190,7 +194,6 @@ function start() {
   wait_zeppelin_is_up_for_ci
   sleep 2
   check_if_process_is_alive
-  echo "ZEPPELIN_CLASSPATH: ${ZEPPELIN_CLASSPATH}" >> "${ZEPPELIN_LOGFILE}"
 }
 
 function stop() {
@@ -255,7 +258,7 @@ case "${1}" in
     start
     ;;
   restart)
-    echo "${ZEPPELIN_NAME} is restarted" >> "${ZEPPELIN_LOGFILE}"
+    echo "${ZEPPELIN_NAME} is restarting" >> "${ZEPPELIN_OUTFILE}"
     stop
     start
     ;;

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -190,6 +190,7 @@ function start() {
   wait_zeppelin_is_up_for_ci
   sleep 2
   check_if_process_is_alive
+  echo "ZEPPELIN_CLASSPATH: ${ZEPPELIN_CLASSPATH}" >> "${ZEPPELIN_LOGFILE}"
 }
 
 function stop() {
@@ -254,6 +255,7 @@ case "${1}" in
     start
     ;;
   restart)
+    echo "${ZEPPELIN_NAME} is restarted" >> "${ZEPPELIN_LOGFILE}"
     stop
     start
     ;;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
+import org.apache.zeppelin.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +103,11 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         conf = new ZeppelinConfiguration();
       }
     }
+    
+    LOG.info("Server Host: " + conf.getServerAddress());
+    LOG.info("Server Port: " + conf.getServerPort());
+    LOG.info("Context Path: " + conf.getServerContextPath());
+    LOG.info("Zeppelin Version: " + Util.getVersion());
 
     return conf;
   }


### PR DESCRIPTION
### What is this PR for?
PR is for logging configuration details of Zeppelin server.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1182

### How should this be tested?
Please check the log if information on Server host, server path, context path, zeppelin version, class path is available in that file.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

Note:
    For configuration details such as  zeppelin version, server host, port & context path , these are available as part of zeppelin configuration. 

Logging information

```
 INFO [2016-09-02 14:35:25,218] ({main} ZeppelinConfiguration.java[create]:107) - Server Host: 0.0.0.0
 INFO [2016-09-02 14:35:25,218] ({main} ZeppelinConfiguration.java[create]:108) - Server Port: 8080
 INFO [2016-09-02 14:35:25,218] ({main} ZeppelinConfiguration.java[create]:109) - Context Path: /
 INFO [2016-09-02 14:35:25,224] ({main} ZeppelinConfiguration.java[create]:110) - Zeppelin Version: 0.7.0-SNAPSHOT
```

For Zeppelin class path and restart information,  I am logging it from Shell script to log file as in below paragraph, So the format of logging is different . I know this is not per standards, Please let me know if you have any suggestions
```
Zeppelin is restarted

ZEPPELIN_CLASSPATH: /home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-server/target/lib/*:/home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-zengine/target/lib/*:/home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-interpreter/target/lib/*:/home/rajarajang/Workspace/stsWorksapce/zeppelin/*::/home/rajarajang/Workspace/stsWorksapce/zeppelin/conf:/home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-interpreter/target/classes:/home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-zengine/target/classes:/home/rajarajang/Workspace/stsWorksapce/zeppelin/zeppelin-server/target/classes
```