### PR TITLE
[ZEPPELIN-1566] Make paragraph editable with double click

### DIFF
--- a/alluxio/src/main/resources/interpreter-setting.json
+++ b/alluxio/src/main/resources/interpreter-setting.json
@@ -16,6 +16,9 @@
         "defaultValue": "19998",
         "description": "Alluxio master port"
       }
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/angular/src/main/resources/interpreter-setting.json
+++ b/angular/src/main/resources/interpreter-setting.json
@@ -4,7 +4,9 @@
     "name": "angular",
     "className": "org.apache.zeppelin.angular.AngularInterpreter",
     "properties": {
-
+    },
+    "editor": {
+      "editOnDblClick": true
     }
   }
 ]

--- a/beam/src/main/resources/interpreter-setting.json
+++ b/beam/src/main/resources/interpreter-setting.json
@@ -5,7 +5,9 @@
     "className": "org.apache.zeppelin.beam.BeamInterpreter",
     "defaultInterpreter": true,
     "properties": {
-     
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/bigquery/src/main/resources/interpreter-setting.json
+++ b/bigquery/src/main/resources/interpreter-setting.json
@@ -24,7 +24,8 @@
       }
     },
     "editor": {
-      "language": "sql"
+      "language": "sql",
+      "editOnDblClick": false
     }
   }
 ]

--- a/cassandra/src/main/resources/interpreter-setting.json
+++ b/cassandra/src/main/resources/interpreter-setting.json
@@ -190,6 +190,9 @@
         "defaultValue": "true",
         "description": "Cassandra socket TCP no delay. Default = true"
       }
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/docs/development/writingzeppelininterpreter.md
+++ b/docs/development/writingzeppelininterpreter.md
@@ -34,7 +34,7 @@ Interpreters in the same InterpreterGroup can reference each other. For example,
 [InterpreterSetting](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java) is configuration of a given [InterpreterGroup](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java) and a unit of start/stop interpreter.
 All Interpreters in the same InterpreterSetting are launched in a single, separate JVM process. The Interpreter communicates with Zeppelin engine via **[Thrift](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/thrift/RemoteInterpreterService.thrift)**.
 
-In 'Separate Interpreter(scoped / isolated) for each note' mode which you can see at the **Interpreter Setting** menu when you create a new interpreter, new interpreter instance will be created per notebook. But it still runs on the same JVM while they're in the same InterpreterSettings.
+In 'Separate Interpreter(scoped / isolated) for each note' mode which you can see at the **Interpreter Setting** menu when you create a new interpreter, new interpreter instance will be created per note. But it still runs on the same JVM while they're in the same InterpreterSettings.
 
 
 ## Make your own Interpreter
@@ -48,7 +48,7 @@ There are three locations where you can store your interpreter group, name and o
 {ZEPPELIN_INTERPRETER_DIR}/{YOUR_OWN_INTERPRETER_DIR}/interpreter-setting.json
 ```
 
-Here is an example of `interpreter-setting.json` on your own interpreter. Note that if you don't specify editor object, your interpreter will use plain text mode for syntax highlighting.
+Here is an example of `interpreter-setting.json` on your own interpreter.
 
 ```json
 [
@@ -71,7 +71,8 @@ Here is an example of `interpreter-setting.json` on your own interpreter. Note t
       }, ...
     },
     "editor": {
-      "language": "your-syntax-highlight-language"
+      "language": "your-syntax-highlight-language",
+      "editOnDblClick": false
     }
   },
   {
@@ -98,15 +99,18 @@ The name of the interpreter is what you later write to identify a paragraph whic
 some interpreter specific code...
 ```
 
-## Programming Languages for Interpreter
-If the interpreter uses a specific programming language (like Scala, Python, SQL), it is generally recommended to add a syntax highlighting supported for that to the notebook paragraph editor.  
+## Editor setting for Interpreter
+You can add `editor` object to `interpreter-setting.json` file to specify paragraph editor settings.
 
-To check out the list of languages supported, see the `mode-*.js` files under `zeppelin-web/bower_components/ace-builds/src-noconflict` or from [github.com/ajaxorg/ace-builds](https://github.com/ajaxorg/ace-builds/tree/master/src-noconflict).  
+### Language
+If the interpreter uses a specific programming language (like Scala, Python, SQL), it is generally recommended to add a syntax highlighting supported for that to the note paragraph editor.
+
+To check out the list of languages supported, see the `mode-*.js` files under `zeppelin-web/bower_components/ace-builds/src-noconflict` or from [github.com/ajaxorg/ace-builds](https://github.com/ajaxorg/ace-builds/tree/master/src-noconflict).
 
 If you want to add a new set of syntax highlighting,  
 
-1. Add the `mode-*.js` file to <code>[zeppelin-web/bower.json](https://github.com/apache/zeppelin/blob/master/zeppelin-web/bower.json)</code> ( when built, <code>[zeppelin-web/src/index.html](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/index.html)</code> will be changed automatically. ).  
-2. Add `editor` object to `interpreter-setting.json` file. If you want to set your language to `java` for example, add:
+1. Add the `mode-*.js` file to <code>[zeppelin-web/bower.json](https://github.com/apache/zeppelin/blob/master/zeppelin-web/bower.json)</code> (when built, <code>[zeppelin-web/src/index.html](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/index.html)</code> will be changed automatically).
+2. Add `language` field to `editor` object. Note that if you don't specify language field, your interpreter will use plain text mode for syntax highlighting. Let's say you want to set your language to `java`, then add:
 
   ```
   "editor": {
@@ -114,6 +118,14 @@ If you want to add a new set of syntax highlighting,
   }
   ```
 
+### Edit on double click
+If your interpreter uses mark-up language such as markdown or HTML, set `editOnDblClick` to `true` so that text editor opens on pargraph double click and closes on paragraph run. Otherwise set it to `false`.
+
+```
+"editor": {
+  "editOnDblClick": false
+}
+```
 ## Install your interpreter binary
 
 Once you have built your interpreter, you can place it under the interpreter directory with all its dependencies.
@@ -150,7 +162,7 @@ Now you are done and ready to use your interpreter.
 ## Use your interpreter
 
 ### 0.5.0
-Inside of a notebook, `%[INTERPRETER_NAME]` directive will call your interpreter.
+Inside of a note, `%[INTERPRETER_NAME]` directive will call your interpreter.
 Note that the first interpreter configuration in zeppelin.interpreters will be the default one.
 
 For example,
@@ -163,7 +175,7 @@ println(a)
 ```
 
 ### 0.6.0 and later
-Inside of a notebook, `%[INTERPRETER_GROUP].[INTERPRETER_NAME]` directive will call your interpreter.
+Inside of a note, `%[INTERPRETER_GROUP].[INTERPRETER_NAME]` directive will call your interpreter.
 
 You can omit either [INTERPRETER\_GROUP] or [INTERPRETER\_NAME]. If you omit [INTERPRETER\_NAME], then first available interpreter will be selected in the [INTERPRETER\_GROUP].
 Likewise, if you skip [INTERPRETER\_GROUP], then [INTERPRETER\_NAME] will be chosen from default interpreter group.
@@ -216,7 +228,7 @@ Checkout some interpreters released with Zeppelin by default.
 We welcome contribution to a new interpreter. Please follow these few steps:
 
  - First, check out the general contribution guide [here](https://zeppelin.apache.org/contribution/contributions.html).
- - Follow the steps in [Make your own Interpreter](#make-your-own-interpreter) section above.
+ - Follow the steps in [Make your own Interpreter](#make-your-own-interpreter) section and [Editor setting for Interpreter](#editor-setting-for-interpreter) above.
  - Add your interpreter as in the [Configure your interpreter](#configure-your-interpreter) section above; also add it to the example template [zeppelin-site.xml.template](https://github.com/apache/zeppelin/blob/master/conf/zeppelin-site.xml.template).
  - Add tests! They are run by [Travis](https://travis-ci.org/apache/zeppelin) for all changes and it is important that they are self-contained.
  - Include your interpreter as a module in [`pom.xml`](https://github.com/apache/zeppelin/blob/master/pom.xml).

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -55,7 +55,7 @@ Stable binary packages are available on the [Apache Zeppelin Download Page](http
 
 If you downloaded the default package, just unpack it in a directory of your choice and you're ready to go. If you downloaded the *net-install* package, you should manually [install additional interpreters](../manual/interpreterinstallation.html) first. You can also install everything by running `./bin/install-interpreter.sh --all`.
 
-After unpacking, jump to the [Starting Apache Zeppelin with Command Line](#starting-apache-zeppelin-with-command-line).
+After unpacking, jump to the [Starting Apache Zeppelin from Command Line](#starting-apache-zeppelin-from-the-command-line).
 
 ### Building from Source
 
@@ -178,7 +178,7 @@ chdir /usr/share/zeppelin
 exec bin/zeppelin-daemon.sh upstart
 ```
 
-## Next Steps:
+## Next Steps
 
 Congratulations, you have successfully installed Apache Zeppelin! Here are two next steps you might find useful:
 

--- a/elasticsearch/src/main/resources/interpreter-setting.json
+++ b/elasticsearch/src/main/resources/interpreter-setting.json
@@ -28,6 +28,9 @@
         "defaultValue": "10",
         "description": "The size of the result set of a search query"
       }
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/file/src/main/resources/interpreter-setting.json
+++ b/file/src/main/resources/interpreter-setting.json
@@ -22,6 +22,9 @@
         "defaultValue": "1000",
         "description": "Maximum number of lines of results fetched"
       }
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -18,7 +18,8 @@
       }
     },
     "editor": {
-      "language": "scala"
+      "language": "scala",
+      "editOnDblClick": false
     }
   }
 ]

--- a/hbase/src/main/resources/interpreter-setting.json
+++ b/hbase/src/main/resources/interpreter-setting.json
@@ -20,6 +20,9 @@
         "defaultValue": "false",
         "description": "Disable checks for unit and manual tests"
       }
+    },
+    "editor": {
+      "editOnDblClick": false
     }
   }
 ]

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -66,7 +66,8 @@
       }
     },
     "editor": {
-      "language": "sql"
+      "language": "sql",
+      "editOnDblClick": false
     }
   }
 ]

--- a/kylin/src/main/resources/interpreter-setting.json
+++ b/kylin/src/main/resources/interpreter-setting.json
@@ -48,7 +48,8 @@
       }
     },
     "editor": {
-      "language": "sql"
+      "language": "sql",
+      "editOnDblClick": false
     }
   }
 ]

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -94,7 +94,8 @@
       }
     },
     "editor": {
-      "language": "scala"
+      "language": "scala",
+      "editOnDblClick": false
     }
   },
   {
@@ -115,7 +116,8 @@
       }
     },
     "editor": {
-      "language": "sql"
+      "language": "sql",
+      "editOnDblClick": false
     }
   },
   {
@@ -125,7 +127,8 @@
     "properties": {
     },
     "editor": {
-      "language": "python"
+      "language": "python",
+      "editOnDblClick": false
     }
   },
   {
@@ -135,7 +138,8 @@
     "properties": {
     },
     "editor": {
-      "language": "r"
+      "language": "r",
+      "editOnDblClick": false
     }
   }
 ]

--- a/markdown/src/main/resources/interpreter-setting.json
+++ b/markdown/src/main/resources/interpreter-setting.json
@@ -13,7 +13,7 @@
     },
     "editor": {
       "language": "markdown",
-      "editOnDblClick": "true"
+      "editOnDblClick": true
     }
   }
 ]

--- a/markdown/src/main/resources/interpreter-setting.json
+++ b/markdown/src/main/resources/interpreter-setting.json
@@ -12,7 +12,8 @@
       }
     },
     "editor": {
-      "language": "markdown"
+      "language": "markdown",
+      "editOnDblClick": "true"
     }
   }
 ]

--- a/pig/src/main/resources/interpreter-setting.json
+++ b/pig/src/main/resources/interpreter-setting.json
@@ -40,7 +40,8 @@
       }
     },
     "editor": {
-      "language": "pig"
+      "language": "pig",
+      "editOnDblClick": false
     }
   }
 ]

--- a/pig/src/main/resources/interpreter-setting.json
+++ b/pig/src/main/resources/interpreter-setting.json
@@ -18,7 +18,8 @@
       }
     },
     "editor": {
-      "language": "pig"
+      "language": "pig",
+      "editOnDblClick": false
     }
   },
   {

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -18,13 +18,19 @@
       }
     },
     "editor": {
-      "language": "python"
+      "language": "python",
+      "editOnDblClick": false
     }
   },
   {
     "group": "python",
     "name": "sql",
     "className": "org.apache.zeppelin.python.PythonInterpreterPandasSql",
-    "properties": { }
+    "properties": {
+    },
+    "editor":{
+      "language": "sql",
+      "editOnDblClick": false
+    }
   }
 ]

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -30,7 +30,8 @@
       }
     },
     "editor": {
-      "language": "sh"
+      "language": "sh",
+      "editOnDblClick": false
     }
   }
 ]

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -56,7 +56,8 @@
       }
     },
     "editor": {
-      "language": "scala"
+      "language": "scala",
+      "editOnDblClick": false
     }
   },
   {
@@ -90,7 +91,8 @@
       }
     },
     "editor": {
-      "language": "sql"
+      "language": "sql",
+      "editOnDblClick": false
     }
   },
   {
@@ -112,7 +114,8 @@
       }
     },
     "editor": {
-      "language": "scala"
+      "language": "scala",
+      "editOnDblClick": false
     }
   },
   {
@@ -128,7 +131,8 @@
       }
     },
     "editor": {
-      "language": "python"
+      "language": "python",
+      "editOnDblClick": false
     }
   }
 ]

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -461,6 +461,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       action.doubleClick(driver.findElement(By.xpath(getParagraphXPath(1)))).perform();
+      ZeppelinITUtils.sleep(1000, false);
       collector.checkThat("Markdown editor is shown after double click ",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(true));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -429,5 +429,50 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
     }
   }
 
+  @Test
+  public void testEditOnDoubleClick() throws Exception {
+    if (!endToEndTestEnabled()) {
+      return;
+    }
+    try {
+      createNewNote();
+      Actions action = new Actions(driver);
 
+      waitForParagraph(1, "READY");
+
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "5");
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys("md" + Keys.ENTER);
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "3");
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(" abc");
+
+      runParagraph(1);
+      waitForParagraph(1, "FINISHED");
+
+      collector.checkThat("Markdown editor is hidden after run ",
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
+          CoreMatchers.equalTo(false));
+
+      collector.checkThat("Markdown editor is shown after run ",
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.tableHide')]")).isDisplayed(),
+          CoreMatchers.equalTo(true));
+
+      // to check if editOnDblClick field is fetched correctly after refresh
+      driver.navigate().refresh();
+      waitForParagraph(1, "FINISHED");
+
+      action.doubleClick(driver.findElement(By.xpath(getParagraphXPath(1)))).perform();
+      collector.checkThat("Markdown editor is shown after double click ",
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
+          CoreMatchers.equalTo(true));
+
+      collector.checkThat("Markdown editor is hidden after double click ",
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.tableHide')]")).isDisplayed(),
+          CoreMatchers.equalTo(false));
+
+      deleteTestNotebook(driver);
+
+    } catch (Exception e) {
+      handleException("Exception in ParagraphActionsIT while testEditOnDoubleClick ", e);
+    }
+  }
 }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -139,6 +139,10 @@
     // register mouseevent handler for focus paragraph
     document.addEventListener('keydown', $scope.keyboardShortcut);
 
+    $scope.paragraphOnDoubleClick = function(paragraphId) {
+      $scope.$broadcast('doubleClickParagraph', paragraphId);
+    };
+
     /** Remove the note and go back tot he main page */
     /** TODO(anthony): In the nearly future, go back to the main page and telle to the dude that the note have been remove */
     $scope.removeNote = function(noteId) {
@@ -352,7 +356,7 @@
       } else {
         $scope.viewOnly = $scope.note.config.looknfeel === 'report' ? true : false;
       }
-      $scope.note.paragraphs[0].focus = true;
+      //$scope.note.paragraphs[0].focus = true;
       $rootScope.$broadcast('setLookAndFeel', $scope.note.config.looknfeel);
     };
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -356,7 +356,7 @@
       } else {
         $scope.viewOnly = $scope.note.config.looknfeel === 'report' ? true : false;
       }
-      //$scope.note.paragraphs[0].focus = true;
+      $scope.note.paragraphs[0].focus = true;
       $rootScope.$broadcast('setLookAndFeel', $scope.note.config.looknfeel);
     };
 

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -113,7 +113,8 @@ limitations under the License.
          ng-include src="'app/notebook/paragraph/paragraph.html'"
          ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused,
                     'lastEmptyParagraph': !paragraph.text && !paragraph.result}"
-         ng-hide="currentParagraph.config.tableHide && viewOnly">
+         ng-hide="currentParagraph.config.tableHide && viewOnly"
+         ng-dblclick="paragraphOnDoubleClick(currentParagraph.id);">
     </div>
     <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || asIframe ">
       <h4 class="plus-sign">&#43;</h4>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -420,23 +420,18 @@
     };
 
     var openEditorAndCloseTable = function() {
-      console.log('open editor and close output');
-
-      var newParams = angular.copy($scope.paragraph.settings.params);
-      var newConfig = angular.copy($scope.paragraph.config);
-      newConfig.editorHide = false;
-      newConfig.tableHide = true;
-
-      commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
+      manageEditorAndTableState(false, true);
     };
 
     var closeEditorAndOpenTable = function() {
-      console.log('close editor and open output');
+      manageEditorAndTableState(true, false);
+    };
 
+    var manageEditorAndTableState = function(showEditor, showTable) {
       var newParams = angular.copy($scope.paragraph.settings.params);
       var newConfig = angular.copy($scope.paragraph.config);
-      newConfig.editorHide = true;
-      newConfig.tableHide = false;
+      newConfig.editorHide = showEditor;
+      newConfig.tableHide = showTable;
 
       commitParagraph($scope.paragraph.title, $scope.paragraph.text, newConfig, newParams);
     };

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -763,7 +763,7 @@
       // or the first 30 characters of the paragraph have been modified
       // or cursor position is at beginning of second line.(in case user hit enter after typing %magic)
       if ((typeof pos === 'undefined') || (pos.row === 0 && pos.column < 30) ||
-          (pos.row === 1 && pos.column === 0) || pastePercentSign) {
+          (pos.row === 1 && pos.column === 0) || pastePercentSign || $scope.paragraphFocused) {
         // If paragraph loading, use config value if exists
         if ((typeof pos === 'undefined') && $scope.paragraph.config.editorMode) {
           session.setMode($scope.paragraph.config.editorMode);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -67,8 +67,7 @@ limitations under the License.
          class="executionTime" ng-bind-html="getExecutionTime()">
     </div>
     <div ng-if = "paragraph.status === 'RUNNING'" class = "paragraphFooterElapsed">
-      <div
-           id="{{paragraph.id}}_elapsedTime"
+      <div id="{{paragraph.id}}_elapsedTime"
            class="elapsedTime" ng-bind-html="getElapsedTime()">
       </div>
     </div>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -127,6 +127,10 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   private Interpreter devInterpreter;
 
+  private static final Map<String, Object> DEFAULT_EDITOR = ImmutableMap.of(
+      "language", (Object) "text",
+      "editOnDblClick", false);
+
   public InterpreterFactory(ZeppelinConfiguration conf,
       AngularObjectRegistryListener angularObjectRegistryListener,
       RemoteInterpreterProcessListener remoteInterpreterProcessListener,
@@ -429,11 +433,15 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       String className) {
     List<InterpreterInfo> intpInfos = intpSetting.getInterpreterInfos();
     for (InterpreterInfo intpInfo : intpInfos) {
+
       if (className.equals(intpInfo.getClassName())) {
+        if (intpInfo.getEditor() == null) {
+          break;
+        }
         return intpInfo.getEditor();
       }
     }
-    return ImmutableMap.of("language", (Object) "text");
+    return DEFAULT_EDITOR;
   }
 
   private void loadInterpreterDependencies(final InterpreterSetting setting) {
@@ -1349,10 +1357,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   public Map<String, Object> getEditorSetting(String user, String noteId, String replName) {
     Interpreter intp = getInterpreter(user, noteId, replName);
-    Map<String, Object> editor = Maps.newHashMap(
-        ImmutableMap.<String, Object>builder()
-            .put("language", "text")
-            .put("editOnDblClick", false).build());
+    Map<String, Object> editor = DEFAULT_EDITOR;
     String defaultSettingName = getDefaultInterpreterSetting(noteId).getName();
     String group = StringUtils.EMPTY;
     try {
@@ -1373,7 +1378,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         }
       }
     } catch (NullPointerException e) {
-      logger.warn("Couldn't get interpreter editor language");
+      logger.warn("Couldn't get interpreter editor setting");
     }
     return editor;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1351,7 +1351,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     Interpreter intp = getInterpreter(user, noteId, replName);
     Map<String, Object> editor = Maps.newHashMap(
         ImmutableMap.<String, Object>builder()
-            .put("language", "text").build());
+            .put("language", "text")
+            .put("editOnDblClick", "false").build());
     String defaultSettingName = getDefaultInterpreterSetting(noteId).getName();
     String group = StringUtils.EMPTY;
     try {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1352,7 +1352,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     Map<String, Object> editor = Maps.newHashMap(
         ImmutableMap.<String, Object>builder()
             .put("language", "text")
-            .put("editOnDblClick", "false").build());
+            .put("editOnDblClick", false).build());
     String defaultSettingName = getDefaultInterpreterSetting(noteId).getName();
     String group = StringUtils.EMPTY;
     try {


### PR DESCRIPTION
### What is this PR for?
This PR enables edit on double click for markdown/angular paragraph.  Users can change `editOnDblClick` field to be `false` by editting `interpreter/md/interpreter-setting.json` or  `conf/interpreter.json`. In the same context, users can set other type paragraphs to be editable on double click by setting `editOnDblClick` to be true.

This PR also fixes bug that syntax highlight doesn't work on pasted code.

### What type of PR is it?
Feature

### Todos
* [x] Create test
* [x] Update docs

### What is the Jira issue?
[ZEPPELIN-1566](https://issues.apache.org/jira/browse/ZEPPELIN-1566)

### How should this be tested?
1. Create new markdown interpreter
2. Create notebook and run markdown paragraph
3. Double click markdown paragraph to edit

### Screenshots (if appropriate)

**Edit on double click and hide editor on paragraph run**
![oct-20-2016 12-28-54](https://cloud.githubusercontent.com/assets/8503346/19545401/ca2a69a8-96c0-11e6-9e70-ca930fd7cc8e.gif)


**Syntax highlight on paste**

Before
![oct-20-2016 12-24-54](https://cloud.githubusercontent.com/assets/8503346/19545333/46a2f2a8-96c0-11e6-910a-2a216da5603b.gif)

After
![oct-20-2016 12-25-06](https://cloud.githubusercontent.com/assets/8503346/19545338/4d3bb852-96c0-11e6-8dc4-ff839234876a.gif)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes
