### PR TITLE
[MINOR] Add markdown escaping to find missing parts

### DIFF
--- a/docs/manual/notebookashomepage.md
+++ b/docs/manual/notebookashomepage.md
@@ -81,7 +81,7 @@ println(
         <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
         <ul style="list-style-type: none;">
           <li ng-repeat="note in home.notes.list track by $index"><i style="font-size: 10px;" class="icon-doc"></i>
-            <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
+            <a style="text-decoration: none;" href="#/notebook/{{"{{note.id"}}}}>{{"{{noteName(note)"}}}}</a>
           </li>
         </ul>
     </div>


### PR DESCRIPTION
### What is this PR for?
Currently `{{note.id}}>{{noteName(note)}}` is not shown in `notebookashomepage.md`. So I added markdown escaping for this. 

### What type of PR is it?
Documentation

### What is the Jira issue?
no Jira issue for this

### How should this be tested?
Please see the below screenshot imgs :)

### Screenshots (if appropriate)
 - Before 
<img width="797" alt="screen shot 2016-11-15 at 9 22 15 am" src="https://cloud.githubusercontent.com/assets/10060731/20298331/9b2e8828-ab15-11e6-9010-50df6100a961.png">

 - After 
![picture1](https://cloud.githubusercontent.com/assets/10060731/20298335/9f55a2c4-ab15-11e6-99e3-ac83a76a2ff6.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

