### PR TITLE
Fix Yarn configuration of Spark2.0

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -319,6 +319,7 @@ public class SparkInterpreter extends Interpreter {
 
     conf.set("spark.scheduler.mode", "FAIR");
     conf.setMaster(getProperty("master"));
+    conf.set("master", "yarn");
     conf.set("spark.submit.deployMode", "client");
 
     Properties intpProperty = getProperty();

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -319,7 +319,6 @@ public class SparkInterpreter extends Interpreter {
 
     conf.set("spark.scheduler.mode", "FAIR");
     conf.setMaster(getProperty("master"));
-    conf.set("master", "yarn");
     conf.set("spark.submit.deployMode", "client");
 
     Properties intpProperty = getProperty();

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -296,6 +296,10 @@ public class SparkInterpreter extends Interpreter {
     return (DepInterpreter) p;
   }
 
+  private boolean isYarnMode() {
+    return getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn");
+  }
+
   /**
    * Spark 2.x
    * Create SparkSession
@@ -319,8 +323,10 @@ public class SparkInterpreter extends Interpreter {
 
     conf.set("spark.scheduler.mode", "FAIR");
     conf.setMaster(getProperty("master"));
-    conf.set("master", "yarn");
-    conf.set("spark.submit.deployMode", "client");
+    if (isYarnMode()) {
+      conf.set("master", "yarn");
+      conf.set("spark.submit.deployMode", "client");
+    }
 
     Properties intpProperty = getProperty();
 
@@ -512,7 +518,7 @@ public class SparkInterpreter extends Interpreter {
 
     // Distributes needed libraries to workers
     // when spark version is greater than or equal to 1.5.0
-    if (getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn")) {
+    if (isYarnMode()) {
       conf.set("spark.yarn.isPython", "true");
     }
   }
@@ -561,7 +567,7 @@ public class SparkInterpreter extends Interpreter {
   @Override
   public void open() {
     // set properties and do login before creating any spark stuff for secured cluster
-    if (getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn")) {
+    if (isYarnMode()) {
       System.setProperty("SPARK_YARN_MODE", "true");
     }
     if (getProperty().containsKey("spark.yarn.keytab") &&

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -319,6 +319,8 @@ public class SparkInterpreter extends Interpreter {
 
     conf.set("spark.scheduler.mode", "FAIR");
     conf.setMaster(getProperty("master"));
+    conf.set("master", "yarn");
+    conf.set("spark.submit.deployMode", "client");
 
     Properties intpProperty = getProperty();
 
@@ -510,7 +512,7 @@ public class SparkInterpreter extends Interpreter {
 
     // Distributes needed libraries to workers
     // when spark version is greater than or equal to 1.5.0
-    if (getProperty("master").equals("yarn-client")) {
+    if (getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn")) {
       conf.set("spark.yarn.isPython", "true");
     }
   }
@@ -559,7 +561,7 @@ public class SparkInterpreter extends Interpreter {
   @Override
   public void open() {
     // set properties and do login before creating any spark stuff for secured cluster
-    if (getProperty("master").equals("yarn-client")) {
+    if (getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn")) {
       System.setProperty("SPARK_YARN_MODE", "true");
     }
     if (getProperty().containsKey("spark.yarn.keytab") &&

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -297,7 +297,7 @@ public class SparkInterpreter extends Interpreter {
   }
 
   private boolean isYarnMode() {
-    return getProperty("master").equals("yarn-client") || getProperty("master").equals("yarn");
+    return getProperty("master").startsWith("yarn");
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
`yarn-client` is deprecated since Spark 2.0, so SparkInterpreter also support `yarn` as `application master`.

### What type of PR is it?
Bug Fix | Improvement

### How should this be tested?
Run spark paragraph with Spark2.0 + yarn.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
