### PR TITLE
ZEPPELIN-1703: frontend - skip PhantomJS on -DskipTests

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -7,7 +7,8 @@
     "postinstall": "node_modules/.bin/bower install --silent",
     "build": "./node_modules/.bin/grunt build",
     "start": "./node_modules/.bin/grunt serve",
-    "test": "./node_modules/.bin/grunt test"
+    "test": "./node_modules/.bin/grunt test",
+    "pretest": "./node_modules/.bin/npm install karma-phantomjs-launcher"
   },
   "dependencies": {
     "grunt-angular-templates": "^0.5.7",
@@ -44,7 +45,6 @@
     "karma": "~1.3.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "~1.0.2",
-    "karma-phantomjs-launcher": "~1.0.2",
     "load-grunt-tasks": "^0.4.0",
     "time-grunt": "^0.3.1"
   },


### PR DESCRIPTION
### What is this PR for?
Skip PhatomJS installation on `mvn package -DskipTests`

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1703](https://issues.apache.org/jira/browse/ZEPPELIN-1703)

### How should this be tested?
`mvn package -DskipTests -pl zeppelin-web` and see no PhantomJS mentions in output.
`mvn package -pl zeppelin-web` and see that PhantomJS is installed\run.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

