### PR TITLE
[ZEPPELIN-1480] Blocking message pending 10000 for BLOCKING

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -65,7 +65,7 @@ public class NotebookSocket extends WebSocketAdapter {
     return protocol;
   }
 
-  public void send(String serializeMessage) throws IOException {
+  public synchronized void send(String serializeMessage) throws IOException {
     connection.getRemote().sendString(serializeMessage);
   }
 


### PR DESCRIPTION
### What is this PR for?
This patch try to address problem described in ZEPPELIN-1480


### What type of PR is it?
Bug Fix

### Todos
* [x] - Make websocket send thread safe

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1480

### How should this be tested?
Create multiple paragraphs (for example 10 ```%sh date``` paragraphs) and schedule it every 10sec `0/10 * * * * ?`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

