### PR TITLE
[ZEPPELIN-1061] Select default interpreter while creating note

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -386,7 +386,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
     // expect the events are broadcasted properly
     verify(sock1, times(2)).send(anyString());
-    verify(sock2, times(1)).send(anyString());
 
     Note createdNote = null;
     for (Note note : notebook.getAllNotes()) {
@@ -400,7 +399,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
       assertEquals(notebook.getInterpreterFactory().getDefaultInterpreterSetting(
               createdNote.getId()).getId(), defaultInterpreterId);
     }
-    notebook.removeNote(createdNote.getId(), null);
+    notebook.removeNote(createdNote.getId(), anonymous);
   }
 
   private NotebookSocket createWebSocket() {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -360,6 +360,49 @@ public class NotebookServerTest extends AbstractTestRestApi {
     verify(otherConn).send(mdMsg1);
   }
 
+  @Test
+  public void testCreateNoteWithDefaultInterpreterId() throws IOException {
+    // create two sockets and open it
+    NotebookSocket sock1 = createWebSocket();
+    NotebookSocket sock2 = createWebSocket();
+
+    assertEquals(sock1, sock1);
+    assertNotEquals(sock1, sock2);
+
+    notebookServer.onOpen(sock1);
+    notebookServer.onOpen(sock2);
+
+    String noteName = "Note with millis " + System.currentTimeMillis();
+    String defaultInterpreterId = "";
+    List<InterpreterSetting> settings = notebook.getInterpreterFactory().get();
+    if (settings.size() > 1) {
+      defaultInterpreterId = settings.get(1).getId();
+    }
+    // create note from sock1
+    notebookServer.onMessage(sock1, gson.toJson(
+        new Message(OP.NEW_NOTE)
+        .put("name", noteName)
+        .put("defaultInterpreterId", defaultInterpreterId)));
+
+    // expect the events are broadcasted properly
+    verify(sock1, times(2)).send(anyString());
+    verify(sock2, times(1)).send(anyString());
+
+    Note createdNote = null;
+    for (Note note : notebook.getAllNotes()) {
+      if (note.getName().equals(noteName)) {
+        createdNote = note;
+        break;
+      }
+    }
+
+    if (settings.size() > 1) {
+      assertEquals(notebook.getInterpreterFactory().getDefaultInterpreterSetting(
+              createdNote.getId()).getId(), defaultInterpreterId);
+    }
+    notebook.removeNote(createdNote.getId(), null);
+  }
+
   private NotebookSocket createWebSocket() {
     NotebookSocket sock = mock(NotebookSocket.class);
     when(sock.getRequest()).thenReturn(mockRequest);

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -26,7 +26,17 @@ limitations under the License.
           <div class="form-group">
             <label for="noteName">Note Name</label> <input
               placeholder="Note name" type="text" class="form-control"
-              id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/>
+              id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/><br/>
+            <div ng-show="!notenamectrl.clone">
+              <label for="defaultInterpreter">Default Interpreter </label>
+              <select ng-model="note.defaultInterpreter"
+                      class="selectpicker"
+                      name="defaultInterpreter"
+                      id="defaultInterpreter"
+                      ng-options="option.name for option in interpreterSettings">
+                <option value="">--Select--</option>
+              </select>
+            </div>
           </div>
           Use '/' to create folders. Example: /NoteDirA/Notebook1
         </div>

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -29,10 +29,15 @@
     vm.notes = noteListDataFactory;
     vm.websocketMsgSrv = websocketMsgSrv;
     $scope.note = {};
+    $scope.interpreterSettings = {};
 
     vm.createNote = function() {
       if (!vm.clone) {
-        vm.websocketMsgSrv.createNote($scope.note.notename);
+        var defaultInterpreterId = '';
+        if ($scope.note.defaultInterpreter !== undefined && $scope.note.defaultInterpreter !== '') {
+          defaultInterpreterId = $scope.note.defaultInterpreter.id;
+        }
+        vm.websocketMsgSrv.createNotebook($scope.note.notename, defaultInterpreterId);
       } else {
         var noteId = $routeParams.noteId;
         vm.websocketMsgSrv.cloneNote(noteId, $scope.note.notename);
@@ -90,6 +95,22 @@
       }
       return newCloneName + ' ' + copyCount;
     };
+
+    vm.getInterpreterSettings = function() {
+      vm.websocketMsgSrv.getInterpreterSettings();
+    };
+
+    $scope.$on('interpreterSettings', function(event, data) {
+      $scope.interpreterSettings = data.interpreterSettings;
+    });
+
+    var init = function() {
+      if (!vm.clone) {
+        vm.getInterpreterSettings();
+      }
+    };
+
+    init();
   }
 
 })();

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -30,14 +30,16 @@
     vm.websocketMsgSrv = websocketMsgSrv;
     $scope.note = {};
     $scope.interpreterSettings = {};
+    $scope.note.defaultInterpreter = null;
 
     vm.createNote = function() {
       if (!vm.clone) {
         var defaultInterpreterId = '';
-        if ($scope.note.defaultInterpreter !== undefined && $scope.note.defaultInterpreter !== '') {
+        if ($scope.note.defaultInterpreter !== null) {
           defaultInterpreterId = $scope.note.defaultInterpreter.id;
         }
         vm.websocketMsgSrv.createNotebook($scope.note.notename, defaultInterpreterId);
+        $scope.note.defaultInterpreter = null;
       } else {
         var noteId = $routeParams.noteId;
         vm.websocketMsgSrv.cloneNote(noteId, $scope.note.notename);

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -138,6 +138,8 @@
         });
       } else if (op === 'CONFIGURATIONS_INFO') {
         $rootScope.$broadcast('configurationsInfo', data);
+      } else if (op === 'INTERPRETER_SETTINGS') {
+        $rootScope.$broadcast('interpreterSettings', data);
       }
     });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -25,8 +25,14 @@
         websocketEvents.sendNewEvent({op: 'GET_HOME_NOTE'});
       },
 
-      createNote: function(noteName) {
-        websocketEvents.sendNewEvent({op: 'NEW_NOTE',data: {name: noteName}});
+      createNotebook: function(noteName, defaultInterpreterId) {
+        websocketEvents.sendNewEvent({
+          op: 'NEW_NOTE',
+          data: {
+            name: noteName,
+            defaultInterpreterId: defaultInterpreterId
+          }
+        });
       },
 
       deleteNote: function(noteId) {
@@ -223,6 +229,10 @@
 
       listConfigurations: function() {
         websocketEvents.sendNewEvent({op: 'LIST_CONFIGURATIONS'});
+      },
+
+      getInterpreterSettings: function() {
+        websocketEvents.sendNewEvent({op: 'GET_INTERPRETER_SETTINGS'});
       }
 
     };

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -140,6 +140,8 @@ public class Message {
                                   // @param noteId
                                   // @param selectedSettingIds
     INTERPRETER_BINDINGS,         // [s-c] interpreter bindings
+    GET_INTERPRETER_SETTINGS,     // [c-s] get interpreter settings
+    INTERPRETER_SETTINGS,         // [s-c] interpreter settings
     ERROR_INFO                    // [s-c] error information to be sent
   }
 


### PR DESCRIPTION
### What is this PR for?

This handles setting the default interpreter on creating a note through the zeppelin UI.
### What type of PR is it?

Feature
### Todos

NA
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1061
### How should this be tested?
- Go to the 'Create Note' dialog and provide the name with the default interpreter selected.After clicking on the Create button, the selected interpreter should be shown properly in the interpreter binding section.
- If there is no interpreter selected, then the system default will be used.
### Screenshots (if appropriate)

![zeppelin-1061](https://cloud.githubusercontent.com/assets/20789766/19378611/200d9d50-920b-11e6-930a-6fdcf67c5215.png)
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
