### PR TITLE
[DOC] Add `/ws` for nginx websocket configuration

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -85,7 +85,7 @@ This instruction based on Ubuntu 14.04 LTS but may work with other OS with few c
         }
 
         location /ws {  # For websocket support
-            proxy_pass http://zeppelin;
+            proxy_pass http://zeppelin/ws;
             proxy_http_version 1.1;
             proxy_set_header Upgrade websocket;
             proxy_set_header Connection upgrade;


### PR DESCRIPTION
### What is this PR for?
It's a bit misleading that both regular webserver location and websocket location use the exact same address. It's better to specify that websocket requests should be proxy-passed to  `/ws` subdirectory.

### What type of PR is it?
Documentation

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no