### PR TITLE
Fix version of cachebust

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -10,7 +10,7 @@
     "autoprefixer": "^6.1.0",
     "bower": "1.7.2",
     "grunt": "^0.4.1",
-    "grunt-cache-bust": "^1.3.0",
+    "grunt-cache-bust": "1.3.0",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
### What is this PR for?
A dependency update of grunt-cache-bust is breaking the build.
https://github.com/hollandben/grunt-cache-bust/issues/204
So fixing the dependency version


### What type of PR is it?
Hot Fix

### Screenshot (before)
![screen shot 2016-10-06 at 12 22 40 pm](https://cloud.githubusercontent.com/assets/710411/19139450/bcad1494-8bbf-11e6-8b22-b9344055e876.png)

### How should this be tested?
Clean your repo, and do mvn package in zeppelin-web

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No