### PR TITLE
[ZEPPELIN-1655] Dynamic forms in Python interpreter do not work

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -119,6 +119,7 @@ class PyZeppelinContext(object):
     def __init__(self):
         self.max_result = 1000
         self._displayhook = lambda *args: None
+        self._setup_matplotlib()
     
     def input(self, name, defaultValue=""):
         print(self.errorMsg)
@@ -231,4 +232,3 @@ class PyZeppelinContext(object):
 
 
 z = PyZeppelinContext()
-z._setup_matplotlib()

--- a/python/src/main/resources/bootstrap_input.py
+++ b/python/src/main/resources/bootstrap_input.py
@@ -26,6 +26,7 @@ class Py4jZeppelinContext(PyZeppelinContext):
     """A context impl that uses Py4j to communicate to JVM
     """
     def __init__(self, z):
+        PyZeppelinContext.__init__(self)
         self.z = z
         self.paramOption = gateway.jvm.org.apache.zeppelin.display.Input.ParamOption
         self.javaList = gateway.jvm.java.util.ArrayList


### PR DESCRIPTION
### What is this PR for?
After #1534 , Dynamic Forms were no longer working in the python interpreter. This is because the `Py4jZeppelinContext` constructor did not initialize the `_displayhook` which is always called on post-execute.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1655](https://issues.apache.org/jira/browse/ZEPPELIN-1655)

### How should this be tested?
Run the following `%python` paragraph, being sure that Py4j is installed:
```python
%python
a, b, c = (1, 2, 3)
z.select("Choose a letter", ([a,"a"], [b,"b"], [c,"c"] ))
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

