### PR TITLE
[HOT-FIX] - Prevent double injection of cross-origin headers from rest api

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -268,9 +268,6 @@ public class ZeppelinServer extends Application {
       SecurityUtils.initSecurityManager(shiroIniPath);
       webapp.addFilter(ShiroFilter.class, "/api/*", EnumSet.allOf(DispatcherType.class));
       webapp.addEventListener(new EnvironmentLoaderListener());
-    } else {
-      webapp.addFilter(new FilterHolder(CorsFilter.class),
-          "/api/*", EnumSet.allOf(DispatcherType.class));
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Prevent error `XMLHttpRequest cannot load http://localhost:8080/api/version. The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost:9000, http://localhost:9000', but only one is allowed. Origin 'http://localhost:9000' is therefore not allowed access`

### What type of PR is it?
[Hot Fix]
