### PR TITLE
[ZEPPELIN-1666] DON'T share mutable deps, options between interpreters in each group (bug)

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.interpreter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -94,6 +95,20 @@ public class InterpreterOption {
     this.remote = remote;
     this.perUser = perUser;
     this.perNote = perNote;
+  }
+
+  public static InterpreterOption fromInterpreterOption(InterpreterOption other) {
+    InterpreterOption option = new InterpreterOption();
+    option.remote = other.remote;
+    option.host = other.host;
+    option.port = other.port;
+    option.perNote = other.perNote;
+    option.perUser = other.perUser;
+    option.isExistingProcess = other.isExistingProcess;
+    option.setPermission = other.setPermission;
+    option.users = new ArrayList<>(other.users);
+
+    return option;
   }
 
   public boolean isRemote() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
@@ -106,7 +106,8 @@ public class InterpreterOption {
     option.perUser = other.perUser;
     option.isExistingProcess = other.isExistingProcess;
     option.setPermission = other.setPermission;
-    option.users = new ArrayList<>(other.users);
+    option.users = (null == other.users) ?
+        new ArrayList<String>() : new ArrayList<>(other.users);
 
     return option;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -290,7 +290,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         new ArrayList<InterpreterInfo>() : new ArrayList<>(o.getInterpreterInfos());
     List<Dependency> deps = (null == o.getDependencies()) ?
         new ArrayList<Dependency>() : new ArrayList<>(o.getDependencies());
-    Properties props = convertInterpreterProperties((Map<String, InterpreterProperty>) o.getProperties());
+    Properties props =
+        convertInterpreterProperties((Map<String, InterpreterProperty>) o.getProperties());
     InterpreterOption option = InterpreterOption.fromInterpreterOption(o.getOption());
 
     InterpreterSetting setting = new InterpreterSetting(o.getName(), o.getName(),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -285,14 +285,16 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   }
 
   private InterpreterSetting createFromInterpreterSettingRef(InterpreterSetting o) {
-    // return immutable objects
-    List<InterpreterInfo> infos = new ArrayList<>(o.getInterpreterInfos());
-    List<Dependency> deps = new ArrayList<>(o.getDependencies());
+    // should return immutable objects
+    List<InterpreterInfo> infos = (null == o.getInterpreterInfos()) ?
+        new ArrayList<InterpreterInfo>() : new ArrayList<>(o.getInterpreterInfos());
+    List<Dependency> deps = (null == o.getDependencies()) ?
+        new ArrayList<Dependency>() : new ArrayList<>(o.getDependencies());
     Properties props = convertInterpreterProperties((Map<String, InterpreterProperty>) o.getProperties());
     InterpreterOption option = InterpreterOption.fromInterpreterOption(o.getOption());
 
     InterpreterSetting setting = new InterpreterSetting(o.getName(), o.getName(),
-        o.getInterpreterInfos(), props, deps, o.getOption(), o.getPath());
+        infos, props, deps, option, o.getPath());
     setting.setInterpreterGroupFactory(this);
     return setting;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -285,10 +285,14 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   }
 
   private InterpreterSetting createFromInterpreterSettingRef(InterpreterSetting o) {
-    InterpreterSetting setting =
-        new InterpreterSetting(o.getName(), o.getName(), o.getInterpreterInfos(),
-            convertInterpreterProperties((Map<String, InterpreterProperty>) o.getProperties()),
-            o.getDependencies(), o.getOption(), o.getPath());
+    // return immutable objects
+    List<InterpreterInfo> infos = new ArrayList<>(o.getInterpreterInfos());
+    List<Dependency> deps = new ArrayList<>(o.getDependencies());
+    Properties props = convertInterpreterProperties((Map<String, InterpreterProperty>) o.getProperties());
+    InterpreterOption option = InterpreterOption.fromInterpreterOption(o.getOption());
+
+    InterpreterSetting setting = new InterpreterSetting(o.getName(), o.getName(),
+        o.getInterpreterInfos(), props, deps, o.getOption(), o.getPath());
     setting.setInterpreterGroupFactory(this);
     return setting;
   }


### PR DESCRIPTION
### What is this PR for?

Every interpreter shares their `List<Dependency>` and `InterpreterOption` object with other interpreters in the same group since these objects are mutable and just returned from `InterpreterSettingRef` in InterpreterFactory.

I attached GIF

### What type of PR is it?
[Bug Fix]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1666](https://issues.apache.org/jira/browse/ZEPPELIN-1666)

### How should this be tested?

I included unit test for it in `InterpreterRestApiTest.testCreatedInterpreterDependencies`.   
You can reproduce and debug this by checking out commit 3acde56 and run the unit test.

If you try to debug, you can see the length of `List<Dependency>` in `md` `InterpreterSettingRef` is increased whenever creating a new interpreter setting. But it shouldn't be.

### Screenshots (if appropriate)

![duplicated_interpreter_params](https://cloud.githubusercontent.com/assets/4968473/20308094/ceeeae70-ab85-11e6-9a8e-da5bb539a03b.gif)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
