### PR TITLE
[ZEPPELIN-1575] Notebook Repo settings UI

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.annotation.ZeppelinApi;
+import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
+import org.apache.zeppelin.notebook.repo.NotebookRepoWithSettings;
+import org.apache.zeppelin.rest.message.NotebookRepoSettingsRequest;
+import org.apache.zeppelin.server.JsonResponse;
+import org.apache.zeppelin.socket.NotebookServer;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.utils.SecurityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * NoteRepo rest API endpoint.
+ *
+ */
+@Path("/notebook-repositories")
+@Produces("application/json")
+public class NotebookRepoRestApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoRestApi.class);
+
+    private Gson gson = new Gson();
+    private NotebookRepoSync noteRepos;
+    private NotebookServer notebookWsServer;
+
+    public NotebookRepoRestApi() {}
+
+    public NotebookRepoRestApi(NotebookRepoSync noteRepos, NotebookServer notebookWsServer) {
+        this.noteRepos = noteRepos;
+        this.notebookWsServer = notebookWsServer;
+    }
+
+    /**
+     * List all notebook repository
+     */
+    @GET
+    @ZeppelinApi
+    public Response listRepoSettings() {
+        AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+        LOG.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
+        List<NotebookRepoWithSettings> settings = noteRepos.getNotebookRepos(subject));
+        return new JsonResponse<>(Status.OK, "", settings).build();
+    }
+
+    /**
+     * Update a specific note repo.
+     *
+     * @param message
+     * @param settingId
+     * @return
+     */
+    @PUT
+    @ZeppelinApi
+    public Response updateRepoSetting(String payload) {
+        if (StringUtils.isBlank(payload)) {
+            return new JsonResponse<>(Status.NOT_FOUND, "", Collections.emptyMap()).build();
+        }
+        AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+        NotebookRepoSettingsRequest newSettings = null;
+        try {
+            newSettings = gson.fromJson(payload, NotebookRepoSettingsRequest.class);
+        } catch (JsonSyntaxException e) {
+            LOG.error("Cannot update notebook repo settings", e);
+            return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
+                    ImmutableMap.of("error", "Invalid payload structure")).build();
+        }
+
+        if (newSettings == null) {
+            LOG.error("Invalid property");
+            return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
+                    ImmutableMap.of("error", "Invalid payload")).build();
+        }
+        LOG.info("User {} is going to change repo setting", subject.getUser());
+        NotebookRepoWithSettings updatedSettings =
+                noteRepos.updateNotebookRepo(newSettings.name, newSettings.settings, subject);
+        if (!updatedSettings.isEmpty()) {
+            notebookWsServer.broadcastReloadedNoteList(subject);
+        }
+        return new JsonResponse<>(Status.OK, "", updatedSettings).build();
+    }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -107,8 +107,8 @@ public class NotebookRepoRestApi {
     NotebookRepoWithSettings updatedSettings =
         noteRepos.updateNotebookRepo(newSettings.name, newSettings.settings, subject);
     if (!updatedSettings.isEmpty()) {
-      //TODO(anthony): need to uncomment bellow once #1537 is merged.
-      // notebookWsServer.broadcastReloadedNoteList(subject);
+      LOG.info("Broadcasting note list to user {}", subject.getUser());
+      notebookWsServer.broadcastReloadedNoteList(subject, null);
     }
     return new JsonResponse<>(Status.OK, "", updatedSettings).build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -90,7 +90,7 @@ public class NotebookRepoRestApi {
             return new JsonResponse<>(Status.NOT_FOUND, "", Collections.emptyMap()).build();
         }
         AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-        NotebookRepoSettingsRequest newSettings = null;
+        NotebookRepoSettingsRequest newSettings = NotebookRepoSettingsRequest.EMPTY;
         try {
             newSettings = gson.fromJson(payload, NotebookRepoSettingsRequest.class);
         } catch (JsonSyntaxException e) {
@@ -99,7 +99,7 @@ public class NotebookRepoRestApi {
                     ImmutableMap.of("error", "Invalid payload structure")).build();
         }
 
-        if (newSettings == null) {
+        if (NotebookRepoSettingsRequest.isEmpty(newSettings)) {
             LOG.error("Invalid property");
             return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
                     ImmutableMap.of("error", "Invalid payload")).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -1,18 +1,19 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.apache.zeppelin.rest;
 
 import java.util.Collections;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -1,18 +1,16 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.apache.zeppelin.rest;
@@ -51,65 +49,66 @@ import com.google.gson.JsonSyntaxException;
 @Produces("application/json")
 public class NotebookRepoRestApi {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoRestApi.class);
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoRestApi.class);
 
-    private Gson gson = new Gson();
-    private NotebookRepoSync noteRepos;
-    private NotebookServer notebookWsServer;
+  private Gson gson = new Gson();
+  private NotebookRepoSync noteRepos;
+  private NotebookServer notebookWsServer;
 
-    public NotebookRepoRestApi() {}
+  public NotebookRepoRestApi() {}
 
-    public NotebookRepoRestApi(NotebookRepoSync noteRepos, NotebookServer notebookWsServer) {
-        this.noteRepos = noteRepos;
-        this.notebookWsServer = notebookWsServer;
+  public NotebookRepoRestApi(NotebookRepoSync noteRepos, NotebookServer notebookWsServer) {
+    this.noteRepos = noteRepos;
+    this.notebookWsServer = notebookWsServer;
+  }
+
+  /**
+   * List all notebook repository
+   */
+  @GET
+  @ZeppelinApi
+  public Response listRepoSettings() {
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    LOG.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
+    List<NotebookRepoWithSettings> settings = noteRepos.getNotebookRepos(subject);
+    return new JsonResponse<>(Status.OK, "", settings).build();
+  }
+
+  /**
+   * Update a specific note repo.
+   *
+   * @param message
+   * @param settingId
+   * @return
+   */
+  @PUT
+  @ZeppelinApi
+  public Response updateRepoSetting(String payload) {
+    if (StringUtils.isBlank(payload)) {
+      return new JsonResponse<>(Status.NOT_FOUND, "", Collections.emptyMap()).build();
+    }
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    NotebookRepoSettingsRequest newSettings = NotebookRepoSettingsRequest.EMPTY;
+    try {
+      newSettings = gson.fromJson(payload, NotebookRepoSettingsRequest.class);
+    } catch (JsonSyntaxException e) {
+      LOG.error("Cannot update notebook repo settings", e);
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
+          ImmutableMap.of("error", "Invalid payload structure")).build();
     }
 
-    /**
-     * List all notebook repository
-     */
-    @GET
-    @ZeppelinApi
-    public Response listRepoSettings() {
-        AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-        LOG.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
-        List<NotebookRepoWithSettings> settings = noteRepos.getNotebookRepos(subject));
-        return new JsonResponse<>(Status.OK, "", settings).build();
+    if (NotebookRepoSettingsRequest.isEmpty(newSettings)) {
+      LOG.error("Invalid property");
+      return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
+          ImmutableMap.of("error", "Invalid payload")).build();
     }
-
-    /**
-     * Update a specific note repo.
-     *
-     * @param message
-     * @param settingId
-     * @return
-     */
-    @PUT
-    @ZeppelinApi
-    public Response updateRepoSetting(String payload) {
-        if (StringUtils.isBlank(payload)) {
-            return new JsonResponse<>(Status.NOT_FOUND, "", Collections.emptyMap()).build();
-        }
-        AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-        NotebookRepoSettingsRequest newSettings = NotebookRepoSettingsRequest.EMPTY;
-        try {
-            newSettings = gson.fromJson(payload, NotebookRepoSettingsRequest.class);
-        } catch (JsonSyntaxException e) {
-            LOG.error("Cannot update notebook repo settings", e);
-            return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
-                    ImmutableMap.of("error", "Invalid payload structure")).build();
-        }
-
-        if (NotebookRepoSettingsRequest.isEmpty(newSettings)) {
-            LOG.error("Invalid property");
-            return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
-                    ImmutableMap.of("error", "Invalid payload")).build();
-        }
-        LOG.info("User {} is going to change repo setting", subject.getUser());
-        NotebookRepoWithSettings updatedSettings =
-                noteRepos.updateNotebookRepo(newSettings.name, newSettings.settings, subject);
-        if (!updatedSettings.isEmpty()) {
-            notebookWsServer.broadcastReloadedNoteList(subject);
-        }
-        return new JsonResponse<>(Status.OK, "", updatedSettings).build();
+    LOG.info("User {} is going to change repo setting", subject.getUser());
+    NotebookRepoWithSettings updatedSettings =
+        noteRepos.updateNotebookRepo(newSettings.name, newSettings.settings, subject);
+    if (!updatedSettings.isEmpty()) {
+      //TODO(anthony): need to uncomment bellow once #1537 is merged.
+      // notebookWsServer.broadcastReloadedNoteList(subject);
     }
+    return new JsonResponse<>(Status.OK, "", updatedSettings).build();
+  }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NotebookRepoSettingsRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NotebookRepoSettingsRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest.message;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Represent payload of a notebook repo settings.
+ */
+public class NotebookRepoSettingsRequest {
+
+    public static final NotebookRepoSettingsRequest EMPTY = new NotebookRepoSettingsRequest();
+
+    public String name;
+    public Map<String, String> settings;
+
+    public NotebookRepoSettingsRequest() {
+        name = StringUtils.EMPTY;
+        settings = Collections.emptyMap();
+    }
+
+    public boolean isEmpty() {
+        return this == EMPTY;
+    }
+
+    public static boolean isEmpty(NotebookRepoSettingsRequest repoSetting) {
+        if (repoSetting == null) {
+            return true;
+        }
+        return repoSetting.isEmpty();
+    }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NotebookRepoSettingsRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NotebookRepoSettingsRequest.java
@@ -16,34 +16,34 @@
  */
 package org.apache.zeppelin.rest.message;
 
-import org.apache.commons.lang.StringUtils;
-
 import java.util.Collections;
 import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Represent payload of a notebook repo settings.
  */
 public class NotebookRepoSettingsRequest {
 
-    public static final NotebookRepoSettingsRequest EMPTY = new NotebookRepoSettingsRequest();
+  public static final NotebookRepoSettingsRequest EMPTY = new NotebookRepoSettingsRequest();
 
-    public String name;
-    public Map<String, String> settings;
+  public String name;
+  public Map<String, String> settings;
 
-    public NotebookRepoSettingsRequest() {
-        name = StringUtils.EMPTY;
-        settings = Collections.emptyMap();
+  public NotebookRepoSettingsRequest() {
+    name = StringUtils.EMPTY;
+    settings = Collections.emptyMap();
+  }
+
+  public boolean isEmpty() {
+    return this == EMPTY;
+  }
+
+  public static boolean isEmpty(NotebookRepoSettingsRequest repoSetting) {
+    if (repoSetting == null) {
+      return true;
     }
-
-    public boolean isEmpty() {
-        return this == EMPTY;
-    }
-
-    public static boolean isEmpty(NotebookRepoSettingsRequest repoSetting) {
-        if (repoSetting == null) {
-            return true;
-        }
-        return repoSetting.isEmpty();
-    }
+    return repoSetting.isEmpty();
+  }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
-import javax.net.ssl.SSLContext;
 import javax.servlet.DispatcherType;
 import javax.ws.rs.core.Application;
 
@@ -37,9 +35,16 @@ import org.apache.zeppelin.helium.HeliumApplicationFactory;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
-import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
-import org.apache.zeppelin.rest.*;
+import org.apache.zeppelin.rest.ConfigurationsRestApi;
+import org.apache.zeppelin.rest.CredentialRestApi;
+import org.apache.zeppelin.rest.HeliumRestApi;
+import org.apache.zeppelin.rest.InterpreterRestApi;
+import org.apache.zeppelin.rest.LoginRestApi;
+import org.apache.zeppelin.rest.NotebookRepoRestApi;
+import org.apache.zeppelin.rest.NotebookRestApi;
+import org.apache.zeppelin.rest.SecurityRestApi;
+import org.apache.zeppelin.rest.ZeppelinRestApi;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.SearchService;
@@ -47,7 +52,12 @@ import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -73,13 +83,8 @@ public class ZeppelinServer extends Application {
 
   private SchedulerFactory schedulerFactory;
   private InterpreterFactory replFactory;
-<<<<<<< HEAD
-  private NotebookRepo notebookRepo;
   private SearchService noteSearchService;
-=======
   private NotebookRepoSync notebookRepo;
-  private SearchService notebookIndex;
->>>>>>> Update zeppelin server and add NotebookRepo rest api to the singleton
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
   private DependencyResolver depResolver;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -73,8 +73,13 @@ public class ZeppelinServer extends Application {
 
   private SchedulerFactory schedulerFactory;
   private InterpreterFactory replFactory;
+<<<<<<< HEAD
   private NotebookRepo notebookRepo;
   private SearchService noteSearchService;
+=======
+  private NotebookRepoSync notebookRepo;
+  private SearchService notebookIndex;
+>>>>>>> Update zeppelin server and add NotebookRepo rest api to the singleton
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
   private DependencyResolver depResolver;
@@ -307,6 +312,9 @@ public class ZeppelinServer extends Application {
     NotebookRestApi notebookApi
       = new NotebookRestApi(notebook, notebookWsServer, noteSearchService);
     singletons.add(notebookApi);
+
+    NotebookRepoRestApi notebookRepoApi = new NotebookRepoRestApi(notebookRepo, notebookWsServer);
+    singletons.add(notebookRepoApi);
 
     HeliumRestApi heliumApi = new HeliumRestApi(helium, heliumApplicationFactory, notebook);
     singletons.add(heliumApi);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * NotebookRepo rest api test.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NotebookRepoRestApiTest extends AbstractTestRestApi {
+
+  Gson gson = new Gson();
+  AuthenticationInfo anonymous;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    AbstractTestRestApi.startUp();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+  
+  @Before
+  public void setUp() {
+    anonymous = new AuthenticationInfo("anonymous");
+  }
+  
+  private List<Map<String, Object>> getListOfReposotiry() throws IOException {
+    GetMethod get = httpGet("/notebook-repositories");
+    Map<String, Object> responce = gson.fromJson(get.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {}.getType());
+    get.releaseConnection();
+    return (List<Map<String, Object>>) responce.get("body");
+  }
+  
+  private void updateNotebookRepoWithNewSetting(String payload) throws IOException {
+    PutMethod put = httpPut("/notebook-repositories", payload);
+    int status = put.getStatusCode();
+    put.releaseConnection();
+    assertThat(status, is(200));
+  }
+  
+  @Test public void ThatCanGetNotebookRepositoiesSettings() throws IOException {
+    List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
+    assertThat(listOfRepositories.size(), is(not(0)));
+  }
+  
+  @Test public void setNewDirectoryForLocalDirectory() throws IOException {
+    List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
+    String localVfs = StringUtils.EMPTY;
+    String className = StringUtils.EMPTY;
+
+    for (int i = 0; i < listOfRepositories.size(); i++) {
+      if (listOfRepositories.get(i).get("name").equals("VFSNotebookRepo")) {
+        localVfs = (String) ((List<Map<String, Object>>)listOfRepositories.get(i).get("settings")).get(0).get("selected");
+        className = (String) listOfRepositories.get(i).get("className");
+        break;
+      }
+    }
+
+    if (StringUtils.isBlank(localVfs)) {
+      // no loval VFS set...
+      return;
+    }
+
+    String payload = "{ \"name\": \"" + className + "\", \"settings\" : { \"Notebook Path\" : \"/tmp/newDir\" } }";
+    updateNotebookRepoWithNewSetting(payload);
+    
+    // Verify
+    listOfRepositories = getListOfReposotiry();
+    String updatedPath = StringUtils.EMPTY;
+    for (int i = 0; i < listOfRepositories.size(); i++) {
+      if (listOfRepositories.get(i).get("name").equals("VFSNotebookRepo")) {
+        updatedPath = (String) ((List<Map<String, Object>>)listOfRepositories.get(i).get("settings")).get(0).get("selected");
+        break;
+      }
+    }
+    assertThat(updatedPath, is("/tmp/newDir"));
+    
+    // go back to normal
+    payload = "{ \"name\": \"" + className + "\", \"settings\" : { \"Notebook Path\" : \"" + localVfs + "\" } }";
+    updateNotebookRepoWithNewSetting(payload);
+  }
+}

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -70,6 +70,10 @@
               templateUrl: 'app/interpreter/interpreter.html',
               controller: 'InterpreterCtrl'
             })
+            .when('/notebookRepos', {
+              templateUrl: 'app/notebookRepos/notebookRepos.html',
+              controller: 'NotebookReposCtrl'
+            })
             .when('/credential', {
               templateUrl: 'app/credential/credential.html',
               controller: 'CredentialCtrl'

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -72,7 +72,8 @@
             })
             .when('/notebookRepos', {
               templateUrl: 'app/notebookRepos/notebookRepos.html',
-              controller: 'NotebookReposCtrl'
+              controller: 'NotebookReposCtrl',
+              controllerAs: 'repo'
             })
             .when('/credential', {
               templateUrl: 'app/credential/credential.html',

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -73,7 +73,7 @@
             .when('/notebookRepos', {
               templateUrl: 'app/notebookRepos/notebookRepos.html',
               controller: 'NotebookReposCtrl',
-              controllerAs: 'repo'
+              controllerAs: 'noterepo'
             })
             .when('/credential', {
               templateUrl: 'app/credential/credential.html',

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -20,13 +20,50 @@
 
   function NotebookReposCtrl($http, baseUrlSrv, ngToast) {
     var vm = this;
-    vm.notebookRepos = [];
+    vm.notebookRepos = [
+      {
+        name: 'Classic Repo',
+        settings: [
+          {
+            name: 'defaulty',
+            type: 'input',
+            value: [],
+            selected: 'Totooo'
+          }
+        ]
+      },
+      {
+        name: 'Empty Repo',
+        settings: []
+      },
+      {
+        name: 'ZeppelinHub',
+        settings: [
+          {
+            name: 'instance',
+            type: 'dropdown',
+            value: [
+              {
+                name: 'instance1',
+                value: 'id1'
+              },
+              {
+                name: 'instanceKikoo',
+                value: 'id2'
+              }
+            ],
+            selected: 'id2'
+          }
+        ]
+      }
+    ];
 
     _init();
 
     // Private functions
 
     function _getInterpreterSettings() {
+      /*
       $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/setting')
       .success(function(data, status, headers, config) {
         vm.notebookRepos = data.body;
@@ -42,7 +79,7 @@
           }, 3000);
         }
         console.log('Error %o %o', status, data.message);
-      });
+      });*/
     }
 
     function _init() {

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -20,51 +20,14 @@
 
   function NotebookReposCtrl($http, baseUrlSrv, ngToast) {
     var vm = this;
-    vm.notebookRepos = [
-      {
-        name: 'Classic Repo',
-        settings: [
-          {
-            name: 'defaulty',
-            type: 'input',
-            value: [],
-            selected: 'Totooo'
-          }
-        ]
-      },
-      {
-        name: 'Empty Repo',
-        settings: []
-      },
-      {
-        name: 'ZeppelinHub',
-        settings: [
-          {
-            name: 'instance',
-            type: 'dropdown',
-            value: [
-              {
-                name: 'instance1',
-                value: 'id1'
-              },
-              {
-                name: 'instanceKikoo',
-                value: 'id2'
-              }
-            ],
-            selected: 'id2'
-          }
-        ]
-      }
-    ];
+    vm.notebookRepos = [];
 
     _init();
 
     // Private functions
 
     function _getInterpreterSettings() {
-      /*
-      $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/setting')
+      $http.get(baseUrlSrv.getRestApiBase() + '/notebook-repositories')
       .success(function(data, status, headers, config) {
         vm.notebookRepos = data.body;
       }).error(function(data, status, headers, config) {
@@ -79,7 +42,7 @@
           }, 3000);
         }
         console.log('Error %o %o', status, data.message);
-      });*/
+      });
     }
 
     function _init() {

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -46,9 +46,10 @@
           verticalPosition: 'bottom',
           timeout: '3000'
         });
+        valueform.$show();
       });
 
-      return false;
+      return 'manual';
     }
 
     function showDropdownSelected(setting) {

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -28,11 +28,27 @@
 
     // Public functions
 
-    function saveNotebookRepo(repo, data) {
-      return $http.post(baseUrlSrv.getRestApiBase() + '/notebook-repositories', {
+    function saveNotebookRepo(valueform, repo, data) {
+      console.log('data %o', data);
+      $http.put(baseUrlSrv.getRestApiBase() + '/notebook-repositories', {
         'name': repo.className,
         'settings': data
+      }).success(function(data) {
+        var index = _.findIndex(vm.notebookRepos, {'className': repo.className});
+        if (index >= 0) {
+          vm.notebookRepos[index] = data.body;
+          console.log('repos %o, data %o', vm.notebookRepos, data.body);
+        }
+        valueform.$show();
+      }).error(function() {
+        ngToast.danger({
+          content: 'We couldn\'t save that NotebookRepo\'s settings',
+          verticalPosition: 'bottom',
+          timeout: '3000'
+        });
       });
+
+      return false;
     }
 
     function showDropdownSelected(setting) {
@@ -50,6 +66,7 @@
       $http.get(baseUrlSrv.getRestApiBase() + '/notebook-repositories')
       .success(function(data, status, headers, config) {
         vm.notebookRepos = data.body;
+        console.log('ya notebookRepos %o', vm.notebookRepos);
       }).error(function(data, status, headers, config) {
         if (status === 401) {
           ngToast.danger({

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+(function() {
+
+  angular.module('zeppelinWebApp').controller('NotebookReposCtrl', NotebookReposCtrl);
+
+  NotebookReposCtrl.$inject = ['$http', 'baseUrlSrv', 'ngToast'];
+
+  function NotebookReposCtrl($http, baseUrlSrv, ngToast) {
+    var vm = this;
+    vm.notebookRepos = [];
+
+    _init();
+
+    // Private functions
+
+    function _getInterpreterSettings() {
+      $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/setting')
+      .success(function(data, status, headers, config) {
+        vm.notebookRepos = data.body;
+      }).error(function(data, status, headers, config) {
+        if (status === 401) {
+          ngToast.danger({
+            content: 'You don\'t have permission on this page',
+            verticalPosition: 'bottom',
+            timeout: '3000'
+          });
+          setTimeout(function() {
+            window.location.replace('/');
+          }, 3000);
+        }
+        console.log('Error %o %o', status, data.message);
+      });
+    }
+
+    function _init() {
+      _getInterpreterSettings();
+    };
+  }
+
+})();

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -21,8 +21,28 @@
   function NotebookReposCtrl($http, baseUrlSrv, ngToast) {
     var vm = this;
     vm.notebookRepos = [];
+    vm.showDropdownSelected = showDropdownSelected;
+    vm.saveNotebookRepo = saveNotebookRepo;
 
     _init();
+
+    // Public functions
+
+    function saveNotebookRepo(repo, data) {
+      return $http.post(baseUrlSrv.getRestApiBase() + '/notebook-repositories', {
+        'name': repo.className,
+        'settings': data
+      });
+    }
+
+    function showDropdownSelected(setting) {
+      var index = _.findIndex(setting.value, {'value': setting.selected});
+      if (index < 0) {
+        return 'No value';
+      } else {
+        return setting.value[index].name;
+      }
+    }
 
     // Private functions
 

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -1,0 +1,324 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div class="interpreterHead">
+  <div class="header">
+    <div class="row">
+      <div class="col-md-12">
+        <h3 class="new_h3">
+          Notebook Repos
+        </h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        Manage your Notebook Repositories' settings.
+      </div>
+    </div>
+  </div>
+
+  <div class="row" ng-if="showRepositoryInfo">
+    <div class="col-md-12">
+      <hr />
+      <h4>Repositories</h4>
+      <p>Available repository lists. These repositories are used to resolve external dependencies of interpreter.</p>
+      <ul class="noDot">
+        <li class="liVertical" ng-repeat="repo in repositories">
+          <a tabindex="0" class="btn btn-info" role="button"
+             popover-trigger="focus"
+             popover-placement="right"
+             popover-html-unsafe="<label>URL: </label>
+               {{repo.url}}<br>
+               <label>Username: </label>
+               {{repo.authentication.username}}">
+            <span class="fa fa-database"></span>
+            {{repo.id}}&nbsp;
+            <span ng-if="!isDefaultRepository(repo.id)" class="fa fa-close blackOpc"
+                  ng-click="removeRepository(repo.id)"></span>
+          </a>
+        </li>
+        <li class="liVertical">
+          <div ng-include src="'components/repository-create/repository-dialog.html'"></div>
+          <div class="btn btn-default"
+               data-toggle="modal"
+               data-target="#repoModal">
+            <span class="fa fa-plus"></span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div ng-include src="'app/interpreter/interpreter-create/interpreter-create.html'"></div>
+</div>
+
+<div class="box width-full"
+     ng-repeat="setting in interpreterSettings | orderBy: 'name' | filter: searchInterpreter" interpreter-directive>
+  <div id="{{setting.name | lowercase}}">
+    <div class="row interpreter">
+
+      <div class="col-md-12">
+        <h3 class="interpreter-title">{{setting.name}}
+          <small>
+            <span style="display:inline-block" ng-repeat="interpreter in setting.interpreterGroup"
+                  title="{{interpreter.class}}">
+              <span ng-show="!$first">, </span>%<span ng-show="!$parent.$first || $first">{{setting.name}}</span>
+              <span ng-show="(!$parent.$first || $first) && !$first">.</span>
+              <span ng-show="!$first">{{interpreter.name}}</span>
+              <span ng-show="$parent.$first && $first">(default)</span>
+            </span>
+          </small>
+
+          <small ng-switch="setting.status">
+            <small ng-switch-when="READY">
+              <i style="color: green; margin-right: 3px;" class="fa fa-circle"
+                 tooltip="Ready">
+              </i>
+            </small>
+            <small ng-switch-when="ERROR">
+              <i style="color: red; cursor: pointer" class="fa fa-circle"
+                 ng-click="showErrorMessage(setting)"
+                 tooltip="Error downloading dependencies">
+              </i>
+            </small>
+            <small ng-switch-default>
+              <i style="color: blue" class="fa fa-spinner spinAnimation"
+                 tooltip="Dependencies are downloading">
+              </i>
+            </small>
+          </small>
+
+        </h3>
+        <span style="float:right">
+          <button class="btn btn-default btn-xs"
+                  ng-click="valueform.$show();
+                  copyOriginInterpreterSettingProperties(setting.id)">
+            <span class="fa fa-pencil"></span> edit</button>
+          <button class="btn btn-default btn-xs"
+                  ng-click="restartInterpreterSetting(setting.id)">
+            <span class="fa fa-refresh"></span> restart</button>
+          <button class="btn btn-default btn-xs"
+                  ng-click="removeInterpreterSetting(setting.id)">
+            <span class="fa fa-remove"></span> remove</button>
+        </span>
+      </div>
+    </div>
+    <div class="row interpreter">
+      <div class="col-md-12">
+        <h5>Option</h5>
+        <span class="btn-group">
+          <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                  data-toggle="dropdown"
+                  ng-disabled="!valueform.$visible">
+            {{getSessionOption(setting.id)}} <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" role="menu">
+            <li>
+              <a style="cursor:pointer"
+                 tooltip="Single interpreter instance are shared across notes"
+                 ng-click="setSessionOption(setting.id, 'shared')">
+                shared
+              </a>
+            </li>
+            <li>
+              <a style="cursor:pointer"
+                 tooltip="Separate Interpreter instance for each note"
+                 ng-click="setSessionOption(setting.id, 'scoped')">
+                scoped
+              </a>
+            </li>
+            <li>
+              <a style="cursor:pointer"
+                 tooltip="Separate Interpreter process for each note"
+                 ng-click="setSessionOption(setting.id, 'isolated')">
+                isolated
+              </a>
+            </li>
+          </ul>
+        </span>
+        <span>Interpreter for note</span>
+      </div>
+    </div>
+    <div class="row interpreter" style="margin-top: 5px;">
+      <div class="col-md-12">
+        <div class="checkbox remove-margin-top-bottom">
+          <span class="input-group" style="line-height:30px;">
+            <label>
+              <input type="checkbox" style="width:20px" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
+              Connect to existing process
+            </label>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="row interpreter" ng-if="setting.option.isExistingProcess">
+      <div class="col-md-12">
+        <b>Host</b>
+          <input id="newInterpreterSettingHost" input pu-elastic-input
+            pu-elastic-input-minwidth="180px" ng-model="setting.option.host" ng-disabled="!valueform.$visible"  />
+      </div>
+      <div class="col-md-12">
+         <b>Port</b>
+         <input id="newInterpreterSettingPort" input pu-elastic-input
+            pu-elastic-input-minwidth="180px" ng-model="setting.option.port"  ng-disabled="!valueform.$visible" />
+      </div>
+    </div>
+    <div class="row interpreter">
+      <div class="col-md-12">
+        <div class="checkbox remove-margin-top-bottom">
+          <span class="input-group" style="line-height:30px;">
+            <label>
+              <input type="checkbox" style="width:20px !important" id="idShowPermission" ng-click="togglePermissions(setting.name)" ng-model="setting.option.setPermission" ng-disabled="!valueform.$visible"/>
+               Set permission
+            </label>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="row interpreter">
+      <div class="col-md-12">
+        <!-- permissions -->
+        <div ng-show="setting.option.setPermission" class="permissionsForm">
+          <div>
+            <p>
+              Enter comma separated users in the fields. <br />
+              Empty field (*) implies anyone can run this interpreter.
+            </p>
+            <div>
+
+            <span class="owners">Owners </span>
+            <select id="{{setting.name}}Users" class="form-control" multiple="multiple" ng-disabled="!valueform.$visible">
+              <option ng-repeat="user in setting.option.users" selected="selected">{{user}}</option>
+            </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div ng-show="_.isEmpty(setting.properties) && _.isEmpty(setting.dependencies) || valueform.$hidden" class="col-md-12 gray40-message">
+        <em>Currently there are no properties and dependencies set for this interpreter</em>
+      </div>
+    </div>
+    <div class="row interpreter">
+      <div class="col-md-12" ng-show="!_.isEmpty(setting.properties) || valueform.$visible">
+        <h5>Properties</h5>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th style="width:40%">name</th>
+              <th style="width:40%">value</th>
+              <th style="width:20%" ng-if="valueform.$visible">action</th>
+            </tr>
+          </thead>
+          <tr ng-repeat="key in setting.properties | sortByKey" >
+            <td>{{key}}</td>
+            <td>
+              <span editable-textarea="setting.properties[key]" e-form="valueform" e-msd-elastic>
+                {{setting.properties[key] | breakFilter}}
+              </span>
+            </td>
+            <td ng-if="valueform.$visible">
+              <button class="btn btn-default btn-sm fa fa-remove"
+                   ng-click="removeInterpreterProperty(key, setting.id)">
+              </button>
+            </td>
+          </tr>
+          <tr ng-if="valueform.$visible">
+            <td>
+              <input ng-model="setting.propertyKey"
+                     pu-elastic-input
+                     pu-elastic-input-minwidth="180px" />
+            </td>
+            <td>
+              <textarea msd-elastic ng-model="setting.propertyValue"></textarea>
+            </td>
+            <td>
+              <button class="btn btn-default btn-sm fa fa-plus"
+                   ng-click="addNewInterpreterProperty(setting.id)">
+              </button>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="row interpreter">
+      <div class="col-md-12" ng-show="!_.isEmpty(setting.dependencies) || valueform.$visible">
+        <h5>Dependencies</h5>
+        <p class="gray40-message" style="font-size:12px" ng-show="valueform.$visible">
+          These dependencies will be added to classpath when interpreter process starts.</p>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th style="width:40%">artifact</th>
+              <th>exclude</th>
+              <th ng-if="valueform.$visible">action</th>
+            </tr>
+          </thead>
+          <tr ng-repeat="dep in setting.dependencies">
+            <td>
+              <span editable-text="dep.groupArtifactVersion" e-placeholder="groupId:artifactId:version or local file path"
+                    e-form="valueform" e-msd-elastic e-style="width:100%">
+                {{dep.groupArtifactVersion | breakFilter}}
+              </span>
+            </td>
+            <td>
+              <textarea ng-if="valueform.$visible" ng-model="dep.exclusions"
+                        placeholder="(Optional) comma separated groupId:artifactId list"
+                        form="valueform"
+                        e-msd-elastic
+                        ng-list="">
+              </textarea>
+              <div ng-if="!valueform.$visible">{{dep.exclusions.join()}}</div>
+            </td>
+            <td ng-if="valueform.$visible">
+              <button class="btn btn-default btn-sm fa fa-remove"
+                   ng-click="removeInterpreterDependency(dep.groupArtifactVersion, setting.id)">
+              </button>
+            </td>
+          </tr>
+          <tr ng-if="valueform.$visible">
+            <td>
+              <input ng-model="setting.depArtifact"
+                     placeholder="groupId:artifactId:version or local file path"
+                     style="width: 100%" />
+            </td>
+            <td>
+              <textarea ng-model="setting.depExclude"
+                        placeholder="(Optional) comma separated groupId:artifactId list"
+                        msd-elastic
+                        ng-list="">
+              </textarea>
+            </td>
+            <td>
+              <button class="btn btn-default btn-sm fa fa-plus"
+                   ng-click="addNewInterpreterDependency(setting.id)">
+              </button>
+            </td>
+          </tr>
+        </table>
+        <form editable-form name="valueform"
+              onaftersave="updateInterpreterSetting(valueform, setting.id)"
+              ng-show="valueform.$visible">
+          <button type="submit" class="btn btn-primary">
+            Save
+          </button>
+          <button type="button" class="btn btn-default"
+                  ng-disabled="valueform.$waiting"
+                  ng-click="valueform.$cancel(); resetInterpreterSetting(setting.id)">
+            Cancel
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -29,7 +29,7 @@ limitations under the License.
 </div>
 
 <div class="box width-full"
-     ng-repeat="repo in repo.notebookRepos | orderBy: 'name'">
+     ng-repeat="repo in noterepo.notebookRepos | orderBy: 'name'">
   <div id="{{repo.name | lowercase}}">
     <div class="row interpreter">
 
@@ -56,11 +56,18 @@ limitations under the License.
             <td ng-bind="setting.name"></td>
             <td>
               <span class="btn-group">
-                <select ng-model="setting.selected" ng-show="setting.type === 'dropdown'"
-                        class="selectpicker" ng-disabled="!valueform.$visible"
-                        ng-options="item.value as item.name for item in setting.value"></select>
-                <span ng-show="setting.type === 'input'" editable-textarea="setting.selectied" e-form="valueform" e-msd-elastic>
-                  {{setting.selected | breakFilter}}
+                <span ng-show="setting.type === 'DROPDOWN'">
+                  <span editable-select="setting.selected"
+                          e-name="{{setting.name}}"
+                          e-ng-options="s.value as s.name for s in setting.value"
+                          class="selectpicker" ng-disabled="!valueform.$visible" e-form="valueform">
+                          {{noterepo.showDropdownSelected(setting)}}
+                  </span>
+                </span>
+                <span ng-show="setting.type === 'INPUT'">
+                  <span editable-textarea="setting.selected" e-name="{{setting.name}}" e-form="valueform" e-msd-elastic>
+                    {{setting.selected | breakFilter}}
+                  </span>
                 </span>
               </span>
             </td>
@@ -68,6 +75,20 @@ limitations under the License.
         </table>
       </div>
     </div>
+    <span style="float:right" ng-show="valueform.$visible">
+      <form editable-form name="valueform"
+            onbeforesave="noterepo.saveNotebookRepo(repo, $data)"
+            ng-show="valueform.$visible">
+        <button type="submit" class="btn btn-primary btn-xs">
+          <span class="fa fa-check"></span> Save
+        </button>
+        <button type="button" class="btn btn-default btn-xs"
+                ng-disabled="valueform.$waiting"
+                ng-click="valueform.$cancel();">
+          <span class="fa fa-remove"></span> Cancel
+        </button>
+      </form>
+    </span>
     <div class="row interpreter">
       <div ng-show="repo.settings.length === 0 || valueform.$hidden" class="col-md-12 gray40-message">
         <em>Currently there are no settings for this Notebook Repository</em>

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -26,298 +26,43 @@ limitations under the License.
       </div>
     </div>
   </div>
-
-  <div class="row" ng-if="showRepositoryInfo">
-    <div class="col-md-12">
-      <hr />
-      <h4>Repositories</h4>
-      <p>Available repository lists. These repositories are used to resolve external dependencies of interpreter.</p>
-      <ul class="noDot">
-        <li class="liVertical" ng-repeat="repo in repositories">
-          <a tabindex="0" class="btn btn-info" role="button"
-             popover-trigger="focus"
-             popover-placement="right"
-             popover-html-unsafe="<label>URL: </label>
-               {{repo.url}}<br>
-               <label>Username: </label>
-               {{repo.authentication.username}}">
-            <span class="fa fa-database"></span>
-            {{repo.id}}&nbsp;
-            <span ng-if="!isDefaultRepository(repo.id)" class="fa fa-close blackOpc"
-                  ng-click="removeRepository(repo.id)"></span>
-          </a>
-        </li>
-        <li class="liVertical">
-          <div ng-include src="'components/repository-create/repository-dialog.html'"></div>
-          <div class="btn btn-default"
-               data-toggle="modal"
-               data-target="#repoModal">
-            <span class="fa fa-plus"></span>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </div>
-
-  <div ng-include src="'app/interpreter/interpreter-create/interpreter-create.html'"></div>
 </div>
 
 <div class="box width-full"
-     ng-repeat="setting in interpreterSettings | orderBy: 'name' | filter: searchInterpreter" interpreter-directive>
-  <div id="{{setting.name | lowercase}}">
+     ng-repeat="repo in repo.notebookRepos | orderBy: 'name'">
+  <div id="{{repo.name | lowercase}}">
     <div class="row interpreter">
 
       <div class="col-md-12">
-        <h3 class="interpreter-title">{{setting.name}}
-          <small>
-            <span style="display:inline-block" ng-repeat="interpreter in setting.interpreterGroup"
-                  title="{{interpreter.class}}">
-              <span ng-show="!$first">, </span>%<span ng-show="!$parent.$first || $first">{{setting.name}}</span>
-              <span ng-show="(!$parent.$first || $first) && !$first">.</span>
-              <span ng-show="!$first">{{interpreter.name}}</span>
-              <span ng-show="$parent.$first && $first">(default)</span>
-            </span>
-          </small>
-
-          <small ng-switch="setting.status">
-            <small ng-switch-when="READY">
-              <i style="color: green; margin-right: 3px;" class="fa fa-circle"
-                 tooltip="Ready">
-              </i>
-            </small>
-            <small ng-switch-when="ERROR">
-              <i style="color: red; cursor: pointer" class="fa fa-circle"
-                 ng-click="showErrorMessage(setting)"
-                 tooltip="Error downloading dependencies">
-              </i>
-            </small>
-            <small ng-switch-default>
-              <i style="color: blue" class="fa fa-spinner spinAnimation"
-                 tooltip="Dependencies are downloading">
-              </i>
-            </small>
-          </small>
-
-        </h3>
+        <h3 class="interpreter-title">{{repo.name}}</h3>
         <span style="float:right">
           <button class="btn btn-default btn-xs"
                   ng-click="valueform.$show();
                   copyOriginInterpreterSettingProperties(setting.id)">
             <span class="fa fa-pencil"></span> edit</button>
-          <button class="btn btn-default btn-xs"
-                  ng-click="restartInterpreterSetting(setting.id)">
-            <span class="fa fa-refresh"></span> restart</button>
-          <button class="btn btn-default btn-xs"
-                  ng-click="removeInterpreterSetting(setting.id)">
-            <span class="fa fa-remove"></span> remove</button>
         </span>
       </div>
     </div>
     <div class="row interpreter">
-      <div class="col-md-12">
-        <h5>Option</h5>
-        <span class="btn-group">
-          <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                  data-toggle="dropdown"
-                  ng-disabled="!valueform.$visible">
-            {{getSessionOption(setting.id)}} <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu" role="menu">
-            <li>
-              <a style="cursor:pointer"
-                 tooltip="Single interpreter instance are shared across notes"
-                 ng-click="setSessionOption(setting.id, 'shared')">
-                shared
-              </a>
-            </li>
-            <li>
-              <a style="cursor:pointer"
-                 tooltip="Separate Interpreter instance for each note"
-                 ng-click="setSessionOption(setting.id, 'scoped')">
-                scoped
-              </a>
-            </li>
-            <li>
-              <a style="cursor:pointer"
-                 tooltip="Separate Interpreter process for each note"
-                 ng-click="setSessionOption(setting.id, 'isolated')">
-                isolated
-              </a>
-            </li>
-          </ul>
-        </span>
-        <span>Interpreter for note</span>
-      </div>
-    </div>
-    <div class="row interpreter" style="margin-top: 5px;">
-      <div class="col-md-12">
-        <div class="checkbox remove-margin-top-bottom">
-          <span class="input-group" style="line-height:30px;">
-            <label>
-              <input type="checkbox" style="width:20px" id="isExistingProcess" ng-model="setting.option.isExistingProcess" ng-disabled="!valueform.$visible"/>
-              Connect to existing process
-            </label>
-          </span>
-        </div>
-      </div>
-    </div>
-    <div class="row interpreter" ng-if="setting.option.isExistingProcess">
-      <div class="col-md-12">
-        <b>Host</b>
-          <input id="newInterpreterSettingHost" input pu-elastic-input
-            pu-elastic-input-minwidth="180px" ng-model="setting.option.host" ng-disabled="!valueform.$visible"  />
-      </div>
-      <div class="col-md-12">
-         <b>Port</b>
-         <input id="newInterpreterSettingPort" input pu-elastic-input
-            pu-elastic-input-minwidth="180px" ng-model="setting.option.port"  ng-disabled="!valueform.$visible" />
-      </div>
-    </div>
-    <div class="row interpreter">
-      <div class="col-md-12">
-        <div class="checkbox remove-margin-top-bottom">
-          <span class="input-group" style="line-height:30px;">
-            <label>
-              <input type="checkbox" style="width:20px !important" id="idShowPermission" ng-click="togglePermissions(setting.name)" ng-model="setting.option.setPermission" ng-disabled="!valueform.$visible"/>
-               Set permission
-            </label>
+      <div class="col-md-12" ng-show="repo.settings.length > 0">
+        <h5>Settings</h5>
+        <div ng-repeat="setting in repo.settings">
+          <span ng-bind="setting.name" style='text-transform: capitalize;'></span>:
+          <span class="btn-group">
+            <form style="display:inline; margin-left:5px;" ng-show="setting.type === 'dropdown'">
+              <select ng-model="setting.selected"
+                      class="selectpicker"
+                      ng-options="item.value as item.name for item in setting.value"></select>
+            </form>
+            <input id="newInterpreterSettingName" input pu-elastic-input
+                   ng-show="setting.type === 'input'" pu-elastic-input-minwidth="180px" ng-model="setting.selected" />
           </span>
         </div>
       </div>
     </div>
     <div class="row interpreter">
-      <div class="col-md-12">
-        <!-- permissions -->
-        <div ng-show="setting.option.setPermission" class="permissionsForm">
-          <div>
-            <p>
-              Enter comma separated users in the fields. <br />
-              Empty field (*) implies anyone can run this interpreter.
-            </p>
-            <div>
-
-            <span class="owners">Owners </span>
-            <select id="{{setting.name}}Users" class="form-control" multiple="multiple" ng-disabled="!valueform.$visible">
-              <option ng-repeat="user in setting.option.users" selected="selected">{{user}}</option>
-            </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div ng-show="_.isEmpty(setting.properties) && _.isEmpty(setting.dependencies) || valueform.$hidden" class="col-md-12 gray40-message">
-        <em>Currently there are no properties and dependencies set for this interpreter</em>
-      </div>
-    </div>
-    <div class="row interpreter">
-      <div class="col-md-12" ng-show="!_.isEmpty(setting.properties) || valueform.$visible">
-        <h5>Properties</h5>
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th style="width:40%">name</th>
-              <th style="width:40%">value</th>
-              <th style="width:20%" ng-if="valueform.$visible">action</th>
-            </tr>
-          </thead>
-          <tr ng-repeat="key in setting.properties | sortByKey" >
-            <td>{{key}}</td>
-            <td>
-              <span editable-textarea="setting.properties[key]" e-form="valueform" e-msd-elastic>
-                {{setting.properties[key] | breakFilter}}
-              </span>
-            </td>
-            <td ng-if="valueform.$visible">
-              <button class="btn btn-default btn-sm fa fa-remove"
-                   ng-click="removeInterpreterProperty(key, setting.id)">
-              </button>
-            </td>
-          </tr>
-          <tr ng-if="valueform.$visible">
-            <td>
-              <input ng-model="setting.propertyKey"
-                     pu-elastic-input
-                     pu-elastic-input-minwidth="180px" />
-            </td>
-            <td>
-              <textarea msd-elastic ng-model="setting.propertyValue"></textarea>
-            </td>
-            <td>
-              <button class="btn btn-default btn-sm fa fa-plus"
-                   ng-click="addNewInterpreterProperty(setting.id)">
-              </button>
-            </td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="row interpreter">
-      <div class="col-md-12" ng-show="!_.isEmpty(setting.dependencies) || valueform.$visible">
-        <h5>Dependencies</h5>
-        <p class="gray40-message" style="font-size:12px" ng-show="valueform.$visible">
-          These dependencies will be added to classpath when interpreter process starts.</p>
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th style="width:40%">artifact</th>
-              <th>exclude</th>
-              <th ng-if="valueform.$visible">action</th>
-            </tr>
-          </thead>
-          <tr ng-repeat="dep in setting.dependencies">
-            <td>
-              <span editable-text="dep.groupArtifactVersion" e-placeholder="groupId:artifactId:version or local file path"
-                    e-form="valueform" e-msd-elastic e-style="width:100%">
-                {{dep.groupArtifactVersion | breakFilter}}
-              </span>
-            </td>
-            <td>
-              <textarea ng-if="valueform.$visible" ng-model="dep.exclusions"
-                        placeholder="(Optional) comma separated groupId:artifactId list"
-                        form="valueform"
-                        e-msd-elastic
-                        ng-list="">
-              </textarea>
-              <div ng-if="!valueform.$visible">{{dep.exclusions.join()}}</div>
-            </td>
-            <td ng-if="valueform.$visible">
-              <button class="btn btn-default btn-sm fa fa-remove"
-                   ng-click="removeInterpreterDependency(dep.groupArtifactVersion, setting.id)">
-              </button>
-            </td>
-          </tr>
-          <tr ng-if="valueform.$visible">
-            <td>
-              <input ng-model="setting.depArtifact"
-                     placeholder="groupId:artifactId:version or local file path"
-                     style="width: 100%" />
-            </td>
-            <td>
-              <textarea ng-model="setting.depExclude"
-                        placeholder="(Optional) comma separated groupId:artifactId list"
-                        msd-elastic
-                        ng-list="">
-              </textarea>
-            </td>
-            <td>
-              <button class="btn btn-default btn-sm fa fa-plus"
-                   ng-click="addNewInterpreterDependency(setting.id)">
-              </button>
-            </td>
-          </tr>
-        </table>
-        <form editable-form name="valueform"
-              onaftersave="updateInterpreterSetting(valueform, setting.id)"
-              ng-show="valueform.$visible">
-          <button type="submit" class="btn btn-primary">
-            Save
-          </button>
-          <button type="button" class="btn btn-default"
-                  ng-disabled="valueform.$waiting"
-                  ng-click="valueform.$cancel(); resetInterpreterSetting(setting.id)">
-            Cancel
-          </button>
-        </form>
+      <div ng-show="repo.settings.length === 0 || valueform.$hidden" class="col-md-12 gray40-message">
+        <em>Currently there are no settings for this Notebook Repository</em>
       </div>
     </div>
   </div>

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -35,10 +35,9 @@ limitations under the License.
 
       <div class="col-md-12">
         <h3 class="interpreter-title">{{repo.name}}</h3>
-        <span style="float:right">
+        <span style="float:right" ng-show="repo.settings.length > 0">
           <button class="btn btn-default btn-xs"
-                  ng-click="valueform.$show();
-                  copyOriginInterpreterSettingProperties(setting.id)">
+                  ng-click="valueform.$show();">
             <span class="fa fa-pencil"></span> edit</button>
         </span>
       </div>
@@ -46,18 +45,27 @@ limitations under the License.
     <div class="row interpreter">
       <div class="col-md-12" ng-show="repo.settings.length > 0">
         <h5>Settings</h5>
-        <div ng-repeat="setting in repo.settings">
-          <span ng-bind="setting.name" style='text-transform: capitalize;'></span>:
-          <span class="btn-group">
-            <form style="display:inline; margin-left:5px;" ng-show="setting.type === 'dropdown'">
-              <select ng-model="setting.selected"
-                      class="selectpicker"
-                      ng-options="item.value as item.name for item in setting.value"></select>
-            </form>
-            <input id="newInterpreterSettingName" input pu-elastic-input
-                   ng-show="setting.type === 'input'" pu-elastic-input-minwidth="180px" ng-model="setting.selected" />
-          </span>
-        </div>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th style="width:40%">name</th>
+              <th style="width:60%">value</th>
+            </tr>
+          </thead>
+          <tr ng-repeat="setting in repo.settings" >
+            <td ng-bind="setting.name"></td>
+            <td>
+              <span class="btn-group">
+                <select ng-model="setting.selected" ng-show="setting.type === 'dropdown'"
+                        class="selectpicker" ng-disabled="!valueform.$visible"
+                        ng-options="item.value as item.name for item in setting.value"></select>
+                <span ng-show="setting.type === 'input'" editable-textarea="setting.selectied" e-form="valueform" e-msd-elastic>
+                  {{setting.selected | breakFilter}}
+                </span>
+              </span>
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
     <div class="row interpreter">

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -77,7 +77,7 @@ limitations under the License.
     </div>
     <span style="float:right" ng-show="valueform.$visible">
       <form editable-form name="valueform"
-            onbeforesave="noterepo.saveNotebookRepo(repo, $data)"
+            onbeforesave="noterepo.saveNotebookRepo(valueform, repo, $data)"
             ng-show="valueform.$visible">
         <button type="submit" class="btn btn-primary btn-xs">
           <span class="fa fa-check"></span> Save

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.html
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.html
@@ -65,7 +65,7 @@ limitations under the License.
                   </span>
                 </span>
                 <span ng-show="setting.type === 'INPUT'">
-                  <span editable-textarea="setting.selected" e-name="{{setting.name}}" e-form="valueform" e-msd-elastic>
+                  <span editable-textarea="setting.selected" e-name="{{setting.name}}" e-form="valueform" e-msd-elastic e-cols="100">
                     {{setting.selected | breakFilter}}
                   </span>
                 </span>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -86,6 +86,7 @@ limitations under the License.
               <li><a href="" data-toggle="modal" data-target="#aboutModal">About Zeppelin</a></li>
               <li role="separator" style="margin: 5px 0;" class="divider"></li>
               <li><a href="#/interpreter">Interpreter</a></li>
+              <li><a href="#/notebookRepos">Notebook Repos</a></li>
               <li><a href="#/credential">Credential</a></li>
               <li><a href="#/configuration">Configuration</a></li>
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'" role="separator" style="margin: 5px 0;" class="divider"></li>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -162,6 +162,7 @@ limitations under the License.
     <script src="app/configuration/configuration.controller.js"></script>
     <script src="app/notebook/paragraph/paragraph.controller.js"></script>
     <script src="app/search/result-list.controller.js"></script>
+    <script src="app/notebookRepos/notebookRepos.controller.js"></script>
     <script src="components/arrayOrderingSrv/arrayOrdering.service.js"></script>
     <script src="components/navbar/navbar.controller.js"></script>
     <script src="components/ngescape/ngescape.directive.js"></script>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -36,9 +36,11 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Azure storage backend for notebooks
@@ -226,5 +228,16 @@ public class AzureNotebookRepo implements NotebookRepo {
   public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
+  }
+
+  @Override
+  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -17,11 +17,19 @@
 
 package org.apache.zeppelin.notebook.repo;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.file.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -33,14 +41,16 @@ import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.*;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.file.CloudFile;
+import com.microsoft.azure.storage.file.CloudFileClient;
+import com.microsoft.azure.storage.file.CloudFileDirectory;
+import com.microsoft.azure.storage.file.CloudFileShare;
+import com.microsoft.azure.storage.file.ListFileItem;
 
 /**
  * Azure storage backend for notebooks
@@ -231,7 +241,7 @@ public class AzureNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
     LOG.warn("Method not implemented");
     return Collections.emptyList();
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -107,7 +107,7 @@ public interface NotebookRepo {
    * @param subject
    * @return
    */
-  @ZeppelinApi public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject);
+  @ZeppelinApi public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject);
 
   /**
    * update notebook repo settings.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.notebook.repo;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.notebook.Note;
@@ -99,6 +100,22 @@ public interface NotebookRepo {
    * @return list of revisions
    */
   @ZeppelinApi public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject);
+
+  /**
+   * Get NotebookRepo settings got the given user.
+   *
+   * @param subject
+   * @return
+   */
+  @ZeppelinApi public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject);
+
+  /**
+   * update notebook repo settings.
+   *
+   * @param settings
+   * @param subject
+   */
+  @ZeppelinApi public void updateSettings(Map<String, String> settings, AuthenticationInfo subject);
 
   /**
    * Represents the 'Revision' a point in life of the notebook

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettings.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettings.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.notebook.repo;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Notebook repo settings.
+ * This represent a structure of a notebook repo settings that will mostly used in the frontend.
+ *
+ */
+public class NotebookRepoSettings {
+
+    /**
+     * Type of value, It can be text or list.
+     */
+    public enum Type {
+        INPUT, DROPDOWN
+    }
+
+    public static NotebookRepoSettings newInstance() {
+        return new NotebookRepoSettings();
+    }
+
+    public Type type;
+    public List<Map<String, String>> value;
+    public String selected;
+    public String name;
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettings.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettings.java
@@ -20,25 +20,25 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Notebook repo settings.
- * This represent a structure of a notebook repo settings that will mostly used in the frontend.
+ * Notebook repo settings. This represent a structure of a notebook repo settings that will mostly
+ * used in the frontend.
  *
  */
 public class NotebookRepoSettings {
 
-    /**
-     * Type of value, It can be text or list.
-     */
-    public enum Type {
-        INPUT, DROPDOWN
-    }
+  /**
+   * Type of value, It can be text or list.
+   */
+  public enum Type {
+    INPUT, DROPDOWN
+  }
 
-    public static NotebookRepoSettings newInstance() {
-        return new NotebookRepoSettings();
-    }
+  public static NotebookRepoSettings newInstance() {
+    return new NotebookRepoSettings();
+  }
 
-    public Type type;
-    public List<Map<String, String>> value;
-    public String selected;
-    public String name;
+  public Type type;
+  public List<Map<String, String>> value;
+  public String selected;
+  public String name;
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettingsInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSettingsInfo.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * used in the frontend.
  *
  */
-public class NotebookRepoSettings {
+public class NotebookRepoSettingsInfo {
 
   /**
    * Type of value, It can be text or list.
@@ -33,8 +33,8 @@ public class NotebookRepoSettings {
     INPUT, DROPDOWN
   }
 
-  public static NotebookRepoSettings newInstance() {
-    return new NotebookRepoSettings();
+  public static NotebookRepoSettingsInfo newInstance() {
+    return new NotebookRepoSettingsInfo();
   }
 
   public Type type;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -17,8 +17,6 @@
 
 package org.apache.zeppelin.notebook.repo;
 
-import com.google.common.collect.Lists;
-
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -26,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +37,8 @@ import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
 
 /**
  * Notebook repository sync with remote storage
@@ -481,8 +480,8 @@ public class NotebookRepoSync implements NotebookRepo {
   }
 
   @Override
-  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
-    List<NotebookRepoSettings> repoSettings = Collections.emptyList();
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
+    List<NotebookRepoSettingsInfo> repoSettings = Collections.emptyList();
     try {
       repoSettings =  getRepo(0).getSettings(subject);
     } catch (IOException e) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -444,4 +444,24 @@ public class NotebookRepoSync implements NotebookRepo {
     }
     return revisions;
   }
+
+  @Override
+  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+    List<NotebookRepoSettings> repoSettings = Collections.emptyList();
+    try {
+      repoSettings =  getRepo(0).getSettings(subject);
+    } catch (IOException e) {
+      LOG.error("Cannot get notebook repo settings", e);
+    }
+    return repoSettings;
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    try {
+      getRepo(0).updateSettings(settings, subject);
+    } catch (IOException e) {
+      LOG.error("Cannot update notebook repo settings", e);
+    }
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
@@ -22,59 +22,58 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * Representation of a notebook repo with settings.
- * This is mostly a Wrapper around notebook repo information plus settings.
+ * Representation of a notebook repo with settings. This is mostly a Wrapper around notebook repo
+ * information plus settings.
  */
 public class NotebookRepoWithSettings {
 
-    public static final NotebookRepoWithSettings EMPTY = NotebookRepoWithSettings
-            .builder(StringUtils.EMPTY)
-            .build();
+  public static final NotebookRepoWithSettings EMPTY =
+      NotebookRepoWithSettings.builder(StringUtils.EMPTY).build();
 
-    public String name;
-    public String className;
-    public List<NotebookRepoSettings> settings;
+  public String name;
+  public String className;
+  public List<NotebookRepoSettings> settings;
 
-    private NotebookRepoWithSettings() {}
+  private NotebookRepoWithSettings() {}
 
-    public static Builder builder(String name) {
-        return new Builder(name);
+  public static Builder builder(String name) {
+    return new Builder(name);
+  }
+
+  private NotebookRepoWithSettings(Builder builder) {
+    name = builder.name;
+    className = builder.className;
+    settings = builder.settings;
+  }
+
+  public boolean isEmpty() {
+    return this.equals(EMPTY);
+  }
+
+  /**
+   * Simple builder :).
+   */
+  public static class Builder {
+    private final String name;
+    private String className = StringUtils.EMPTY;
+    private List<NotebookRepoSettings> settings = Collections.emptyList();
+
+    public Builder(String name) {
+      this.name = name;
     }
 
-    private NotebookRepoWithSettings(Builder builder) {
-        name = builder.name;
-        className = builder.className;
-        settings = builder.settings;
+    public NotebookRepoWithSettings build() {
+      return new NotebookRepoWithSettings(this);
     }
 
-    public boolean isEmpty() {
-        return this.equals(EMPTY);
+    public Builder className(String className) {
+      this.className = className;
+      return this;
     }
 
-    /**
-     * Simple builder :).
-     */
-    public static class Builder {
-        private final String name;
-        private String className = StringUtils.EMPTY;
-        private List<NotebookRepoSettings> settings = Collections.emptyList();
-
-        public Builder(String name) {
-            this.name = name;
-        }
-
-        public NotebookRepoWithSettings build() {
-            return new NotebookRepoWithSettings(this);
-        }
-
-        public Builder className(String className) {
-            this.className = className;
-            return this;
-        }
-
-        public Builder settings(List<NotebookRepoSettings> settings) {
-            this.settings = settings;
-            return this;
-        }
+    public Builder settings(List<NotebookRepoSettings> settings) {
+      this.settings = settings;
+      return this;
     }
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
@@ -32,7 +32,7 @@ public class NotebookRepoWithSettings {
 
   public String name;
   public String className;
-  public List<NotebookRepoSettings> settings;
+  public List<NotebookRepoSettingsInfo> settings;
 
   private NotebookRepoWithSettings() {}
 
@@ -56,7 +56,7 @@ public class NotebookRepoWithSettings {
   public static class Builder {
     private final String name;
     private String className = StringUtils.EMPTY;
-    private List<NotebookRepoSettings> settings = Collections.emptyList();
+    private List<NotebookRepoSettingsInfo> settings = Collections.emptyList();
 
     public Builder(String name) {
       this.name = name;
@@ -71,7 +71,7 @@ public class NotebookRepoWithSettings {
       return this;
     }
 
-    public Builder settings(List<NotebookRepoSettings> settings) {
+    public Builder settings(List<NotebookRepoSettingsInfo> settings) {
       this.settings = settings;
       return this;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoWithSettings.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.notebook.repo;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Representation of a notebook repo with settings.
+ * This is mostly a Wrapper around notebook repo information plus settings.
+ */
+public class NotebookRepoWithSettings {
+
+    public static final NotebookRepoWithSettings EMPTY = NotebookRepoWithSettings
+            .builder(StringUtils.EMPTY)
+            .build();
+
+    public String name;
+    public String className;
+    public List<NotebookRepoSettings> settings;
+
+    private NotebookRepoWithSettings() {}
+
+    public static Builder builder(String name) {
+        return new Builder(name);
+    }
+
+    private NotebookRepoWithSettings(Builder builder) {
+        name = builder.name;
+        className = builder.className;
+        settings = builder.settings;
+    }
+
+    public boolean isEmpty() {
+        return this.equals(EMPTY);
+    }
+
+    /**
+     * Simple builder :).
+     */
+    public static class Builder {
+        private final String name;
+        private String className = StringUtils.EMPTY;
+        private List<NotebookRepoSettings> settings = Collections.emptyList();
+
+        public Builder(String name) {
+            this.name = name;
+        }
+
+        public NotebookRepoWithSettings build() {
+            return new NotebookRepoWithSettings(this);
+        }
+
+        public Builder className(String className) {
+            this.className = className;
+            return this;
+        }
+
+        public Builder settings(List<NotebookRepoSettings> settings) {
+            this.settings = settings;
+            return this;
+        }
+    }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -29,10 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.s3.AmazonS3EncryptionClient;
-import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
-import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -47,10 +43,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3EncryptionClient;
+import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.KMSEncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -274,7 +274,7 @@ public class S3NotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
     LOG.warn("Method not implemented");
     return Collections.emptyList();
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
@@ -269,5 +271,16 @@ public class S3NotebookRepo implements NotebookRepo {
   public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
+  }
+
+  @Override
+  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -326,7 +326,7 @@ public class VFSNotebookRepo implements NotebookRepo {
       return;
     }
     LOG.warn("{} will change notebook dir from {} to {}",
-        getNotebookDirPath(), newNotebookDirectotyPath);
+        subject.getUser(), getNotebookDirPath(), newNotebookDirectotyPath);
     try {
       setNotebookDirectory(newNotebookDirectotyPath);
     } catch (IOException e) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -23,9 +23,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.vfs2.FileContent;
@@ -283,6 +285,17 @@ public class VFSNotebookRepo implements NotebookRepo {
   public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
     // Auto-generated method stub
     return null;
+  }
+
+  @Override
+  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+    logger.warn("Method not implemented");
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    logger.warn("Method not implemented");
   }
 
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -297,12 +297,12 @@ public class VFSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
-    NotebookRepoSettings repoSetting = NotebookRepoSettings.newInstance();
-    List<NotebookRepoSettings> settings = Lists.newArrayList();
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
+    NotebookRepoSettingsInfo repoSetting = NotebookRepoSettingsInfo.newInstance();
+    List<NotebookRepoSettingsInfo> settings = Lists.newArrayList();
 
     repoSetting.name = "Notebook Path";
-    repoSetting.type = NotebookRepoSettings.Type.INPUT;
+    repoSetting.type = NotebookRepoSettingsInfo.Type.INPUT;
     repoSetting.value = Collections.emptyList();
     repoSetting.selected = getNotebookDirPath();
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -33,7 +33,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileContent;
 import org.apache.commons.vfs2.FileObject;
-import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.NameScope;
@@ -44,15 +43,13 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
-import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.NotebookImportDeserializer;
+import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -61,7 +58,7 @@ import com.google.gson.GsonBuilder;
 *
 */
 public class VFSNotebookRepo implements NotebookRepo {
-  private final static Logger LOG = LoggerFactory.getLogger(VFSNotebookRepo.class);
+  private static final Logger LOG = LoggerFactory.getLogger(VFSNotebookRepo.class);
 
   private FileSystemManager fsManager;
   private URI filesystemRoot;
@@ -328,7 +325,8 @@ public class VFSNotebookRepo implements NotebookRepo {
       LOG.error("Notebook path is invalid");
       return;
     }
-    LOG.warn("{} will change notebook dir from {} to {}", getNotebookDirPath(), newNotebookDirectotyPath);
+    LOG.warn("{} will change notebook dir from {} to {}",
+        getNotebookDirPath(), newNotebookDirectotyPath);
     try {
       setNotebookDirectory(newNotebookDirectotyPath);
     } catch (IOException e) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -28,7 +28,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
-import org.apache.zeppelin.notebook.repo.NotebookRepoSettings;
+import org.apache.zeppelin.notebook.repo.NotebookRepoSettingsInfo;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.rest.ZeppelinhubRestApiHandler;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.Client;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -237,7 +237,7 @@ public class ZeppelinHubRepo implements NotebookRepo {
   }
 
   @Override
-  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
     LOG.warn("Method not implemented");
     return Collections.emptyList();
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -21,12 +21,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.apache.zeppelin.notebook.repo.NotebookRepoSettings;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.rest.ZeppelinhubRestApiHandler;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.Client;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -232,6 +234,17 @@ public class ZeppelinHubRepo implements NotebookRepo {
       LOG.error("Cannot get note history", e);
     }
     return history;
+  }
+
+  @Override
+  public List<NotebookRepoSettings> getSettings(AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+    LOG.warn("Method not implemented");
   }
 
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -31,18 +32,21 @@ import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
-import org.apache.zeppelin.notebook.*;
-import org.apache.zeppelin.notebook.repo.zeppelinhub.security.Authentication;
-import org.apache.zeppelin.scheduler.JobListener;
+import org.apache.zeppelin.notebook.JobListenerFactory;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.ParagraphJobListener;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
-import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 public class VFSNotebookRepoTest implements JobListenerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(VFSNotebookRepoTest.class);
@@ -140,6 +144,24 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     notebookRepo.save(note, null);
     assertEquals(note.getName(), "SaveTest");
     notebookRepo.remove(note.getId(), null);
+  }
+  
+  @Test
+  public void testUpdateSettings() throws IOException {
+    AuthenticationInfo subject = new AuthenticationInfo("anonymous");
+    File tmpDir = File.createTempFile("temp", Long.toString(System.nanoTime()));
+    Map<String, String> settings = ImmutableMap.of("Notebook Path", tmpDir.getAbsolutePath());
+    
+    List<NotebookRepoSettingsInfo> repoSettings = notebookRepo.getSettings(subject);
+    String originalDir = repoSettings.get(0).selected;
+    
+    notebookRepo.updateSettings(settings, subject);
+    repoSettings = notebookRepo.getSettings(subject);
+    assertEquals(repoSettings.get(0).selected, tmpDir.getAbsolutePath());
+    
+    // restaure
+    notebookRepo.updateSettings(ImmutableMap.of("Notebook Path", originalDir), subject);
+    FileUtils.deleteQuietly(tmpDir);
   }
 
   class NotebookWriter implements Runnable {


### PR DESCRIPTION
### What is this PR for?
The idea behind this feature is to bring flexibility to the user to let him configure his repo via UI without restarting Apache Zeppelin.
This is flexible enough to handle most of the basic needs, but more complex case can be added in the future. I will not implement all NotebookRepo, this should be done in different PR since it will depend on special needs. I will just provide a simple example with VFS notebook repo.

***NB***: this scope of the PR doesn't include save change in the configuration file of zeppelin as well as implementation of every notebook repo, git, s3 etcetc, this will be added later if needed.

### What type of PR is it?
 * **Improvement**

### Todos
* [x] - Implement backend.
* [x] - Implement frontend.
* [x] - Implement LocalVFS directory change as exemple.

### What is the Jira issue?
 * [ZEPPELIN-1575](https://issues.apache.org/jira/browse/ZEPPELIN-1575)

### How should this be tested?
Go to notebook repo setting page, edit the notebook path and save.

### Screenshots (if appropriate)
![notebook_repo_settings](https://cloud.githubusercontent.com/assets/3139557/19643248/583dbc2a-9a24-11e6-8f14-7deda9c443f2.gif)


### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? YES
