### PR TITLE
[ZEPPELIN-1684] Add GET /interpreter/setting/id REST API

### DIFF
--- a/docs/rest-api/rest-interpreter.md
+++ b/docs/rest-api/rest-interpreter.md
@@ -178,6 +178,65 @@ The role of registered interpreters, settings and interpreters group are describ
       </td>
     </tr>
   </table>
+  
+<br/>
+### Get a registered interpreter setting by the setting id 
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns a registered interpreter setting on the server.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/setting/[setting ID]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>
+          400 if such interpreter setting id does not exist <br/>
+          500 for any other errors
+      </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+    "id": "2AYW25ANY",
+    "name": "Markdown setting name",
+    "group": "md",
+    "properties": {
+      "propname": "propvalue"
+    },
+    "interpreterGroup": [
+      {
+        "class": "org.apache.zeppelin.markdown.Markdown",
+        "name": "md"
+      }
+    ],
+    "dependencies": [
+      {
+        "groupArtifactVersion": "groupId:artifactId:version",
+        "exclusions": [
+          "groupId:artifactId"
+        ]
+      }
+    ]
+  }
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
 
 <br/>
 ### Create a new interpreter setting  

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -80,7 +80,6 @@ public class InterpreterRestApi {
     return new JsonResponse<>(Status.OK, "", interpreterFactory.get()).build();
   }
 
-
   /**
    * Get a setting
    */
@@ -95,10 +94,10 @@ public class InterpreterRestApi {
       } else {
         return new JsonResponse<>(Status.OK, "", setting).build();
       }
-    } catch (NullPointerException e){
+    } catch (NullPointerException e) {
       logger.error("Exception in InterpreterRestApi while creating ", e);
       return new JsonResponse<>(Status.INTERNAL_SERVER_ERROR, e.getMessage(),
-          ExceptionUtils.getStackTrace(e)) .build();
+          ExceptionUtils.getStackTrace(e)).build();
     }
   }
 
@@ -231,7 +230,7 @@ public class InterpreterRestApi {
     try {
       Repository request = gson.fromJson(message, Repository.class);
       interpreterFactory.addRepository(request.getId(), request.getUrl(), request.isSnapshot(),
-        request.getAuthentication(), request.getProxy());
+          request.getAuthentication(), request.getProxy());
       logger.info("New repository {} added", request.getId());
     } catch (Exception e) {
       logger.error("Exception in InterpreterRestApi while adding repository ", e);
@@ -247,7 +246,7 @@ public class InterpreterRestApi {
   @GET
   @Path("getmetainfos/{settingId}")
   public Response getMetaInfo(@Context HttpServletRequest req,
-      @PathParam("settingId") String settingId) {
+                              @PathParam("settingId") String settingId) {
     String propName = req.getParameter("propName");
     if (propName == null) {
       return new JsonResponse<>(Status.BAD_REQUEST).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -80,6 +80,28 @@ public class InterpreterRestApi {
     return new JsonResponse<>(Status.OK, "", interpreterFactory.get()).build();
   }
 
+
+  /**
+   * Get a setting
+   */
+  @GET
+  @Path("setting/{settingId}")
+  @ZeppelinApi
+  public Response getSetting(@PathParam("settingId") String settingId) {
+    try {
+      InterpreterSetting setting = interpreterFactory.get(settingId);
+      if (setting == null) {
+        return new JsonResponse<>(Status.NOT_FOUND).build();
+      } else {
+        return new JsonResponse<>(Status.OK, "", setting).build();
+      }
+    } catch (NullPointerException e){
+      logger.error("Exception in InterpreterRestApi while creating ", e);
+      return new JsonResponse<>(Status.INTERNAL_SERVER_ERROR, e.getMessage(),
+          ExceptionUtils.getStackTrace(e)) .build();
+    }
+  }
+
   /**
    * Add new interpreter setting
    *

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -294,6 +294,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
     JsonObject response = gson.fromJson(rawResponse, JsonElement.class).getAsJsonObject();
     return response.getAsJsonObject("body");
   }
+
   public JsonArray getArrayBodyFieldFromResponse(String rawResponse) {
     JsonObject response = gson.fromJson(rawResponse, JsonElement.class).getAsJsonObject();
     return response.getAsJsonArray("body");


### PR DESCRIPTION
### What is this PR for?

Due to the lack of this missing API, some front-end code retrieve all settings. This is inefficient. 
We can modify those codes by adding this API.

Also, i refactored the whole `InterpreterRestApiTest`

### What type of PR is it?
[Feature | Documentation | Refactoring]

### What is the Jira issue?
[ZEPPELIN-1684](https://issues.apache.org/jira/browse/ZEPPELIN-1684)

### How should this be tested?

You can run unit test `InterpreterRestApiTest`

### Screenshots (if appropriate)

Updated doc screenshots

<img width="900" alt="new_api_doc" src="https://cloud.githubusercontent.com/assets/4968473/20423419/74eeb2a0-adb3-11e6-9a69-58e33457d514.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - YES, but done.

