### PR TITLE
[MINOR] Remove spaces between intepreter group and name

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -97,9 +97,10 @@ limitations under the License.
           <small>
             <span style="display:inline-block" ng-repeat="interpreter in setting.interpreterGroup"
                   title="{{interpreter.class}}">
-              <span ng-show="!$first">, </span>%<span ng-show="!$parent.$first || $first">{{setting.name}}</span>
-              <span ng-show="(!$parent.$first || $first) && !$first">.</span>
-              <span ng-show="!$first">{{interpreter.name}}</span>
+              <span ng-show="!$first">, </span>
+              %<span ng-show="!$parent.$first || $first">{{setting.name}}</span
+              ><span ng-show="(!$parent.$first || $first) && !$first">.</span
+              ><span ng-show="!$first">{{interpreter.name}}</span>
               <span ng-show="$parent.$first && $first">(default)</span>
             </span>
           </small>


### PR DESCRIPTION
### What is this PR for?
#1395 changed alignment of html tag and it caused to make space between interpreter group and name.

### What type of PR is it?
Bug Fix

### Screenshots (if appropriate)
**Before**
<img width="436" alt="screen shot 2016-09-22 at 11 31 35 am" src="https://cloud.githubusercontent.com/assets/8503346/18743269/7fa34b16-80b8-11e6-979a-194e7f6bef8f.png">

**After**
<img width="411" alt="screen shot 2016-09-22 at 11 32 02 am" src="https://cloud.githubusercontent.com/assets/8503346/18743271/83807038-80b8-11e6-80b1-775c3369940e.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

