### PR TITLE
ZEPPELIN-1516. NPE LivySparkSQLInterpreter thrown with %livy.sql interpreter

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -69,13 +69,14 @@ public class LivyHelper {
 
       String confData = gson.toJson(conf);
       String user = context.getAuthenticationInfo().getUser();
-
+      LOGGER.debug("Try to create session for user:" + user);
       String json = executeHTTP(property.getProperty("zeppelin.livy.url") + "/sessions", "POST",
           "{" +
               "\"kind\": \"" + kind + "\", " +
               "\"conf\": " + confData + ", " +
-              "\"proxyUser\": " + (StringUtils.isEmpty(user) ? null : "\"" + user + "\"") +
-              "}",
+              "\"proxyUser\": " + (context.getAuthenticationInfo().isAnonymous() ? null : "\"" +
+              user + "\"") +
+          "}",
           context.getParagraphId()
       );
 
@@ -129,6 +130,12 @@ public class LivyHelper {
       LOGGER.error("Error getting session for user", e);
       throw e;
     }
+  }
+
+  protected void initializeSpark(final InterpreterContext context,
+                                 final Map<String, Integer> userSessionMap) throws Exception {
+    interpret("val sqlContext = new org.apache.spark.sql.SQLContext(sc)\n" +
+        "import sqlContext.implicits._", context, userSessionMap);
   }
 
   public InterpreterResult interpretInput(String stringLines,

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -37,12 +38,12 @@ public class LivyPySparkInterpreter extends Interpreter {
 
   Logger LOGGER = LoggerFactory.getLogger(LivyPySparkInterpreter.class);
 
-  protected Map<String, Integer> userSessionMap;
+  protected ConcurrentHashMap<String, Integer> userSessionMap;
   protected LivyHelper livyHelper;
 
   public LivyPySparkInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
+    userSessionMap = new ConcurrentHashMap<>();
     livyHelper = new LivyHelper(property);
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class LivySparkInterpreter extends Interpreter {
 
-  Logger LOGGER = LoggerFactory.getLogger(LivySparkInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LivySparkInterpreter.class);
   private LivyOutputStream out;
 
   protected static ConcurrentHashMap<String, Integer> userSessionMap = new ConcurrentHashMap();

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Livy Spark interpreter for Zeppelin.
@@ -37,29 +38,22 @@ public class LivySparkInterpreter extends Interpreter {
   Logger LOGGER = LoggerFactory.getLogger(LivySparkInterpreter.class);
   private LivyOutputStream out;
 
-  protected static Map<String, Integer> userSessionMap;
-  protected static Map<Integer, String> sessionId2AppIdMap;
-  protected static Map<Integer, String> sessionId2WebUIMap;
+  protected static ConcurrentHashMap<String, Integer> userSessionMap = new ConcurrentHashMap();
+  protected static ConcurrentHashMap<Integer, String> sessionId2AppIdMap = new ConcurrentHashMap();
+  protected static ConcurrentHashMap<Integer, String> sessionId2WebUIMap = new ConcurrentHashMap();
 
   private LivyHelper livyHelper;
   private boolean displayAppInfo;
 
   public LivySparkInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
-    sessionId2AppIdMap = new HashMap<>();
-    sessionId2WebUIMap = new HashMap<>();
     livyHelper = new LivyHelper(property);
     out = new LivyOutputStream();
     this.displayAppInfo = Boolean.parseBoolean(getProperty("zeppelin.livy.displayAppInfo"));
   }
 
-  protected static Map<String, Integer> getUserSessionMap() {
+  protected static ConcurrentHashMap<String, Integer> getUserSessionMap() {
     return userSessionMap;
-  }
-
-  public void setUserSessionMap(Map<String, Integer> userSessionMap) {
-    this.userSessionMap = userSessionMap;
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -37,12 +38,12 @@ public class LivySparkRInterpreter extends Interpreter {
 
   Logger LOGGER = LoggerFactory.getLogger(LivySparkRInterpreter.class);
 
-  protected Map<String, Integer> userSessionMap;
+  protected ConcurrentHashMap<String, Integer> userSessionMap;
   private LivyHelper livyHelper;
 
   public LivySparkRInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
+    userSessionMap = new ConcurrentHashMap<>();
     livyHelper = new LivyHelper(property);
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -77,8 +77,13 @@ public class LivySparkSQLInterpreter extends Interpreter {
       if (line == null || line.trim().length() == 0) {
         return new InterpreterResult(InterpreterResult.Code.SUCCESS, "");
       }
-
-      InterpreterResult res = livyHelper.interpret("sqlContext.sql(\"" +
+      // check sqlContext
+      InterpreterResult res = livyHelper.interpret("sqlContext", interpreterContext,
+          userSessionMap);
+      if (res.code() == InterpreterResult.Code.ERROR) {
+        livyHelper.initializeSpark(interpreterContext, userSessionMap);
+      }
+      res = livyHelper.interpret("sqlContext.sql(\"" +
               line.replaceAll("\"", "\\\\\"")
                   .replaceAll("\\n", " ")
               + "\").show(" +

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyHelperTest.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyHelperTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.livy;
 import com.google.gson.GsonBuilder;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.Mockito.doReturn;
 
@@ -56,15 +58,16 @@ public class LivyHelperTest {
 
   @Before
   public void prepareContext() throws Exception {
-    interpreter.userSessionMap = new HashMap<>();
-    interpreter.userSessionMap.put(null, 1);
-
+    interpreter.userSessionMap = new ConcurrentHashMap<>();
+    interpreter.userSessionMap.put("anonymous", 1);
     Properties properties = new Properties();
     properties.setProperty("zeppelin.livy.url", "http://localhost:8998");
     livyHelper.property = properties;
     livyHelper.paragraphHttpMap = new HashMap<>();
     livyHelper.gson = new GsonBuilder().setPrettyPrinting().create();
     livyHelper.LOGGER = LoggerFactory.getLogger(LivyHelper.class);
+    AuthenticationInfo authInfo = new AuthenticationInfo("anonymous");
+    doReturn(authInfo).when(interpreterContext).getAuthenticationInfo();
 
     doReturn("{\"id\":1,\"state\":\"idle\",\"kind\":\"spark\",\"proxyUser\":\"null\",\"log\":[]}")
         .when(livyHelper)

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class LivyIntegrationTest {
+public class LivyInterpreterIT {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(LivyIntegrationTest.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(LivyInterpreterIT.class);
   private static Cluster cluster;
   private static Properties properties;
 
@@ -165,6 +165,32 @@ public class LivyIntegrationTest {
     assertEquals(InterpreterResult.Type.TEXT, result.type());
     assertNull(result.message());
     assertTrue(outputListener.getOutputAppended().contains("defined module Person"));
+
+    // close session
+    sparkInterpreter.close();
+  }
+
+  // Test for ZEPPELIN-1516
+  @Test
+  public void testSparkSQLInterpreter() {
+    if (!checkPreCondition()) {
+      return;
+    }
+
+    LivySparkSQLInterpreter sparkSQLInterpreter = new LivySparkSQLInterpreter(properties);
+    AuthenticationInfo authInfo = new AuthenticationInfo("zeppelin-1516");
+    MyInterpreterOutputListener outputListener = new MyInterpreterOutputListener();
+    InterpreterOutput output = new InterpreterOutput(outputListener);
+    InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "title",
+        "text", authInfo, null, null, null, null, null, output);
+    sparkSQLInterpreter.open();
+    InterpreterResult result = sparkSQLInterpreter.interpret("show tables", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(InterpreterResult.Type.TABLE, result.type());
+
+
+    // close session
+    sparkSQLInterpreter.close();
   }
 
   @Test
@@ -200,6 +226,9 @@ public class LivyIntegrationTest {
     assertTrue(result.message().contains("[Row(_1=u'hello', _2=20)]"));
     assertEquals(InterpreterResult.Type.TEXT, result.type());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    // close session
+    pysparkInterpreter.close();
   }
 
   @Test

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterTest.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.livy;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -33,6 +34,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -56,10 +58,12 @@ public class LivyInterpreterTest {
   @Before
   public void prepareContext() throws Exception {
     interpreter = new LivyPySparkInterpreter(new Properties());
-    interpreter.userSessionMap = new HashMap<>();
-    interpreter.userSessionMap.put(null, 0);
+    interpreter.userSessionMap = new ConcurrentHashMap<>();
+    interpreter.userSessionMap.put("anonymous", 1);
     interpreter.livyHelper = Mockito.mock(LivyHelper.class);
     interpreter.open();
+    AuthenticationInfo authInfo = new AuthenticationInfo("anonymous");
+    doReturn(authInfo).when(interpreterContext).getAuthenticationInfo();
 
     doReturn(new InterpreterResult(InterpreterResult.Code.SUCCESS)).when(interpreter.livyHelper)
         .interpret("print \"x is 1.\"", interpreterContext, interpreter.userSessionMap);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -341,6 +341,10 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p0);
         assertEquals(Status.FINISHED, p0.getStatus());
 
+        note.run(p1.getId());
+        waitForFinish(p1);
+        assertEquals(Status.FINISHED, p1.getStatus());
+
         note.run(p2.getId());
         waitForFinish(p2);
         assertEquals(Status.FINISHED, p2.getStatus());


### PR DESCRIPTION
### What is this PR for?

This PR fixed NPE issue in `LivySparkSQLIntepreter`, also it resolves the multiple thread issues discussed in #1503
### What type of PR is it?

[Bug Fix]
### Todos
- [ ] - Task
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-1516
### How should this be tested?
- Enable shiro
- Log in 2 users in 2 browsers
- Start livy sql paragraph at almost the same time
- 2 livy sessions are created correctly. 
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
