### PR TITLE
[ZEPPELIN-1615] - Zeppelin should be able to run without Shiro

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -26,7 +26,10 @@ import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.ws.rs.core.Application;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
+import org.apache.shiro.web.env.EnvironmentLoaderListener;
+import org.apache.shiro.web.servlet.ShiroFilter;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.dep.DependencyResolver;
@@ -259,15 +262,16 @@ public class ZeppelinServer extends Application {
     webapp.setSessionHandler(new SessionHandler());
     webapp.addServlet(cxfServletHolder, "/api/*");
 
-    webapp.setInitParameter("shiroConfigLocations",
-        new File(conf.getShiroPath()).toURI().toString());
-
-    SecurityUtils.initSecurityManager(conf.getShiroPath());
-    webapp.addFilter(org.apache.shiro.web.servlet.ShiroFilter.class, "/api/*",
-        EnumSet.allOf(DispatcherType.class));
-
-    webapp.addEventListener(new org.apache.shiro.web.env.EnvironmentLoaderListener());
-
+    String shiroIniPath = conf.getShiroPath();
+    if (!StringUtils.isBlank(shiroIniPath)) {
+      webapp.setInitParameter("shiroConfigLocations", new File(shiroIniPath).toURI().toString());
+      SecurityUtils.initSecurityManager(shiroIniPath);
+      webapp.addFilter(ShiroFilter.class, "/api/*", EnumSet.allOf(DispatcherType.class));
+      webapp.addEventListener(new EnvironmentLoaderListener());
+    } else {
+      webapp.addFilter(new FilterHolder(CorsFilter.class),
+          "/api/*", EnumSet.allOf(DispatcherType.class));
+    }
   }
 
   private static WebAppContext setupWebAppContext(ContextHandlerCollection contexts,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -16,6 +16,13 @@
  */
 package org.apache.zeppelin.integration;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.AbstractZeppelinIT;
@@ -34,13 +41,6 @@ import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
-
 
 /**
  * Created for org.apache.zeppelin.integration on 13/06/16.
@@ -50,7 +50,7 @@ public class AuthenticationIT extends AbstractZeppelinIT {
 
   @Rule
   public ErrorCollector collector = new ErrorCollector();
-
+  static String shiroPath;
   static String authShiro = "[users]\n" +
       "admin = password1, admin\n" +
       "finance1 = finance1, finance\n" +
@@ -82,7 +82,8 @@ public class AuthenticationIT extends AbstractZeppelinIT {
     try {
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(), "../");
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-      File file = new File(conf.getShiroPath());
+      shiroPath = conf.getRelativeDir(String.format("%s/shiro.ini", conf.getConfDir()));
+      File file = new File(shiroPath);
       originalShiro = StringUtils.join(FileUtils.readLines(file, "UTF-8"), "\n");
       FileUtils.write(file, authShiro, "UTF-8");
     } catch (IOException e) {
@@ -98,12 +99,9 @@ public class AuthenticationIT extends AbstractZeppelinIT {
     if (!endToEndTestEnabled()) {
       return;
     }
-    try {
-      ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-      File file = new File(conf.getShiroPath());
-      FileUtils.write(file, originalShiro, "UTF-8");
-    } catch (IOException e) {
-      LOG.error("Error in AuthenticationIT tearDown::", e);
+    if (!StringUtils.isBlank(shiroPath)) {
+      File file = new File(shiroPath);
+      FileUtils.deleteQuietly(file);
     }
     ZeppelinITUtils.restartZeppelin();
     driver.quit();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -84,7 +84,9 @@ public class AuthenticationIT extends AbstractZeppelinIT {
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
       shiroPath = conf.getRelativeDir(String.format("%s/shiro.ini", conf.getConfDir()));
       File file = new File(shiroPath);
-      originalShiro = StringUtils.join(FileUtils.readLines(file, "UTF-8"), "\n");
+      if (file.exists()) {
+        originalShiro = StringUtils.join(FileUtils.readLines(file, "UTF-8"), "\n");
+      }
       FileUtils.write(file, authShiro, "UTF-8");
     } catch (IOException e) {
       LOG.error("Error in AuthenticationIT startUp::", e);
@@ -99,9 +101,17 @@ public class AuthenticationIT extends AbstractZeppelinIT {
     if (!endToEndTestEnabled()) {
       return;
     }
-    if (!StringUtils.isBlank(shiroPath)) {
-      File file = new File(shiroPath);
-      FileUtils.deleteQuietly(file);
+    try {
+      if (!StringUtils.isBlank(shiroPath)) {
+        File file = new File(shiroPath);
+        if (StringUtils.isBlank(originalShiro)) {
+          FileUtils.deleteQuietly(file);
+        } else {
+          FileUtils.write(file, originalShiro, "UTF-8");
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("Error in AuthenticationIT tearDown::", e);
     }
     ZeppelinITUtils.restartZeppelin();
     driver.quit();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.zeppelin.rest;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
@@ -27,11 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.*;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 public class SecurityRestApiTest extends AbstractTestRestApi {
   Gson gson = new Gson();
@@ -41,7 +40,7 @@ public class SecurityRestApiTest extends AbstractTestRestApi {
 
   @BeforeClass
   public static void init() throws Exception {
-    AbstractTestRestApi.startUp();
+    AbstractTestRestApi.startUpWithAuthenticationEnable();;
   }
 
   @AfterClass

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.tree.ConfigurationNode;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
 import org.apache.zeppelin.util.Util;
 import org.slf4j.Logger;
@@ -402,9 +403,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
   public String getShiroPath() {
-    String shiroPath =  getRelativeDir(String.format("%s/shiro.ini", getConfDir()));
-    return new File(shiroPath).exists() ? shiroPath
-        : getRelativeDir(String.format("%s/shiro.ini.template", getConfDir()));
+    String shiroPath = getRelativeDir(String.format("%s/shiro.ini", getConfDir()));
+    return new File(shiroPath).exists() ? shiroPath : StringUtils.EMPTY;
   }
 
   public String getInterpreterRemoteRunnerPath() {


### PR DESCRIPTION
### What is this PR for?
Right now, Zeppelin use Shiro by default even if you dont need it.
(It will use shiro.ini.template file if it doenst find shiro.ini), this behaviors is a little flacky and we should start zeppelin without shiro context if user doenst want to use it.

### What type of PR is it?
[Bug Fix | Improvement ]

### Todos
* [x] - Update configuration - Return empty if shiro file not found
* [x] - refactor Rest Api handler, if shiro.ini not found start a handler without shiro context
* [x] - refactor SecurityUtils to handle the case of shiro is disabled.

### What is the Jira issue?
 * [ZEPPELIN-1615](https://issues.apache.org/jira/browse/ZEPPELIN-1615)

### How should this be tested?
Start zeppelin without shiro.ini

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
