### PR TITLE
ZEPPELIN-1645: JDBC Interpreter does not commit updates

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -25,7 +25,11 @@ limitations under the License.
 
 ## Overview
 
-JDBC interpreter lets you create a JDBC connection to any data sources seamlessly. By now, it has been tested with:
+JDBC interpreter lets you create a JDBC connection to any data sources seamlessly.
+
+Inserts, Updates, and Upserts are applied immediately after running each statement.
+
+By now, it has been tested with:
 
 <div class="row" style="margin: 30px auto;">
   <div class="col-md-6">

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -462,6 +462,8 @@ public class JDBCInterpreter extends Interpreter {
           msg.append(UPDATE_COUNT_HEADER).append(NEWLINE);
           msg.append(updateCount).append(NEWLINE);
         }
+        //In case user ran an insert/update/upsert statement
+        if (connection.getAutoCommit() != true) connection.commit();
       } finally {
         if (resultSet != null) {
           try {


### PR DESCRIPTION
### What is this PR for?
Allow users to issue insert/update/upsert statements from Zeppelin notes

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-1645](https://issues.apache.org/jira/browse/ZEPPELIN-1645)

### How should this be tested?
For Phoenix Interpreter:
Paragraph 1:
%jdbc
UPSERT INTO CX_TEST (ACCT_NBR, HSE_ID) VALUES ('a', 'b')

Paragraph 2:
%jdbc
select count(*) from cx_test

Result: 1

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
Yes - JDBC README updated

