### PR TITLE
[ZEPPELIN-1647] Save roles and use for broadcasting note list per user

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.rest;
 import org.apache.shiro.authc.*;
 import org.apache.shiro.subject.Subject;
 import org.apache.zeppelin.annotation.ZeppelinApi;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.utils.SecurityUtils;
@@ -89,6 +90,9 @@ public class LoginRestApi {
 
         response = new JsonResponse(Response.Status.OK, "", data);
         //if no exception, that's it, we're done!
+        
+        //set roles for user in NotebookAuthorization module
+        NotebookAuthorization.getInstance().setRoles(principal, roles);
       } catch (UnknownAccountException uae) {
         //username wasn't in the system, show them an error message?
         LOG.error("Exception in login: ", uae);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -257,8 +257,10 @@ public class NotebookRestApi {
   @ZeppelinApi
   public Response getNoteList() throws IOException {
     AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    HashSet<String> userAndRoles = SecurityUtils.getRoles();
+    userAndRoles.add(subject.getUser());
     List<Map<String, String>> notesInfo = notebookServer.generateNotesInfo(false, subject,
-        SecurityUtils.getRoles());
+        userAndRoles);
     return new JsonResponse<>(Status.OK, "", notesInfo).build();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -542,7 +542,7 @@ public class Notebook implements NoteEventListener {
     }
   }
 
-  public List<Note> getAllNotes(HashSet<String> userAndRoles) {
+  public List<Note> getAllNotes(Set<String> userAndRoles) {
     final Set<String> entities = Sets.newHashSet();
     if (userAndRoles != null) {
       entities.addAll(userAndRoles);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -53,6 +55,10 @@ public class NotebookAuthorization {
    * { "note1": { "owners": ["u1"], "readers": ["u1", "u2"], "writers": ["u1"] },  "note2": ... } }
    */
   private static Map<String, Map<String, Set<String>>> authInfo = new HashMap<>();
+  /*
+   * contains roles for each user
+   */
+  private static Map<String, Set<String>> userRoles = new HashMap<>();
   private static ZeppelinConfiguration conf;
   private static Gson gson;
   private static String filePath;
@@ -108,7 +114,24 @@ public class NotebookAuthorization {
             NotebookAuthorizationInfoSaving.class);
     authInfo = info.authInfo;
   }
-
+  
+  public void setRoles(String user, Set<String> roles) {
+    if (StringUtils.isBlank(user)) {
+      LOG.warn("Setting roles for empty user");
+      return;
+    }
+    roles = validateUser(roles);
+    userRoles.put(user, roles);
+  }
+  
+  public Set<String> getRoles(String user) {
+    Set<String> roles = Sets.newHashSet();
+    if (userRoles.containsKey(user)) {
+      roles.addAll(userRoles.get(user));
+    }
+    return roles;
+  }
+  
   private void saveToFile() {
     String jsonString;
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorizationInfoSaving.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorizationInfoSaving.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.notebook;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -675,6 +675,48 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   @Test
+  public void testAuthorizationRoles() throws IOException {
+    String user1 = "user1";
+    String user2 = "user2";
+    Set<String> roles = Sets.newHashSet("admin");
+    // set admin roles for both user1 and user2
+    notebookAuthorization.setRoles(user1, roles);
+    notebookAuthorization.setRoles(user2, roles);
+    
+    Note note = notebook.createNote(new AuthenticationInfo(user1));
+    
+    // check that user1 is owner, reader and writer
+    assertEquals(notebookAuthorization.isOwner(note.getId(),
+        Sets.newHashSet(user1)), true);
+    assertEquals(notebookAuthorization.isReader(note.getId(),
+        Sets.newHashSet(user1)), true);
+    assertEquals(notebookAuthorization.isWriter(note.getId(),
+        Sets.newHashSet(user1)), true);
+    
+    // since user1 and user2 both have admin role, user2 will be reader and writer as well
+    assertEquals(notebookAuthorization.isOwner(note.getId(),
+        Sets.newHashSet(user2)), false);
+    assertEquals(notebookAuthorization.isReader(note.getId(),
+        Sets.newHashSet(user2)), true);
+    assertEquals(notebookAuthorization.isWriter(note.getId(),
+        Sets.newHashSet(user2)), true);
+    
+    // check that user1 has note listed in his workbench
+    Set<String> user1AndRoles = notebookAuthorization.getRoles(user1);
+    user1AndRoles.add(user1);
+    List<Note> user1Notes = notebook.getAllNotes(user1AndRoles);
+    assertEquals(user1Notes.size(), 1);
+    assertEquals(user1Notes.get(0).getId(), note.getId());
+    
+    // check that user2 has note listed in his workbech because of admin role
+    Set<String> user2AndRoles = notebookAuthorization.getRoles(user2);
+    user2AndRoles.add(user2);
+    List<Note> user2Notes = notebook.getAllNotes(user2AndRoles);
+    assertEquals(user2Notes.size(), 1);
+    assertEquals(user2Notes.get(0).getId(), note.getId());
+  }
+  
+  @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws InterruptedException,
       IOException {
     Note note = notebook.createNote(anonymous);


### PR DESCRIPTION
### What is this PR for?
So far roles have been accessible only from SecurityUtils for Rest api or from websocket message field. However sometimes it's required to access roles in websocket server even without receiving message, say for broadcasting note list per user. More details in issue.


### What type of PR is it?
Bug Fix | Improvement 

### Todos
* [x] - add roles in NotebookAuthorization
* [x] - assign roles on login
* [x] - use roles on broadcast 
* [x] - test

### What is the Jira issue?
[ZEPPELIN-1647](https://issues.apache.org/jira/browse/ZEPPELIN-1647)

### How should this be tested?
login as user1, and user2 at same time and each user should have own workbench (based on notebook permissions)

### Screenshots (if appropriate)
TBD

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
