### PR TITLE
[ZEPPELIN-1659] DON'T reset filter whenever each interpreter setting is updated

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -24,6 +24,7 @@
     $scope.availableInterpreters = {};
     $scope.showAddNewSetting = false;
     $scope.showRepositoryInfo = false;
+    $scope.searchInterpreter = '';
     $scope._ = _;
     ngToast.dismiss();
 
@@ -346,8 +347,8 @@
               .success(function(data, status, headers, config) {
                 $scope.interpreterSettings[index] = data.body;
                 removeTMPSettings(index);
+                checkDownloadingDependencies();
                 thisConfirm.close();
-                $route.reload();
               })
               .error(function(data, status, headers, config) {
                 console.log('Error %o %o', status, data.message);


### PR DESCRIPTION
### What is this PR for?

Filter is cleared whenever each interpreter setting is updated. 
it's sometimes annoying if an user want to debug interpreter settings (I attached GIF)

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?

[ZEPPELIN-1659](https://issues.apache.org/jira/browse/ZEPPELIN-1659)

### How should this be tested?

1. insert interpreter filter
2. update a interpreter setting
3. check whether the filter is cleared or not

### Screenshots (if appropriate)

![filter_is_cleared_everytime](https://cloud.githubusercontent.com/assets/4968473/20266522/c61410fa-aab9-11e6-8d1d-5e28748a7830.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
