### PR TITLE
Relative path on windows getAbsolutePath() and new URI causes excepti…

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -81,12 +81,8 @@ public class VFSNotebookRepo implements NotebookRepo {
     }
 
     if (filesystemRoot.getScheme() == null) { // it is local path
-      try {
-        this.filesystemRoot = new URI(new File(
-                conf.getRelativeDir(filesystemRoot.getPath())).getAbsolutePath());
-      } catch (URISyntaxException e) {
-        throw new IOException(e);
-      }
+      File f = new File(conf.getRelativeDir(filesystemRoot.getPath()));
+      this.filesystemRoot = f.toURI();
     }
 
     fsManager = VFS.getManager();


### PR DESCRIPTION
### What is this PR for?
Relative path on windows getAbsolutePath() and new URI causes exception and most test cases to fail. Switched to create new File() and use f.toURI() so that test cases pass on windows

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?

* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
Run zengine JUnit test cases in on windows with relative path

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
