### PR TITLE
[ZEPPELIN-1654] Fix csv/tsv download

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1297,15 +1297,15 @@
         dsv += tableData.columns[titleIndex].name + delimiter;
       }
       dsv = dsv.substring(0, dsv.length - 1) + '\n';
-      for (var r in $scope.paragraph.result.msgTable) {
-        var row = $scope.paragraph.result.msgTable[r];
+      for (var r in tableData.rows) {
+        var row = tableData.rows[r];
         var dsvRow = '';
         for (var index in row) {
-          var stringValue =  (row[index].value).toString();
+          var stringValue =  (row[index]).toString();
           if (stringValue.contains(delimiter)) {
             dsvRow += '"' + stringValue + '"' + delimiter;
           } else {
-            dsvRow += row[index].value + delimiter;
+            dsvRow += row[index] + delimiter;
           }
         }
         dsv += dsvRow.substring(0, dsvRow.length - 1) + '\n';


### PR DESCRIPTION
### What is this PR for?
Downloaded csv, tsv file contains only header of table after https://github.com/apache/zeppelin/pull/1529 is merged

### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix csv/tsv download

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1654

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

