### PR TITLE
[ZEPPELIN-1612] Fix NPE when initializing Notebook

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -120,7 +120,8 @@ public class Notebook implements NoteEventListener {
     quartzSched.start();
     CronJob.notebook = this;
 
-    loadAllNotes();
+    AuthenticationInfo anonymous = AuthenticationInfo.ANONYMOUS;
+    loadAllNotes(anonymous);
     if (this.noteSearchService != null) {
       long start = System.nanoTime();
       logger.info("Notebook indexing started...");
@@ -462,11 +463,11 @@ public class Notebook implements NoteEventListener {
     return note;
   }
 
-  private void loadAllNotes() throws IOException {
-    List<NoteInfo> noteInfos = notebookRepo.list(null);
+  private void loadAllNotes(AuthenticationInfo subject) throws IOException {
+    List<NoteInfo> noteInfos = notebookRepo.list(subject);
 
     for (NoteInfo info : noteInfos) {
-      loadNoteFromRepo(info.getId(), null);
+      loadNoteFromRepo(info.getId(), subject);
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -463,7 +463,7 @@ public class Notebook implements NoteEventListener {
     return note;
   }
 
-  private void loadAllNotes(AuthenticationInfo subject) throws IOException {
+  void loadAllNotes(AuthenticationInfo subject) throws IOException {
     List<NoteInfo> noteInfos = notebookRepo.list(subject);
 
     for (NoteInfo info : noteInfos) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -209,8 +209,7 @@ public class NotebookTest implements JobListenerFactory{
       p1.setText("hello world");
       note.persist(anonymous);
     } catch (IOException fe) {
-      logger.warn("Failed to create note and paragraph. Safe to return, other tests might be failing as well", fe);
-      return;
+      logger.warn("Failed to create note and paragraph. Possible problem with persisting note, safe to ignore", fe);
     }
 
     try {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -65,7 +65,7 @@ public class NotebookTest implements JobListenerFactory{
   private DependencyResolver depResolver;
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
-  private AuthenticationInfo anonymous = new AuthenticationInfo("anonymous");
+  private AuthenticationInfo anonymous = AuthenticationInfo.ANONYMOUS;
 
   @Before
   public void setUp() throws Exception {
@@ -196,6 +196,31 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notes.size(), 0);
   }
 
+  @Test
+  public void testLoadAllNotes() {
+    Note note;
+    try {
+      assertEquals(0, notebook.getAllNotes().size());
+      note = notebook.createNote(anonymous);
+      Paragraph p1 = note.addParagraph();
+      Map config = p1.getConfig();
+      config.put("enabled", true);
+      p1.setConfig(config);
+      p1.setText("hello world");
+      note.persist(anonymous);
+    } catch (IOException fe) {
+      logger.warn("Failed to create note and paragraph. Safe to return, other tests might be failing as well", fe);
+      return;
+    }
+
+    try {
+      notebook.loadAllNotes(anonymous);
+      assertEquals(1, notebook.getAllNotes().size());
+    } catch (IOException e) {
+      fail("Subject is non-emtpy anonymous, shouldn't fail");
+    }
+  }
+  
   @Test
   public void testPersist() throws IOException, SchedulerException, RepositoryException {
     Note note = notebook.createNote(anonymous);


### PR DESCRIPTION
### What is this PR for?
Sometimes Zeppelin wasn't able to start because of empty subject when initializing Notebook class, more details in issue.

### What type of PR is it?
Bug Fix

### Todos
* [x] - add anonymous subject
* [x] - add test

### What is the Jira issue?
[ZEPPELIN-1612](https://issues.apache.org/jira/browse/ZEPPELIN-1612)

### How should this be tested?
* added test passing and no relevant CI failures
* also can be starting Zeppelin in anonymous mode when you have notes with angular objects

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
