### PR TITLE
[ZEPPELIN-1412] add support multiline for pythonErrorIn method on python interpreter

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -150,8 +150,17 @@ public class PythonInterpreter extends Interpreter {
    * @return true if syntax error or exception has happened
    */
   private boolean pythonErrorIn(String output) {
-    Matcher errorMatcher = errorInLastLine.matcher(output);
-    return errorMatcher.find();
+    boolean isError = false;
+    String[] outputMultiline = output.split("\n");
+    Matcher errorMatcher;
+    for (String row : outputMultiline) {
+      errorMatcher = errorInLastLine.matcher(row);
+      if (errorMatcher.find() == true) {
+        isError = true;
+        break;
+      }
+    }
+    return isError;
   }
 
   @Override

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -218,4 +218,25 @@ public class PythonInterpreterTest {
     }
   }
 
+  @Test
+  public void checkMultiRowErrorFails() {
+    PythonInterpreter pythonInterpreter = new PythonInterpreter(
+      PythonInterpreterTest.getPythonTestProperties()
+    );
+    pythonInterpreter.open();
+    String codeRaiseException = "raise Exception(\"test exception\")";
+    InterpreterResult ret = pythonInterpreter.interpret(codeRaiseException, null);
+
+    assertNotNull("Interpreter result for raise exception is Null", ret);
+
+    assertEquals(InterpreterResult.Code.ERROR, ret.code());
+    assertTrue(ret.message().length() > 0);
+
+    assertNotNull("Interpreter result for text is Null", ret);
+    String codePrintText = "print (\"Exception(\\\"test exception\\\")\")";
+    ret = pythonInterpreter.interpret(codePrintText, null);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertTrue(ret.message().length() > 0);
+  }
+
 }


### PR DESCRIPTION
### What is this PR for?
currently, has not support multiline exception text on python interpreter.
for example:

```
Exception: blabla
```
is error.

but

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
Exception: test exception
```
is sucess (now)


to resolve this issue.

### What type of PR is it?
Bug Fix

### Todos
- [x] modification pythonErrorIn method
- [x] add test case

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1412?jql=project%20%3D%20ZEPPELIN%20AND%20status%20%3D%20Open

### How should this be tested?
added test case.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

