### PR TITLE
[ZEPPELIN-1678] Improve main page notebook filter style

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -171,7 +171,8 @@ a.navbar-brand:hover {
   color: #000;
   height: 28px;
   width: 200px;
-  font: normal normal normal 14px/1 FontAwesome;
+  font-size: 14px;
+  font-family: 'Helvetica Neue', Helvetica, Arial, 'FontAwesome', sans-serif;
 }
 
 .dropdown-submenu {

--- a/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
+++ b/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
@@ -11,4 +11,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()" placeholder="&#xf002 Filter" ng-model="$parent.query.q" />
+<input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()"
+       placeholder="&#xf002 Filter" ng-model="$parent.query.q" />


### PR DESCRIPTION
### What is this PR for?

Current notebook filter has different style compared to other filters used in zeppelin. So users can feel mismatch from the main page. (I attached PNG)

<img width="313" alt="old_1" src="https://cloud.githubusercontent.com/assets/4968473/20378935/a88a1e2e-acdc-11e6-92eb-502a0fedaca7.png">
<img width="321" alt="old_2" src="https://cloud.githubusercontent.com/assets/4968473/20378937/aa14387e-acdc-11e6-87f1-c92e5ac0d1e5.png">

  <br/>
<br/>
  
Let me add some comments already included in the commit for description.

- Use common font-style which is widely used in zeppelin
- Modify inlined font css while removing some useless properties which have default value

`font-style`, `font-variant`, `font-weight` default value is already `normal`

see http://www.w3schools.com/csSref/pr_font_font.asp

### What type of PR is it?
[Improvement ]

### What is the Jira issue?

[ZEPPELIN-1678](https://issues.apache.org/jira/browse/ZEPPELIN-1678)

### How should this be tested?

See main page and navbar :)

### Screenshots (if appropriate)

After fixed (chrome, firefox, safari)

<img width="324" alt="chrome" src="https://cloud.githubusercontent.com/assets/4968473/20378955/c8c60f2c-acdc-11e6-86c2-5b1db11332a0.png">
<img width="274" alt="firefox" src="https://cloud.githubusercontent.com/assets/4968473/20378956/c9fc60bc-acdc-11e6-883b-2cf8b730b037.png">
<img width="271" alt="safari" src="https://cloud.githubusercontent.com/assets/4968473/20378958/cd9aa9d6-acdc-11e6-85c0-e3504d72d5e1.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older version s - NO?
* Does this needs documentation? - NO
