### PR TITLE
[ZEPPELIN-1564] Enable note deletion and paragraph output clear from main page

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -493,7 +493,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <col width="200">
     <tr>
       <td>Description</td>
-      <td> This ```POST``` method runs the paragraph synchronously by given note and paragraph id. This API can return SUCCESS or ERROR depending on the outcome of the paragraph execution
+      <td>This ```POST``` method runs the paragraph synchronously by given note and paragraph id. This API can return SUCCESS or ERROR depending on the outcome of the paragraph execution
       </td>
     </tr>
     <tr>
@@ -969,6 +969,34 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
   "message": "",
   "body": "2AZPHY918"
 }</pre></td>
+    </tr>
+    </tr>
+  </table>
+
+<br />
+### Clear all paragraph result
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method clear all paragraph results from note of given id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/clear```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>sample JSON response</td>
+      <td><pre>{"status": "OK"}</pre></td>
     </tr>
     </tr>
   </table>

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -991,8 +991,16 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       <td>200</td>
     </tr>
     <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
+      <td>Forbidden code</td>
+      <td>401</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>500</td>
     </tr>
     <tr>
       <td>sample JSON response</td>

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -979,7 +979,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```POST``` method clear all paragraph results from note of given id.
+      <td>This ```PUT``` method clear all paragraph results from note of given id.
       </td>
     </tr>
     <tr>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -528,14 +528,11 @@ public class NotebookRestApi {
   public Response clearAllParagraphOutput(@PathParam("noteId") String noteId)
       throws IOException {
     LOG.info("clear all paragraph output of note {}", noteId);
+    checkIfUserCanWrite(noteId, "Insufficient privileges you cannot clear this note");
 
-    if (!noteId.isEmpty()) {
-      Note note = notebook.getNote(noteId);
-      if (note == null) {
-        return new JsonResponse(Status.NOT_FOUND, "note not found.").build();
-      }
-      note.clearAllParagraphOutput();
-    }
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    note.clearAllParagraphOutput();
 
     return new JsonResponse(Status.OK, "").build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -43,7 +43,7 @@ import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.rest.exception.NotFoundException;
-import org.apache.zeppelin.rest.exception.UnauthorizedException;
+import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.rest.message.CronRequest;
 import org.apache.zeppelin.rest.message.NewNoteRequest;
 import org.apache.zeppelin.rest.message.NewParagraphRequest;
@@ -124,7 +124,7 @@ public class NotebookRestApi {
     userAndRoles.add(SecurityUtils.getPrincipal());
     userAndRoles.addAll(SecurityUtils.getRoles());
     if (!notebookAuthorization.isOwner(userAndRoles, noteId)) {
-      throw new UnauthorizedException(errorMsg);
+      throw new ForbiddenException(errorMsg);
     }
   }
   
@@ -136,7 +136,7 @@ public class NotebookRestApi {
     userAndRoles.add(SecurityUtils.getPrincipal());
     userAndRoles.addAll(SecurityUtils.getRoles());
     if (!notebookAuthorization.hasWriteAuthorization(userAndRoles, noteId)) {
-      throw new UnauthorizedException(errorMsg);
+      throw new ForbiddenException(errorMsg);
     }
   }
   
@@ -148,7 +148,7 @@ public class NotebookRestApi {
     userAndRoles.add(SecurityUtils.getPrincipal());
     userAndRoles.addAll(SecurityUtils.getRoles());
     if (!notebookAuthorization.hasReadAuthorization(userAndRoles, noteId)) {
-      throw new UnauthorizedException(errorMsg);
+      throw new ForbiddenException(errorMsg);
     }
   }
   

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -462,6 +462,30 @@ public class NotebookRestApi {
   }
 
   /**
+   * Clear result of all paragraphs REST API
+   *
+   * @param noteId ID of Note
+   * @return JSON with status.ok
+   */
+  @POST
+  @Path("{noteId}/clear")
+  @ZeppelinApi
+  public Response clearAllParagraphOutput(@PathParam("noteId") String noteId)
+      throws IOException {
+    LOG.info("clear all paragraph output of note {}", noteId);
+
+    if (!noteId.isEmpty()) {
+      Note note = notebook.getNote(noteId);
+      if (note == null) {
+        return new JsonResponse(Status.NOT_FOUND, "note not found.").build();
+      }
+      note.clearAllParagraphOutput();
+    }
+
+    return new JsonResponse(Status.OK, "").build();
+  }
+
+  /**
    * Run note jobs REST API
    *
    * @param noteId ID of Note

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -467,7 +467,7 @@ public class NotebookRestApi {
    * @param noteId ID of Note
    * @return JSON with status.ok
    */
-  @POST
+  @PUT
   @Path("{noteId}/clear")
   @ZeppelinApi
   public Response clearAllParagraphOutput(@PathParam("noteId") String noteId)

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/ForbiddenException.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/ForbiddenException.java
@@ -17,6 +17,7 @@
 package org.apache.zeppelin.rest.exception;
 
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -27,24 +28,24 @@ import org.apache.zeppelin.utils.ExceptionUtils;
  * UnauthorizedException handler for WebApplicationException.
  * 
  */
-public class UnauthorizedException extends WebApplicationException {
+public class ForbiddenException extends WebApplicationException {
   private static final long serialVersionUID = 4394749068760407567L;
-  private static final String UNAUTHORIZED_MSG = "Authorization required";
+  private static final String FORBIDDEN_MSG = "Not allowed to access";
 
-  public UnauthorizedException() {
-    super(unauthorizedJson(UNAUTHORIZED_MSG));
+  public ForbiddenException() {
+    super(forbiddenJson(FORBIDDEN_MSG));
   }
 
-  private static Response unauthorizedJson(String message) {
+  private static Response forbiddenJson(String message) {
     return ExceptionUtils.jsonResponseContent(FORBIDDEN, message);
   }
   
-  public UnauthorizedException(Throwable cause, String message) {
-    super(cause, unauthorizedJson(message));
+  public ForbiddenException(Throwable cause, String message) {
+    super(cause, forbiddenJson(message));
   }
   
-  public UnauthorizedException(String message) {
-    super(unauthorizedJson(message));
+  public ForbiddenException(String message) {
+    super(forbiddenJson(message));
   }
 
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -792,7 +792,7 @@ public class NotebookServer extends WebSocketServlet implements
     }
     Note note = notebook.getNote(noteId);
     NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
-    if (!notebookAuthorization.isOwner(noteId, userAndRoles)) {
+    if (!notebookAuthorization.isWriter(noteId, userAndRoles)) {
       permissionError(conn, "clear output", fromMessage.principal,
           userAndRoles, notebookAuthorization.getOwners(noteId));
       return;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -215,6 +215,9 @@ public class NotebookServer extends WebSocketServlet implements
           case PARAGRAPH_CLEAR_OUTPUT:
             clearParagraphOutput(conn, userAndRoles, notebook, messagereceived);
             break;
+          case PARAGRAPH_CLEAR_ALL_OUTPUT:
+            clearAllParagraphOutput(conn, userAndRoles, notebook, messagereceived);
+            break;
           case NOTE_UPDATE:
             updateNote(conn, userAndRoles, notebook, messagereceived);
             break;
@@ -778,6 +781,25 @@ public class NotebookServer extends WebSocketServlet implements
     addConnectionToNote(newNote.getId(), (NotebookSocket) conn);
     conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", newNote)));
     broadcastNoteList(subject, userAndRoles);
+  }
+
+  private void clearAllParagraphOutput(NotebookSocket conn, HashSet<String> userAndRoles,
+                                       Notebook notebook, Message fromMessage)
+      throws IOException {
+    final String noteId = (String) fromMessage.get("id");
+    if (StringUtils.isBlank(noteId)) {
+      return;
+    }
+    Note note = notebook.getNote(noteId);
+    NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
+    if (!notebookAuthorization.isOwner(noteId, userAndRoles)) {
+      permissionError(conn, "clear output", fromMessage.principal,
+          userAndRoles, notebookAuthorization.getOwners(noteId));
+      return;
+    }
+
+    note.clearAllParagraphOutput();
+    broadcastNote(note);
   }
 
   protected Note importNote(NotebookSocket conn, HashSet<String> userAndRoles,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -539,7 +539,7 @@ public abstract class AbstractTestRestApi {
 
 
   /** Status code matcher */
-  protected Matcher<? super HttpMethodBase> isForbiden() { return responsesWith(403); }
+  protected Matcher<? super HttpMethodBase> isForbidden() { return responsesWith(403); }
 
   protected Matcher<? super HttpMethodBase> isAllowed() {
     return responsesWith(200);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -191,10 +191,10 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     p2.setReturn(result, new Throwable());
 
     // clear paragraph result
-    PostMethod post = httpPost("/notebook/" + note.getId() + "/clear", "");
-    LOG.info("test clear paragraph output response\n" + post.getResponseBodyAsString());
-    assertThat(post, isAllowed());
-    post.releaseConnection();
+    PutMethod put = httpPut("/notebook/" + note.getId() + "/clear", "");
+    LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
+    assertThat(put, isAllowed());
+    put.releaseConnection();
 
     // check if paragraph results are cleared
     GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p1.getId());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -82,10 +82,10 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     //set permission
     String payload = "{ \"owners\": [\"admin\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
     PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
-    assertThat("test set note premission method:", put, isAllowed());
+    assertThat("test set note permission method:", put, isAllowed());
     put.releaseConnection();
     
-    userTryGetNote(noteId, "user1", "password2", isForbiden());
+    userTryGetNote(noteId, "user1", "password2", isForbidden());
     
     userTryGetNote(noteId, "user2", "password3", isAllowed());
     
@@ -99,10 +99,10 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     //set permission
     String payload = "{ \"owners\": [\"admin\", \"user1\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
     PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
-    assertThat("test set note premission method:", put, isAllowed());
+    assertThat("test set note permission method:", put, isAllowed());
     put.releaseConnection();
     
-    userTryRemoveNote(noteId, "user2", "password3", isForbiden());
+    userTryRemoveNote(noteId, "user2", "password3", isForbidden());
     userTryRemoveNote(noteId, "user1", "password2", isAllowed());
     
     Note deletedNote = ZeppelinServer.notebook.getNote(noteId);

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -22,10 +22,12 @@
     'websocketMsgSrv',
     '$rootScope',
     'arrayOrderingSrv',
-    'ngToast'
+    'ngToast',
+    'noteActionSrv'
   ];
 
-  function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv, ngToast) {
+  function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv,
+                    ngToast, noteActionSrv) {
     ngToast.dismiss();
     var vm = this;
     vm.notes = noteListDataFactory;
@@ -85,6 +87,13 @@
         vm.notebookHome = false;
       }
     });
-  }
 
+    $scope.removeNote = function(noteId) {
+      noteActionSrv.removeNote(noteId, false);
+    };
+
+    $scope.clearAllParagraphOutput = function(noteId) {
+      noteActionSrv.clearAllParagraphOutput(noteId);
+    };
+  }
 })();

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -13,9 +13,23 @@ limitations under the License.
 -->
 
 <script type="text/ng-template" id="notebook_folder_renderer.html">
-  <div ng-if="node.children == null">
+  <div ng-if="node.children == null"
+       ng-mouseenter="showButton=true"
+       ng-mouseleave="showButton=false">
     <a style="text-decoration: none;" href="#/notebook/{{node.id}}">
       <i style="font-size: 10px;" class="icon-doc"/> {{noteName(node)}}
+    </a>
+    <a style="text-decoration: none;">
+      <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
+         class="fa fa-eraser" ng-show="showButton" ng-click="clearAllParagraphOutput(node.id)"
+         tooltip-placement="bottom" tooltip="Clear output">
+      </i>
+    </a>
+    <a style="text-decoration: none;">
+      <i style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+         class="fa fa-trash-o" ng-show="showButton" ng-click="removeNote(node.id)"
+         tooltip-placement="bottom" tooltip="Remove note">
+      </i>
     </a>
   </div>
   <div ng-if="node.children != null">

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -43,7 +43,7 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-click="clearAllParagraphOutput()"
+              ng-click="clearAllParagraphOutput(note.id)"
               ng-hide="viewOnly"
               ng-class="{'disabled':isNoteRunning()}"
               tooltip-placement="bottom" tooltip="Clear output">

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -27,12 +27,13 @@
     'baseUrlSrv',
     '$timeout',
     'saveAsService',
-    'ngToast'
+    'ngToast',
+    'noteActionSrv'
   ];
 
   function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
                         $http, websocketMsgSrv, baseUrlSrv, $timeout, saveAsService,
-                        ngToast) {
+                        ngToast, noteActionSrv) {
 
     ngToast.dismiss();
 
@@ -143,20 +144,9 @@
       $scope.$broadcast('doubleClickParagraph', paragraphId);
     };
 
-    /** Remove the note and go back tot he main page */
-    /** TODO(anthony): In the nearly future, go back to the main page and telle to the dude that the note have been remove */
+    // Remove the note and go back to the main page
     $scope.removeNote = function(noteId) {
-      BootstrapDialog.confirm({
-        closable: true,
-        title: '',
-        message: 'Do you want to delete this note?',
-        callback: function(result) {
-          if (result) {
-            websocketMsgSrv.deleteNote(noteId);
-            $location.path('/');
-          }
-        }
-      });
+      noteActionSrv.removeNote(noteId, true);
     };
 
     //Export notebook
@@ -230,19 +220,8 @@
       }
     };
 
-    $scope.clearAllParagraphOutput = function() {
-      BootstrapDialog.confirm({
-        closable: true,
-        title: '',
-        message: 'Do you want to clear all output?',
-        callback: function(result) {
-          if (result) {
-            _.forEach($scope.note.paragraphs, function(n, key) {
-              angular.element('#' + n.id + '_paragraphColumn_main').scope().clearParagraphOutput();
-            });
-          }
-        }
-      });
+    $scope.clearAllParagraphOutput = function(noteId) {
+      noteActionSrv.clearAllParagraphOutput(noteId);
     };
 
     $scope.toggleAllEditor = function() {

--- a/zeppelin-web/src/components/noteAction/noteAction.service.js
+++ b/zeppelin-web/src/components/noteAction/noteAction.service.js
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+(function() {
+
+  angular.module('zeppelinWebApp').service('noteActionSrv', noteActionSrv);
+
+  noteActionSrv.$inject = ['websocketMsgSrv', '$location'];
+
+  function noteActionSrv(websocketMsgSrv, $location) {
+    this.removeNote = function(noteId, redirectToHome) {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Do you want to delete this note?',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.deleteNote(noteId);
+            if (redirectToHome) {
+              $location.path('/');
+            }
+          }
+        }
+      });
+    };
+
+    this.clearAllParagraphOutput = function(noteId) {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Do you want to clear all output?',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.clearAllParagraphOutput(noteId);
+          }
+        }
+      });
+    };
+  }
+})();

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -122,6 +122,10 @@
         websocketEvents.sendNewEvent({op: 'PARAGRAPH_CLEAR_OUTPUT', data: {id: paragraphId}});
       },
 
+      clearAllParagraphOutput: function(noteId) {
+        websocketEvents.sendNewEvent({op: 'PARAGRAPH_CLEAR_ALL_OUTPUT', data: {id: noteId}});
+      },
+
       completion: function(paragraphId, buf, cursor) {
         websocketEvents.sendNewEvent({
           op: 'COMPLETION',

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -185,6 +185,7 @@ limitations under the License.
     <script src="components/searchService/search.service.js"></script>
     <script src="components/login/login.controller.js"></script>
     <script src="components/elasticInputCtrl/elasticInput.controller.js"></script>
+    <script src="components/noteAction/noteAction.service.js"></script>
     <!-- endbuild -->
   </body>
 </html>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -327,6 +327,17 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   /**
+   * Clear all paragraph output of note
+   */
+  public void clearAllParagraphOutput() {
+    synchronized (paragraphs) {
+      for (Paragraph p : paragraphs) {
+        p.setReturn(null, null);
+      }
+    }
+  }
+
+  /**
    * Move paragraph into the new index (order from 0 ~ n-1).
    *
    * @param paragraphId ID of paragraph

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -48,7 +48,7 @@ public class Message {
                       // @param id note id
     CLONE_NOTE,       // [c-s] clone new notebook
                       // @param id id of note to clone
-                      // @param name name fpor the cloned note
+                      // @param name name for the cloned note
     IMPORT_NOTE,      // [c-s] import notebook
                       // @param object notebook
     NOTE_UPDATE,
@@ -96,7 +96,8 @@ public class Message {
                                   // @param notes serialized List<NoteInfo> object
 
     PARAGRAPH_REMOVE,
-    PARAGRAPH_CLEAR_OUTPUT,
+    PARAGRAPH_CLEAR_OUTPUT,       // [c-s] clear output of paragraph
+    PARAGRAPH_CLEAR_ALL_OUTPUT,   // [c-s] clear output of all paragraphs
     PARAGRAPH_APPEND_OUTPUT,      // [s-c] append output
     PARAGRAPH_UPDATE_OUTPUT,      // [s-c] update (replace) output
     PING,

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -33,7 +33,6 @@ import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
-import org.apache.zeppelin.notebook.repo.zeppelinhub.security.Authentication;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.notebook.JobListenerFactory;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.notebook;
 
-import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterResult;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.zeppelin.notebook;
 
+import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.search.SearchService;
@@ -123,6 +125,25 @@ public class NoteTest {
     Paragraph p2 = note.insertParagraph(note.getParagraphs().size());
 
     assertNull(p2.getText());
+  }
+
+  @Test
+  public void clearAllParagraphOutputTest() {
+    when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("md"))).thenReturn(interpreter);
+    when(interpreter.getScheduler()).thenReturn(scheduler);
+
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Paragraph p1 = note.addParagraph();
+    InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
+    p1.setResult(result);
+
+    Paragraph p2 = note.addParagraph();
+    p2.setReturn(result, new Throwable());
+
+    note.clearAllParagraphOutput();
+
+    assertNull(p1.getReturn());
+    assertNull(p2.getReturn());
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
- Enables removing note and clear all paragraph's output from Zeppelin main page.
- Add rest api for clearing all paragraph output
  
Next possible improvement can be removing notes in folder level and rename folder.

### What type of PR is it?
Improvement

### Todos
* [x] - Merge #1567 and apply security to `clearAllParagraphOutput` rest api method

### What is the Jira issue?

[ZEPPELIN-1564](https://issues.apache.org/jira/browse/ZEPPELIN-1564)
### Screenshots (if appropriate)

![oct-27-2016 18-26-03](https://cloud.githubusercontent.com/assets/8503346/19761938/e013ea02-9c72-11e6-9a08-0a70aca145d2.gif)
### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? yes
