### PR TITLE
[Zeppelin-1540] fix note url input placeholder

### DIFF
--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -57,7 +57,7 @@ limitations under the License.
           <div class="form-group slide-right" ng-show="note.step2">
 
             <label for="noteImportUrl">URL</label>
-            <input placeholder="Note name" type="text" class="form-control" id="noteImportUrl"
+            <input placeholder="Note url" type="text" class="form-control" id="noteImportUrl"
                    ng-model="note.importUrl" />
           </div>
 


### PR DESCRIPTION
### What is this PR for?
Fix input form placeholder for `note url`

### What type of PR is it?
Improvement

### Todos
* [x] - Task

### What is the Jira issue?
[ZEPPELIN-1540](https://issues.apache.org/jira/browse/ZEPPELIN-1540)

### How should this be tested?
go to import note menu -> add from url -> see input forms

### Screenshots (if appropriate)
Before:
<img width="593" alt="screen shot 2016-10-13 at 2 37 24 pm" src="https://cloud.githubusercontent.com/assets/1642088/19337731/9ea41248-9152-11e6-859b-757f44b2866a.png">


After:
<img width="601" alt="screen shot 2016-10-13 at 2 36 06 pm" src="https://cloud.githubusercontent.com/assets/1642088/19337716/7f90522c-9152-11e6-8ad2-cbfcdc241e10.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

