### PR TITLE
[ZEPPELIN-1490]  pass subject while persisting note on running status change

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -22,6 +22,8 @@ package org.apache.zeppelin.user;
  *
  */
 public class AuthenticationInfo {
+  public static final AuthenticationInfo ANONYMOUS = new AuthenticationInfo("anonymous", "anonymous");
+
   String user;
   String ticket;
   UserCredentials userCredentials;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -22,7 +22,8 @@ package org.apache.zeppelin.user;
  *
  */
 public class AuthenticationInfo {
-  public static final AuthenticationInfo ANONYMOUS = new AuthenticationInfo("anonymous", "anonymous");
+  public static final AuthenticationInfo ANONYMOUS = new AuthenticationInfo("anonymous",
+      "anonymous");
 
   String user;
   String ticket;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1472,14 +1472,12 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     private AuthenticationInfo getJobSubject(Job job) {
-      //may need to go through all paragraphs
-      //TODO(khalid): find possibly a faster way
-      for (Paragraph p: note.getParagraphs()) {
-        if (p.getJobName() == job.getJobName()) {
-          return p.getAuthenticationInfo();
-        }
+      AuthenticationInfo authInfo = AuthenticationInfo.ANONYMOUS;
+      if (job instanceof Paragraph) {
+        Paragraph p = (Paragraph) job;
+        authInfo = p.getAuthenticationInfo();
       }
-      return AuthenticationInfo.ANONYMOUS;
+      return authInfo; 
     }
 
     /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1125,6 +1125,7 @@ public class NotebookServer extends WebSocketServlet implements
     String text = (String) fromMessage.get("paragraph");
     p.setText(text);
     p.setTitle((String) fromMessage.get("title"));
+
     if (!fromMessage.principal.equals("anonymous")) {
       AuthenticationInfo authenticationInfo = new AuthenticationInfo(fromMessage.principal,
           fromMessage.ticket);
@@ -1147,10 +1148,8 @@ public class NotebookServer extends WebSocketServlet implements
       note.addParagraph();
     }
 
-    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-
     try {
-      note.persist(subject);
+      note.persist(p.getAuthenticationInfo());
     } catch (FileSystemException ex) {
       LOG.error("Exception from run", ex);
       conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
@@ -1159,6 +1158,7 @@ public class NotebookServer extends WebSocketServlet implements
       // don't run the paragraph when there is error on persisting the note information
       return;
     }
+
 
     try {
       note.run(paragraphId);
@@ -1456,8 +1456,8 @@ public class NotebookServer extends WebSocketServlet implements
       if (job.isTerminated()) {
         LOG.info("Job {} is finished", job.getId());
         try {
-          //TODO(khalid): may change interface for JobListener and pass subject from interpreter
-          note.persist(null);
+          AuthenticationInfo subject = getJobSubject(job);
+          note.persist(subject);
         } catch (IOException e) {
           LOG.error(e.toString(), e);
         }
@@ -1469,6 +1469,17 @@ public class NotebookServer extends WebSocketServlet implements
       } catch (IOException e) {
         LOG.error("can not broadcast for job manager {}", e);
       }
+    }
+
+    private AuthenticationInfo getJobSubject(Job job) {
+      //may need to go through all paragraphs
+      //TODO(khalid): find possibly a faster way
+      for (Paragraph p: note.getParagraphs()) {
+        if (p.getJobName() == job.getJobName()) {
+          return p.getAuthenticationInfo();
+        }
+      }
+      return new AuthenticationInfo("anonymous");
     }
 
     /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1479,7 +1479,7 @@ public class NotebookServer extends WebSocketServlet implements
           return p.getAuthenticationInfo();
         }
       }
-      return new AuthenticationInfo("anonymous");
+      return AuthenticationInfo.ANONYMOUS;
     }
 
     /**


### PR DESCRIPTION
### What is this PR for?
This PR makes sure correct subject passed to `note.persist`. The subject is obtained from the paragraph level `authInfo` based on the job running.


### What type of PR is it?
Bug Fix

### Todos
* [x] - pass correct subject

### What is the Jira issue?
[ZEPPELIN-1490](https://issues.apache.org/jira/browse/ZEPPELIN-1490)

### How should this be tested?
CI is green

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
