### PR TITLE
[MINOR] Move tutorial notes under one folder

### DIFF
--- a/notebook/2A94M5J1Z/note.json
+++ b/notebook/2A94M5J1Z/note.json
@@ -334,7 +334,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial/Spark",
+  "name": "Zeppelin Tutorial/Basic Features (Spark)",
   "id": "2A94M5J1Z",
   "angularObjects": {
     "2B6FF8NNU": [],

--- a/notebook/2A94M5J1Z/note.json
+++ b/notebook/2A94M5J1Z/note.json
@@ -334,7 +334,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial",
+  "name": "Zeppelin Tutorial/Spark",
   "id": "2A94M5J1Z",
   "angularObjects": {
     "2B6FF8NNU": [],

--- a/notebook/2BWJFTXKJ/note.json
+++ b/notebook/2BWJFTXKJ/note.json
@@ -1037,7 +1037,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial/R",
+  "name": "Zeppelin Tutorial/R (SparkR)",
   "id": "2BWJFTXKJ",
   "lastReplName": {
     "value": ""

--- a/notebook/2BWJFTXKJ/note.json
+++ b/notebook/2BWJFTXKJ/note.json
@@ -1037,7 +1037,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "R Tutorial",
+  "name": "Zeppelin Tutorial/R",
   "id": "2BWJFTXKJ",
   "lastReplName": {
     "value": ""

--- a/notebook/2BYEZ5EVK/note.json
+++ b/notebook/2BYEZ5EVK/note.json
@@ -743,7 +743,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial/Mahout",
+  "name": "Zeppelin Tutorial/Using Mahout",
   "id": "2BYEZ5EVK",
   "angularObjects": {
     "2BWWSVNY7:shared_process": [],

--- a/notebook/2BYEZ5EVK/note.json
+++ b/notebook/2BYEZ5EVK/note.json
@@ -743,7 +743,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Mahout Tutorial",
+  "name": "Zeppelin Tutorial/Mahout",
   "id": "2BYEZ5EVK",
   "angularObjects": {
     "2BWWSVNY7:shared_process": [],

--- a/notebook/2C2AUG798/note.json
+++ b/notebook/2C2AUG798/note.json
@@ -669,7 +669,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial/Python - matplotlib basic",
+  "name": "Zeppelin Tutorial/Matplotlib (Python • PySpark)",
   "id": "2C2AUG798",
   "angularObjects": {
     "2BWWUCUVW:shared_process": [],

--- a/notebook/2C2AUG798/note.json
+++ b/notebook/2C2AUG798/note.json
@@ -669,7 +669,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial: Python - matplotlib basic",
+  "name": "Zeppelin Tutorial/Python - matplotlib basic",
   "id": "2C2AUG798",
   "angularObjects": {
     "2BWWUCUVW:shared_process": [],


### PR DESCRIPTION
### What is this PR for?
Change title of tutorial notes so all of them can be placed under one folder.

### What type of PR is it?
Documentation

### Screenshots (if appropriate)
Before
<img width="418" alt="screen shot 2016-11-17 at 4 01 45 pm" src="https://cloud.githubusercontent.com/assets/8503346/20394292/4d2a9060-acdf-11e6-92c6-8274134a799d.png">

After
<img width="366" alt="screen shot 2016-11-18 at 5 34 30 pm" src="https://cloud.githubusercontent.com/assets/8503346/20437718/4fc128bc-adb5-11e6-969f-0a23ac45f1e8.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

