### PR TITLE
[MINOR] Turn on authenticaiton in shiro.ini.template by default

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -78,5 +78,5 @@ admin = *
 #/api/interpreter/** = authc, roles[admin]
 #/api/configurations/** = authc, roles[admin]
 #/api/credential/** = authc, roles[admin]
-/** = anon
-#/** = authc
+#/** = anon
+/** = authc


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/zeppelin/pull/1568 moved conf/shiro.ini to conf/shiro.ini.template.
Now i think it make sense to turn authentication on by default in conf/shiro.ini.template.

### What type of PR is it?
Improvement

### Todos
* [x] - Turn authentication on by default in the template

### What is the Jira issue?
related to issues.apache.org/jira/browse/ZEPPELIN-1590

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

