### PR TITLE
[ZEPPELIN-1672] - Fix import note

### DIFF
--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -83,12 +83,20 @@
     vm.importNote = function() {
       $scope.note.errorText = '';
       if ($scope.note.importUrl) {
-        jQuery.getJSON($scope.note.importUrl, function(result) {
-          vm.processImportJson(result);
-        }).fail(function() {
-          $scope.note.errorText = 'Unable to Fetch URL';
-          $scope.$apply();
-        });
+        jQuery.ajax({
+          url: $scope.note.importUrl,
+          type: 'GET',
+          dataType: 'json',
+          jsonp: false,
+          xhrFields: {
+            withCredentials: false
+          },
+          error: function(xhr, ajaxOptions, thrownError) {
+            $scope.note.errorText = 'Unable to Fetch URL';
+            $scope.$apply();
+          }}).done(function(data) {
+            vm.processImportJson(data);
+          });
       } else {
         $scope.note.errorText = 'Enter URL';
         $scope.$apply();


### PR DESCRIPTION
### What is this PR for?
Importing note from github doenst work, instead you will have the following error
```
XMLHttpRequest cannot load xxxx/note.json. A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.
Origin 'http://localhost:9000' is therefore not allowed access. The credentials mode of an XMLHttpRequest is controlled by the withCredentials attribute.
```

### What type of PR is it?
[Bug Fix | Hot Fix ]

### Todos
* [x] - Rework how front end get json resource.

### What is the Jira issue?
* [ZEPPELIN-1672](https://issues.apache.org/jira/browse/ZEPPELIN-1672)

### How should this be tested?
Get a [note](https://raw.githubusercontent.com/apache/zeppelin/master/notebook/2C2AUG798/note.json) from github, and try to import it.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

