### PR TITLE
[BUILD][MINOR] Change build profile for distributing artifact to maven repository

### DIFF
--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Pbuild-distr -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
+PUBLISH_PROFILES="-Ppublish-distr -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"


### PR DESCRIPTION
### What is this PR for?
While removing duplication of specifying build profile in #1321, build profile has been changed from `-Ppublish-distr` to `-Pbuild-distr`. We need to restore this change and use `-Ppublish-distr` profile to publish `*.javadoc.jar ` and `*.sources.jar`.

### What type of PR is it?
Hot Fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

