### PR TITLE
[ZEPPELIN-675] "No data available" in invalid graph types for sql queries

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1070,6 +1070,7 @@
     var setD3Chart = function(type, data, refresh) {
       if (!$scope.chart[type]) {
         var chart = nv.models[type]();
+        chart._options.noData = 'Invalid Data, check graph settings';
         $scope.chart[type] = chart;
       }
 
@@ -1086,7 +1087,6 @@
 
         $scope.chart[type].xAxis.tickFormat(function(d) {return xAxisTickFormat(d, xLabels);});
         $scope.chart[type].yAxis.tickFormat(function(d) {return yAxisTickFormat(d, yLabels);});
-
         // configure how the tooltip looks.
         $scope.chart[type].tooltipContent(function(key, x, y, graph, data) {
           var tooltipContent = '<h3>' + key + '</h3>';


### PR DESCRIPTION
### What is this PR for?
Overriding graph message 'No data available' to 'Invalid Data, check graph settings'

### What type of PR is it?
Improvement

### Todos
* For Table and Map in graphs 'No data available' message is not shown, Maybe we want to implement this.

### What is the Jira issue?
[ZEPPELIN-675]  "No data available" in invalid graph types for sql queries

### How should this be tested?
Step 1: Run a sql query which will return 1 column or no records.
Step 2: Choose pie chart / bar chart
Verification: Earlier the message is "No data available", It should have been changed to 'Invalid Data, check graph settings'

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

