### PR TITLE
Add message of localhost:port on script

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -93,6 +93,8 @@ function initialize_default_directories() {
     echo "Pid dir doesn't exist, create ${ZEPPELIN_PID_DIR}"
     $(mkdir -p "${ZEPPELIN_PID_DIR}")
   fi
+
+  echo "Browse localhost:8080 in your browser"
 }
 
 function wait_for_zeppelin_to_die() {

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -96,15 +96,18 @@ function initialize_default_directories() {
 
   PORT_NUMBER="8080"
   ZEPPELIN_SITE="conf/zeppelin-site.xml"
+  ZEPPELIN_ENV="conf/zeppelin-env.sh"
   if [ -e "${ZEPPELIN_SITE}" ]; then
     PORT_NUMBER="$(xmllint --xpath 'string(//configuration/property[@name="zeppelin.server.port"]/value)' conf/zeppelin-site.xml)"
   fi
 
-  PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
 
-  if [[ ! ${#PORT_LINE} -lt 0 ]]; then
-    if [[ $PORT_LINE != \#* ]]; then
-      PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+  if [ -e "${ZEPPELIN_ENV}" ]; then
+    PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
+    if [[ ! ${#PORT_LINE} -lt 0 ]]; then
+      if [[ $PORT_LINE != \#* ]]; then
+        PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+      fi
     fi
   fi
   

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -94,7 +94,8 @@ function initialize_default_directories() {
     $(mkdir -p "${ZEPPELIN_PID_DIR}")
   fi
 
-  echo "Browse localhost:8080 in your browser"
+  IP_ADDR="$(ifconfig en0 | grep inet | grep -v inet6 | cut -d ' ' -f2)"
+  echo -e "Browse $IP_ADDR:8080 in your browser.\nIf you are testing on your local computer, use localhost:8080"
 }
 
 function wait_for_zeppelin_to_die() {

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -94,8 +94,22 @@ function initialize_default_directories() {
     $(mkdir -p "${ZEPPELIN_PID_DIR}")
   fi
 
+  PORT_NUMBER="8080"
+  ZEPPELIN_SITE="conf/zeppelin-site.xml"
+  if [ -e "${ZEPPELIN_SITE}" ]; then
+    PORT_NUMBER="$(xmllint --xpath 'string(//configuration/property[@name="zeppelin.server.port"]/value)' conf/zeppelin-site.xml)"
+  fi
+
+  PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
+
+  if [[ ! ${#PORT_LINE} -lt 0 ]]; then
+    if [[ $PORT_LINE != \#* ]]; then
+      PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+    fi
+  fi
+  
   IP_ADDR="$(ifconfig en0 | grep inet | grep -v inet6 | cut -d ' ' -f2)"
-  echo -e "Browse $IP_ADDR:8080 in your browser.\nIf you are testing on your local computer, use localhost:8080"
+  echo -e "Browse $IP_ADDR:$PORT_NUMBER in your browser.\nIf you are testing on your local computer, use localhost:$PORT_NUMBER"
 }
 
 function wait_for_zeppelin_to_die() {

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Run Zeppelin 
+# Run Zeppelin
 #
 
 USAGE="Usage: bin/zeppelin.sh [--config <conf-dir>]"
@@ -46,7 +46,7 @@ fi
 HOSTNAME=$(hostname)
 ZEPPELIN_LOGFILE="${ZEPPELIN_LOG_DIR}/zeppelin-${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.log"
 LOG="${ZEPPELIN_LOG_DIR}/zeppelin-cli-${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.out"
-  
+
 ZEPPELIN_SERVER=org.apache.zeppelin.server.ZeppelinServer
 JAVA_OPTS+=" -Dzeppelin.log.file=${ZEPPELIN_LOGFILE}"
 
@@ -87,4 +87,5 @@ if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
   $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
 fi
 
+echo "Browse localhost:8080 in your browser"
 exec $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_SERVER "$@"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -87,6 +87,20 @@ if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
   $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
 fi
 
+PORT_NUMBER="8080"
+ZEPPELIN_SITE="conf/zeppelin-site.xml"
+if [ -e "${ZEPPELIN_SITE}" ]; then
+  PORT_NUMBER="$(xmllint --xpath 'string(//configuration/property[@name="zeppelin.server.port"]/value)' conf/zeppelin-site.xml)"
+fi
+
+PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
+
+if [[ ! ${#PORT_LINE} -lt 0 ]]; then
+  if [[ $PORT_LINE != \#* ]]; then
+    PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+  fi
+fi
+  
 IP_ADDR="$(ifconfig en0 | grep inet | grep -v inet6 | cut -d ' ' -f2)"
-echo -e "Browse $IP_ADDR:8080 in your browser.\nIf you are testing on your local computer, use localhost:8080"
+echo -e "Browse $IP_ADDR:$PORT_NUMBER in your browser.\nIf you are testing on your local computer, use localhost:$PORT_NUMBER"
 exec $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_SERVER "$@"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -87,5 +87,6 @@ if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
   $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
 fi
 
-echo "Browse localhost:8080 in your browser"
+IP_ADDR="$(ifconfig en0 | grep inet | grep -v inet6 | cut -d ' ' -f2)"
+echo -e "Browse $IP_ADDR:8080 in your browser.\nIf you are testing on your local computer, use localhost:8080"
 exec $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_SERVER "$@"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -89,15 +89,18 @@ fi
 
 PORT_NUMBER="8080"
 ZEPPELIN_SITE="conf/zeppelin-site.xml"
+ZEPPELIN_ENV="conf/zeppelin-env.sh"
 if [ -e "${ZEPPELIN_SITE}" ]; then
   PORT_NUMBER="$(xmllint --xpath 'string(//configuration/property[@name="zeppelin.server.port"]/value)' conf/zeppelin-site.xml)"
 fi
 
-PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
 
-if [[ ! ${#PORT_LINE} -lt 0 ]]; then
-  if [[ $PORT_LINE != \#* ]]; then
-    PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+if [ -e "${ZEPPELIN_ENV}" ]; then
+  PORT_LINE="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | xargs)"
+  if [[ ! ${#PORT_LINE} -lt 0 ]]; then
+    if [[ $PORT_LINE != \#* ]]; then
+      PORT_NUMBER="$(cat conf/zeppelin-env.sh | grep ZEPPELIN_PORT | cut -d '=' -f2)"
+    fi
   fi
 fi
   

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -19,13 +19,13 @@
 
 <configuration>
 
-<property>
+<property name="zeppelin.server.addr">
   <name>zeppelin.server.addr</name>
   <value>0.0.0.0</value>
   <description>Server address</description>
 </property>
 
-<property>
+<property name="zeppelin.server.port">
   <name>zeppelin.server.port</name>
   <value>8080</value>
   <description>Server port.</description>


### PR DESCRIPTION
### What is this PR for?

To show the localhost:port number info when running zeppelin.sh script.
### What type of PR is it?

[Improvement]
### Todos
- [ ] - Task
### What is the Jira issue?
- Not an issue.
### How should this be tested?

Run ./zeppelin.sh or ./zeppelin_daemon.sh and see the message about localhost is appearing.
