### PR TITLE
[ ZEPPELIN-1461 ] Doesn't display "description" value in interpreter creation page

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -295,9 +295,12 @@
       for (var i = 0; i < el.length; i++) {
         var intpInfo = el[i];
         for (var key in intpInfo) {
+          if (/.*(-description)$/.test(key)) {
+              continue;
+          }
           properties[key] = {
             value: intpInfo[key],
-            description: intpInfo[key].description
+            description: intpInfo[key + '-description']
           };
         }
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -287,6 +287,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     Properties properties = new Properties();
     for (String key : p.keySet()) {
       properties.put(key, p.get(key).getValue());
+      properties.put(key + "-description", p.get(key).getDescription());
     }
     return properties;
   }
@@ -346,6 +347,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       if (null != p) {
         for (String key : p.keySet()) {
           properties.setProperty(key, p.get(key).getValue());
+          properties.setProperty(key + "-description", p.get(key).getDescription());
         }
       }
 


### PR DESCRIPTION
### What is this PR for?
As you can see in the attached screenshot image, "description" value doesn't show up in interpreter creation page. Moreover, the "+" (action button) is not working as well.


### What type of PR is it?
Bug Fix

### Todos
- [x] modification - interpreterfactory description 
- [x] modification - interpreter page

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1461?jql=project%20%3D%20ZEPPELIN%20AND%20text%20~%20%22description%22

### How should this be tested?
1. on click to zeppelin interpreter page.


### Screenshots (if appropriate)
#### after
<img width="752" alt="2016-10-14 4 03 52" src="https://cloud.githubusercontent.com/assets/10525473/19378483/d8f20ae2-9227-11e6-9e73-7894fd5064de.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no


