### PR TITLE
[MINOR] Rearrange the contents in "About Zeppelin"

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -813,6 +813,7 @@ This part should be removed when new version of bootstrap handles this issue.
 .about .logo {
   padding-top: 30px;
 }
+
 .about .logo img {
   width: 95%;
 }

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -804,24 +804,47 @@ This part should be removed when new version of bootstrap handles this issue.
   background: #3071a9;
 }
 
-.about{
+/* About Zeppelin */
+.about {
   height: 200px;
-  padding-top: 20px;
-  padding-left: 20px;
+  padding: 36px;
 }
 
 .about .logo {
-  width: 20%;
+  width: 35%;
+  top: 50%;
   float: left;
 }
 
-.about .content{
-  float: left;
-  padding-left: 10px;
-  top: -30px;
+.about .logo img {
+  width: 82%;
+  padding-top: 30px;
+}
+
+.about .content {
   position: relative;
+  float: left;
+  text-align: center;
 }
 
-.about .logo img{
-  width: 100%;
+.about .content h3 {
+  font-family: 'Patua One';
+  color: #3071A9;
+  font-size: 30px;
+  margin: 0 auto;
+}
+
+@media (max-width: 767px) {
+  .about {
+    height: 170px;
+    padding: 20px;
+  }
+
+  .about .logo {
+    display: none;
+  }
+
+  .about .content {
+    float: none;
+  }
 }

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -807,23 +807,17 @@ This part should be removed when new version of bootstrap handles this issue.
 /* About Zeppelin */
 .about {
   height: 200px;
-  padding: 36px;
+  padding: 25px;
 }
 
 .about .logo {
-  width: 35%;
-  top: 50%;
-  float: left;
-}
-
-.about .logo img {
-  width: 82%;
   padding-top: 30px;
+}
+.about .logo img {
+  width: 95%;
 }
 
 .about .content {
-  position: relative;
-  float: left;
   text-align: center;
 }
 
@@ -832,19 +826,4 @@ This part should be removed when new version of bootstrap handles this issue.
   color: #3071A9;
   font-size: 30px;
   margin: 0 auto;
-}
-
-@media (max-width: 767px) {
-  .about {
-    height: 170px;
-    padding: 20px;
-  }
-
-  .about .logo {
-    display: none;
-  }
-
-  .about .content {
-    float: none;
-  }
 }

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -114,11 +114,11 @@ limitations under the License.
       </div>
       <div class="modal-body">
 
-        <div class="about">
-          <div class="logo">
+        <div class="row about">
+          <div class="hidden-xs col-sm-4 col-md-4 logo">
             <img src="assets/images/zepLogo.png" alt="Apache Zeppelin" title="Apache Zeppelin" />
           </div>
-          <div class="content">
+          <div class="col-xs-12 col-sm-8 col-md-8 content">
             <h3>Apache Zeppelin</h3>
             <br/>
             <span id="i18n-14">Version</span>


### PR DESCRIPTION
### What is this PR for?
Just rearranged the placement of Zeppelin logo, title and text in "About Zeppelin". In the mobile screen as well. 

### What type of PR is it?
Improvement

### What is the Jira issue?
No Jira issue for this 

### How should this be tested?
To check this change in your local, build only `zeppelin-web` with `./grunt build` and then browse with `./grunt serve`.

### Screenshots (if appropriate)
- **Before** 
  1. desktop & tablet screen
<img src="https://cloud.githubusercontent.com/assets/10060731/18860571/8aa85aec-84b9-11e6-9112-b6869291f8f0.png" width="500px">

  2. mobile screen
<img src="https://cloud.githubusercontent.com/assets/10060731/18860576/91f623a6-84b9-11e6-96ba-e34c43221143.png" width="300px">

- **After** 
  1. desktop & tablet screen
<img src="https://cloud.githubusercontent.com/assets/10060731/19140869/b5ab79e0-8bcb-11e6-946f-df63045e6f1e.png" width="500px">

  2. mobile screen
<img src="https://cloud.githubusercontent.com/assets/10060731/19140879/c034b476-8bcb-11e6-977b-29deb6776f13.png" width="300px">



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

