### PR TITLE
[HOTFIX][ZEPPELIN-1458] Fix compiling error on branch-0.6

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -493,13 +493,12 @@ public class SparkInterpreter extends Interpreter {
   }
 
   private void setupConfForSparkR(SparkConf conf) {
-    String sparkRBasePath = new InterpreterProperty("SPARK_HOME", null, null, null).getValue();
+    String sparkRBasePath = getSystemDefault("SPARK_HOME", null, null);
     File sparkRPath;
     if (null == sparkRBasePath) {
-      sparkRBasePath =
-              new InterpreterProperty("ZEPPELIN_HOME", "zeppelin.home", "../", null).getValue();
+      sparkRBasePath = getSystemDefault("ZEPPELIN_HOME", "zeppelin.home", "../");
       sparkRPath = new File(sparkRBasePath,
-              "interpreter" + File.separator + "spark" + File.separator + "R");
+          "interpreter" + File.separator + "spark" + File.separator + "R");
     } else {
       sparkRPath = new File(sparkRBasePath, "R" + File.separator + "lib");
     }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -462,19 +462,4 @@ public class RemoteInterpreter extends Interpreter {
       client.angularRegistryPush(gson.toJson(registry, registryType));
     }
   }
-
-  public Map<String, String> getEnv() {
-    return env;
-  }
-
-  public void setEnv(Map<String, String> env) {
-    this.env = env;
-  }
-
-  public void addEnv(Map<String, String> env) {
-    if (this.env == null) {
-      this.env = new HashMap<>();
-    }
-    this.env.putAll(env);
-  }
 }

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -258,14 +258,5 @@
         <filtering>true</filtering>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
-        <configuration combine.children="append">
-          <forkMode>always</forkMode>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -890,13 +890,11 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     String localRepoPath = conf.getInterpreterLocalRepoPath() + "/" + interpreterSettingId;
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
 
-    RemoteInterpreter remoteInterpreter =
-        new RemoteInterpreter(property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
-            interpreterPath, localRepoPath, connectTimeout, maxPoolSize,
-            remoteInterpreterProcessListener);
-    remoteInterpreter.addEnv(env);
-
-    return new LazyOpenInterpreter(remoteInterpreter);
+    LazyOpenInterpreter intp = new LazyOpenInterpreter(new RemoteInterpreter(
+        property, noteId, className, conf.getInterpreterRemoteRunnerPath(),
+        interpreterPath, localRepoPath, connectTimeout,
+        maxPoolSize, remoteInterpreterProcessListener));
+    return intp;
   }
 
   private URL[] recursiveBuildLibList(File path) throws MalformedURLException {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -20,8 +20,6 @@ package org.apache.zeppelin.interpreter;
 import java.io.*;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Properties;
 
 import org.apache.commons.lang.NullArgumentException;
@@ -31,7 +29,6 @@ import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
-import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,10 +50,7 @@ public class InterpreterFactoryTest {
     tmpDir.mkdirs();
     new File(tmpDir, "conf").mkdirs();
 
-    Map<String, InterpreterProperty> propertiesMockInterpreter1 = new HashMap<String, InterpreterProperty>();
-    propertiesMockInterpreter1.put("PROPERTY_1", new InterpreterProperty("PROPERTY_1", "", "VALUE_1", "desc"));
-    propertiesMockInterpreter1.put("property_2", new InterpreterProperty("", "property_2", "value_2", "desc"));
-    MockInterpreter1.register("mock1", "mock1", "org.apache.zeppelin.interpreter.mock.MockInterpreter1", propertiesMockInterpreter1);
+    MockInterpreter1.register("mock1", "org.apache.zeppelin.interpreter.mock.MockInterpreter1");
     MockInterpreter2.register("mock2", "org.apache.zeppelin.interpreter.mock.MockInterpreter2");
 
     System.setProperty(ConfVars.ZEPPELIN_HOME.getVarName(), tmpDir.getAbsolutePath());
@@ -102,29 +96,6 @@ public class InterpreterFactoryTest {
     // restart interpreter
     factory.restart(all.get(0));
     assertNull(setting.getInterpreterGroup("sharedProcess").get("session"));
-  }
-
-  @Test
-  public void testRemoteRepl() throws Exception {
-    factory = new InterpreterFactory(conf, new InterpreterOption(true), null, null, null, depResolver);
-    List<InterpreterSetting> all = factory.get();
-    InterpreterSetting mock1Setting = null;
-    for (InterpreterSetting setting : all) {
-      if (setting.getName().equals("mock1")) {
-        mock1Setting = setting;
-        break;
-      }
-    }
-    InterpreterGroup interpreterGroup = mock1Setting.getInterpreterGroup("sharedProcess");
-    factory.createInterpretersForNote(mock1Setting, "sharedProcess", "session");
-    // get interpreter
-    assertNotNull("get Interpreter", interpreterGroup.get("session").get(0));
-    assertTrue(interpreterGroup.get("session").get(0) instanceof LazyOpenInterpreter);
-    LazyOpenInterpreter lazyInterpreter = (LazyOpenInterpreter)(interpreterGroup.get("session").get(0));
-    assertTrue(lazyInterpreter.getInnerInterpreter() instanceof RemoteInterpreter);
-    RemoteInterpreter remoteInterpreter = (RemoteInterpreter) lazyInterpreter.getInnerInterpreter();
-    assertEquals("VALUE_1", remoteInterpreter.getEnv().get("PROPERTY_1"));
-    assertEquals("value_2", remoteInterpreter.getProperty("property_2"));
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
Fix compiling error on branch-0.6.
- Revert #1333
- Change `InterpreterProperty.getValue` ->  `SparkInterpreter.getSystemDefault` method since `InterpreterProperty.getValue` only exists in master.

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1458](https://issues.apache.org/jira/browse/ZEPPELIN-1458)

### How should this be tested?
Try mvn build on branch-0.6 and see if compile error is gone.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
