### PR TITLE
[ZEPPELIN-1623] Fix flaky test - testEditOnDoubleClick

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -439,9 +439,10 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       Actions action = new Actions(driver);
 
       waitForParagraph(1, "READY");
-      pollingWait(By.xpath(getParagraphXPath(1) + "//textarea"), MAX_PARAGRAPH_TIMEOUT_SEC);
-      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "5");
-      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys("md" + Keys.ENTER);
+
+      setTextOfParagraph(1, "%md");
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.ARROW_RIGHT);
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.ENTER);
       driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(Keys.SHIFT + "3");
       driver.findElement(By.xpath(getParagraphXPath(1) + "//textarea")).sendKeys(" abc");
 


### PR DESCRIPTION
### What is this PR for?
#1657 is merged, but CI failure still exists on master. Check [this link](https://issues.apache.org/jira/browse/ZEPPELIN-1623) to see the test failure.
I will trigger this PR 5 times and attach CI link on comments if all of them pass to be sure that the issue is gone.

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1623](https://issues.apache.org/jira/browse/ZEPPELIN-1623)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

