### PR TITLE
[ZEPPELIN-451] Save codes and messages as multi-line

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -60,6 +60,7 @@ import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
+import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
 import org.apache.zeppelin.resource.ResourcePoolUtils;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
@@ -204,7 +205,7 @@ public class Notebook implements NoteEventListener {
     gsonBuilder.setPrettyPrinting();
 
     Gson gson =
-        gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer()).create();
+        gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer()).create();
     JsonReader reader = new JsonReader(new StringReader(sourceJson));
     reader.setLenient(true);
     Note newNote;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -33,10 +33,13 @@ import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageSerializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job;
@@ -138,6 +141,8 @@ public class AzureNotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageDeserializer());
     gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
     Gson gson = gsonBuilder.create();
 
@@ -162,6 +167,8 @@ public class AzureNotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -37,6 +37,8 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -135,8 +137,9 @@ public class AzureNotebookRepo implements NotebookRepo {
 
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
-        .create();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
+    Gson gson = gsonBuilder.create();
 
     Note note = gson.fromJson(json, Note.class);
 
@@ -158,6 +161,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   public void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -35,8 +35,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
-import org.apache.zeppelin.notebook.NotebookImportDeserializer;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -135,7 +135,7 @@ public class AzureNotebookRepo implements NotebookRepo {
 
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
         .create();
 
     Note note = gson.fromJson(json, Note.class);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -38,6 +38,8 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -185,8 +187,9 @@ public class S3NotebookRepo implements NotebookRepo {
   private Note getNote(String key) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
-        .create();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
+    Gson gson = gsonBuilder.create();
 
     S3Object s3object;
     try {
@@ -225,6 +228,7 @@ public class S3NotebookRepo implements NotebookRepo {
   public void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
     String key = user + "/" + "notebook" + "/" + note.getId() + "/" + "note.json";

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -36,8 +36,8 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
-import org.apache.zeppelin.notebook.NotebookImportDeserializer;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -185,7 +185,7 @@ public class S3NotebookRepo implements NotebookRepo {
   private Note getNote(String key) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
         .create();
 
     S3Object s3object;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -34,10 +34,13 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageSerializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job.Status;
@@ -188,6 +191,8 @@ public class S3NotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageDeserializer());
     gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
     Gson gson = gsonBuilder.create();
 
@@ -229,6 +234,8 @@ public class S3NotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
     String key = user + "/" + "notebook" + "/" + note.getId() + "/" + "note.json";

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -40,11 +40,14 @@ import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.VFS;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.InterpreterResultMessageSerializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
 import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job.Status;
@@ -170,6 +173,8 @@ public class VFSNotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageDeserializer());
     gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
     Gson gson = gsonBuilder.create();
 
@@ -232,6 +237,8 @@ public class VFSNotebookRepo implements NotebookRepo {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
+    gsonBuilder.registerTypeAdapter(InterpreterResultMessage.class,
+        new InterpreterResultMessageSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -43,8 +43,8 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
-import org.apache.zeppelin.notebook.NotebookImportDeserializer;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -167,7 +167,7 @@ public class VFSNotebookRepo implements NotebookRepo {
 
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
         .create();
 
     FileContent content = noteJson.getContent();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -45,6 +45,8 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.typeadapter.DateDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphDeserializer;
+import org.apache.zeppelin.notebook.typeadapter.ParagraphSerializer;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -167,8 +169,9 @@ public class VFSNotebookRepo implements NotebookRepo {
 
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer())
-        .create();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphDeserializer());
+    gsonBuilder.registerTypeAdapter(Date.class, new DateDeserializer());
+    Gson gson = gsonBuilder.create();
 
     FileContent content = noteJson.getContent();
     InputStream ins = content.getInputStream();
@@ -228,6 +231,7 @@ public class VFSNotebookRepo implements NotebookRepo {
   public synchronized void save(Note note, AuthenticationInfo subject) throws IOException {
     GsonBuilder gsonBuilder = new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
+    gsonBuilder.registerTypeAdapter(Paragraph.class, new ParagraphSerializer());
     Gson gson = gsonBuilder.create();
     String json = gson.toJson(note);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/DateDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/DateDeserializer.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.notebook;
+package org.apache.zeppelin.notebook.typeadapter;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -32,7 +32,7 @@ import java.util.Locale;
 /**
  *  importNote date format deserializer
  */
-public class NotebookImportDeserializer implements JsonDeserializer<Date> {
+public class DateDeserializer implements JsonDeserializer<Date> {
   private static final String[] DATE_FORMATS = new String[] {
     "yyyy-MM-dd'T'HH:mm:ssZ",
     "MMM d, yyyy h:mm:ss a",

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/InterpreterResultMessageDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/InterpreterResultMessageDeserializer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.typeadapter;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.commons.lang.StringUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Custom deserializer for InterpreterResultMessage
+ */
+public class InterpreterResultMessageDeserializer
+    implements JsonDeserializer<InterpreterResultMessage> {
+  @Override
+  public InterpreterResultMessage deserialize(JsonElement json, Type typeOfT,
+    JsonDeserializationContext context) throws JsonParseException {
+    JsonObject jsonObject = (JsonObject) json;
+
+    JsonElement typeObject = jsonObject.get("type");
+    InterpreterResult.Type type = InterpreterResult.Type.NULL;
+    if (typeObject.isJsonPrimitive()) {
+      type = context.deserialize(typeObject, InterpreterResult.Type.class);
+    }
+
+    JsonElement dataObject = jsonObject.get("data");
+    String data = "";
+    if (dataObject != null) {
+      if (dataObject.isJsonArray()) {
+        String[] value = context.deserialize(dataObject, String[].class);
+        data = StringUtils.join(value, "\n");
+      } else if (dataObject.isJsonPrimitive()) {
+        data = dataObject.getAsJsonPrimitive().getAsString();
+      }
+    }
+
+    return new InterpreterResultMessage(type, data);
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/InterpreterResultMessageSerializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/InterpreterResultMessageSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.typeadapter;
+
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+/**
+ * Custom serializer for InterpreterResultMessage
+ */
+public class InterpreterResultMessageSerializer
+    implements JsonSerializer<InterpreterResultMessage> {
+  @Override
+  public JsonElement serialize(InterpreterResultMessage src, Type typeOfSrc,
+    JsonSerializationContext context) {
+    JsonObject json = new JsonObject();
+    json.add("type", context.serialize(src.getType()));
+    String data = src.getData();
+    if (data != null) {
+      json.add("data", context.serialize(data.split("\n")));
+    }
+    return json;
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/ParagraphDeserializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/ParagraphDeserializer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.typeadapter;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.commons.lang.StringUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Custom deserializer for Paragraph
+ */
+public class ParagraphDeserializer implements JsonDeserializer<Paragraph> {
+  private static Paragraph createParagraph() {
+    try {
+      Constructor<Paragraph> constructor = Paragraph.class.getDeclaredConstructor();
+      if (!constructor.isAccessible()) {
+        constructor.setAccessible(true);
+      }
+      return constructor.newInstance();
+    } catch (NoSuchMethodException e) {
+    } catch (InstantiationException e) {
+    } catch (IllegalAccessException e) {
+    } catch (InvocationTargetException e) {
+    }
+    return null;
+  }
+
+  private static Field getField(String fieldName) {
+    Class klass = Paragraph.class;
+    while (klass != Object.class) {
+      try {
+        Field field = klass.getDeclaredField(fieldName);
+        if (!field.isAccessible()) {
+          field.setAccessible(true);
+        }
+        return field;
+      } catch (NoSuchFieldException e) {
+      }
+      klass = klass.getSuperclass();
+    }
+    return null;
+  }
+
+  private static void extractFieldValue(JsonDeserializationContext context, JsonObject json,
+    Paragraph dst, String fieldName) {
+    Field field = getField(fieldName);
+    if (field != null) {
+      Object value = context.deserialize(json.get(fieldName), field.getType());
+      try {
+        field.set(dst, value);
+      } catch (IllegalAccessException e) {
+      }
+    }
+  }
+
+  @Override
+  public Paragraph deserialize(JsonElement json, Type typeOfT,
+    JsonDeserializationContext context) throws JsonParseException {
+    JsonObject jsonObject = (JsonObject) json;
+    Paragraph dst = createParagraph();
+    if (dst == null) {
+      return null;
+    }
+    extractFieldValue(context, jsonObject, dst, "title");
+    JsonElement textObject = jsonObject.get("text");
+    if (textObject != null) {
+      if (textObject.isJsonArray()) {
+        String[] value = context.deserialize(textObject, String[].class);
+        dst.setText(StringUtils.join(value, "\n"));
+      } else if (textObject.isJsonPrimitive()) {
+        dst.setText(textObject.getAsJsonPrimitive().getAsString());
+      }
+    }
+    extractFieldValue(context, jsonObject, dst, "user");
+    extractFieldValue(context, jsonObject, dst, "dateUpdated");
+    extractFieldValue(context, jsonObject, dst, "config");
+    extractFieldValue(context, jsonObject, dst, "settings");
+    extractFieldValue(context, jsonObject, dst, "jobName");
+    extractFieldValue(context, jsonObject, dst, "id");
+    extractFieldValue(context, jsonObject, dst, "results");
+    extractFieldValue(context, jsonObject, dst, "dateCreated");
+    extractFieldValue(context, jsonObject, dst, "dateStarted");
+    extractFieldValue(context, jsonObject, dst, "dateFinished");
+    extractFieldValue(context, jsonObject, dst, "status");
+    extractFieldValue(context, jsonObject, dst, "errorMessage");
+    extractFieldValue(context, jsonObject, dst, "progressUpdateIntervalMs");
+    return dst;
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/ParagraphSerializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/typeadapter/ParagraphSerializer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.typeadapter;
+
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.apache.zeppelin.notebook.Paragraph;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+/**
+ * Custom serializer for Paragraph
+ */
+public class ParagraphSerializer implements JsonSerializer<Paragraph> {
+  private static Field getField(String fieldName) {
+    Class klass = Paragraph.class;
+    while (klass != Object.class) {
+      try {
+        Field field = klass.getDeclaredField(fieldName);
+        if (!field.isAccessible()) {
+          field.setAccessible(true);
+        }
+        return field;
+      } catch (NoSuchFieldException e) {
+      }
+      klass = klass.getSuperclass();
+    }
+    return null;
+  }
+
+  private static void addFieldValue(JsonSerializationContext context, JsonObject json,
+    Paragraph src, String fieldName) {
+    Field field = getField(fieldName);
+    if (field != null) {
+      try {
+        Object value = field.get(src);
+        if (value != null) {
+          json.add(fieldName, context.serialize(value));
+        }
+      } catch (IllegalAccessException e) {
+      }
+    }
+  }
+
+  @Override
+  public JsonElement serialize(Paragraph src, Type typeOfSrc,
+    JsonSerializationContext context) {
+    JsonObject json = new JsonObject();
+    addFieldValue(context, json, src, "title");
+    String text = src.getText();
+    if (text != null) {
+      json.add("text", context.serialize(text.split("\n")));
+    }
+    addFieldValue(context, json, src, "user");
+    addFieldValue(context, json, src, "dateUpdated");
+    addFieldValue(context, json, src, "config");
+    addFieldValue(context, json, src, "settings");
+    addFieldValue(context, json, src, "jobName");
+    addFieldValue(context, json, src, "id");
+    addFieldValue(context, json, src, "results");
+    addFieldValue(context, json, src, "dateCreated");
+    addFieldValue(context, json, src, "dateStarted");
+    addFieldValue(context, json, src, "dateFinished");
+    addFieldValue(context, json, src, "status");
+    addFieldValue(context, json, src, "errorMessage");
+    addFieldValue(context, json, src, "progressUpdateIntervalMs");
+    return json;
+  }
+}


### PR DESCRIPTION
### What is this PR for?

Save Paragraph texts and result msgs as array of strings instead of one long string.
One long strings are not VCS-friendly.
### What type of PR is it?

Improvement
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-451
### How should this be tested?

Modify notebooks and check saved note files
### Screenshots (if appropriate)

<img width="932" alt="2016-10-07 11 53 28" src="https://cloud.githubusercontent.com/assets/1409279/19177502/bdd40b28-8c84-11e6-8b43-3d6e1318e1c0.png">
<img width="832" alt="2016-10-07 11 53 44" src="https://cloud.githubusercontent.com/assets/1409279/19177508/c218d768-8c84-11e6-9d4f-ae5227ccb96b.png">
### Questions:
- Does the licenses files need update? NO
- Is there breaking changes for older versions? Notebooks from new zeppelin can not be imported in old zeppelin.
- Does this needs documentation? NO
