### PR TITLE
ZEPPELIN-1410  SLF4J: Class path contains multiple SLF4J bindings

### DIFF
--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -72,6 +72,16 @@
       <groupId>org.apache.lens</groupId>
       <artifactId>lens-client</artifactId>
       <version>${lens.version}</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>ch.qos.logback</groupId>
+      		<artifactId>logback-classic</artifactId>
+      	</exclusion>
+      	<exclusion>
+      		<groupId>ch.qos.logback</groupId>
+      		<artifactId>logback-core</artifactId>
+      	</exclusion>
+    </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
SLF4J is having 2 depedencies in classpath. one is slf4j-log4j12 and another is logback. The Logback is added in class path by apache lens projec used in lens module. I have added exclusion to remove that in this PR

###  PR type
Bug Fix

###  JIRA
* [ZEPPELIN-1410](https://issues.apache.org/jira/browse/ZEPPELIN-1410)  SLF4J: Class path contains multiple SLF4J bindings

### Fix
This removes logback in the package of zeppelin. But still logback is shown in install logs. This is caused by cobertura plugin. Please look into [ZEPPELIN-1410](https://issues.apache.org/jira/browse/ZEPPELIN-1410) for more details 
