### PR TITLE
[ZEPPELIN-1502] Highlights initialization code editor bugs

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1595,9 +1595,11 @@ public class NotebookServer extends WebSocketServlet implements
 
   private void getEditorSetting(NotebookSocket conn, Message fromMessage)
       throws IOException {
+    String orderId = (String) fromMessage.get("orderId");
     String replName = (String) fromMessage.get("magic");
     String noteId = getOpenNoteId(conn);
     Message resp = new Message(OP.EDITOR_SETTING);
+    resp.put("orderId", orderId);
     resp.put("editor", notebook().getInterpreterFactory().getEditorSetting(noteId, replName));
     conn.send(serializeMessage(resp));
     return;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1595,11 +1595,11 @@ public class NotebookServer extends WebSocketServlet implements
 
   private void getEditorSetting(NotebookSocket conn, Message fromMessage)
       throws IOException {
-    String orderId = (String) fromMessage.get("orderId");
+    String paragraphId = (String) fromMessage.get("paragraphId");
     String replName = (String) fromMessage.get("magic");
     String noteId = getOpenNoteId(conn);
     Message resp = new Message(OP.EDITOR_SETTING);
-    resp.put("orderId", orderId);
+    resp.put("paragraphId", paragraphId);
     resp.put("editor", notebook().getInterpreterFactory().getEditorSetting(noteId, replName));
     conn.send(serializeMessage(resp));
     return;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -705,13 +705,15 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
 
   var getAndSetEditorSetting = function(session, interpreterName) {
     var deferred = $q.defer();
-    websocketMsgSrv.getEditorSetting(interpreterName);
+    websocketMsgSrv.getEditorSetting($scope.paragraph.id, interpreterName);
     $timeout(
       $scope.$on('editorSetting', function(event, data) {
-        deferred.resolve(data);
+        if ($scope.paragraph.id === data.orderId) {
+          deferred.resolve(data);
+        }
       }
     ), 1000);
-
+    
     deferred.promise.then(function(editorSetting) {
       if (!_.isEmpty(editorSetting.editor)) {
         var mode = 'ace/mode/' + editorSetting.editor.language;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -708,7 +708,7 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
     websocketMsgSrv.getEditorSetting($scope.paragraph.id, interpreterName);
     $timeout(
       $scope.$on('editorSetting', function(event, data) {
-        if ($scope.paragraph.id === data.orderId) {
+        if ($scope.paragraph.id === data.paragraphId) {
           deferred.resolve(data);
         }
       }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -713,7 +713,6 @@ angular.module('zeppelinWebApp').controller('ParagraphCtrl', function($scope, $r
         }
       }
     ), 1000);
-    
     deferred.promise.then(function(editorSetting) {
       if (!_.isEmpty(editorSetting.editor)) {
         var mode = 'ace/mode/' + editorSetting.editor.language;

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -180,10 +180,11 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    getEditorSetting: function(replName) {
+    getEditorSetting: function(orderId, replName) {
       websocketEvents.sendNewEvent({
         op: 'EDITOR_SETTING',
         data: {
+          orderId: orderId,
           magic: replName
         }
       });

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -180,11 +180,11 @@ angular.module('zeppelinWebApp').service('websocketMsgSrv', function($rootScope,
       });
     },
 
-    getEditorSetting: function(orderId, replName) {
+    getEditorSetting: function(paragraphId, replName) {
       websocketEvents.sendNewEvent({
         op: 'EDITOR_SETTING',
         data: {
-          orderId: orderId,
+          paragraphId: paragraphId,
           magic: replName
         }
       });


### PR DESCRIPTION
### What is this PR for?
When there are a variety of para graph interpreter present,
When you refresh the page, the code highlights are incorrectly applied.


### What type of PR is it?
Bug Fix

### Todos
- [x] - Create orderId key in getEditorMode function.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1502

### How should this be tested?
1. Create a para-graph form below.
```
%spark
println("spark syn 01");
```
```
%spark
println("spark syn 02");
```
```
%spark
println("spark syn 03");
```
```
%spark
println("spark syn 04");
```
```
%spark
println("spark syn 05");
```
```
%pyspark
print ("pyspark syn);
```
```
%sql
SELECT * FROM SQL_HIGH WHERE ONMYCOM
```

2. Check the highlights of each of the para graphs.
3. Refresh the page and check the highlights again.

### Screenshots (if appropriate)
#### bug (focus on pyspark)
![codeeidtorhigh](https://cloud.githubusercontent.com/assets/10525473/18906890/66b8ede0-85a4-11e6-96fb-6cc000edf477.png)

#### this pr (focus on pyspark)
![code](https://cloud.githubusercontent.com/assets/10525473/18907220/bcc9f818-85a5-11e6-949c-db94fa753d3c.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

