### PR TITLE
Add missing TOC(Table of Contents) in install_with_flink_and_spark_cluster.md

### DIFF
--- a/docs/quickstart/install_with_flink_and_spark_cluster.md
+++ b/docs/quickstart/install_with_flink_and_spark_cluster.md
@@ -18,6 +18,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+{% include JB/setup %}
+
+# Install with flink and spark cluster
+
+<div id="toc"></div>
+
 This tutorial is extremely entry-level. It assumes no prior knowledge of Linux, git, or other tools. If you carefully type what I tell you when I tell you, you should be able to get Zeppelin running.
 
 ## Installing Zeppelin with Flink and Spark in cluster mode


### PR DESCRIPTION
### What is this PR for?
Add missing TOC(Table of Contents) in install_with_flink_and_spark_cluster.md

### What type of PR is it?
Documentation

### What is the Jira issue?
no Jira issue for this 

