### PR TITLE
[ZEPPELIN-868] Notebook import fails when notebook is large

### DIFF
--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -30,7 +30,7 @@ limitations under the License.
                    ng-model="note.noteImportName" />
           </div>
           <div class="form-group">             
-            <label for="fileSizeLimit">JSON file size cannot exceed 1MB</label>
+            <label for="fileSizeLimit">JSON file size cannot exceed {{config.maxLimit}} bytes</label>
           </div>
 
           <div class="form-group" ng-show="note.errorText">

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -29,6 +29,9 @@ limitations under the License.
             <input placeholder="Note name" type="text" class="form-control" id="noteImportName"
                    ng-model="note.noteImportName" />
           </div>
+          <div class="form-group">             
+            <label for="fileSizeLimit">JSON file size cannot exceed 1MB</label>
+          </div>
 
           <div class="form-group" ng-show="note.errorText">
             <div class="alert alert-danger">{{note.errorText}}</div>

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -29,8 +29,8 @@ limitations under the License.
             <input placeholder="Note name" type="text" class="form-control" id="noteImportName"
                    ng-model="note.noteImportName" />
           </div>
-          <div class="form-group">             
-            <label for="fileSizeLimit">JSON file size cannot exceed {{config.maxLimit}} bytes</label>
+          <div class="form-group">
+            <label for="fileSizeLimit">JSON file size cannot exceed {{maxLimit}} MB</label>
           </div>
 
           <div class="form-group" ng-show="note.errorText">

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -110,4 +110,11 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     vm.resetFlags();
     angular.element('#noteImportModal').modal('hide');
   });
+  
+  $scope.$on('checkCloseEventCode', function(scope, event) {
+	  $scope.note.errorText = '';
+	  if(event.code === 1009 || event.code === 1006){
+		  $scope.note.errorText = 'File size limit Exceeded!';
+	  }
+  });
 });

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -19,6 +19,13 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
   $scope.note = {};
   $scope.note.step1 = true;
   $scope.note.step2 = false;
+  $scope.config = {};
+  $scope.config.maxLimit = '';
+
+  websocketMsgSrv.listConfigurations();
+  $scope.$on('configurationsInfo', function(scope, event) {
+    $scope.config.maxLimit = event.configurations['zeppelin.websocket.max.text.message.size'];
+  });
 
   vm.resetFlags = function() {
     $scope.note = {};

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -44,6 +44,12 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     var file = $scope.note.importFile;
     var reader = new FileReader();
 
+    if (file.size > $scope.config.maxLimit) {
+      $scope.note.errorText = 'File size limit Exceeded!';
+      $scope.$apply();
+      return;
+    }
+
     reader.onloadend = function() {
       vm.processImportJson(reader.result);
     };
@@ -118,10 +124,4 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     angular.element('#noteImportModal').modal('hide');
   });
 
-  $scope.$on('checkCloseEventCode', function(scope, event) {
-    $scope.note.errorText = '';
-    if (event.code === 1009 || event.code === 1006) {
-      $scope.note.errorText = 'File size limit Exceeded!';
-    }
-  });
 });

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -110,11 +110,11 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     vm.resetFlags();
     angular.element('#noteImportModal').modal('hide');
   });
-  
+
   $scope.$on('checkCloseEventCode', function(scope, event) {
-	  $scope.note.errorText = '';
-	  if(event.code === 1009 || event.code === 1006){
-		  $scope.note.errorText = 'File size limit Exceeded!';
-	  }
+    $scope.note.errorText = '';
+    if (event.code === 1009 || event.code === 1006) {
+      $scope.note.errorText = 'File size limit Exceeded!';
+    }
   });
 });

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -19,12 +19,13 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
   $scope.note = {};
   $scope.note.step1 = true;
   $scope.note.step2 = false;
-  $scope.config = {};
-  $scope.config.maxLimit = '';
+  $scope.maxLimit = '';
+  var limit = 0;
 
   websocketMsgSrv.listConfigurations();
   $scope.$on('configurationsInfo', function(scope, event) {
-    $scope.config.maxLimit = event.configurations['zeppelin.websocket.max.text.message.size'];
+    limit = event.configurations['zeppelin.websocket.max.text.message.size'];
+    $scope.maxLimit = Math.round(limit / 1048576);
   });
 
   vm.resetFlags = function() {
@@ -44,7 +45,7 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     var file = $scope.note.importFile;
     var reader = new FileReader();
 
-    if (file.size > $scope.config.maxLimit) {
+    if (file.size > limit) {
       $scope.note.errorText = 'File size limit Exceeded!';
       $scope.$apply();
       return;

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -117,21 +117,8 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('noteRevision', data);
     } else if (op === 'INTERPRETER_BINDINGS') {
       $rootScope.$broadcast('interpreterBindings', data);
-    } else if (op === 'ERROR_INFO') {
-      BootstrapDialog.show({
-        closable: false,
-        closeByBackdrop: false,
-        closeByKeyboard: false,
-        title: 'Details',
-        message: data.info.toString(),
-        buttons: [{
-            // close all the dialogs when there are error on running all paragraphs
-            label: 'Close',
-            action: function() {
-              BootstrapDialog.closeAll();
-            }
-          }]
-      });
+    } else if (op === 'CONFIGURATIONS_INFO') {
+      $rootScope.$broadcast('configurationsInfo', data);
     }
   });
 
@@ -143,7 +130,6 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
   websocketCalls.ws.onClose(function(event) {
     console.log('close message: ', event);
     $rootScope.$broadcast('setConnectedStatus', false);
-    $rootScope.$broadcast('checkCloseEventCode', event);
   });
 
   return websocketCalls;

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -117,6 +117,21 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
       $rootScope.$broadcast('noteRevision', data);
     } else if (op === 'INTERPRETER_BINDINGS') {
       $rootScope.$broadcast('interpreterBindings', data);
+    } else if (op === 'ERROR_INFO') {
+      BootstrapDialog.show({
+        closable: false,
+        closeByBackdrop: false,
+        closeByKeyboard: false,
+        title: 'Details',
+        message: data.info.toString(),
+        buttons: [{
+          // close all the dialogs when there are error on running all paragraphs
+          label: 'Close',
+          action: function() {
+            BootstrapDialog.closeAll();
+          }
+        }]
+      });
     } else if (op === 'CONFIGURATIONS_INFO') {
       $rootScope.$broadcast('configurationsInfo', data);
     }

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -143,6 +143,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
   websocketCalls.ws.onClose(function(event) {
     console.log('close message: ', event);
     $rootScope.$broadcast('setConnectedStatus', false);
+    $rootScope.$broadcast('checkCloseEventCode', event);
   });
 
   return websocketCalls;

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -214,6 +214,10 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
     saveInterpreterBindings: function(noteID, selectedSettingIds) {
       websocketEvents.sendNewEvent({op: 'SAVE_INTERPRETER_BINDINGS',
         data: {noteID: noteID, selectedSettingIds: selectedSettingIds}});
+    },
+
+    listConfigurations: function() {
+      websocketEvents.sendNewEvent({op: 'LIST_CONFIGURATIONS'});
     }
 
   };


### PR DESCRIPTION
### What is this PR for?
A bug fix: Added validation in the note import dialog box to check for the uploaded json file size and throw error report if the file size exceeds 1MB, as the websocket frame is not able to send json file of size over 1MB.

### What type of PR is it?
Bug Fix

### Todos
NA

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-868

### How should this be tested?
1. Deploy Zeppelin and click on 'Import Note' in the Welcome to Zeppelin page.
2. Click 'Choose a JSON here' and upload a json file whose file size is over 1MB

### Screenshots (if appropriate)
![1](https://cloud.githubusercontent.com/assets/12062069/18556899/7add7a12-7b8a-11e6-85e6-f8b4fcef2195.png)
![2](https://cloud.githubusercontent.com/assets/12062069/18556966/b10bcb0c-7b8a-11e6-9448-1381d8e05d8f.png)
![3](https://cloud.githubusercontent.com/assets/12062069/18556999/d166b8a8-7b8a-11e6-927b-caa3a56618d1.png)
![4](https://cloud.githubusercontent.com/assets/12062069/18557002/d58f8d74-7b8a-11e6-8955-710eb093a795.png)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
