### PR TITLE
[ZEPPELIN-1537] Elasticsearch improvement for results of aggregations

### DIFF
--- a/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
+++ b/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
@@ -21,7 +21,12 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -177,6 +182,11 @@ public class ElasticsearchInterpreterTest {
     // Multi-buckets
     res = interpreter.interpret("search /logs { \"aggs\" : { \"status_count\" : " +
             " { \"terms\" : { \"field\" : \"status\" } } } }", null);
+    assertEquals(Code.SUCCESS, res.code());
+    
+    res = interpreter.interpret("search /logs { \"aggs\" : { " +
+            " \"length\" : { \"terms\": { \"field\": \"status\" }, " +
+            "   \"aggs\" : { \"sum_length\" : { \"sum\" : { \"field\" : \"content_length\" } }, \"sum_status\" : { \"sum\" : { \"field\" : \"status\" } } } } } }", null);
     assertEquals(Code.SUCCESS, res.code());
   }
 


### PR DESCRIPTION
### What is this PR for?
The result of an aggregation query returned by the interpreter contains only "key" and "doc_count" in case of a multi-buckets aggregations.
But the result returned by Elasticsearch can contain more data according to the query.
This PR is an improvement of the result returned by the interpreter.

### What type of PR is it?
[Improvement]

### Todos
* [X] - Dev of the improvement in the interpreter
* [X] - Add a test case 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1537

### How should this be tested?
In a paragraph, enter a query with multiple aggregations:
search /logs { "aggs" : { 
            "length" : { "terms": { "field": "status" }, 
            "aggs" : { "sum_length" : { "sum" : { "field" : "content_length" } } } } }

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

