### PR TITLE
[ZEPPELIN-1488]  JDBC Interpreter throws error while the interpreter is downloading dependencies

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -289,9 +289,12 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       logger.error("Can not find interpreter name " + repl);
       throw new RuntimeException("Can not find interpreter for " + getRequiredReplName());
     }
-
+    InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
+    while (intp.getStatus().equals(
+      org.apache.zeppelin.interpreter.InterpreterSetting.Status.DOWNLOADING_DEPENDENCIES)) {
+      intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
+    }
     if (this.noteHasUser() && this.noteHasInterpreters()) {
-      InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
       if (intp != null &&
         interpreterHasUser(intp) &&
         isUserAuthorizedToAccessInterpreter(intp.getOption()) == false) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -292,7 +292,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
     while (intp.getStatus().equals(
       org.apache.zeppelin.interpreter.InterpreterSetting.Status.DOWNLOADING_DEPENDENCIES)) {
-      Thread.sleep(200);	
+      Thread.sleep(200);
       intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
     }
     if (this.noteHasUser() && this.noteHasInterpreters()) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -293,7 +293,6 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     while (intp.getStatus().equals(
       org.apache.zeppelin.interpreter.InterpreterSetting.Status.DOWNLOADING_DEPENDENCIES)) {
       Thread.sleep(200);
-      intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
     }
     if (this.noteHasUser() && this.noteHasInterpreters()) {
       if (intp != null &&

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -292,6 +292,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     InterpreterSetting intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
     while (intp.getStatus().equals(
       org.apache.zeppelin.interpreter.InterpreterSetting.Status.DOWNLOADING_DEPENDENCIES)) {
+      Thread.sleep(200);	
       intp = getInterpreterSettingById(repl.getInterpreterGroup().getId());
     }
     if (this.noteHasUser() && this.noteHasInterpreters()) {


### PR DESCRIPTION
### What is this PR for?
For first time, when we add dependencies for JDBC interpreter, dependencies will start getting downloaded in background. During that time, if user runs a paragraph of JDBC interpreter now user getting error , But instead paragraph execution should be put on 'PENDING' state and wait for dependencies to get downloaded and then run the paragraph 

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-1488] https://issues.apache.org/jira/browse/ZEPPELIN-1488

### How should this be tested?
prerequisites:
1. Any DB setup.(For my testing, i considered hive)
Steps:
1. Delete the local-repo folder under zeppelin project, if it exists
2. Go to interpreter settings page, provide hive connection details under JDBC interprepreter
3. For hive interpreter to run, it needs some dependencies to be added in interpreter settings page
    For hive below dependencies needs to added
    1. org.apache.hive:hive-jdbc:0.14.0
    2. org.apache.hadoop:hadoop-common:2.6.0
4. Once the settings for JDBC interpreter is saved, dependencies will start getting downloaded in background.
5. Run any paragraph with JDBC as interpreter, paragraph should not throw error, status of the paragraph should change to 'pending' while the dependencies are getting downloaded in background.
6. Once the downloading of dependencies is done, the paragraph which were in pending will start executing in order depending on the execution mode of the interpreter (i.e Shared, Scoped, Isolated)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

