### PR TITLE
ZEPPELIN-1452: Include Phoenix 'thin client' instructions in docs

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -269,7 +269,6 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
  </table>
 
 ### Phoenix
-#### Properties:
  Phoenix supports 'thick' and 'thin' connection types:
 
  The thick client is faster, but must connect directly to ZooKeeper and HBase RegionServers.
@@ -278,6 +277,7 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
 
  Use the appropriate phoenix.driver and phoenix.url for your connection type. Include only the dependency for your connection type.
 
+#### Properties:
  <table class="table-configuration">
    <tr>
      <th>Name</th>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -275,7 +275,7 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
 
  The thin client has fewer dependencies and connects through a [Phoenix Query Server](http://phoenix.apache.org/server.html) instance.
 
- Use the appropriate phoenix.driver and phoenix.url for your connection type. Include only the dependency for your connection type.
+ Use the appropriate phoenix.driver and phoenix.url for your connection type.
 
 #### Properties:
  <table class="table-configuration">
@@ -316,6 +316,9 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
    </tr>
  </table>
 #### Dependencies:
+ 
+ Include the dependency for your connection type (it should be only *one* of the following).
+ 
  <table class="table-configuration">
    <tr>
      <th>Artifact</th>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -269,38 +269,68 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
  </table>
 
 ### Phoenix
-#### Properties
+#### Properties:
+ Phoenix supports 'thick' and 'thin' connection types:
+
+ The thick client is faster, but must connect directly to ZooKeeper and HBase RegionServers.
+
+ The thin client has fewer dependencies and connects through a [Phoenix Query Server](http://phoenix.apache.org/server.html) instance.
+
+ Use the appropriate phoenix.driver and phoenix.url for your connection type. Include only the dependency for your connection type.
+
  <table class="table-configuration">
    <tr>
      <th>Name</th>
      <th>Value</th>
+     <th>Description</th>
    </tr>
    <tr>
      <td>phoenix.driver</td>
      <td>org.apache.phoenix.jdbc.PhoenixDriver</td>
+     <td>'Thick Client', connects directly to Phoenix</td>
+   </tr>
+   <tr>
+     <td>phoenix.driver</td>
+     <td>org.apache.calcite.avatica.remote.Driver</td>
+     <td>'Thin Client', connects via Phoenix Query Server</td>
    </tr>
    <tr>
      <td>phoenix.url</td>
      <td>jdbc:phoenix:localhost:2181:/hbase-unsecure</td>
+     <td>'Thick Client', connects directly to Phoenix</td>
+   </tr>
+   <tr>
+     <td>phoenix.url</td>
+     <td>jdbc:phoenix:thin:url=http://localhost:8765;serialization=PROTOBUF</td>
+     <td>'Thin Client', connects via Phoenix Query Server</td>
    </tr>
    <tr>
      <td>phoenix.user</td>
      <td>phoenix_user</td>
+     <td></td>
    </tr>
    <tr>
      <td>phoenix.password</td>
      <td>phoenix_password</td>
+     <td></td>
    </tr>
  </table>
-#### Dependencies
+#### Dependencies:
  <table class="table-configuration">
    <tr>
      <th>Artifact</th>
      <th>Excludes</th>
+     <th>Description</th>
    </tr>
    <tr>
      <td>org.apache.phoenix:phoenix-core:4.4.0-HBase-1.0</td>
      <td></td>
+     <td>'Thick Client', connects directly to Phoenix</td>
+   </tr>
+   <tr>
+     <td>org.apache.phoenix:phoenix-server-client:4.7.0-HBase-1.1</td>
+     <td></td>
+     <td>'Thin Client', connects via Phoenix Query Server</td>
    </tr>
  </table>
 

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -291,7 +291,7 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
    </tr>
    <tr>
      <td>phoenix.driver</td>
-     <td>org.apache.calcite.avatica.remote.Driver</td>
+     <td>org.apache.phoenix.queryserver.client.Driver</td>
      <td>'Thin Client', connects via Phoenix Query Server</td>
    </tr>
    <tr>
@@ -330,7 +330,12 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
    <tr>
      <td>org.apache.phoenix:phoenix-server-client:4.7.0-HBase-1.1</td>
      <td></td>
-     <td>'Thin Client', connects via Phoenix Query Server</td>
+     <td>'Thin Client' for Phoenix 4.7, connects via Phoenix Query Server</td>
+   </tr>
+   <tr>
+     <td>org.apache.phoenix:phoenix-queryserver-client:4.8.0-HBase-1.2</td>
+     <td></td>
+     <td>'Thin Client' for Phoenix 4.8+, connects via Phoenix Query Server</td>
    </tr>
  </table>
 

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -269,13 +269,13 @@ To develop this functionality use this [method](http://docs.oracle.com/javase/7/
  </table>
 
 ### Phoenix
- Phoenix supports 'thick' and 'thin' connection types:
 
- The thick client is faster, but must connect directly to ZooKeeper and HBase RegionServers.
+ Phoenix supports `thick` and `thin` connection types:
 
- The thin client has fewer dependencies and connects through a [Phoenix Query Server](http://phoenix.apache.org/server.html) instance.
+ - Thick client is faster, but must connect directly to ZooKeeper and HBase RegionServers.
+ - Thin client has fewer dependencies and connects through a [Phoenix Query Server](http://phoenix.apache.org/server.html) instance.
 
- Use the appropriate phoenix.driver and phoenix.url for your connection type.
+Use the appropriate `phoenix.driver` and `phoenix.url` for your connection type.
 
 #### Properties:
  <table class="table-configuration">


### PR DESCRIPTION
### What is this PR for?
Phoenix has two different connection types: thick and thin.
This PR is about describing the difference between the two and including properties for both in docs/interpreter/jdbc.md
### What type of PR is it?
Documentation


### What is the Jira issue?
[ZEPPELIN-1452](https://issues.apache.org/jira/browse/ZEPPELIN-1452)

### How should this be tested?
No tests necessary

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
