### PR TITLE
[HOTFIX] Fix CI on branch-0.6

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -102,6 +102,7 @@ public abstract class AbstractTestRestApi {
 
   protected static void startUp() throws Exception {
     if (!wasRunning) {
+      System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(), "../");
       LOG.info("Staring test Zeppelin up...");
 
 


### PR DESCRIPTION
### What is this PR for?
Set `zeppelin.home` property to avoid NullPointer Exception for `getSparkHome` method.
```
Results :

Tests in error: 
  InterpreterRestApiTest.init:54->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  CredentialsRestApiTest.init:39->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  ZeppelinRestApiTest.init:56->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  NotebookRestApiTest.init:54->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  SecurityRestApiTest.init:44->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  ConfigurationsRestApiTest.init:39->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  ZeppelinSparkClusterTest.init:48->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer
  NotebookServerTest.init:63->AbstractTestRestApi.startUp:163->AbstractTestRestApi.getSparkHome:211 Â» NullPointer

Tests run: 23, Failures: 0, Errors: 8, Skipped: 0
```
https://s3.amazonaws.com/archive.travis-ci.org/jobs/162374466/log.txt


### What type of PR is it?
Hot Fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

