### PR TITLE
[Zeppelin 796] Duplicated notebook names should not be allowed

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -104,6 +104,12 @@
       <version>1.0.8</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.0.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -236,7 +236,7 @@ public class NotebookRestApi {
    * @param req - notebook Json
    * @return JSON with new note ID
    * @throws IOException
- * @throws DuplicateNameException 
+   * @throws DuplicateNameException 
    */
   @POST
   @Path("import")
@@ -259,7 +259,7 @@ public class NotebookRestApi {
    * @param message - JSON with new note name
    * @return JSON with new note ID
    * @throws IOException
- * @throws DuplicateNameException 
+   * @throws DuplicateNameException 
    */
   @POST
   @Path("/")

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -247,8 +247,8 @@ public class NotebookRestApi {
     try {
       newNote = notebook.importNote(req, null, subject);
     } catch (DuplicateNameException e) {
-      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "Notebook"
-              + " already exists with same name").build();
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, 
+          "Notebook already exists with same name").build();
     }
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.zeppelin.annotation.ZeppelinApi;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
@@ -235,13 +236,20 @@ public class NotebookRestApi {
    * @param req - notebook Json
    * @return JSON with new note ID
    * @throws IOException
+ * @throws DuplicateNameException 
    */
   @POST
   @Path("import")
   @ZeppelinApi
   public Response importNotebook(String req) throws IOException {
     AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-    Note newNote = notebook.importNote(req, null, subject);
+    Note newNote;
+    try {
+      newNote = notebook.importNote(req, null, subject);
+    } catch (DuplicateNameException e) {
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "Notebook"
+              + " already exists with same name").build();
+    }
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
 
@@ -251,33 +259,38 @@ public class NotebookRestApi {
    * @param message - JSON with new note name
    * @return JSON with new note ID
    * @throws IOException
+ * @throws DuplicateNameException 
    */
   @POST
   @Path("/")
   @ZeppelinApi
   public Response createNote(String message) throws IOException {
     LOG.info("Create new notebook by JSON {}", message);
-    NewNotebookRequest request = gson.fromJson(message, NewNotebookRequest.class);
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-    Note note = notebook.createNote(subject);
-    List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
-    if (initialParagraphs != null) {
-      for (NewParagraphRequest paragraphRequest : initialParagraphs) {
-        Paragraph p = note.addParagraph();
-        p.setTitle(paragraphRequest.getTitle());
-        p.setText(paragraphRequest.getText());
+    String noteName = null;
+    Note note;
+    try {
+      NewNotebookRequest request = gson.fromJson(message, NewNotebookRequest.class);
+      noteName = request.getName();
+      AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+      note = notebook.createNote(subject, noteName);
+      List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
+      if (initialParagraphs != null) {
+        for (NewParagraphRequest paragraphRequest : initialParagraphs) {
+          Paragraph p = note.addParagraph();
+          p.setTitle(paragraphRequest.getTitle());
+          p.setText(paragraphRequest.getText());
+        }
       }
-    }
-    note.addParagraph(); // add one paragraph to the last
-    String noteName = request.getName();
-    if (noteName.isEmpty()) {
-      noteName = "Note " + note.getId();
-    }
+      note.addParagraph(); // add one paragraph to the last
 
-    note.setName(noteName);
-    note.persist(subject);
-    notebookServer.broadcastNote(note);
-    notebookServer.broadcastNoteList(subject);
+      note.setName(noteName);
+      note.persist(subject);
+      notebookServer.broadcastNote(note);
+      notebookServer.broadcastNoteList(subject);
+    } catch (DuplicateNameException e) {
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "Notebook with name " + noteName +
+              "already exists").build();
+    }
     return new JsonResponse<>(Status.CREATED, "", note.getId()).build();
   }
 
@@ -311,6 +324,7 @@ public class NotebookRestApi {
    * @param notebookId ID of Notebook
    * @return JSON with status.CREATED
    * @throws IOException, CloneNotSupportedException, IllegalArgumentException
+   * @throws DuplicateNameException 
    */
   @POST
   @Path("{notebookId}")
@@ -318,15 +332,21 @@ public class NotebookRestApi {
   public Response cloneNote(@PathParam("notebookId") String notebookId, String message)
       throws IOException, CloneNotSupportedException, IllegalArgumentException {
     LOG.info("clone notebook by JSON {}", message);
-    NewNotebookRequest request = gson.fromJson(message, NewNotebookRequest.class);
     String newNoteName = null;
-    if (request != null) {
-      newNoteName = request.getName();
+    Note newNote;
+    try {
+      NewNotebookRequest request = gson.fromJson(message, NewNotebookRequest.class);
+      if (request != null) {
+        newNoteName = request.getName();
+      }
+      AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+      newNote = notebook.cloneNote(notebookId, newNoteName, subject);
+      notebookServer.broadcastNote(newNote);
+      notebookServer.broadcastNoteList(subject);
+    } catch (DuplicateNameException e) {
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "Note with name " + newNoteName +
+              "already exists").build();
     }
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-    Note newNote = notebook.cloneNote(notebookId, newNoteName, subject);
-    notebookServer.broadcastNote(newNote);
-    notebookServer.broadcastNoteList(subject);
     return new JsonResponse<>(Status.CREATED, "", newNote.getId()).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -283,7 +283,6 @@ public class NotebookRestApi {
       }
       note.addParagraph(); // add one paragraph to the last
 
-      note.setName(noteName);
       note.persist(subject);
       notebookServer.broadcastNote(note);
       notebookServer.broadcastNoteList(subject);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -124,10 +124,10 @@ public class NotebookServer extends WebSocketServlet implements
     Notebook notebook = notebook();
     try {
       Message messagereceived = deserializeMessage(msg);
-      LOG.info("RECEIVE << " + messagereceived.op);
-      LOG.info("RECEIVE PRINCIPAL << " + messagereceived.principal);
-      LOG.info("RECEIVE TICKET << " + messagereceived.ticket);
-      LOG.info("RECEIVE ROLES << " + messagereceived.roles);
+      LOG.debug("RECEIVE << " + messagereceived.op);
+      LOG.debug("RECEIVE PRINCIPAL << " + messagereceived.principal);
+      LOG.debug("RECEIVE TICKET << " + messagereceived.ticket);
+      LOG.debug("RECEIVE ROLES << " + messagereceived.roles);
 
       if (LOG.isTraceEnabled()) {
         LOG.trace("RECEIVE MSG = " + messagereceived);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -738,7 +738,10 @@ public class NotebookServer extends WebSocketServlet implements
       if (fromMessage != null) {
         String noteName = (String) ((Map) fromMessage.get("notebook")).get("name");
         String noteJson = gson.toJson(fromMessage.get("notebook"));
-        AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+        AuthenticationInfo subject = null;
+        if (fromMessage.principal != null) {
+          subject = new AuthenticationInfo(fromMessage.principal);
+        }
         note = notebook.importNote(noteJson, noteName, subject);
         note.persist(subject);
         broadcastNote(note);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -28,6 +28,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
@@ -123,10 +124,10 @@ public class NotebookServer extends WebSocketServlet implements
     Notebook notebook = notebook();
     try {
       Message messagereceived = deserializeMessage(msg);
-      LOG.debug("RECEIVE << " + messagereceived.op);
-      LOG.debug("RECEIVE PRINCIPAL << " + messagereceived.principal);
-      LOG.debug("RECEIVE TICKET << " + messagereceived.ticket);
-      LOG.debug("RECEIVE ROLES << " + messagereceived.roles);
+      LOG.info("RECEIVE << " + messagereceived.op);
+      LOG.info("RECEIVE PRINCIPAL << " + messagereceived.principal);
+      LOG.info("RECEIVE TICKET << " + messagereceived.ticket);
+      LOG.info("RECEIVE ROLES << " + messagereceived.roles);
 
       if (LOG.isTraceEnabled()) {
         LOG.trace("RECEIVE MSG = " + messagereceived);
@@ -640,20 +641,23 @@ public class NotebookServer extends WebSocketServlet implements
                           Notebook notebook, Message message)
       throws IOException {
     AuthenticationInfo subject = new AuthenticationInfo(message.principal);
-    Note note = notebook.createNote(subject);
-    note.addParagraph(); // it's an empty note. so add one paragraph
+    String noteName = null;
     if (message != null) {
-      String noteName = (String) message.get("name");
-      if (noteName == null || noteName.isEmpty()){
-        noteName = "Note " + note.getId();
-      }
-      note.setName(noteName);
+      noteName = (String) message.get("name");
     }
+    try {
+      Note note = notebook.createNote(subject, noteName);
+    
+      note.addParagraph(); // it's an empty note. so add one paragraph
 
-    note.persist(subject);
-    addConnectionToNote(note.getId(), (NotebookSocket) conn);
-    conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", note)));
-    broadcastNoteList(subject);
+      note.persist(subject);
+      addConnectionToNote(note.getId(), (NotebookSocket) conn);
+      conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", note)));
+      broadcastNoteList(subject);
+    } catch (DuplicateNameException dne) {
+      conn.send(serializeMessage(new Message(OP.ERROR_DIALOG).put("info", 
+        "Please provide a unique notebook name")));
+    }
   }
 
   private void removeNote(NotebookSocket conn, HashSet<String> userAndRoles,
@@ -710,31 +714,39 @@ public class NotebookServer extends WebSocketServlet implements
 
   private void cloneNote(NotebookSocket conn, HashSet<String> userAndRoles,
                          Notebook notebook, Message fromMessage)
-      throws IOException, CloneNotSupportedException {
-    String noteId = getOpenNoteId(conn);
-    String name = (String) fromMessage.get("name");
-    Note newNote = notebook.cloneNote(noteId, name, new AuthenticationInfo(fromMessage.principal));
-    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
-    addConnectionToNote(newNote.getId(), (NotebookSocket) conn);
-    conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", newNote)));
-    broadcastNoteList(subject);
+      throws IOException, CloneNotSupportedException, IllegalArgumentException {
+    try {
+      String noteId = getOpenNoteId(conn);
+      String name = (String) fromMessage.get("name");
+      Note newNote = notebook.cloneNote(noteId, name, 
+        new AuthenticationInfo(fromMessage.principal));
+      AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+      addConnectionToNote(newNote.getId(), (NotebookSocket) conn);
+      conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", newNote)));
+      broadcastNoteList(subject);
+    } catch (DuplicateNameException dne) {
+      conn.send(serializeMessage(new Message(OP.ERROR_DIALOG).put("info", 
+              "Please provide a unique notebook name")));
+    }
   }
 
   protected Note importNote(NotebookSocket conn, HashSet<String> userAndRoles,
                             Notebook notebook, Message fromMessage)
       throws IOException {
     Note note = null;
-    if (fromMessage != null) {
-      String noteName = (String) ((Map) fromMessage.get("notebook")).get("name");
-      String noteJson = gson.toJson(fromMessage.get("notebook"));
-      AuthenticationInfo subject = null;
-      if (fromMessage.principal != null) {
-        subject = new AuthenticationInfo(fromMessage.principal);
+    try {
+      if (fromMessage != null) {
+        String noteName = (String) ((Map) fromMessage.get("notebook")).get("name");
+        String noteJson = gson.toJson(fromMessage.get("notebook"));
+        AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+        note = notebook.importNote(noteJson, noteName, subject);
+        note.persist(subject);
+        broadcastNote(note);
+        broadcastNoteList(subject);
       }
-      note = notebook.importNote(noteJson, noteName, subject);
-      note.persist(subject);
-      broadcastNote(note);
-      broadcastNoteList(subject);
+    } catch (DuplicateNameException dne) {
+      conn.send(serializeMessage(new Message(OP.IMPORT_ERROR_DIALOG).put("info", 
+              "Please provide a unique notebook name")));
     }
     return note;
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -462,5 +462,7 @@ public abstract class AbstractTestRestApi {
   protected Matcher<? super HttpMethodBase> isNotAllowed() {
     return responsesWith(405);
   }
+  
+  protected Matcher<? super HttpMethodBase> isNotAcceptable() { return responsesWith(404); }
 
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -463,6 +463,6 @@ public abstract class AbstractTestRestApi {
     return responsesWith(405);
   }
   
-  protected Matcher<? super HttpMethodBase> isNotAcceptable() { return responsesWith(404); }
+  protected Matcher<? super HttpMethodBase> isNotAcceptable() { return responsesWith(406); }
 
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class InterpreterRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
-  private final String NOTE_NAME = "Note";
+  private final String EMPTY_STRING = "";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -133,7 +133,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   @Test
   public void testInterpreterAutoBinding() throws IOException, DuplicateNameException {
     // create note
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     // check interpreter is binded
     GetMethod get = httpGet("/notebook/interpreter/bind/" + note.getId());
@@ -152,7 +152,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   @Test
   public void testInterpreterRestart() throws IOException, InterruptedException, DuplicateNameException {
     // create new note
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     note.addParagraph();
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -47,6 +48,7 @@ import static org.junit.Assert.*;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class InterpreterRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
+  private final String NOTE_NAME = "Note";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -129,9 +131,9 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testInterpreterAutoBinding() throws IOException {
+  public void testInterpreterAutoBinding() throws IOException, DuplicateNameException {
     // create note
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     // check interpreter is binded
     GetMethod get = httpGet("/notebook/interpreter/bind/" + note.getId());
@@ -148,9 +150,9 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testInterpreterRestart() throws IOException, InterruptedException {
+  public void testInterpreterRestart() throws IOException, InterruptedException, DuplicateNameException {
     // create new note
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     note.addParagraph();
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -176,18 +176,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   
   @Test
   public void testCloneNotebookWithSameName() throws IOException, DuplicateNameException {
-    Note note1 = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
-    PostMethod post = httpPost("/notebook/" + note1.getId(), "");
+    String noteName = "Test_Note";
+    String jsonRequest = "{\"name\":\"" + noteName + "\"}";
+    Note note1 = ZeppelinServer.notebook.createNote(null, noteName);
+    PostMethod post = httpPost("/notebook/" + note1.getId(), jsonRequest);
     LOG.info("testCloneNotebookWithSameName response\n" + post.getResponseBodyAsString());
-    assertThat(post, isCreated());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {
-    }.getType());
-    String clonedNotebookId = (String) resp.get("body");
-    post.releaseConnection();
-
-    GetMethod get = httpGet("/notebook/" + clonedNotebookId);
-    assertThat(get, isNotAcceptable());
-    get.releaseConnection();
+    assertThat(post, isNotAcceptable());
 
     //cleanup
     ZeppelinServer.notebook.removeNote(note1.getId(), null);
@@ -195,12 +189,11 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   
   @Test
   public void testCreateNotebookWithSameName() throws IOException, DuplicateNameException {
-    Note note1 = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
-    PostMethod post = httpPost("/notebook/" + note1.getId(), "");
+    String noteName = "Test_Note";
+    Note note1 = ZeppelinServer.notebook.createNote(null, noteName);
+    String jsonRequest = "{\"name\":\"" + noteName + "\"}";
+    PostMethod post = httpPost("/notebook/", jsonRequest);
     LOG.info("testCloneNotebookWithSameName response\n" + post.getResponseBodyAsString());
-    assertThat(post, isCreated());
-
-    post = httpPost("/notebook/" + note1.getId(), "");
     assertThat(post, isNotAcceptable());
     post.releaseConnection();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -24,6 +24,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
@@ -49,6 +50,7 @@ import static org.junit.Assert.assertThat;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class NotebookRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
+  private final String NOTE_NAME = "Note";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -61,8 +63,8 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testPermissions() throws IOException {
-    Note note1 = ZeppelinServer.notebook.createNote(null);
+  public void testPermissions() throws IOException, DuplicateNameException {
+    Note note1 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     // Set only readers
     String jsonRequest = "{\"readers\":[\"admin-team\"],\"owners\":[]," +
             "\"writers\":[]}";
@@ -85,7 +87,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     get.releaseConnection();
 
 
-    Note note2 = ZeppelinServer.notebook.createNote(null);
+    Note note2 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     // Set only writers
     jsonRequest = "{\"readers\":[],\"owners\":[]," +
             "\"writers\":[\"admin-team\"]}";
@@ -125,8 +127,8 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testGetNoteParagraphJobStatus() throws IOException {
-    Note note1 = ZeppelinServer.notebook.createNote(null);
+  public void testGetNoteParagraphJobStatus() throws IOException, DuplicateNameException {
+    Note note1 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     note1.addParagraph();
 
     String paragraphId = note1.getLastParagraph().getId();
@@ -147,8 +149,8 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testCloneNotebook() throws IOException {
-    Note note1 = ZeppelinServer.notebook.createNote(null);
+  public void testCloneNotebook() throws IOException, DuplicateNameException {
+    Note note1 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     PostMethod post = httpPost("/notebook/" + note1.getId(), "");
     LOG.info("testCloneNotebook response\n" + post.getResponseBodyAsString());
     assertThat(post, isCreated());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -254,21 +254,9 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String oldJson = getNoteContent(sourceNoteID);
     // call notebook post
     PostMethod importPost = httpPost("/notebook/import/", oldJson);
-    assertThat(importPost, isCreated());
-    resp =
-        gson.fromJson(importPost.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    String importId = (String) resp.get("body");
-
-    assertNotNull("Did not get back a notebook id in body", importId);
-    Note newNote = ZeppelinServer.notebook.getNote(importId);
-    //Imported notebook should not have same name as existing note 
-    assertNotEquals("Compare note names", noteName, newNote.getName());
-    assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs()
-        .size());
+    assertThat(importPost, isNotAcceptable());
     // cleanup
     ZeppelinServer.notebook.removeNote(note.getId(), null);
-    ZeppelinServer.notebook.removeNote(newNote.getId(), null);
     importPost.releaseConnection();
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.*;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZeppelinRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
-  private final String NOTE_NAME = "Note";
+  private final String EMPTY_STRING = "";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -79,7 +79,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testGetNotebookInfo() throws IOException, DuplicateNameException {
     LOG.info("testGetNotebookInfo");
     // Create note to get info
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("note");
     Paragraph paragraph = note.addParagraph();
@@ -191,7 +191,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testDeleteNote() throws IOException, DuplicateNameException {
     LOG.info("testDeleteNote");
     //Create note and get ID
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     String noteId = note.getId();
     testDeleteNotebook(noteId);
   }
@@ -207,7 +207,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testExportNotebook() throws IOException, DuplicateNameException {
     LOG.info("testExportNotebook");
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
     Paragraph paragraph = note.addParagraph();
@@ -240,7 +240,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String noteName = "source note for import";
     LOG.info("testImortNotebook");
     // create test notebook
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName(noteName);
     Paragraph paragraph = note.addParagraph();
@@ -303,7 +303,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       IllegalArgumentException, DuplicateNameException {
     LOG.info("testCloneNotebook");
     // Create note to clone
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("source note for clone");
     Paragraph paragraph = note.addParagraph();
@@ -352,7 +352,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testNoteJobs() throws IOException, InterruptedException, DuplicateNameException {
     LOG.info("testNoteJobs");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -408,7 +408,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       DuplicateNameException {
     LOG.info("testGetNotebookJob");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -462,7 +462,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       DuplicateNameException {
     LOG.info("testRunParagraphWithParams");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -506,7 +506,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testCronJobs() throws InterruptedException, IOException, DuplicateNameException{
     // create a note and a paragraph
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -555,7 +555,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testRegressionZEPPELIN_527() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -577,7 +577,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testInsertParagraph() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
     PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
@@ -617,7 +617,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testGetParagraph() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     Paragraph p = note.addParagraph();
     p.setTitle("hello");
@@ -646,7 +646,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testMoveParagraph() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
@@ -678,7 +678,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testDeleteParagraph() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
@@ -710,12 +710,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String username = body.get("principal");
     getSecurityTicket.releaseConnection();
 
-    Note note1 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note1 = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 1\"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note1.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
 
-    Note note2 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note2 = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 2\"}";
     postNotebookText = httpPost("/notebook/" + note2.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
@@ -763,7 +763,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testTitleSearch() throws IOException, DuplicateNameException {
-    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+    Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
     String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", \"text\": \"ThisIsToTestSearchMethodWithTitle \"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -262,7 +262,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
     assertNotNull("Did not get back a notebook id in body", importId);
     Note newNote = ZeppelinServer.notebook.getNote(importId);
-    assertEquals("Compare note names", noteName, newNote.getName());
+    //Imported notebook should not have same name as existing note 
+    assertNotEquals("Compare note names", noteName, newNote.getName());
     assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs()
         .size());
     // cleanup

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -27,6 +27,7 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -50,6 +51,7 @@ import static org.junit.Assert.*;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZeppelinRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
+  private final String NOTE_NAME = "Note";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -74,10 +76,10 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testGetNotebookInfo() throws IOException {
+  public void testGetNotebookInfo() throws IOException, DuplicateNameException {
     LOG.info("testGetNotebookInfo");
     // Create note to get info
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("note");
     Paragraph paragraph = note.addParagraph();
@@ -186,10 +188,10 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testDeleteNote() throws IOException {
+  public void testDeleteNote() throws IOException, DuplicateNameException {
     LOG.info("testDeleteNote");
     //Create note and get ID
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     String noteId = note.getId();
     testDeleteNotebook(noteId);
   }
@@ -203,9 +205,9 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
 
   @Test
-  public void testExportNotebook() throws IOException {
+  public void testExportNotebook() throws IOException, DuplicateNameException {
     LOG.info("testExportNotebook");
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
     Paragraph paragraph = note.addParagraph();
@@ -233,12 +235,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testImportNotebook() throws IOException {
+  public void testImportNotebook() throws IOException, DuplicateNameException {
     Map<String, Object> resp;
     String noteName = "source note for import";
     LOG.info("testImortNotebook");
     // create test notebook
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName(noteName);
     Paragraph paragraph = note.addParagraph();
@@ -297,10 +299,11 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testCloneNotebook() throws IOException, CloneNotSupportedException, IllegalArgumentException {
+  public void testCloneNotebook() throws IOException, CloneNotSupportedException, 
+      IllegalArgumentException, DuplicateNameException {
     LOG.info("testCloneNotebook");
     // Create note to clone
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("source note for clone");
     Paragraph paragraph = note.addParagraph();
@@ -346,10 +349,10 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testNoteJobs() throws IOException, InterruptedException {
+  public void testNoteJobs() throws IOException, InterruptedException, DuplicateNameException {
     LOG.info("testNoteJobs");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -401,10 +404,11 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testGetNotebookJob() throws IOException, InterruptedException {
+  public void testGetNotebookJob() throws IOException, InterruptedException, 
+      DuplicateNameException {
     LOG.info("testGetNotebookJob");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -454,10 +458,11 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testRunParagraphWithParams() throws IOException, InterruptedException {
+  public void testRunParagraphWithParams() throws IOException, InterruptedException, 
+      DuplicateNameException {
     LOG.info("testRunParagraphWithParams");
     // Create note to run test.
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -499,9 +504,9 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testCronJobs() throws InterruptedException, IOException{
+  public void testCronJobs() throws InterruptedException, IOException, DuplicateNameException{
     // create a note and a paragraph
-    Note note = ZeppelinServer.notebook.createNote(null);
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -549,8 +554,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testRegressionZEPPELIN_527() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testRegressionZEPPELIN_527() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     note.setName("note for run test");
     Paragraph paragraph = note.addParagraph();
@@ -571,8 +576,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testInsertParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testInsertParagraph() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
     PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
@@ -611,8 +616,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testGetParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testGetParagraph() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     Paragraph p = note.addParagraph();
     p.setTitle("hello");
@@ -640,8 +645,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testMoveParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testMoveParagraph() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
@@ -672,8 +677,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testDeleteParagraph() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testDeleteParagraph() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
     Paragraph p = note.addParagraph();
     p.setTitle("title1");
@@ -693,7 +698,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testSearch() throws IOException {
+  public void testSearch() throws IOException, DuplicateNameException {
     Map<String, String> body;
 
     GetMethod getSecurityTicket = httpGet("/security/ticket");
@@ -705,12 +710,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String username = body.get("principal");
     getSecurityTicket.releaseConnection();
 
-    Note note1 = ZeppelinServer.notebook.createNote(null);
+    Note note1 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     String jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 1\"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note1.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
 
-    Note note2 = ZeppelinServer.notebook.createNote(null);
+    Note note2 = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     jsonRequest = "{\"title\": \"title1\", \"text\": \"ThisIsToTestSearchMethodWithPermissions 2\"}";
     postNotebookText = httpPost("/notebook/" + note2.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();
@@ -757,8 +762,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testTitleSearch() throws IOException {
-    Note note = ZeppelinServer.notebook.createNote(null);
+  public void testTitleSearch() throws IOException, DuplicateNameException {
+    Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
     String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", \"text\": \"ThisIsToTestSearchMethodWithTitle \"}";
     PostMethod postNotebookText = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
     postNotebookText.releaseConnection();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Note;
@@ -43,6 +44,7 @@ import com.google.gson.Gson;
  */
 public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     Gson gson = new Gson();
+    private final String NOTE_NAME = "Note";
 
     @BeforeClass
     public static void init() throws Exception {
@@ -67,9 +69,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void basicRDDTransformationAndActionTest() throws IOException {
+    public void basicRDDTransformationAndActionTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
 
         // run markdown paragraph, again
         Paragraph p = note.addParagraph();
@@ -85,9 +87,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void sparkSQLTest() throws IOException {
+    public void sparkSQLTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
         int sparkVersion = getSparkVersionNumber(note);
         // DataFrame API is available from spark 1.3
         if (sparkVersion >= 13) {
@@ -136,9 +138,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void sparkRTest() throws IOException {
+    public void sparkRTest() throws IOException, DuplicateNameException {
       // create new note
-      Note note = ZeppelinServer.notebook.createNote(null);
+      Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
       int sparkVersion = getSparkVersionNumber(note);
 
       if (isSparkR() && sparkVersion >= 14) {   // sparkr supported from 1.4.0
@@ -175,9 +177,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void pySparkTest() throws IOException {
+    public void pySparkTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
         note.setName("note");
         int sparkVersion = getSparkVersionNumber(note);
 
@@ -265,9 +267,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void pySparkAutoConvertOptionTest() throws IOException {
+    public void pySparkAutoConvertOptionTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
         note.setName("note");
 
         int sparkVersionNumber = getSparkVersionNumber(note);
@@ -295,9 +297,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void zRunTest() throws IOException {
+    public void zRunTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
         Paragraph p0 = note.addParagraph();
         Map config0 = p0.getConfig();
         config0.put("enabled", true);
@@ -327,9 +329,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
-    public void pySparkDepLoaderTest() throws IOException {
+    public void pySparkDepLoaderTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null);
+        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
         int sparkVersionNumber = getSparkVersionNumber(note);
 
         if (isPyspark() && sparkVersionNumber >= 14) {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -83,7 +83,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p);
         assertEquals(Status.FINISHED, p.getStatus());
         assertEquals("55", p.getResult().message());
-        ZeppelinServer.notebook.removeNote(EMPTY_STRING, null);
+        ZeppelinServer.notebook.removeNote(note.getId(), null);
     }
 
     @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -44,7 +44,7 @@ import com.google.gson.Gson;
  */
 public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     Gson gson = new Gson();
-    private final String NOTE_NAME = "Note";
+    private final String EMPTY_STRING = "";
 
     @BeforeClass
     public static void init() throws Exception {
@@ -71,7 +71,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void basicRDDTransformationAndActionTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
 
         // run markdown paragraph, again
         Paragraph p = note.addParagraph();
@@ -83,13 +83,13 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p);
         assertEquals(Status.FINISHED, p.getStatus());
         assertEquals("55", p.getResult().message());
-        ZeppelinServer.notebook.removeNote(note.getId(), null);
+        ZeppelinServer.notebook.removeNote(EMPTY_STRING, null);
     }
 
     @Test
     public void sparkSQLTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
         int sparkVersion = getSparkVersionNumber(note);
         // DataFrame API is available from spark 1.3
         if (sparkVersion >= 13) {
@@ -140,7 +140,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void sparkRTest() throws IOException, DuplicateNameException {
       // create new note
-      Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+      Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
       int sparkVersion = getSparkVersionNumber(note);
 
       if (isSparkR() && sparkVersion >= 14) {   // sparkr supported from 1.4.0
@@ -179,7 +179,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
         note.setName("note");
         int sparkVersion = getSparkVersionNumber(note);
 
@@ -269,7 +269,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkAutoConvertOptionTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
         note.setName("note");
 
         int sparkVersionNumber = getSparkVersionNumber(note);
@@ -299,7 +299,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void zRunTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
         Paragraph p0 = note.addParagraph();
         Map config0 = p0.getConfig();
         config0.put("enabled", true);
@@ -331,7 +331,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void pySparkDepLoaderTest() throws IOException, DuplicateNameException {
         // create new note
-        Note note = ZeppelinServer.notebook.createNote(null, NOTE_NAME);
+        Note note = ZeppelinServer.notebook.createNote(null, EMPTY_STRING);
         int sparkVersionNumber = getSparkVersionNumber(note);
 
         if (isPyspark() && sparkVersionNumber >= 14) {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
@@ -92,9 +93,9 @@ public class NotebookServerTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testMakeSureNoAngularObjectBroadcastToWebsocketWhoFireTheEvent() throws IOException {
+  public void testMakeSureNoAngularObjectBroadcastToWebsocketWhoFireTheEvent() throws IOException, DuplicateNameException {
     // create a notebook
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, "Note");
 
     // get reference to interpreterGroup
     InterpreterGroup interpreterGroup = null;
@@ -148,7 +149,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testImportNotebook() throws IOException {
+  public void testImportNotebook() throws IOException, DuplicateNameException {
     String msg = "{\"op\":\"IMPORT_NOTE\",\"data\":" +
         "{\"notebook\":{\"paragraphs\": [{\"text\": \"Test " +
         "paragraphs import\",\"config\":{},\"settings\":{}}]," +

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -95,7 +95,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
   @Test
   public void testMakeSureNoAngularObjectBroadcastToWebsocketWhoFireTheEvent() throws IOException, DuplicateNameException {
     // create a notebook
-    Note note1 = notebook.createNote(null, "Note");
+    Note note1 = notebook.createNote(null, "");
 
     // get reference to interpreterGroup
     InterpreterGroup interpreterGroup = null;

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -29,11 +29,12 @@ limitations under the License.
               id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/>
           </div>
           Use '/' to create folders. Example: /NoteDirA/Notebook1
+          <div class="text-danger" ng-show="notenamectrl.error">Please provide a unique Notebook name</div>
         </div>
         <div class="modal-footer">
           <button type="button" id="createNoteButton"
                   class="btn btn-default"
-                  data-dismiss="modal" ng-click="notenamectrl.createNote()">
+                  ng-click="notenamectrl.createNote()">
             <span ng-show="!notenamectrl.clone">Create Note</span>
             <span ng-show="notenamectrl.clone">Clone Note</span>
           </button>

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -18,6 +18,7 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, not
                                                                       $routeParams, websocketMsgSrv) {
   var vm = this;
   vm.clone = false;
+  vm.error = false;
   vm.notes = notebookListDataFactory;
   vm.websocketMsgSrv = websocketMsgSrv;
   $scope.note = {};
@@ -37,6 +38,7 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, not
   };
 
   vm.preVisible = function(clone) {
+    vm.error = false;
     $scope.note.notename = vm.newNoteName();
     vm.clone = clone;
     $scope.$apply();
@@ -55,5 +57,10 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, not
     });
     return 'Untitled Note ' + newCount;
   };
+
+  $scope.$on('errorDialog', function(event, data) {
+    console.log('test');
+    vm.error = true;
+  });
 
 });

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -59,7 +59,6 @@ angular.module('zeppelinWebApp').controller('NotenameCtrl', function($scope, not
   };
 
   $scope.$on('errorDialog', function(event, data) {
-    console.log('test');
     vm.error = true;
   });
 

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-  <div id="noteImportModal" class="modal fade" role="dialog"
+  <div id="noteImportModal" class="modal fade" role="dialog" modalvisible previsiblecallback="noteimportctrl.preVisible"
        tabindex="-1">
     <div class="modal-dialog">
 
@@ -50,14 +50,13 @@ limitations under the License.
               </a>
             </div>
           </div>
-
           <div class="form-group slide-right" ng-show="note.step2">
 
             <label for="noteImportUrl">URL</label>
             <input placeholder="Note name" type="text" class="form-control" id="noteImportUrl"
                    ng-model="note.importUrl" />
           </div>
-
+          <div class="text-danger" ng-show="noteimportctrl.error">Please provide a unique Notebook name</div>
         </div>
         <div class="modal-footer">
           <div ng-show="note.step2">

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -50,6 +50,7 @@ limitations under the License.
               </a>
             </div>
           </div>
+
           <div class="form-group slide-right" ng-show="note.step2">
 
             <label for="noteImportUrl">URL</label>

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -16,6 +16,7 @@
 
 angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $timeout, websocketMsgSrv) {
   var vm = this;
+  vm.error = false;
   $scope.note = {};
   $scope.note.step1 = true;
   $scope.note.step2 = false;
@@ -60,6 +61,11 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
       $scope.note.step1 = true;
     }, 400);
     $scope.note.step2 = false;
+  };
+
+  vm.preVisible = function() {
+    vm.error = false;
+    $scope.$apply();
   };
 
   vm.importNote = function() {
@@ -109,5 +115,10 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
   $scope.$on('setNoteMenu', function(event, notes) {
     vm.resetFlags();
     angular.element('#noteImportModal').modal('hide');
+  });
+  $scope.$on('importErrorDialog', function(event, data) {
+    console.log('testing');
+    vm.resetFlags();
+    vm.error = true;
   });
 });

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -117,7 +117,6 @@ angular.module('zeppelinWebApp').controller('NoteImportCtrl', function($scope, $
     angular.element('#noteImportModal').modal('hide');
   });
   $scope.$on('importErrorDialog', function(event, data) {
-    console.log('testing');
     vm.resetFlags();
     vm.error = true;
   });

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -57,6 +57,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NEW_NOTE') {
+      angular.element('#noteNameModal').modal('hide');
       $location.path('/notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
@@ -132,6 +133,10 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
             }
           }]
       });
+    } else if (op === 'ERROR_DIALOG') {
+      $rootScope.$broadcast('errorDialog', data);
+    } else if (op === 'IMPORT_ERROR_DIALOG') {
+      $rootScope.$broadcast('importErrorDialog', data);
     }
   });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -57,6 +57,7 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NEW_NOTE') {
+      angular.element('#noteNameModal').modal('hide');
       $location.path('/notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -57,7 +57,6 @@ angular.module('zeppelinWebApp').factory('websocketEvents',
     if (op === 'NOTE') {
       $rootScope.$broadcast('setNoteContent', data.note);
     } else if (op === 'NEW_NOTE') {
-      angular.element('#noteNameModal').modal('hide');
       $location.path('/notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/exception/DuplicateNameException.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/exception/DuplicateNameException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.exception;
+
+/**
+ * Custom Exception for duplicate Notebook name
+ */
+public class DuplicateNameException extends Exception{
+  private static final long serialVersionUID = -807097165104866579L;
+
+  public DuplicateNameException() {
+    super();
+  }
+
+  public DuplicateNameException(String message) {
+    super(message);
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -32,30 +32,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.stream.JsonReader;
-import org.apache.commons.codec.binary.StringUtils;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-import org.quartz.JobKey;
-import org.quartz.SchedulerException;
-import org.quartz.TriggerBuilder;
-import org.quartz.impl.StdSchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
@@ -69,6 +50,25 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
 
 /**
  * Collection of Notes.
@@ -135,14 +135,27 @@ public class Notebook implements NoteEventListener {
    * Create new note.
    *
    * @throws IOException
+ * @throws DuplicateNameException 
    */
-  public Note createNote(AuthenticationInfo subject) throws IOException {
+  public Note createNote(AuthenticationInfo subject, String noteName) throws IOException
+    , DuplicateNameException {
     Note note;
+    List<Note> notes;
+    notes = getAllNotes();
+    for (Note entry : notes) {
+      if (entry.getName().equals(noteName)){
+        throw new DuplicateNameException();
+      }
+    }
     if (conf.getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_AUTO_INTERPRETER_BINDING)) {
       note = createNote(replFactory.getDefaultInterpreterSettingList(), subject);
     } else {
       note = createNote(null, subject);
     }
+    if (noteName == null) {
+      noteName = "Note " + note.getId();
+    }
+    note.setName(noteName);
     notebookIndex.addIndexDoc(note);
     return note;
   }
@@ -199,9 +212,10 @@ public class Notebook implements NoteEventListener {
    * @param noteName   - the name of the new note
    * @return notebook ID
    * @throws IOException
+   * @throws DuplicateNameException 
    */
   public Note importNote(String sourceJson, String noteName, AuthenticationInfo subject)
-      throws IOException {
+      throws IOException, DuplicateNameException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
 
@@ -212,11 +226,7 @@ public class Notebook implements NoteEventListener {
     Note newNote;
     try {
       Note oldNote = gson.fromJson(reader, Note.class);
-      newNote = createNote(subject);
-      if (noteName != null)
-        newNote.setName(noteName);
-      else
-        newNote.setName(oldNote.getName());
+      newNote = createNote(subject, noteName);
       List<Paragraph> paragraphs = oldNote.getParagraphs();
       for (Paragraph p : paragraphs) {
         newNote.addCloneParagraph(p);
@@ -238,20 +248,17 @@ public class Notebook implements NoteEventListener {
    * @param newNoteName  - the name of the new note
    * @return noteId
    * @throws IOException, CloneNotSupportedException, IllegalArgumentException
+ * @throws DuplicateNameException 
    */
   public Note cloneNote(String sourceNoteID, String newNoteName, AuthenticationInfo subject)
-      throws IOException, CloneNotSupportedException, IllegalArgumentException {
+      throws IOException, CloneNotSupportedException, IllegalArgumentException,
+      DuplicateNameException {
 
     Note sourceNote = getNote(sourceNoteID);
     if (sourceNote == null) {
       throw new IllegalArgumentException(sourceNoteID + "not found");
     }
-    Note newNote = createNote(subject);
-    if (newNoteName != null) {
-      newNote.setName(newNoteName);
-    } else {
-      newNote.setName("Note " + newNote.getId());
-    }
+    Note newNote = createNote(subject, newNoteName);
     // Copy the interpreter bindings
     List<String> boundInterpreterSettingsIds = getBindedInterpreterSettingsIds(sourceNote.getId());
     bindInterpretersToNote(newNote.getId(), boundInterpreterSettingsIds);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -229,7 +229,7 @@ public class Notebook implements NoteEventListener {
     Note newNote;
     try {
       Note oldNote = gson.fromJson(reader, Note.class);
-      if(noteName == null || noteName.isEmpty()) {
+      if (noteName == null || noteName.isEmpty()) {
         noteName = oldNote.getName();
       }
       newNote = createNote(subject, noteName);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -142,9 +142,11 @@ public class Notebook implements NoteEventListener {
     Note note;
     List<Note> notes;
     notes = getAllNotes();
-    for (Note entry : notes) {
-      if (entry.getName().equals(noteName)){
-        throw new DuplicateNameException();
+    if (noteName != null && !noteName.isEmpty()) {
+      for (Note entry : notes) {
+        if (entry.getName().equals(noteName)){
+          throw new DuplicateNameException();
+        }
       }
     }
     if (conf.getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_AUTO_INTERPRETER_BINDING)) {
@@ -152,7 +154,7 @@ public class Notebook implements NoteEventListener {
     } else {
       note = createNote(null, subject);
     }
-    if (noteName == null) {
+    if (noteName == null || noteName.trim().isEmpty()) {
       noteName = "Note " + note.getId();
     }
     note.setName(noteName);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -135,7 +135,7 @@ public class Notebook implements NoteEventListener {
    * Create new note.
    *
    * @throws IOException
- * @throws DuplicateNameException 
+   * @throws DuplicateNameException 
    */
   public Note createNote(AuthenticationInfo subject, String noteName) throws IOException
     , DuplicateNameException {
@@ -248,7 +248,7 @@ public class Notebook implements NoteEventListener {
    * @param newNoteName  - the name of the new note
    * @return noteId
    * @throws IOException, CloneNotSupportedException, IllegalArgumentException
- * @throws DuplicateNameException 
+   * @throws DuplicateNameException 
    */
   public Note cloneNote(String sourceNoteID, String newNoteName, AuthenticationInfo subject)
       throws IOException, CloneNotSupportedException, IllegalArgumentException,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -289,9 +289,13 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       logger.error("Can not find interpreter name " + repl);
       throw new RuntimeException("Can not find interpreter for " + getRequiredReplName());
     }
-
+    InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
+    while (intp.getStatus().equals(
+      org.apache.zeppelin.interpreter.InterpreterSetting.Status.DOWNLOADING_DEPENDENCIES)) {
+      Thread.sleep(200);
+      intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
+    }
     if (this.noteHasUser() && this.noteHasInterpreters()) {
-      InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
       if (intp != null &&
         interpreterHasUser(intp) &&
         isUserAuthorizedToAccessInterpreter(intp.getOption()) == false) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -140,7 +140,9 @@ public class Message {
                                   // @param noteID
                                   // @param selectedSettingIds
     INTERPRETER_BINDINGS,         // [s-c] interpreter bindings
-    ERROR_INFO                    // [s-c] error information to be sent
+    ERROR_INFO,                   // [s-c] error information to be sent
+    ERROR_DIALOG,
+    IMPORT_ERROR_DIALOG
   }
 
   public OP op;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.helium;
 import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.DependencyResolver;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
@@ -50,6 +51,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
   private VFSNotebookRepo notebookRepo;
   private Notebook notebook;
   private HeliumApplicationFactory heliumAppFactory;
+  private final String NOTE_NAME = "Note";
 
   @Before
   public void setUp() throws Exception {
@@ -122,7 +124,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
 
   @Test
   public void testLoadRunUnloadApplication()
-      throws IOException, ApplicationException, InterruptedException {
+      throws IOException, ApplicationException, InterruptedException, DuplicateNameException {
     // given
     HeliumPackage pkg1 = new HeliumPackage(HeliumPackage.Type.APPLICATION,
         "name1",
@@ -131,7 +133,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
         HeliumTestApplication.class.getName(),
         new String[][]{});
 
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note1.getId(),factory.getDefaultInterpreterSettingList());
 
     Paragraph p1 = note1.addParagraph();
@@ -166,7 +168,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
   }
 
   @Test
-  public void testUnloadOnParagraphRemove() throws IOException {
+  public void testUnloadOnParagraphRemove() throws IOException, DuplicateNameException {
     // given
     HeliumPackage pkg1 = new HeliumPackage(HeliumPackage.Type.APPLICATION,
         "name1",
@@ -175,7 +177,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
         HeliumTestApplication.class.getName(),
         new String[][]{});
 
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note1.getId(), factory.getDefaultInterpreterSettingList());
 
     Paragraph p1 = note1.addParagraph();
@@ -204,7 +206,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
 
 
   @Test
-  public void testUnloadOnInterpreterUnbind() throws IOException {
+  public void testUnloadOnInterpreterUnbind() throws IOException, DuplicateNameException {
     // given
     HeliumPackage pkg1 = new HeliumPackage(HeliumPackage.Type.APPLICATION,
         "name1",
@@ -213,7 +215,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
         HeliumTestApplication.class.getName(),
         new String[][]{});
 
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
     notebook.bindInterpretersToNote(note1.getId(), factory.getDefaultInterpreterSettingList());
 
     Paragraph p1 = note1.addParagraph();
@@ -241,9 +243,10 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
   }
 
   @Test
-  public void testInterpreterUnbindOfNullReplParagraph() throws IOException {
+  public void testInterpreterUnbindOfNullReplParagraph() throws IOException, 
+      DuplicateNameException {
     // create note
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
 
     // add paragraph with invalid magic
     Paragraph p1 = note1.addParagraph();
@@ -263,7 +266,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
 
 
   @Test
-  public void testUnloadOnInterpreterRestart() throws IOException {
+  public void testUnloadOnInterpreterRestart() throws IOException, DuplicateNameException {
     // given
     HeliumPackage pkg1 = new HeliumPackage(HeliumPackage.Type.APPLICATION,
         "name1",
@@ -272,7 +275,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
         HeliumTestApplication.class.getName(),
         new String[][]{});
 
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
     notebook.bindInterpretersToNote(note1.getId(), factory.getDefaultInterpreterSettingList());
     String mock1IntpSettingId = null;
     for (InterpreterSetting setting : notebook.getBindedInterpreterSettings(note1.getId())) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -66,7 +66,7 @@ public class NotebookTest implements JobListenerFactory{
   private DependencyResolver depResolver;
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
-  private final String NOTE_NAME = "Note";
+  private final String EMPTY_STRING = "";
 
   @Before
   public void setUp() throws Exception {
@@ -108,7 +108,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testSelectingReplImplementation() throws IOException, DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     // run with default repl
@@ -197,7 +197,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPersist() throws IOException, SchedulerException, RepositoryException, 
       DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
 
     // run with default repl
     Paragraph p1 = note.addParagraph();
@@ -217,7 +217,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testCreateNoteWithSubject() throws IOException, SchedulerException, RepositoryException,
       DuplicateNameException {
     AuthenticationInfo subject = new AuthenticationInfo("user1");
-    Note note = notebook.createNote(subject, NOTE_NAME);
+    Note note = notebook.createNote(subject, EMPTY_STRING);
 
     assertNotNull(notebook.getNotebookAuthorization().getOwners(note.getId()));
     assertEquals(1, notebook.getNotebookAuthorization().getOwners(note.getId()).size());
@@ -229,7 +229,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException, 
       DuplicateNameException{
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     Paragraph p1 = note.addParagraph();
     Map config = p1.getConfig();
     config.put("enabled", true);
@@ -247,7 +247,7 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testRunAll() throws IOException, DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     // p1
@@ -286,7 +286,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testSchedule() throws InterruptedException, IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     Paragraph p = note.addParagraph();
@@ -319,7 +319,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException, 
       DuplicateNameException{
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
     
     Paragraph p = note.addParagraph();
@@ -372,7 +372,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testExportAndImportNote() throws IOException, CloneNotSupportedException,
           InterruptedException, InterpreterException, SchedulerException, RepositoryException,
           DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -409,7 +409,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testCloneNote() throws IOException, CloneNotSupportedException,
       InterruptedException, InterpreterException, SchedulerException, RepositoryException, 
       DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -440,7 +440,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testCloneNoteWithNoName() throws IOException, CloneNotSupportedException,
       InterruptedException, IllegalArgumentException, DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, "Note");
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     Note cloneNote = notebook.cloneNote(note.getId(), null, null);
@@ -450,7 +450,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testCloneNoteWithExceptionResult() throws IOException, CloneNotSupportedException,
       InterruptedException, DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -475,32 +475,32 @@ public class NotebookTest implements JobListenerFactory{
   public void testCloneNoteWithDuplicateName() throws IOException, IllegalArgumentException, 
       CloneNotSupportedException, DuplicateNameException {
 	//create note
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, "Note");
     //clone note with same name
-    notebook.cloneNote(note.getId(), NOTE_NAME, null);
+    notebook.cloneNote(note.getId(), "Note", null);
   }
   
   @Test(expected = DuplicateNameException.class)
   public void testCreateNoteWithDuplicateName() throws IOException, DuplicateNameException {
 	//create note
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, "Note");
     //create note with same name
-    notebook.createNote(null, NOTE_NAME);
+    notebook.createNote(null, "Note");
   }
   
   @Test(expected = DuplicateNameException.class)
   public void testImportNoteWithDuplicateName() throws IOException, DuplicateNameException {
 	//create note
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, "Note");
     String exportedNoteJson = notebook.exportNote(note.getId());
     //import note with same name
-    notebook.importNote(exportedNoteJson, NOTE_NAME, null);
+    notebook.importNote(exportedNoteJson, "Note", null);
   }
 
   @Test
   public void testResourceRemovealOnParagraphNoteRemove() throws IOException, 
       DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
     for (InterpreterGroup intpGroup : InterpreterGroup.getAll()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
@@ -529,7 +529,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnNotebookRemove() throws InterruptedException,
       IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -562,7 +562,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnParagraphRemove() throws InterruptedException,
       IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -595,7 +595,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testAngularObjectRemovalOnInterpreterRestart() throws InterruptedException,
       IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -621,7 +621,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPermissions() throws IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
     // empty owners, readers and writers means note is public
     assertEquals(notebookAuthorization.isOwner(note.getId(),
@@ -666,7 +666,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws InterruptedException,
       IOException, DuplicateNameException {
-    Note note = notebook.createNote(null, NOTE_NAME);
+    Note note = notebook.createNote(null, EMPTY_STRING);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     ArrayList<Paragraph> paragraphs = new ArrayList<>();
@@ -703,7 +703,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException, DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null, NOTE_NAME);
+    Note note1  = notebook.createNote(null, EMPTY_STRING);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -719,7 +719,7 @@ public class NotebookTest implements JobListenerFactory{
 
     // remove note and recreate
     notebook.removeNote(note1.getId(), null);
-    note1 = notebook.createNote(null, NOTE_NAME);
+    note1 = notebook.createNote(null, EMPTY_STRING);
     p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -733,7 +733,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testPerSessionInterpreter() throws IOException, DuplicateNameException {
     // create two notes
-    Note note1  = notebook.createNote(null, NOTE_NAME);
+    Note note1  = notebook.createNote(null, EMPTY_STRING);
     Paragraph p1 = note1.addParagraph();
 
     Note note2  = notebook.createNote(null, "Second Note");
@@ -775,7 +775,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException, 
       DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null, NOTE_NAME);
+    Note note1  = notebook.createNote(null, EMPTY_STRING);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -842,7 +842,7 @@ public class NotebookTest implements JobListenerFactory{
       }
     });
 
-    Note note1 = notebook.createNote(null, NOTE_NAME);
+    Note note1 = notebook.createNote(null, EMPTY_STRING);
     assertEquals(1, onNoteCreate.get());
 
     Paragraph p1 = note1.addParagraph();
@@ -866,7 +866,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testNormalizeNoteName() throws IOException, DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null, NOTE_NAME);
+    Note note1  = notebook.createNote(null, EMPTY_STRING);
 
     note1.setName("MyNote");
     assertEquals(note1.getName(), "MyNote");
@@ -891,8 +891,8 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testGetAllNotes() throws Exception {
-    Note note1 = notebook.createNote(null, NOTE_NAME);
-    Note note2 = notebook.createNote(null, NOTE_NAME);
+    Note note1 = notebook.createNote(null, EMPTY_STRING);
+    Note note2 = notebook.createNote(null, EMPTY_STRING);
     assertEquals(2, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
 
     notebook.getNotebookAuthorization().setOwners(note1.getId(), Sets.newHashSet("user1"));

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -31,6 +31,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
@@ -65,6 +66,7 @@ public class NotebookTest implements JobListenerFactory{
   private DependencyResolver depResolver;
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
+  private final String NOTE_NAME = "Note";
 
   @Before
   public void setUp() throws Exception {
@@ -105,8 +107,8 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testSelectingReplImplementation() throws IOException {
-    Note note = notebook.createNote(null);
+  public void testSelectingReplImplementation() throws IOException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     // run with default repl
@@ -193,8 +195,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testPersist() throws IOException, SchedulerException, RepositoryException {
-    Note note = notebook.createNote(null);
+  public void testPersist() throws IOException, SchedulerException, RepositoryException, 
+      DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
 
     // run with default repl
     Paragraph p1 = note.addParagraph();
@@ -211,9 +214,10 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testCreateNoteWithSubject() throws IOException, SchedulerException, RepositoryException {
+  public void testCreateNoteWithSubject() throws IOException, SchedulerException, RepositoryException,
+      DuplicateNameException {
     AuthenticationInfo subject = new AuthenticationInfo("user1");
-    Note note = notebook.createNote(subject);
+    Note note = notebook.createNote(subject, NOTE_NAME);
 
     assertNotNull(notebook.getNotebookAuthorization().getOwners(note.getId()));
     assertEquals(1, notebook.getNotebookAuthorization().getOwners(note.getId()).size());
@@ -223,8 +227,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testClearParagraphOutput() throws IOException, SchedulerException{
-    Note note = notebook.createNote(null);
+  public void testClearParagraphOutput() throws IOException, SchedulerException, 
+      DuplicateNameException{
+    Note note = notebook.createNote(null, NOTE_NAME);
     Paragraph p1 = note.addParagraph();
     Map config = p1.getConfig();
     config.put("enabled", true);
@@ -241,8 +246,8 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testRunAll() throws IOException {
-    Note note = notebook.createNote(null);
+  public void testRunAll() throws IOException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     // p1
@@ -279,9 +284,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testSchedule() throws InterruptedException, IOException {
+  public void testSchedule() throws InterruptedException, IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     Paragraph p = note.addParagraph();
@@ -311,9 +316,10 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException{
+  public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException, 
+      DuplicateNameException{
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
     
     Paragraph p = note.addParagraph();
@@ -364,8 +370,9 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testExportAndImportNote() throws IOException, CloneNotSupportedException,
-          InterruptedException, InterpreterException, SchedulerException, RepositoryException {
-    Note note = notebook.createNote(null);
+          InterruptedException, InterpreterException, SchedulerException, RepositoryException,
+          DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -400,8 +407,9 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testCloneNote() throws IOException, CloneNotSupportedException,
-      InterruptedException, InterpreterException, SchedulerException, RepositoryException {
-    Note note = notebook.createNote(null);
+      InterruptedException, InterpreterException, SchedulerException, RepositoryException, 
+      DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -431,8 +439,8 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testCloneNoteWithNoName() throws IOException, CloneNotSupportedException,
-      InterruptedException {
-    Note note = notebook.createNote(null);
+      InterruptedException, IllegalArgumentException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     Note cloneNote = notebook.cloneNote(note.getId(), null, null);
@@ -441,8 +449,8 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testCloneNoteWithExceptionResult() throws IOException, CloneNotSupportedException,
-      InterruptedException {
-    Note note = notebook.createNote(null);
+      InterruptedException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     final Paragraph p = note.addParagraph();
@@ -462,10 +470,37 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(cp.text, p.text);
     assertNull(cp.getResult());
   }
+  
+  @Test(expected = DuplicateNameException.class)
+  public void testCloneNoteWithDuplicateName() throws IOException, IllegalArgumentException, 
+      CloneNotSupportedException, DuplicateNameException {
+	//create note
+    Note note = notebook.createNote(null, NOTE_NAME);
+    //clone note with same name
+    notebook.cloneNote(note.getId(), NOTE_NAME, null);
+  }
+  
+  @Test(expected = DuplicateNameException.class)
+  public void testCreateNoteWithDuplicateName() throws IOException, DuplicateNameException {
+	//create note
+    Note note = notebook.createNote(null, NOTE_NAME);
+    //create note with same name
+    notebook.createNote(null, NOTE_NAME);
+  }
+  
+  @Test(expected = DuplicateNameException.class)
+  public void testImportNoteWithDuplicateName() throws IOException, DuplicateNameException {
+	//create note
+    Note note = notebook.createNote(null, NOTE_NAME);
+    String exportedNoteJson = notebook.exportNote(note.getId());
+    //import note with same name
+    notebook.importNote(exportedNoteJson, NOTE_NAME, null);
+  }
 
   @Test
-  public void testResourceRemovealOnParagraphNoteRemove() throws IOException {
-    Note note = notebook.createNote(null);
+  public void testResourceRemovealOnParagraphNoteRemove() throws IOException, 
+      DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
     for (InterpreterGroup intpGroup : InterpreterGroup.getAll()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
@@ -492,9 +527,9 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testAngularObjectRemovalOnNotebookRemove() throws InterruptedException,
-      IOException {
+      IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -525,9 +560,9 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testAngularObjectRemovalOnParagraphRemove() throws InterruptedException,
-      IOException {
+      IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -558,9 +593,9 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testAngularObjectRemovalOnInterpreterRestart() throws InterruptedException,
-      IOException {
+      IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     AngularObjectRegistry registry = factory
@@ -584,9 +619,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testPermissions() throws IOException {
+  public void testPermissions() throws IOException, DuplicateNameException {
     // create a note and a paragraph
-    Note note = notebook.createNote(null);
+    Note note = notebook.createNote(null, NOTE_NAME);
     NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
     // empty owners, readers and writers means note is public
     assertEquals(notebookAuthorization.isOwner(note.getId(),
@@ -630,8 +665,8 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws InterruptedException,
-      IOException {
-    Note note = notebook.createNote(null);
+      IOException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     ArrayList<Paragraph> paragraphs = new ArrayList<>();
@@ -666,9 +701,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException {
+  public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException, DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null);
+    Note note1  = notebook.createNote(null, NOTE_NAME);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -684,7 +719,7 @@ public class NotebookTest implements JobListenerFactory{
 
     // remove note and recreate
     notebook.removeNote(note1.getId(), null);
-    note1 = notebook.createNote(null);
+    note1 = notebook.createNote(null, NOTE_NAME);
     p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -696,12 +731,12 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testPerSessionInterpreter() throws IOException {
+  public void testPerSessionInterpreter() throws IOException, DuplicateNameException {
     // create two notes
-    Note note1  = notebook.createNote(null);
+    Note note1  = notebook.createNote(null, NOTE_NAME);
     Paragraph p1 = note1.addParagraph();
 
-    Note note2  = notebook.createNote(null);
+    Note note2  = notebook.createNote(null, "Second Note");
     Paragraph p2 = note2.addParagraph();
 
     p1.setText("getId");
@@ -737,9 +772,10 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException {
+  public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException, 
+      DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null);
+    Note note1  = notebook.createNote(null, NOTE_NAME);
     Paragraph p1 = note1.addParagraph();
     p1.setText("getId");
 
@@ -768,7 +804,7 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testNotebookEventListener() throws IOException {
+  public void testNotebookEventListener() throws IOException, DuplicateNameException {
     final AtomicInteger onNoteRemove = new AtomicInteger(0);
     final AtomicInteger onNoteCreate = new AtomicInteger(0);
     final AtomicInteger onParagraphRemove = new AtomicInteger(0);
@@ -806,7 +842,7 @@ public class NotebookTest implements JobListenerFactory{
       }
     });
 
-    Note note1 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
     assertEquals(1, onNoteCreate.get());
 
     Paragraph p1 = note1.addParagraph();
@@ -828,9 +864,9 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
-  public void testNormalizeNoteName() throws IOException {
+  public void testNormalizeNoteName() throws IOException, DuplicateNameException {
     // create a notes
-    Note note1  = notebook.createNote(null);
+    Note note1  = notebook.createNote(null, NOTE_NAME);
 
     note1.setName("MyNote");
     assertEquals(note1.getName(), "MyNote");
@@ -855,8 +891,8 @@ public class NotebookTest implements JobListenerFactory{
 
   @Test
   public void testGetAllNotes() throws Exception {
-    Note note1 = notebook.createNote(null);
-    Note note2 = notebook.createNote(null);
+    Note note1 = notebook.createNote(null, NOTE_NAME);
+    Note note2 = notebook.createNote(null, NOTE_NAME);
     assertEquals(2, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
 
     notebook.getNotebookAuthorization().setOwners(note1.getId(), Sets.newHashSet("user1"));

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.dep.DependencyResolver;
+import org.apache.zeppelin.exception.DuplicateNameException;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
@@ -50,6 +51,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
   private NotebookRepo notebookRepo;
   private InterpreterFactory factory;
   private DependencyResolver depResolver;
+  private final String NOTE_NAME = "Note";
 
   private File mainZepDir;
   private File mainNotebookDir;
@@ -105,8 +107,8 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
   }
 
   @Test
-  public void testSaveNotebook() throws IOException, InterruptedException {
-    Note note = notebook.createNote(null);
+  public void testSaveNotebook() throws IOException, InterruptedException, DuplicateNameException {
+    Note note = notebook.createNote(null, NOTE_NAME);
     factory.setInterpreters(note.getId(), factory.getDefaultInterpreterSettingList());
 
     Paragraph p1 = note.addParagraph();


### PR DESCRIPTION
### What is this PR for?
When a notebook is created/cloned/imported the title/name of the new notebook should not be duplicate of the existing notebook's title/name

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-796

### How should this be tested?
1. Create a notebook with name 'Note', Notebook should allow user to create a note
2. When a user try to create/clone/import a notebook with name 'Note', Notebook should not 
allow user to create note.

### Screenshots (if appropriate)
Screenshot of error message displayed during create/clone notebook
![create](https://cloud.githubusercontent.com/assets/11922701/18878102/05b401ea-84ed-11e6-92c4-539cae37c4f9.png)

Screenshot of error message displayed during import notebook
![import](https://cloud.githubusercontent.com/assets/11922701/18878072/f69716a2-84ec-11e6-965a-3fbb29dd63d7.png)
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
