### PR TITLE
ZEPPELIN-1653: Make UI responsive

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -568,6 +568,20 @@ public class NotebookServer extends WebSocketServlet implements
     broadcast(noteId, new Message(OP.INTERPRETER_BINDINGS).put("interpreterBindings", settingList));
   }
 
+  public void broadcastParagraph(Note note, Paragraph p) {
+    broadcast(note.getId(), new Message(OP.PARAGRAPH).put("paragraph", p));
+  }
+
+  private void broadcastNewParagraph(Note note, Paragraph para) {
+    LOG.info("Broadcasting paragraph on run call instead of note.");
+    int paraIndex = note.getParagraphs().indexOf(para);
+    broadcast(
+        note.getId(),
+        new Message(OP.UPDATE_NOTE).put("operation", "addParagraph")
+                                   .put("paragraph", para)
+                                   .put("index", paraIndex));
+  }
+
   public void broadcastNoteList(AuthenticationInfo subject, HashSet userAndRoles) {
     if (subject == null) {
       subject = new AuthenticationInfo(StringUtils.EMPTY);
@@ -715,7 +729,11 @@ public class NotebookServer extends WebSocketServlet implements
 
       AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
       note.persist(subject);
-      broadcastNote(note);
+      broadcast(note.getId(), new Message(OP.UPDATE_NOTE)
+          .put("operation", "updateNote")
+          .put("name", name)
+          .put("config", config)
+          .put("info", note.getInfo()));
       broadcastNoteList(subject, userAndRoles);
     }
   }
@@ -857,7 +875,7 @@ public class NotebookServer extends WebSocketServlet implements
     p.setTitle((String) fromMessage.get("title"));
     p.setText((String) fromMessage.get("paragraph"));
     note.persist(subject);
-    broadcast(note.getId(), new Message(OP.PARAGRAPH).put("paragraph", p));
+    broadcastParagraph(note, p);;
   }
 
   private void cloneNote(NotebookSocket conn, HashSet<String> userAndRoles,
@@ -930,9 +948,13 @@ public class NotebookServer extends WebSocketServlet implements
 
     /** We dont want to remove the last paragraph */
     if (!note.isLastParagraph(paragraphId)) {
-      note.removeParagraph(subject.getUser(), paragraphId);
+      Paragraph para = note.removeParagraph(subject.getUser(), paragraphId);
       note.persist(subject);
-      broadcastNote(note);
+      if (para != null) {
+        broadcast(note.getId(), new Message(OP.UPDATE_NOTE).
+                                  put("operation", "removeParagraph").
+                                  put("id", para.getId()));
+      }
     }
   }
 
@@ -950,9 +972,9 @@ public class NotebookServer extends WebSocketServlet implements
           userAndRoles, notebookAuthorization.getWriters(noteId));
       return;
     }
-
     note.clearParagraphOutput(paragraphId);
-    broadcastNote(note);
+    Paragraph paragraph = note.getParagraph(paragraphId);
+    broadcastParagraph(note, paragraph);
   }
 
   private void completion(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1237,7 +1259,10 @@ public class NotebookServer extends WebSocketServlet implements
 
     note.moveParagraph(paragraphId, newIndex);
     note.persist(subject);
-    broadcastNote(note);
+    broadcast(note.getId(), new Message(OP.UPDATE_NOTE)
+              .put("operation", "moveParagraph")
+              .put("id", paragraphId)
+              .put("index", newIndex));
   }
 
   private void insertParagraph(NotebookSocket conn, HashSet<String> userAndRoles,
@@ -1254,9 +1279,9 @@ public class NotebookServer extends WebSocketServlet implements
       return;
     }
 
-    note.insertParagraph(index);
+    Paragraph newPara = note.insertParagraph(index);
     note.persist(subject);
-    broadcastNote(note);
+    broadcastNewParagraph(note, newPara);
   }
 
   private void cancelParagraph(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1313,7 +1338,8 @@ public class NotebookServer extends WebSocketServlet implements
     boolean isTheLastParagraph = note.isLastParagraph(p.getId());
     if (!(text.trim().equals(p.getMagic()) || Strings.isNullOrEmpty(text)) &&
         isTheLastParagraph) {
-      note.addParagraph();
+      Paragraph newPara = note.addParagraph();
+      broadcastNewParagraph(note, newPara);
     }
 
     AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
@@ -1631,8 +1657,9 @@ public class NotebookServer extends WebSocketServlet implements
           LOG.error(e.toString(), e);
         }
       }
-      notebookServer.broadcastNote(note);
-
+      if (job instanceof Paragraph) {
+        notebookServer.broadcastParagraph(note, (Paragraph) job);
+      }
       try {
         notebookServer.broadcastUpdateNoteJobInfo(System.currentTimeMillis() - 5000);
       } catch (IOException e) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -577,9 +577,9 @@ public class NotebookServer extends WebSocketServlet implements
     int paraIndex = note.getParagraphs().indexOf(para);
     broadcast(
         note.getId(),
-        new Message(OP.UPDATE_NOTE).put("operation", "addParagraph")
-                                   .put("paragraph", para)
-                                   .put("index", paraIndex));
+        new Message(OP.PARAGRAPH_ADDED)
+          .put("paragraph", para)
+          .put("index", paraIndex));
   }
 
   public void broadcastNoteList(AuthenticationInfo subject, HashSet userAndRoles) {
@@ -729,8 +729,7 @@ public class NotebookServer extends WebSocketServlet implements
 
       AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
       note.persist(subject);
-      broadcast(note.getId(), new Message(OP.UPDATE_NOTE)
-          .put("operation", "updateNote")
+      broadcast(note.getId(), new Message(OP.NOTE_UPDATED)
           .put("name", name)
           .put("config", config)
           .put("info", note.getInfo()));
@@ -951,8 +950,7 @@ public class NotebookServer extends WebSocketServlet implements
       Paragraph para = note.removeParagraph(subject.getUser(), paragraphId);
       note.persist(subject);
       if (para != null) {
-        broadcast(note.getId(), new Message(OP.UPDATE_NOTE).
-                                  put("operation", "removeParagraph").
+        broadcast(note.getId(), new Message(OP.PARAGRAPH_REMOVED).
                                   put("id", para.getId()));
       }
     }
@@ -1259,8 +1257,7 @@ public class NotebookServer extends WebSocketServlet implements
 
     note.moveParagraph(paragraphId, newIndex);
     note.persist(subject);
-    broadcast(note.getId(), new Message(OP.UPDATE_NOTE)
-              .put("operation", "moveParagraph")
+    broadcast(note.getId(), new Message(OP.PARAGRAPH_MOVED)
               .put("id", paragraphId)
               .put("index", newIndex));
   }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -360,86 +360,49 @@
       return noteCopy;
     };
 
-    var updateNote = function(note) {
-      /** update Note name */
-      if (note.name !== $scope.note.name) {
-        console.log('change note name: %o to %o', $scope.note.name, note.name);
-        $scope.note.name = note.name;
-      }
-
-      $scope.note.config = note.config;
-      $scope.note.info = note.info;
-
-      var newParagraphIds = note.paragraphs.map(function(x) {return x.id;});
-      var oldParagraphIds = $scope.note.paragraphs.map(function(x) {return x.id;});
-
-      var numNewParagraphs = newParagraphIds.length;
-      var numOldParagraphs = oldParagraphIds.length;
-
-      var paragraphToBeFocused;
-      var focusedParagraph;
-      for (var i = 0; i < $scope.note.paragraphs.length; i++) {
-        var paragraphId = $scope.note.paragraphs[i].id;
-        if (angular.element('#' + paragraphId + '_paragraphColumn_main').scope().paragraphFocused) {
-          focusedParagraph = paragraphId;
-          break;
+    var addPara = function(paragraph, index) {
+      $scope.note.paragraphs.splice(index, 0, paragraph);
+      _.each($scope.note.paragraphs, function(para) {
+        if (para.id === paragraph.id) {
+          para.focus = true;
         }
-      }
-
-      /** add a new paragraph */
-      if (numNewParagraphs > numOldParagraphs) {
-        for (var index in newParagraphIds) {
-          if (oldParagraphIds[index] !== newParagraphIds[index]) {
-            $scope.note.paragraphs.splice(index, 0, note.paragraphs[index]);
-            paragraphToBeFocused = note.paragraphs[index].id;
-            break;
-          }
-          $scope.$broadcast('updateParagraph', {
-            note: $scope.note, // pass the note object to paragraph scope
-            paragraph: note.paragraphs[index]});
-        }
-      }
-
-      /** update or move paragraph */
-      if (numNewParagraphs === numOldParagraphs) {
-        for (var idx in newParagraphIds) {
-          var newEntry = note.paragraphs[idx];
-          if (oldParagraphIds[idx] === newParagraphIds[idx]) {
-            $scope.$broadcast('updateParagraph', {
-              note: $scope.note, // pass the note object to paragraph scope
-              paragraph: newEntry});
-          } else {
-            // move paragraph
-            var oldIdx = oldParagraphIds.indexOf(newParagraphIds[idx]);
-            $scope.note.paragraphs.splice(oldIdx, 1);
-            $scope.note.paragraphs.splice(idx, 0, newEntry);
-            // rebuild id list since paragraph has moved.
-            oldParagraphIds = $scope.note.paragraphs.map(function(x) {return x.id;});
-          }
-
-          if (focusedParagraph === newParagraphIds[idx]) {
-            paragraphToBeFocused = focusedParagraph;
-          }
-        }
-      }
-
-      /** remove paragraph */
-      if (numNewParagraphs < numOldParagraphs) {
-        for (var oldidx in oldParagraphIds) {
-          if (oldParagraphIds[oldidx] !== newParagraphIds[oldidx]) {
-            $scope.note.paragraphs.splice(oldidx, 1);
-            break;
-          }
-        }
-      }
-
-      // restore focus of paragraph
-      for (var f = 0; f < $scope.note.paragraphs.length; f++) {
-        if (paragraphToBeFocused === $scope.note.paragraphs[f].id) {
-          $scope.note.paragraphs[f].focus = true;
-        }
-      }
+      });
     };
+
+    var removePara = function(paragraphId) {
+      var removeIdx;
+      _.each($scope.note.paragraphs, function(para, idx) {
+        if (para.id === paragraphId) {
+          removeIdx = idx;
+        }
+      });
+      return $scope.note.paragraphs.splice(removeIdx, 1);
+    };
+
+    $scope.$on('addParagraph', function(event, paragraph, index) {
+      addPara(paragraph, index);
+    });
+
+    $scope.$on('removeParagraph', function(event, paragraphId) {
+      removePara(paragraphId);
+    });
+
+    $scope.$on('moveParagraph', function(event, paragraphId, newIdx) {
+      var removedPara = removePara(paragraphId);
+      if (removedPara && removedPara.length === 1) {
+        addPara(removedPara[0], newIdx);
+      }
+    });
+
+    $scope.$on('updateNote', function(event, name, config, info) {
+      /** update Note name */
+      if (name !== $scope.note.name) {
+        console.log('change note name to : %o', $scope.note.name);
+        $scope.note.name = name;
+      }
+      $scope.note.config = config;
+      $scope.note.info = info;
+    });
 
     var getInterpreterBindings = function() {
       websocketMsgSrv.getInterpreterBindings($scope.note.id);
@@ -856,8 +819,6 @@
 
       if ($scope.note === null) {
         $scope.note = note;
-      } else {
-        updateNote(note);
       }
       initializeLookAndFeel();
       //open interpreter binding setting when there're none selected

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -402,6 +402,7 @@
       }
       $scope.note.config = config;
       $scope.note.info = info;
+      initializeLookAndFeel();
     });
 
     var getInterpreterBindings = function() {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -140,16 +140,14 @@
         $rootScope.$broadcast('configurationsInfo', data);
       } else if (op === 'INTERPRETER_SETTINGS') {
         $rootScope.$broadcast('interpreterSettings', data);
-      } else if (op === 'UPDATE_NOTE') {
-        if (data.operation === 'addParagraph') {
-          $rootScope.$broadcast('addParagraph', data.paragraph, data.index);
-        } else if (data.operation === 'removeParagraph') {
-          $rootScope.$broadcast('removeParagraph', data.id);
-        } else if (data.operation === 'moveParagraph') {
-          $rootScope.$broadcast('moveParagraph', data.id, data.index);
-        } else if (data.operation === 'updateNote') {
-          $rootScope.$broadcast('updateNote', data.name, data.config, data.info);
-        }
+      } else if (op === 'PARAGRAPH_ADDED') {
+        $rootScope.$broadcast('addParagraph', data.paragraph, data.index);
+      } else if (op === 'PARAGRAPH_REMOVED') {
+        $rootScope.$broadcast('removeParagraph', data.id);
+      } else if (op === 'PARAGRAPH_MOVED') {
+        $rootScope.$broadcast('moveParagraph', data.id, data.index);
+      } else if (op === 'NOTE_UPDATED') {
+        $rootScope.$broadcast('updateNote', data.name, data.config, data.info);
       }
     });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -140,6 +140,16 @@
         $rootScope.$broadcast('configurationsInfo', data);
       } else if (op === 'INTERPRETER_SETTINGS') {
         $rootScope.$broadcast('interpreterSettings', data);
+      } else if (op === 'UPDATE_NOTE') {
+        if (data.operation === 'addParagraph') {
+          $rootScope.$broadcast('addParagraph', data.paragraph, data.index);
+        } else if (data.operation === 'removeParagraph') {
+          $rootScope.$broadcast('removeParagraph', data.id);
+        } else if (data.operation === 'moveParagraph') {
+          $rootScope.$broadcast('moveParagraph', data.id, data.index);
+        } else if (data.operation === 'updateNote') {
+          $rootScope.$broadcast('updateNote', data.name, data.config, data.info);
+        }
       }
     });
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -147,6 +147,7 @@ public class Message {
     INTERPRETER_SETTINGS,         // [s-c] interpreter settings
     ERROR_INFO,                   // [s-c] error information to be sent
     WATCHER,                      // [s-c] Change websocket to watcher mode.
+    UPDATE_NOTE
   }
 
   public static final Message EMPTY = new Message(null);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -147,7 +147,10 @@ public class Message {
     INTERPRETER_SETTINGS,         // [s-c] interpreter settings
     ERROR_INFO,                   // [s-c] error information to be sent
     WATCHER,                      // [s-c] Change websocket to watcher mode.
-    UPDATE_NOTE
+    PARAGRAPH_ADDED,              // [s-c] paragraph is added
+    PARAGRAPH_REMOVED,            // [s-c] paragraph deleted
+    PARAGRAPH_MOVED,              // [s-c] paragraph moved
+    NOTE_UPDATED                  // [s-c] paragraph updated(name, config)
   }
 
   public static final Message EMPTY = new Message(null);


### PR DESCRIPTION
### What is this PR for?
When we do the following operations, the entire notebook is transmitted back to client.
1) Insert paragraph
2) Remove paragraph
3) Update paragraph
4) Paragraph status update
5) commit paragraph
When the json becomes larger(which happens when large  output is stored in the json), the time to transfer the notebook to client is directly proportional.(we can check this in chrome browser-> dev console-> select ws request-> on the right pane that opens, select frames tab and observe the length column)

And since the UI update is based on this new transmitted json, the UI seems unresponsive/laggy.
In this PR, Making the updates selective.(Not sending the complete json back to client)


### What type of PR is it?
Improvement

### Todos
NA

### What is the Jira issue?
ZEPPELIN-1653

### How should this be tested?

-In chrome browser-> dev console-> select ws request-> on the right pane that opens, select frames tab and observe  *NOTE* message.
We should not see the message for the above mentioned operations except when the notebook is loaded is for first time
-    We should not see *GET_NOTE* log message for above operations.

### Screenshots 
NA

### Questions:
* Does the licenses files need update?No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

