### PR TITLE
[Zeppelin-1555] Eliminate prefix in PythonInterpreter exception

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -68,7 +68,7 @@ public class PythonInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    LOG.info("Starting Python interpreter .....");
+    LOG.info("Starting Python interpreter ---->");
     LOG.info("Python path is set to:" + property.getProperty(ZEPPELIN_PYTHON));
 
     maxResult = Integer.valueOf(getProperty(MAX_RESULT));
@@ -111,7 +111,7 @@ public class PythonInterpreter extends Interpreter {
 
   @Override
   public void close() {
-    LOG.info("closing Python interpreter .....");
+    LOG.info("closing Python interpreter <----");
     try {
       if (process != null) {
         process.close();
@@ -134,11 +134,9 @@ public class PythonInterpreter extends Interpreter {
 
     InterpreterResult result;
     if (pythonErrorIn(output)) {
-      result = new InterpreterResult(Code.ERROR, output);
+      result = new InterpreterResult(Code.ERROR, output.replaceAll("\\.\\.\\.", ""));
     } else {
-      // TODO(zjffdu), we should not do string replacement operation in the result, as it is
-      // possible that the output contains the kind of pattern itself, e.g. print("...")
-      result = new InterpreterResult(Code.SUCCESS, output.replaceAll("\\.\\.\\.", ""));
+      result = new InterpreterResult(Code.SUCCESS, output);
     }
     return result;
   }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
@@ -91,11 +91,6 @@ public class PythonProcess {
     String line = null;
     while (!(line = reader.readLine()).contains(STATEMENT_END)) {
       logger.debug("Read line from python shell : " + line);
-      if (line.equals("...")) {
-        logger.warn("Syntax error ! ");
-        output.append("Syntax error ! ");
-        break;
-      }
       output.append(line + "\n");
     }
     return output.toString();

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterWithPythonInstalledTest.java
@@ -56,6 +56,8 @@ public class PythonInterpreterWithPythonInstalledTest {
     //System.out.println("\nInterpreter response: \n" + ret.message());
     assertEquals(InterpreterResult.Code.ERROR, ret.code());
     assertTrue(ret.message().length() > 0);
+
+    realPython.close();
   }
 
   @Test
@@ -73,6 +75,36 @@ public class PythonInterpreterWithPythonInstalledTest {
     //System.out.println("\nInterpreter response: \n" + ret.message());
     assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
     assertTrue(ret.message().length() > 0);
+
+    realPython.close();
+  }
+
+  @Test
+  public void testZeppelin1555() {
+    //given
+    PythonInterpreter realPython = new PythonInterpreter(
+            PythonInterpreterTest.getPythonTestProperties());
+    realPython.open();
+
+    //when
+    InterpreterResult ret1 = realPython.interpret("print \"...\"", null);
+
+    //then
+    //System.out.println("\nInterpreter response: \n" + ret.message());
+    assertEquals(InterpreterResult.Code.SUCCESS, ret1.code());
+    assertEquals("...\n", ret1.message());
+
+
+    InterpreterResult ret2 = realPython.interpret("for i in range(5):", null);
+    //then
+    //System.out.println("\nInterpreterResultterpreter response: \n" + ret2.message());
+    assertEquals(InterpreterResult.Code.ERROR, ret2.code());
+    assertEquals("   File \"<stdin>\", line 2\n" +
+            "    \n" +
+            "    ^\n" +
+            "IndentationError: expected an indented block\n", ret2.message());
+
+    realPython.close();
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
Solve bug metioned [here](https://github.com/apache/zeppelin/blob/3dec4d7006b8a57136f34ae330ba937d8990f2d2/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java#L139)

Since we launch python interpreter as a process and redirect stdin and stdout, only exception occurred (like syntax error or indentation error, etc) could give string like `...`. Thus, we don't need to determine whether syntax error happened in [`PythonProcess.sendAndGetResult`](https://github.com/apache/zeppelin/blob/3dec4d7006b8a57136f34ae330ba937d8990f2d2/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java#L86) because we have detected error in [`PythonInterpreter.pythonErrorIn`](https://github.com/apache/zeppelin/blob/3dec4d7006b8a57136f34ae330ba937d8990f2d2/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java#L152)
### What type of PR is it?
Bug Fix

### What is the Jira issue?
Jira: https://issues.apache.org/jira/browse/ZEPPELIN-1555
### How should this be tested?
Test locally.

### Screenshots
<img width="1175" alt="screen shot 2016-10-16 at 18 05 00" src="https://cloud.githubusercontent.com/assets/3419881/19422552/192a8b3a-93cb-11e6-89e8-63f2652a7f85.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No