### PR TITLE
[ZEPPELIN-1542]  Cleanup of Note created during jUnit test in zeppelin-server, zeppelin-zengine

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -104,6 +104,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
     assertTrue(paragraphs.size() > 0);
     assertEquals(paragraphText, paragraphs.get(0).get("text"));
+    //
+    ZeppelinServer.notebook.removeNote(sourceNoteID, null);
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -126,6 +126,7 @@ public class NotebookTest implements JobListenerFactory{
     note.run(p2.getId());
     while(p2.isTerminated()==false || p2.getResult()==null) Thread.yield();
     assertEquals("repl2: hello world", p2.getResult().message());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -208,6 +209,7 @@ public class NotebookTest implements JobListenerFactory{
         conf, notebookRepo, schedulerFactory,
         new InterpreterFactory(conf, null, null, null, depResolver), this, null, null, null);
     assertEquals(1, notebook2.getAllNotes().size());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -220,6 +222,7 @@ public class NotebookTest implements JobListenerFactory{
     Set<String> owners = new HashSet<>();
     owners.add("user1");
     assertEquals(owners, notebook.getNotebookAuthorization().getOwners(note.getId()));
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -238,6 +241,7 @@ public class NotebookTest implements JobListenerFactory{
     // clear paragraph output/result
     note.clearParagraphOutput(p1.getId());
     assertNull(p1.getResult());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -308,6 +312,7 @@ public class NotebookTest implements JobListenerFactory{
     assertNotNull(dateFinished);
     Thread.sleep(1 * 1000);
     assertEquals(dateFinished, p.getDateFinished());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -360,6 +365,7 @@ public class NotebookTest implements JobListenerFactory{
     // make sure all paragraph has been executed
     assertNotNull(p.getDateFinished());
     assertNotNull(p2.getDateFinished());
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -396,6 +402,9 @@ public class NotebookTest implements JobListenerFactory{
     Set<String> owners = new HashSet<>();
     owners.add("user1");
     assertEquals(owners, notebook.getNotebookAuthorization().getOwners(importedNote2.getId()));
+    notebook.removeNote(note.getId(), null);
+    notebook.removeNote(importedNote.getId(), null);
+    notebook.removeNote(importedNote2.getId(), null);
   }
 
   @Test
@@ -427,6 +436,9 @@ public class NotebookTest implements JobListenerFactory{
     Set<String> owners = new HashSet<>();
     owners.add("user1");
     assertEquals(owners, notebook.getNotebookAuthorization().getOwners(cloneNote2.getId()));
+    notebook.removeNote(note.getId(), null);
+    notebook.removeNote(cloneNote.getId(), null);
+    notebook.removeNote(cloneNote2.getId(), null);
   }
 
   @Test
@@ -437,6 +449,8 @@ public class NotebookTest implements JobListenerFactory{
 
     Note cloneNote = notebook.cloneNote(note.getId(), null, null);
     assertEquals(cloneNote.getName(), "Note " + cloneNote.getId());
+    notebook.removeNote(note.getId(), null);
+    notebook.removeNote(cloneNote.getId(), null);
   }
 
   @Test
@@ -461,6 +475,8 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(cp.getId(), p.getId());
     assertEquals(cp.text, p.text);
     assertNull(cp.getResult());
+    notebook.removeNote(note.getId(), null);
+    notebook.removeNote(cloneNote.getId(), null);
   }
 
   @Test
@@ -554,6 +570,7 @@ public class NotebookTest implements JobListenerFactory{
     // notebook scope and global object sould be remained
     assertNotNull(registry.get("o2", note.getId(), null));
     assertNotNull(registry.get("o3", null, null));
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -663,6 +680,7 @@ public class NotebookTest implements JobListenerFactory{
     }
 
     assertTrue(isAborted);
+    notebook.removeNote(note.getId(), null);
   }
 
   @Test
@@ -871,6 +889,8 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(0, notebook.getAllNotes(new AuthenticationInfo("anonymous")).size());
     assertEquals(1, notebook.getAllNotes(new AuthenticationInfo("user1")).size());
     assertEquals(1, notebook.getAllNotes(new AuthenticationInfo("user2")).size());
+    notebook.removeNote(note1.getId(), null);
+    notebook.removeNote(note2.getId(), null);
   }
 
   private void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -129,7 +129,8 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(1, notebookRepoSync.list(0, null).size());
     assertEquals(1, notebookRepoSync.list(1, null).size());
     assertEquals(notebookRepoSync.list(0, null).get(0).getId(),notebookRepoSync.list(1, null).get(0).getId());
-    
+
+    notebookSync.removeNote(notebookRepoSync.list(0, null).get(0).getId(), null);
   }
 
   @Test
@@ -194,6 +195,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
         notebookRepoSync.list(0, null).get(0).getId(), null).getLastParagraph().getId());
     assertEquals(p1.getId(), notebookRepoSync.get(1,
         notebookRepoSync.list(1, null).get(0).getId(), null).getLastParagraph().getId());
+    notebookRepoSync.remove(note.getId(), null);
   }
 
   @Test
@@ -306,6 +308,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     vRepoSync.save(note, null);
     vRepoSync.checkpoint(noteId, "checkpoint message 2", null);
     assertThat(gitRepo.revisionHistory(noteId, null).size()).isEqualTo(vCount + 1);
+    notebookRepoSync.remove(note.getId(), null);
   }
   
   static void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -135,6 +135,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     note.setName("SaveTest");
     notebookRepo.save(note, null);
     assertEquals(note.getName(), "SaveTest");
+    notebookRepo.remove(note.getId(), null);
   }
 
   class NotebookWriter implements Runnable {


### PR DESCRIPTION
### What is this PR for?
While running jUnit tests in zeppelin-server & zeppelin-zengine projects, several note are created during the process and those notes are never purged after the execution of the tests.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1542

### How should this be tested?
Prerequisites:
1. Get the list of note that already exist in server.

Now build zeppelin project by running maven commands(mvn clean package)(mvn clean package -pl 'zeppelin-interpreter,zeppelin-zengine,zeppelin-server').
1. Now no extra note should get created after running the maven command

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

