### PR TITLE
[ZEPPELIN-1695] Centralize libs, plugin versions in all pom.xml

### DIFF
--- a/alluxio/pom.xml
+++ b/alluxio/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <alluxio.version>1.0.0</alluxio.version>
         <powermock.version>1.6.1</powermock.version>
+        <mockito.version>1.10.8</mockito.version>
     </properties>
     <dependencies>
         <dependency>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.10.8</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -133,7 +134,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -144,7 +144,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -61,8 +61,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -72,7 +71,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -36,13 +36,18 @@
     <beam.hadoop.version>2.3.0</beam.hadoop.version>
     <beam.spark.version>1.6.2</beam.spark.version>
     <beam.beam.version>0.2.0-incubating</beam.beam.version>
+
+    <!-- library versions -->
+    <netty.version>4.1.1.Final</netty.version>
+    <servlet.api.version>3.1.0</servlet.api.version>
+    <commons.exec.version>1.3</commons.exec.version>
   </properties>
   
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.1.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     
     <dependency>
@@ -185,7 +190,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <version>${servlet.api.version}</version>
     </dependency>
   
     <dependency>
@@ -217,7 +222,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>${commons.exec.version}</version>
     </dependency>
   
     <dependency>

--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -233,7 +233,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -241,7 +240,6 @@
   
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -252,7 +250,6 @@
   
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -32,12 +32,23 @@
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: BigQuery interpreter</name>
 
+  <properties>
+    <project.http.version>1.21.0</project.http.version>
+    <project.oauth.version>1.21.0</project.oauth.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <bigquery.test.exclude>**/BigQueryInterpreterTest.java</bigquery.test.exclude>
+
+    <!-- library versions -->
+    <bigquery.api.version>v2-rev265-1.21.0</bigquery.api.version>
+    <gson.version>2.6</gson.version>
+  </properties>
+
   <dependencies>
 
     <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-bigquery</artifactId>
-        <version>v2-rev265-1.21.0</version>
+        <version>${bigquery.api.version}</version>
     </dependency>
     <dependency>
         <groupId>com.google.oauth-client</groupId>
@@ -57,7 +68,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.6</version>
+      <version>${gson.version}</version>
     </dependency>
 
     <dependency>
@@ -84,18 +95,10 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <project.http.version>1.21.0</project.http.version>
-    <project.oauth.version>1.21.0</project.oauth.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <bigquery.test.exclude>**/BigQueryInterpreterTest.java</bigquery.test.exclude>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -116,7 +119,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -41,11 +41,17 @@
         <scalate.version>1.7.1</scalate.version>
         <cassandra.guava.version>16.0.1</cassandra.guava.version>
 
-        <!--TEST-->
+        <!-- test library versions -->
         <junit.version>4.12</junit.version>
         <achilles.version>3.2.4-Zeppelin</achilles.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.9.5</mockito.version>
+        <jna.version>4.2.0</jna.version>
+
+        <!-- plugin versions -->
+        <plugin.scala.version>2.15.2</plugin.scala.version>
+        <plugin.scalatest.version>1.0</plugin.scalatest.version>
+        <plugin.scalate.version>1.7.1</plugin.scalate.version>
     </properties>
 
     <dependencies>
@@ -116,7 +122,7 @@
             <version>${scalate.version}</version>
         </dependency>
 
-        <!--TEST-->
+        <!-- test libraries -->
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
@@ -134,7 +140,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.2.0</version>
+            <version>${jna.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -180,7 +186,7 @@
             <plugin>
                 <groupId>org.scala-tools</groupId>
                 <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
+                <version>${plugin.scala.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -208,7 +214,7 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>${plugin.scalatest.version}</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -222,7 +228,7 @@
             <plugin>
                 <groupId>org.scalatra.scalate</groupId>
                 <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
-                <version>1.7.1</version>
+                <version>${plugin.scalate.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -240,7 +246,6 @@
 
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -251,7 +256,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -80,8 +80,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -91,7 +90,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -31,6 +31,15 @@
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: File System Interpreters</name>
 
+  <properties>
+    <!--library versions-->
+    <ws.rsapi.version>2.0</ws.rsapi.version>
+    <jersey.common.version>2.22.2</jersey.common.version>
+
+    <!--plugin versions-->
+    <plugin.surefire.version>2.18.1</plugin.surefire.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
@@ -42,7 +51,7 @@
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0</version>
+      <version>${ws.rsapi.version}</version>
     </dependency>
 
     <dependency>
@@ -58,9 +67,8 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
-      <version>2.22.2</version>
+      <version>${jersey.common.version}</version>
     </dependency>
-
 
     <dependency>
       <groupId>junit</groupId>
@@ -74,13 +82,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>${plugin.surefire.version}</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -90,7 +97,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -34,9 +34,16 @@
   <description>Zeppelin flink support</description>
 
   <properties>
+    <!--library versions-->
     <flink.version>1.1.3</flink.version>
     <flink.akka.version>2.3.7</flink.akka.version>
     <scala.macros.version>2.0.1</scala.macros.version>
+
+    <!--plugin versions-->
+    <plugin.scalamaven.version>3.2.2</plugin.scalamaven.version>
+    <plugin.eclipse.version>2.8</plugin.eclipse.version>
+    <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
+    <plugin.scalastyle.version>0.5.0</plugin.scalastyle.version>
   </properties>
 
   <dependencies>
@@ -148,7 +155,7 @@
       <plugin>
 	<groupId>net.alchim31.maven</groupId>
 	<artifactId>scala-maven-plugin</artifactId>
-	<version>3.2.2</version>
+	<version>${plugin.scalamaven.version}</version>
 	<executions>
 	  <!-- Run scala compiler in the process-resources phase, so that dependencies on
 	       scala classes can be resolved later in the (Java) compile phase -->
@@ -189,7 +196,7 @@
       <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
 	<artifactId>maven-eclipse-plugin</artifactId>
-	<version>2.8</version>
+	<version>${plugin.eclipse.version}</version>
 	<configuration>
 	  <downloadSources>true</downloadSources>
 	  <projectnatures>
@@ -218,7 +225,7 @@
       <plugin>
 	<groupId>org.codehaus.mojo</groupId>
 	<artifactId>build-helper-maven-plugin</artifactId>
-	<version>1.7</version>
+	<version>${plugin.buildhelper.version}</version>
 	<executions>
 	  <!-- Add src/main/scala to eclipse build path -->
 	  <execution>
@@ -252,7 +259,7 @@
       <plugin>
 	<groupId>org.scalastyle</groupId>
 	<artifactId>scalastyle-maven-plugin</artifactId>
-	<version>0.5.0</version>
+	<version>${plugin.scalastyle.version}</version>
 	<executions>
 	  <execution>
 	    <goals>
@@ -275,7 +282,6 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -287,7 +293,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -33,7 +33,12 @@
   <name>Zeppelin: Apache Geode interpreter</name>
 
   <properties>
+    <!--library versions-->
     <geode.version>1.0.0-incubating-SNAPSHOT</geode.version>
+    <commons.exec.version>1.3</commons.exec.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.5</mockito.all.version>
   </properties>
 
   <dependencies>
@@ -53,7 +58,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>${commons.exec.version}</version>
     </dependency>
 
     <dependency>
@@ -75,7 +80,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -85,7 +90,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -96,7 +100,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -32,10 +32,16 @@
   <name>Zeppelin: HBase interpreter</name>
 
   <properties>
+    <!--library versions-->
     <hbase.hbase.version>1.0.0</hbase.hbase.version>
     <hbase.hadoop.version>2.6.0</hbase.hadoop.version>
     <jruby.version>1.6.8</jruby.version>
     <protobuf.version>2.5.0</protobuf.version>
+    <commons.exec.version>1.1</commons.exec.version>
+    <jline.version>2.12.1</jline.version>
+
+    <!--test library versions-->
+    <hamcrest.all.version>1.3</hamcrest.all.version>
   </properties>
 
   <dependencies>
@@ -49,19 +55,18 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.1</version>
+      <version>${commons.exec.version}</version>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.all.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -102,7 +107,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.12.1</version>
+      <version>${jline.version}</version>
     </dependency>
   </dependencies>
 
@@ -110,7 +115,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -121,7 +125,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -106,8 +106,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -33,7 +33,16 @@
   <name>Zeppelin: JDBC interpreter</name>
   
   <properties>
+    <!--library versions-->
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
+    <jline.version>2.12.1</jline.version>
+    <hadoop.common.version>2.7.2</hadoop.common.version>
+    <h2.version>1.4.190</h2.version>
+    <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.5</mockito.all.version>
+    <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
   </properties>
   
   <dependencies>
@@ -68,14 +77,27 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.12.1</version>
+      <version>${jline.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.7.2</version>
+      <version>${hadoop.common.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${h2.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>${commons.dbcp2.version}</version>
     </dependency>
 
     <dependency>
@@ -83,32 +105,19 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>1.4.190</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.mockrunner</groupId>
       <artifactId>mockrunner-jdbc</artifactId>
-      <version>1.0.8</version>
+      <version>${mockrunner.jdbc.version}</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
-      <version>2.0.1</version>
     </dependency>
   </dependencies>
 
@@ -116,7 +125,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -127,7 +135,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -34,6 +34,7 @@
     <name>Zeppelin: Kylin interpreter</name>
 
     <dependencies>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>zeppelin-interpreter</artifactId>
@@ -41,27 +42,25 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.5</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -72,7 +71,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -33,9 +33,14 @@
   <name>Zeppelin: Lens interpreter</name>
   
   <properties>
+    <!--library versions-->
     <lens.version>2.5.0-beta</lens.version>
     <spring-shell.version>1.1.0.RELEASE</spring-shell.version>
     <hadoop-common.version>2.4.0</hadoop-common.version>
+    <checkerframework.jdk7.version>1.9.1</checkerframework.jdk7.version>
+    <jackson.asl.version>1.9.13</jackson.asl.version>
+    <jackson.version>1.9.11</jackson.version>
+    <jersey.core.version>2.3.1</jersey.core.version>
   </properties>
 
   <dependencies>
@@ -59,7 +64,7 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>jdk7</artifactId>
-      <version>1.9.1</version>
+      <version>${checkerframework.jdk7.version}</version>
     </dependency>
 
     <dependency>
@@ -87,37 +92,37 @@
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
+     <version>${jackson.asl.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
+      <version>${jackson.asl.version}</version>
     </dependency>
       
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-xc</artifactId>
-      <version>1.9.11</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-jaxrs</artifactId>
-      <version>1.9.11</version>
+      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.3.1</version>
+      <version>${jersey.core.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.3.1</version>
+      <version>${jersey.core.version}</version>
     </dependency>
 
     <dependency>
@@ -151,14 +156,14 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -168,7 +173,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -212,7 +216,6 @@
 	<plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.4.1</version>
           <configuration>
             <filesets>
               <fileset>

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -35,7 +35,13 @@
     <name>Zeppelin: Livy interpreter</name>
 
     <properties>
-        <!--TEST-->
+        <!--library versions-->
+        <commons.exec.version>1.3</commons.exec.version>
+        <httpcomponents.client.version>4.3.4</httpcomponents.client.version>
+        <spring.web.version>4.3.0.RELEASE</spring.web.version>
+        <spring.security.kerberosclient>1.0.1.RELEASE</spring.security.kerberosclient>
+
+        <!--test library versions-->
         <junit.version>4.12</junit.version>
         <achilles.version>3.2.4-Zeppelin</achilles.version>
         <assertj.version>1.7.0</assertj.version>
@@ -43,6 +49,10 @@
         <livy.version>0.2.0</livy.version>
         <spark.version>1.5.2</spark.version>
         <hadoop.version>2.6.0</hadoop.version>
+
+        <!--plugin versions-->
+        <plugin.failsafe.version>2.16</plugin.failsafe.version>
+        <plugin.antrun.version>1.8</plugin.antrun.version>
     </properties>
 
     <dependencies>
@@ -56,7 +66,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
+            <version>${commons.exec.version}</version>
         </dependency>
 
         <dependency>
@@ -72,12 +82,24 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>${httpcomponents.client.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security.kerberos</groupId>
+            <artifactId>spring-security-kerberos-client</artifactId>
+            <version>${spring.security.kerberosclient}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>${spring.web.version}</version>
         </dependency>
 
         <dependency>
@@ -97,16 +119,6 @@
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security.kerberos</groupId>
-            <artifactId>spring-security-kerberos-client</artifactId>
-            <version>1.0.1.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>4.3.0.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -287,7 +299,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
-            <version>2.6.0</version>
+            <version>${hadoop.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -345,7 +357,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -356,7 +367,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -401,7 +411,7 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
+                <version>${plugin.failsafe.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -421,7 +431,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+                <version>${plugin.antrun.version}</version>
                 <executions>
                     <!-- Cleans up files that tests append to (because we have two test plugins). -->
                     <execution>

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -32,6 +32,11 @@
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Markdown interpreter</name>
 
+  <properties>
+    <markdown4j.version>2.2-cj-1.0</markdown4j.version>
+    <pegdown.version>1.6.0</pegdown.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -46,22 +51,22 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.commonjava.googlecode.markdown4j</groupId>
       <artifactId>markdown4j</artifactId>
-      <version>2.2-cj-1.0</version>
+      <version>${markdown4j.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.pegdown</groupId>
       <artifactId>pegdown</artifactId>
-      <version>1.6.0</version>
+      <version>${pegdown.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -73,8 +78,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -84,7 +88,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -50,13 +50,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.pig</groupId>
-            <artifactId>pig</artifactId>
-            <classifier>h2</classifier>
-            <version>${pig.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -64,6 +57,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.pig</groupId>
+            <artifactId>pig</artifactId>
+            <classifier>h2</classifier>
+            <version>${pig.version}</version>
         </dependency>
 
         <dependency>
@@ -126,7 +126,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -137,7 +136,6 @@
 
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -671,12 +671,14 @@
       <build>
         <pluginManagement>
           <plugins>
+
             <plugin>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
                 <skipTests>true</skipTests>
               </configuration>
             </plugin>
+
             <plugin>
               <artifactId>maven-assembly-plugin</artifactId>
               <executions>
@@ -689,6 +691,7 @@
                 </execution>
               </executions>
             </plugin>
+
           </plugins>
         </pluginManagement>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${plugin.dependency.version}</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -82,17 +82,46 @@
   </modules>
 
   <properties>
+    <!-- language versions -->
     <scala.version>2.10.5</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 
+    <!-- common library versions -->
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <libthrift.version>0.9.2</libthrift.version>
     <gson.version>2.2</gson.version>
     <guava.version>15.0</guava.version>
     <jetty.version>9.2.15.v20160210</jetty.version>
+    <httpcomponents.core.version>4.3.3</httpcomponents.core.version>
+    <httpcomponents.client.version>4.3.6</httpcomponents.client.version>
+    <commons.lang.version>2.5</commons.lang.version>
+    <commons.configuration.version>1.9</commons.configuration.version>
+    <commons.codec.version>1.5</commons.codec.version>
+    <commons.io.version>2.4</commons.io.version>
+    <commons.collections.version>3.2.1</commons.collections.version>
+    <commons.logging.version>1.1.1</commons.logging.version>
+    <junit.version>4.11</junit.version>
+    <shiro.version>1.2.3</shiro.version>
+
+    <!-- plugin versions -->
+    <plugin.compiler.version>3.1</plugin.compiler.version>
+    <plugin.resource.version>2.7</plugin.resource.version>
+    <plugin.dependency.version>2.8</plugin.dependency.version>
+    <plugin.jar.version>2.4</plugin.jar.version>
+    <plugin.remote.resource.version>1.5</plugin.remote.resource.version>
+    <plugin.scm.version>1.8.1</plugin.scm.version>
+    <plugin.enforcer.version>1.3.1</plugin.enforcer.version>
+    <plugin.checkstyle.version>2.13</plugin.checkstyle.version>
+    <plugin.surefire.version>2.17</plugin.surefire.version>
+    <plugin.assembly.version>3.0.0</plugin.assembly.version>
+    <plugin.exec.version>1.2.1</plugin.exec.version>
+    <plugin.cobertura.version>2.7</plugin.cobertura.version>
+    <plugin.clean.version>2.6.1</plugin.clean.version>
+    <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
+    <plugin.antrun.version>1.7</plugin.antrun.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
@@ -128,19 +157,19 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.3.3</version>
+        <version>${httpcomponents.core.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.6</version>
+        <version>${httpcomponents.client.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.5</version>
+        <version>${commons.lang.version}</version>
       </dependency>
 
       <dependency>
@@ -152,31 +181,31 @@
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>1.9</version>
+        <version>${commons.configuration.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.5</version>
+        <version>${commons.codec.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>${commons.io.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>${commons.collections.version}</version>
       </dependency>
 
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.1</version>
+        <version>${commons.logging.version}</version>
       </dependency>
 
       <dependency>
@@ -188,7 +217,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -196,17 +225,17 @@
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-core</artifactId>
-        <version>1.2.3</version>
+        <version>${shiro.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-web</artifactId>
-        <version>1.2.3</version>
+        <version>${shiro.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-config-core</artifactId>
-        <version>1.2.3</version>
+        <version>${shiro.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -215,7 +244,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>${plugin.compiler.version}</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -244,7 +273,6 @@
         </executions>
       </plugin>
 
-      <!-- Checkstyle plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -279,7 +307,7 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
+        <version>${plugin.resource.version}</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -305,7 +333,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
+        <version>${plugin.dependency.version}</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -326,7 +354,7 @@
 
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
+        <version>${plugin.jar.version}</version>
         <configuration>
           <archive>
             <manifest>
@@ -340,7 +368,7 @@
 
       <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>1.5</version>
+        <version>${plugin.remote.resource.version}</version>
         <executions>
           <execution>
             <id>process-remote-resources</id>
@@ -358,7 +386,7 @@
 
       <plugin>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.8.1</version>
+        <version>${plugin.scm.version}</version>
         <configuration>
           <connectionType>developerConnection</connectionType>
           <scmVersion>branch-0.1</scmVersion>
@@ -368,7 +396,7 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
+        <version>${plugin.enforcer.version}</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -416,18 +444,18 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.13</version>
+          <version>${plugin.checkstyle.version}</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>${plugin.dependency.version}</version>
         </plugin>
 
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
-          <configuration>
+          <version>${plugin.surefire.version}</version>
+          <configuration combine.children="append">
             <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
           </configuration>
           <!-- <excludes> <exclude>**/itest/**</exclude> </excludes> <executions>
@@ -439,25 +467,25 @@
 
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>${plugin.assembly.version}</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.2.1</version>
+          <version>${plugin.exec.version}</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
+          <version>${plugin.cobertura.version}</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.6.1</version>
+          <version>${plugin.clean.version}</version>
           <configuration>
             <filesets>
               <fileset>
@@ -472,6 +500,7 @@
         </plugin>
 
         <plugin>
+<<<<<<< HEAD
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
           <version>1.0.1</version>
@@ -498,12 +527,18 @@
           </configuration>
         </plugin>
 
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${plugin.antrun.version}</version>
+        </plugin>
+
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
+          <version>${plugin.lifecycle.mapping.version}</version>
           <configuration>
             <lifecycleMappingMetadata>
               <pluginExecutions>
@@ -549,12 +584,6 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.7</version>
         </plugin>
 
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <plugin.clean.version>2.6.1</plugin.clean.version>
     <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
     <plugin.antrun.version>1.7</plugin.antrun.version>
+    <plugin.deploy.version>2.8.2</plugin.deploy.version>
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
@@ -413,8 +414,9 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>xml-maven-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${plugin.deploy.version}</version>
       </plugin>
 
       <!--TODO(alex): make part of the build and reconcile conflicts
@@ -499,7 +501,6 @@
         </plugin>
 
         <plugin>
-<<<<<<< HEAD
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
           <version>1.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <plugin.clean.version>2.6.1</plugin.clean.version>
     <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
     <plugin.antrun.version>1.7</plugin.antrun.version>
+    <plugin.download.version>1.3.0</plugin.download.version>
     <plugin.deploy.version>2.8.2</plugin.deploy.version>
 
     <PermGen>64m</PermGen>
@@ -525,6 +526,12 @@
               </validationSet>
             </validationSets>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>com.googlecode.maven-download-plugin</groupId>
+          <artifactId>download-maven-plugin</artifactId>
+          <version>${plugin.download.version}</version>
         </plugin>
 
         <plugin>

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -33,7 +33,14 @@
   <name>Zeppelin: PostgreSQL interpreter</name>
 
   <properties>
+    <!--library versions-->
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
+    <jline.version>2.12.1</jline.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.5</mockito.all.version>
+    <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
+
   </properties>
 
   <dependencies>
@@ -68,7 +75,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.12.1</version>
+      <version>${jline.version}</version>
     </dependency>
 
     <dependency>
@@ -80,14 +87,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.mockrunner</groupId>
       <artifactId>mockrunner-jdbc</artifactId>
-      <version>1.0.8</version>
+      <version>${mockrunner.jdbc.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -96,7 +103,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -107,7 +113,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -35,7 +35,18 @@
   <properties>
     <script.extension>.sh</script.extension>
     <path.separator>/</path.separator>
+    <!--library versions-->
     <spark.version>1.4.1</spark.version>
+    <jsoup.version>[1.8.0,)</jsoup.version>
+
+    <!--test library versions-->
+    <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
+    <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
+    <datanucleus.core.version>3.2.10</datanucleus.core.version>
+
+    <!--plugin versions-->
+    <plugin.shade.version>2.3</plugin.shade.version>
+    <plugin.scalatest.version>1.0</plugin.scalatest.version>
   </properties>
 
   <dependencies>
@@ -44,34 +55,40 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-spark-dependencies_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-spark_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
@@ -113,54 +130,62 @@
       <version>${scala.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>${scalatest.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
       <version>${scalacheck.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>compile</scope>
     </dependency>
+
     <dependency>
-      <!-- jsoup HTML parser library @ http://jsoup.org/ -->
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>[1.8.0,)</version>
+      <version>${jsoup.version}</version>
       <scope>compile</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-core</artifactId>
+      <version>${datanucleus.core.version}</version>
       <scope>test</scope>
-      <version>3.2.10</version>
     </dependency>
+
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-api-jdo</artifactId>
-      <version>3.2.6</version>
+      <version>${datanucleus.apijdo.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-rdbms</artifactId>
-      <version>3.2.9</version>
+      <version>${datanucleus.rdbms.version}</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>
@@ -205,7 +230,6 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -217,7 +241,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -228,7 +251,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>${plugin.scalatest.version}</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
@@ -251,7 +274,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -285,7 +308,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -354,7 +376,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.6.1</version>
         <configuration>
           <filesets>
             <fileset>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -33,8 +33,13 @@
   <name>Zeppelin: Scalding interpreter</name>
 
   <properties>
+    <!--library versions-->
     <hadoop.version>2.6.0</hadoop.version>
     <scalding.version>0.16.1-RC1</scalding.version>
+    <commons.exec.version>1.3</commons.exec.version>
+
+    <!--plugin versions-->
+    <plugin.scala.version>2.15.2</plugin.scala.version>
   </properties>
 
   <repositories>
@@ -61,7 +66,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>${commons.exec.version}</version>
     </dependency>
     
     <dependency>
@@ -142,8 +147,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -153,7 +157,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -197,7 +200,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -34,7 +34,14 @@
   <description>Zeppelin Scio support</description>
 
   <properties>
+    <!--library versions-->
     <scio.version>0.2.4</scio.version>
+    <guava.version>14.0.1</guava.version> <!-- update needed -->
+
+    <!--plugin versions-->
+    <plugin.shade.version>2.3</plugin.shade.version>
+    <plugin.scala.version>2.15.2</plugin.scala.version>
+    <plugin.avro.version>1.7.7</plugin.avro.version>
   </properties>
 
   <dependencies>
@@ -58,7 +65,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <dependency>
@@ -79,7 +86,7 @@
       <version>${scala.version}</version>
     </dependency>
 
-    <!--TEST-->
+    <!-- test libraries -->
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
@@ -99,7 +106,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -111,7 +117,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -122,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -154,7 +159,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -180,11 +184,10 @@
         </executions>
       </plugin>
 
-      <!-- Plugin to compile Scala code -->
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <id>compile</id>
@@ -209,11 +212,11 @@
         </executions>
       </plugin>
 
-      <!-- Plugin to compile avro for tests -->
+      <!-- plugin to compile avro for tests -->
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.7.7</version>
+        <version>${plugin.avro.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -226,6 +229,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -32,6 +32,11 @@
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Shell interpreter</name>
 
+  <properties>
+    <!--library versions -->
+    <commons.exec.version>1.3</commons.exec.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -39,13 +44,7 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    
-	<dependency>
-		<groupId>org.apache.commons</groupId>
-		<artifactId>commons-exec</artifactId>
-		<version>1.3</version>
-	</dependency>
-	
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -55,7 +54,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>${commons.exec.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -67,8 +72,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>            
-        <executions> 
+        <executions>
           <execution> 
             <id>enforce</id> 
             <phase>none</phase> 
@@ -78,7 +82,6 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -800,7 +800,6 @@
       </repositories>
     </profile>
 
-
     <profile>
       <id>yarn</id>
       <dependencies>
@@ -825,7 +824,6 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>download-pyspark-files</id>
@@ -889,7 +887,6 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>download-sparkr-files</id>
@@ -956,6 +953,12 @@
           <reuseForks>false</reuseForks>
           <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>${plugin.download.version}</version>
       </plugin>
 
       <plugin>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -63,6 +63,9 @@
       http://d3kbcqa49mib13.cloudfront.net/spark-${spark.version}-bin-without-hadoop.tgz
     </spark.bin.download.url>
     <py4j.version>0.8.2.1</py4j.version>
+
+    <!--plugin versions-->
+    <plugin.shade.version>2.3</plugin.shade.version>
   </properties>
 
   <dependencyManagement>
@@ -937,7 +940,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -949,7 +951,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -960,7 +961,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -994,7 +995,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -34,29 +34,34 @@
   <description>Zeppelin spark support</description>
 
   <properties>
+    <!--library versions-->
     <jsoup.version>1.8.2</jsoup.version>
+    <spark.version>2.0.1</spark.version>
+    <guava.version>14.0.1</guava.version>
+    <commons.exec.version>1.3</commons.exec.version>
+    <commons.compress.version>1.9</commons.compress.version>
+    <maven.plugin.api.version>3.0</maven.plugin.api.version>
+    <aether.version>1.12</aether.version>
+    <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
+    <wagon.version>1.0</wagon.version>
+
+    <!--test library versions-->
     <mockito.version>1.10.19</mockito.version>
     <powermock.version>1.6.4</powermock.version>
-    <spark.version>2.0.1</spark.version>
-    <pyspark.test.exclude>
-        **/PySparkInterpreterMatplotlibTest.java
-    </pyspark.test.exclude>
-    <pyspark.test.include>
-        **/*Test.*
-    </pyspark.test.include>
+    <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
+    <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
+    <datanucleus.core.version>3.2.10</datanucleus.core.version>
+
+    <!--plugin versions-->
+    <plugin.shade.version>2.3</plugin.shade.version>
+    <plugin.scala.version>2.15.2</plugin.scala.version>
+
+    <!-- settings -->
+    <pyspark.test.exclude>**/PySparkInterpreterMatplotlibTest.java</pyspark.test.exclude>
+    <pyspark.test.include>**/*Test.*</pyspark.test.include>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-display_${scala.binary.version}</artifactId>
@@ -67,6 +72,16 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
     <dependency>
@@ -86,14 +101,14 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <!-- Aether :: maven dependency resolution -->
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.0</version>
+      <version>${maven.plugin.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -109,26 +124,29 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-api</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-util</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-impl</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>3.0.3</version>
+      <version>${maven.aeither.provider.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.sonatype.aether</groupId>
@@ -156,13 +174,13 @@
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-connector-file</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-connector-wagon</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
@@ -174,7 +192,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -186,7 +204,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http-lightweight</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
@@ -198,7 +216,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
       </exclusions>
     </dependency>
@@ -206,7 +224,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>${commons.exec.version}</version>
     </dependency>
 
     <dependency>
@@ -239,7 +257,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.9</version>
+      <version>${commons.compress.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -249,7 +267,7 @@
       <version>${jsoup.version}</version>
     </dependency>
 
-    <!--TEST-->
+    <!--test libraries-->
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
@@ -266,21 +284,21 @@
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-core</artifactId>
-      <version>3.2.10</version>
+      <version>${datanucleus.core.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-api-jdo</artifactId>
-      <version>3.2.6</version>
+      <version>${datanucleus.apijdo.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-rdbms</artifactId>
-      <version>3.2.9</version>
+      <version>${datanucleus.rdbms.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -290,12 +308,14 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
@@ -309,7 +329,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -321,7 +340,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -336,7 +354,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -368,7 +386,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -398,7 +415,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <version>${plugin.scala.version}</version>
         <configuration>
           <excludes>
             <exclude>**/ZeppelinR.scala</exclude>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -32,6 +32,13 @@
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: Display system apis</name>
 
+  <properties>
+    <!--plugin versions -->
+    <plugin.failsafe.version>2.16</plugin.failsafe.version>
+    <plugin.scala.version>2.15.2</plugin.scala.version>
+    <plugin.scalatest.version>1.0</plugin.scalatest.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -110,7 +117,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.16</version>
+        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -127,7 +134,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <id>compile</id>
@@ -155,7 +162,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>${plugin.scalatest.version}</version>
         <executions>
           <execution>
             <id>test</id>

--- a/zeppelin-examples/pom.xml
+++ b/zeppelin-examples/pom.xml
@@ -43,7 +43,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -51,7 +50,6 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -36,7 +36,20 @@
   <description>Zeppelin Interpreter</description>
 
   <properties>
-    <commons-lang.version>3.4</commons-lang.version>
+    <!--library versions-->
+    <commons.lang3.version>3.4</commons.lang3.version>
+    <commons.pool2.version>2.3</commons.pool2.version>
+    <commons.exec.version>1.3</commons.exec.version>
+    <maven.plugin.api.version>3.0</maven.plugin.api.version>
+    <aether.version>1.12</aether.version>
+    <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
+    <wagon.version>1.0</wagon.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.0</mockito.all.version>
+
+    <!--plugin versions-->
+    <plugin.shade.version>2.3</plugin.shade.version>
   </properties>
 
   <dependencies>
@@ -54,13 +67,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.3</version>
+      <version>${commons.exec.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
-      <version>2.3</version>
+      <version>${commons.pool2.version}</version>
     </dependency>
 
     <dependency>
@@ -79,29 +92,16 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
     	<groupId>org.apache.commons</groupId>
     	<artifactId>commons-lang3</artifactId>
-        <version>${commons-lang.version}</version>
+        <version>${commons.lang3.version}</version>
     </dependency>
 
     <!-- Aether :: maven dependency resolution -->
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.0</version>
+      <version>${maven.plugin.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -121,25 +121,25 @@
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-api</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-util</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-impl</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>3.0.3</version>
+      <version>${maven.aeither.provider.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.sonatype.aether</groupId>
@@ -167,13 +167,13 @@
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-connector-file</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-connector-wagon</artifactId>
-      <version>1.12</version>
+      <version>${aether.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http-lightweight</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.wagon</groupId>
@@ -209,10 +209,24 @@
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <version>1.0</version>
+      <version>${wagon.version}</version>
       <exclusions>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.all.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -220,7 +234,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>${plugin.shade.version}</version>
         <configuration>
           <artifactSet>
             <includes>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -33,9 +33,24 @@
   <name>Zeppelin: Server</name>
 
   <properties>
+    <!--library versions-->
     <cxf.version>2.7.8</cxf.version>
-    <commons.httpclient.version>4.3.6</commons.httpclient.version>
     <hadoop-common.version>2.6.0</hadoop-common.version>
+    <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
+    <jersey.servlet.version>1.13</jersey.servlet.version>
+    <javax.ws.rsapi.version>2.0-m10</javax.ws.rsapi.version>
+    <libpam4j.version>1.8</libpam4j.version>
+    <jna.version>4.1.0</jna.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.0</mockito.all.version>
+    <selenium.java.version>2.48.2</selenium.java.version>
+    <xml.apis.version>1.4.01</xml.apis.version>
+
+    <!--plugin library versions-->
+    <plugin.failsafe.version>2.16</plugin.failsafe.version>
+    <plugin.scala.version>2.15.2</plugin.scala.version>
+    <plugin.scalatest.version>1.0</plugin.scalatest.version>
   </properties>
 
   <dependencyManagement>
@@ -67,6 +82,7 @@
   </dependencyManagement>
 
   <dependencies>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-zengine</artifactId>
@@ -81,6 +97,39 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>libpam4j</artifactId>
+      <version>${libpam4j.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
     </dependency>
 
     <dependency>
@@ -179,31 +228,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>${gson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
     </dependency>
 
     <dependency>
@@ -223,7 +247,6 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-server</artifactId>
         </exclusion>
-
 
         <exclusion>
           <groupId>javax.servlet</groupId>
@@ -264,19 +287,19 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+      <version>${quartz.scheduler.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
-      <version>1.13</version>
+      <version>${jersey.servlet.version}</version>
     </dependency>
 
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.0-m10</version>
+      <version>${javax.ws.rsapi.version}</version>
     </dependency>
 
     <dependency>
@@ -297,10 +320,43 @@
       <version>${scala.version}</version>
     </dependency>
 
+    <!--test libraries-->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.all.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <version>${scalatest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>2.48.2</version>
+      <version>${selenium.java.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -326,60 +382,20 @@
       </exclusions>
     </dependency>
 
-
     <dependency> <!-- because there are two of them above  -->
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
+      <version>${xml.apis.version}</version>
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>${scalatest.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Apache Shiro -->
-    <dependency>
-      <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>libpam4j</artifactId>
-      <version>1.8</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.java.dev.jna</groupId>
-          <artifactId>jna</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <version>4.1.0</version>
-    </dependency>
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.16</version>
+        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -396,7 +412,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <goals>
@@ -409,7 +425,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>${plugin.scalatest.version}</version>
         <configuration>
           <stderr/>
           <systemProperties>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -37,6 +37,15 @@
     <maven>3.1.0</maven>
   </prerequisites>
 
+  <properties>
+    <node.version>v6.9.1</node.version>
+    <npm.version>3.10.8</npm.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!--plugin versions-->
+    <plugin.frontned.version>1.3</plugin.frontned.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -90,7 +99,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.3</version>
+        <version>${plugin.frontned.version}</version>
         <executions>
 
           <execution>
@@ -99,8 +108,8 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v6.9.1</nodeVersion>
-              <npmVersion>3.10.8</npmVersion>
+              <nodeVersion>${node.version}</nodeVersion>
+              <npmVersion>${npm.version}</npmVersion>
             </configuration>
           </execution>
 
@@ -159,7 +168,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
       </plugin>
 
       <plugin>
@@ -175,8 +183,5 @@
     </plugins>
   </build>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 
 </project>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -34,37 +34,28 @@
   <name>Zeppelin: Zengine</name>
   <description>Zeppelin Zengine</description>
 
+  <properties>
+    <!--library versions-->
+    <commons.vfs2.version>2.0</commons.vfs2.version>
+    <aws.sdk.s3.version>1.10.62</aws.sdk.s3.version>
+    <azure.storage.version>4.0.0</azure.storage.version>
+    <jackrabbit.webdav.version>1.5.2</jackrabbit.webdav.version>
+    <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
+    <lucene.version>5.3.1</lucene.version>
+    <org.reflections.version>0.9.8</org.reflections.version>
+    <xml.apis.version>1.4.01</xml.apis.version>
+    <eclipse.jgit.version>4.1.1.201511131810-r</eclipse.jgit.version>
+
+    <!--test library versions-->
+    <mockito.all.version>1.9.0</mockito.all.version>
+    <google.truth.version>0.27</google.truth.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.10.62</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-storage</artifactId>
-      <version>4.0.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -95,13 +86,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>2.0</version>
+      <version>${commons.vfs2.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
-      <version>1.5.2</version>
+      <version>${jackrabbit.webdav.version}</version>
        <exclusions>
          <exclusion>
            <groupId>org.apache.httpcomponents</groupId>
@@ -113,7 +104,32 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>${aws.sdk.s3.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-storage</artifactId>
+      <version>${azure.storage.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -131,7 +147,7 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+      <version>${quartz.scheduler.version}</version>
     </dependency>
 
     <dependency>
@@ -147,31 +163,31 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>5.3.1</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>5.3.1</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queryparser</artifactId>
-      <version>5.3.1</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-highlighter</artifactId>
-      <version>5.3.1</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.8</version>
+      <version>${org.reflections.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -187,13 +203,13 @@
     <dependency> <!-- because there are two of them above  -->
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
+      <version>${xml.apis.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
-      <version>4.1.1.201511131810-r</version>
+      <version>${eclipse.jgit.version}</version>
     </dependency>
 
     <dependency>
@@ -205,14 +221,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
+      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.27</version>
+      <version>${google.truth.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -249,7 +265,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
         <configuration>
           <forkMode>always</forkMode>
         </configuration>


### PR DESCRIPTION
### What is this PR for?

**First of all, this PR doesn't affect on runtime application behaivor and existing build processes. Just abstracting variables in pom.xml**

The main goal of this PR is bringing consistency and maintainability in all pom.xml.  I referred these 2 projects.

- [apache/spark: pom.xml](https://github.com/apache/spark/blob/master/pom.xml)
- [apache/storm: pom.xml](https://github.com/apache/storm/blob/master/pom.xml)

Currently, all libraries and plugins have duplicated version fields since we are not using `dependencyManagement`, `pluginManagement` efficiently in pom.xml

This results in 

- unmanaged plugin, library versions (someone might update only a child's library version. it happend in our pom.xml files)
- so many duplicated code blocks (bad)
- fragmented plugin, library versions (some project uses junit 4.11 while another uses 4.12)

These are some examples

```xml
// hard coded, non consistent version management

      <dependency>
        <groupId>org.apache.thrift</groupId>
        <artifactId>libthrift</artifactId>
        <version>${libthrift.version}</version>
      </dependency>

      <dependency>
        <groupId>org.apache.httpcomponents</groupId>
        <artifactId>httpcore</artifactId>
        <version>4.3.3</version>
      </dependency>
```

```xml
// a/pom.xml
              <plugin>
                <artifactId>maven-enforcer-plugin</artifactId>
                <version>1.3.1</version>

              <plugin>
                <artifactId>maven-dependency-plugin</artifactId>
                <version>2.8</version>

// b/pom.xml
              <plugin>
                <artifactId>maven-enforcer-plugin</artifactId>
                <version>1.3.1</version>

              <plugin>
                <artifactId>maven-dependency-plugin</artifactId>
                <version>2.8</version>

// c/pom.xml
              <plugin>
                <artifactId>maven-enforcer-plugin</artifactId>
                <version>1.3.1</version>

              <plugin>
                <artifactId>maven-dependency-plugin</artifactId>
                <version>2.8</version>
```

### What type of PR is it?

[Refactoring]

### Todos

- [x] refactor all pom.xml

### What is the Jira issue?

[ZEPPELIN-1695](https://issues.apache.org/jira/browse/ZEPPELIN-1695)

### How should this be tested?

Since this PR doesn't affect runtime behavior at all, CI test would be enough.

### Questions:
* Does the licenses files need update - NO
* Is there breaking changes for older versions - NO
* Does this needs documentation - NO