### PR TITLE
ZEPPELIN-1473. It is not necessary to create SQLContext in LivyInterpreter

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -130,12 +130,6 @@ public class LivyHelper {
     }
   }
 
-  protected void initializeSpark(final InterpreterContext context,
-                                 final Map<String, Integer> userSessionMap) throws Exception {
-    interpret("val sqlContext = new org.apache.spark.sql.SQLContext(sc)\n" +
-        "import sqlContext.implicits._", context, userSessionMap);
-  }
-
   public InterpreterResult interpretInput(String stringLines,
                                           final InterpreterContext context,
                                           final Map<String, Integer> userSessionMap,

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -75,7 +75,6 @@ public class LivySparkInterpreter extends Interpreter {
                   interpreterContext,
                   "spark")
           );
-          livyHelper.initializeSpark(interpreterContext, userSessionMap);
         } catch (Exception e) {
           LOGGER.error("Exception in LivySparkInterpreter while interpret ", e);
           return new InterpreterResult(InterpreterResult.Code.ERROR, e.getMessage());

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -65,7 +65,6 @@ public class LivySparkSQLInterpreter extends Interpreter {
                   interpreterContext,
                   "spark")
           );
-          livyHelper.initializeSpark(interpreterContext, userSessionMap);
         } catch (Exception e) {
           LOGGER.error("Exception in LivySparkSQLInterpreter while interpret ", e);
           return new InterpreterResult(InterpreterResult.Code.ERROR, e.getMessage());


### PR DESCRIPTION
### What is this PR for?
Livy will create SQLContext/HiveContext internally, (LIVY-94), so it is not necessary to create that in LivyInterpreter. Otherwise sqlContext in zeppelin will override that in livy. 



### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1473

### How should this be tested?
Tested manually.  HiveContext is created properly in livy (with proper livy configuration), and can access hive data. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/18743886/bff7ae8e-80ed-11e6-83e6-0769c30e4094.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

