### PR TITLE
[ZEPPELIN-1605] zeppelin-interpreter: don't publish shaded JAR on maven central

### DIFF
--- a/bin/interpreter.cmd
+++ b/bin/interpreter.cmd
@@ -39,11 +39,6 @@ call "%bin%\common.cmd"
 
 if exist "%ZEPPELIN_HOME%\zeppelin-interpreter\target\classes" (
     set ZEPPELIN_CLASSPATH=%ZEPPELIN_CLASSPATH%;"%ZEPPELIN_HOME%\zeppelin-interpreter\target\classes"
-) else (
-    for %%d in ("%ZEPPELIN_HOME%\lib\zeppelin-interpreter*.jar") do (
-        set ZEPPELIN_INTERPRETER_JAR=%%d
-    )
-    set ZEPPELIN_CLASSPATH=%ZEPPELIN_CLASSPATH%;"!ZEPPELIN_INTERPRETER_JAR!"
 )
 
 REM add test classes for unittest
@@ -55,6 +50,7 @@ if exist "%ZEPPELIN_HOME%\zeppelin-zengine\target\test-classes" (
 )
 
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\zeppelin-interpreter\target\lib"
+call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\lib\interpreter"
 call "%bin%\functions.cmd" ADDJARINDIR "%INTERPRETER_DIR%"
 
 set HOSTNAME=%COMPUTERNAME%

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -66,9 +66,6 @@ ZEPPELIN_INTP_CLASSPATH=""
 # construct classpath
 if [[ -d "${ZEPPELIN_HOME}/zeppelin-interpreter/target/classes" ]]; then
   ZEPPELIN_INTP_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-interpreter/target/classes"
-else
-  ZEPPELIN_INTERPRETER_JAR="$(ls ${ZEPPELIN_HOME}/lib/zeppelin-interpreter*.jar)"
-  ZEPPELIN_INTP_CLASSPATH+=":${ZEPPELIN_INTERPRETER_JAR}"
 fi
 
 # add test classes for unittest
@@ -79,8 +76,8 @@ if [[ -d "${ZEPPELIN_HOME}/zeppelin-zengine/target/test-classes" ]]; then
   ZEPPELIN_INTP_CLASSPATH+=":${ZEPPELIN_HOME}/zeppelin-zengine/target/test-classes"
 fi
 
-
 addJarInDirForIntp "${ZEPPELIN_HOME}/zeppelin-interpreter/target/lib"
+addJarInDirForIntp "${ZEPPELIN_HOME}/lib/interpreter"
 addJarInDirForIntp "${INTERPRETER_DIR}"
 
 HOSTNAME=$(hostname)

--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -72,6 +72,7 @@ fi
 
 addJarInDir "${ZEPPELIN_HOME}"
 addJarInDir "${ZEPPELIN_HOME}/lib"
+addJarInDir "${ZEPPELIN_HOME}/lib/interpreter"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-interpreter/target/lib"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-zengine/target/lib"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-server/target/lib"

--- a/bin/zeppelin.cmd
+++ b/bin/zeppelin.cmd
@@ -56,6 +56,7 @@ if exist "%ZEPPELIN_HOME%\zeppelin-server\target\classes" (
 
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%"
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\lib"
+call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\lib\interpreter"
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\zeppelin-interpreter\target\lib"
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\zeppelin-zengine\target\lib"
 call "%bin%\functions.cmd" ADDJARINDIR "%ZEPPELIN_HOME%\zeppelin-server\target\lib"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -65,6 +65,7 @@ fi
 
 addJarInDir "${ZEPPELIN_HOME}"
 addJarInDir "${ZEPPELIN_HOME}/lib"
+addJarInDir "${ZEPPELIN_HOME}/lib/interpreter"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-interpreter/target/lib"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-zengine/target/lib"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-server/target/lib"

--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -33,17 +33,25 @@
       <useAllReactorProjects>true</useAllReactorProjects> -->
       <!-- Now, select which projects to include in this module-set. -->
       <includes>
-        <include>org.apache.zeppelin:zeppelin-web</include>
+        <include>${project.groupId}:zeppelin-web</include>
       </includes>
       <useProjectArtifact>false</useProjectArtifact>
       <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>
     <dependencySet>
+      <outputDirectory>/lib/interpreter</outputDirectory>
+      <includes>
+        <include>${project.groupId}:zeppelin-interpreter</include>
+      </includes>
+    </dependencySet>
+    <dependencySet>
       <outputDirectory>/lib</outputDirectory>
-      <useProjectArtifact>false</useProjectArtifact>
       <excludes>
+        <exclude>${project.groupId}:zeppelin-interpreter</exclude>
         <exclude>${project.groupId}:zeppelin-web</exclude>
       </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
     </dependencySet>
   </dependencySets>
 
@@ -68,7 +76,10 @@
     <fileSet>
       <directory>../conf</directory>
       <excludes>
+        <exclude>credentials.json</exclude>
         <exclude>interpreter.json</exclude>
+        <exclude>notebook-authorization.json</exclude>
+        <exclude>shiro.ini</exclude>
         <exclude>zeppelin-env.cmd</exclude>
         <exclude>zeppelin-env.sh</exclude>
         <exclude>zeppelin-site.xml</exclude>
@@ -80,15 +91,9 @@
     <fileSet>
       <directory>../notebook</directory>
     </fileSet>
-  </fileSets>
-    <!--<fileSet>
-      <directory>zeppelin-cli/target</directory>
-      <outputDirectory></outputDirectory>
-      <includes>
-        <include>*.jar</include>
-        <include>lib/*.jar</include>
-      </includes>
+    <fileSet>
+      <outputDirectory>/lib/interpreter</outputDirectory>
+      <directory>../zeppelin-interpreter/target/lib</directory>
     </fileSet>
-  </fileSets>-->
-
+  </fileSets>
 </assembly>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -210,8 +210,6 @@
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
       <version>${wagon.version}</version>
-      <exclusions>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -226,41 +224,5 @@
       <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
-        <configuration>
-          <artifactSet>
-            <includes>
-              <include>*:*</include>
-            </includes>
-          </artifactSet>
-          <filters>
-            <filter>
-              <artifact>*:*</artifact>
-              <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
-              </excludes>
-            </filter>
-          </filters>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -87,19 +87,25 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
       <version>${commons.vfs2.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
       <version>${jackrabbit.webdav.version}</version>
-       <exclusions>
-         <exclusion>
-           <groupId>org.apache.httpcomponents</groupId>
-           <artifactId>httpclient</artifactId>
-         </exclusion>
-       </exclusions>
-     </dependency>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-httpclient</groupId>
+          <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### What is this PR for?
* Instead of creating fat jar for zeppelin-interpreter and add it to classpath, place zeppelin-interpreter.jar and dependencies under `lib/interpreter` directory and add this dir to classpath of zeppelin-server and interpreter. (removed maven-shade-plugin)
* Exclude some transitive dependencies from `zeppelin-zengine` which cause conflicts with those of `zeppelin-interpreter`
* Exclude configuration files(`credential.json`, `notebook-authorization.json`, `shiro.ini`) when create binary package.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1605](https://issues.apache.org/jira/browse/ZEPPELIN-1605)

### How should this be tested?
1. Check if `interpreter` directory has created under `zeppelin-distribution/target/zeppelin-0.7.0-SNAPSHOT/zeppelin-0.7.0-SNAPSHOT/`
2. Test `md` interpreter works as expected after running below command:
```
$ mvn clean package -DskipTests -Pbuild-distr
$ cd zeppelin-distribution/target/zeppelin-0.7.0-SNAPSHOT/zeppelin-0.7.0-SNAPSHOT
$ ./bin/zeppelin-daemon.sh start
```
3. Check if md intepreter process has `zeppelin-distribution/target/zeppelin-0.7.0-SNAPSHOT/zeppelin-0.7.0-SNAPSHOT/lib/interpreter/*` in it's classpath.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
