### PR TITLE
ZEPPELIN-1454: Wrong property value on interpreter page

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -839,17 +839,21 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     synchronized (interpreterSettings) {
       InterpreterSetting intpsetting = interpreterSettings.get(id);
       if (intpsetting != null) {
+        try {
+          stopJobAllInterpreter(intpsetting);
 
-        stopJobAllInterpreter(intpsetting);
+          intpsetting.closeAndRmoveAllInterpreterGroups();
+          intpsetting.setOption(option);
+          intpsetting.setProperties(properties);
+          intpsetting.setDependencies(dependencies);
+          loadInterpreterDependencies(intpsetting);
 
-        intpsetting.closeAndRmoveAllInterpreterGroups();
-
-        intpsetting.setOption(option);
-        intpsetting.setProperties(properties);
-        intpsetting.setDependencies(dependencies);
-
-        loadInterpreterDependencies(intpsetting);
-        saveToFile();
+          saveToFile();
+        } catch (Exception e) {
+          throw e;
+        } finally {
+          loadFromFile();
+        }
       } else {
         throw new InterpreterException("Interpreter setting id " + id + " not found");
       }


### PR DESCRIPTION
### What is this PR for?
If for some reason (for example permission issue in file system) while saving interpreter setting, UI shows wrong value till the next restart.
IMO interpreter.json should be the source of truth, that should always be reflected on UI

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - read from file-system after saving

### What is the Jira issue?
* [ZEPPELIN-1454](https://issues.apache.org/jira/browse/ZEPPELIN-1454)

### How should this be tested?
Change file system permission of "interpreter.json", and make it readonly, then on interpreter setting page try and change any property and refresh the page, refer screenshot

### Screenshots (if appropriate)
Before
![fix-permission-before](https://cloud.githubusercontent.com/assets/674497/18627830/ced6673a-7e7a-11e6-88a6-426e1d2d2582.gif)

After
![fix-permission-after](https://cloud.githubusercontent.com/assets/674497/18627831/ceda24f6-7e7a-11e6-880b-4a7d1f9be3d8.gif)


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

