### PR TITLE
[ZEPPELIN-1587] (WIP) Add impersonation routine in SparkInterpreter for current user

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -1152,11 +1152,12 @@ public class SparkInterpreter extends Interpreter {
     }
     final String[] linesFinal = lines;
     final InterpreterContext contextFinal = context;
-    PrivilegedExceptionAction<InterpreterResult> action = new PrivilegedExceptionAction<InterpreterResult>() {
-      public InterpreterResult run() throws Exception {
-        return interpret(linesFinal, contextFinal);
-      }
-    };
+    PrivilegedExceptionAction<InterpreterResult> action = 
+      new PrivilegedExceptionAction<InterpreterResult>() {
+        public InterpreterResult run() throws Exception {
+          return interpret(linesFinal, contextFinal);
+        }
+      };
     try {
       interpreterResult = remoteUser.doAs(action);
     } catch (Exception e) {
@@ -1168,7 +1169,7 @@ public class SparkInterpreter extends Interpreter {
 
   private UserGroupInformation getCurrentUser() {
     UserGroupInformation currentUser = null;
-    try{
+    try {
       currentUser = UserGroupInformation.getCurrentUser();
     } catch (IOException e) {
       logger.error("Can't get current user from ugi", e);
@@ -1177,9 +1178,9 @@ public class SparkInterpreter extends Interpreter {
   }
   
   private void transferUserCredentials(UserGroupInformation source, UserGroupInformation dest) {
-      for (Token token: source.getTokens()) {
-        dest.addToken(token);
-      }
+    for (Token token : source.getTokens()) {
+      dest.addToken(token);
+    }
   }
   
   public InterpreterResult interpret(String[] lines, InterpreterContext context) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -26,6 +26,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.security.PrivilegedExceptionAction;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1120,7 +1121,42 @@ public class SparkInterpreter extends Interpreter {
     if (line == null || line.trim().length() == 0) {
       return new InterpreterResult(Code.SUCCESS);
     }
-    return interpret(line.split("\n"), context);
+    return interpretByUser(line.split("\n"), context);
+  }
+
+  public InterpreterResult interpretByUser(String[] lines, InterpreterContext context) {
+    String user = context.getAuthenticationInfo().getUser();
+    if (StringUtils.isBlank(user)) {
+      logger.warn("User is blank, run spark command as 'anonymous'");
+      user = "anonymous";
+    }
+    logger.debug("Running Spark command by user: {}", user);
+
+    if (interpreter == null) {
+      logger.error(
+          "interpreter == null, open may not have been called because max.open.instances reached");
+      return new InterpreterResult(Code.ERROR, "interpreter == null\n"
+          + "open may not have been called because max.open.instances reached");
+    }
+
+    InterpreterResult interpreterResult = new InterpreterResult(Code.ERROR);
+
+    UserGroupInformation ugi = null;
+    ugi = UserGroupInformation.createRemoteUser(user);
+    final String[] linesFinal = lines;
+    final InterpreterContext contextFinal = context;
+    PrivilegedExceptionAction<InterpreterResult> action = new PrivilegedExceptionAction<InterpreterResult>() {
+      public InterpreterResult run() throws Exception {
+        return interpret(linesFinal, contextFinal);
+      }
+    };
+    try {
+      interpreterResult = ugi.doAs(action);
+    } catch (Exception e) {
+      logger.error("Error running command with ugi.doAs", e);
+      return new InterpreterResult(Code.ERROR, e.getMessage());
+    }
+    return interpreterResult;
   }
 
   public InterpreterResult interpret(String[] lines, InterpreterContext context) {


### PR DESCRIPTION
### What is this PR for?
This is to add impersonation routine for SparkInterpreter, meaning any communication with hadoop hdfs should be done with current user credentials

### What type of PR is it?
Improvement

### Todos
- [x] - add privilege mode
- [ ] - add tests
### What is the Jira issue?

[ZEPPELIN-1587](https://issues.apache.org/jira/browse/ZEPPELIN-1587)
### How should this be tested?
executing hdfs related file write should be done by your logged in username, e.g. in the example i used the following code:
```
val file = sc.textFile("hdfs:/inputFilePath")
file.cache()
val wordCount = file.flatMap(line => line.split(" ")).map(word => (word, 1)).reduceByKey(_ + _)
wordCount.saveAsTextFile("hdfs:/outputFolderPath")
```

### Screenshots (if appropriate)
![impersonate user](https://cloud.githubusercontent.com/assets/1642088/20516664/e36ff250-b0da-11e6-9a0b-916eb9857f4e.gif)


### Questions:
- Does the licenses files need update? no
- Is there breaking changes for older versions? no
- Does this needs documentation? possibly
