### PR TITLE
[ZEPPELIN-1487] Resolve possible NPEs in storage sync mechanism

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -183,7 +183,8 @@ public class NotebookRepoSync implements NotebookRepo {
     List <NoteInfo> srcNotes = srcRepo.list(subject);
     List <NoteInfo> dstNotes = dstRepo.list(subject);
 
-    Map<String, List<String>> noteIDs = notesCheckDiff(srcNotes, srcRepo, dstNotes, dstRepo);
+    Map<String, List<String>> noteIDs = notesCheckDiff(srcNotes, srcRepo, dstNotes, dstRepo,
+        subject);
     List<String> pushNoteIDs = noteIDs.get(pushKey);
     List<String> pullNoteIDs = noteIDs.get(pullKey);
     List<String> delDstNoteIDs = noteIDs.get(delDstKey);
@@ -256,7 +257,8 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   private Map<String, List<String>> notesCheckDiff(List<NoteInfo> sourceNotes,
-      NotebookRepo sourceRepo, List<NoteInfo> destNotes, NotebookRepo destRepo)
+      NotebookRepo sourceRepo, List<NoteInfo> destNotes, NotebookRepo destRepo,
+      AuthenticationInfo subject)
       throws IOException {
     List <String> pushIDs = new ArrayList<String>();
     List <String> pullIDs = new ArrayList<String>();
@@ -268,8 +270,8 @@ public class NotebookRepoSync implements NotebookRepo {
       dnote = containsID(destNotes, snote.getId());
       if (dnote != null) {
         /* note exists in source and destination storage systems */
-        sdate = lastModificationDate(sourceRepo.get(snote.getId(), null));
-        ddate = lastModificationDate(destRepo.get(dnote.getId(), null));
+        sdate = lastModificationDate(sourceRepo.get(snote.getId(), subject));
+        ddate = lastModificationDate(destRepo.get(dnote.getId(), subject));
 
         if (sdate.compareTo(ddate) != 0) {
           if (sdate.after(ddate) || oneWaySync) {


### PR DESCRIPTION
### What is this PR for?
This is to resolve possible NPEs in storage mechanism related to empty subject

### What type of PR is it?
Bug Fix 

### Todos
* [x] - pass `subject` instead of `null`

### What is the Jira issue?
[ZEPPELIN-1487](https://issues.apache.org/jira/browse/ZEPPELIN-1487)

### How should this be tested?
storage tests pass, CI green

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

