### PR TITLE
[ZEPPELIN-1439] Support for running multiple version of spark

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -23,7 +23,7 @@ function usage() {
     echo "usage) $0 -p <port> -d <interpreter dir to load> -l <local interpreter repo dir to load>"
 }
 
-while getopts "hp:d:l:v" o; do
+while getopts "hp:d:l:s:v" o; do
     case ${o} in
         h)
             usage
@@ -41,6 +41,9 @@ while getopts "hp:d:l:v" o; do
         v)
             . "${bin}/common.sh"
             getZeppelinVersion
+            ;;
+        s)
+            SPARK_HOME_OPT=${OPTARG}
             ;;
         esac
 done
@@ -90,6 +93,9 @@ fi
 
 # set spark related env variables
 if [[ "${INTERPRETER_ID}" == "spark" ]]; then
+  if [[ -n "${SPARK_HOME_OPT}" ]]; then
+    export SPARK_HOME=${SPARK_HOME_OPT}
+  fi
   if [[ -n "${SPARK_HOME}" ]]; then
     export SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
     SPARK_APP_JAR="$(ls ${ZEPPELIN_HOME}/interpreter/spark/zeppelin-spark*.jar)"

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -17,14 +17,15 @@
 
 package org.apache.zeppelin.interpreter.remote;
 
-import java.util.*;
-
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.GUI;
-import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.display.Input;
+import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
@@ -36,8 +37,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
+import java.util.*;
 
 /**
  * Proxy for Interpreter instance that runs on separate process
@@ -185,6 +185,9 @@ public class RemoteInterpreter extends Interpreter {
               port);
         } else {
           // create new remote process
+          if (!StringUtils.isAnyEmpty(property.getProperty("spark.home"))) {
+            env.put("spark.home", property.getProperty("spark.home"));
+          }
           remoteProcess = new RemoteInterpreterManagedProcess(
               interpreterRunner, interpreterPath, localRepoPath, env, connectTimeout,
               remoteInterpreterProcessListener, applicationEventListener);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -19,13 +19,13 @@ package org.apache.zeppelin.interpreter.remote;
 
 import org.apache.commons.exec.*;
 import org.apache.commons.exec.environment.EnvironmentUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Map;
 
 /**
@@ -101,6 +101,10 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
     cmdLine.addArgument(interpreterDir, false);
     cmdLine.addArgument("-p", false);
     cmdLine.addArgument(Integer.toString(port), false);
+    if (!StringUtils.isAnyEmpty(env.get("spark.home"))) {
+      cmdLine.addArgument("-s", false);
+      cmdLine.addArgument(env.get("spark.home"), false);
+    }
     cmdLine.addArgument("-l", false);
     cmdLine.addArgument(localRepoDir, false);
 


### PR DESCRIPTION
### What is this PR for?
Zeppelin to have support for running multiple version of spark.
Currently it's limited to work with either default spark which is shipped or SPARK_HOME configured in zeppelin-env.sh


### What type of PR is it?
[Improvement]

### Todos
* [x] - override SPARK_HOME

### What is the Jira issue?
* [ZEPPELIN-1439](https://issues.apache.org/jira/browse/ZEPPELIN-1439)

### How should this be tested?
Edit spark interpreter setting, add "spark.home" and give a valid path

### Screenshots (if appropriate)
![multi-version-spark](https://cloud.githubusercontent.com/assets/674497/18504603/c18c5b6e-7a80-11e6-9b0e-9bb044d717b1.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A

