### PR TITLE
[ZEPPELIN-1535] Override JNA version with 4.2.0 for Power PC users

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -132,6 +132,13 @@
         </dependency>
 
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>info.archinnov</groupId>
             <artifactId>achilles-embedded</artifactId>
             <version>${achilles.version}</version>
@@ -144,6 +151,10 @@
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
### What is this PR for?
For Power PC users, running embedded Cassandra fails because JNA version 4.0.0 is not working. Upgrading JNA to 4.2.0 works


### What type of PR is it?
**[Bug Fix]**

### Todos
* [] - Check by **Pravin Dsilva** and/or **sonali shrivastava** to ensure the fix works for them

### What is the Jira issue?
* [ZEPPELIN-1535]

### How should this be tested?

1. Checkout this PR with `git fetch origin pull/1631/head:CASSANDRA_JNA_FIX`
2. Switch to this brand `git checkout CASSANDRA_JNA_FIX`
2. Execute the following commands on a **Power PC** machine to build Zeppelin

```sh
>export MAVEN_OPTS="-Xmx2g -XX:MaxPermSize=1024m -Drat.numUnapprovedLicenses=128"
>mvn -Dhadoop.version=2.7.3 -Dspark.version=1.6.2 clean test -Drat.skip -fn
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? --> **No**
* Is there breaking changes for older versions? --> **No**
* Does this needs documentation? --> **No**

[ZEPPELIN-1535]: https://issues.apache.org/jira/browse/ZEPPELIN-1535#