### PR TITLE
[ZEPPELIN-1623] Fix flaky test - ParagraphActionsIT.testEditOnDoubleClick

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -439,7 +439,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       Actions action = new Actions(driver);
 
       waitForParagraph(1, "READY");
-
+      pollingWait(By.xpath(getParagraphXPath(1) + "//textarea"), MAX_PARAGRAPH_TIMEOUT_SEC);
       driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "5");
       driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys("md" + Keys.ENTER);
       driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "3");


### PR DESCRIPTION
### What is this PR for?
Fix flaky test - ParagraphActionsIT.testEditOnDoubleClick

Before send the keyevent, make sure textarea is displayed.

### What type of PR is it?
Bug Fix

### Todos
* [x] - wait for textarea ready

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1623

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

