### PR TITLE
Prevent from version collision on test task

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -96,6 +96,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
       <version>2.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -106,6 +112,10 @@
          <exclusion>
            <groupId>org.apache.httpcomponents</groupId>
            <artifactId>httpclient</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>commons-httpclient</groupId>
+           <artifactId>commons-httpclient</artifactId>
          </exclusion>
        </exclusions>
      </dependency>


### PR DESCRIPTION
### What is this PR for?
Fix version conflict on `test` in Zengine.

Error looks like this:

```
➜  zeppelin git:(master) mvn test -Pscala-2.10

<truncated>

[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Zeppelin: Zengine 0.7.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-checkstyle-plugin:2.13:check (checkstyle-fail-build) @ zeppelin-zengine ---
[INFO]
[INFO]
[INFO] --- maven-resources-plugin:2.7:copy-resources (copy-resources) @ zeppelin-zengine ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 17 resources
[INFO]
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce) @ zeppelin-zengine ---
[WARNING]
Dependency convergence error for org.codehaus.plexus:plexus-utils:2.0.7 paths to dependency are:
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
    +-org.sonatype.aether:aether-connector-wagon:1.12
      +-org.codehaus.plexus:plexus-utils:2.0.7
and
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
    +-org.sonatype.aether:aether-connector-wagon:1.12
      +-org.sonatype.sisu:sisu-inject-plexus:2.2.2
        +-org.codehaus.plexus:plexus-utils:2.0.7
and
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.commons:commons-vfs2:2.0
    +-org.apache.maven.scm:maven-scm-api:1.4
      +-org.codehaus.plexus:plexus-utils:1.5.6
and
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.commons:commons-vfs2:2.0
    +-org.apache.maven.scm:maven-scm-provider-svnexe:1.4
      +-org.apache.maven.scm:maven-scm-provider-svn-commons:1.4
        +-org.codehaus.plexus:plexus-utils:1.5.6
and
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.commons:commons-vfs2:2.0
    +-org.apache.maven.scm:maven-scm-provider-svnexe:1.4
      +-org.codehaus.plexus:plexus-utils:1.5.6

[WARNING]
Dependency convergence error for commons-httpclient:commons-httpclient:3.1 paths to dependency are:
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
    +-org.apache.maven.wagon:wagon-http:1.0
      +-org.apache.maven.wagon:wagon-http-shared:1.0
        +-commons-httpclient:commons-httpclient:3.1
and
+-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
  +-org.apache.jackrabbit:jackrabbit-webdav:1.5.2
    +-commons-httpclient:commons-httpclient:3.0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Zeppelin ........................................... SUCCESS [  2.856 s]
[INFO] Zeppelin: Interpreter .............................. SUCCESS [02:14 min]
[INFO] Zeppelin: Zengine .................................. FAILURE [  1.937 s]
[INFO] Zeppelin: Display system apis ...................... SKIPPED
[INFO] Zeppelin: Spark dependencies ....................... SKIPPED
[INFO] Zeppelin: Spark .................................... SKIPPED
[INFO] Zeppelin: Markdown interpreter ..................... SKIPPED
[INFO] Zeppelin: Angular interpreter ...................... SKIPPED
[INFO] Zeppelin: Shell interpreter ........................ SKIPPED
[INFO] Zeppelin: Livy interpreter ......................... SKIPPED
[INFO] Zeppelin: HBase interpreter ........................ SKIPPED
[INFO] Zeppelin: PostgreSQL interpreter ................... SKIPPED
[INFO] Zeppelin: JDBC interpreter ......................... SKIPPED
[INFO] Zeppelin: File System Interpreters ................. SKIPPED
[INFO] Zeppelin: Flink .................................... SKIPPED
[INFO] Zeppelin: Apache Ignite interpreter ................ SKIPPED
[INFO] Zeppelin: Kylin interpreter ........................ SKIPPED
[INFO] Zeppelin: Python interpreter ....................... SKIPPED
[INFO] Zeppelin: Lens interpreter ......................... SKIPPED
[INFO] Zeppelin: Apache Cassandra interpreter ............. SKIPPED
[INFO] Zeppelin: Elasticsearch interpreter ................ SKIPPED
[INFO] Zeppelin: BigQuery interpreter ..................... SKIPPED
[INFO] Zeppelin: Alluxio interpreter ...................... SKIPPED
[INFO] Zeppelin: web Application .......................... SKIPPED
[INFO] Zeppelin: Server ................................... SKIPPED
[INFO] Zeppelin: Packaging distribution ................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:19 min
[INFO] Finished at: 2016-10-04T23:35:47-04:00
[INFO] Final Memory: 47M/960M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.3.1:enforce (enforce) on project zeppelin-zengine: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
[ERROR] Failed while enforcing releasability the error(s) are [
[ERROR] Dependency convergence error for org.codehaus.plexus:plexus-utils:2.0.7 paths to dependency are:
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
[ERROR] +-org.sonatype.aether:aether-connector-wagon:1.12
[ERROR] +-org.codehaus.plexus:plexus-utils:2.0.7
[ERROR] and
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
[ERROR] +-org.sonatype.aether:aether-connector-wagon:1.12
[ERROR] +-org.sonatype.sisu:sisu-inject-plexus:2.2.2
[ERROR] +-org.codehaus.plexus:plexus-utils:2.0.7
[ERROR] and
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.commons:commons-vfs2:2.0
[ERROR] +-org.apache.maven.scm:maven-scm-api:1.4
[ERROR] +-org.codehaus.plexus:plexus-utils:1.5.6
[ERROR] and
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.commons:commons-vfs2:2.0
[ERROR] +-org.apache.maven.scm:maven-scm-provider-svnexe:1.4
[ERROR] +-org.apache.maven.scm:maven-scm-provider-svn-commons:1.4
[ERROR] +-org.codehaus.plexus:plexus-utils:1.5.6
[ERROR] and
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.commons:commons-vfs2:2.0
[ERROR] +-org.apache.maven.scm:maven-scm-provider-svnexe:1.4
[ERROR] +-org.codehaus.plexus:plexus-utils:1.5.6
[ERROR] ,
[ERROR] Dependency convergence error for commons-httpclient:commons-httpclient:3.1 paths to dependency are:
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.zeppelin:zeppelin-interpreter:0.7.0-SNAPSHOT
[ERROR] +-org.apache.maven.wagon:wagon-http:1.0
[ERROR] +-org.apache.maven.wagon:wagon-http-shared:1.0
[ERROR] +-commons-httpclient:commons-httpclient:3.1
[ERROR] and
[ERROR] +-org.apache.zeppelin:zeppelin-zengine:0.7.0-SNAPSHOT
[ERROR] +-org.apache.jackrabbit:jackrabbit-webdav:1.5.2
[ERROR] +-commons-httpclient:commons-httpclient:3.0
[ERROR] ]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :zeppelin-zengine
```

### What type of PR is it?
Bug Fix

### What is the Jira issue?
Is there need for Jira issue here?

### How should this be tested?
Try to run `mvn test -Pscala-2.10` before and after this commit.

### Questions:
* Does the licenses files need update? `No`
* Is there breaking changes for older versions? `No`
* Does this needs documentation? `No`

