### PR TITLE
[ZEPPELIN-1610] - Add notebook watcher

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -65,6 +65,7 @@ import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.util.WatcherSecurityKey;
 import org.apache.zeppelin.utils.InterpreterBindingUtils;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
@@ -1793,6 +1794,12 @@ public class NotebookServer extends WebSocketServlet implements
     // add the connection to the watcher.
     if (watcherSockets.contains(conn)) {
       LOG.info("connection alrerady present in the watcher");
+      return;
+    }
+    String watcherSecurityKey = conn.getRequest().getHeader(WatcherSecurityKey.HTTP_HEADER);
+    if (StringUtils.isBlank(watcherSecurityKey) ||
+        !watcherSecurityKey.equals(WatcherSecurityKey.getKey())) {
+      LOG.error("Cannot switch this client to watcher, invalid security key");
       return;
     }
     watcherSockets.add(conn);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -402,7 +402,6 @@ public class NotebookServer extends WebSocketServlet implements
       for (String id : ids) {
         if (id.equals(interpreterGroupId)) {
           broadcast(note.getId(), m);
-          broadcastToWatchers(note.getId(), StringUtils.EMPTY, m);
         }
       }
     }
@@ -563,7 +562,6 @@ public class NotebookServer extends WebSocketServlet implements
 
   public void broadcastNote(Note note) {
     broadcast(note.getId(), new Message(OP.NOTE).put("note", note));
-    broadcastToWatchers(note.getId(), "", new Message(OP.NOTE).put("note", note));
   }
 
   public void broadcastInterpreterBindings(String noteId, List settingList) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -409,12 +409,12 @@ public class NotebookServer extends WebSocketServlet implements
 
   private void broadcast(String noteId, Message m) {
     synchronized (noteSocketMap) {
+      broadcastToWatchers(noteId, StringUtils.EMPTY, m);
       List<NotebookSocket> socketLists = noteSocketMap.get(noteId);
       if (socketLists == null || socketLists.size() == 0) {
         return;
       }
       LOG.debug("SEND >> " + m.op);
-      broadcastToWatchers(noteId, StringUtils.EMPTY, m);
       for (NotebookSocket conn : socketLists) {
         try {
           conn.send(serializeMessage(m));
@@ -427,12 +427,12 @@ public class NotebookServer extends WebSocketServlet implements
 
   private void broadcastExcept(String noteId, Message m, NotebookSocket exclude) {
     synchronized (noteSocketMap) {
+      broadcastToWatchers(noteId, StringUtils.EMPTY, m);
       List<NotebookSocket> socketLists = noteSocketMap.get(noteId);
       if (socketLists == null || socketLists.size() == 0) {
         return;
       }
       LOG.debug("SEND >> " + m.op);
-      broadcastToWatchers(noteId, StringUtils.EMPTY, m);
       for (NotebookSocket conn : socketLists) {
         if (exclude.equals(conn)) {
           continue;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -30,12 +30,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -57,6 +52,11 @@ import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
 
 /**
  * Binded interpreters for a note

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -312,4 +312,11 @@ public class ZeppelinClient {
     }
     watcherSession.getRemote().sendStringByFuture(serialize(new Message(OP.PING)));
   }
+  
+  /**
+   * Only used in test.
+   */
+  public int countConnectedNotes() {
+    return notesConnection.size();
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -298,7 +298,7 @@ public class ZeppelinClient {
     Session noteSession = null;
     for (Map.Entry<String, Session> note: notesConnection.entrySet()) {
       noteSession = note.getValue();
-      if(isSessionOpen(noteSession)) {
+      if (isSessionOpen(noteSession)) {
         noteSession.close();
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -35,6 +35,7 @@ import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.scheduler.Schedul
 import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.scheduler.ZeppelinHeartbeat;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.Message.OP;
+import org.apache.zeppelin.util.WatcherSecurityKey;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -168,6 +169,7 @@ public class ZeppelinClient {
   
   private Session openWatcherSession() {
     ClientUpgradeRequest request = new ClientUpgradeRequest();
+    request.setHeader(WatcherSecurityKey.HTTP_HEADER, WatcherSecurityKey.getKey());
     WatcherWebsocket socket = WatcherWebsocket.createInstace();
     Future<Session> future = null;
     Session session = null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/WatcherWebsocket.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/WatcherWebsocket.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.listener;
 
 import org.apache.commons.lang.StringUtils;
@@ -13,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 
 /**
- * 
+ * Zeppelin Watcher that will forward user note to ZeppelinHub.
  *
  */
 public class WatcherWebsocket implements WebSocketListener {
@@ -48,7 +64,6 @@ public class WatcherWebsocket implements WebSocketListener {
 
   @Override
   public void onWebSocketText(String message) {
-    LOG.debug("WatcherWebsocket client received Message: " + message);
     WatcherMessage watcherMsg = GSON.fromJson(message, WatcherMessage.class);
     if (StringUtils.isBlank(watcherMsg.noteId)) {
       return;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/WatcherWebsocket.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/WatcherWebsocket.java
@@ -1,0 +1,66 @@
+package org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.ZeppelinClient;
+import org.apache.zeppelin.notebook.socket.Message;
+import org.apache.zeppelin.notebook.socket.Message.OP;
+import org.apache.zeppelin.notebook.socket.WatcherMessage;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+
+/**
+ * 
+ *
+ */
+public class WatcherWebsocket implements WebSocketListener {
+  private static final Logger LOG = LoggerFactory.getLogger(ZeppelinWebsocket.class);
+  private static final Gson GSON = new Gson();
+  public Session connection;
+  
+  public static WatcherWebsocket createInstace() {
+    return new WatcherWebsocket();
+  }
+  
+  @Override
+  public void onWebSocketBinary(byte[] payload, int offset, int len) {
+  }
+
+  @Override
+  public void onWebSocketClose(int code, String reason) {
+    LOG.info("WatcherWebsocket connection closed with code: {}, message: {}", code, reason);
+  }
+
+  @Override
+  public void onWebSocketConnect(Session session) {
+    LOG.info("WatcherWebsocket connection opened");
+    this.connection = session;
+    session.getRemote().sendStringByFuture(GSON.toJson(new Message(OP.WATCHER)));
+  }
+
+  @Override
+  public void onWebSocketError(Throwable cause) {
+    LOG.warn("WatcherWebsocket socket connection error ", cause);
+  }
+
+  @Override
+  public void onWebSocketText(String message) {
+    LOG.debug("WatcherWebsocket client received Message: " + message);
+    WatcherMessage watcherMsg = GSON.fromJson(message, WatcherMessage.class);
+    if (StringUtils.isBlank(watcherMsg.noteId)) {
+      return;
+    }
+    try {
+      ZeppelinClient zeppelinClient = ZeppelinClient.getInstance();
+      if (zeppelinClient != null) {
+        zeppelinClient.handleMsgFromZeppelin(watcherMsg.message, watcherMsg.noteId);
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to send message to ZeppelinHub: ", e);
+    }
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/ZeppelinWebsocket.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/listener/ZeppelinWebsocket.java
@@ -43,7 +43,7 @@ public class ZeppelinWebsocket implements WebSocketListener {
   @Override
   public void onWebSocketClose(int code, String message) {
     LOG.info("Zeppelin connection closed with code: {}, message: {}", code, message);
-    // parentClient.removeConnMap(noteId);
+    ZeppelinClient.getInstance().removeNoteConnection(noteId);
   }
 
   @Override
@@ -54,7 +54,8 @@ public class ZeppelinWebsocket implements WebSocketListener {
 
   @Override
   public void onWebSocketError(Throwable e) {
-    LOG.warn("Zeppelin socket connection error: {}", e.toString());
+    LOG.warn("Zeppelin socket connection error ", e);
+    ZeppelinClient.getInstance().removeNoteConnection(noteId);
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/scheduler/ZeppelinHeartbeat.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/scheduler/ZeppelinHeartbeat.java
@@ -38,7 +38,7 @@ public class ZeppelinHeartbeat implements Runnable {
 
   @Override
   public void run() {
-    LOG.debug("Sending PING to all connected Zeppelin notes");
-    client.pingAllNotes();
+    LOG.debug("Sending PING to Zeppelin Websocket Server");
+    client.ping();
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -146,7 +146,7 @@ public class Message {
     GET_INTERPRETER_SETTINGS,     // [c-s] get interpreter settings
     INTERPRETER_SETTINGS,         // [s-c] interpreter settings
     ERROR_INFO,                   // [s-c] error information to be sent
-    WATCHER,                      // [s-c] TODO(anthonycorbacho): add description.
+    WATCHER,                      // [s-c] Change websocket to watcher mode.
   }
 
   public static final Message EMPTY = new Message(null);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -145,9 +145,12 @@ public class Message {
     INTERPRETER_BINDINGS,         // [s-c] interpreter bindings
     GET_INTERPRETER_SETTINGS,     // [c-s] get interpreter settings
     INTERPRETER_SETTINGS,         // [s-c] interpreter settings
-    ERROR_INFO                    // [s-c] error information to be sent
+    ERROR_INFO,                   // [s-c] error information to be sent
+    WATCHER,                      // [s-c] TODO(anthonycorbacho): add description.
   }
 
+  public static final Message EMPTY = new Message(null);
+  
   public OP op;
   public Map<String, Object> data = new HashMap<>();
   public String ticket = "anonymous";

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.notebook.socket;
+
+import com.google.gson.Gson;
+
+/**
+ * Zeppelin websocket massage template class for watcher socket.
+ */
+public class WatcherMessage {
+
+  private String message;
+  private String noteId;
+  private String subject;
+  
+  private static final Gson gson = new Gson();
+  
+  public static Builder builder(String noteId) {
+    return new Builder(noteId);
+  }
+  
+  private WatcherMessage(Builder builder) {
+    this.noteId = builder.noteId;
+    this.message = builder.message;
+    this.subject = builder.subject;
+  }
+  
+  public String serialize() {
+    return gson.toJson(this);
+  }
+  
+  /**
+   * Simple builder.
+   */
+  public static class Builder {
+    private final String noteId;
+    private String subject;
+    private String message;
+    
+    public Builder(String noteId) {
+      this.noteId = noteId;
+    }
+    
+    public Builder subject(String subject) {
+      this.subject = subject;
+      return this;
+    }
+    
+    public Builder message(String message) {
+      this.message = message;
+      return this;
+    }
+
+    public WatcherMessage build() {
+      return new WatcherMessage(this);
+    }
+  }
+  
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/WatcherMessage.java
@@ -23,9 +23,9 @@ import com.google.gson.Gson;
  */
 public class WatcherMessage {
 
-  private String message;
-  private String noteId;
-  private String subject;
+  public String message;
+  public String noteId;
+  public String subject;
   
   private static final Gson gson = new Gson();
   

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/WatcherSecurityKey.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/WatcherSecurityKey.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.util;
+
+import java.util.UUID;
+
+/**
+ * Simple implementation of a auto-generated key for websocket watcher.
+ * This is a LAZY implementation, we might want to update this later on :)
+ */
+public class WatcherSecurityKey {
+  public static final String HTTP_HEADER = "X-Watcher-Key";
+  private static final String KEY = UUID.randomUUID().toString();
+
+  protected WatcherSecurityKey() {}
+
+  public static String getKey() {
+    return KEY;
+  }
+
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClientTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClientTest.java
@@ -121,7 +121,7 @@ public class ZeppelinClientTest {
     msg.data = Maps.newHashMap();
     msg.data.put("key", "value");
     client.send(msg, "DDDD");
-    //client.removeZeppelinConnection("DDDD");
+    client.removeNoteConnection("DDDD");
     client.stop();
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClientTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClientTest.java
@@ -1,6 +1,10 @@
 package org.apache.zeppelin.notebook.repo.zeppelinhub.websocket;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,7 +78,7 @@ public class ZeppelinClientTest {
     assertEquals(connectionB, client.getZeppelinConnection("BBBB"));
 
     // Remove connection to note AAAA
-    client.removeZeppelinConnection("AAAA");
+    client.removeNoteConnection("AAAA");
     assertEquals(client.countConnectedNotes(), 1);
     assertNotEquals(connectionA, client.getZeppelinConnection("AAAA"));
     assertEquals(client.countConnectedNotes(), 2);
@@ -117,7 +121,7 @@ public class ZeppelinClientTest {
     msg.data = Maps.newHashMap();
     msg.data.put("key", "value");
     client.send(msg, "DDDD");
-    client.removeZeppelinConnection("DDDD");
+    //client.removeZeppelinConnection("DDDD");
     client.stop();
   }
 }


### PR DESCRIPTION
### What is this PR for?
Add a Simple way to switch a websocket connection to a new state; watcher.
A websocket watcher is a special connection that will watch most of the web socket even in Zeppelin, this cam be used to monitor zeppelin server activity.

### What type of PR is it?
[Feature]

### Todos
* [x] - Add watcher Queue
* [x] - Add endpoint to switch from regular client to watcher
* [x] - Add a way to generate a uniq key when zeppelin server restart
* [x] - Add example on how to use watcher.

### What is the Jira issue?
* [ZEPPELIN-1610](https://issues.apache.org/jira/browse/ZEPPELIN-1610)

### How should this be tested?
You will have to create your own websocket client and provide a valid http header (`X-Watcher-Key`) when you connect to zeppelin ws
 something like 
```
private Session openWatcherSession() {
    ClientUpgradeRequest request = new ClientUpgradeRequest();
    request.setHeader(WatcherSecurityKey.HTTP_HEADER, WatcherSecurityKey.getKey());
    WatcherWebsocket socket = WatcherWebsocket.createInstace();
    Future<Session> future = null;
    Session session = null;
    try {
      future = wsClient.connect(socket, zeppelinWebsocketUrl, request);
      session = future.get();
    } catch (IOException | InterruptedException | ExecutionException e) {
      LOG.error("Couldn't establish websocket connection to Zeppelin ", e);
      return session;
    }
    return session;
  }
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
