### PR TITLE
[ Hotfix ] Incorrect (per user) setup ui for "create new interpreter component"

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -37,45 +37,165 @@ limitations under the License.
 
         <div>
           <h5>Option</h5>
-          <span class="checkbox input-group">
-            <label><input type="checkbox" style="width:0%;height:0%" id="perNote" ng-model="newInterpreterSetting.option.perNote"/>
-            perNote </label>
-          </span>
-          <span class="checkbox input-group">
-            <label><input type="checkbox" style="width:0%;height:0%" id="perUser" ng-model="newInterpreterSetting.option.perUser"/>
-            perUser</label>
-          </span>
-          <span class="btn-group">
-            <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                    data-toggle="dropdown">
-              {{getSessionOption(newInterpreterSetting.id)}} <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu" role="menu">
-              <li>
-                <a style="cursor:pointer"
-                   tooltip="Single interpreter instance are shared across notes"
-                   ng-click="setSessionOption(newInterpreterSetting.id, 'shared')">
-                  shared
-                </a>
-              </li>
-              <li>
-                <a style="cursor:pointer"
-                   tooltip="Separate Interpreter instance for each note"
-                   ng-click="setSessionOption(newInterpreterSetting.id, 'scoped')">
-                  scoped
-                </a>
-              </li>
-              <li>
-                <a style="cursor:pointer"
-                   tooltip="Separate Interpreter process for each note"
-                   ng-click="setSessionOption(setting.id, 'isolated')">
-                  isolated
-                </a>
-              </li>
-            </ul>
-          </span>
-        </div>
+          <div class="row interpreter" style="margin-top: 5px;">
+            <div class="col-md-6">
+              The interpreter will be instantiated
+              <span class="btn-group">
+              <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                      data-toggle="dropdown"
+              >
+                {{getInterpreterRunningOption(setting.id)}} <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu">
+                <li>
+                  <a style="cursor:pointer"
+                     ng-click="setInterpreterRunningOption(setting.id, 'shared', 'shared')">
+                    Globally
+                  </a>
+                </li>
+                <li>
+                  <a style="cursor:pointer"
+                     ng-click="setInterpreterRunningOption(setting.id, 'scoped', '')">
+                    Per Note
+                  </a>
+                </li>
+                <li ng-if="ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+                  <a style="cursor:pointer"
+                     ng-click="setInterpreterRunningOption(setting.id, 'shared', 'scoped')">
+                    Per User
+                  </a>
+                </li>
+              </ul>
+            </span>
+              in
+              <span class="btn-group">
+              <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                      data-toggle="dropdown"
+                      ng-disabled="getInterpreterRunningOption(setting.id) === 'Globally'">
+                <span ng-if="getInterpreterRunningOption(setting.id) !== 'Per User'">
+                  {{getPerNoteOption(setting.id)}}
+                </span>
+                <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User'">
+                  {{getPerUserOption(setting.id)}}
+                </span>
+                  <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" role="menu">
+                <li
+                  ng-if="getInterpreterRunningOption(setting.id) === 'Globally'">
+                  <a style="cursor:pointer"
+                     tooltip="Single interpreter instance are shared across notes"
+                     ng-click="setPerNoteOption(setting.id, 'shared')">
+                    shared per note
+                  </a>
+                </li>
 
+                <li>
+                  <a style="cursor:pointer"
+                     ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
+                     tooltip="Separate Interpreter instance for each note"
+                     ng-click="setPerNoteOption(setting.id, 'scoped')">
+                    scoped per note
+                  </a>
+                </li>
+                <li>
+                  <a style="cursor:pointer"
+                     ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
+                     tooltip="Separate Interpreter instance for each note"
+                     ng-click="setPerUserOption(setting.id, 'scoped')">
+                    scoped per user
+                  </a>
+                </li>
+
+                <li>
+                  <a style="cursor:pointer"
+                     ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
+                     tooltip="Separate Interpreter process for each note"
+                     ng-click="setPerNoteOption(setting.id, 'isolated')">
+                    isolated per note
+                  </a>
+                </li>
+                <li>
+                  <a style="cursor:pointer"
+                     ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
+                     tooltip="Separate Interpreter process for each note"
+                     ng-click="setPerUserOption(setting.id, 'isolated')">
+                    isolated per user
+                  </a>
+                </li>
+              </ul>
+            </span>
+              process.
+            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+              <span ng-if="getPerNoteOption(setting.id) === 'shared'">
+                <button type="button" class="btn btn-default btn-xs"
+                        ng-click="setPerNoteOption(setting.id, 'scoped')"
+                        data-toggle="dropdown">
+                  <i class="fa fa-plus"></i>
+                </button>
+              </span>
+            </span>
+            </div>
+            <div class="col-md-6">
+              &nbsp;
+            </div>
+          </div>
+          <div class="row interpreter"
+               style="margin-top: 6px;"
+               ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
+                      && ticket.ticket !== 'anonymous'
+                      && ticket.roles !== '[]'
+                      && getPerNoteOption(setting.id) !== 'shared'">
+            <div class="col-md-12">
+              <span>
+                <span class="hidden-xs" style="padding-left: 190px;">And </span>
+                <span class="visible-xs" style="padding-left: 0px;">And </span>
+                <span class="btn-group">
+                  <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                          data-toggle="dropdown"
+                          ng-disabled="true">
+                    <span>
+                      Per Note
+                    </span>
+                    <span class="caret"></span>
+                  </button>
+                </span>
+                in
+                <span class="btn-group">
+                  <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                          data-toggle="dropdown">
+                    <span>
+                      {{getPerNoteOption(setting.id)}}
+                    </span>
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu" role="menu">
+                    <li>
+                      <a style="cursor:pointer"
+                         tooltip="Separate Interpreter instance for each note"
+                         ng-click="setPerNoteOption(setting.id, 'scoped')">
+                        scoped per note
+                      </a>
+                    </li>
+                    <li>
+                      <a style="cursor:pointer"
+                         tooltip="Separate Interpreter process for each note"
+                         ng-click="setPerNoteOption(setting.id, 'isolated')">
+                        isolated per note
+                      </a>
+                    </li>
+                  </ul>
+                </span>
+                process.
+                <button type="button" class="btn btn-default btn-xs"
+                        ng-click="setPerNoteOption(setting.id, 'shared')"
+                        data-toggle="dropdown">
+                  <i class="fa fa-minus"></i>
+                </button>
+              </span>
+            </div>
+          </div>
+        </div>
         <div class="row interpreter" style="margin-top: 5px;">
           <div class="col-md-12">
             <div class="checkbox remove-margin-top-bottom">

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -250,61 +250,61 @@ limitations under the License.
             &nbsp;
           </div>
         </div>
-        <div class="row interpreter" style="margin-top: 6px;">
-          <div class="col-md-6">
-            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
-              <span ng-if="getPerNoteOption(setting.id) !== 'shared'">
-                <span class="hidden-xs" style="padding-left: 190px;">And </span>
-                <span class="visible-xs" style="padding-left: 0px;">And </span>
-                <span class="btn-group">
-                  <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                          data-toggle="dropdown"
-                          ng-disabled="true">
-                    <span>
-                      Per Note
-                    </span>
-                    <span class="caret"></span>
-                  </button>
-                </span>
-                in
-                <span class="btn-group">
-                  <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                          data-toggle="dropdown"
-                          ng-disabled="!valueform.$visible">
-                    <span>
-                      {{getPerNoteOption(setting.id)}}
-                    </span>
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu" role="menu">
-                    <li>
-                      <a style="cursor:pointer"
-                         tooltip="Separate Interpreter instance for each note"
-                         ng-click="setPerNoteOption(setting.id, 'scoped')">
-                        scoped per note
-                      </a>
-                    </li>
-                    <li>
-                      <a style="cursor:pointer"
-                         tooltip="Separate Interpreter process for each note"
-                         ng-click="setPerNoteOption(setting.id, 'isolated')">
-                        isolated per note
-                      </a>
-                    </li>
-                  </ul>
-                </span>
-                process.
-                <button type="button" class="btn btn-default btn-xs"
-                        ng-disabled="!valueform.$visible"
-                        ng-click="setPerNoteOption(setting.id, 'shared')"
-                        data-toggle="dropdown">
-                  <i class="fa fa-minus"></i>
+        <div class="row interpreter"
+             style="margin-top: 6px;"
+             ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
+                    && ticket.ticket !== 'anonymous'
+                    && ticket.roles !== '[]'
+                    && getPerNoteOption(setting.id) !== 'shared'">
+          <div class="col-md-12">
+            <span>
+              <span class="hidden-xs" style="padding-left: 190px;">And </span>
+              <span class="visible-xs" style="padding-left: 0px;">And </span>
+              <span class="btn-group">
+                <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                        data-toggle="dropdown"
+                        ng-disabled="true">
+                  <span>
+                    Per Note
+                  </span>
+                  <span class="caret"></span>
                 </button>
               </span>
+              in
+              <span class="btn-group">
+                <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                        data-toggle="dropdown"
+                        ng-disabled="!valueform.$visible">
+                  <span>
+                    {{getPerNoteOption(setting.id)}}
+                  </span>
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu">
+                  <li>
+                    <a style="cursor:pointer"
+                       tooltip="Separate Interpreter instance for each note"
+                       ng-click="setPerNoteOption(setting.id, 'scoped')">
+                      scoped per note
+                    </a>
+                  </li>
+                  <li>
+                    <a style="cursor:pointer"
+                       tooltip="Separate Interpreter process for each note"
+                       ng-click="setPerNoteOption(setting.id, 'isolated')">
+                      isolated per note
+                    </a>
+                  </li>
+                </ul>
+              </span>
+              process.
+              <button type="button" class="btn btn-default btn-xs"
+                      ng-disabled="!valueform.$visible"
+                      ng-click="setPerNoteOption(setting.id, 'shared')"
+                      data-toggle="dropdown">
+                <i class="fa fa-minus"></i>
+              </button>
             </span>
-          </div>
-          <div class="col-md-6">
-            &nbsp;
           </div>
         </div>
       </div>


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
Bug Fix

### Todos
- [x] fix to text margin top
- [x] implement to (per note / per user) setup feature of create new insterpreter 

### How should this be tested?
1. on click interpreter menu.
2. on click interpreter menu.
3. check per user and per note setting. (`per user` setting must be shiro is activated)
4. save and check to result.

### Screenshots (if appropriate)
#### - Create new Interpreter  - before
![pernotebefore](https://cloud.githubusercontent.com/assets/10525473/19588103/6d1236a4-979e-11e6-972b-bb6d35f83ac5.png)

#### - Create new Interpreter  - after
![new create interpreter](https://cloud.githubusercontent.com/assets/10525473/19588118/87ad23ca-979e-11e6-9a2b-4ec8be27c74f.png)

#### - fix margin for interpreter settings  - before
![pernotebefore](https://cloud.githubusercontent.com/assets/10525473/19588140/a8b701ee-979e-11e6-804b-4e39c063281d.png)

#### - fix margin for interpreter settings  - after
![margin](https://cloud.githubusercontent.com/assets/10525473/19588145/b13ca8f0-979e-11e6-9a02-186b92a0dad1.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

