### PR TITLE
[ZEPPELIN-1519] Fix notebook importer AM/PM omission problem

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
@@ -35,7 +35,8 @@ import java.util.Locale;
 public class NotebookImportDeserializer implements JsonDeserializer<Date> {
   private static final String[] DATE_FORMATS = new String[] {
     "yyyy-MM-dd'T'HH:mm:ssZ",
-    "MMM d, yyyy h:mm:ss a"
+    "MMM d, yyyy h:mm:ss a",
+    "MMM dd, yyyy HH:mm:ss"
   };
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookImportDeserializer.java
@@ -35,7 +35,7 @@ import java.util.Locale;
 public class NotebookImportDeserializer implements JsonDeserializer<Date> {
   private static final String[] DATE_FORMATS = new String[] {
     "yyyy-MM-dd'T'HH:mm:ssZ",
-    "MMM dd, yyyy HH:mm:ss"
+    "MMM d, yyyy h:mm:ss a"
   };
 
   @Override


### PR DESCRIPTION
### What is this PR for?
When loading note from storage (or importing note), AM/PM informations are gone. So dates are always in AM.
Fix this problem.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1519

### How should this be tested?
Do some changes on sample notebooks, and see file changes.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

