### PR TITLE
[ZEPPELIN-1190] Visit and switch notebook revisions

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1506,6 +1506,11 @@ public class NotebookServer extends WebSocketServlet implements
 
     conn.send(serializeMessage(new Message(OP.SET_NOTE_REVISION)
         .put("status", setRevisionStatus)));
+    if (!setRevisionStatus) {
+      conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
+          "Couldn't set note to the given revision. "
+          + "Please check the logs for more details.")));
+    }
     //TODO(khalid): broadcast?
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1486,8 +1486,8 @@ public class NotebookServer extends WebSocketServlet implements
     try {
       Note currentNote = notebook.setNoteRevision(noteId, revisionId, subject);
     } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+      //TODO(khalid): notify user 
+      LOG.error("Failed to set note revision", e);
     }
     //TODO(khalid): send back, update note or notify user
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1492,13 +1492,21 @@ public class NotebookServer extends WebSocketServlet implements
     }
 
     Note headNote = null;
+    boolean setRevisionStatus;
     try {
       headNote = notebook.setNoteRevision(noteId, revisionId, subject);
-    } catch (IOException e) {
+      setRevisionStatus = headNote != null;
+    } catch (Exception e) {
+      setRevisionStatus = false;
       LOG.error("Failed to set given note revision", e);
     }
+    if (setRevisionStatus) {
+      notebook.loadNoteFromRepo(noteId, subject);
+    }
 
-    //TODO(khalid): send back, update note
+    conn.send(serializeMessage(new Message(OP.SET_NOTE_REVISION)
+        .put("status", setRevisionStatus)));
+    //TODO(khalid): broadcast?
   }
 
   private void getNoteByRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1506,12 +1506,15 @@ public class NotebookServer extends WebSocketServlet implements
 
     conn.send(serializeMessage(new Message(OP.SET_NOTE_REVISION)
         .put("status", setRevisionStatus)));
-    if (!setRevisionStatus) {
+
+    if (setRevisionStatus) {
+      Note reloadedNote = notebook.getNote(headNote.getId());
+      broadcastNote(reloadedNote);
+    } else {
       conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
           "Couldn't set note to the given revision. "
           + "Please check the logs for more details.")));
     }
-    //TODO(khalid): broadcast?
   }
 
   private void getNoteByRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1483,7 +1483,7 @@ public class NotebookServer extends WebSocketServlet implements
     conn.send(serializeMessage(new Message(OP.NOTE_REVISION)
         .put("noteId", noteId)
         .put("revisionId", revisionId)
-        .put("data", revisionNote)));
+        .put("note", revisionNote)));
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -283,6 +283,9 @@ public class NotebookServer extends WebSocketServlet implements
           case LIST_REVISION_HISTORY:
             listRevisionHistory(conn, notebook, messagereceived);
             break;
+          case SET_NOTE_REVISION:
+            setNoteRevision(conn, notebook, messagereceived);
+            break;
           case NOTE_REVISION:
             getNoteByRevision(conn, notebook, messagereceived);
             break;
@@ -1472,6 +1475,21 @@ public class NotebookServer extends WebSocketServlet implements
 
     conn.send(serializeMessage(new Message(OP.LIST_REVISION_HISTORY)
       .put("revisionList", revisions)));
+  }
+  
+  private void setNoteRevision(NotebookSocket conn, Notebook notebook,
+      Message fromMessage) {
+    String noteId = (String) fromMessage.get("noteId");
+    String revisionId = (String) fromMessage.get("revisionId");
+    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
+    
+    try {
+      Note currentNote = notebook.setNoteRevision(noteId, revisionId, subject);
+    } catch (IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    //TODO(khalid): send back, update note or notify user
   }
 
   private void getNoteByRevision(NotebookSocket conn, Notebook notebook, Message fromMessage)

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -62,6 +62,10 @@
               templateUrl: 'app/notebook/notebook.html',
               controller: 'NotebookCtrl'
             })
+            .when('/notebook/:noteId/revision/:revisionId', {
+              templateUrl: 'app/notebook/notebook.html',
+              controller: 'NotebookCtrl'
+            })
             .when('/jobmanager', {
               templateUrl: 'app/jobmanager/jobmanager.html',
               controller: 'JobmanagerCtrl'

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -77,6 +77,13 @@ limitations under the License.
                 tooltip-placement="bottom" tooltip="Version control">
           <i class="fa fa-file-code-o"></i>
         </button>
+        <button type="button"
+                class="btn btn-default btn-xs"
+                id="setRevision"
+                ng-hide="viewOnly"
+                tooltip-placement="bottom" tooltip="Set revision">
+          <i class="fa fa-arrow-circle-o-right"></i>
+        </button>
         <ul class="dropdown-menu" style="width:250px"
           aria-labelledby="versionControlDropdown">
           <li>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -101,8 +101,8 @@ limitations under the License.
         </ul>
       </div>
       <div class="btn-group" role="group">
-        <button type="button" class="btn btn-default btn-xs revisionName">
-          Head
+        <button type="button" class="btn btn-default btn-xs revisionName" title="{{currentRevision}}">
+          <div style="overflow: hidden">{{currentRevision}}</div>
         </button>
         <button type="button" ng-if="noteRevisions.length > 0"
           class="btn btn-default dropdown-toggle caretSeparator"

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -111,7 +111,7 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer" ng-click="visitRevision(revision)>
+            <a style="cursor:pointer" ng-click="visitRevision(revision)">
               <span style="display: block;">
                 <strong>{{revision.message}}</strong>
               </span>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -81,6 +81,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 id="setRevision"
                 ng-hide="viewOnly"
+                ng-click="setNoteRevision()"
                 tooltip-placement="bottom" tooltip="Set revision">
           <i class="fa fa-arrow-circle-o-right"></i>
         </button>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -82,6 +82,7 @@ limitations under the License.
                 id="setRevision"
                 ng-hide="viewOnly"
                 ng-click="setNoteRevision()"
+                ng-disabled="revisionDisabled"
                 tooltip-placement="bottom" tooltip="Set revision">
           <i class="fa fa-arrow-circle-o-right"></i>
         </button>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -111,7 +111,7 @@ limitations under the License.
         </button>
         <ul class="dropdown-menu pull-right" aria-labelledby="revisionsDropdown">
           <li ng-repeat="revision in noteRevisions | orderBy:'time':true" class="revision">
-            <a style="cursor:pointer">
+            <a style="cursor:pointer" ng-click="visitRevision(revision)>
               <span style="display: block;">
                 <strong>{{revision.message}}</strong>
               </span>

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -92,7 +92,7 @@
       if ($routeParams.revisionId) {
         websocketMsgSrv.getNoteByRevision($routeParams.noteId, $routeParams.revisionId);
       } else {
-        websocketMsgSrv.getNotebook($routeParams.noteId);
+        websocketMsgSrv.getNote($routeParams.noteId);
       }
       websocketMsgSrv.listRevisionHistory($routeParams.noteId);
       var currentRoute = $route.current;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -191,6 +191,20 @@
       document.getElementById('note.checkpoint.message').value = '';
     };
 
+    // set notebook head to given revision
+    $scope.setNoteRevision = function() {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Set notebook head to current revision?',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.setNoteRevision($routeParams.noteId, $routeParams.revisionId);
+          }
+        }
+      });
+    };
+
     $scope.$on('listRevisionHistory', function(event, data) {
       console.log('received list of revisions %o', data);
       $scope.noteRevisions = data.revisionList;

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -193,6 +193,7 @@
 
     // set notebook head to given revision
     $scope.setNoteRevision = function() {
+      console.log('set revision');
       BootstrapDialog.confirm({
         closable: true,
         title: '',
@@ -200,6 +201,9 @@
         callback: function(result) {
           if (result) {
             websocketMsgSrv.setNoteRevision($routeParams.noteId, $routeParams.revisionId);
+            $location.path('/notebook/' + $routeParams.noteId);
+          } else {
+            console.log('no result on set revision');
           }
         }
       });

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -62,9 +62,14 @@
     $scope.saveTimer = null;
 
     var connectedOnce = false;
+    var isRevisionPath = function(path) {
+      var pattern = new RegExp('^.*\/notebook\/[a-zA-Z0-9_]*\/revision\/[a-zA-Z0-9_]*');
+      return pattern.test(path);
+    };
 
     $scope.noteRevisions = [];
     $scope.currentRevision = 'Head';
+    $scope.revisionDisabled = !isRevisionPath($location.path());
 
     $scope.$on('setConnectedStatus', function(event, param) {
       if (connectedOnce && param) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -193,7 +193,6 @@
 
     // set notebook head to given revision
     $scope.setNoteRevision = function() {
-      console.log('set revision');
       BootstrapDialog.confirm({
         closable: true,
         title: '',
@@ -201,9 +200,6 @@
         callback: function(result) {
           if (result) {
             websocketMsgSrv.setNoteRevision($routeParams.noteId, $routeParams.revisionId);
-            $location.path('/notebook/' + $routeParams.noteId);
-          } else {
-            console.log('no result on set revision');
           }
         }
       });
@@ -230,6 +226,13 @@
         $scope.note = data.note;
       } else {
         $location.path('/');
+      }
+    });
+
+    $scope.$on('setNoteRevisionResult', function(event, data) {
+      console.log('received set note revision result %o', data);
+      if (data.status) {
+        $location.path('/notebook/' + $routeParams.noteId);
       }
     });
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -206,10 +206,10 @@
       }
     });
 
-    $scope.$on('noteRevision', function(event, note) {
-      console.log('received note revision %o', note);
-      if (note) {
-        $scope.note = note;
+    $scope.$on('noteRevision', function(event, data) {
+      console.log('received note revision %o', data);
+      if (data.note) {
+        $scope.note = data.note;
       } else {
         $location.path('/');
       }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -63,7 +63,6 @@
 
     var connectedOnce = false;
 
-    // user auto complete related
     $scope.noteRevisions = [];
 
     $scope.$on('setConnectedStatus', function(event, param) {
@@ -194,6 +193,10 @@
     $scope.$on('listRevisionHistory', function(event, data) {
       console.log('received list of revisions %o', data);
       $scope.noteRevisions = data.revisionList;
+      $scope.noteRevisions.splice(0, 0, {
+        id: 'Head',
+        message: 'Head'
+      });
     });
 
     $scope.$on('noteRevision', function(event, note) {
@@ -204,6 +207,19 @@
         $location.path('/');
       }
     });
+
+    $scope.visitRevision = function(revision) {
+      if (revision.id) {
+        if (revision.id === 'Head') {
+          $location.path('/notebook/' + $routeParams.noteId);
+        } else {
+          $location.path('/notebook/' + $routeParams.noteId + '/revision/' + revision.id);
+        }
+      } else {
+        ngToast.danger({content: 'There is a problem with this Revision',
+          verticalPosition: 'top', dismissOnTimeout: false});
+      }
+    };
 
     $scope.runNote = function() {
       BootstrapDialog.confirm({

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -64,6 +64,7 @@
     var connectedOnce = false;
 
     $scope.noteRevisions = [];
+    $scope.currentRevision = 'Head';
 
     $scope.$on('setConnectedStatus', function(event, param) {
       if (connectedOnce && param) {
@@ -197,6 +198,12 @@
         id: 'Head',
         message: 'Head'
       });
+      if ($routeParams.revisionId) {
+        var index = _.findIndex($scope.noteRevisions, {'id': $routeParams.revisionId});
+        if (index > -1) {
+          $scope.currentRevision = $scope.noteRevisions[index].message;
+        }
+      }
     });
 
     $scope.$on('noteRevision', function(event, note) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -192,14 +192,17 @@
     };
 
     $scope.$on('listRevisionHistory', function(event, data) {
-      console.log('We got the revisions %o', data);
+      console.log('received list of revisions %o', data);
       $scope.noteRevisions = data.revisionList;
     });
 
-    // receive certain revision of note
-    $scope.$on('noteRevision', function(event, data) {
-      console.log('received note revision %o', data);
-      //TODO(xxx): render it
+    $scope.$on('noteRevision', function(event, note) {
+      console.log('received note revision %o', note);
+      if (note) {
+        $scope.note = note;
+      } else {
+        $location.path('/');
+      }
     });
 
     $scope.runNote = function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -89,7 +89,11 @@
     /** Init the new controller */
     var initNotebook = function() {
       noteVarShareService.clear();
-      websocketMsgSrv.getNote($routeParams.noteId);
+      if ($routeParams.revisionId) {
+        websocketMsgSrv.getNoteByRevision($routeParams.noteId, $routeParams.revisionId);
+      } else {
+        websocketMsgSrv.getNotebook($routeParams.noteId);
+      }
       websocketMsgSrv.listRevisionHistory($routeParams.noteId);
       var currentRoute = $route.current;
       if (currentRoute) {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -117,7 +117,7 @@
       } else if (op === 'APP_STATUS_CHANGE') {
         $rootScope.$broadcast('appStatusChange', data);
       } else if (op === 'LIST_REVISION_HISTORY') {
-        $rootScope.$broadcast('listRevisionHistory', data);
+        $rootScope.$broadcast('listRevisionHistory', data.data);
       } else if (op === 'NOTE_REVISION') {
         $rootScope.$broadcast('noteRevision', data);
       } else if (op === 'INTERPRETER_BINDINGS') {

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -149,6 +149,8 @@
         $rootScope.$broadcast('moveParagraph', data.id, data.index);
       } else if (op === 'NOTE_UPDATED') {
         $rootScope.$broadcast('updateNote', data.name, data.config, data.info);
+      } else if (op === 'SET_NOTE_REVISION') {
+        $rootScope.$broadcast('setNoteRevisionResult', data);
       }
     });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -117,7 +117,7 @@
       } else if (op === 'APP_STATUS_CHANGE') {
         $rootScope.$broadcast('appStatusChange', data);
       } else if (op === 'LIST_REVISION_HISTORY') {
-        $rootScope.$broadcast('listRevisionHistory', data.data);
+        $rootScope.$broadcast('listRevisionHistory', data);
       } else if (op === 'NOTE_REVISION') {
         $rootScope.$broadcast('noteRevision', data);
       } else if (op === 'INTERPRETER_BINDINGS') {

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -197,6 +197,16 @@
         });
       },
 
+      setNoteRevision: function(noteId, revisionId) {
+        websocketEvents.sendNewEvent({
+          op: 'SET_NOTE_REVISION',
+          data: {
+            noteId: noteId,
+            revisionId: revisionId
+          }
+        });
+      },
+
       listRevisionHistory: function(noteId) {
         websocketEvents.sendNewEvent({
           op: 'LIST_REVISION_HISTORY',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -437,7 +437,7 @@ public class Notebook implements NoteEventListener {
   }
 
   @SuppressWarnings("rawtypes")
-  private Note loadNoteFromRepo(String id, AuthenticationInfo subject) {
+  public Note loadNoteFromRepo(String id, AuthenticationInfo subject) {
     Note note = null;
     try {
       note = notebookRepo.get(id, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -379,6 +379,11 @@ public class Notebook implements NoteEventListener {
     return notebookRepo.revisionHistory(noteId, subject);
   }
 
+  public Note setNoteRevision(String noteId, String revisionId, AuthenticationInfo subject)
+      throws IOException {
+    return notebookRepo.setNoteRevision(noteId, revisionId, subject);
+  }
+  
   public Note getNoteByRevision(String noteId, String revisionId, AuthenticationInfo subject)
       throws IOException {
     return notebookRepo.get(noteId, revisionId, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/AzureNotebookRepo.java
@@ -250,4 +250,11 @@ public class AzureNotebookRepo implements NotebookRepo {
   public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
     LOG.warn("Method not implemented");
   }
+
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    // Auto-generated method stub
+    return null;
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/GitNotebookRepo.java
@@ -162,6 +162,16 @@ public class GitNotebookRepo extends VFSNotebookRepo {
   }
 
   @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    Note revisionNote = get(noteId, revId, subject);
+    if (revisionNote != null) {
+      save(revisionNote, subject);
+    }
+    return revisionNote;
+  }
+  
+  @Override
   public void close() {
     git.getRepository().close();
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepo.java
@@ -103,6 +103,18 @@ public interface NotebookRepo {
   @ZeppelinApi public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject);
 
   /**
+   * Set note to particular revision.
+   * 
+   * @param noteId Id of the Notebook
+   * @param rev revision of the Notebook
+   * @return a Notebook
+   * @throws IOException
+   */
+  @ZeppelinApi
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException;
+
+  /**
    * Get NotebookRepo settings got the given user.
    *
    * @param subject

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -498,4 +498,25 @@ public class NotebookRepoSync implements NotebookRepo {
       LOG.error("Cannot update notebook repo settings", e);
     }
   }
+
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    int repoCount = getRepoCount();
+    int repoBound = Math.min(repoCount, getMaxRepoNum());
+    Note currentNote = null, revisionNote = null;
+    for (int i = 0; i < repoBound; i++) {
+      try {
+        currentNote = getRepo(i).setNoteRevision(noteId, revId, subject);
+      } catch (IOException e) {
+        // already logged
+        currentNote = null;
+      }
+      // second condition assures that fist successful is returned
+      if (currentNote != null && revisionNote == null) {
+        revisionNote = currentNote;
+      }
+    }
+    return revisionNote;
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/S3NotebookRepo.java
@@ -284,4 +284,11 @@ public class S3NotebookRepo implements NotebookRepo {
   public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
     LOG.warn("Method not implemented");
   }
+
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    // Auto-generated method stub
+    return null;
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -331,4 +331,11 @@ public class VFSNotebookRepo implements NotebookRepo {
     }
   }
 
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    // Auto-generated method stub
+    return null;
+  }
+
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -408,4 +408,11 @@ public class ZeppelinHubRepo implements NotebookRepo {
     changeToken(instanceId, subject.getUser());
   }
 
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    // Auto-generated method stub
+    return null;
+  }
+
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -136,7 +136,9 @@ public class Message {
     NOTE_REVISION,                // [c-s] get certain revision of note
                                   // @param noteId
                                   // @param revisionId
-
+    SET_NOTE_REVISION,            // [c-s] set current notebook head to this revision
+                                  // @param noteId
+                                  // @param revisionId
     APP_APPEND_OUTPUT,            // [s-c] append output
     APP_UPDATE_OUTPUT,            // [s-c] update (replace) output
     APP_LOAD,                     // [s-c] on app load

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -40,10 +40,13 @@ import org.eclipse.jgit.diff.DiffEntry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 
 public class GitNotebookRepoTest {
+  private static final Logger LOG = LoggerFactory.getLogger(GitNotebookRepoTest.class);
 
   private static final String TEST_NOTE_ID = "2A94M5J1Z";
   private static final String TEST_NOTE_ID2 = "2A94M5J2Z";
@@ -301,4 +304,64 @@ public class GitNotebookRepoTest {
     assertThat(note).isNull();
   }
 
+  @Test
+  public void setRevisionTest() throws IOException {
+    //create repo and check that note doesn't contain revisions
+    notebookRepo = new GitNotebookRepo(conf);
+    assertThat(notebookRepo.list(null)).isNotEmpty();
+    assertThat(containsNote(notebookRepo.list(null), TEST_NOTE_ID)).isTrue();
+    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null)).isEmpty();
+    
+    // get current note
+    Note note = notebookRepo.get(TEST_NOTE_ID, null);
+    int paragraphCount_1 = note.getParagraphs().size();
+    LOG.info("initial paragraph count: {}", paragraphCount_1);
+    
+    // checkpoint revision1
+    Revision revision1 = notebookRepo.checkpoint(TEST_NOTE_ID, "set revision: first commit", null);
+    //TODO(khalid): change to EMPTY after rebase
+    assertThat(revision1).isNotNull();
+    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null).size()).isEqualTo(1);
+    
+    // add one more paragraph and save
+    Paragraph p1 = note.addParagraph();
+    Map<String, Object> config = p1.getConfig();
+    config.put("enabled", true);
+    p1.setConfig(config);
+    p1.setText("set revision sample text");
+    notebookRepo.save(note, null);
+    int paragraphCount_2 = note.getParagraphs().size();
+    assertThat(paragraphCount_2).isEqualTo(paragraphCount_1 + 1);
+    LOG.info("paragraph count after modification: {}", paragraphCount_2);
+    
+    // checkpoint revision2
+    Revision revision2 = notebookRepo.checkpoint(TEST_NOTE_ID, "set revision: second commit", null);
+    //TODO(khalid): change to EMPTY after rebase
+    assertThat(revision2).isNotNull();
+    assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null).size()).isEqualTo(2);
+    
+    // set note to revision1
+    Note returnedNote = notebookRepo.setNoteRevision(note.getId(), revision1.id, null);
+    assertThat(returnedNote).isNotNull();
+    assertThat(returnedNote.getParagraphs().size()).isEqualTo(paragraphCount_1);
+    
+    // check note from repo
+    Note updatedNote = notebookRepo.get(note.getId(), null);
+    assertThat(updatedNote).isNotNull();
+    assertThat(updatedNote.getParagraphs().size()).isEqualTo(paragraphCount_1);
+    
+    // set back to revision2
+    returnedNote = notebookRepo.setNoteRevision(note.getId(), revision2.id, null);
+    assertThat(returnedNote).isNotNull();
+    assertThat(returnedNote.getParagraphs().size()).isEqualTo(paragraphCount_2);
+    
+    // check note from repo
+    updatedNote = notebookRepo.get(note.getId(), null);
+    assertThat(updatedNote).isNotNull();
+    assertThat(updatedNote.getParagraphs().size()).isEqualTo(paragraphCount_2);
+    
+    // try failure case - set to invalid revision
+    returnedNote = notebookRepo.setNoteRevision(note.getId(), "nonexistent_id", null);
+    assertThat(returnedNote).isNull();
+  }
 }


### PR DESCRIPTION
### What is this PR for?
This is to enable switching between revisions and being able to set `Head`/current note to one of those revisions. Currently notes are editable when switching between them, next step after this PR would be make them non-editable during revision switches. 

### What type of PR is it?
Improvement | Feature

### Todos
* [x] - routes and switching revisions
* [x] - set revision button and api
* [x] - test for setting revision

### What is the Jira issue?
[ZEPPELIN-1190](https://issues.apache.org/jira/browse/ZEPPELIN-1190)

### How should this be tested?
set config in conf/zeppelin-env.sh
```
export ZEPPELIN_NOTEBOOK_STORAGE="org.apache.zeppelin.notebook.repo.GitNotebookRepo"
```
and switch between notes in note action bar, as well as set certain revisions as shown below

### Screenshots (if appropriate)
![switch revisions](https://cloud.githubusercontent.com/assets/1642088/20833665/2b7d67d4-b8d4-11e6-95d0-0c4ae66e349d.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no?
