### PR TITLE
[ZEPPELIN-1013] Don't run paragraph on selectbox change

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -29,7 +29,6 @@ limitations under the License.
 
       <select class="form-control input-sm"
              ng-if="paragraph.settings.forms[formulaire.name].options && paragraph.settings.forms[formulaire.name].type != 'checkbox'"
-             ng-change="runParagraph(getEditorValue())"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
              name="{{formulaire.name}}"


### PR DESCRIPTION
### What is this PR for?
Enabling to change values of multiple selectboxes witout running the paragraph

### What type of PR is it?
[Bug Fix]

### Todos
No

### What is the Jira issue?
[ZEPPELIN-1013]

### How should this be tested?
1. Create a paragraph with  a selectbox via z.select(...)
2. Select any value other than currently selected
Actual result:   value changes and paragraph gets executed
Expected result: value changes

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No