### PR TITLE
ZEPPELIN-1616. Interpreter open happens in jobRun

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -226,7 +226,7 @@ public class RemoteInterpreter extends Interpreter {
         }
         client.createInterpreter(groupId, noteId,
           getClassName(), (Map) property);
-
+        client.open(noteId, getClassName());
         // Push angular object loaded from JSON file to remote interpreter
         if (!interpreterGroup.isAngularRegistryPushed()) {
           pushAngularObjectRegistryToRemote(client);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -436,9 +436,9 @@ public class RemoteInterpreterServer
         // This is necessary because the earliest we can register a hook
         // is from within the open() method.
         LazyOpenInterpreter lazy = (LazyOpenInterpreter) interpreter;
-        if (!lazy.isOpen()) {
-          lazy.open();
-        }
+//        if (!lazy.isOpen()) {
+//          lazy.open();
+//        }
         
         // Add hooks to script from registry.
         // Global scope first, followed by notebook scope

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -431,15 +431,7 @@ public class RemoteInterpreterServer
     protected Object jobRun() throws Throwable {
       try {
         InterpreterContext.set(context);
-        
-        // Open the interpreter instance prior to calling interpret().
-        // This is necessary because the earliest we can register a hook
-        // is from within the open() method.
         LazyOpenInterpreter lazy = (LazyOpenInterpreter) interpreter;
-//        if (!lazy.isOpen()) {
-//          lazy.open();
-//        }
-        
         // Add hooks to script from registry.
         // Global scope first, followed by notebook scope
         processInterpreterHooks(null);


### PR DESCRIPTION
### What is this PR for?
Not sure why we put interpreter open in jobRun, that means the thrift service method open is never used. I think open method in remote interpreter process should be called when RemoteInterpreter call open method in client side. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1616


### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
