### PR TITLE
[HOT FIX][ZEPPELIN-1144] Fix compilation errors in Notebook.java

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -550,11 +550,11 @@ public class Notebook implements NoteEventListener {
       }).toSortedList(new Comparator<Note>() {
         @Override
         public int compare(Note note1, Note note2) {
-          String name1 = note1.id();
+          String name1 = note1.getId();
           if (note1.getName() != null) {
             name1 = note1.getName();
           }
-          String name2 = note2.id();
+          String name2 = note2.getId();
           if (note2.getName() != null) {
             name2 = note2.getName();
           }


### PR DESCRIPTION
### What is this PR for?
After #1330 merged, the latest master build failed with below compilation errors.

```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/ahyoungryu/Dev/zeppelin/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java:[553,31] cannot find symbol
  symbol:   method id()
  location: variable note1 of type org.apache.zeppelin.notebook.Note
[ERROR] /Users/ahyoungryu/Dev/zeppelin/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java:[557,31] cannot find symbol
  symbol:   method id()
  location: variable note2 of type org.apache.zeppelin.notebook.Note
```


### What type of PR is it?
 Hot Fix

### What is the Jira issue?

### How should this be tested?
 - Build the latest master branch with `mvn clean package -DskipTests` -> compilation error in `zeppelin-zengine`

 - Apply this patch and build with `mvn clean package -DskipTests` -> build success 
You can also check #1330 works properly.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

