### PR TITLE
[gh-pages] Add ignite version info to supported interpreters table

### DIFF
--- a/supported_interpreters.md
+++ b/supported_interpreters.md
@@ -235,11 +235,12 @@ Please check the below table before you download Zeppelin package.
   <tr>
     <td>
       <h6><a href="https://ignite.apache.org/" target="_blank">Ignite</a></h6>
+      <span style="font-size:75%">Please use the next Ignite version to use Scala code</span>
     </td>
-    <td>O</td>
-    <td>O</td>
-    <td>O</td>
-    <td>O</td>
+    <td>1.7.0</td>
+    <td>1.6.0</td>
+    <td>1.5.0.final</td>
+    <td>1.4.0</td>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
### What is this PR for?
As described in [ignite docs](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/interpreter/ignite.html#installing-and-running-ignite-example), to use Scala code with Ignite interpreter, the user should use the Ignite version same as Zeppelin provides. So the below info should be provided in somewhere. 

```
Zeppelin-0.5.5: Ignite-1.4.0
Zeppelin-0.5.6: Ignite-1.5.0.final
Zeppelin-0.6.0: Ignite-1.6.0
Zeppelin-0.6.1&0.6.2: Ignite-1.7.0
```


### What type of PR is it?
Documentation

### What is the Jira issue?
no Jira issue for this

### Screenshots (if appropriate)
![screen shot 2016-11-03 at 11 37 09 am](https://cloud.githubusercontent.com/assets/10060731/19954332/b8690e68-a1ba-11e6-9649-d7b841e832ea.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

