### PR TITLE
[ZEPPELIN-808] Changed Permissions on Notebooks do not provide helpful error to user

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -258,6 +258,12 @@ public class NotebookServer extends WebSocketServlet implements
       }
     } catch (Exception e) {
       LOG.error("Can't handle message", e);
+      try {
+        conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
+                "Oops! Something went wrong. Please check with your administrator.")));
+      } catch (IOException e1) {
+        LOG.error("Can't handle message", e);
+      }
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1156,6 +1156,8 @@ public class NotebookServer extends WebSocketServlet implements
       conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
                 "Oops! There is something wrong with the notebook file system. "
                 + "Please check the logs for more details.")));
+      // don't run the paragraph when there is error on persisting the note information
+      return;
     }
 
     try {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -117,6 +117,21 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('noteRevision', data);
     } else if (op === 'INTERPRETER_BINDINGS') {
       $rootScope.$broadcast('interpreterBindings', data);
+    } else if (op === 'ERROR_INFO') {
+      BootstrapDialog.show({
+        closable: false,
+        closeByBackdrop: false,
+        closeByKeyboard: false,
+        title: 'Details',
+        message: data.info.toString(),
+        buttons: [{
+            // close all the dialogs when there are error on running all paragraphs
+            label: 'Close',
+            action: function() {
+              BootstrapDialog.closeAll();
+            }
+          }]
+      });
     }
   });
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -139,7 +139,8 @@ public class Message {
     SAVE_INTERPRETER_BINDINGS,    // [c-s] save interpreter bindings
                                   // @param noteID
                                   // @param selectedSettingIds
-    INTERPRETER_BINDINGS          // [s-c] interpreter bindings
+    INTERPRETER_BINDINGS,         // [s-c] interpreter bindings
+    ERROR_INFO                    // [s-c] error information to be sent
   }
 
   public OP op;


### PR DESCRIPTION
### What is this PR for?
This is about showing information to the user when there are errors on running paragraphs eg. there could be permission related issue with notebook.

### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-808

### How should this be tested?
* Create a notebook and change the file system permission for the notebook folder to have system level write permission to a different user.For eg. if you are running your local zeppelin server with id [USERNAME], then change the file system permission for one of your notebooks created with the former username to different one eg. ROOT user who will only have the write permission
* Try to run all the paragraphs or any individual paragraph for the notebook
* The information as shown in the screenshot should be displayed and the dialog could be closed by the 'Close' button.

### Screenshots (if appropriate)
![erroraboutrunningparagraph-2](https://cloud.githubusercontent.com/assets/20789766/18507272/4cdffe08-7a8d-11e6-8ec7-c712d28cd155.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No