### PR TITLE
ZEPPELIN-1430. Display appId and webui link in LivyInterpreter's output

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -65,7 +65,12 @@ Example: `spark.master` to `livy.spark.master`
     <td>1000</td>
     <td>Max number of Spark SQL result to display.</td>
   </tr>
-    <tr>
+  <tr>
+    <td>zeppelin.livy.displayAppInfo</td>
+    <td>false</td>
+    <td>Whether to display app info</td>
+  </tr>
+  <tr>
     <td>livy.spark.driver.cores</td>
     <td></td>
     <td>Driver cores. ex) 1, 2.</td>

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -136,15 +136,13 @@ public class LivyHelper {
                                           final Map<String, Integer> userSessionMap,
                                           LivyOutputStream out,
                                           String appId,
-                                          String webUI) {
+                                          String webUI,
+                                          boolean displayAppInfo) {
     try {
       out.setInterpreterOutput(context.out);
       context.out.clear();
-      out.write("%angular ");
       String incomplete = "";
       boolean inComment = false;
-      out.write("<pre><code>");
-
       String[] lines = stringLines.split("\n");
       String[] linesToRun = new String[lines.length + 1];
       for (int i = 0; i < lines.length; i++) {
@@ -152,6 +150,7 @@ public class LivyHelper {
       }
       linesToRun[lines.length] = "print(\"\")";
       Code r = null;
+      StringBuilder outputBuilder = new StringBuilder();
       for (int l = 0; l < linesToRun.length; l++) {
         String s = linesToRun[l];
         // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
@@ -200,19 +199,26 @@ public class LivyHelper {
         } else if (r == Code.INCOMPLETE) {
           incomplete += s + "\n";
         } else {
-          out.write((res.message() + "\n"));
+          outputBuilder.append(res.message() + "\n");
           incomplete = "";
         }
       }
 
-      out.write("</code></pre>");
-      out.write("<hr/>");
-      out.write("Spark Application Id:" + appId + "<br/>");
-      out.write("Spark WebUI: <a href=" + webUI + ">" + webUI + "</a>");
       if (r == Code.INCOMPLETE) {
         out.setInterpreterOutput(null);
         return new InterpreterResult(r, "Incomplete expression");
       } else {
+        if (displayAppInfo) {
+          out.write("%angular ");
+          out.write("<pre><code>");
+          out.write(outputBuilder.toString());
+          out.write("</code></pre>");
+          out.write("<hr/>");
+          out.write("Spark Application Id:" + appId + "<br/>");
+          out.write("Spark WebUI: <a href=" + webUI + ">" + webUI + "</a>");
+        } else {
+          out.write(outputBuilder.toString());
+        }
         out.setInterpreterOutput(null);
         return new InterpreterResult(Code.SUCCESS);
       }

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.livy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -133,21 +134,24 @@ public class LivyHelper {
   public InterpreterResult interpretInput(String stringLines,
                                           final InterpreterContext context,
                                           final Map<String, Integer> userSessionMap,
-                                          LivyOutputStream out) {
+                                          LivyOutputStream out,
+                                          String appId,
+                                          String webUI) {
     try {
+      out.setInterpreterOutput(context.out);
+      context.out.clear();
+      out.write("%angular ");
+      String incomplete = "";
+      boolean inComment = false;
+      out.write("<pre><code>");
+
       String[] lines = stringLines.split("\n");
       String[] linesToRun = new String[lines.length + 1];
       for (int i = 0; i < lines.length; i++) {
         linesToRun[i] = lines[i];
       }
       linesToRun[lines.length] = "print(\"\")";
-
-      out.setInterpreterOutput(context.out);
-      context.out.clear();
       Code r = null;
-      String incomplete = "";
-      boolean inComment = false;
-
       for (int l = 0; l < linesToRun.length; l++) {
         String s = linesToRun[l];
         // check if next line starts with "." (but not ".." or "./") it is treated as an invocation
@@ -196,11 +200,15 @@ public class LivyHelper {
         } else if (r == Code.INCOMPLETE) {
           incomplete += s + "\n";
         } else {
-          out.write((res.message() + "\n").getBytes(Charset.forName("UTF-8")));
+          out.write((res.message() + "\n"));
           incomplete = "";
         }
       }
 
+      out.write("</code></pre>");
+      out.write("<hr/>");
+      out.write("Spark Application Id:" + appId + "<br/>");
+      out.write("Spark WebUI: <a href=" + webUI + ">" + webUI + "</a>");
       if (r == Code.INCOMPLETE) {
         out.setInterpreterOutput(null);
         return new InterpreterResult(r, "Incomplete expression");
@@ -208,7 +216,6 @@ public class LivyHelper {
         out.setInterpreterOutput(null);
         return new InterpreterResult(Code.SUCCESS);
       }
-
     } catch (Exception e) {
       LOGGER.error("error in interpretInput", e);
       return new InterpreterResult(Code.ERROR, e.getMessage());
@@ -219,16 +226,6 @@ public class LivyHelper {
                                      final InterpreterContext context,
                                      final Map<String, Integer> userSessionMap)
       throws Exception {
-    stringLines = stringLines
-        //for "\n" present in string
-        .replaceAll("\\\\n", "\\\\\\\\n")
-        //for new line present in string
-        .replaceAll("\\n", "\\\\n")
-        // for \" present in string
-        .replaceAll("\\\\\"", "\\\\\\\\\"")
-        // for " present in string
-        .replaceAll("\"", "\\\\\"");
-
     if (stringLines.trim().equals("")) {
       return new InterpreterResult(Code.SUCCESS, "");
     }
@@ -295,7 +292,7 @@ public class LivyHelper {
             + userSessionMap.get(context.getAuthenticationInfo().getUser())
             + "/statements",
         "POST",
-        "{\"code\": \"" + lines + "\" }",
+        "{\"code\": \"" + StringEscapeUtils.escapeJson(lines) + "\"}",
         context.getParagraphId());
     if (json.matches("^(\")?Session (\'[0-9]\' )?not found(.?\"?)$")) {
       throw new Exception("Exception: Session not found, Livy server would have restarted, " +
@@ -340,6 +337,7 @@ public class LivyHelper {
 
   protected String executeHTTP(String targetURL, String method, String jsonData, String paragraphId)
       throws Exception {
+    LOGGER.debug("Call rest api in {}, method: {}, jsonData: {}", targetURL, method, jsonData);
     RestTemplate restTemplate = getRestTemplate();
     HttpHeaders headers = new HttpHeaders();
     headers.add("Content-Type", "application/json");

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyOutputStream.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyOutputStream.java
@@ -52,6 +52,10 @@ public class LivyOutputStream extends OutputStream {
     }
   }
 
+  public void write(String text) throws IOException {
+    write(text.getBytes("UTF-8"));
+  }
+
   @Override
   public void write(byte[] b, int offset, int len) throws IOException {
     if (interpreterOutput != null) {

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyOutputStream.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyOutputStream.java
@@ -17,6 +17,8 @@
 package org.apache.zeppelin.livy;
 
 import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,6 +27,8 @@ import java.io.OutputStream;
  * InterpreterOutput can be attached / detached.
  */
 public class LivyOutputStream extends OutputStream {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(LivyOutputStream.class);
   InterpreterOutput interpreterOutput;
 
   public LivyOutputStream() {
@@ -53,6 +57,7 @@ public class LivyOutputStream extends OutputStream {
   }
 
   public void write(String text) throws IOException {
+    LOGGER.debug("livy output:" + text);
     write(text.getBytes("UTF-8"));
   }
 

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -86,6 +86,11 @@
         "propertyName": "livy.spark.jars.packages",
         "defaultValue": "",
         "description": "Adding extra libraries to livy interpreter"
+      },
+      "livy.spark.displayAppInfo": {
+        "propertyName": "livy.spark.displayAppInfo",
+        "defaultValue": "false",
+        "description": "Whether display app info"
       }
     },
     "editor": {

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -88,7 +88,7 @@
         "description": "Adding extra libraries to livy interpreter"
       },
       "livy.spark.displayAppInfo": {
-        "propertyName": "livy.spark.displayAppInfo",
+        "propertyName": "zeppelin.livy.displayAppInfo",
         "defaultValue": "false",
         "description": "Whether display app info"
       }


### PR DESCRIPTION
### What is this PR for?
For now, it is hard to figure out what the yarn application of the livy session represent, it would be better to display the appId and webui link in the output of LivyInterpreter for diagnosing purpose. It can also be applied to the native SparkInterpreter, but could be done in another ticket. 

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1430

### How should this be tested?
Tested manually

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/18463333/e4eab580-79bb-11e6-8c8d-393ab6805638.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

