### PR TITLE
[ZEPPELIN-1700] ConnectException between ZeppelinServer and RemoteInterpreterProcess.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1101,7 +1101,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   private Interpreter connectToRemoteRepl(String noteId, String className, String host, int port,
       Properties property, String userName, Boolean isUserImpersonate) {
-    int connectTimeout = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT);
+    int connectTimeout = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT) * 10;
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
     LazyOpenInterpreter intp = new LazyOpenInterpreter(
         new RemoteInterpreter(property, noteId, className, host, port, connectTimeout, maxPoolSize,
@@ -1112,7 +1112,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   private Interpreter createRemoteRepl(String interpreterPath, String noteId, String className,
       Properties property, String interpreterSettingId, String userName,
       Boolean isUserImpersonate) {
-    int connectTimeout = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT);
+    int connectTimeout = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT) * 10;
     String localRepoPath = conf.getInterpreterLocalRepoPath() + "/" + interpreterSettingId;
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
 


### PR DESCRIPTION
### What is this PR for?
The default value of interpreter connection timeout is 30s but sometimes 30 seconds may be insufficient to connect to RemoteInterpreterProcess.
I think to increase the timeout value doesn't effect of performance so it's okay to give large value.
and in the later, It's better give users to be able to edit Zeppelin Configurations on the web.

### What type of PR is it?
Bug Fix | Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1700

### Screenshots (if appropriate)
- before
![image](https://cloud.githubusercontent.com/assets/3348133/20549811/01c12b46-b173-11e6-8c25-721e1bb45c02.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

