### PR TITLE
[ZEPPELIN-1667] add support for es6

### DIFF
--- a/zeppelin-web/.eslintrc
+++ b/zeppelin-web/.eslintrc
@@ -2,7 +2,13 @@
   "env": {
     "browser": true,
     "jasmine": true,
-    "node": true
+    "node": true,
+    "es6": true
+  },
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "globals": {
     "angular": false,

--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -44,6 +44,30 @@ module.exports = function(grunt) {
     // Project settings
     yeoman: appConfig,
 
+    babel: {
+      options: {
+        sourceMap: true,
+        presets: ['es2015'],
+        plugins: ['transform-object-rest-spread']
+      },
+      dev: {
+        files: [{
+          expand: true,
+          cwd: './src/',
+          src: ['**/*.js'],
+          dest: '.tmp',
+        }]
+      },
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '.tmp/concat/scripts',
+          src: ['scripts.js'],
+          dest: '.tmp/concat/scripts',
+        }]
+      }
+    },
+
     // use ngAnnotate instead og ngMin
     ngAnnotate: {
       dist: {
@@ -138,7 +162,7 @@ module.exports = function(grunt) {
           '<%= yeoman.app %>/app/**/*.js',
           '<%= yeoman.app %>/components/**/*.js'
         ],
-        tasks: ['newer:eslint:all', 'newer:jscs:all'],
+        tasks: ['newer:eslint:all', 'newer:jscs:all', 'newer:babel:dev'],
         options: {
           livereload: '<%= connect.options.livereload %>'
         }
@@ -147,11 +171,16 @@ module.exports = function(grunt) {
         files: [
           '<%= yeoman.app %>/**/*.html'
         ],
-        tasks: ['newer:htmlhint']
+        tasks: ['newer:htmlhint', 'newer:copy:dev']
       },
       jsTest: {
         files: ['test/spec/{,*/}*.js'],
-        tasks: ['newer:eslint:test', 'newer:jscs:test', 'karma']
+        tasks: [
+          'newer:eslint:test',
+          'newer:jscs:test',
+          'newer:babel:dev',
+          'karma'
+        ]
       },
       styles: {
         files: [
@@ -185,11 +214,12 @@ module.exports = function(grunt) {
         port: 9000,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
-        livereload: 35729
+        livereload: 35729,
+        base: '.tmp',
       },
       livereload: {
         options: {
-          open: true,
+          open: false,
           middleware: function(connect) {
             return [
               connect.static('.tmp'),
@@ -197,7 +227,6 @@ module.exports = function(grunt) {
                 '/bower_components',
                 connect.static('./bower_components')
               ),
-              connect.static(appConfig.app)
             ];
           }
         }
@@ -220,7 +249,7 @@ module.exports = function(grunt) {
       },
       dist: {
         options: {
-          open: true,
+          open: false,
           base: '<%= yeoman.dist %>'
         }
       }
@@ -382,9 +411,6 @@ module.exports = function(grunt) {
         }
       }
     },
-    // concat: {
-    //   dist: {}
-    // },
 
     svgmin: {
       dist: {
@@ -421,6 +447,60 @@ module.exports = function(grunt) {
 
     // Copies remaining files to places other tasks can use
     copy: {
+      dev: {
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '.tmp',
+          src: [
+            '*.{ico,png,txt}',
+            '.htaccess',
+            '*.html',
+            '**/*.css',
+            'assets/styles/**/*',
+            'assets/images/**/*',
+            'WEB-INF/*'
+          ]
+        }, {
+          // copy fonts
+          expand: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '.tmp',
+          src: ['fonts/**/*.{eot,svg,ttf,woff}']
+        }, {
+          expand: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '.tmp',
+          src: ['app/**/*.html', 'components/**/*.html']
+        }, {
+          expand: true,
+          cwd: 'bower_components/datatables/media/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '.tmp/images'
+        }, {
+          expand: true,
+          cwd: '.tmp/images',
+          dest: '.tmp/images',
+          src: ['generated/*']
+        }, {
+          expand: true,
+          cwd: 'bower_components/bootstrap/dist',
+          src: 'fonts/*',
+          dest: '.tmp'
+        }, {
+          expand: true,
+          cwd: 'bower_components/jquery-ui/themes/base/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '.tmp/styles/images'
+        }, {
+          expand: true,
+          cwd: 'bower_components/MathJax',
+          src: [
+            'extensions/**', 'jax/**', 'fonts/**'],
+          dest: '.tmp'
+        }]
+      },
       dist: {
         files: [{
           expand: true,
@@ -486,10 +566,10 @@ module.exports = function(grunt) {
     // Run some tasks in parallel to speed up the build process
     concurrent: {
       server: [
-        'copy:styles'
+        'copy:dev'
       ],
       test: [
-        'copy:styles'
+        'copy:dev',
       ],
       dist: [
         'copy:styles',
@@ -516,6 +596,7 @@ module.exports = function(grunt) {
       'wiredep',
       'concurrent:server',
       'postcss',
+      'babel:dev',
       'connect:livereload',
       'watch'
     ]);
@@ -528,9 +609,11 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test', [
     'clean:server',
+    'babel',
     'wiredep',
     'concurrent:test',
     'postcss',
+    'babel:dev',
     'connect:test',
     'karma'
   ]);
@@ -546,6 +629,7 @@ module.exports = function(grunt) {
     'concurrent:dist',
     'postcss',
     'concat',
+    'babel:dist',
     'ngAnnotate',
     'copy:dist',
     'cssmin',

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -16,7 +16,10 @@
   "devDependencies": {
     "autoprefixer": "^6.1.0",
     "bower": "^1.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-preset-es2015": "^6.18.0",
     "grunt": "^0.4.1",
+    "grunt-babel": "^6.0.0",
     "grunt-cache-bust": "1.3.0",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^0.5.0",

--- a/zeppelin-web/test/karma.conf.js
+++ b/zeppelin-web/test/karma.conf.js
@@ -68,17 +68,17 @@ module.exports = function(config) {
       'bower_components/MathJax/MathJax.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
-      'src/app/app.js',
-      'src/app/app.controller.js',
-      'src/app/tabledata/transformation.js',
-      'src/app/**/*.js',
-      'src/components/**/*.js',
+      '.tmp/app/app.js',
+      '.tmp/app/app.controller.js',
+      '.tmp/app/tabledata/transformation.js',
+      '.tmp/app/**/*.js',
+      '.tmp/components/**/*.js',
       'test/spec/**/*.js'
     ],
 
     // list of files / patterns to exclude
     exclude: [
-      'src/app/visualization/builtins/*.js'
+      '.tmp/app/visualization/builtins/*.js'
     ],
 
     // web server port


### PR DESCRIPTION
### What is this PR for?
This PR adds support for the current ECMAScript standard [es6](http://www.ecma-international.org/ecma-262/6.0/) via [babel](http://babeljs.io/) ([babel-grunt](https://github.com/babel/grunt-babel) plugin)

### What type of PR is it?
Improvement

### Todos
* [x] - Add babel presets for es6 (aka es2015) and object spread operator
* [x] - Add eslint rules to lint es6 correctly
* [x] - Add `babel` task to grunt and modify `serve`, `test` and `build` tasks

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1667

### How should this be tested?
1. Run `grunt serve` and make sure it works properly (including reload on change)
2. Run `grunt test` and make sure tests pass
3. Run `grunt build` and make sure it builds and runs correctly

