### PR TITLE
[ZEPPELIN-1407] Fix Scala 2.11 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
     <profile>
       <id>scala-2.10</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property><name>!scala-2.11</name></property>
       </activation>
       <properties>
         <scala.version>2.10.5</scala.version>
@@ -541,6 +541,9 @@
 
     <profile>
       <id>scala-2.11</id>
+      <activation>
+        <property><name>scala-2.11</name></property>
+      </activation>
       <properties>
         <scala.version>2.11.7</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
@@ -826,5 +829,6 @@
       </build>
     </profile>
   </profiles>
+
 
 </project>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -95,6 +95,9 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
+      <activation>
+        <property><name>scala-2.11</name></property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.scala-lang.modules</groupId>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -114,6 +114,9 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
+      <activation>
+        <property><name>scala-2.11</name></property>
+      </activation>
       <dependencyManagement>
         <dependencies>
           <dependency>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -448,6 +448,9 @@
   <profiles>
     <profile>
       <id>scala-2.11</id>
+      <activation>
+        <property><name>scala-2.11</name></property>
+      </activation>
       <dependencyManagement>
         <dependencies>
           <dependency>


### PR DESCRIPTION
### What is this PR for?
Avoid activating the Scala 2.10 profile when building for Scala 2.11

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* (https://issues.apache.org/jira/browse/ZEPPELIN-1407)[https://issues.apache.org/jira/browse/ZEPPELIN-1407]

### How should this be tested?
Perform Scala 2.10 and 2.11 builds starting from a maven repository that does not have org.apache.zeppelin artifacts.
