### PR TITLE
HOT FIX: Fix NPE while getting default interpreter setting

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1382,9 +1382,9 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   public Map<String, Object> getEditorSetting(String user, String noteId, String replName) {
     Interpreter intp = getInterpreter(user, noteId, replName);
     Map<String, Object> editor = DEFAULT_EDITOR;
-    String defaultSettingName = getDefaultInterpreterSetting(noteId).getName();
     String group = StringUtils.EMPTY;
     try {
+      String defaultSettingName = getDefaultInterpreterSetting(noteId).getName();
       List<InterpreterSetting> intpSettings = getInterpreterSettings(noteId);
       for (InterpreterSetting intpSetting : intpSettings) {
         String[] replNameSplit = replName.split("\\.");


### PR DESCRIPTION
### What is this PR for?
NPE while starting Zeppelin for the first time without interpreter settings

### What type of PR is it?
Hot Fix

### What is the Jira issue?
n/a

### How should this be tested?
remove conf/interpreter.json and start Zeppelin

### Logs
**Before**
`
java.lang.NullPointerException
        at org.apache.zeppelin.interpreter.InterpreterFactory.getEditorSetting(InterpreterFactory.java:1385)
        at org.apache.zeppelin.socket.NotebookServer.getEditorSetting(NotebookServer.java:1796)
        at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:290)
        at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:59)
        at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:128)
        at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
        at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:65)
        at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:122)
        at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:161)
        at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:309)
        at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:214)
        at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220)
        at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:258)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:632)
        at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:480)
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
        at java.lang.Thread.run(Thread.java:745)
`

**After**
`
 WARN [2016-11-22 18:52:16,890] ({qtp1702660825-60} InterpreterFactory.java[getEditorSetting]:1405) - Couldn't get interpreter editor setting
`

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a

