### PR TITLE
[ZEPPELIN-1422][zeppelin-interpreter] fix InterpreterProperty equals methods, add null check

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
@@ -75,6 +75,7 @@ public class InterpreterProperty {
   }
 
   public boolean equals(Object o) {
+    if (o == null) return false;
     return this.toString().equals(o.toString());
   }
 


### PR DESCRIPTION
### What is this PR for?
in PR https://github.com/apache/zeppelin/pull/1382,
there is a small bug that `InterpreterProperty.equals` do not check `null`.
jdk lib request the `null` check otherwise it has the risk causing java collections operation throw exception.
so I fix it.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1422

### How should this be tested?
existing test.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

