### PR TITLE
ZEPPELIN-1625  add support for user specific properties

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -98,12 +98,16 @@
                 <li><a href="{{BASE_PATH}}/rest-api/rest-notebook.html">Notebook API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-configuration.html">Configuration API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-credential.html">Credential API</a></li>
+                <li><a href="{{BASE_PATH}}/rest-api/rest-property.html">Property API</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Security</b><span></li>
                 <li><a href="{{BASE_PATH}}/security/authentication.html">Authentication for NGINX</a></li>
                 <li><a href="{{BASE_PATH}}/security/shiroauthentication.html">Shiro Authentication</a></li>
                 <li><a href="{{BASE_PATH}}/security/notebook_authorization.html">Notebook Authorization</a></li>
                 <li><a href="{{BASE_PATH}}/security/datasource_authorization.html">Data Source Authorization</a></li>
+                <li role="separator" class="divider"></li>
+                <li class="title"><span><b>Multi-user</b><span></li>
+                <li><a href="{{BASE_PATH}}/multi-user/properties.html">User Specific Properties</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Advanced</b><span></li>
                 <li><a href="{{BASE_PATH}}/install/virtual_machine.html">Zeppelin on Vagrant VM</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,6 +162,7 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Notebook API](./rest-api/rest-notebook.html)
   * [Configuration API](./rest-api/rest-configuration.html)
   * [Credential API](./rest-api/rest-credential.html)
+  * [Property API](./rest-api/rest-property.html)
 * Security: available security support in Apache Zeppelin
   * [Authentication for NGINX](./security/authentication.html)
   * [Shiro Authentication](./security/shiroauthentication.html)
@@ -173,6 +174,8 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Zeppelin on Spark Cluster Mode (YARN via Docker)](./install/spark_cluster_mode.html#spark-on-yarn-mode)
   * [Zeppelin on Spark Cluster Mode (Mesos via Docker)](./install/spark_cluster_mode.html#spark-on-mesos-mode)
   * [Zeppelin on CDH (via Docker)](./install/cdh.html)
+* Multi-User
+  * [User Specific Properties](./multi-user/properties.html)
 * Contribute
   * [Writing Zeppelin Interpreter](./development/writingzeppelininterpreter.html)
   * [Writing Zeppelin Application (Experimental)](./development/writingzeppelinapplication.html)

--- a/docs/multi-user/properties.md
+++ b/docs/multi-user/properties.md
@@ -1,0 +1,46 @@
+---
+layout: page
+title: "User Specific properties in Apache Zeppelin"
+description: "Apache Zeppelin allows users to add new properties and these are specific to a user. The user defined properties can be referred in interpreter configuration via place holders."
+group:
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# User specific Properties in Apache Zeppelin
+
+<div id="toc"></div>
+
+## Overview
+
+Apache Zeppelin allows users to add properties and these are specific to a user. The user defined properties can be referred in interpreter configuration via place holders.
+
+For example, let's assume individual users in your organisation need to submit their livy paragraphs to different queues in the Hadoop cluster.
+To accomplish this, you will set *livy.spark.yarn.queue* to *${queue, defaultQueue}* as a livy interpreter property.
+
+Now individual users can specify their queues by adding property *queue*. 
+If the users do not specify the property *queue*, then *defaultQueue* will be used as the value of *livy.spark.yarn.queue*.
+
+## How to add user specific properties?
+You can add new properties in the dropdown menu.
+
+<img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/properties_tab.png" width="180px"/>
+
+Type **name & value** for the property.
+
+
+<img class="img-responsive" src="../assets/themes/zeppelin/img/docs-img/add_property.png" />
+
+The properties will be persisted in file **conf/properties.json**  based on the configuration **zeppelin.userproperties.persist**.

--- a/docs/rest-api/rest-property.md
+++ b/docs/rest-api/rest-property.md
@@ -1,0 +1,175 @@
+---
+layout: page
+title: "Apache Zeppelin Properties REST API"
+description: "This page contains Apache Zeppelin Properties REST API information."
+group: rest-api
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Apache Zeppelin Properties REST API
+
+<div id="toc"></div>
+
+## Overview
+Apache Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
+All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. 
+Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
+
+If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
+
+<br />
+## Property REST API List
+
+### List properties 
+  <table class="table-property">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns all properties(key/value pairs) of the current user</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/property```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+        "property1":"value1",
+        "property2":"value2"
+      }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Create or update a property 
+  <table class="table-property">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method creates or updates the property.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/property/```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON input</td>
+      <td>
+        <pre>
+{
+  "name": "property1",
+  "value": "value1"
+}
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK"
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+
+<br/>
+### Delete all properties
+  <table class="table-property">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method deletes the property information.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/property```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <code>{"status":"OK"}</code>
+      </td>
+    </tr>
+  </table>
+
+
+<br/>
+### Delete a Property
+
+  <table class="table-property">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method deletes a given property.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/property/[name]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <code>{"status":"OK"}</code>
+      </td>
+    </tr>
+  </table>
+
+
+<br/>
+

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/PropertyInfoSaving.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/PropertyInfoSaving.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.user.properties;
+
+import java.util.Map;
+
+/**
+ * Helper class to save properties
+ */
+public class PropertyInfoSaving {
+  public Map<String, Map<String, String>> userProperties;
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/UserProperties.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/UserProperties.java
@@ -1,0 +1,144 @@
+package org.apache.zeppelin.user.properties;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Class defining user specific properties
+ */
+
+public class UserProperties {
+  private static final Logger LOG = LoggerFactory.getLogger(UserProperties.class);
+
+  private Map<String, Map<String, String>> propertiesMap;
+  private Gson gson;
+  private Boolean persist = true;
+  File propertiesFile;
+
+  public UserProperties(Boolean persist, String propertiesFilePath) {
+    this.persist = persist;
+    if (propertiesFilePath != null) {
+      propertiesFile = new File(propertiesFilePath);
+    }
+    propertiesMap = new ConcurrentHashMap<>();
+
+    if (persist) {
+      GsonBuilder builder = new GsonBuilder();
+      builder.setPrettyPrinting();
+      gson = builder.create();
+      loadFromFile();
+    }
+  }
+
+  public Map<String, String> get(String userName) {
+    Map<String, String> properties = propertiesMap.get(userName);
+    if (properties == null) {
+      properties = new HashMap<>();
+      propertiesMap.put(userName, properties);
+    }
+    return properties;
+  }
+
+  public void put(String userName, Map<String, String> properties)
+      throws IOException {
+    propertiesMap.put(userName, properties);
+    saveProperties();
+  }
+
+  public void put(String userName, String name, String value)
+      throws IOException {
+    Map<String, String> properties = get(userName);
+    properties.put(name, value);
+    saveProperties();
+  }
+
+  public Map<String, String> remove(String userName) throws IOException {
+    Map<String, String> properties = propertiesMap.remove(userName);
+    saveProperties();
+    return properties;
+  }
+
+  public boolean remove(String userName, String name) throws IOException {
+    Map<String, String> properties  = propertiesMap.get(userName);
+    if (properties != null && !properties.containsKey(name)) {
+      return false;
+    }
+    properties.remove(name);
+    if (properties.isEmpty()) {
+      propertiesMap.remove(userName);
+    }
+    saveProperties();
+    return true;
+  }
+
+  private void saveProperties() throws IOException {
+    if (persist) {
+      saveToFile();
+    }
+  }
+
+  private void loadFromFile() {
+    LOG.info(propertiesFile.getAbsolutePath());
+    if (!propertiesFile.exists()) {
+      // nothing to read
+      return;
+    }
+
+    try {
+      FileInputStream fis = new FileInputStream(propertiesFile);
+      InputStreamReader isr = new InputStreamReader(fis);
+      BufferedReader bufferedReader = new BufferedReader(isr);
+      StringBuilder sb = new StringBuilder();
+      String line;
+      while ((line = bufferedReader.readLine()) != null) {
+        sb.append(line);
+      }
+      isr.close();
+      fis.close();
+
+      String json = sb.toString();
+      PropertyInfoSaving info = gson.fromJson(json, PropertyInfoSaving.class);
+      this.propertiesMap = info.userProperties;
+    } catch (IOException e) {
+      LOG.error("Error loading properties file", e);
+    }
+  }
+
+  private void saveToFile() throws IOException {
+    String jsonString;
+
+    synchronized (propertiesMap) {
+      PropertyInfoSaving info = new PropertyInfoSaving();
+      info.userProperties = propertiesMap;
+      jsonString = gson.toJson(info);
+    }
+
+    try {
+      if (!propertiesFile.exists()) {
+        propertiesFile.createNewFile();
+      }
+
+      FileOutputStream fos = new FileOutputStream(propertiesFile, false);
+      OutputStreamWriter out = new OutputStreamWriter(fos);
+      out.append(jsonString);
+      out.close();
+      fos.close();
+    } catch (IOException e) {
+      LOG.error("Error saving properties file", e);
+    }
+  }
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/UserProperties.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/properties/UserProperties.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.user.properties;
 
 import java.io.BufferedReader;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/TestInterpreterutils.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/TestInterpreterutils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.interpreter;
 
 import static org.junit.Assert.assertEquals;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/TestInterpreterutils.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/TestInterpreterutils.java
@@ -1,0 +1,73 @@
+package org.apache.zeppelin.interpreter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class TestInterpreterutils {
+  
+  @Test
+  public void  testSubstitution() {
+    Properties properties = new Properties ();
+    properties.put("substitute", "${name,default_value}");
+    properties.put("regular", "value");
+    Map<String, Object> map = new HashMap<>();
+    map.put("name", "userValue");
+    
+    Properties props = InterpreterUtils.substitute(properties, map);
+    
+    assertEquals (2, props.size());
+    assertEquals("userValue", props.get("substitute"));
+    assertEquals("value", props.get("regular"));
+  }
+  
+  @Test
+  public void  testDefaultSubstitution() {
+    Properties properties = new Properties ();
+    properties.put("substitute", "${name,default_value}");
+    properties.put("regular", "value");
+    
+    Properties props = InterpreterUtils.substitute(properties, null);
+    
+    assertEquals (2, props.size());
+    assertEquals("default_value", props.get("substitute"));
+    assertEquals("value", props.get("regular"));
+  }
+  
+  @Test
+  public void  testDefaultSubstitutionWithEmptyConfig() {
+    Properties properties = new Properties ();
+    properties.put("substitute", "${name,default_value}");
+    properties.put("regular", "value");
+    
+    Map<String, Object> map = new HashMap<>();
+    Properties props = InterpreterUtils.substitute(properties, map);
+    
+    assertEquals (2, props.size());
+    assertEquals("default_value", props.get("substitute"));
+    assertEquals("value", props.get("regular"));
+  }
+  
+  @Test
+  public void  testSubstitutionWithStringWithCommas() {
+    Properties properties = new Properties ();
+    properties.put("substitute1", "${name1,default_value1,default_value2}");
+    properties.put("substitute2", "${name,default_value1,default_value2}");
+    properties.put("regular", "value");
+    
+    Map<String, Object> map = new HashMap<>();
+    map.put("name1", "userValue1,userValue2");
+    Properties props = InterpreterUtils.substitute(properties, map);
+    
+    
+    assertEquals (3, props.size());
+    assertEquals("userValue1,userValue2", props.get("substitute1"));
+    assertEquals("default_value1,default_value2", props.get("substitute2"));
+    assertEquals("value", props.get("regular"));
+  }
+
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/properties/PropertyTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/properties/PropertyTest.java
@@ -1,0 +1,47 @@
+package org.apache.zeppelin.user.properties;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class PropertyTest {
+  @Test
+  public void testProperties() throws IOException {
+    UserProperties userProperties = new UserProperties(false, null);
+    userProperties.put("user1", "key1", "value1");
+    userProperties.put("user1", "key2", "value2");
+    userProperties.put("user2", "key1", "value1");
+
+    Map<String, String> user1Properties = userProperties.get("user1");
+    
+    assertEquals(user1Properties.size(), 2);
+    assertEquals("value1", user1Properties.get("key1"));
+    assertEquals("value2", user1Properties.get("key2"));
+
+    userProperties.remove("user1", "key1");
+    
+    user1Properties = userProperties.get("user1");
+
+    assertEquals(user1Properties.size(), 1);
+    assertEquals("value2", user1Properties.get("key2"));
+
+    userProperties.remove("user1");
+
+    user1Properties = userProperties.get("user1");
+    assertTrue(user1Properties.isEmpty());
+
+    Map<String, String> user2Properties = userProperties.get("user2");
+    assertEquals(user2Properties.size(), 1);
+    assertEquals("value1", user2Properties.get("key1"));
+    
+    userProperties.put("user2", "key1", "newvalue1");
+    
+    user2Properties = userProperties.get("user2");
+    assertEquals(user2Properties.size(), 1);
+    assertEquals("newvalue1", user2Properties.get("key1"));
+  }
+
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/properties/PropertyTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/properties/PropertyTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.user.properties;
 
 import static org.junit.Assert.*;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/PropertyRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/PropertyRestApi.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.zeppelin.server.JsonResponse;
+import org.apache.zeppelin.user.properties.UserProperties;
+import org.apache.zeppelin.utils.SecurityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Properties Rest API
+ *
+ */
+@Path("/property")
+@Produces("application/json")
+public class PropertyRestApi {
+  Logger logger = LoggerFactory.getLogger(PropertyRestApi.class);
+  private UserProperties userProperties;
+  private Gson gson = new Gson();
+  File propertiesFile;
+
+  @Context
+  private HttpServletRequest servReq;
+
+  public PropertyRestApi() {
+  }
+
+  public PropertyRestApi(UserProperties userProperties) {
+    this.userProperties = userProperties;
+  }
+
+  /**
+   * Put User Properties REST API
+   * @param message - JSON with name, value.
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @PUT
+  public Response putProperty(String message) throws IOException, IllegalArgumentException {
+    Map<String, String> messageMap = gson.fromJson(message,
+        new TypeToken<Map<String, String>>(){}.getType());
+    String name = messageMap.get("name");
+    String value = messageMap.get("value");
+
+    if (Strings.isNullOrEmpty(name) || Strings.isNullOrEmpty(value) ) {
+      return new JsonResponse(Status.BAD_REQUEST).build();
+    }
+    logger.info("Update properties for name {} value {}", name, value);
+    String userName = SecurityUtils.getPrincipal();
+    userProperties.put(userName, name, value);
+    return new JsonResponse(Status.OK).build();
+  }
+
+  /**
+   * Get User Properties list REST API
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @GET
+  public Response getProperties(String message) throws
+  IOException, IllegalArgumentException {
+    String userName = SecurityUtils.getPrincipal();
+    Map<String, String> properties = userProperties.get(userName);
+    return new JsonResponse(Status.OK, properties).build();
+  }
+
+  /**
+   * Remove User Properties REST API
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @DELETE
+  public Response removeProperties(String message) throws
+  IOException, IllegalArgumentException {
+    String userName = SecurityUtils.getPrincipal();
+    logger.info("removeProperties for user {} ", userName);
+    if (userProperties.remove(userName) == null) {
+      return new JsonResponse(Status.NOT_FOUND).build();
+    }
+    return new JsonResponse(Status.OK).build();
+  }
+  
+  
+  /**
+   * Remove Entity of User Properties entity REST API
+   * @param
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @DELETE
+  @Path("{name}")
+  public Response removeProperty(@PathParam("name") String name) throws
+          IOException, IllegalArgumentException {
+    String userName = SecurityUtils.getPrincipal();
+    logger.info("removeProperty for user {} name {}", userName, name);
+    if (!userProperties.remove(userName, name)) {
+      return new JsonResponse(Status.NOT_FOUND).build();
+    }
+    return new JsonResponse(Status.OK).build();
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -46,6 +46,7 @@ import org.apache.zeppelin.rest.InterpreterRestApi;
 import org.apache.zeppelin.rest.LoginRestApi;
 import org.apache.zeppelin.rest.NotebookRepoRestApi;
 import org.apache.zeppelin.rest.NotebookRestApi;
+import org.apache.zeppelin.rest.PropertyRestApi;
 import org.apache.zeppelin.rest.SecurityRestApi;
 import org.apache.zeppelin.rest.ZeppelinRestApi;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
@@ -53,6 +54,7 @@ import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -90,6 +92,8 @@ public class ZeppelinServer extends Application {
   private NotebookRepoSync notebookRepo;
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
+  private UserProperties userProperties;
+  
   private DependencyResolver depResolver;
 
   public ZeppelinServer() throws Exception {
@@ -107,9 +111,11 @@ public class ZeppelinServer extends Application {
     this.noteSearchService = new LuceneSearch();
     this.notebookAuthorization = NotebookAuthorization.init(conf);
     this.credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath());
+    this.userProperties = new UserProperties(conf.userPropertiesPersist(),
+        conf.getUserPropertiesPath());
     notebook = new Notebook(conf,
         notebookRepo, schedulerFactory, replFactory, notebookWsServer,
-            noteSearchService, notebookAuthorization, credentials);
+            noteSearchService, notebookAuthorization, credentials, userProperties);
 
     // to update notebook from application event from remote process.
     heliumApplicationFactory.setNotebook(notebook);
@@ -330,6 +336,9 @@ public class ZeppelinServer extends Application {
 
     CredentialRestApi credentialApi = new CredentialRestApi(credentials);
     singletons.add(credentialApi);
+    
+    PropertyRestApi propertyApi = new PropertyRestApi(userProperties);
+    singletons.add(propertyApi);
 
     SecurityRestApi securityApi = new SecurityRestApi();
     singletons.add(securityApi);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/PropertiesRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/PropertiesRestApiTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.httpclient.methods.DeleteMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+public class PropertiesRestApiTest extends AbstractTestRestApi {
+  protected static final Logger LOG = LoggerFactory.getLogger(PropertiesRestApiTest.class);
+  Gson gson = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    AbstractTestRestApi.startUp();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+
+  @Test
+  public void testInvalidRequest() throws IOException {
+    String jsonInvalidRequestNameNull = "{\"name\" : null, \"value\" : \"value\"}";
+    String jsonInvalidRequestValueNull = "{\"name\" : \"test\", \"value\" : null}";
+    String jsonInvalidRequestAllNull = "{\"name\" : null, \"value\" : null}";
+
+    PutMethod nameNullPut = httpPut("/property", jsonInvalidRequestNameNull);
+    nameNullPut.addRequestHeader("Origin", "http://localhost");
+    assertThat(nameNullPut, isBadRequest());
+    nameNullPut.releaseConnection();
+
+    PutMethod passwordNullPut = httpPut("/property", jsonInvalidRequestValueNull);
+    passwordNullPut.addRequestHeader("Origin", "http://localhost");
+    assertThat(passwordNullPut, isBadRequest());
+    passwordNullPut.releaseConnection();
+
+    PutMethod allNullPut = httpPut("/property", jsonInvalidRequestAllNull);
+    allNullPut.addRequestHeader("Origin", "http://localhost");
+    assertThat(allNullPut, isBadRequest());
+    allNullPut.releaseConnection();
+  }
+
+  public Map<String, String> testGetProperties() throws IOException {
+    GetMethod getMethod = httpGet("/property");
+    getMethod.addRequestHeader("Origin", "http://localhost");
+    Map<String, Object> resp = gson.fromJson(getMethod.getResponseBodyAsString(),
+            new TypeToken<Map<String, Object>>(){}.getType());
+    Map<String, String> properties = (Map<String, String>) resp.get("body");
+    getMethod.releaseConnection();
+    return properties;
+  }
+
+  public void testPutProperties(String requestData) throws IOException {
+    PutMethod putMethod = httpPut("/property", requestData);
+    putMethod.addRequestHeader("Origin", "http://localhost");
+    assertThat(putMethod, isAllowed());
+    putMethod.releaseConnection();
+  }
+
+  public void testRemoveProperties() throws IOException {
+    DeleteMethod deleteMethod = httpDelete("/property/");
+    assertThat("Test delete method:", deleteMethod, isAllowed());
+    deleteMethod.releaseConnection();
+  }
+
+  public void testRemoveProperty(String name) throws IOException {
+    DeleteMethod deleteMethod = httpDelete("/property/" + name);
+    assertThat("Test delete method:", deleteMethod, isAllowed());
+    deleteMethod.releaseConnection();
+  }
+
+  @Test
+  public void testPropertyAPIs() throws IOException {
+    String requestData1 = "{\"name\" : \"property1\", \"value\" : \"value1\"}";
+    String property = "property1";
+    Map<String, String> properties;
+
+    testPutProperties(requestData1);
+    properties = testGetProperties();
+    assertNotNull("CredentialMap should not be null", testGetProperties());
+
+    testRemoveProperty(property);
+    properties = testGetProperties();
+    assertNull("property should be null", properties.get("property1"));
+    
+    testPutProperties(requestData1);
+    properties = testGetProperties();
+    assertNotNull("CredentialMap should not be null", testGetProperties());
+
+    testRemoveProperties();
+    properties = testGetProperties();
+    assertEquals("Compare properties", properties.toString(), "{}");
+  }
+}

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -79,6 +79,10 @@
               templateUrl: 'app/credential/credential.html',
               controller: 'CredentialCtrl'
             })
+            .when('/property', {
+              templateUrl: 'app/property/property.html',
+              controller: 'PropertyCtrl'
+            })
             .when('/configuration', {
               templateUrl: 'app/configuration/configuration.html',
               controller: 'ConfigurationCtrl'

--- a/zeppelin-web/src/app/property/property.controller.js
+++ b/zeppelin-web/src/app/property/property.controller.js
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+angular.module('zeppelinWebApp').controller('PropertyCtrl', function($scope, $rootScope, $http, baseUrlSrv, ngToast) {
+  $scope._ = _;
+
+  $scope.PropertyInfo = [];
+  $scope.showAddNewPropertyInfo = false;
+
+  var getPropertyInfo = function() {
+    $http.get(baseUrlSrv.getRestApiBase() + '/property').
+    success(function(data, status, headers, config) {
+      $scope.PropertyInfo  = _.map(data.body, function(value, prop) {
+        return {name: prop, value: value};
+      });
+      console.log('Success %o %o', status, $scope.PropertyInfo);
+    }).
+    error(function(data, status, headers, config) {
+      if (status === 401) {
+        ngToast.danger({
+          content: 'You don\'t have permission on this page',
+          verticalPosition: 'bottom',
+          timeout: '3000'
+        });
+        setTimeout(function() {
+          window.location.replace('/');
+        }, 3000);
+      }
+      console.log('Error %o %o', status, data.message);
+    });
+  };
+
+  $scope.addNewPropertyInfo = function() {
+    if ($scope.name && _.isEmpty($scope.name.trim()) &&
+      $scope.value && _.isEmpty($scope.value.trim())) {
+      ngToast.danger({
+        content: 'name \\ value can not be empty.',
+        verticalPosition: 'bottom',
+        timeout: '3000'
+      });
+      return;
+    }
+
+    var newProperty  = {
+      'name': $scope.name,
+      'value': $scope.value
+    };
+
+    $http.put(baseUrlSrv.getRestApiBase() + '/property', newProperty).
+    success(function(data, status, headers, config) {
+      ngToast.success({
+        content: 'Successfully saved properties.',
+        verticalPosition: 'bottom',
+        timeout: '3000'
+      });
+      $scope.PropertyInfo.push(newProperty);
+      resetPropertyInfo();
+      $scope.showAddNewPropertyInfo = false;
+      console.log('Success %o %o', status, data.message);
+    }).
+    error(function(data, status, headers, config) {
+      ngToast.danger({
+        content: 'Error saving properties',
+        verticalPosition: 'bottom',
+        timeout: '3000'
+      });
+      console.log('Error %o %o', status, data.message);
+    });
+  };
+
+  $scope.cancelPropertyInfo = function() {
+    $scope.showAddNewPropertyInfo = false;
+    resetPropertyInfo();
+  };
+
+  var resetPropertyInfo = function() {
+    $scope.name = '';
+    $scope.value = '';
+  };
+
+  $scope.copyOriginPropertysInfo = function() {
+    ngToast.info({
+      content: 'Since name is a unique key, you can edit only value',
+      verticalPosition: 'bottom',
+      timeout: '3000'
+    });
+  };
+
+  $scope.updatePropertyInfo = function(form, data, name) {
+    var request = {
+      name: name,
+      value: data.value
+    };
+
+    $http.put(baseUrlSrv.getRestApiBase() + '/property/', request).
+    success(function(data, status, headers, config) {
+      var index = _.findIndex($scope.PropertyInfo, {'name': name});
+      $scope.PropertyInfo[index] = request;
+      return true;
+    }).
+    error(function(data, status, headers, config) {
+      console.log('Error %o %o', status, data.message);
+      ngToast.danger({
+        content: 'We couldn\'t save the Property',
+        verticalPosition: 'bottom',
+        timeout: '3000'
+      });
+      form.$show();
+    });
+    return false;
+  };
+
+  $scope.removePropertyInfo = function(name) {
+    BootstrapDialog.confirm({
+      closable: false,
+      closeByBackdrop: false,
+      closeByKeyboard: false,
+      title: '',
+      message: 'Do you want to delete this Property information?',
+      callback: function(result) {
+        if (result) {
+          $http.delete(baseUrlSrv.getRestApiBase() + '/property/' + name).
+          success(function(data, status, headers, config) {
+            var index = _.findIndex($scope.PropertyInfo, {'name': name});
+            $scope.PropertyInfo.splice(index, 1);
+            console.log('Success %o %o', status, data.message);
+          }).
+          error(function(data, status, headers, config) {
+            console.log('Error %o %o', status, data.message);
+          });
+        }
+      }
+    });
+  };
+
+  var init = function() {
+    getPropertyInfo();
+  };
+
+  init();
+});

--- a/zeppelin-web/src/app/property/property.css
+++ b/zeppelin-web/src/app/property/property.css
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.interpreterHead {
+  margin: -10px -10px 20px;
+  padding: 10px 15px 15px 15px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  border-bottom: 1px solid #E5E5E5;
+}
+
+.interpreterHead .header {
+  font-family: 'Roboto', sans-serif;
+}
+
+.interpreterHead textarea,
+.interpreter textarea {
+  width: 100%;
+  display: block;
+  height: 20px;
+  resize: none;
+  border: 1px solid #CCCCCC;
+  font-size: 12px;
+}
+
+.interpreter .interpreter-title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #3071a9;
+  float: left;
+  margin-top: 0;
+}
+
+.interpreter ul {
+  margin: 0;
+  padding: 0;
+}
+
+.interpreter .interpreterInfo {
+  list-style-type: none;
+}
+
+.interpreter table tr .interpreterPropertyKey {
+  padding : 5px 5px 5px 5px;
+}
+
+.interpreter table tr .interpreterPropertyValue {
+  padding : 5px 5px 5px 5px;
+  display: block;
+  max-height: 100px;
+  overflow-y: auto;
+}
+
+.interpreterSettingAdd {
+  margin : 5px 5px 5px 5px;
+  padding : 10px 10px 10px 10px;
+}
+
+.editable-wrap {
+  width : 100%;
+}
+
+.interpreter h5 {
+  font-weight: bold;
+}
+
+.new_h3 {
+  margin-top: 1px;
+  padding-top: 7px;
+  float: left;
+}
+
+.empty-properties-message {
+  color: #666;
+}

--- a/zeppelin-web/src/app/property/property.html
+++ b/zeppelin-web/src/app/property/property.html
@@ -1,0 +1,140 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div class="interpreterHead">
+  <div class="header">
+    <div class="row">
+      <div class="col-md-12">
+        <h3 class="new_h3">
+          Properties
+        </h3>
+        <div class="pull-right" style="margin-top:10px;">
+          <a style="cursor:pointer;margin-right:10px;text-decoration:none;"
+             target="_blank"
+             ng-href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/properties.html"
+             tooltip-placement="bottom" tooltip="Learn more">
+            <i class="icon-question" ng-style="{color: showRepositoryInfo ? '#3071A9' : 'black' }"></i>
+          </a>
+          <button class="btn btn-default btn-sm"
+                  ng-click="showAddNewPropertyInfo = !showAddNewPropertyInfo">
+            <i class="fa fa-plus"></i>
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        Manage your properties. You can add new property information.
+      </div>
+    </div>
+  </div>
+
+  <!--Property addition form-->
+  <div class="row interpreter">
+    <div class="col-md-12" ng-show="showAddNewPropertyInfo">
+      <hr />
+      <div class="interpreterSettingAdd">
+        <h4>Add new Property</h4>
+        <div>
+          <div class="row interpreter">
+            <div class="col-md-12">
+              <table class="table table-striped">
+                <thead>
+                <tr>
+                  <th style="width:30%">name</th>
+                  <th>value</th>
+                </tr>
+                </thead>
+                <tr>
+                  <td>
+                    <textarea msd-elastic ng-model="name"></textarea>
+                  </td>
+                  <td>
+                    <textarea msd-elastic ng-model="value"></textarea>
+                  </td>
+                </tr>
+              </table>
+              <span class="btn btn-primary" ng-click="addNewPropertyInfo()">
+                Save
+              </span>
+              <span class="btn btn-default" ng-click="cancelPropertyInfo()">
+                Cancel
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="box width-full">
+  <div class="row interpreter">
+    <div ng-show="_.isEmpty(PropertyInfo) || valueform.$hidden"
+         class="col-md-12 gray40-message">
+      <em>Currently there are no properties.</em>
+    </div>
+    <div class="col-md-12" ng-show="!_.isEmpty(PropertyInfo) || valueform.$visible">
+      <table class="table table-striped">
+        <thead>
+        <tr>
+          <th style="width:50%">name</th>
+          <th>value</th>
+          <th></th>
+        </tr>
+        </thead>
+        <tr ng-repeat="Property in PropertyInfo">
+          <td>
+            <span>
+              {{Property.name}}
+            </span>
+          </td>
+          <td>
+            <span editable-textarea="Property.value" e-name="value" e-form="valueform"
+                  e-msd-elastic focus-if="Property.value.length == 0">
+              {{Property.value}}
+            </span>
+          </td>
+          <td>
+            <!-- Edit Property info -->
+            <span style="float:right" ng-show="!valueform.$visible">
+              <button class="btn btn-default btn-xs"
+                      ng-click="valueform.$show();
+                      copyOriginPropertysInfo();">
+                <span class="fa fa-pencil"></span> edit</button>
+              <button class="btn btn-default btn-xs"
+                      ng-click="removePropertyInfo(Property.name)">
+                <span class="fa fa-trash"></span> remove</button>
+
+            </span>
+            <span style="float:right" ng-show="valueform.$visible">
+              <form editable-form name="valueform"
+                    onbeforesave="updatePropertyInfo(valueform, $data, Property.name)"
+                    ng-show="valueform.$visible">
+                <button type="submit" class="btn btn-primary btn-xs">
+                  <span class="fa fa-check"></span> save
+                </button>
+                <button type="button" class="btn btn-default btn-xs"
+                        ng-disabled="valueform.$waiting"
+                        ng-click="valueform.$cancel();">
+                  <span class="fa fa-remove"></span> cancel
+                </button>
+              </form>
+            </span>
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</div>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -89,6 +89,7 @@ limitations under the License.
               <li><a href="#/notebookRepos">Notebook Repos</a></li>
               <li><a href="#/credential">Credential</a></li>
               <li><a href="#/configuration">Configuration</a></li>
+              <li><a href="#/property">Properties</a></li>
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'" role="separator" style="margin: 5px 0;" class="divider"></li>
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'"><a ng-click="navbar.logout()">Logout</a></li>
             </ul>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -185,6 +185,7 @@ limitations under the License.
     <script src="app/interpreter/interpreter.controller.js"></script>
     <script src="app/interpreter/interpreter.filter.js"></script>
     <script src="app/credential/credential.controller.js"></script>
+    <script src="app/property/property.controller.js"></script>
     <script src="app/configuration/configuration.controller.js"></script>
     <script src="app/notebook/paragraph/paragraph.controller.js"></script>
     <script src="app/search/result-list.controller.js"></script>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -402,6 +402,14 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getRelativeDir(String.format("%s/credentials.json", getConfDir()));
   }
 
+  public Boolean userPropertiesPersist() {
+    return getBoolean(ConfVars.ZEPPELIN_USER_PROPERTIES_PERSIST);
+  }
+
+  public String getUserPropertiesPath() {
+    return getRelativeDir(String.format("%s/properties.json", getConfDir()));
+  }
+
   public String getShiroPath() {
     String shiroPath = getRelativeDir(String.format("%s/shiro.ini", getConfDir()));
     return new File(shiroPath).exists() ? shiroPath : StringUtils.EMPTY;
@@ -582,6 +590,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
     ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
     ZEPPELIN_CREDENTIALS_PERSIST("zeppelin.credentials.persist", true),
+    ZEPPELIN_USER_PROPERTIES_PERSIST("zeppelin.userproperties.persist", true),
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000");
 
     private String varName;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -57,6 +57,7 @@ import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
 
 /**
  * Binded interpreters for a note
@@ -89,6 +90,8 @@ public class Note implements Serializable, ParagraphJobListener {
   private transient ScheduledFuture delayedPersist;
   private transient NoteEventListener noteEventListener;
   private transient Credentials credentials;
+  private transient UserProperties userProperties;
+
 
   /*
    * note configurations.
@@ -107,13 +110,15 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public Note(NotebookRepo repo, InterpreterFactory factory, JobListenerFactory jlFactory,
-      SearchService noteIndex, Credentials credentials, NoteEventListener noteEventListener) {
+      SearchService noteIndex, Credentials credentials, UserProperties userProperties,
+      NoteEventListener noteEventListener) {
     this.repo = repo;
     this.factory = factory;
     this.jobListenerFactory = jlFactory;
     this.index = noteIndex;
     this.noteEventListener = noteEventListener;
     this.credentials = credentials;
+    this.userProperties = userProperties;
     generateId();
   }
 
@@ -203,6 +208,14 @@ public class Note implements Serializable, ParagraphJobListener {
 
   public void setCredentials(Credentials credentials) {
     this.credentials = credentials;
+  }
+  
+  public UserProperties getUserProperties() {
+    return userProperties;
+  }
+
+  public void setUserProperties(UserProperties userProperties) {
+    this.userProperties = userProperties;
   }
 
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -69,6 +69,8 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
+
 
 /**
  * Collection of Notes.
@@ -94,6 +96,7 @@ public class Notebook implements NoteEventListener {
   private final List<NotebookEventListener> notebookEventListeners =
       Collections.synchronizedList(new LinkedList<NotebookEventListener>());
   private Credentials credentials;
+  private UserProperties userProperties;
 
   /**
    * Main constructor \w manual Dependency Injection
@@ -105,7 +108,8 @@ public class Notebook implements NoteEventListener {
   public Notebook(ZeppelinConfiguration conf, NotebookRepo notebookRepo,
       SchedulerFactory schedulerFactory, InterpreterFactory replFactory,
       JobListenerFactory jobListenerFactory, SearchService noteSearchService,
-      NotebookAuthorization notebookAuthorization, Credentials credentials)
+      NotebookAuthorization notebookAuthorization, Credentials credentials,
+      UserProperties userProperties)
       throws IOException, SchedulerException {
     this.conf = conf;
     this.notebookRepo = notebookRepo;
@@ -115,6 +119,7 @@ public class Notebook implements NoteEventListener {
     this.noteSearchService = noteSearchService;
     this.notebookAuthorization = notebookAuthorization;
     this.credentials = credentials;
+    this.userProperties = userProperties;
     quertzSchedFact = new org.quartz.impl.StdSchedulerFactory();
     quartzSched = quertzSchedFact.getScheduler();
     quartzSched.start();
@@ -158,7 +163,7 @@ public class Notebook implements NoteEventListener {
       throws IOException {
     Note note =
         new Note(notebookRepo, replFactory, jobListenerFactory,
-                noteSearchService, credentials, this);
+                noteSearchService, credentials, userProperties, this);
     synchronized (notes) {
       notes.put(note.getId(), note);
     }
@@ -401,6 +406,7 @@ public class Notebook implements NoteEventListener {
     //Manually inject ALL dependencies, as DI constructor was NOT used
     note.setIndex(this.noteSearchService);
     note.setCredentials(this.credentials);
+    note.setUserProperties(userProperties);
 
     note.setInterpreterFactory(replFactory);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -25,6 +25,7 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.user.UserCredentials;
+import org.apache.zeppelin.user.properties.UserProperties;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.display.Input;
 import org.apache.zeppelin.interpreter.*;
@@ -458,13 +459,19 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       runners.add(new ParagraphRunner(note, note.getId(), p.getId()));
     }
 
-    final Paragraph self = this;
-
     Credentials credentials = note.getCredentials();
+    Map<String, Object> tempConfig = this.getConfig();
     if (authenticationInfo != null) {
       UserCredentials userCredentials = credentials.getUserCredentials(
           authenticationInfo.getUser());
       authenticationInfo.setUserCredentials(userCredentials);
+      Map<String, String> properties = note.getUserProperties().get(
+          authenticationInfo.getUser());
+      if (properties != null) {
+        tempConfig = new HashMap<>();
+        tempConfig.putAll(config);
+        tempConfig.putAll(properties);
+      }
     }
 
     InterpreterContext interpreterContext = new InterpreterContext(
@@ -473,7 +480,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
         this.getTitle(),
         this.getText(),
         this.getAuthenticationInfo(),
-        this.getConfig(),
+        tempConfig,
         this.settings,
         registry,
         resourcePool,

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -16,22 +16,8 @@
  */
 package org.apache.zeppelin.helium;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.dep.DependencyResolver;
-import org.apache.zeppelin.interpreter.*;
-import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
-import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
-import org.apache.zeppelin.notebook.*;
-import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
-import org.apache.zeppelin.scheduler.Job;
-import org.apache.zeppelin.scheduler.SchedulerFactory;
-import org.apache.zeppelin.search.SearchService;
-import org.apache.zeppelin.user.AuthenticationInfo;
-import org.apache.zeppelin.user.Credentials;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,8 +25,34 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
+import org.apache.commons.io.FileUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.dep.DependencyResolver;
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
+import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
+import org.apache.zeppelin.notebook.ApplicationState;
+import org.apache.zeppelin.notebook.JobListenerFactory;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.ParagraphJobListener;
+import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
+import org.apache.zeppelin.scheduler.Job;
+import org.apache.zeppelin.scheduler.SchedulerFactory;
+import org.apache.zeppelin.search.SearchService;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class HeliumApplicationFactoryTest implements JobListenerFactory {
   private File tmpDir;
@@ -101,7 +113,8 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
         this,
         search,
         notebookAuthorization,
-        new Credentials(false, null));
+        new Credentials(false, null),
+        new UserProperties(false, null));
 
     heliumAppFactory.setNotebook(notebook);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -98,7 +98,7 @@ public class InterpreterFactoryTest {
     SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo(conf);
     notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, jobListenerFactory, search,
-        null, null);
+        null, null, null);
   }
 
   @After

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -17,6 +17,14 @@
 
 package org.apache.zeppelin.notebook;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -25,14 +33,12 @@ import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NoteTest {
@@ -47,6 +53,9 @@ public class NoteTest {
 
   @Mock
   Credentials credentials;
+  
+  @Mock
+  UserProperties userProperties;
 
   @Mock
   Interpreter interpreter;
@@ -68,7 +77,8 @@ public class NoteTest {
     when(interpreter.getScheduler()).thenReturn(scheduler);
 
     String pText = "%spark sc.version";
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, 
+        userProperties, noteEventListener);
 
     Paragraph p = note.addParagraph();
     p.setText(pText);
@@ -84,7 +94,8 @@ public class NoteTest {
 
   @Test
   public void addParagraphWithEmptyReplNameTest() {
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, userProperties,
+    		noteEventListener);
 
     Paragraph p = note.addParagraph();
     assertNull(p.getText());
@@ -94,7 +105,8 @@ public class NoteTest {
   public void addParagraphWithLastReplNameTest() {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, userProperties,
+    		noteEventListener);
     Paragraph p1 = note.addParagraph();
     p1.setText("%spark ");
     Paragraph p2 = note.addParagraph();
@@ -106,7 +118,8 @@ public class NoteTest {
   public void insertParagraphWithLastReplNameTest() {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, userProperties,
+    		noteEventListener);
     Paragraph p1 = note.addParagraph();
     p1.setText("%spark ");
     Paragraph p2 = note.insertParagraph(note.getParagraphs().size());
@@ -118,7 +131,8 @@ public class NoteTest {
   public void insertParagraphWithInvalidReplNameTest() {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("invalid"))).thenReturn(null);
 
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, userProperties,
+    		noteEventListener);
     Paragraph p1 = note.addParagraph();
     p1.setText("%invalid ");
     Paragraph p2 = note.insertParagraph(note.getParagraphs().size());
@@ -131,7 +145,8 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("md"))).thenReturn(interpreter);
     when(interpreter.getScheduler()).thenReturn(scheduler);
 
-    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials,
+        userProperties, noteEventListener);
     Paragraph p1 = note.addParagraph();
     InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
     p1.setResult(result);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -46,6 +46,7 @@ import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.properties.UserProperties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,6 +69,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
   private SearchService search;
   private NotebookAuthorization notebookAuthorization;
   private Credentials credentials;
+  private UserProperties userProperties;
   private AuthenticationInfo anonymous;
   private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoSyncTest.class);
   
@@ -105,8 +107,9 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     notebookRepoSync = new NotebookRepoSync(conf);
     notebookAuthorization = NotebookAuthorization.init(conf);
     credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath());
+    userProperties = new UserProperties(conf.userPropertiesPersist(), conf.getUserPropertiesPath());
     notebookSync = new Notebook(conf, notebookRepoSync, schedulerFactory, factory, this, search,
-            notebookAuthorization, credentials);
+            notebookAuthorization, credentials, userProperties);
     anonymous = new AuthenticationInfo("anonymous");
   }
 
@@ -235,7 +238,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     conf = ZeppelinConfiguration.create();
     notebookRepoSync = new NotebookRepoSync(conf);
     notebookSync = new Notebook(conf, notebookRepoSync, schedulerFactory, factory, this, search,
-            notebookAuthorization, credentials);
+            notebookAuthorization, credentials, userProperties);
 
     // check that both storage repos are empty
     assertTrue(notebookRepoSync.getRepoCount() > 1);
@@ -282,8 +285,9 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     ZeppelinConfiguration vConf = ZeppelinConfiguration.create();
 
     NotebookRepoSync vRepoSync = new NotebookRepoSync(vConf);
+    userProperties = new UserProperties(conf.credentialsPersist(), conf.getCredentialsPath());
     Notebook vNotebookSync = new Notebook(vConf, vRepoSync, schedulerFactory, factory, this, search,
-            notebookAuthorization, credentials);
+            notebookAuthorization, credentials, userProperties);
 
     // one git versioned storage initialized
     assertThat(vRepoSync.getRepoCount()).isEqualTo(1);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -86,7 +86,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
 
     SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo(conf);
-    notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, this, search, null, null);
+    notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, this, search, null, null, null);
   }
 
   @After

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -288,7 +288,8 @@ public class LuceneSearchTest {
   }
 
   private Note newNote(String name) {
-    Note note = new Note(notebookRepoMock, interpreterFactory, null, noteSearchService, null, null);
+	  Note note = new Note(notebookRepoMock, interpreterFactory, null, noteSearchService, null, 
+			  null, null);
     note.setName(name);
     return note;
   }


### PR DESCRIPTION
### What is this PR for?
User should be able to define properties and these properties must be passed to Interpreter via Interpreter Context.
Add functionality so that Interpreter can substitute the its property value with the value specified by the user.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1625

### How should this be tested?
unit tests provided
Manual testing steps:
Add a property, update the property and then delete it

### Screenshots (if appropriate)
Available in documentation

### Questions:
* Does the licenses files need update?  NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? Yes, Documentation is provided.

