### PR TITLE
[ZEPPELIN-1435] Move zeppelin-server-*.jar under lib in distribution binary package

### DIFF
--- a/zeppelin-distribution/README.md
+++ b/zeppelin-distribution/README.md
@@ -23,18 +23,12 @@ Apache Zeppelin is distributed as a single gzip archive with the following struc
 Zeppelin
  ├── bin
  │   ├── zeppelin.sh
- │   └── seppelin-deamon.sh
+ │   └── zeppelin-daemon.sh
  ├── conf
  ├── interpreter
  ├── lib
  ├── licenses
- ├── zan-repo
- │    ├── txt.wordcount
- │    ├── vis.bubble
- │    ├── vis.gchart
- │    ├── ml.something
- │    └── ...
- ├── zeppelin-server-<verion>.jar
+ ├── notebook
  └── zeppelin-web-<verion>.war
  
 ```
@@ -42,4 +36,4 @@ Zeppelin
 We use `maven-assembly-plugin` to build it, see `zeppelin-distribution/src/assemble/distribution.xml ` for details.
 
 >**IMPORTANT:** `_/lib_` subdirectory contains all transitive dependencies of the `zeppelin-distribution` module,
-automatically resolved by maven, except for explicitly excluded `_server_` and `_web_`  Zeppelin sub-modules.
+automatically resolved by maven, except for explicitly excluded `_web_` Zeppelin sub-modules.

--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -33,7 +33,6 @@
       <useAllReactorProjects>true</useAllReactorProjects> -->
       <!-- Now, select which projects to include in this module-set. -->
       <includes>
-        <include>org.apache.zeppelin:zeppelin-server</include>
         <include>org.apache.zeppelin:zeppelin-web</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
@@ -44,7 +43,6 @@
       <useProjectArtifact>false</useProjectArtifact>
       <excludes>
         <exclude>${project.groupId}:zeppelin-web</exclude>
-        <exclude>${project.groupId}:zeppelin-server</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
### What is this PR for?

Move zeppelin-server-*.jar package under `lib` directory like other zeppelin modules such as `zeppelin-engine`, `zeppelin-interpreter`
### What type of PR is it?

Refactoring
### What is the Jira issue?

[ZEPPELIN-1435](https://issues.apache.org/jira/browse/ZEPPELIN-1435)
### How should this be tested?

Build with:

```
mvn clean package -DskipTests -Pbuild-distr -pl '!alluxio,!angular,!cassandra,!elasticsearch,!file,!flink,!hbase,!ignite,!jdbc,!kylin,!lens,!livy,!postgresql,!python,!shell,!bigquery'
```

and check if `zeppelin-server-0.7.0-SNAPSHOT.jar` file is placed under `zeppelin-distribution/target/zeppelin-0.7.0-SNAPSHOT/zeppelin-0.7.0-SNAPSHOT/lib` not `zeppelin-distribution/target/zeppelin-0.7.0-SNAPSHOT/zeppelin-0.7.0-SNAPSHOT`
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? no
