### PR TITLE
[ZEPPELIN-917] Apply new mechanism to LensInterpreter

### DIFF
--- a/lens/src/main/java/org/apache/zeppelin/lens/LensInterpreter.java
+++ b/lens/src/main/java/org/apache/zeppelin/lens/LensInterpreter.java
@@ -88,21 +88,7 @@ public class LensInterpreter extends Interpreter {
   private LensClient m_lensClient;
   
 
-  /*static {
-    Interpreter.register(
-      "lens",
-      "lens",
-      LensInterpreter.class.getName(),
-      new InterpreterPropertyBuilder()
-        .add(ZEPPELIN_LENS_RUN_CONCURRENT_SESSION, "true", "Run concurrent Lens Sessions")
-        .add(ZEPPELIN_LENS_CONCURRENT_SESSIONS, "10", 
-          "If concurrency is true then how many threads?")
-        .add(ZEPPELIN_MAX_ROWS, "1000", "max number of rows to display")
-        .add(LENS_SERVER_URL, "http://<hostname>:<port>/lensapi", "The URL for Lens Server")
-        .add(LENS_CLIENT_DBNAME, "default", "The database schema name")
-        .add(LENS_PERSIST_RESULTSET, "false", "Apache Lens to persist result in HDFS?")
-        .add(LENS_SESSION_CLUSTER_USER, "default", "Hadoop cluster username").build());
-  }*/
+
 
   public LensInterpreter(Properties property) {
     super(property);

--- a/lens/src/main/java/org/apache/zeppelin/lens/LensInterpreter.java
+++ b/lens/src/main/java/org/apache/zeppelin/lens/LensInterpreter.java
@@ -88,7 +88,7 @@ public class LensInterpreter extends Interpreter {
   private LensClient m_lensClient;
   
 
-  static {
+  /*static {
     Interpreter.register(
       "lens",
       "lens",
@@ -102,7 +102,7 @@ public class LensInterpreter extends Interpreter {
         .add(LENS_CLIENT_DBNAME, "default", "The database schema name")
         .add(LENS_PERSIST_RESULTSET, "false", "Apache Lens to persist result in HDFS?")
         .add(LENS_SESSION_CLUSTER_USER, "default", "Hadoop cluster username").build());
-  }
+  }*/
 
   public LensInterpreter(Properties property) {
     super(property);

--- a/lens/src/main/resources/interpreter-setting.json
+++ b/lens/src/main/resources/interpreter-setting.json
@@ -1,0 +1,52 @@
+[
+  {
+    "group": "lens",
+    "name": "lens",
+    "className": "org.apache.zeppelin.lens.LensInterpreter",
+    "properties": {
+      "zeppelin.lens.run.concurrent": {
+        "envName": null,
+        "propertyName": "zeppelin.lens.run.concurrent",
+        "defaultValue": "true",
+        "description": "Run concurrent Lens Sessions"
+      },
+      "zeppelin.lens.maxThreads": {
+        "envName": null,
+        "propertyName": "zeppelin.lens.maxThreads",
+        "defaultValue": "10",
+        "description": "If concurrency is true then how many threads?"
+      },
+      "zeppelin.lens.maxResults": {
+        "envName": null,
+        "propertyName": "zeppelin.lens.maxResults",
+        "defaultValue": "1000",
+        "description": "max number of rows to display"
+      },
+       "lens.server.base.url": {
+        "envName": null,
+        "propertyName": "lens.server.base.url",
+        "defaultValue": "http://<hostname>:<port>/lensapi",
+        "description": "The URL for Lens Server"
+      },
+      "lens.client.dbname": {
+        "envName": null,
+        "propertyName": "lens.client.dbname",
+        "defaultValue": "default",
+        "description": "The database schema name"
+      },
+       "lens.query.enable.persistent.resultset": {
+        "envName": null,
+        "propertyName": "lens.query.enable.persistent.resultset",
+        "defaultValue": "false",
+        "description": "Apache Lens to persist result in HDFS?"
+      },
+         "lens.session.cluster.user": {
+        "envName": null,
+        "propertyName": "lens.session.cluster.user",
+        "defaultValue": "default",
+        "description": "Hadoop cluster username"
+      }
+    }
+    
+  }
+]

--- a/lens/src/main/resources/interpreter-setting.json
+++ b/lens/src/main/resources/interpreter-setting.json
@@ -1,52 +1,51 @@
 [
-  {
-    "group": "lens",
-    "name": "lens",
-    "className": "org.apache.zeppelin.lens.LensInterpreter",
-    "properties": {
-      "zeppelin.lens.run.concurrent": {
-        "envName": null,
-        "propertyName": "zeppelin.lens.run.concurrent",
-        "defaultValue": "true",
-        "description": "Run concurrent Lens Sessions"
-      },
-      "zeppelin.lens.maxThreads": {
-        "envName": null,
-        "propertyName": "zeppelin.lens.maxThreads",
-        "defaultValue": "10",
-        "description": "If concurrency is true then how many threads?"
-      },
-      "zeppelin.lens.maxResults": {
-        "envName": null,
-        "propertyName": "zeppelin.lens.maxResults",
-        "defaultValue": "1000",
-        "description": "max number of rows to display"
-      },
-       "lens.server.base.url": {
-        "envName": null,
-        "propertyName": "lens.server.base.url",
-        "defaultValue": "http://<hostname>:<port>/lensapi",
-        "description": "The URL for Lens Server"
-      },
-      "lens.client.dbname": {
-        "envName": null,
-        "propertyName": "lens.client.dbname",
-        "defaultValue": "default",
-        "description": "The database schema name"
-      },
-       "lens.query.enable.persistent.resultset": {
-        "envName": null,
-        "propertyName": "lens.query.enable.persistent.resultset",
-        "defaultValue": "false",
-        "description": "Apache Lens to persist result in HDFS?"
-      },
-         "lens.session.cluster.user": {
-        "envName": null,
-        "propertyName": "lens.session.cluster.user",
-        "defaultValue": "default",
-        "description": "Hadoop cluster username"
-      }
-    }
-    
-  }
+	{
+		"group": "lens",
+		"name": "lens",
+		"className": "org.apache.zeppelin.lens.LensInterpreter",
+		"properties": {
+			"zeppelin.lens.run.concurrent": {
+				"envName": null,
+				"propertyName": "zeppelin.lens.run.concurrent",
+				"defaultValue": "true",
+				"description": "Run concurrent Lens Sessions"
+			},
+			"zeppelin.lens.maxThreads": {
+				"envName": null,
+				"propertyName": "zeppelin.lens.maxThreads",
+				"defaultValue": "10",
+				"description": "If concurrency is true then how many threads?"
+			},
+			"zeppelin.lens.maxResults": {
+				"envName": null,
+				"propertyName": "zeppelin.lens.maxResults",
+				"defaultValue": "1000",
+				"description": "max number of rows to display"
+			},
+			"lens.server.base.url": {
+				"envName": null,
+				"propertyName": "lens.server.base.url",
+				"defaultValue": "http://<hostname>:<port>/lensapi",
+				"description": "The URL for Lens Server"
+			},
+			"lens.client.dbname": {
+				"envName": null,
+				"propertyName": "lens.client.dbname",
+				"defaultValue": "default",
+				"description": "The database schema name"
+			},
+			"lens.query.enable.persistent.resultset": {
+				"envName": null,
+				"propertyName": "lens.query.enable.persistent.resultset",
+				"defaultValue": "false",
+				"description": "Apache Lens to persist result in HDFS?"
+			},
+			"lens.session.cluster.user": {
+				"envName": null,
+				"propertyName": "lens.session.cluster.user",
+				"defaultValue": "default",
+				"description": "Hadoop cluster username"
+			}
+		}
+	}
 ]

--- a/lens/src/main/resources/interpreter-setting.json
+++ b/lens/src/main/resources/interpreter-setting.json
@@ -1,51 +1,51 @@
 [
   {
     "group": "lens",
-	"name": "lens",
-	"className": "org.apache.zeppelin.lens.LensInterpreter",
-	"properties": {
+    "name": "lens",
+    "className": "org.apache.zeppelin.lens.LensInterpreter",
+    "properties": {
       "zeppelin.lens.run.concurrent": {
         "envName": null,
-		"propertyName": "zeppelin.lens.run.concurrent",
-		"defaultValue": "true",
-		"description": "Run concurrent Lens Sessions"
-	  },
-	  "zeppelin.lens.maxThreads": {
-		"envName": null,
-		"propertyName": "zeppelin.lens.maxThreads",
-		"defaultValue": "10",
-		"description": "If concurrency is true then how many threads?"
-	  },
-	  "zeppelin.lens.maxResults": {
+        "propertyName": "zeppelin.lens.run.concurrent",
+        "defaultValue": "true",
+        "description": "Run concurrent Lens Sessions"
+      },
+      "zeppelin.lens.maxThreads": {
         "envName": null,
-   	    "propertyName": "zeppelin.lens.maxResults",
-	    "defaultValue": "1000",
-	    "description": "max number of rows to display"
-	  },
-	  "lens.server.base.url": {
-		"envName": null,
-		"propertyName": "lens.server.base.url",
-		"defaultValue": "http://<hostname>:<port>/lensapi",
-		"description": "The URL for Lens Server"
-	  },
-	  "lens.client.dbname": {
-		"envName": null,
-		"propertyName": "lens.client.dbname",
-		"defaultValue": "default",
-		"description": "The database schema name"
-	  },
-	  "lens.query.enable.persistent.resultset": {
-		"envName": null,
-		"propertyName": "lens.query.enable.persistent.resultset",
-		"defaultValue": "false",
-		"description": "Apache Lens to persist result in HDFS?"
-	  },
-	  "lens.session.cluster.user": {
-		"envName": null,
-		"propertyName": "lens.session.cluster.user",
-		"defaultValue": "default",
-		"description": "Hadoop cluster username"
-	  }
-	}
+        "propertyName": "zeppelin.lens.maxThreads",
+        "defaultValue": "10",
+        "description": "If concurrency is true then how many threads?"
+      },
+      "zeppelin.lens.maxResults": {
+        "envName": null,
+        "propertyName": "zeppelin.lens.maxResults",
+        "defaultValue": "1000",
+        "description": "max number of rows to display"
+      },
+      "lens.server.base.url": {
+        "envName": null,
+        "propertyName": "lens.server.base.url",
+        "defaultValue": "http://<hostname>:<port>/lensapi",
+        "description": "The URL for Lens Server"
+      },
+      "lens.client.dbname": {
+        "envName": null,
+        "propertyName": "lens.client.dbname",
+        "defaultValue": "default",
+        "description": "The database schema name"
+      },
+      "lens.query.enable.persistent.resultset": {
+        "envName": null,
+        "propertyName": "lens.query.enable.persistent.resultset",
+        "defaultValue": "false",
+        "description": "Apache Lens to persist result in HDFS?"
+      },
+      "lens.session.cluster.user": {
+        "envName": null,
+        "propertyName": "lens.session.cluster.user",
+        "defaultValue": "default",
+        "description": "Hadoop cluster username"
+      }
+    }
   }
 ]

--- a/lens/src/main/resources/interpreter-setting.json
+++ b/lens/src/main/resources/interpreter-setting.json
@@ -1,51 +1,51 @@
 [
-	{
-		"group": "lens",
-		"name": "lens",
-		"className": "org.apache.zeppelin.lens.LensInterpreter",
-		"properties": {
-			"zeppelin.lens.run.concurrent": {
-				"envName": null,
-				"propertyName": "zeppelin.lens.run.concurrent",
-				"defaultValue": "true",
-				"description": "Run concurrent Lens Sessions"
-			},
-			"zeppelin.lens.maxThreads": {
-				"envName": null,
-				"propertyName": "zeppelin.lens.maxThreads",
-				"defaultValue": "10",
-				"description": "If concurrency is true then how many threads?"
-			},
-			"zeppelin.lens.maxResults": {
-				"envName": null,
-				"propertyName": "zeppelin.lens.maxResults",
-				"defaultValue": "1000",
-				"description": "max number of rows to display"
-			},
-			"lens.server.base.url": {
-				"envName": null,
-				"propertyName": "lens.server.base.url",
-				"defaultValue": "http://<hostname>:<port>/lensapi",
-				"description": "The URL for Lens Server"
-			},
-			"lens.client.dbname": {
-				"envName": null,
-				"propertyName": "lens.client.dbname",
-				"defaultValue": "default",
-				"description": "The database schema name"
-			},
-			"lens.query.enable.persistent.resultset": {
-				"envName": null,
-				"propertyName": "lens.query.enable.persistent.resultset",
-				"defaultValue": "false",
-				"description": "Apache Lens to persist result in HDFS?"
-			},
-			"lens.session.cluster.user": {
-				"envName": null,
-				"propertyName": "lens.session.cluster.user",
-				"defaultValue": "default",
-				"description": "Hadoop cluster username"
-			}
-		}
+  {
+    "group": "lens",
+	"name": "lens",
+	"className": "org.apache.zeppelin.lens.LensInterpreter",
+	"properties": {
+      "zeppelin.lens.run.concurrent": {
+        "envName": null,
+		"propertyName": "zeppelin.lens.run.concurrent",
+		"defaultValue": "true",
+		"description": "Run concurrent Lens Sessions"
+	  },
+	  "zeppelin.lens.maxThreads": {
+		"envName": null,
+		"propertyName": "zeppelin.lens.maxThreads",
+		"defaultValue": "10",
+		"description": "If concurrency is true then how many threads?"
+	  },
+	  "zeppelin.lens.maxResults": {
+        "envName": null,
+   	    "propertyName": "zeppelin.lens.maxResults",
+	    "defaultValue": "1000",
+	    "description": "max number of rows to display"
+	  },
+	  "lens.server.base.url": {
+		"envName": null,
+		"propertyName": "lens.server.base.url",
+		"defaultValue": "http://<hostname>:<port>/lensapi",
+		"description": "The URL for Lens Server"
+	  },
+	  "lens.client.dbname": {
+		"envName": null,
+		"propertyName": "lens.client.dbname",
+		"defaultValue": "default",
+		"description": "The database schema name"
+	  },
+	  "lens.query.enable.persistent.resultset": {
+		"envName": null,
+		"propertyName": "lens.query.enable.persistent.resultset",
+		"defaultValue": "false",
+		"description": "Apache Lens to persist result in HDFS?"
+	  },
+	  "lens.session.cluster.user": {
+		"envName": null,
+		"propertyName": "lens.session.cluster.user",
+		"defaultValue": "default",
+		"description": "Hadoop cluster username"
+	  }
 	}
+  }
 ]


### PR DESCRIPTION
### What is this PR for?

This handles replacing the registration of interpreter with static block by the interpreter-setting.json file
### What type of PR is it?

[| Improvement | 
### Todos

Sub-Task
### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-917
### How should this be tested?

here shouldn't be any warning like below on starting the server
INFO [2016-09-29 00:25:46,247]({main} LensInterpreter.java[<clinit>]:155) - Bootstrapping Cassandra Interpreter WARN [2016-09-29 00:25:46,250]({main} Interpreter.java[register]:347) - Static initialization is deprecated for interpreter lens, You should change it to use interpreter-setting.json in your jar or interpreter/{interpreter}/interpreter-setting.json INFO [2016-09-29 00:25:46,250]({main} InterpreterFactory.java[init]:204) - Inclass=org.apache.zeppelin.lens.LensInterpreter

And ensure that the lens related paragraphs run without any error
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
