### PR TITLE
[ZEPPELIN-1553] Updated pom dependency to support spark 2.0.1

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -518,6 +518,19 @@
         <protobuf.version>2.5.0</protobuf.version>
       </properties>
     </profile>
+    
+    <profile>
+      <id>spark-2.0.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.version>2.0.1</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.3</py4j.version>
+        <scala.version>2.11.8</scala.version>
+      </properties>
+    </profile>
 
     <profile>
       <id>spark-2.0</id>

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -30,7 +30,7 @@
     "ngtoast": "~2.0.0",
     "ng-focus-if": "~1.0.2",
     "bootstrap3-dialog": "bootstrap-dialog#~1.34.7",
-    "handsontable": "~0.24.2",
+    "handsontable": "~0.28.4",
     "moment-duration-format": "^1.3.0",
     "select2": "^4.0.3",
     "angular-esri-map": "~2.0.0",

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1025,23 +1025,8 @@
           fillHandle: false,
           fragmentSelection: true,
           disableVisualSelection: true,
-          cells: function(row, col, prop) {
-            var cellProperties = {};
-            cellProperties.renderer = function(instance, td, row, col, prop, value, cellProperties) {
-              if (value instanceof moment) {
-                td.innerHTML = value._i;
-              } else if (!isNaN(value)) {
-                cellProperties.format = '0,0.[00000]';
-                td.style.textAlign = 'left';
-                Handsontable.renderers.NumericRenderer.apply(this, arguments);
-              } else if (value.length > '%html'.length && '%html ' === value.substring(0, '%html '.length)) {
-                td.innerHTML = value.substring('%html'.length);
-              } else {
-                Handsontable.renderers.TextRenderer.apply(this, arguments);
-              }
-            };
-            return cellProperties;
-          }
+          viewportRowRenderingOffset: 0,
+          viewportColumnRenderingOffset: 0
         });
       };
 


### PR DESCRIPTION
### What is this PR for?

The spark 2.0 profile have py4j version 0.10.1, but the spark 2.0.1 dist tarball only contains py4j 0.10.3. Need to update pom.xml for 2.0.1
### What type of PR is it?

Bug Fix
### Todos
- [ ] - Task
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1553
### How should this be tested?

Outline the steps to test the PR here.

```
mvn clean package -Pspark-2.0.1 -Pscala-2.11 -Ppyspark -Pvendor-repo -DskipTests
```
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update?
  No
- Is there breaking changes for older versions?
  No
- Does this needs documentation?
  No
