### PR TITLE
[HOTFIX] Fix testWidth selnium test

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -115,10 +115,10 @@ limitations under the License.
       <div class="modal-body">
 
         <div class="row about">
-          <div class="hidden-xs col-sm-4 col-md-4 logo">
+          <div class="hidden-xs col-sm-4 logo">
             <img src="assets/images/zepLogo.png" alt="Apache Zeppelin" title="Apache Zeppelin" />
           </div>
-          <div class="col-xs-12 col-sm-8 col-md-8 content">
+          <div class="col-xs-12 col-sm-8 content">
             <h3>Apache Zeppelin</h3>
             <br/>
             <span id="i18n-14">Version</span>


### PR DESCRIPTION
### What is this PR for?
Last profile of CI test fails after #1461. This PR fixes it.
```
Tests run: 9, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 110.883 sec <<< FAILURE! - in org.apache.zeppelin.integration.ParagraphActionsIT
testWidth(org.apache.zeppelin.integration.ParagraphActionsIT)  Time elapsed: 20.055 sec  <<< FAILURE!
java.lang.AssertionError: New Width is : 4
Expected: <true>
     but: was <false>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.rules.ErrorCollector$1.call(ErrorCollector.java:65)
	at org.junit.rules.ErrorCollector.checkSucceeds(ErrorCollector.java:78)
	at org.junit.rules.ErrorCollector.checkThat(ErrorCollector.java:63)
	at org.apache.zeppelin.integration.ParagraphActionsIT.testWidth(ParagraphActionsIT.java:314)

testWidth(org.apache.zeppelin.integration.ParagraphActionsIT)  Time elapsed: 20.056 sec  <<< FAILURE!
java.lang.AssertionError: New Width is : 8
Expected: <true>
     but: was <false>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.rules.ErrorCollector$1.call(ErrorCollector.java:65)
	at org.junit.rules.ErrorCollector.checkSucceeds(ErrorCollector.java:78)
	at org.junit.rules.ErrorCollector.checkThat(ErrorCollector.java:63)
	at org.apache.zeppelin.integration.ParagraphActionsIT.testWidth(ParagraphActionsIT.java:314)
```
### What type of PR is it?
Test fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

