### PR TITLE
Update Zeppelin Website building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 ## Deploy to ASF svnpubsub infra (committers only)
  1. generate static website in `./_site`
     ```
-    bundle exec jekyll build
+    JEKYLL_ENV=production bundle exec jekyll build
     ```
 
  2. checkout ASF repo

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 ## Deploy to ASF svnpubsub infra (committers only)
  1. generate static website in `./_site`
     ```
-    bundle exec jekyll build --safe
+    bundle exec jekyll build
     ```
 
  2. checkout ASF repo

--- a/contribution/documentation.md
+++ b/contribution/documentation.md
@@ -171,7 +171,7 @@ If you're going to create new pages, there are some spots you need to add the lo
 
     ```
     # go to /docs under Zeppelin source
-    bundle exec jekyll build --safe
+    JEKYLL_ENV=production bundle exec jekyll build
     ```
 
  2. checkout ASF repo


### PR DESCRIPTION
### What is this PR for?
Usually in order to push jekyll code to github pages, it will compile using the `--safe`
One drawback is that you cannot use any plugins.

After working on PR #1356 and introduction a plugin, using the build line with `--safe` specified in the README is failing.

However in our case, we are not forced to use that flag, since we are sending the compiled website directly to the Apache SVN, and I was able to confirm that fact when I sent the updated website to the SVN and it was rendered correctly

Also since plugins like Google Analytics needs to be activated only in production we are adding a special production environment option to add `JEKYLL_ENV=production`

### What type of PR is it?
Documentation

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No