### PR TITLE
ZEPPELIN-1321 Zeppelin HTTP and HTTPS port should be managed seperately

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -22,6 +22,7 @@
 # export ZEPPELIN_MEM            		# Zeppelin jvm mem options Default -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options.
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options.
+# export ZEPPELIN_SSL_PORT       		# ssl port (used when ssl environment variable is set to true)
 
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -32,6 +32,12 @@
 </property>
 
 <property>
+  <name>zeppelin.server.ssl.port</name>
+  <value>8443</value>
+  <description>Server ssl port. (used when ssl property is set to true)</description>
+</property>
+
+<property>
   <name>zeppelin.server.context.path</name>
   <value>/</value>
   <description>Context Path of the Web Application</description>

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -212,6 +212,12 @@ You can configure Apache Zeppelin with either **environment variables** in `conf
     <td>Zeppelin server port</td>
   </tr>
   <tr>
+    <td>ZEPPELIN_SSL_PORT</td>
+    <td>zeppelin.server.ssl.port</td>
+    <td>8443</td>
+    <td>Zeppelin Server ssl port (used when ssl environment/property is set to true)</td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_MEM</td>
     <td>N/A</td>
     <td>-Xmx1024m -XX:MaxPermSize=512m</td>

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -51,3 +51,4 @@ So, copying `notebook` and `conf` directory should be enough.
 
  - From 0.7, we don't use `ZEPPELIN_JAVA_OPTS` as default value of `ZEPPELIN_INTP_JAVA_OPTS` and also the same for `ZEPPELIN_MEM`/`ZEPPELIN_INTP_MEM`. If user want to configure the jvm opts of interpreter process, please set `ZEPPELIN_INTP_JAVA_OPTS` and `ZEPPELIN_INTP_MEM` explicitly.
  - Mapping from `%jdbc(prefix)` to `%prefix` is no longer available. Instead, you can use %[interpreter alias] with multiple interpreter setttings on GUI.
+ - Usage of `ZEPPELIN_PORT` is not supported in ssl mode. Instead use `ZEPPELIN_SSL_PORT` to configure the ssl port. Value from `ZEPPELIN_PORT` is used only when `ZEPPELIN_SSL` is set to `false`.

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -174,29 +174,24 @@ public class ZeppelinServer extends Application {
     ServerConnector connector;
 
     if (conf.useSsl()) {
-
       HttpConfiguration httpConfig = new HttpConfiguration();
       httpConfig.setSecureScheme("https");
-      httpConfig.setSecurePort(conf.getServerPort());
+      httpConfig.setSecurePort(conf.getServerSslPort());
       httpConfig.setOutputBufferSize(32768);
 
       HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
       SecureRequestCustomizer src = new SecureRequestCustomizer();
       // Only with Jetty 9.3.x
-//      src.setStsMaxAge(2000);
-//      src.setStsIncludeSubDomains(true);
+      // src.setStsMaxAge(2000);
+      // src.setStsIncludeSubDomains(true);
       httpsConfig.addCustomizer(src);
 
       connector = new ServerConnector(
               server,
               new SslConnectionFactory(getSslContextFactory(conf), HttpVersion.HTTP_1_1.asString()),
               new HttpConnectionFactory(httpsConfig));
-
-
     } else {
-
       connector = new ServerConnector(server);
-
     }
 
     // Set some timeout options to make debugging easier.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -261,6 +261,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_SSL);
   }
 
+  public int getServerSslPort() {
+    return getInt(ConfVars.ZEPPELIN_SSL_PORT);
+  }
+
   public boolean useClientAuth() {
     return getBoolean(ConfVars.ZEPPELIN_SSL_CLIENT_AUTH);
   }
@@ -489,6 +493,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_PORT("zeppelin.server.port", 8080),
     ZEPPELIN_SERVER_CONTEXT_PATH("zeppelin.server.context.path", "/"),
     ZEPPELIN_SSL("zeppelin.ssl", false),
+    ZEPPELIN_SSL_PORT("zeppelin.server.ssl.port", 8443),
     ZEPPELIN_SSL_CLIENT_AUTH("zeppelin.ssl.client.auth", false),
     ZEPPELIN_SSL_KEYSTORE_PATH("zeppelin.ssl.keystore.path", "keystore"),
     ZEPPELIN_SSL_KEYSTORE_TYPE("zeppelin.ssl.keystore.type", "JKS"),


### PR DESCRIPTION
### What is this PR for?
Use a different variable for ssl port number
- add new property for ssl port

### What type of PR is it?
Improvement

### Todos
* [x] - Add documentation in upgrade.md

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1321

### How should this be tested?
Add ZEPPELIN_SSL_PORT or  zeppelin.server.ssl.port in zeppelin env or site xml and configure the rest of ssl properties and start zeppelin.

### Screenshots (if appropriate)
n/a

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? Updated install doc