### PR TITLE
ZEPPELIN-1368. interpreter-setting.json may be loaded mutliple times

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -338,9 +338,9 @@ public abstract class Interpreter {
   @Deprecated
   public static void register(String name, String group, String className,
       boolean defaultInterpreter, Map<String, InterpreterProperty> properties) {
-    logger.error("Static initialization is deprecated. You should change it to use " +
-                     "interpreter-setting.json in your jar or " +
-                     "interpreter/{interpreter}/interpreter-setting.json");
+    logger.warn("Static initialization is deprecated for interpreter {}, You should change it " +
+                     "to use interpreter-setting.json in your jar or " +
+                     "interpreter/{interpreter}/interpreter-setting.json", name);
     register(new RegisteredInterpreter(name, group, className, defaultInterpreter, properties));
   }
 


### PR DESCRIPTION
### What is this PR for?
here're several ways to load interpreter-setting.json, but for now we will load it multiple times. It is supposed to load only once. We should load it by the following orders
         * 1. Register it from path {ZEPPELIN_HOME}/interpreter/{interpreter_name}/ interpreter-setting.json
         * 2. Register it from interpreter-setting.json in classpath {ZEPPELIN_HOME}/interpreter/{interpreter_name}
         * 3. Register it by Interpreter.register


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1368

### How should this be tested?
Check the log that each interpreter is registered once. And also modify file interpreter/spark/interpreter-setting.json to make pyspark as the default interpreter and it works. Before this PR, it doesn't work, because it would be override by interpreter-setting.json in `interpreter/spark/zeppelin-spark_2.10-0.7.0-SNAPSHOT.jar`

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/18621557/a4510966-7e57-11e6-8c9a-80697ebf2600.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

