### PR TITLE
[ZEPPELIN-1593] Enforce sorting on dynamic form elements

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -15,7 +15,7 @@ limitations under the License.
       ng-show="!paragraph.config.tableHide"
       class=" paragraphForm form-horizontal row">
   <div class="form-group col-sm-6 col-md-6 col-lg-4"
-       ng-repeat="formulaire in paragraph.settings.forms"
+       ng-repeat="formulaire in paragraph.settings.forms | toArray | orderBy:'name.toString()'"
        ng-init="loadForm(formulaire, paragraph.settings.params)">
     <label class="control-label input-sm" ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }">{{formulaire.name}}</label>
     <div>


### PR DESCRIPTION
### What is this PR for?
Current dynamic forms elements in zeppelin-web have no ordering. The ordering of the dynamic elements is random which can be annoying when you have many of them.

The root cause is that the angular frontend uses "for key in object" pattern with no sorting. I have added sorting.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1593](https://issues.apache.org/jira/browse/ZEPPELIN-1593)

### How should this be tested?
Dynamic forms should now have fields sorted by name.
```
%md
${a=1}
${b=1}
${c=1}
${d=1}
${bb=1}
${ba=1}
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

