### PR TITLE
[ZEPPELIN-1550] fixed 'add from URL' button

### DIFF
--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -13,13 +13,15 @@ limitations under the License.
 -->
 
   <div id="noteImportModal" class="modal fade" role="dialog"
-       tabindex="-1">
-    <div class="modal-dialog">
+       tabindex="-1" data-backdrop="static" data-keyboard="false">
+    <div class="modal-dialog" >
 
       <!-- Modal content-->
       <div class="modal-content" id="NoteImportCtrl" ng-init="NoteImportInit">
         <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <!-- close button -->
+          <button type="button" class="close" data-dismiss="modal" ng-click="noteimportctrl.resetFlags()">&times;</button>
+
           <h4 class="modal-title">Import new note</h4>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
### What is this PR for?

fixed 'add from URL' button and disable backdrop function.

### What type of PR is it?
Bug Fix

### Todos
None

### What is the Jira issue?
[ZEPPELIN-1550](https://issues.apache.org/jira/browse/ZEPPELIN-1550)

### How should this be tested?
click 'Import note' -> click 'Add from URL' -> click 'x' button -> open the dialog again -> it shows the URL page not the initial page.

### Screenshots (if appropriate)

 - before
![import_note_window](https://cloud.githubusercontent.com/assets/7574765/19379302/36a0fc12-922c-11e6-9018-c67893305005.gif)

 - after
![after_2](https://cloud.githubusercontent.com/assets/7574765/19379491/2c5a072a-922d-11e6-8804-55c9766b3c5c.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
