### PR TITLE
[DOCS] Fix dead link in docs/datasource_authorization.md

### DIFF
--- a/docs/security/datasource_authorization.md
+++ b/docs/security/datasource_authorization.md
@@ -57,5 +57,5 @@ You have to store the password information for users.
 
 ## Please note
 As a first step of data source authentication feature, [ZEPPELIN-828](https://issues.apache.org/jira/browse/ZEPPELIN-828) was proposed and implemented in Pull Request [#860](https://github.com/apache/zeppelin/pull/860).
-Currently, only customized 3rd party interpreters can use this feature. We are planning to apply this mechanism to [the community interpreters](../manual/interpreterinstallation.html#available-community-managed-interpreters) in the near future. 
+Currently, only customized 3rd party interpreters can use this feature. We are planning to apply this mechanism to [the community managed interpreters](../manual/interpreterinstallation.html#available-community-managed-interpreters) in the near future. 
 Please keep track [ZEPPELIN-1070](https://issues.apache.org/jira/browse/ZEPPELIN-1070). 

--- a/docs/security/datasource_authorization.md
+++ b/docs/security/datasource_authorization.md
@@ -57,5 +57,5 @@ You have to store the password information for users.
 
 ## Please note
 As a first step of data source authentication feature, [ZEPPELIN-828](https://issues.apache.org/jira/browse/ZEPPELIN-828) was proposed and implemented in Pull Request [#860](https://github.com/apache/zeppelin/pull/860).
-Currently, only customized 3rd party interpreters can use this feature. We are planning to apply this mechanism to [the community interpreters](../manual/interpreterinstallation.md#available-community-managed-interpreters) in the near future. 
+Currently, only customized 3rd party interpreters can use this feature. We are planning to apply this mechanism to [the community interpreters](../manual/interpreterinstallation.html#available-community-managed-interpreters) in the near future. 
 Please keep track [ZEPPELIN-1070](https://issues.apache.org/jira/browse/ZEPPELIN-1070). 


### PR DESCRIPTION
### What is this PR for?
A link for `the community interpreters` in [here](http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/datasource_authorization.html#please-note) is pointing to `../manual/interpreterinstallation.md#available-community-managed-interpreters` now. It should be `../manual/interpreterinstallation.html#available-community-managed-interpreters`.

### What type of PR is it?
Bug Fix & Documenation

### What is the Jira issue?
no Jira issue

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
