### PR TITLE
[Zeppelin-1001]  Take care of comma/tab escape in csv/tsv download

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2169,7 +2169,12 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       var row = $scope.paragraph.result.msgTable[r];
       var dsvRow = '';
       for (var index in row) {
-        dsvRow += row[index].value + delimiter;
+        var stringValue =  (row[index].value).toString();
+        if (stringValue.contains(delimiter)) {
+          dsvRow += stringValue.replace(stringValue, '"' + stringValue + '"') + delimiter;
+        } else {
+          dsvRow += row[index].value + delimiter;
+        }
       }
       dsv += dsvRow.substring(0, dsvRow.length - 1) + '\n';
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2172,7 +2172,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         var stringValue =  (row[index].value).toString();
         if (stringValue.contains(delimiter)) {
           dsvRow += '"' + stringValue + '"' + delimiter;
-        } else {
+          } else {
           dsvRow += row[index].value + delimiter;
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2172,7 +2172,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         var stringValue =  (row[index].value).toString();
         if (stringValue.contains(delimiter)) {
           dsvRow += '"' + stringValue + '"' + delimiter;
-          } else {
+        } else {
           dsvRow += row[index].value + delimiter;
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -2171,7 +2171,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
       for (var index in row) {
         var stringValue =  (row[index].value).toString();
         if (stringValue.contains(delimiter)) {
-          dsvRow += stringValue.replace(stringValue, '"' + stringValue + '"') + delimiter;
+          dsvRow += '"' + stringValue + '"' + delimiter;
         } else {
           dsvRow += row[index].value + delimiter;
         }


### PR DESCRIPTION
### What is this PR for?
When the data is downloaded as CSV/TSV, the comma/tab in the actual data has to be handled so that they come exactly as the same data when downloaded.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1001

### How should this be tested?
Modify the data to be loaded to have a comma.
Create a paragraph to pull up that data and display.
Now click on the download as CSV/TSV button in the tool bar.
Once the data is downloaded verify whether the original data is unaltered and the comma is escaped.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

