### PR TITLE
[ZEPPELIN-1534] Does not load dependency library when creating new interpreter.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -596,6 +596,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     setting.setProperties(p);
     setting.setInterpreterGroupFactory(this);
     interpreterSettings.put(setting.getId(), setting);
+    loadInterpreterDependencies(setting);
     saveToFile();
     return setting;
   }


### PR DESCRIPTION
### What is this PR for?
This PR fixes dependency library loading bug when creating new interpreter.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1534


### How should this be tested?
1. Create new JDBC interpreter refer to http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/interpreter/jdbc.html#mysql.
2. Create new paragraph for testing new JDBC interpreter.
3. Run paragraph.


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

