### PR TITLE
[MINOR] Change Markdown class name from MarkdownInterpreter to Markdown

### DIFF
--- a/markdown/src/main/java/org/apache/zeppelin/markdown/Markdown.java
+++ b/markdown/src/main/java/org/apache/zeppelin/markdown/Markdown.java
@@ -34,8 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** MarkdownInterpreter interpreter for Zeppelin. */
-public class MarkdownInterpreter extends Interpreter {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MarkdownInterpreter.class);
+public class Markdown extends Interpreter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Markdown.class);
 
   private MarkdownParser parser;
 
@@ -60,7 +60,7 @@ public class MarkdownInterpreter extends Interpreter {
   public static final String PARSER_TYPE_PEGDOWN = "pegdown";
   public static final String PARSER_TYPE_MARKDOWN4J = "markdown4j";
 
-  public MarkdownInterpreter(Properties property) {
+  public Markdown(Properties property) {
     super(property);
   }
 
@@ -114,7 +114,7 @@ public class MarkdownInterpreter extends Interpreter {
   @Override
   public Scheduler getScheduler() {
     return SchedulerFactory.singleton()
-        .createOrGetParallelScheduler(MarkdownInterpreter.class.getName() + this.hashCode(), 5);
+        .createOrGetParallelScheduler(Markdown.class.getName() + this.hashCode(), 5);
   }
 
   @Override

--- a/markdown/src/main/resources/interpreter-setting.json
+++ b/markdown/src/main/resources/interpreter-setting.json
@@ -2,7 +2,7 @@
   {
     "group": "md",
     "name": "md",
-    "className": "org.apache.zeppelin.markdown.MarkdownInterpreter",
+    "className": "org.apache.zeppelin.markdown.Markdown",
     "properties": {
       "markdown.parser.type": {
         "envName": "MARKDOWN_PARSER_TYPE",

--- a/markdown/src/test/java/org/apache/zeppelin/markdown/Markdown4jParserTest.java
+++ b/markdown/src/test/java/org/apache/zeppelin/markdown/Markdown4jParserTest.java
@@ -28,13 +28,13 @@ import static org.junit.Assert.assertEquals;
 
 public class Markdown4jParserTest {
 
-  MarkdownInterpreter md;
+  Markdown md;
 
   @Before
   public void setUp() throws Exception {
     Properties props = new Properties();
-    props.put(MarkdownInterpreter.MARKDOWN_PARSER_TYPE, MarkdownInterpreter.PARSER_TYPE_MARKDOWN4J);
-    md = new MarkdownInterpreter(props);
+    props.put(Markdown.MARKDOWN_PARSER_TYPE, Markdown.PARSER_TYPE_MARKDOWN4J);
+    md = new Markdown(props);
     md.open();
   }
 

--- a/markdown/src/test/java/org/apache/zeppelin/markdown/PegdownParserTest.java
+++ b/markdown/src/test/java/org/apache/zeppelin/markdown/PegdownParserTest.java
@@ -29,13 +29,13 @@ import org.junit.Test;
 
 public class PegdownParserTest {
 
-  MarkdownInterpreter md;
+  Markdown md;
 
   @Before
   public void setUp() throws Exception {
     Properties props = new Properties();
-    props.put(MarkdownInterpreter.MARKDOWN_PARSER_TYPE, MarkdownInterpreter.PARSER_TYPE_PEGDOWN);
-    md = new MarkdownInterpreter(props);
+    props.put(Markdown.MARKDOWN_PARSER_TYPE, Markdown.PARSER_TYPE_PEGDOWN);
+    md = new Markdown(props);
     md.open();
   }
 


### PR DESCRIPTION
### What is this PR for?
Markdown interpreter's class name have changed from `Markdown` to `MarkdownInterpreter` in #1384 and this will bring some compatibility issue in case user have `Markdown` class specified in `conf/interpreter.json` file. This PR rollbacks markdown class name from `MarkdownInterpreter` to `Markdown` to avoid side effect

### What type of PR is it?
Hotfix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

