### PR TITLE
[MINOR] Hide "Currently there are no properties ~" msg & "edit", "restart" and "remove" btn in edit mode

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -285,8 +285,8 @@ limitations under the License.
           <thead>
             <tr>
               <th style="width:40%">artifact</th>
-              <th>exclude</th>
-              <th ng-if="valueform.$visible">action</th>
+              <th style="width:40%">exclude</th>
+              <th style="width:20%" ng-if="valueform.$visible">action</th>
             </tr>
           </thead>
           <tr ng-repeat="dep in setting.dependencies">

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -299,7 +299,7 @@ limitations under the License.
             <td>
               <textarea ng-if="valueform.$visible" ng-model="dep.exclusions"
                         placeholder="(Optional) comma separated groupId:artifactId list"
-                        e-form="valueform"
+                        form="valueform"
                         e-msd-elastic
                         ng-list="">
               </textarea>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -124,7 +124,7 @@ limitations under the License.
           </small>
 
         </h3>
-        <span style="float:right">
+        <span style="float:right" ng-show="!valueform.$visible" >
           <button class="btn btn-default btn-xs"
                   ng-click="valueform.$show();
                   copyOriginInterpreterSettingProperties(setting.id)">
@@ -134,7 +134,7 @@ limitations under the License.
             <span class="fa fa-refresh"></span> restart</button>
           <button class="btn btn-default btn-xs"
                   ng-click="removeInterpreterSetting(setting.id)">
-            <span class="fa fa-remove"></span> remove</button>
+            <span class="fa fa-trash"></span> remove</button>
         </span>
       </div>
     </div>
@@ -229,12 +229,12 @@ limitations under the License.
           </div>
         </div>
       </div>
+    </div>
 
-      <div ng-show="_.isEmpty(setting.properties) && _.isEmpty(setting.dependencies) || valueform.$hidden" class="col-md-12 gray40-message">
+    <div class="row interpreter" style="margin-top:20px !important">
+      <div ng-show="_.isEmpty(setting.properties) && _.isEmpty(setting.dependencies) && !valueform.$visible" class="col-md-12 gray40-message">
         <em>Currently there are no properties and dependencies set for this interpreter</em>
       </div>
-    </div>
-    <div class="row interpreter">
       <div class="col-md-12" ng-show="!_.isEmpty(setting.properties) || valueform.$visible">
         <h5>Properties</h5>
         <table class="table table-striped">
@@ -299,7 +299,7 @@ limitations under the License.
             <td>
               <textarea ng-if="valueform.$visible" ng-model="dep.exclusions"
                         placeholder="(Optional) comma separated groupId:artifactId list"
-                        form="valueform"
+                        e-form="valueform"
                         e-msd-elastic
                         ng-list="">
               </textarea>


### PR DESCRIPTION
### What is this PR for?
"Currently there are no properties and dependencies set for this interpreter" message is shown when there are no properties & dependencies in interpreter setting page. But this message can be seen even in the edit mode. It's quite wired. This message needs to be shown only in non-editable mode.

The `edit`, `restart` and `remove` button are same. 
 - `edit` button doesn't do any work after changing to edit mode
 - `restart` button: it doesn't make sense that someone is editing and restarting interpreter at the same time
 - `remove` button: Maybe someone wants to remove the interpreter while he is editing the interpreter. But it would be better this button is shown only in non-editable mode for the consistency with the other buttons. 

For the above reasons, I changed those buttons to be shown in non-editable mode only. `Save` & `Cancel` buttons are enough to the edit page I think. Please see the attached gif image. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?

### How should this be tested?
1. After applying this patch and build only `zeppelin-web` with `./grunt build` under `zeppelin-web`. 
2. You can quickly check this change in dev mode with `./grunt serve`. 
3. Go to `Interpreter` menu and click "edit" button on Angular interpreter to see "Currently there are no properties and dependencies set for this interpreter" message. Can also check the existence of `edit`, `restart` and `remove` buttons. 

### Screenshots (if appropriate)
 - Before
![before](https://cloud.githubusercontent.com/assets/10060731/18616987/79b40d3a-7e01-11e6-85a1-e3888ef7f2f5.gif)

 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/18616988/7df1d094-7e01-11e6-9146-400e36b2392a.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

