### PR TITLE
[ZEPPELIN-1512] Support Kylin project name in interpreter runtime

### DIFF
--- a/docs/interpreter/kylin.md
+++ b/docs/interpreter/kylin.md
@@ -30,7 +30,6 @@ To get start with Apache Kylin, please see [Apache Kylin Quickstart](https://kyl
 
 ## Configuration
 <table class="table-configuration">
-<table class="table-configuration">
   <tr>
     <th>Name</th>
     <th>Default</th>
@@ -54,7 +53,7 @@ To get start with Apache Kylin, please see [Apache Kylin Quickstart](https://kyl
   <tr>
     <td>kylin.query.project</td>
     <td>learn_kylin</td>
-    <td>String, Project to perform query.</td>
+    <td>String, Project to perform query. Could update at notebook level</td>
   </tr>
   <tr>
     <td>kylin.query.ispartial</td>
@@ -72,15 +71,12 @@ To get start with Apache Kylin, please see [Apache Kylin Quickstart](https://kyl
     <td>int, Query offset <br/> If offset is set in sql, curIndex will be ignored.</td>
   </tr>
 </table>
-  
-  
-</table>
 
 ## Using the Apache Kylin Interpreter
-In a paragraph, use `%kylin` to select the **kylin** interpreter and then input sql.
+In a paragraph, use `%kylin(project_name)` to select the **kylin** interpreter, **project name** and then input **sql**. If no project name defined, will use the default project name from the above configuration.
 
 ```
-%kylin
+%kylin(learn_project)
 select count(*) from kylin_sales group by part_dt
 ```
 

--- a/kylin/src/main/resources/interpreter-setting.json
+++ b/kylin/src/main/resources/interpreter-setting.json
@@ -14,37 +14,37 @@
         "envName": null,
         "propertyName": "kylin.api.user",
         "defaultValue": "ADMIN",
-        "description": "username for kylin user"
+        "description": "Kylin username"
       },
       "kylin.api.password": {
         "envName": null,
         "propertyName": "kylin.api.password",
         "defaultValue": "KYLIN",
-        "description": "password for kylin user"
+        "description": "Kylin password"
       },
       "kylin.query.project": {
         "envName": null,
         "propertyName": "kylin.query.project",
-        "defaultValue": "default",
-        "description": "kylin project name"
+        "defaultValue": "learn_kylin",
+        "description": "Default Kylin project name"
       },
       "kylin.query.offset": {
         "envName": null,
         "propertyName": "kylin.query.offset",
         "defaultValue": "0",
-        "description": "kylin query offset"
+        "description": "Kylin query offset"
       },
       "kylin.query.limit": {
         "envName": null,
         "propertyName": "kylin.query.limit",
         "defaultValue": "5000",
-        "description": "kylin query limit"
+        "description": "Kylin query limit"
       },
       "kylin.query.ispartial": {
         "envName": null,
         "propertyName": "kylin.query.ispartial",
         "defaultValue": "true",
-        "description": "The kylin query partial flag"
+        "description": "Kylin query partial flag, deprecated"
       }
     },
     "editor": {

--- a/kylin/src/test/java/KylinInterpreterTest.java
+++ b/kylin/src/test/java/KylinInterpreterTest.java
@@ -47,12 +47,35 @@ public class KylinInterpreterTest {
   }
 
   @Test
-  public void test(){
-    KylinInterpreter t = new MockKylinInterpreter(kylinProperties);
+  public void testWithDefault(){
+    KylinInterpreter t = new MockKylinInterpreter(getDefaultProperties());
     InterpreterResult result = t.interpret(
         "select a.date,sum(b.measure) as measure from kylin_fact_table a " +
             "inner join kylin_lookup_table b on a.date=b.date group by a.date", null);
+    assertEquals("default", t.getProject("select a.date,sum(b.measure) as measure " +
+                    "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
     assertEquals(InterpreterResult.Type.TABLE,result.message().get(0).getType());
+  }
+
+  @Test
+  public void testWithProject(){
+    KylinInterpreter t = new MockKylinInterpreter(getDefaultProperties());
+    assertEquals("project2", t.getProject("(project2)\n select a.date,sum(b.measure) as measure " +
+            "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
+    assertEquals("", t.getProject("()\n select a.date,sum(b.measure) as measure " +
+            "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
+  }
+
+  private Properties getDefaultProperties(){
+    Properties prop = new Properties();
+    prop.put("kylin.api.username", "ADMIN");
+    prop.put("kylin.api.password", "KYLIN");
+    prop.put("kylin.api.url", "http://<host>:<port>/kylin/api/query");
+    prop.put("kylin.query.project", "default");
+    prop.put("kylin.query.offset", "0");
+    prop.put("kylin.query.limit", "5000");
+    prop.put("kylin.query.ispartial", "true");
+    return prop;
   }
 }
 


### PR DESCRIPTION
### What is this PR for?

Currently, the parameter "project" is defined with "kylin.query.project" in properties. It's not convenience when query Kylin among different projects. May I propose introducing %kylin(project_name) at the interpreter runtime? If not set, the default project will work, otherwise, will use explicit project_name for the query request.
### What type of PR is it?

Improvement
### Todos

DONE
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1512
### How should this be tested?

%kylin select ...
%kylin(new_project) select ....
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update?
  No.
- Is there breaking changes for older versions?
  No.
- Does this needs documentation?
  Will do later.
