### PR TITLE
[ZEPPELIN-1552] Search button goes to next line when display's width shortens.

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -118,8 +118,6 @@
                 <li><a href="{{BASE_PATH}}/development/howtocontributewebsite.html">How to contribute (website)</a></li>
               </ul>
             </li>
-          </ul>
-          <ul class="nav navbar-nav">
             <li>
               <a href="{{BASE_PATH}}/search.html" class="nav-search-link">
                 <span class="fa fa-search nav-search-icon"></span>

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -552,12 +552,6 @@ a.anchor {
   background: #286090;
 }
 
-@media only screen and (min-width: 768px) {
-	.navbar-fixed-top > .container {
-		width: 800px;
-	}
-}
-
 a.anchorjs-link:hover { text-decoration: none; }
 
 /* Table of Contents(TOC) */
@@ -624,6 +618,10 @@ and (max-width: 1024px) {
 
   .navbar-collapse.collapse {
     padding-right: 0;
+  }
+
+  .navbar-fixed-top > .container {
+    width: 800px;
   }
 }
 

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -552,7 +552,7 @@ a.anchor {
   background: #286090;
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (min-width: 768px) {
 	.navbar-fixed-top > .container {
 		width: 800px;
 	}

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -552,6 +552,12 @@ a.anchor {
   background: #286090;
 }
 
+@media only screen and (max-width: 768px) {
+	.navbar-fixed-top > .container {
+		width: 800px;
+	}
+}
+
 a.anchorjs-link:hover { text-decoration: none; }
 
 /* Table of Contents(TOC) */


### PR DESCRIPTION
### What is this PR for?
In document page(http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/), the search button goes to next line when display's width shortens.


### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1552

### Screenshots (if appropriate)
<img width="927" alt="2016-10-15 2 04 00" src="https://cloud.githubusercontent.com/assets/6567102/19398321/0d76a1c4-9287-11e6-86e0-9f120c00b143.png">
when (768px ≤ width < 992px)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
