### PR TITLE
[ZEPPELIN-1657] Private/public mode for user note creation/import

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -38,6 +38,7 @@
 # export ZEPPELIN_INTERPRETER_LOCALREPO         # Local repository for interpreter's additional dependency loading
 # export ZEPPELIN_NOTEBOOK_STORAGE 		# Refers to pluggable notebook storage class, can have two classes simultaneously with a sync between them (e.g. local and remote).
 # export ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC	# If there are multiple notebook storages, should we treat the first one as the only source of truth?
+# export ZEPPELIN_NOTEBOOK_PUBLIC   # Make notebook public by default when created, private otherwise
 
 #### Spark interpreter configuration ####
 

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -278,10 +278,15 @@
 </property>
 
 <property>
+  <name>zeppelin.notebook.public</name>
+  <value>true</value>
+  <description>Make notebook public by default when created, private otherwise</description>
+</property>
+
+<property>
   <name>zeppelin.websocket.max.text.message.size</name>
   <value>1024000</value>
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
 </property>
 
 </configuration>
-

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -87,7 +87,7 @@ Congratulations, you have successfully installed Apache Zeppelin! Here are few s
  * For an in-depth overview, head to [Explore Apache Zeppelin UI](../quickstart/explorezeppelinui.html).
  * And then, try run [tutorial](http://localhost:8080/#/notebook/2A94M5J1Z) notebook in your Zeppelin.
  * And see how to change [configurations](#apache-zeppelin-configuration) like port number, etc.
- 
+
 #### Zeppelin with Apache Spark ...
  * To know more about deep integration with [Apache Spark](http://spark.apache.org/), check [Spark Interpreter](../interpreter/spark.html).
 
@@ -305,6 +305,12 @@ You can configure Apache Zeppelin with either **environment variables** in `conf
     <td>zeppelin.notebook.one.way.sync</td>
     <td>false</td>
     <td>If there are multiple notebook storage locations, should we treat the first one as the only source of truth?</td>
+  </tr>
+  <tr>
+    <td>ZEPPELIN_NOTEBOOK_PUBLIC</td>
+    <td>zeppelin.notebook.public</td>
+    <td>true</td>
+    <td>Make notebook public (set only `owners`) by default when created/imported. If set to `false` will add `user` to `readers` and `writers` as well, making it private and invisible to other users unless permissions are granted.</td>
   </tr>
   <tr>
     <td>ZEPPELIN_INTERPRETERS</td>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -435,6 +435,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED);
   }
 
+  public boolean isNotebokPublic() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC);
+  }
+  
   public String getConfDir() {
     return getString(ConfVars.ZEPPELIN_CONF_DIR);
   }
@@ -570,6 +574,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),
     ZEPPELIN_NOTEBOOK_STORAGE("zeppelin.notebook.storage", VFSNotebookRepo.class.getName()),
     ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC("zeppelin.notebook.one.way.sync", false),
+    // whether by default note is public or private
+    ZEPPELIN_NOTEBOOK_PUBLIC("zeppelin.notebook.public", true),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner",
         System.getProperty("os.name")
                 .startsWith("Windows") ? "bin/interpreter.cmd" : "bin/interpreter.sh"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -166,11 +166,7 @@ public class Notebook implements NoteEventListener {
       bindInterpretersToNote(subject.getUser(), note.getId(), interpreterIds);
     }
 
-    if (subject != null && !"anonymous".equals(subject.getUser())) {
-      Set<String> owners = new HashSet<>();
-      owners.add(subject.getUser());
-      notebookAuthorization.setOwners(note.getId(), owners);
-    }
+    notebookAuthorization.setNewNotePermissions(note.getId(), subject);
     noteSearchService.addIndexDoc(note);
     note.persist(subject);
     fireNoteCreateEvent(note);
@@ -225,6 +221,7 @@ public class Notebook implements NoteEventListener {
         newNote.addCloneParagraph(p);
       }
 
+      notebookAuthorization.setNewNotePermissions(newNote.getId(), subject);
       newNote.persist(subject);
     } catch (IOException e) {
       logger.error(e.toString(), e);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -62,7 +62,6 @@ public class NotebookAuthorization {
   private static ZeppelinConfiguration conf;
   private static Gson gson;
   private static String filePath;
-  private static boolean isPublic;
 
   private NotebookAuthorization() {}
 
@@ -74,7 +73,6 @@ public class NotebookAuthorization {
       GsonBuilder builder = new GsonBuilder();
       builder.setPrettyPrinting();
       gson = builder.create();
-      isPublic = config.isNotebokPublic();
       try {
         loadFromFile();
       } catch (IOException e) {
@@ -157,6 +155,10 @@ public class NotebookAuthorization {
     } catch (IOException e) {
       LOG.error("Error saving notebook authorization file: " + e.getMessage());
     }
+  }
+  
+  public boolean isPublic() {
+    return conf.isNotebokPublic();
   }
 
   private Set<String> validateUser(Set<String> users) {
@@ -330,7 +332,7 @@ public class NotebookAuthorization {
   
   public void setNewNotePermissions(String noteId, AuthenticationInfo subject) {
     if (!AuthenticationInfo.isAnonymous(subject)) {
-      if (isPublic) {
+      if (isPublic()) {
         // add current user to owners - can be public
         Set<String> owners = getOwners(noteId);
         owners.add(subject.getUser());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -24,6 +24,8 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 import java.net.MalformedURLException;
 import java.util.List;
 
@@ -86,5 +88,13 @@ public class ZeppelinConfigurationTest {
         ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
         String notebookLocation = conf.getNotebookDir();
         Assert.assertEquals("notebook", notebookLocation);
+    }
+    
+    @Test
+    public void isNotebookPublicTest() throws ConfigurationException {
+      
+      ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+      boolean isIt = conf.isNotebokPublic();
+      assertTrue(isIt);
     }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -42,6 +42,7 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.notebook.JobListenerFactory;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
@@ -66,6 +67,7 @@ public class InterpreterFactoryTest {
   private NotebookRepo notebookRepo;
   private DependencyResolver depResolver;
   private SchedulerFactory schedulerFactory;
+  private NotebookAuthorization notebookAuthorization;
   @Mock
   private JobListenerFactory jobListenerFactory;
 
@@ -97,8 +99,9 @@ public class InterpreterFactoryTest {
 
     SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo(conf);
+    notebookAuthorization = NotebookAuthorization.init(conf);
     notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, jobListenerFactory, search,
-        null, null);
+        notebookAuthorization, null);
   }
 
   @After

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1119,6 +1119,10 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notebookAuthorization.getOwners(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getReaders(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getWriters(notePrivate.getId()).size(), 1);
+    
+    //set back public to true
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
+    ZeppelinConfiguration.create();
   }
   
   private void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -35,6 +35,7 @@ import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.notebook.JobListenerFactory;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.ParagraphJobListener;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
@@ -56,6 +57,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
   private NotebookRepo notebookRepo;
   private InterpreterFactory factory;
   private DependencyResolver depResolver;
+  private NotebookAuthorization notebookAuthorization;
 
   private File mainZepDir;
   private File mainNotebookDir;
@@ -86,7 +88,9 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
 
     SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo(conf);
-    notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, this, search, null, null);
+    notebookAuthorization = NotebookAuthorization.init(conf);
+    notebook = new Notebook(conf, notebookRepo, schedulerFactory, factory, this, search,
+        notebookAuthorization, null);
   }
 
   @After

--- a/zeppelin-zengine/src/test/resources/zeppelin-site.xml
+++ b/zeppelin-zengine/src/test/resources/zeppelin-site.xml
@@ -148,5 +148,11 @@
 </property>
 -->
 
+<property>
+  <name>zeppelin.notebook.public</name>
+  <value>true</value>
+  <description>Make notebook public by default when created, private otherwise</description>
+</property>
+
 </configuration>
 


### PR DESCRIPTION
### What is this PR for?
In multi-user environment when users create a notebook normally they would expect that notebook be listed only in their list/workbench. Currently Zeppelin creates/imports notes as public by default. There should be at least a way to pass through configuration to make this behaviour private be default. Should discuss whether it's public or private by default.


### What type of PR is it?
Improvement

### Todos
* [x] - set permissions on create/import
* [x] - test
* [x] - review, feedback, decide whether public/private by default
* [x] - pass through env. config

### What is the Jira issue?
[ZEPPELIN-1657](https://issues.apache.org/jira/browse/ZEPPELIN-1657)

### How should this be tested?
1. set `zeppelin.notebook.public` property as false in `zeppelin-site.xml`
2. login as user1 and create noteA, note should appear in your list of notes
3. logout and login as user2, shouldn't be able to see noteA

### Screenshots (if appropriate)
TBD

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? maybe
