### PR TITLE
[ZEPPELIN-1652] Fix cursor move on double click in markdown editor

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1850,7 +1850,8 @@
     });
 
     $scope.$on('doubleClickParagraph', function(event, paragraphId) {
-      if ($scope.paragraph.id === paragraphId && editorSetting.editOnDblClick) {
+      if ($scope.paragraph.id === paragraphId && $scope.paragraph.config.editorHide &&
+          editorSetting.editOnDblClick) {
         var deferred = $q.defer();
         openEditorAndCloseTable();
         $timeout(


### PR DESCRIPTION
### What is this PR for?
There is a bug that when you double click markdown editor, cursor moves to end of the line. This PR fixes it.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1652](https://issues.apache.org/jira/browse/ZEPPELIN-1652)

### How should this be tested?
1. Type `%md ### Hello Zeppelin`
2. Double click Hello in editor
3. See if Hello stay highlighted

### Screenshots (if appropriate)
**Before**
![nov-11-2016 12-04-44](https://cloud.githubusercontent.com/assets/8503346/20213106/1a8f6f90-a807-11e6-8e30-8087db6ae97a.gif)


**After**
![nov-11-2016 12-03-14](https://cloud.githubusercontent.com/assets/8503346/20213062/de4c75aa-a806-11e6-83ab-c917f41e5ed4.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

