### PR TITLE
ZEPPELIN-1595. Make ZeppelinContext extensible

### DIFF
--- a/r/src/main/java/org/apache/zeppelin/rinterpreter/RStatics.java
+++ b/r/src/main/java/org/apache/zeppelin/rinterpreter/RStatics.java
@@ -25,7 +25,7 @@ package org.apache.zeppelin.rinterpreter;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
-import org.apache.zeppelin.spark.ZeppelinContext;
+import org.apache.zeppelin.spark.SparkZeppelinContext;
 
 /**
  * RStatics provides static class methods that can be accessed through the SparkR bridge
@@ -33,7 +33,7 @@ import org.apache.zeppelin.spark.ZeppelinContext;
  */
 public class RStatics {
   private static SparkContext sc = null;
-  private static ZeppelinContext z = null;
+  private static SparkZeppelinContext z = null;
   private static SQLContext sql = null;
   private static RContext rCon = null;
 
@@ -42,7 +42,7 @@ public class RStatics {
     return sc;
   }
 
-  public static ZeppelinContext setZ(ZeppelinContext newZ) {
+  public static SparkZeppelinContext setZ(SparkZeppelinContext newZ) {
     z = newZ;
     return z;
   }

--- a/r/src/main/scala/org/apache/zeppelin/rinterpreter/RContext.scala
+++ b/r/src/main/scala/org/apache/zeppelin/rinterpreter/RContext.scala
@@ -28,7 +28,7 @@ import org.apache.zeppelin.interpreter._
 import org.apache.zeppelin.rinterpreter.rscala.RClient._
 import org.apache.zeppelin.rinterpreter.rscala._
 import org.apache.zeppelin.scheduler._
-import org.apache.zeppelin.spark.{SparkInterpreter, ZeppelinContext}
+import org.apache.zeppelin.spark.{SparkInterpreter, SparkZeppelinContext}
 import org.slf4j._
 
 import scala.collection.JavaConversions._
@@ -45,7 +45,7 @@ private[rinterpreter] class RContext(private val sockets: ScalaSockets,
   val backend: RBackendHelper = RBackendHelper()
   private var sc: Option[SparkContext] = None
   private var sql: Option[SQLContext] = None
-  private var z: Option[ZeppelinContext] = None
+  private var z: Option[SparkZeppelinContext] = None
 
   val rPkgMatrix = collection.mutable.HashMap[String,Boolean]()
 
@@ -126,7 +126,7 @@ private[rinterpreter] class RContext(private val sockets: ScalaSockets,
     check whether SPARK_HOME is set properly.""", e)
   }
 
-  private def initializeSparkR(sc : SparkContext, sql : SQLContext, z : ZeppelinContext) : Unit = synchronized {
+  private def initializeSparkR(sc : SparkContext, sql : SQLContext, z : SparkZeppelinContext) : Unit = synchronized {
 
     logger.trace("Getting a handle to the JavaSparkContext")
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -391,7 +391,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       return new InterpreterResult(Code.ERROR, errorMessage);
     }
     String jobGroup = Utils.buildJobGroupId(context);
-    ZeppelinContext __zeppelin__ = sparkInterpreter.getZeppelinContext();
+    SparkZeppelinContext __zeppelin__ = sparkInterpreter.getZeppelinContext();
     __zeppelin__.setInterpreterContext(context);
     __zeppelin__.setGui(context.getGui());
     pythonInterpretRequest = new PythonInterpretRequest(st, jobGroup);
@@ -576,7 +576,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     return spark;
   }
 
-  public ZeppelinContext getZeppelinContext() {
+  public SparkZeppelinContext getZeppelinContext() {
     SparkInterpreter sparkIntp = getSparkInterpreter();
     if (sparkIntp != null) {
       return getSparkInterpreter().getZeppelinContext();

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -47,15 +47,8 @@ import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.ui.SparkUI;
 import org.apache.spark.ui.jobs.JobProgressListener;
-import org.apache.zeppelin.interpreter.Interpreter;
-import org.apache.zeppelin.interpreter.InterpreterContext;
-import org.apache.zeppelin.interpreter.InterpreterException;
-import org.apache.zeppelin.interpreter.InterpreterHookRegistry;
-import org.apache.zeppelin.interpreter.InterpreterProperty;
-import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
-import org.apache.zeppelin.interpreter.InterpreterUtils;
-import org.apache.zeppelin.interpreter.WrappedInterpreter;
 import org.apache.zeppelin.interpreter.util.InterpreterOutputStream;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.resource.WellKnownResourceName;
@@ -95,7 +88,7 @@ import scala.tools.nsc.settings.MutableSettings.PathSetting;
 public class SparkInterpreter extends Interpreter {
   public static Logger logger = LoggerFactory.getLogger(SparkInterpreter.class);
 
-  private ZeppelinContext z;
+  private SparkZeppelinContext z;
   private SparkILoop interpreter;
   /**
    * intp - org.apache.spark.repl.SparkIMain (scala 2.10)
@@ -179,7 +172,7 @@ public class SparkInterpreter extends Interpreter {
         String noteId = Utils.getNoteId(jobGroupId);
         String paragraphId = Utils.getParagraphId(jobGroupId);
         if (jobUrl != null && noteId != null && paragraphId != null) {
-          RemoteEventClientWrapper eventClient = ZeppelinContext.getEventClient();
+          RemoteEventClientWrapper eventClient = BaseZeppelinContext.getEventClient();
           Map<String, String> infos = new java.util.HashMap<>();
           infos.put("jobUrl", jobUrl);
           infos.put("label", "SPARK JOB");
@@ -876,7 +869,7 @@ public class SparkInterpreter extends Interpreter {
       
       hooks = getInterpreterGroup().getInterpreterHookRegistry();
 
-      z = new ZeppelinContext(sc, sqlc, null, dep, hooks,
+      z = new SparkZeppelinContext(sc, sqlc, hooks,
               Integer.parseInt(getProperty("zeppelin.spark.maxResult")));
 
       interpret("@transient val _binder = new java.util.HashMap[String, Object]()");
@@ -895,7 +888,7 @@ public class SparkInterpreter extends Interpreter {
       }
 
       interpret("@transient val z = "
-              + "_binder.get(\"z\").asInstanceOf[org.apache.zeppelin.spark.ZeppelinContext]");
+              + "_binder.get(\"z\").asInstanceOf[org.apache.zeppelin.spark.SparkZeppelinContext]");
       interpret("@transient val sc = "
               + "_binder.get(\"sc\").asInstanceOf[org.apache.spark.SparkContext]");
       interpret("@transient val sqlc = "
@@ -1474,7 +1467,7 @@ public class SparkInterpreter extends Interpreter {
       SparkInterpreter.class.getName() + this.hashCode());
   }
 
-  public ZeppelinContext getZeppelinContext() {
+  public SparkZeppelinContext getZeppelinContext() {
     return z;
   }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -126,7 +126,7 @@ public class SparkSqlInterpreter extends Interpreter {
       throw new InterpreterException(e);
     }
 
-    String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
+    String msg = getSparkInterpreter().getZeppelinContext().showData(rdd);
     sc.clearJobGroup();
     return new InterpreterResult(Code.SUCCESS, msg);
   }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.spark;
+
+import com.google.common.collect.Lists;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.zeppelin.annotation.ZeppelinApi;
+import org.apache.zeppelin.display.AngularObjectWatcher;
+import org.apache.zeppelin.display.Input;
+import org.apache.zeppelin.display.ui.OptionInput;
+import org.apache.zeppelin.interpreter.*;
+import scala.Tuple2;
+import scala.Unit;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static scala.collection.JavaConversions.asJavaCollection;
+import static scala.collection.JavaConversions.asJavaIterable;
+import static scala.collection.JavaConversions.collectionAsScalaIterable;
+
+/**
+ * ZeppelinContext for Spark
+ */
+public class SparkZeppelinContext extends BaseZeppelinContext {
+
+
+  private SparkContext sc;
+  public SQLContext sqlContext;
+  private List<Class> supportedClasses;
+  private Map<String, String> interpreterClassMap;
+
+  public SparkZeppelinContext(
+      SparkContext sc, SQLContext sql,
+      InterpreterHookRegistry hooks,
+      int maxResult) {
+    super(hooks, maxResult);
+    this.sc = sc;
+    this.sqlContext = sql;
+
+    interpreterClassMap = new HashMap<String, String>();
+    interpreterClassMap.put("spark", "org.apache.zeppelin.spark.SparkInterpreter");
+    interpreterClassMap.put("sql", "org.apache.zeppelin.spark.SparkSqlInterpreter");
+    interpreterClassMap.put("dep", "org.apache.zeppelin.spark.DepInterpreter");
+    interpreterClassMap.put("pyspark", "org.apache.zeppelin.spark.PySparkInterpreter");
+
+    this.supportedClasses = new ArrayList<>();
+    try {
+      supportedClasses.add(this.getClass().forName("org.apache.spark.sql.Dataset"));
+    } catch (ClassNotFoundException e) {
+    }
+
+    try {
+      supportedClasses.add(this.getClass().forName("org.apache.spark.sql.DataFrame"));
+    } catch (ClassNotFoundException e) {
+    }
+
+    try {
+      supportedClasses.add(this.getClass().forName("org.apache.spark.sql.SchemaRDD"));
+    } catch (ClassNotFoundException e) {
+    }
+
+    if (supportedClasses.isEmpty()) {
+      throw new InterpreterException("Can not load Dataset/DataFrame/SchemaRDD class");
+    }
+  }
+
+  @Override
+  public List<Class> getSupportedClasses() {
+    return supportedClasses;
+  }
+
+  @Override
+  public Map<String, String> getInterpreterClassMap() {
+    return interpreterClassMap;
+  }
+
+  @Override
+  public String showData(Object df) {
+    Object[] rows = null;
+    Method take;
+    String jobGroup = Utils.buildJobGroupId(interpreterContext);
+    sc.setJobGroup(jobGroup, "Zeppelin", false);
+
+    try {
+      // convert it to DataFrame if it is Dataset, as we will iterate all the records
+      // and assume it is type Row.
+      if (df.getClass().getCanonicalName().equals("org.apache.spark.sql.Dataset")) {
+        Method convertToDFMethod = df.getClass().getMethod("toDF");
+        df = convertToDFMethod.invoke(df);
+      }
+      take = df.getClass().getMethod("take", int.class);
+      rows = (Object[]) take.invoke(df, maxResult + 1);
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException | InvocationTargetException | ClassCastException e) {
+      sc.clearJobGroup();
+      throw new InterpreterException(e);
+    }
+
+    List<Attribute> columns = null;
+    // get field names
+    try {
+      // Use reflection because of classname returned by queryExecution changes from
+      // Spark <1.5.2 org.apache.spark.sql.SQLContext$QueryExecution
+      // Spark 1.6.0> org.apache.spark.sql.hive.HiveContext$QueryExecution
+      Object qe = df.getClass().getMethod("queryExecution").invoke(df);
+      Object a = qe.getClass().getMethod("analyzed").invoke(qe);
+      scala.collection.Seq seq = (scala.collection.Seq) a.getClass().getMethod("output").invoke(a);
+
+      columns = (List<Attribute>) scala.collection.JavaConverters.seqAsJavaListConverter(seq)
+          .asJava();
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException | InvocationTargetException e) {
+      throw new InterpreterException(e);
+    }
+
+    StringBuilder msg = new StringBuilder();
+    msg.append("%table ");
+    for (Attribute col : columns) {
+      msg.append(col.name() + "\t");
+    }
+    String trim = msg.toString().trim();
+    msg = new StringBuilder(trim);
+    msg.append("\n");
+
+    // ArrayType, BinaryType, BooleanType, ByteType, DecimalType, DoubleType, DynamicType,
+    // FloatType, FractionalType, IntegerType, IntegralType, LongType, MapType, NativeType,
+    // NullType, NumericType, ShortType, StringType, StructType
+
+    try {
+      for (int r = 0; r < maxResult && r < rows.length; r++) {
+        Object row = rows[r];
+        Method isNullAt = row.getClass().getMethod("isNullAt", int.class);
+        Method apply = row.getClass().getMethod("apply", int.class);
+
+        for (int i = 0; i < columns.size(); i++) {
+          if (!(Boolean) isNullAt.invoke(row, i)) {
+            msg.append(apply.invoke(row, i).toString());
+          } else {
+            msg.append("null");
+          }
+          if (i != columns.size() - 1) {
+            msg.append("\t");
+          }
+        }
+        msg.append("\n");
+      }
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException | InvocationTargetException e) {
+      throw new InterpreterException(e);
+    }
+
+    if (rows.length > maxResult) {
+      msg.append("\n");
+      msg.append(ResultMessages.getExceedsLimitRowsMessage(maxResult,
+          SparkSqlInterpreter.MAX_RESULTS));
+    }
+
+    sc.clearJobGroup();
+    return msg.toString();
+  }
+
+  @ZeppelinApi
+  public Object select(String name, scala.collection.Iterable<Tuple2<Object, String>> options) {
+    return select(name, "", options);
+  }
+
+  @ZeppelinApi
+  public Object select(String name, Object defaultValue,
+                       scala.collection.Iterable<Tuple2<Object, String>> options) {
+    return select(name, defaultValue, tuplesToParamOptions(options));
+  }
+
+  @ZeppelinApi
+  public scala.collection.Seq<Object> checkbox(
+      String name,
+      scala.collection.Iterable<Tuple2<Object, String>> options) {
+    List<Object> allChecked = new LinkedList<>();
+    for (Tuple2<Object, String> option : asJavaIterable(options)) {
+      allChecked.add(option._1());
+    }
+    return checkbox(name, collectionAsScalaIterable(allChecked), options);
+  }
+
+  @ZeppelinApi
+  public scala.collection.Seq<Object> checkbox(
+      String name,
+      scala.collection.Iterable<Object> defaultChecked,
+      scala.collection.Iterable<Tuple2<Object, String>> options) {
+    return scala.collection.JavaConversions.asScalaBuffer(
+        gui.checkbox(name, asJavaCollection(defaultChecked),
+            tuplesToParamOptions(options))).toSeq();
+  }
+
+  private OptionInput.ParamOption[] tuplesToParamOptions(
+      scala.collection.Iterable<Tuple2<Object, String>> options) {
+    int n = options.size();
+    OptionInput.ParamOption[] paramOptions = new OptionInput.ParamOption[n];
+    Iterator<Tuple2<Object, String>> it = asJavaIterable(options).iterator();
+
+    int i = 0;
+    while (it.hasNext()) {
+      Tuple2<Object, String> valueAndDisplayValue = it.next();
+      paramOptions[i++] = new OptionInput.ParamOption(valueAndDisplayValue._1(),
+          valueAndDisplayValue._2());
+    }
+
+    return paramOptions;
+  }
+
+  @ZeppelinApi
+  public void angularWatch(String name,
+                           final scala.Function2<Object, Object, Unit> func) {
+    angularWatch(name, interpreterContext.getNoteId(), func);
+  }
+
+  @Deprecated
+  public void angularWatchGlobal(String name,
+                                 final scala.Function2<Object, Object, Unit> func) {
+    angularWatch(name, null, func);
+  }
+
+  @ZeppelinApi
+  public void angularWatch(
+      String name,
+      final scala.Function3<Object, Object, InterpreterContext, Unit> func) {
+    angularWatch(name, interpreterContext.getNoteId(), func);
+  }
+
+  @Deprecated
+  public void angularWatchGlobal(
+      String name,
+      final scala.Function3<Object, Object, InterpreterContext, Unit> func) {
+    angularWatch(name, null, func);
+  }
+
+  private void angularWatch(String name, String noteId,
+                            final scala.Function2<Object, Object, Unit> func) {
+    AngularObjectWatcher w = new AngularObjectWatcher(getInterpreterContext()) {
+      @Override
+      public void watch(Object oldObject, Object newObject,
+                        InterpreterContext context) {
+        func.apply(newObject, newObject);
+      }
+    };
+    angularWatch(name, noteId, w);
+  }
+
+  private void angularWatch(
+      String name,
+      String noteId,
+      final scala.Function3<Object, Object, InterpreterContext, Unit> func) {
+    AngularObjectWatcher w = new AngularObjectWatcher(getInterpreterContext()) {
+      @Override
+      public void watch(Object oldObject, Object newObject,
+                        InterpreterContext context) {
+        func.apply(oldObject, newObject, context);
+      }
+    };
+    angularWatch(name, noteId, w);
+  }
+}

--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinRContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinRContext.java
@@ -27,7 +27,7 @@ import org.apache.spark.sql.SQLContext;
 public class ZeppelinRContext {
   private static SparkContext sparkContext;
   private static SQLContext sqlContext;
-  private static ZeppelinContext zeppelinContext;
+  private static SparkZeppelinContext zeppelinContext;
   private static Object sparkSession;
   private static JavaSparkContext javaSparkContext;
 
@@ -35,7 +35,7 @@ public class ZeppelinRContext {
     ZeppelinRContext.sparkContext = sparkContext;
   }
 
-  public static void setZeppelinContext(ZeppelinContext zeppelinContext) {
+  public static void setZeppelinContext(SparkZeppelinContext zeppelinContext) {
     ZeppelinRContext.zeppelinContext = zeppelinContext;
   }
 
@@ -55,7 +55,7 @@ public class ZeppelinRContext {
     return sqlContext;
   }
 
-  public static ZeppelinContext getZeppelinContext() {
+  public static SparkZeppelinContext getZeppelinContext() {
     return zeppelinContext;
   }
 

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -57,7 +57,7 @@ class PyZeppelinContext(dict):
   def show(self, obj):
     from pyspark.sql import DataFrame
     if isinstance(obj, DataFrame):
-      print(gateway.jvm.org.apache.zeppelin.spark.ZeppelinContext.showDF(self.z, obj._jdf))
+      print(self.z.showData(obj._jdf))
     else:
       print(str(obj))
 


### PR DESCRIPTION
### What is this PR for?
For now, ZeppelinContext only support Spark Interpreter. I'd like to make it extensible, so that it can support other interpreters as well. For now, user need to implement the following 3 methods to extend ZeppelinContext

* public List<Class> getSupportedClasses() 
* public abstract Map<String, String> getInterpreterClassMap();
* protected abstract String showData(Object obj);


### What type of PR is it?
[Feature | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1595

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

