### PR TITLE
[Hot Fix] Add a newline for bullet list markdown rendering

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -45,6 +45,7 @@ Apache Zeppelin officially supports and is tested on the following environments:
 </table>
 
 To install Apache Zeppelin, you have two options:
+
 * You can [download pre-built binary packages](#downloading-binary-package) from the archive. This is usually easier than building from source, and you can download the latest stable version (or older versions, if necessary).
 * You can also [build from source](#building-from-source). This gives you a development version of Zeppelin, which is more unstable but has new features.
 


### PR DESCRIPTION
### What is this PR for?
After #1416 merged, the bullet list in https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/install.html#installation isn't properly rendered now. It needs an extra newline.

### What type of PR is it?
Hot Fix

### Screenshots (if appropriate)
 - Before 
<img width="834" alt="screen shot 2016-09-25 at 4 13 25 pm" src="https://cloud.githubusercontent.com/assets/10060731/18813621/5e10c2dc-833b-11e6-8410-bb1d37d8228b.png">

 - After 
<img width="834" alt="screen shot 2016-09-25 at 4 13 36 pm" src="https://cloud.githubusercontent.com/assets/10060731/18813622/6705b744-833b-11e6-8fab-3a69d8585c7a.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

