### PR TITLE
[ZEPPELIN-1622] Remove %dep interpreter deprecated message

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -228,8 +228,7 @@ Here are few examples:
   ```
 
 ### 3. Dynamic Dependency Loading via %spark.dep interpreter
-> Note: `%spark.dep` interpreter is deprecated since v0.6.0.
-`%spark.dep` interpreter loads libraries to `%spark` and `%spark.pyspark` but not to  `%spark.sql` interpreter. So we recommend you to use the first option instead.
+> Note: `%spark.dep` interpreter loads libraries to `%spark` and `%spark.pyspark` but not to  `%spark.sql` interpreter. So we recommend you to use the first option instead.
 
 When your code requires external library, instead of doing download/copy/restart Zeppelin, you can easily do following jobs using `%spark.dep` interpreter.
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/dep/SparkDependencyContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/dep/SparkDependencyContext.java
@@ -42,8 +42,6 @@ import org.sonatype.aether.util.artifact.JavaScopes;
 import org.sonatype.aether.util.filter.DependencyFilterUtils;
 import org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter;
 
-import scala.Console;
-
 
 /**
  *
@@ -66,8 +64,6 @@ public class SparkDependencyContext {
   }
 
   public Dependency load(String lib) {
-    Console.println("DepInterpreter(%dep) deprecated. "
-        + "Load dependency through GUI interpreter menu instead.");
     Dependency dep = new Dependency(lib);
 
     if (dependencies.contains(dep)) {
@@ -78,16 +74,12 @@ public class SparkDependencyContext {
   }
 
   public Repository addRepo(String name) {
-    Console.println("DepInterpreter(%dep) deprecated. "
-        + "Add repository through GUI interpreter menu instead.");
     Repository rep = new Repository(name);
     repositories.add(rep);
     return rep;
   }
 
   public void reset() {
-    Console.println("DepInterpreter(%dep) deprecated. "
-        + "Remove dependencies and repositories through GUI interpreter menu instead.");
     dependencies = new LinkedList<>();
     repositories = new LinkedList<>();
 

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -232,6 +232,16 @@ public class SparkInterpreterTest {
   }
 
   @Test
+  public void testZContextDependencyLoading() {
+    // try to import library does not exist on classpath. it'll fail
+    assertEquals(InterpreterResult.Code.ERROR, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
+
+    // load library from maven repository and try to import again
+    repl.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
+  }
+
+  @Test
   public void emptyConfigurationVariablesOnlyForNonSparkProperties() {
     Properties intpProperty = repl.getProperty();
     SparkConf sparkConf = repl.getSparkContext().getConf();

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -232,16 +232,6 @@ public class SparkInterpreterTest {
   }
 
   @Test
-  public void testZContextDependencyLoading() {
-    // try to import library does not exist on classpath. it'll fail
-    assertEquals(InterpreterResult.Code.ERROR, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
-
-    // load library from maven repository and try to import again
-    repl.interpret("z.load(\"org.apache.commons:commons-csv:1.1\")", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, repl.interpret("import org.apache.commons.csv.CSVFormat", context).code());
-  }
-
-  @Test
   public void emptyConfigurationVariablesOnlyForNonSparkProperties() {
     Properties intpProperty = repl.getProperty();
     SparkConf sparkConf = repl.getSparkContext().getConf();


### PR DESCRIPTION
### What is this PR for?
%dep interpreter was going to be deprecated, but we had feedback from many users that this feature provide different advantage over dependency loading via GUI so we want to keep supporting it. This PR remove deprecated message when users use %dep interpreter.

### Todos
- [x] Fix test

### What type of PR is it?
Documentation

### What is the Jira issue?
[ZEPPELIN-1622](https://issues.apache.org/jira/browse/ZEPPELIN-1622)

### How should this be tested?
Run %dep interpreter such as `z.load('/your/library.jar)` and see if deprecated message is gone.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

