### PR TITLE
ZEPPELIN-1562 updated api doc

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -498,7 +498,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     </tr>
     <tr>
       <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]```</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[noteId]/[paragraphId]```</td>
     </tr>
     <tr>
       <td>Success code</td>


### PR DESCRIPTION
What is this PR for?

The URL for running a paragraph synchronously using REST api is mistakenly given as "http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[notebookId]/[paragraphId] "

Changed the doc as per code

What type of PR is it?

[Documentation]

Todos

What is the Jira issue?

ZEPPELIN-1562
How should this be tested?

Hit the url in below format for asynchrnous
http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[notebookId]/[paragraphId]

the same in synchronous 
http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[notebookId]/[paragraphId]

Screenshots (if appropriate)

Questions:

Does the licenses files need update? NO
Is there breaking changes for older versions? NO
Does this needs documentation? NO