### PR TITLE
Change path to tutorial images

### DIFF
--- a/docs/quickstart/install_with_flink_and_spark_cluster.md
+++ b/docs/quickstart/install_with_flink_and_spark_cluster.md
@@ -284,7 +284,7 @@ build-target/bin/start-cluster.sh
 
 In a browser, navigate to http://`yourip`:8082 to see the Flink Web-UI.  Click on 'Task Managers' in the left navigation bar. Ensure there is at least one Task Manager present.
 
-<center>![alt text](../../assets/themes/zeppelin/img/screenshots/flink-webui.png "The Flink Web-UI")</center>
+<center>![alt text](../assets/themes/zeppelin/img/screenshots/flink-webui.png "The Flink Web-UI")</center>
 
 
 If no task managers are present, restart the Flink cluster with the following commands:
@@ -362,7 +362,7 @@ spark/sbin/start-master.sh --webui-port 8082
 
 Open a browser and navigate to http://`yourip`:8082 to ensure the Spark master is running.
 
-<center>![alt text](../../assets/themes/zeppelin/img/screenshots/spark-master-webui1.png "It should look like this...")</center>
+<center>![alt text](../assets/themes/zeppelin/img/screenshots/spark-master-webui1.png "It should look like this...")</center>
 
 Toward the top of the page there will be a *URL*: spark://`yourhost`:7077.  Note this URL, the Spark Master URI, it will be needed in subsequent steps.
 


### PR DESCRIPTION
### What is this PR for?
Fixing the image path of the tutorial made in #418 


### What type of PR is it?
Hot Fix

### What is the Jira issue?
None, just a Hotfix

### How should this be tested?
Build, move into full website, you should see the images

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
