### PR TITLE
[ZEPPELIN-1688] Display comment of table data

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-results.html
@@ -21,8 +21,8 @@ limitations under the License.
 
   <div id="{{paragraph.id}}_comment"
        class="text"
-       ng-if="getResultType()=='TABLE' && paragraph.result.comment"
-       ng-bind-html="paragraph.result.comment">
+       ng-if="getResultType()=='TABLE' && tableDataComment"
+       ng-bind-html="tableDataComment">
   </div>
 
   <div id="{{paragraph.id}}_text"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -200,6 +200,7 @@
         tableData = new TableData();
         tableData.loadParagraphResult($scope.paragraph.result);
         $scope.tableDataColumns = tableData.columns;
+        $scope.tableDataComment = tableData.comment;
         $scope.setGraphMode($scope.getGraphMode(), false, false);
       } else if ($scope.getResultType() === 'HTML') {
         $scope.renderHtml();
@@ -1691,6 +1692,7 @@
             tableData = new TableData();
             tableData.loadParagraphResult($scope.paragraph.result);
             $scope.tableDataColumns = tableData.columns;
+            $scope.tableDataComment = tableData.comment;
             clearUnknownColsFromGraphOption();
             selectDefaultColsForGraphOption();
           }


### PR DESCRIPTION
### What is this PR for?
After https://github.com/apache/zeppelin/pull/1529, max number of rows limitation message is not displayed.

### What type of PR is it?
Hot Fix

### Todos
* [x] - display comment of tabledata

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1668

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

