### PR TITLE
[ZEPPELIN-1421] Fix dead link in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Apache Zeppelin documentation
 
-This README will walk you through building the documentation of Apache Zeppelin. The documentation is included here with Apache Zeppelin source code. The online documentation at [https://zeppelin.apache.org/docs/<ZEPPELIN_VERSION>](https://zeppelin.apache.org/docs/latest) is also generated from the files found in here.
+This README will walk you through building the documentation of Apache Zeppelin. The documentation is included here with Apache Zeppelin source code. The online documentation at [https://zeppelin.apache.org/docs/<ZEPPELIN_VERSION>](https://zeppelin.apache.org/docs/latest/) is also generated from the files found in here.
 
 ## Build documentation
 Zeppelin is using [Jekyll](https://jekyllrb.com/) which is a static site generator and [Github Pages](https://pages.github.com/) as a site publisher. For the more details, see [help.github.com/articles/about-github-pages-and-jekyll/](https://help.github.com/articles/about-github-pages-and-jekyll/).

--- a/docs/interpreter/elasticsearch.md
+++ b/docs/interpreter/elasticsearch.md
@@ -243,7 +243,7 @@ delete /index/type/id
 ```
 
 ### Apply Zeppelin Dynamic Forms
-You can leverage [Zeppelin Dynamic Form]({{BASE_PATH}}/manual/dynamicform.html) inside your queries. You can use both the `text input` and `select form` parameterization features.
+You can leverage [Zeppelin Dynamic Form](../manual/dynamicform.html) inside your queries. You can use both the `text input` and `select form` parameterization features.
 
 ```bash
 %elasticsearch

--- a/docs/interpreter/hive.md
+++ b/docs/interpreter/hive.md
@@ -151,7 +151,7 @@ select * from my_table;
 You can also run multiple queries up to 10 by default. Changing these settings is not implemented yet.
 
 ### Apply Zeppelin Dynamic Forms
-You can leverage [Zeppelin Dynamic Form]({{BASE_PATH}}/manual/dynamicform.html) inside your queries. You can use both the `text input` and `select form` parameterization features.
+You can leverage [Zeppelin Dynamic Form](../manual/dynamicform.html) inside your queries. You can use both the `text input` and `select form` parameterization features.
 
 ```sql
 %hive

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -174,7 +174,7 @@ When Zeppelin server is running with authentication enabled, then this interpret
 
 
 ## Apply Zeppelin Dynamic Forms
-You can leverage [Zeppelin Dynamic Form]({{BASE_PATH}}/manual/dynamicform.html). You can use both the `text input` and `select form` parameterization features.
+You can leverage [Zeppelin Dynamic Form](../manual/dynamicform.html). You can use both the `text input` and `select form` parameterization features.
 
 ```
 %livy.pyspark

--- a/docs/interpreter/markdown.md
+++ b/docs/interpreter/markdown.md
@@ -30,9 +30,9 @@ In Zeppelin notebook, you can use ` %md ` in the beginning of a paragraph to inv
 
 In Zeppelin, Markdown interpreter is enabled by default.
 
-<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-interpreter-setting.png" width="60%" />
+<img src="../assets/themes/zeppelin/img/docs-img/markdown-interpreter-setting.png" width="60%" />
 
 ## Example
 The following example demonstrates the basic usage of Markdown in a Zeppelin notebook.
 
-<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-example.png" width="70%" />
+<img src="../assets/themes/zeppelin/img/docs-img/markdown-example.png" width="70%" />

--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -108,7 +108,7 @@ z.show(plt, height='150px', fmt='svg')
 
 
 ## Pandas integration
-Apache Zeppelin [Table Display System]({{BASE_PATH}}/displaysystem/basicdisplaysystem.html#table) provides built-in data visualization capabilities. Python interpreter leverages it to visualize Pandas DataFrames though similar `z.show()` API, same as with [Matplotlib integration](#matplotlib-integration).
+Apache Zeppelin [Table Display System](../displaysystem/basicdisplaysystem.html#table) provides built-in data visualization capabilities. Python interpreter leverages it to visualize Pandas DataFrames though similar `z.show()` API, same as with [Matplotlib integration](#matplotlib-integration).
 
 Example:
 
@@ -120,7 +120,7 @@ z.show(rates)
 
 ## SQL over Pandas DataFrames
 
-There is a convenience `%python.sql` interpreter that matches Apache Spark experience in Zeppelin and enables usage of SQL language to query [Pandas DataFrames](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html) and visualization of results though built-in [Table Display System]({{BASE_PATH}}/displaysystem/basicdisplaysystem.html#table).
+There is a convenience `%python.sql` interpreter that matches Apache Spark experience in Zeppelin and enables usage of SQL language to query [Pandas DataFrames](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html) and visualization of results though built-in [Table Display System](../displaysystem/basicdisplaysystem.html#table).
 
  **Pre-requests**
 

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -63,6 +63,6 @@ At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property v
 ## Example
 The following example demonstrates the basic usage of Shell in a Zeppelin notebook.
 
-<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-example.png" />
+<img src="../assets/themes/zeppelin/img/docs-img/shell-example.png" />
 
 If you need further information about **Zeppelin Interpreter Setting** for using Shell interpreter, please read [What is interpreter setting?](../manual/interpreters.html#what-is-interpreter-setting) section first.

--- a/docs/manual/dependencymanagement.md
+++ b/docs/manual/dependencymanagement.md
@@ -33,8 +33,8 @@ When your code requires external library, instead of doing download/copy/restart
 <hr>
 <div class="row">
   <div class="col-md-6">
-    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png">
-      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png" />
+    <a data-lightbox="compiler" href="../assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png">
+      <img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png" />
     </a>
   </div>
   <div class="col-md-6" style="padding-top:30px">
@@ -52,11 +52,11 @@ When your code requires external library, instead of doing download/copy/restart
 <hr>
 <div class="row">
   <div class="col-md-6">
-    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png">
-      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png" />
+    <a data-lightbox="compiler" href="../assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png">
+      <img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png" />
     </a>
-    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png">
-      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png" />
+    <a data-lightbox="compiler" href="../assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png">
+      <img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png" />
     </a>
   </div>
   <div class="col-md-6" style="padding-top:30px">


### PR DESCRIPTION
### What is this PR for?
There is a dead link in [docs/README.md](https://github.com/apache/zeppelin/blob/master/docs/README.md). 

It should be `https://zeppelin.apache.org/docs/latest/` not `https://zeppelin.apache.org/docs/latest`

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1421](https://issues.apache.org/jira/browse/ZEPPELIN-1421)

### How should this be tested?
 - Before [https://zeppelin.apache.org/docs/latest](https://zeppelin.apache.org/docs/latest)
 - After [https://zeppelin.apache.org/docs/latest/](https://zeppelin.apache.org/docs/latest/)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

