### PR TITLE
ZEPPELIN-1643:Make spark web UI accesible from interpreters page

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -315,6 +315,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    sparkInterpreter.populateSparkWebUrl(context);
     if (sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -960,7 +960,9 @@ public class SparkInterpreter extends Interpreter {
       if (url != null) {
         infos.put("url", url);
         logger.info("Sending metainfos to Zeppelin server: {}", infos.toString());
-        ctx.getClient().onMetaInfosReceived(infos);
+        if (ctx != null && ctx.getClient() != null) {
+          ctx.getClient().onMetaInfosReceived(infos);
+        }
       }
     }
   }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 import scala.*;
 import scala.Enumeration.Value;
 import scala.collection.Iterator;
-import scala.collection.JavaConversions;x
+import scala.collection.JavaConversions;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.convert.WrapAsJava$;

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 import scala.*;
 import scala.Enumeration.Value;
 import scala.collection.Iterator;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConversions;x
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.convert.WrapAsJava$;
@@ -955,10 +955,10 @@ public class SparkInterpreter extends Interpreter {
 
   public void populateSparkWebUrl(InterpreterContext ctx) {
     if (sparkUrl == null) {
-      String url = getSparkUIUrl();
+      sparkUrl = getSparkUIUrl();
       Map<String, String> infos = new java.util.HashMap<>();
-      if (url != null) {
-        infos.put("url", url);
+      if (sparkUrl != null) {
+        infos.put("url", sparkUrl);
         logger.info("Sending metainfos to Zeppelin server: {}", infos.toString());
         if (ctx != null && ctx.getClient() != null) {
           ctx.getClient().onMetaInfosReceived(infos);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -97,6 +97,7 @@ public class SparkRInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String lines, InterpreterContext interpreterContext) {
 
+    getSparkInterpreter().populateSparkWebUrl(interpreterContext);
     String imageWidth = getProperty("zeppelin.R.image.width");
 
     String[] sl = lines.split("\n");

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -96,6 +96,7 @@ public class SparkSqlInterpreter extends Interpreter {
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }
 
+    sparkInterpreter.populateSparkWebUrl(context);
     sqlc = getSparkInterpreter().getSQLContext();
     SparkContext sc = sqlc.sparkContext();
     if (concurrentSQL()) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
@@ -20,10 +20,12 @@ package org.apache.zeppelin.interpreter;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.display.GUI;
+import org.apache.zeppelin.interpreter.remote.RemoteEventClientWrapper;
+import org.apache.zeppelin.interpreter.remote.RemoteEventClient;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.apache.zeppelin.resource.ResourcePool;
 
 /**
@@ -57,6 +59,7 @@ public class InterpreterContext {
   private ResourcePool resourcePool;
   private List<InterpreterContextRunner> runners;
   private String className;
+  private RemoteEventClientWrapper client;
 
   public InterpreterContext(String noteId,
                             String paragraphId,
@@ -83,6 +86,22 @@ public class InterpreterContext {
     this.out = out;
   }
 
+  public InterpreterContext(String noteId,
+                            String paragraphId,
+                            String paragraphTitle,
+                            String paragraphText,
+                            AuthenticationInfo authenticationInfo,
+                            Map<String, Object> config,
+                            GUI gui,
+                            AngularObjectRegistry angularObjectRegistry,
+                            ResourcePool resourcePool,
+                            List<InterpreterContextRunner> contextRunners,
+                            InterpreterOutput output,
+                            RemoteInterpreterEventClient eventClient) {
+    this(noteId, paragraphId, paragraphTitle, paragraphText, authenticationInfo, config, gui,
+        angularObjectRegistry, resourcePool, contextRunners, output);
+    this.client = new RemoteEventClient(eventClient);
+  }
 
   public String getNoteId() {
     return noteId;
@@ -130,5 +149,9 @@ public class InterpreterContext {
   
   public void setClassName(String className) {
     this.className = className;
+  }
+
+  public RemoteEventClientWrapper getClient() {
+    return client;
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.log4j.Logger;
 import org.apache.zeppelin.display.AngularObjectRegistry;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.scheduler.Scheduler;
@@ -49,6 +50,8 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
   RemoteInterpreterProcess remoteInterpreterProcess;    // attached remote interpreter process
   ResourcePool resourcePool;
   boolean angularRegistryPushed = false;
+
+  private RemoteInterpreterEventClient eventClient;
 
   // map [notebook session, Interpreters in the group], to support per note session interpreters
   //Map<String, List<Interpreter>> interpreters = new ConcurrentHashMap<String,
@@ -80,6 +83,11 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
   public InterpreterGroup() {
     getId();
     allInterpreterGroups.put(id, this);
+  }
+
+  public InterpreterGroup(String interpreterGroupId, RemoteInterpreterEventClient eventClient) {
+    this(interpreterGroupId);
+    this.eventClient = eventClient;
   }
 
   private static String generateId() {
@@ -279,5 +287,9 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
 
   public void setAngularRegistryPushed(boolean angularRegistryPushed) {
     this.angularRegistryPushed = angularRegistryPushed;
+  }
+
+  public RemoteInterpreterEventClient getEventClient() {
+    return eventClient;
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.log4j.Logger;
 import org.apache.zeppelin.display.AngularObjectRegistry;
-import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.scheduler.Scheduler;
@@ -50,8 +49,6 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
   RemoteInterpreterProcess remoteInterpreterProcess;    // attached remote interpreter process
   ResourcePool resourcePool;
   boolean angularRegistryPushed = false;
-
-  private RemoteInterpreterEventClient eventClient;
 
   // map [notebook session, Interpreters in the group], to support per note session interpreters
   //Map<String, List<Interpreter>> interpreters = new ConcurrentHashMap<String,
@@ -83,11 +80,6 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
   public InterpreterGroup() {
     getId();
     allInterpreterGroups.put(id, this);
-  }
-
-  public InterpreterGroup(String interpreterGroupId, RemoteInterpreterEventClient eventClient) {
-    this(interpreterGroupId);
-    this.eventClient = eventClient;
   }
 
   private static String generateId() {
@@ -287,9 +279,5 @@ public class InterpreterGroup extends ConcurrentHashMap<String, List<Interpreter
 
   public void setAngularRegistryPushed(boolean angularRegistryPushed) {
     this.angularRegistryPushed = angularRegistryPushed;
-  }
-
-  public RemoteInterpreterEventClient getEventClient() {
-    return eventClient;
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClient.java
@@ -1,0 +1,24 @@
+package org.apache.zeppelin.interpreter.remote;
+
+import java.util.Map;
+
+/**
+ * 
+ * Wrapper arnd RemoteInterpreterEventClient
+ * to expose methods in the client
+ *
+ */
+public class RemoteEventClient implements RemoteEventClientWrapper {
+
+  private RemoteInterpreterEventClient client;
+
+  public RemoteEventClient(RemoteInterpreterEventClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public void onMetaInfosReceived(Map<String, String> infos) {
+    client.onMetaInfodReceived(infos);
+  }
+
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClient.java
@@ -18,7 +18,7 @@ public class RemoteEventClient implements RemoteEventClientWrapper {
 
   @Override
   public void onMetaInfosReceived(Map<String, String> infos) {
-    client.onMetaInfodReceived(infos);
+    client.onMetaInfosReceived(infos);
   }
 
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClientWrapper.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteEventClientWrapper.java
@@ -1,0 +1,15 @@
+package org.apache.zeppelin.interpreter.remote;
+
+import java.util.Map;
+
+/**
+ * 
+ * Wrapper interface for RemoterInterpreterEventClient
+ * to expose only required methods from EventClient
+ *
+ */
+public interface RemoteEventClientWrapper {
+
+  public void onMetaInfosReceived(Map<String, String> infos);
+
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
@@ -279,7 +279,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector {
         gson.toJson(appendOutput)));
   }
 
-  public void onMetaInfodReceived(Map<String, String> infos) {
+  public void onMetaInfosReceived(Map<String, String> infos) {
     sendEvent(new RemoteInterpreterEvent(RemoteInterpreterEventType.META_INFOS,
         gson.toJson(infos)));
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
@@ -279,6 +279,11 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector {
         gson.toJson(appendOutput)));
   }
 
+  public void onMetaInfodReceived(Map<String, String> infos) {
+    sendEvent(new RemoteInterpreterEvent(RemoteInterpreterEventType.META_INFOS,
+        gson.toJson(infos)));
+  }
+
   /**
    * Wait for eventQueue becomes empty
    */

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -196,7 +196,6 @@ public class RemoteInterpreterEventPoller extends Thread {
 
           appListener.onStatusChange(noteId, paragraphId, appId, status);
         } else if (event.getType() == RemoteInterpreterEventType.META_INFOS) {
-          // on output update
           Map<String, String> metaInfos = gson.fromJson(event.getData(),
               new TypeToken<Map<String, String>>() {
               }.getType());

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -195,6 +195,15 @@ public class RemoteInterpreterEventPoller extends Thread {
           String status = appStatusUpdate.get("status");
 
           appListener.onStatusChange(noteId, paragraphId, appId, status);
+        } else if (event.getType() == RemoteInterpreterEventType.META_INFOS) {
+          // on output update
+          Map<String, String> metaInfos = gson.fromJson(event.getData(),
+              new TypeToken<Map<String, String>>() {
+              }.getType());
+          String id = interpreterGroup.getId();
+          int indexOfColon = id.indexOf(":");
+          String settingId = id.substring(0, indexOfColon);
+          listener.onMetaInfosReceived(settingId, metaInfos);
         }
         logger.debug("Event from remoteproceess {}", event.getType());
       } catch (Exception e) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcessListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcessListener.java
@@ -16,10 +16,13 @@
  */
 package org.apache.zeppelin.interpreter.remote;
 
+import java.util.Map;
+
 /**
  * Event from remoteInterpreterProcess
  */
 public interface RemoteInterpreterProcessListener {
   public void onOutputAppend(String noteId, String paragraphId, String output);
   public void onOutputUpdated(String noteId, String paragraphId, String output);
+  public void onMetaInfosReceived(String settingId, Map<String, String> metaInfos);
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -153,7 +153,7 @@ public class RemoteInterpreterServer
   public void createInterpreter(String interpreterGroupId, String noteId, String
       className, Map<String, String> properties) throws TException {
     if (interpreterGroup == null) {
-      interpreterGroup = new InterpreterGroup(interpreterGroupId, eventClient);
+      interpreterGroup = new InterpreterGroup(interpreterGroupId);
       angularObjectRegistry = new AngularObjectRegistry(interpreterGroup.getId(), this);
       hookRegistry = new InterpreterHookRegistry(interpreterGroup.getId());
       resourcePool = new DistributedResourcePool(interpreterGroup.getId(), eventClient);
@@ -552,7 +552,7 @@ public class RemoteInterpreterServer
         gson.fromJson(ric.getGui(), GUI.class),
         interpreterGroup.getAngularObjectRegistry(),
         interpreterGroup.getResourcePool(),
-        contextRunners, output);
+        contextRunners, output, eventClient);
   }
 
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -153,7 +153,7 @@ public class RemoteInterpreterServer
   public void createInterpreter(String interpreterGroupId, String noteId, String
       className, Map<String, String> properties) throws TException {
     if (interpreterGroup == null) {
-      interpreterGroup = new InterpreterGroup(interpreterGroupId);
+      interpreterGroup = new InterpreterGroup(interpreterGroupId, eventClient);
       angularObjectRegistry = new AngularObjectRegistry(interpreterGroup.getId(), this);
       hookRegistry = new InterpreterHookRegistry(interpreterGroup.getId());
       resourcePool = new DistributedResourcePool(interpreterGroup.getId(), eventClient);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventType.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventType.java
@@ -24,9 +24,6 @@
 package org.apache.zeppelin.interpreter.thrift;
 
 
-import java.util.Map;
-import java.util.HashMap;
-import org.apache.thrift.TEnum;
 
 public enum RemoteInterpreterEventType implements org.apache.thrift.TEnum {
   NO_OP(1),
@@ -39,7 +36,8 @@ public enum RemoteInterpreterEventType implements org.apache.thrift.TEnum {
   OUTPUT_APPEND(8),
   OUTPUT_UPDATE(9),
   ANGULAR_REGISTRY_PUSH(10),
-  APP_STATUS_UPDATE(11);
+  APP_STATUS_UPDATE(11),
+  META_INFOS(12);
 
   private final int value;
 
@@ -82,6 +80,8 @@ public enum RemoteInterpreterEventType implements org.apache.thrift.TEnum {
         return ANGULAR_REGISTRY_PUSH;
       case 11:
         return APP_STATUS_UPDATE;
+      case 12:
+        return META_INFOS;
       default:
         return null;
     }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterOutputTestStream.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterOutputTestStream.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -152,6 +153,11 @@ public class RemoteInterpreterOutputTestStream implements RemoteInterpreterProce
 
   @Override
   public void onOutputUpdated(String noteId, String paragraphId, String output) {
+
+  }
+
+  @Override
+  public void onMetaInfosReceived(String settingId, Map<String, String> metaInfos) {
 
   }
 }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -299,4 +299,9 @@ public class RemoteSchedulerTest implements RemoteInterpreterProcessListener {
   public void onOutputUpdated(String noteId, String paragraphId, String output) {
 
   }
+
+  @Override
+  public void onMetaInfosReceived(String settingId, Map<String, String> metaInfos) {
+
+  }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -29,6 +31,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -217,20 +220,27 @@ public class InterpreterRestApi {
   }
 
   /**
-   * get the property value
+   * get the metainfo property value
    */
   @GET
   @Path("getmetainfos/{settingId}")
-  public Response getMetaInfo(@PathParam("settingId") String settingId,
-      @PathParam("name") String propName) {
-    String url = null;
+  public Response getMetaInfo(@Context HttpServletRequest req,
+      @PathParam("settingId") String settingId) {
+    String propName = req.getParameter("propName");
+    if (propName == null) {
+      return new JsonResponse<>(Status.BAD_REQUEST).build();
+    }
+    String propValue = null;
     InterpreterSetting interpreterSetting = interpreterFactory.get(settingId);
     Map<String, String> infos = interpreterSetting.getInfos();
     if (infos != null) {
-      url = infos.get("url");
+      propValue = infos.get(propName);
     }
     Map<String, String> respMap = new HashMap<>();
-    respMap.put("url", url);
+    respMap.put(propName, propValue);
+    logger.debug("Get meta info");
+    logger.debug("Interpretersetting Id: {}, property Name:{}, property value: {}", settingId,
+        propName, propValue);
     return new JsonResponse<>(Status.OK, respMap).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.rest;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -213,6 +214,24 @@ public class InterpreterRestApi {
           ExceptionUtils.getStackTrace(e)).build();
     }
     return new JsonResponse(Status.CREATED).build();
+  }
+
+  /**
+   * get the property value
+   */
+  @GET
+  @Path("getmetainfos/{settingId}")
+  public Response getMetaInfo(@PathParam("settingId") String settingId,
+      @PathParam("name") String propName) {
+    String url = null;
+    InterpreterSetting interpreterSetting = interpreterFactory.get(settingId);
+    Map<String, String> infos = interpreterSetting.getInfos();
+    if (infos != null) {
+      url = infos.get("url");
+    }
+    Map<String, String> respMap = new HashMap<>();
+    respMap.put("url", url);
+    return new JsonResponse<>(Status.OK, respMap).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1759,5 +1759,12 @@ public class NotebookServer extends WebSocketServlet implements
             .put("interpreterSettings", availableSettings)));
   }
 
+  @Override
+  public void onMetaInfosReceived(String settingId, Map<String, String> metaInfos) {
+    InterpreterSetting interpreterSetting = notebook().getInterpreterFactory()
+        .get(settingId);
+    interpreterSetting.setInfos(metaInfos);
+  }
+
 }
 

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -692,7 +692,7 @@
     };
 
     $scope.showSparkUI = function(settingId) {
-      $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId)
+      $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId + '?propName=url')
         .success(function(data, status, headers, config) {
           var url = data.body.url;
           if (!url) {

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -691,6 +691,22 @@
       getRepositories();
     };
 
+    $scope.showSparkUI = function(settingId) {
+      $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId)
+        .success(function(data, status, headers, config) {
+          var url = data.body.url;
+          if (!url) {
+            BootstrapDialog.alert({
+              message: 'No spark application running'
+            });
+            return;
+          }
+          window.open(url, '_blank');
+        }).error(function(data, status, headers, config) {
+         console.log('Error %o %o', status, data.message);
+       });
+    };
+
     init();
   }
 

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -129,6 +129,10 @@ limitations under the License.
         </h3>
         <span style="float:right" ng-show="!valueform.$visible" >
           <button class="btn btn-default btn-xs"
+                  ng-click="showSparkUI(setting.id)"
+                  ng-show="setting.group == 'spark'">
+            <span class="fa fa-external-link"></span> spark ui</button>
+          <button class="btn btn-default btn-xs"
                   ng-click="valueform.$show();
                   copyOriginInterpreterSettingProperties(setting.id)">
             <span class="fa fa-pencil"></span> edit</button>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -982,6 +982,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       // Check if dependency in specified path is changed
       // If it did, overwrite old dependency jar with new one
       if (intpSetting != null) {
+        //clean up metaInfos
+        intpSetting.setInfos(null);
         copyDependenciesFromLocalPath(intpSetting);
 
         stopJobAllInterpreter(intpSetting);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -44,6 +44,8 @@ public class InterpreterSetting {
   private String name;
   // always be null in case of InterpreterSettingRef
   private String group;
+  private transient Map<String, String> infos;
+
   /**
    * properties can be either Properties or Map<String, InterpreterProperty>
    * properties should be:
@@ -275,5 +277,13 @@ public class InterpreterSetting {
 
   public void setErrorReason(String errorReason) {
     this.errorReason = errorReason;
+  }
+
+  public void setInfos(Map<String, String> infos) {
+    this.infos = infos;
+  }
+
+  public Map<String, String> getInfos() {
+    return infos;
   }
 }


### PR DESCRIPTION
### What is this PR for?
Make spark web UI accesible from interpreters page


### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
ZEPPELIN-1643

### How should this be tested?
Start sparkcontext.
Goto interpreters page. Corresponding to the spark interpreter used in notebook, there will be *spark ui* button.
Clicking the button should open a new tab with the application's spark web UI.

### Screenshots (if appropriate)
![zscpr58qdi](https://cloud.githubusercontent.com/assets/5082742/20110797/c6852202-a60b-11e6-8264-93437a58f752.gif)

### Questions:
* Does the licenses files need update? NA
* Is there breaking changes for older versions? No
* Does this needs documentation? No

