### PR TITLE
NPE LivySparkSQLInterpreter thrown with %livy.sql interpreter function

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
@@ -37,13 +37,15 @@ public class LivyPySparkInterpreter extends Interpreter {
 
   Logger LOGGER = LoggerFactory.getLogger(LivyPySparkInterpreter.class);
 
-  protected Map<String, Integer> userSessionMap;
+  private LivyPySparkSessionMap lsmap;
   protected LivyHelper livyHelper;
+  private String type = "pyspark";
+
 
   public LivyPySparkInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
-    livyHelper = new LivyHelper(property);
+    lsmap = LivyPySparkSessionMap.getInstance();
+    livyHelper = new LivyHelper(property, type);
   }
 
   @Override
@@ -52,15 +54,15 @@ public class LivyPySparkInterpreter extends Interpreter {
 
   @Override
   public void close() {
-    livyHelper.closeSession(userSessionMap);
+    livyHelper.closeSession(lsmap.getSparkUserSessionMap());
   }
 
   @Override
   public InterpreterResult interpret(String line, InterpreterContext interpreterContext) {
     try {
-      if (userSessionMap.get(interpreterContext.getAuthenticationInfo().getUser()) == null) {
+      if (lsmap.getSparkUserSession(interpreterContext.getAuthenticationInfo().getUser()) == null) {
         try {
-          userSessionMap.put(
+          lsmap.setSparkUserSessionMap(
               interpreterContext.getAuthenticationInfo().getUser(),
               livyHelper.createSession(
                   interpreterContext,
@@ -76,7 +78,7 @@ public class LivyPySparkInterpreter extends Interpreter {
         return new InterpreterResult(InterpreterResult.Code.SUCCESS, "");
       }
 
-      return livyHelper.interpret(line, interpreterContext, userSessionMap);
+      return livyHelper.interpret(line, interpreterContext);
     } catch (Exception e) {
       LOGGER.error("Exception in LivyPySparkInterpreter while interpret ", e);
       return new InterpreterResult(InterpreterResult.Code.ERROR,

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkSessionMap.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkSessionMap.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.livy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Livy PySparkSessionMap for Zeppelin.
+ */
+public class LivyPySparkSessionMap {
+  private static LivyPySparkSessionMap instance = null;
+  protected static Map<String, Integer> userSparkSessionMap = 
+        new ConcurrentHashMap<String, Integer>(); 
+  private static Object mutex = new Object();
+
+  
+  protected LivyPySparkSessionMap() {
+    // Exists only to defeat instantiation
+  }
+  public static LivyPySparkSessionMap getInstance() {
+    if (instance == null) {
+      synchronized (mutex){
+        if (instance == null) instance = new LivyPySparkSessionMap();
+      }
+    }
+    return instance;
+  }
+  public void setSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.put(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.remove(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user) {
+    userSparkSessionMap.remove(user);
+  }
+  public Integer getSparkUserSession(String user) {
+    return userSparkSessionMap.get(user); 
+  }
+  public Map<String, Integer> getSparkUserSessionMap() {
+    return userSparkSessionMap; 
+  }
+}

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -37,22 +37,15 @@ public class LivySparkInterpreter extends Interpreter {
   Logger LOGGER = LoggerFactory.getLogger(LivySparkInterpreter.class);
   private LivyOutputStream out;
 
-  protected static Map<String, Integer> userSessionMap;
   private LivyHelper livyHelper;
+  private LivySparkSessionMap lsmap;
+  private String type = "spark";
 
   public LivySparkInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
-    livyHelper = new LivyHelper(property);
+    lsmap = LivySparkSessionMap.getInstance();
+    livyHelper = new LivyHelper(property, type);
     out = new LivyOutputStream();
-  }
-
-  protected static Map<String, Integer> getUserSessionMap() {
-    return userSessionMap;
-  }
-
-  public void setUserSessionMap(Map<String, Integer> userSessionMap) {
-    this.userSessionMap = userSessionMap;
   }
 
   @Override
@@ -61,15 +54,15 @@ public class LivySparkInterpreter extends Interpreter {
 
   @Override
   public void close() {
-    livyHelper.closeSession(userSessionMap);
+    livyHelper.closeSession(lsmap.getSparkUserSessionMap());
   }
 
   @Override
   public InterpreterResult interpret(String line, InterpreterContext interpreterContext) {
     try {
-      if (userSessionMap.get(interpreterContext.getAuthenticationInfo().getUser()) == null) {
+      if (lsmap.getSparkUserSession(interpreterContext.getAuthenticationInfo().getUser()) == null) {
         try {
-          userSessionMap.put(
+          lsmap.setSparkUserSessionMap(
               interpreterContext.getAuthenticationInfo().getUser(),
               livyHelper.createSession(
                   interpreterContext,
@@ -84,7 +77,7 @@ public class LivySparkInterpreter extends Interpreter {
         return new InterpreterResult(InterpreterResult.Code.SUCCESS, "");
       }
 
-      return livyHelper.interpretInput(line, interpreterContext, userSessionMap, out);
+      return livyHelper.interpretInput(line, interpreterContext, out);
     } catch (Exception e) {
       LOGGER.error("Exception in LivySparkInterpreter while interpret ", e);
       return new InterpreterResult(InterpreterResult.Code.ERROR,

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRSessionMap.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRSessionMap.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.livy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Livy SparkRSessionMap for Zeppelin.
+ */
+public class LivySparkRSessionMap {
+  private static LivySparkRSessionMap instance = null;
+  protected static Map<String, Integer> userSparkSessionMap = 
+        new ConcurrentHashMap<String, Integer>(); 
+  private static Object mutex = new Object();
+
+  
+  protected LivySparkRSessionMap() {
+    // Exists only to defeat instantiation
+  }
+  public static LivySparkRSessionMap getInstance() {
+    if (instance == null) {
+      synchronized (mutex){
+        if (instance == null) instance = new LivySparkRSessionMap();
+      }
+    }
+    return instance;
+  }
+  public void setSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.put(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.remove(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user) {
+    userSparkSessionMap.remove(user);
+  }
+  public Integer getSparkUserSession(String user) {
+    return userSparkSessionMap.get(user); 
+  }
+  public Map<String, Integer> getSparkUserSessionMap() {
+    return userSparkSessionMap; 
+  }
+}

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSessionMap.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSessionMap.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.livy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Livy SparkSessionMap for Zeppelin.
+ */
+public class LivySparkSessionMap {
+  private static LivySparkSessionMap instance = null;
+  protected static Map<String, Integer> userSparkSessionMap = 
+        new ConcurrentHashMap<String, Integer>(); 
+  private static Object mutex = new Object();
+
+  
+  protected LivySparkSessionMap() {
+    // Exists only to defeat instantiation
+  }
+  public static LivySparkSessionMap getInstance() {
+    if (instance == null) {
+      synchronized (mutex){
+        if (instance == null) instance = new LivySparkSessionMap();
+      }
+    }
+    return instance;
+  }
+  public void setSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.put(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user, Integer sessionInt) {
+    userSparkSessionMap.remove(user, sessionInt);
+  }
+  public void deleteSparkUserSessionMap(String user) {
+    userSparkSessionMap.remove(user);
+  }
+  public Integer getSparkUserSession(String user) {
+    return userSparkSessionMap.get(user); 
+  }
+  public Map<String, Integer> getSparkUserSessionMap() {
+    return userSparkSessionMap; 
+  }
+}


### PR DESCRIPTION
### What is this PR for?

The LivySparkSQLInterpreter class does not correctly process the userSessionMap throwing back an NPE when using %livy.sql or %sql when livy is default binding. This prevents correct sharing between Spark Sessions and SparkSQL Sessions. I have attached a fix that implements seperate static single instance classes that manage userSessionMaps.
### What type of PR is it?

Bug Fix/Improvement
### Todos

Documentation/Unit Tests
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1516
### How should this be tested?

Run %sql or %livy.sql against a sql enabled dataset such as hive metastore.
### Questions:
- Does the licenses files need update? n
- Is there breaking changes for older versions? n
- Does this needs documentation? m
