### PR TITLE
[ ZEPPELIN-1559 ] Code Editor slow performance resolve of the many Notebooks 

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -57,6 +57,7 @@
     }
 
     function initController() {
+      $scope.isDrawNavbarNotebookList = false;
       angular.element('#notebook-list').perfectScrollbar({suppressScrollX: true});
 
       angular.element(document).click(function() {
@@ -121,6 +122,19 @@
 
     $scope.$on('loginSuccess', function(event, param) {
       loadNotes();
+    });
+
+    /*
+    ** Performance optimization for Browser Render.
+    */
+    angular.element(document).ready(function() {
+      angular.element('.notebook-list-dropdown').on('show.bs.dropdown', function() {
+        $scope.isDrawNavbarNotebookList = true;
+      });
+
+      angular.element('.notebook-list-dropdown').on('hide.bs.dropdown', function() {
+        $scope.isDrawNavbarNotebookList = false;
+      });
     });
   }
 

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -25,7 +25,7 @@ limitations under the License.
 
     <div class="collapse navbar-collapse" ng-controller="NavCtrl as navbar">
       <ul class="nav navbar-nav" ng-if="ticket">
-        <li id="notebook-list-button" class="dropdown notebook-list-dropdown" dropdown>
+        <li class="dropdown notebook-list-dropdown" dropdown>
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" dropdown-toggle>Notebook <span class="caret"></span></a>
           <ul class="dropdown-menu navbar-dropdown-maxHeight" role="menu">
             <li><a href="" data-toggle="modal" data-target="#noteNameModal"><i class="fa fa-plus"></i> Create new note</a></li>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -25,12 +25,12 @@ limitations under the License.
 
     <div class="collapse navbar-collapse" ng-controller="NavCtrl as navbar">
       <ul class="nav navbar-nav" ng-if="ticket">
-        <li class="dropdown" dropdown>
-          <a href="#" class="dropdown-toggle" dropdown-toggle>Notebook <span class="caret"></span></a>
+        <li id="notebook-list-button" class="dropdown notebook-list-dropdown" dropdown>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" dropdown-toggle>Notebook <span class="caret"></span></a>
           <ul class="dropdown-menu navbar-dropdown-maxHeight" role="menu">
             <li><a href="" data-toggle="modal" data-target="#noteNameModal"><i class="fa fa-plus"></i> Create new note</a></li>
             <li class="divider"></li>
-            <div id="notebook-list" class="scrollbar-container">
+            <div id="notebook-list" class="scrollbar-container" ng-if="isDrawNavbarNotebookList">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
               <li ng-repeat="note in navbar.notes.root.children | filter:query.q | orderBy:navbar.arrayOrderingSrv.notebookListOrdering track by $index"
                   ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'components/navbar/navbar-notebookList-elem.html'">


### PR DESCRIPTION
### What is this PR for?
Currently, if you have a Notebook large number of,
There is a sharp decrease in performance of the Code editor.
The number and Paragraph creation of the Notebook does not have a relationship.
We are should always use the Code editor of the same performance.

I had to print a Notebook list only if there is a request.
There was quite a lot of performance improvements.


### What type of PR is it?
Improvement

### Todos
- [x] - change Notebook list render logic

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1559
https://issues.apache.org/jira/browse/ZEPPELIN-1513

### How should this be tested?
1. Create a notebook over 1000. (tested 10,000)
   I've used script on this.  (important! please, backup for notebooks directory.)
```
#/bin/bash

idx="0"

while [ $idx -lt 1000 ] # notebooks count 1000
do
  mkdir $idx
  echo """
{
	\"paragraphs\": [
	{
		\"text\": \"fsdkljfowiejfowejfoiwefiowejfiojlkdsjfklsdjflkjsdflkjwlkjefewf\",
			\"dateUpdated\": \"Oct 13, 2016 5:02:44 PM\",
			\"config\": {
				\"colWidth\": 12.0,
			\"graph\": {
				\"mode\": \"table\",
			\"height\": 300.0,
			\"optionOpen\": false,
			\"keys\": [],
			\"values\": [],
			\"groups\": [],
			\"scatter\": {},
			\"map\": {
				\"baseMapType\": \"Streets\",
			\"isOnline\": true,
			\"pinCols\": []
	}
	},
		\"enabled\": true,
		\"editorMode\": \"ace/mode/scala\"
	},
		\"settings\": {
			\"params\": {},
		\"forms\": {}
	},
		\"apps\": [],
		\"jobName\": \"paragraph_1476345687682_-1459653828\",
		\"id\": \"20161013-170127_68316618\",
		\"dateCreated\": \"Oct 13, 2016 5:01:27 PM\",
		\"status\": \"READY\",
		\"progressUpdateIntervalMs\": 500
	}
	],
		\"name\": \""${idx}"\",
		\"id\": \""${idx}"\",
		\"angularObjects\": {
			\"2BZSC9D3G:shared_process\": [],
		\"2BXGWF5TF:shared_process\": [],
		\"2BYKTADMA:shared_process\": [],
		\"2BYFT9HTZ:shared_process\": [],
		\"2BXDTJMED:shared_process\": [],
		\"2BZHPZ6NS:shared_process\": [],
		\"2BYKRWYB3:shared_process\": [],
		\"2BZH2UAT4:shared_process\": [],
		\"2BZ38J35G:shared_process\": [],
		\"2BXJ2X464:shared_process\": [],
		\"2BYQ57ED9:shared_process\": [],
		\"2BXDSA2SN:shared_process\": [],
		\"2BWZCTD2B:shared_process\": [],
		\"2BWT81MNU:shared_process\": [],
		\"2BWA7ZTRD:shared_process\": [],
		\"2BXW6X5KN:shared_process\": [],
		\"2BVWDQPXH:shared_process\": [],
		\"2BZGAF8KG:shared_process\": []
},
	\"config\": {},
	\"info\": {}
	}
  """ > $idx/note.json
  
  idx=$[$idx+1]
done
 
```

2. zeppelin restart or refresh notebook.
3. Try coding in any notebook. (fast)

### Screenshots (if appropriate)
#### before ( 5000 notebooks)
![optimization_before_codeditor](https://cloud.githubusercontent.com/assets/10525473/19457150/f18845a0-94ff-11e6-876d-4386dbf1e7de.gif)

#### after ( 5000 notebooks)
![optimization_for_codeeidtor](https://cloud.githubusercontent.com/assets/10525473/19457184/1f7d5036-9500-11e6-8b0c-91b301641c73.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

