### PR TITLE
[ZEPPELIN-1514] Make atom, rss, sitemap file not to be searched

### DIFF
--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -1,6 +1,6 @@
 ---
 layout: nil
-title : Atom Feed
+title :
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/docs/rss.xml
+++ b/docs/rss.xml
@@ -1,6 +1,6 @@
 ---
 layout: nil
-title : RSS Feed
+title :
 ---
 
 <?xml version="1.0" encoding="UTF-8" ?>

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -1,6 +1,6 @@
 ---
 # Remember to set production_url in your _config.yml file!
-title : Sitemap
+title :
 ---
 {% for page in site.pages %}
 {{site.production_url}}{{ page.url }}{% endfor %}


### PR DESCRIPTION
### What is this PR for?
I excluded some docs pages from [search page](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/search.html) in Zeppelin documentation site. This can be done by removing `title` value in [front matter](https://jekyllrb.com/docs/frontmatter/) as I did same for `pleasecontribute.md` in [here](https://github.com/apache/zeppelin/pull/1266/commits/6e775f5c28b80538fff1484b4eb1f66c795ca2c1). 


### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1514](https://issues.apache.org/jira/browse/ZEPPELIN-1514)

### How should this be tested?
1) build gh-pages (website) branch
```
JEKYLL_ENV=production bundle exec jekyll build
mkdir -p tmp/zeppelin_website/docs/
cp -r  _site/ /tmp/zeppelin_website/
```

2) build this patch(docs) and copy it under docs/0.7.0-SNAPSHOT of website
```
cd ZEPPELIN_HOME/docs/
bundle exec jekyll build --safe
cp -r  _site/ /tmp/zeppelin_website/docs/0.7.0-SNAPSHOT/
```

3) start httpServer
```
cd /tmp/zeppelin_website
python -m SimpleHTTPServer
```

4) browse `http://localhost:8000`

### Screenshots (if appropriate)
The below pages shouldn't be searched 
<img width="861" alt="screen shot 2016-10-01 at 4 01 37 pm" src="https://cloud.githubusercontent.com/assets/10060731/19012559/80339cbe-87f4-11e6-8ee5-59405c048171.png">
<img width="539" alt="screen shot 2016-10-01 at 4 08 03 pm" src="https://cloud.githubusercontent.com/assets/10060731/19012560/82f32f3c-87f4-11e6-9c25-0f22eb723245.png">
<img width="558" alt="screen shot 2016-10-01 at 4 08 11 pm" src="https://cloud.githubusercontent.com/assets/10060731/19012561/8780398c-87f4-11e6-8446-39f0f8f8c994.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

