### PR TITLE
ZEPPELIN-1459: Zeppelin JDBC URL properties mangled

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -210,7 +210,7 @@ public class JDBCInterpreter extends Interpreter {
       }
     }
     if (null == connection) {
-      final Properties properties = propertiesMap.get(propertyKey);
+      final Properties properties = (Properties) propertiesMap.get(propertyKey).clone();
       logger.info(properties.getProperty(DRIVER_KEY));
       Class.forName(properties.getProperty(DRIVER_KEY));
       final String url = properties.getProperty(URL_KEY);


### PR DESCRIPTION
### What is this PR for?
While creating connection `DriverManager.getConnection(url, properties);` for JDBC interpreter, phoenix driver is modifying the properties that is passed as parameter, which in modifies propertiesMap.

This all is resulting in, not able to execute any other paragraph with phoenix interpreter.

This only happens if JDBC URI is "jdbc:phoenix:thin:url"

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Pass a copy of `properties` to `DriverManager.getConnection(url, properties)`

### What is the Jira issue?
* [ZEPPELIN-1459](https://issues.apache.org/jira/browse/ZEPPELIN-1459)

### How should this be tested?
Use the example setting below
https://issues.apache.org/jira/browse/ZEPPELIN-1459?focusedCommentId=15505750&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15505750



### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

