### PR TITLE
[ZEPPELIN-1586] Add security check in NotebookRestApi

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -33,7 +33,7 @@
   <name>Zeppelin: Server</name>
 
   <properties>
-    <cxf.version>2.7.7</cxf.version>
+    <cxf.version>2.7.8</cxf.version>
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
     <hadoop-common.version>2.6.0</hadoop-common.version>
   </properties>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -178,7 +178,7 @@ public class NotebookRestApi {
     userAndRoles.add(principal);
     userAndRoles.addAll(roles);
     
-    checkIfUserCanWrite(noteId,
+    checkIfUserIsOwner(noteId,
         ownerPermissionError(userAndRoles, notebookAuthorization.getOwners(noteId)));
     
     HashMap<String, HashSet<String>> permMap =
@@ -502,7 +502,7 @@ public class NotebookRestApi {
 
     Note note = notebook.getNote(noteId);
     checkIfNoteIsNotNull(note);
-    checkIfUserIsOwner(noteId,
+    checkIfUserCanRead(noteId,
         "Insufficient privileges you cannot remove paragraph from this note");
 
     Paragraph p = note.getParagraph(paragraphId);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -123,7 +123,7 @@ public class NotebookRestApi {
     Set<String> userAndRoles = Sets.newHashSet();
     userAndRoles.add(SecurityUtils.getPrincipal());
     userAndRoles.addAll(SecurityUtils.getRoles());
-    if (!notebookAuthorization.hasReadAuthorization(userAndRoles, noteId)) {
+    if (!notebookAuthorization.isOwner(userAndRoles, noteId)) {
       throw new UnauthorizedException(errorMsg);
     }
   }
@@ -191,7 +191,7 @@ public class NotebookRestApi {
     HashSet<String> readers = permMap.get("readers");
     HashSet<String> owners = permMap.get("owners");
     HashSet<String> writers = permMap.get("writers");
-    // Set readers, if writers and owners if empty -> set to user requesting the change
+    // Set readers, if writers and owners is empty -> set to user requesting the change
     if (readers != null && !readers.isEmpty()) {
       if (writers.isEmpty()) {
         writers = Sets.newHashSet(SecurityUtils.getPrincipal());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/NotFoundException.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/NotFoundException.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest.exception;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.apache.zeppelin.utils.ExceptionUtils;
+
+/**
+ * Not Found handler for WebApplicationException.
+ * 
+ */
+public class NotFoundException extends WebApplicationException {
+  private static final long serialVersionUID = 2459398393216512293L;
+
+  /**
+   * Create a HTTP 404 (Not Found) exception.
+   */
+  public NotFoundException() {
+    super(ExceptionUtils.jsonResponse(NOT_FOUND));
+  }
+
+  /**
+   * Create a HTTP 404 (Not Found) exception.
+   * @param message the String that is the entity of the 404 response.
+   */
+  public NotFoundException(String message) {
+    super(notFoundJson(message));
+  }
+
+  private static Response notFoundJson(String message) {
+    return ExceptionUtils.jsonResponseContent(NOT_FOUND, message);
+  }
+
+  public NotFoundException(Throwable cause) {
+    super(cause, notFoundJson(cause.getMessage()));
+  }
+
+  public NotFoundException(Throwable cause, String message) {
+    super(cause, notFoundJson(message));
+  }
+
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/UnauthorizedException.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/UnauthorizedException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest.exception;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.apache.zeppelin.utils.ExceptionUtils;
+
+/**
+ * UnauthorizedException handler for WebApplicationException.
+ * 
+ */
+public class UnauthorizedException extends WebApplicationException {
+  private static final long serialVersionUID = 4394749068760407567L;
+  private static final String UNAUTHORIZED_MSG = "Authorization required";
+
+  public UnauthorizedException() {
+    super(unauthorizedJson(UNAUTHORIZED_MSG));
+  }
+
+  private static Response unauthorizedJson(String message) {
+    return ExceptionUtils.jsonResponseContent(FORBIDDEN, message);
+  }
+  
+  public UnauthorizedException(Throwable cause, String message) {
+    super(cause, unauthorizedJson(message));
+  }
+  
+  public UnauthorizedException(String message) {
+    super(unauthorizedJson(message));
+  }
+
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -16,10 +16,22 @@
  */
 package org.apache.zeppelin.socket;
 
-import com.google.common.base.Strings;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -36,7 +48,13 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.notebook.*;
+import org.apache.zeppelin.notebook.JobListenerFactory;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.NotebookEventListener;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.ParagraphJobListener;
 import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.Message.OP;
@@ -54,13 +72,10 @@ import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
 /**
  * Zeppelin websocket service.
@@ -147,8 +162,7 @@ public class NotebookServer extends WebSocketServlet implements
       }
 
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-      boolean allowAnonymous = conf.
-          getBoolean(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED);
+      boolean allowAnonymous = conf.isAnonymousAllowed();
       if (!allowAnonymous && messagereceived.principal.equals("anonymous")) {
         throw new Exception("Anonymous access not allowed ");
       }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/ExceptionUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/ExceptionUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.utils;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.zeppelin.server.JsonResponse;
+
+/**
+ * Utility method for exception in rest api.
+ *
+ */
+public class ExceptionUtils {
+
+  public static javax.ws.rs.core.Response jsonResponse(Status status) {
+    return new JsonResponse<>(status).build();
+  }
+  
+  public static javax.ws.rs.core.Response jsonResponseContent(Status status, String message) {
+    return new JsonResponse<>(status, message).build();
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -66,6 +66,7 @@ public abstract class AbstractTestRestApi {
   static boolean pySpark = false;
   static boolean sparkR = false;
   static Gson gson = new Gson();
+  static boolean isRunningWithAuth = false;
 
   private static File shiroIni = null;
   private static String zeppelinShiro =
@@ -130,6 +131,7 @@ public abstract class AbstractTestRestApi {
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
 
       if (withAuth) {
+        isRunningWithAuth = true;
         // Set Anonymous session to false.
         System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED.getVarName(), "false");
         
@@ -313,6 +315,11 @@ public abstract class AbstractTestRestApi {
       LOG.info("Test Zeppelin terminated.");
 
       System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETERS.getVarName());
+      if (isRunningWithAuth) {
+        isRunningWithAuth = false;
+        System
+            .clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED.getVarName());
+      }
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -223,7 +223,7 @@ public abstract class AbstractTestRestApi {
     }
   }
   
-  protected static void startUpWithAutenticationEnabled() throws Exception {
+  protected static void startUpWithAuthenticationEnable() throws Exception {
     start(true);
   }
   

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -26,18 +26,22 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethodBase;
+import org.apache.commons.httpclient.cookie.CookiePolicy;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.server.ZeppelinServer;
@@ -47,6 +51,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
@@ -60,6 +65,28 @@ public abstract class AbstractTestRestApi {
   protected static final boolean wasRunning = checkIfServerIsRunning();
   static boolean pySpark = false;
   static boolean sparkR = false;
+  static Gson gson = new Gson();
+
+  private static File shiroIni = null;
+  private static String zeppelinShiro =
+      "[users]\n" +
+      "admin = password1, admin\n" +
+      "user1 = password2, role1, role2\n" +
+      "user2 = password3, role3\n" +
+      "user3 = password4, role2\n" +
+      "[main]\n" +
+      "sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager\n" +
+      "securityManager.sessionManager = $sessionManager\n" +
+      "securityManager.sessionManager.globalSessionTimeout = 86400000\n" +
+      "shiro.loginUrl = /api/login\n" +
+      "[roles]\n" +
+      "role1 = *\n" +
+      "role2 = *\n" +
+      "role3 = *\n" +
+      "admin = *" +
+      "[urls]\n" +
+      "/api/version = anon\n" +
+      "/** = authc";
 
   private String getUrl(String path) {
     String url;
@@ -95,15 +122,26 @@ public abstract class AbstractTestRestApi {
     }
   };
 
-  protected static void startUp() throws Exception {
+  private static void start(boolean withAuth) throws Exception {
     if (!wasRunning) {
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(), "../");
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_WAR.getVarName(), "../zeppelin-web/dist");
       LOG.info("Staring test Zeppelin up...");
+      ZeppelinConfiguration conf = ZeppelinConfiguration.create();
 
+      if (withAuth) {
+        // Set Anonymous session to false.
+        System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED.getVarName(), "false");
+        
+        // Create a shiro env test.
+        shiroIni = new File("../conf/shiro.ini");
+        if (!shiroIni.exists()) {
+          shiroIni.createNewFile();
+        }
+        FileUtils.writeStringToFile(shiroIni, zeppelinShiro);
+      }
 
       // exclude org.apache.zeppelin.rinterpreter.* for scala 2.11 test
-      ZeppelinConfiguration conf = ZeppelinConfiguration.create();
       String interpreters = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETERS);
       String interpretersCompatibleWithScala211Test = null;
 
@@ -184,6 +222,14 @@ public abstract class AbstractTestRestApi {
       }
     }
   }
+  
+  protected static void startUpWithAutenticationEnabled() throws Exception {
+    start(true);
+  }
+  
+  protected static void startUp() throws Exception {
+    start(false);
+  }
 
   private static String getHostname() {
     try {
@@ -244,7 +290,9 @@ public abstract class AbstractTestRestApi {
       for (String setting : settingList) {
         ZeppelinServer.notebook.getInterpreterFactory().restart(setting);
       }
-
+      if (shiroIni != null) {
+        FileUtils.deleteQuietly(shiroIni);
+      }
       LOG.info("Terminating test Zeppelin...");
       ZeppelinServer.jettyWebServer.stop();
       executor.shutdown();
@@ -286,49 +334,97 @@ public abstract class AbstractTestRestApi {
   }
 
   protected static GetMethod httpGet(String path) throws IOException {
+    return httpGet(path, StringUtils.EMPTY, StringUtils.EMPTY);
+  }
+  
+  protected static GetMethod httpGet(String path, String user, String pwd) throws IOException {
     LOG.info("Connecting to {}", url + path);
     HttpClient httpClient = new HttpClient();
     GetMethod getMethod = new GetMethod(url + path);
     getMethod.addRequestHeader("Origin", url);
+    if (userAndPasswordAreNotBlank(user, pwd)) {
+      getMethod.setRequestHeader("Cookie", "JSESSIONID="+ getCookie(user, pwd));
+    }
     httpClient.executeMethod(getMethod);
     LOG.info("{} - {}", getMethod.getStatusCode(), getMethod.getStatusText());
     return getMethod;
   }
 
   protected static DeleteMethod httpDelete(String path) throws IOException {
+    return httpDelete(path, StringUtils.EMPTY, StringUtils.EMPTY);
+  }
+
+  protected static DeleteMethod httpDelete(String path, String user, String pwd) throws IOException {
     LOG.info("Connecting to {}", url + path);
     HttpClient httpClient = new HttpClient();
     DeleteMethod deleteMethod = new DeleteMethod(url + path);
     deleteMethod.addRequestHeader("Origin", url);
+    if (userAndPasswordAreNotBlank(user, pwd)) {
+      deleteMethod.setRequestHeader("Cookie", "JSESSIONID="+ getCookie(user, pwd));
+    }
     httpClient.executeMethod(deleteMethod);
     LOG.info("{} - {}", deleteMethod.getStatusCode(), deleteMethod.getStatusText());
     return deleteMethod;
   }
 
   protected static PostMethod httpPost(String path, String body) throws IOException {
+    return httpPost(path, body, StringUtils.EMPTY, StringUtils.EMPTY);
+  }
+
+  protected static PostMethod httpPost(String path, String request, String user, String pwd)
+      throws IOException {
     LOG.info("Connecting to {}", url + path);
     HttpClient httpClient = new HttpClient();
     PostMethod postMethod = new PostMethod(url + path);
-    postMethod.addRequestHeader("Origin", url);
-    RequestEntity entity = new ByteArrayRequestEntity(body.getBytes("UTF-8"));
-    postMethod.setRequestEntity(entity);
+    postMethod.setRequestBody(request);
+    postMethod.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
+    if (userAndPasswordAreNotBlank(user, pwd)) {
+      postMethod.setRequestHeader("Cookie", "JSESSIONID="+ getCookie(user, pwd));
+    }
     httpClient.executeMethod(postMethod);
     LOG.info("{} - {}", postMethod.getStatusCode(), postMethod.getStatusText());
     return postMethod;
   }
 
   protected static PutMethod httpPut(String path, String body) throws IOException {
+    return httpPut(path, body, StringUtils.EMPTY, StringUtils.EMPTY);
+  }
+
+  protected static PutMethod httpPut(String path, String body, String user, String pwd) throws IOException {
     LOG.info("Connecting to {}", url + path);
     HttpClient httpClient = new HttpClient();
     PutMethod putMethod = new PutMethod(url + path);
     putMethod.addRequestHeader("Origin", url);
     RequestEntity entity = new ByteArrayRequestEntity(body.getBytes("UTF-8"));
     putMethod.setRequestEntity(entity);
+    if (userAndPasswordAreNotBlank(user, pwd)) {
+      putMethod.setRequestHeader("Cookie", "JSESSIONID="+ getCookie(user, pwd));
+    }
     httpClient.executeMethod(putMethod);
     LOG.info("{} - {}", putMethod.getStatusCode(), putMethod.getStatusText());
     return putMethod;
   }
 
+  private static String getCookie(String user, String password) throws IOException {
+    HttpClient httpClient = new HttpClient();
+    PostMethod postMethod = new PostMethod(url + "/login");
+    postMethod.addRequestHeader("Origin", url);
+    postMethod.setParameter("password", password);
+    postMethod.setParameter("userName", user);
+    httpClient.executeMethod(postMethod);
+    LOG.info("{} - {}", postMethod.getStatusCode(), postMethod.getStatusText());
+    Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]*)");
+    java.util.regex.Matcher matcher = pattern.matcher(postMethod.getResponseHeaders("Set-Cookie")[0].toString());
+    return matcher.find()? matcher.group(1) : StringUtils.EMPTY;
+  }
+
+  protected static boolean userAndPasswordAreNotBlank(String user, String pwd) {
+    if (StringUtils.isBlank(user) && StringUtils.isBlank(pwd)) {
+      return false;
+    }
+    return true;
+  }
+  
   protected Matcher<HttpMethodBase> responsesWith(final int expectedStatusCode) {
     return new TypeSafeMatcher<HttpMethodBase>() {
       WeakReference<HttpMethodBase> method;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -46,7 +46,7 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
 
   @BeforeClass
   public static void init() throws Exception {
-    AbstractTestRestApi.startUpWithAutenticationEnabled();
+    AbstractTestRestApi.startUpWithAuthenticationEnable();
   }
 
   @AfterClass

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.httpclient.HttpMethodBase;
+import org.apache.commons.httpclient.methods.DeleteMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.server.ZeppelinServer;
+import org.hamcrest.Matcher;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
+
+  Gson gson = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    AbstractTestRestApi.startUpWithAutenticationEnabled();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+
+  @Before
+  public void setUp() {}
+  
+  @Test
+  public void testThatUserCanCreateAndRemoveNote() throws IOException {
+    String noteId = createNoteForUser("test", "admin", "password1");
+    assertNotNull(noteId);
+    String id = getNoteIdForUser(noteId, "admin", "password1");
+    assertThat(id, is(noteId));
+    deleteNoteForUser(noteId, "admin", "password1");
+  }
+  
+  @Test
+  public void testThatOtherUserCanAccessNoteIfPermissionNotSet() throws IOException {
+    String noteId = createNoteForUser("test", "admin", "password1");
+    
+    userTryGetNote(noteId, "user1", "password2", isAllowed());
+    
+    deleteNoteForUser(noteId, "admin", "password1");
+  }
+  
+  @Test
+  public void testThatOtherUserCannotAccessNoteIfPermissionSet() throws IOException {
+    String noteId = createNoteForUser("test", "admin", "password1");
+    
+    //set permission
+    String payload = "{ \"owners\": [\"admin\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
+    PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
+    assertThat("test set note premission method:", put, isAllowed());
+    put.releaseConnection();
+    
+    userTryGetNote(noteId, "user1", "password2", isForbiden());
+    
+    userTryGetNote(noteId, "user2", "password3", isAllowed());
+    
+    deleteNoteForUser(noteId, "admin", "password1");
+  }
+  
+  @Test
+  public void testThatWriterCannotRemoveNote() throws IOException {
+    String noteId = createNoteForUser("test", "admin", "password1");
+    
+    //set permission
+    String payload = "{ \"owners\": [\"admin\", \"user1\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
+    PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
+    assertThat("test set note premission method:", put, isAllowed());
+    put.releaseConnection();
+    
+    userTryRemoveNote(noteId, "user2", "password3", isForbiden());
+    userTryRemoveNote(noteId, "user1", "password2", isAllowed());
+    
+    Note deletedNote = ZeppelinServer.notebook.getNote(noteId);
+    assertNull("Deleted note should be null", deletedNote);
+  }
+  
+  private void userTryRemoveNote(String noteId, String user, String pwd, Matcher<? super HttpMethodBase> m) throws IOException {
+    DeleteMethod delete = httpDelete(("/notebook/" + noteId), user, pwd);
+    assertThat(delete, m);
+    delete.releaseConnection();
+  }
+  
+  private void userTryGetNote(String noteId, String user, String pwd, Matcher<? super HttpMethodBase> m) throws IOException {
+    GetMethod get = httpGet("/notebook/" + noteId, user, pwd);
+    assertThat(get, m);
+    get.releaseConnection();
+  }
+
+  private String getNoteIdForUser(String noteId, String user, String pwd) throws IOException {
+    GetMethod get = httpGet("/notebook/" + noteId, user, pwd);
+    assertThat("test note create method:", get, isAllowed());
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {
+    }.getType());
+    get.releaseConnection();
+    return (String) ((Map<String, Object>)resp.get("body")).get("id");
+  }
+  
+  private String createNoteForUser(String noteName, String user, String pwd) throws IOException {
+    String jsonRequest = "{\"name\":\"" + noteName + "\"}";
+    PostMethod post = httpPost("/notebook/", jsonRequest, user, pwd);
+    assertThat("test note create method:", post, isCreated());
+    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {
+    }.getType());
+    post.releaseConnection();
+    String newNoteId =  (String) resp.get("body");
+    Note newNote = ZeppelinServer.notebook.getNote(newNoteId);
+    assertNotNull("Can not find new note by id", newNote);
+    return newNoteId;
+  }
+
+  private void deleteNoteForUser(String noteId, String user, String pwd) throws IOException {
+    DeleteMethod delete = httpDelete(("/notebook/" + noteId), user, pwd);
+    assertThat("Test delete method:", delete, isAllowed());
+    delete.releaseConnection();
+    // make sure note is deleted
+    if (!noteId.isEmpty()) {
+      Note deletedNote = ZeppelinServer.notebook.getNote(noteId);
+      assertNull("Deleted note should be null", deletedNote);
+    }
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -344,7 +344,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   public String getNotebookDir() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_DIR);
   }
-
+  
   public String getUser() {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_USER);
   }
@@ -429,6 +429,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
   public boolean isWindowsPath(String path){
     return path.matches("^[A-Za-z]:\\\\.*");
+  }
+  
+  public boolean isAnonymousAllowed() {
+    return getBoolean(ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED);
   }
 
   public String getConfDir() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -17,18 +17,33 @@
 
 package org.apache.zeppelin.notebook;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.util.*;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * Contains authorization information for notes
@@ -237,6 +252,26 @@ public class NotebookAuthorization {
     Set<String> intersection = new HashSet<>(b);
     intersection.retainAll(a);
     return (b.isEmpty() || (intersection.size() > 0));
+  }
+  
+  public boolean isUserOwnerOrWriter(String user, String noteId) {
+    if (StringUtils.isBlank(user)) {
+      LOG.error("Cannot check user permission with blank login");
+      return false;
+    }
+    Set<String> users = ImmutableSet.of(user);
+    return isUserOwnerOrWriter(users, noteId); 
+  }
+  
+  public boolean isUserOwnerOrWriter(Set<String> users, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOG.debug("Zeppelin runs in anonymous mode");
+      return true;
+    }
+    if (users == null) {
+      return false;
+    }
+    return isWriter(noteId, users);
   }
 
   public void removeNote(String noteId) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -276,7 +276,7 @@ public class NotebookAuthorization {
   
   public boolean hasReadAuthorization(Set<String> userAndRoles, String noteId) {
     if (conf.isAnonymousAllowed()) {
-      LOG.debug("Zeppelin runs in anonymous mode, everybody can read");
+      LOG.debug("Zeppelin runs in anonymous mode, everybody is reader");
       return true;
     }
     if (userAndRoles == null) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -253,25 +251,16 @@ public class NotebookAuthorization {
     intersection.retainAll(a);
     return (b.isEmpty() || (intersection.size() > 0));
   }
-  
-  public boolean isUserOwnerOrWriter(String user, String noteId) {
-    if (StringUtils.isBlank(user)) {
-      LOG.error("Cannot check user permission with blank login");
-      return false;
-    }
-    Set<String> users = ImmutableSet.of(user);
-    return isUserOwnerOrWriter(users, noteId); 
-  }
-  
-  public boolean isUserOwnerOrWriter(Set<String> users, String noteId) {
+
+  public boolean isUserOwnerOrWriter(Set<String> userAndRoles, String noteId) {
     if (conf.isAnonymousAllowed()) {
       LOG.debug("Zeppelin runs in anonymous mode");
       return true;
     }
-    if (users == null) {
+    if (userAndRoles == null) {
       return false;
     }
-    return isWriter(noteId, users);
+    return isWriter(noteId, userAndRoles);
   }
 
   public void removeNote(String noteId) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -252,15 +252,37 @@ public class NotebookAuthorization {
     return (b.isEmpty() || (intersection.size() > 0));
   }
 
-  public boolean isUserOwnerOrWriter(Set<String> userAndRoles, String noteId) {
+  public boolean isOwner(Set<String> userAndRoles, String noteId) {
     if (conf.isAnonymousAllowed()) {
-      LOG.debug("Zeppelin runs in anonymous mode");
+      LOG.debug("Zeppelin runs in anonymous mode, everybody is owner");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isOwner(noteId, userAndRoles);
+  }
+  
+  public boolean hasWriteAuthorization(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOG.debug("Zeppelin runs in anonymous mode, everybody is writer");
       return true;
     }
     if (userAndRoles == null) {
       return false;
     }
     return isWriter(noteId, userAndRoles);
+  }
+  
+  public boolean hasReadAuthorization(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOG.debug("Zeppelin runs in anonymous mode, everybody can read");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isReader(noteId, userAndRoles);
   }
 
   public void removeNote(String noteId) {


### PR DESCRIPTION
### What is this PR for?

Bring some security check in `NotebookRestApi`.
### What type of PR is it?

[Bug Fix | Improvement | Refactoring]
### Todos
- [x] - Create a proper way to throw webapp error
- [x] - Add in `NotebookAuthorization` some method to check if user is owner, reader or writer
- [x] - Add Authorization check in `NotebookRestapi` 
- [x] - Add New test for security in notebook rest api

### What is the Jira issue?
- [ZEPPELIN-1586](https://issues.apache.org/jira/browse/ZEPPELIN-1586)
### How should this be tested?

First, force Zeppelin to use auth.
- In `conf/zeppelin-site.xml` change `zeppelin.anonymous.allowed` to **false**
  
  ```
  <property>
  <name>zeppelin.anonymous.allowed</name>
  <value>false</value>
  <description>Anonymous user allowed by default</description>
  </property>
  ```
- In `conf/shiro.ini` set Shiro to use `Auth` at the end of the file
  
  ```
  #/** = anon                                                                                                                                           
  /** = authc
  ```
- Start Zeppelin, login and set some permission to a note
- try to get a note from Zeppelin Rest Api `http://localhost:8080/api/notebook/{noteId}` (you can use your browser or curl (if you use curl please add shiro token to curl cookie))
### Screenshots (if appropriate)

![note_permission_rest_api](https://cloud.githubusercontent.com/assets/3139557/19827600/ffd68a06-9dea-11e6-8dd5-43f3bd401011.gif)
### Questions:
- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? Maybe
