### PR TITLE
[HOTFIX][ZEPPELIN-1656] z.show in Python interpreter does not work

### DIFF
--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -207,7 +207,7 @@ class PyZeppelinContext(object):
         try:
             import matplotlib
         except ImportError:
-            pass
+            return
         # Make sure custom backends are available in the PYTHONPATH
         rootdir = os.environ.get('ZEPPELIN_HOME', os.getcwd())
         mpl_path = os.path.join(rootdir, 'interpreter', 'lib', 'python')

--- a/python/src/main/resources/bootstrap.py
+++ b/python/src/main/resources/bootstrap.py
@@ -218,7 +218,7 @@ class PyZeppelinContext(object):
         try:
             matplotlib.use('module://backend_zinline')
             import backend_zinline
-      
+            
             # Everything looks good so make config assuming that we are using
             # an inline backend
             self._displayhook = backend_zinline.displayhook


### PR DESCRIPTION
### What is this PR for?
There have been reports of #1534 causing the python interpreter to always show an error because `z` is not being set. As it turns out this is a result of improperly handling the case when matplotlib isn't found when initializing the interpreter.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1656](https://issues.apache.org/jira/browse/ZEPPELIN-1656)

### How should this be tested?
Run any simple python paragraph.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No