### PR TITLE
Enable to search interpreters only based on the name

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -90,7 +90,7 @@ limitations under the License.
 </div>
 
 <div class="box width-full"
-     ng-repeat="setting in interpreterSettings | orderBy: 'name' | filter: searchInterpreter" interpreter-directive>
+     ng-repeat="setting in interpreterSettings | orderBy: 'name' | filter: {name:searchInterpreter} " interpreter-directive>
   <div id="{{setting.name | lowercase}}">
     <div class="row interpreter">
 


### PR DESCRIPTION
### What is this PR for?
Currently when you're trying to search some interpreters, for example "Spark", the page shows both "Livy" and "Spark". It's because Livy contains Spark related properties such as `livy.spark.driver.cores`, `livy.spark.driver.memory` and etc etc. As an user aspect, I felt a bit uncomfortable with this.
So I added one more condition so that it can search only based on interpreter name. 

### What type of PR is it?
Improvement

### What is the Jira issue?
no Jira issue for this

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
 - Before
![before](https://cloud.githubusercontent.com/assets/10060731/20309013/a20c60f8-ab46-11e6-9b68-bf3980de3b6b.gif)
 
 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/20309017/a4376300-ab46-11e6-92c9-a8b6a674f312.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

