### PR TITLE
[ZEPPELIN-1694] Show result when editor language changed from markup to another

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -848,7 +848,7 @@
     };
 
     var getInterpreterName = function(paragraphText) {
-      var intpNameRegexp = /%(.+?)\s/g;
+      var intpNameRegexp = /^\s*%(.+?)\s/g;
       var match = intpNameRegexp.exec(paragraphText);
       if (match) {
         return match[1].trim();


### PR DESCRIPTION
### What is this PR for?
* Show result when editor language changed from markup to another
* Fix syntax highlight bug when paragraph contains String `%something` in the middle of contents in case the default repl name(`%spark`) is not specified at the beginning of paragraph.
* Save `editOnDblClick` field in note.json so it can be applied after reloading page.

### What type of PR is it?
Bug Fix | Improvement

### What is the Jira issue?
[ZEPPELIN-1694](https://issues.apache.org/jira/browse/ZEPPELIN-1694)

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
**Show result after repl change**
Before
![nov-21-2016 17-21-17](https://cloud.githubusercontent.com/assets/8503346/20490686/1479aba6-b00f-11e6-9376-0d3e1df484b1.gif)

After
![nov-21-2016 17-21-28](https://cloud.githubusercontent.com/assets/8503346/20490690/17d1c3d8-b00f-11e6-9d5f-7217b74044ae.gif)


**Fix highlight bug**
Before
<img width="324" alt="screen shot 2016-11-21 at 5 14 23 pm" src="https://cloud.githubusercontent.com/assets/8503346/20490467/694e522c-b00e-11e6-984e-611d0a7ff4a5.png">

After
<img width="332" alt="screen shot 2016-11-21 at 5 12 00 pm" src="https://cloud.githubusercontent.com/assets/8503346/20490472/6d00ee2a-b00e-11e6-9908-8f7b8a0f42f0.png">

**Fix edit on double click bug after refresh**
Before
![nov-21-2016 17-25-13](https://cloud.githubusercontent.com/assets/8503346/20490833/916d7f20-b00f-11e6-992a-7b9946898e30.gif)

After
![nov-21-2016 17-25-44](https://cloud.githubusercontent.com/assets/8503346/20490838/95fe9682-b00f-11e6-96a4-40b67e859267.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
