### PR TITLE
ZEPPELIN-1577. LivyInterpreter should not use FIFOScheduler

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
@@ -101,8 +101,8 @@ public class LivyPySparkInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
-        LivyPySparkInterpreter.class.getName() + this.hashCode());
+    return SchedulerFactory.singleton().createOrGetFIFOPerUserScheduler(
+        LivySparkInterpreter.class.getName());
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Livy Spark interpreter for Zeppelin.
@@ -37,7 +38,7 @@ public class LivySparkInterpreter extends Interpreter {
   Logger LOGGER = LoggerFactory.getLogger(LivySparkInterpreter.class);
   private LivyOutputStream out;
 
-  protected static Map<String, Integer> userSessionMap;
+  protected static Map<String, Integer> userSessionMap = new ConcurrentHashMap<>();
   protected static Map<Integer, String> sessionId2AppIdMap;
   protected static Map<Integer, String> sessionId2WebUIMap;
 
@@ -46,7 +47,6 @@ public class LivySparkInterpreter extends Interpreter {
 
   public LivySparkInterpreter(Properties property) {
     super(property);
-    userSessionMap = new HashMap<>();
     sessionId2AppIdMap = new HashMap<>();
     sessionId2WebUIMap = new HashMap<>();
     livyHelper = new LivyHelper(property);
@@ -151,8 +151,8 @@ public class LivySparkInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
-        LivySparkInterpreter.class.getName() + this.hashCode());
+    return SchedulerFactory.singleton().createOrGetFIFOPerUserScheduler(
+        LivySparkInterpreter.class.getName());
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
@@ -101,8 +101,8 @@ public class LivySparkRInterpreter extends Interpreter {
 
   @Override
   public Scheduler getScheduler() {
-    return SchedulerFactory.singleton().createOrGetFIFOScheduler(
-        LivySparkRInterpreter.class.getName() + this.hashCode());
+    return SchedulerFactory.singleton().createOrGetFIFOPerUserScheduler(
+        LivySparkInterpreter.class.getName());
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -146,7 +146,7 @@ public class LivySparkSQLInterpreter extends Interpreter {
     if (concurrentSQL()) {
       int maxConcurrency = 10;
       return SchedulerFactory.singleton().createOrGetParallelScheduler(
-          LivySparkInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+              LivySparkSQLInterpreter.class.getName() + this.hashCode(), maxConcurrency);
     } else {
       Interpreter intp =
           getInterpreterInTheSameSessionByClassName(LivySparkInterpreter.class.getName());

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -34,7 +34,7 @@ import java.util.Properties;
  */
 public class LivySparkSQLInterpreter extends Interpreter {
 
-  Logger LOGGER = LoggerFactory.getLogger(LivySparkSQLInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LivySparkSQLInterpreter.class);
 
   protected Map<String, Integer> userSessionMap;
   private LivyHelper livyHelper;
@@ -57,6 +57,10 @@ public class LivySparkSQLInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String line, InterpreterContext interpreterContext) {
     try {
+      LOGGER.info("***********sessionMap size:" + userSessionMap.size());
+      for (Map.Entry entry : userSessionMap.entrySet()) {
+        LOGGER.info("Session {}, user:{}", entry.getValue(), entry.getKey());
+      }
       if (userSessionMap.get(interpreterContext.getAuthenticationInfo().getUser()) == null) {
         try {
           userSessionMap.put(

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -296,7 +296,7 @@ public class RemoteInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     if (logger.isDebugEnabled()) {
-      logger.debug("st:\n{}", st);
+      logger.debug("st:\n{},\nuser:{}", st, context.getAuthenticationInfo().getUser());
     }
 
     FormType form = getFormType();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -428,6 +428,11 @@ public class RemoteInterpreterServer
     }
 
     @Override
+    public String getUser() {
+      return context.getAuthenticationInfo().getUser();
+    }
+
+    @Override
     protected Object jobRun() throws Throwable {
       try {
         InterpreterContext.set(context);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/ExecutorFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/ExecutorFactory.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 /**
  *
@@ -53,10 +54,18 @@ public class ExecutorFactory {
     return createOrGet(name, 100);
   }
 
-  public ExecutorService createOrGet(String name, int numThread) {
+  public ExecutorService createOrGet(final String name, int numThread) {
     synchronized (executor) {
       if (!executor.containsKey(name)) {
-        executor.put(name, Executors.newScheduledThreadPool(numThread));
+        executor.put(name, Executors.newScheduledThreadPool(numThread, new ThreadFactory(){
+          int i = 0;
+          @Override
+          public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r);
+            thread.setName(name + "-" + i++);
+            return thread;
+          }
+        }));
       }
       return executor.get(name);
     }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/FIFOPerUserScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/FIFOPerUserScheduler.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zeppelin.scheduler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Each user use one FIFOScheduler
+ */
+public class FIFOPerUserScheduler implements Scheduler {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(FIFOScheduler.class);
+
+  private ExecutorService executor;
+  private SchedulerListener listener;
+  boolean terminate = false;
+  private String name;
+  private int maxUser = 10;
+
+  private Map<String, FIFOScheduler> schedulerMap = new HashMap<>();
+
+  public FIFOPerUserScheduler(String name, ExecutorService executor, SchedulerListener listener) {
+    this.name = name;
+    this.executor = executor;
+    this.listener = listener;
+  }
+
+  @Override
+  public String getName() {
+    return this.name;
+  }
+
+  @Override
+  public Collection<Job> getJobsWaiting() {
+    synchronized (schedulerMap) {
+      List<Job> waitingJobs = new ArrayList();
+      for (FIFOScheduler scheduler : schedulerMap.values()) {
+        waitingJobs.addAll(scheduler.getJobsWaiting());
+      }
+      return waitingJobs;
+    }
+  }
+
+  @Override
+  public Collection<Job> getJobsRunning() {
+//    return new ArrayList<>();
+    synchronized (schedulerMap) {
+      List<Job> runningJobs = new ArrayList();
+      for (FIFOScheduler scheduler : schedulerMap.values()) {
+        runningJobs.addAll(scheduler.getJobsRunning());
+      }
+      return runningJobs;
+    }
+  }
+
+  @Override
+  public void submit(Job job) {
+    synchronized (schedulerMap) {
+      FIFOScheduler scheduler = schedulerMap.get(job.getUser());
+      if (scheduler == null) {
+        scheduler = (FIFOScheduler) SchedulerFactory.singleton()
+                .createOrGetFIFOScheduler(this.name + "_" + job.getUser());
+        executor.execute(scheduler);
+      }
+      LOGGER.debug("Submitting job for owner:" + job.getUser());
+      scheduler.submit(job);
+      schedulerMap.put(job.getUser(), scheduler);
+    }
+  }
+
+  @Override
+  public Job removeFromWaitingQueue(String jobId) {
+    synchronized (schedulerMap) {
+      for (FIFOScheduler scheduler : schedulerMap.values()) {
+        Job job = scheduler.removeFromWaitingQueue(jobId);
+        if (job != null) {
+          schedulerMap.notify();
+          return job;
+        }
+      }
+      return null;
+    }
+  }
+
+  @Override
+  public void stop() {
+    synchronized (schedulerMap) {
+      for (FIFOScheduler scheduler : schedulerMap.values()) {
+        scheduler.stop();
+      }
+    }
+  }
+
+  @Override
+  public void run() {
+    // Do nothing, all the work is delegated to FIFOScheduler in schedulerMap
+  }
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/FIFOScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/FIFOScheduler.java
@@ -35,7 +35,7 @@ public class FIFOScheduler implements Scheduler {
   private ExecutorService executor;
   private SchedulerListener listener;
   boolean terminate = false;
-  Job runningJob = null;
+  volatile Job runningJob = null;
   private String name;
 
   static Logger LOGGER = LoggerFactory.getLogger(FIFOScheduler.class);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -107,19 +107,23 @@ public abstract class Job {
     this(jobId, jobName, listener, JobProgressPoller.DEFAULT_INTERVAL_MSEC);
   }
 
-  public Job(String jobId, String jobName, JobListener listener, long progressUpdateIntervalMs) {
+  public Job(String jobId, String jobName, JobListener listener,
+             long progressUpdateIntervalMs) {
     this.jobName = jobName;
     this.listener = listener;
     this.progressUpdateIntervalMs = progressUpdateIntervalMs;
 
     dateCreated = new Date();
     id = jobId;
-
     setStatus(Status.READY);
   }
 
   public String getId() {
     return id;
+  }
+
+  public String getUser() {
+    return null;
   }
 
   @Override

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/ParallelScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/ParallelScheduler.java
@@ -111,7 +111,7 @@ public class ParallelScheduler implements Scheduler {
           try {
             queue.wait(500);
           } catch (InterruptedException e) {
-            LOGGER.error("Exception in MockInterpreterAngular while interpret queue.wait", e);
+            LOGGER.error("Exception in ParallelScheduler while interpret queue.wait", e);
           }
           continue;
         }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
@@ -84,6 +84,17 @@ public class SchedulerFactory implements SchedulerListener {
     }
   }
 
+  public Scheduler createOrGetFIFOPerUserScheduler(String name) {
+    synchronized (schedulers) {
+      if (schedulers.containsKey(name) == false) {
+        Scheduler s = new FIFOPerUserScheduler(name, executor, this);
+        schedulers.put(name, s);
+        executor.execute(s);
+      }
+      return schedulers.get(name);
+    }
+  }
+
   public Scheduler createOrGetRemoteScheduler(
       String name,
       String noteId,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -341,6 +341,10 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p0);
         assertEquals(Status.FINISHED, p0.getStatus());
 
+        note.run(p1.getId());
+        waitForFinish(p1);
+        assertEquals(Status.FINISHED, p1.getStatus());
+
         note.run(p2.getId());
         waitForFinish(p2);
         assertEquals(Status.FINISHED, p2.getStatus());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -69,7 +69,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
 
   @VisibleForTesting
   Paragraph() {
-    super(generateId(), null);
+    super(generateId(), null, null);
     config = new HashMap<>();
     settings = new GUI();
   }
@@ -105,10 +105,6 @@ public class Paragraph extends Job implements Serializable, Cloneable {
            + new Random(System.currentTimeMillis()).nextInt();
   }
 
-  public String getUser() {
-    return user;
-  }
-
   public String getText() {
     return text;
   }
@@ -125,6 +121,11 @@ public class Paragraph extends Job implements Serializable, Cloneable {
   public void setAuthenticationInfo(AuthenticationInfo authenticationInfo) {
     this.authenticationInfo = authenticationInfo;
     this.user = authenticationInfo.getUser();
+  }
+
+  @Override
+  public String getUser() {
+    return user;
   }
 
   public String getTitle() {
@@ -330,7 +331,6 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       InterpreterContext context = getInterpreterContext();
       InterpreterContext.set(context);
       InterpreterResult ret = repl.interpret(script, context);
-
       if (Code.KEEP_PREVIOUS_RESULT == ret.code()) {
         return getReturn();
       }


### PR DESCRIPTION
### What is this PR for?

This PR create a new scheduler FIFOPerUserScheduler. So that each user's request is isolated. and it is FIFOSchduler per user. 
### What type of PR is it?

[Bug Fix | Improvement]
### Todos
- [ ] - Task
### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-1577
### How should this be tested?

Tested manually 
### Screenshots (if appropriate)
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No
