### PR TITLE
[ZEPPELIN-1681] - Fix note permission settings order

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -33,7 +33,7 @@ limitations under the License.
            as-sortable="interpreterSelectionListeners" data-ng-model="interpreterBindings">
         <div data-ng-repeat="item in interpreterBindings" as-sortable-item>
           <div>
-            <a ng-click="restartInterpreter(item)" 
+            <a ng-click="restartInterpreter(item)"
                ng-class="{'inactivelink': !item.selected}"
                tooltip="Restart">
               <span class="glyphicon glyphicon-refresh btn-md"></span>
@@ -83,17 +83,17 @@ limitations under the License.
           </select>
           Owners can change permissions,read and write the note.
         </p>
-        <p><span class="readers">Readers </span>
-          <select id="selectReaders" multiple="multiple">
-            <option ng-repeat="readers in permissions.readers" selected="selected">{{readers}}</option>
-          </select>
-            Readers can only read the note.
-        </p>
         <p><span class="writers">Writers </span>
           <select id="selectWriters" multiple="multiple">
             <option ng-repeat="writers in permissions.writers" selected="selected">{{writers}}</option>
           </select>
             Writers can read and write the note.
+        </p>
+        <p><span class="readers">Readers </span>
+          <select id="selectReaders" multiple="multiple">
+            <option ng-repeat="readers in permissions.readers" selected="selected">{{readers}}</option>
+          </select>
+            Readers can only read the note.
         </p>
       </div>
     </div>


### PR DESCRIPTION
### What is this PR for?
The list of option (Owner, Reader and Writer) doesnt look natural, it should be from the stronger to the weakest (Owner, Writer and Reader)

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-1681](https://issues.apache.org/jira/browse/ZEPPELIN-1681)

### Screenshots (if appropriate)

**Before**
<img width="611" alt="screen shot 2016-11-17 at 9 54 41 pm" src="https://cloud.githubusercontent.com/assets/3139557/20390528/b61f8c96-ad12-11e6-800d-2393459c217a.png">

**After**
<img width="611" alt="screen shot 2016-11-17 at 9 55 29 pm" src="https://cloud.githubusercontent.com/assets/3139557/20390537/bad101e8-ad12-11e6-8e1b-15873e6b93db.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

