### PR TITLE
[ZEPPELIN-1705] Exclude unnecessary source file when check style on scio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
             </goals>
             <configuration>
               <failOnViolation>true</failOnViolation>
-              <excludes>org/apache/zeppelin/interpreter/thrift/*</excludes>
+              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*,org/apache/zeppelin/scio/avro/*</excludes>
             </configuration>
           </execution>
           <execution>
@@ -271,7 +271,7 @@
               <goal>checkstyle-aggregate</goal>
             </goals>
             <configuration>
-              <excludes>org/apache/zeppelin/interpreter/thrift/*</excludes>
+              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*,org/apache/zeppelin/scio/avro/*</excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### What is this PR for?
When building Zeppelin with `mvn clean package install -DskipTests -DskipRat`, it fails on `scio` with an error log below:
```sh
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.13:check (checkstyle-fail-build) on project zeppelin-scio_2.10: You have 51 Checkstyle violations. -> [Help 1]
```
This is because of **style check on a generated source**, which is exactly `$ZEPPELIN_HOME/scio/target/generated-sources/avro/org/apache/zeppelin/scio/avro/Account.java`

This PR will make style check excludes the generated source.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1705](https://issues.apache.org/jira/browse/ZEPPELIN-1705)

### How should this be tested?
Run `mvn clean package install -DskipTests -DskipRat`. It should print `BUILD SUCCESS`

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

