### PR TITLE
[MINOR] Invalid constructor call in a test causes all CI failure

### DIFF
--- a/python/src/test/java/org/apache/zeppelin/python/PythonDockerInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonDockerInterpreterTest.java
@@ -73,6 +73,7 @@ public class PythonDockerInterpreterTest implements InterpreterOutputListener {
     return new InterpreterContext(
         "noteId",
         "paragraphId",
+        "replName",
         "paragraphTitle",
         "paragraphText",
         new AuthenticationInfo(),


### PR DESCRIPTION
### What is this PR for?

A small minor fix for CI failure

- PR A added `replName` to a constructor of `InterpreterContext`  as an argument.
- and PR B was merged without rebase

This results in compilation failure.

see also

- (current master) https://travis-ci.org/apache/zeppelin/builds/178654143
- (raw log) https://api.travis-ci.org/jobs/178654145/log.txt?deansi=true

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/travis/build/apache/zeppelin/python/src/test/java/org/apache/zeppelin/python/PythonDockerInterpreterTest.java:[73,12] no suitable constructor found for InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.HashMap<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,<nulltype>,<nulltype>,<nulltype>,org.apache.zeppelin.interpreter.InterpreterOutput)
    constructor org.apache.zeppelin.interpreter.InterpreterContext.InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.Map<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,org.apache.zeppelin.display.AngularObjectRegistry,org.apache.zeppelin.resource.ResourcePool,java.util.List<org.apache.zeppelin.interpreter.InterpreterContextRunner>,org.apache.zeppelin.interpreter.InterpreterOutput,org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.apache.zeppelin.interpreter.InterpreterContext.InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.Map<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,org.apache.zeppelin.display.AngularObjectRegistry,org.apache.zeppelin.resource.ResourcePool,java.util.List<org.apache.zeppelin.interpreter.InterpreterContextRunner>,org.apache.zeppelin.interpreter.InterpreterOutput) is not applicable
      (actual and formal argument lists differ in length)
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Zeppelin ........................................... SUCCESS [  4.191 s]
[INFO] Zeppelin: Interpreter .............................. SUCCESS [ 10.154 s]
[INFO] Zeppelin: Zengine .................................. SUCCESS [  4.848 s]
[INFO] Zeppelin: Display system apis ...................... SUCCESS [ 16.617 s]
[INFO] Zeppelin: Spark dependencies ....................... SUCCESS [ 36.233 s]
[INFO] Zeppelin: Spark .................................... SUCCESS [ 22.821 s]
[INFO] Zeppelin: Markdown interpreter ..................... SUCCESS [  0.633 s]
[INFO] Zeppelin: Angular interpreter ...................... SUCCESS [  0.371 s]
[INFO] Zeppelin: Shell interpreter ........................ SUCCESS [  0.523 s]
[INFO] Zeppelin: Livy interpreter ......................... SUCCESS [  6.972 s]
[INFO] Zeppelin: HBase interpreter ........................ SUCCESS [  3.623 s]
[INFO] Zeppelin: Apache Pig Interpreter ................... SUCCESS [  3.531 s]
[INFO] Zeppelin: PostgreSQL interpreter ................... SUCCESS [  0.591 s]
[INFO] Zeppelin: JDBC interpreter ......................... SUCCESS [  1.166 s]
[INFO] Zeppelin: File System Interpreters ................. SUCCESS [  1.054 s]
[INFO] Zeppelin: Flink .................................... SUCCESS [  6.863 s]
[INFO] Zeppelin: Apache Ignite interpreter ................ SUCCESS [  0.987 s]
[INFO] Zeppelin: Kylin interpreter ........................ SUCCESS [  0.421 s]
[INFO] Zeppelin: Python interpreter ....................... FAILURE [  0.481 s]
[INFO] Zeppelin: Lens interpreter ......................... SKIPPED
[INFO] Zeppelin: Apache Cassandra interpreter ............. SKIPPED
[INFO] Zeppelin: Elasticsearch interpreter ................ SKIPPED
[INFO] Zeppelin: BigQuery interpreter ..................... SKIPPED
[INFO] Zeppelin: Alluxio interpreter ...................... SKIPPED
[INFO] Zeppelin: Scio ..................................... SKIPPED
[INFO] Zeppelin: web Application .......................... SKIPPED
[INFO] Zeppelin: Server ................................... SKIPPED
[INFO] Zeppelin: Packaging distribution ................... SKIPPED
[INFO] Zeppelin: Scalding interpreter ..................... SKIPPED
[INFO] Zeppelin: Examples ................................. SKIPPED
[INFO] Zeppelin: Example application - Clock .............. SKIPPED
[INFO] Zeppelin: Example application - Horizontal Bar chart SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:02 min
[INFO] Finished at: 2016-11-24T17:21:08+00:00
[INFO] Final Memory: 181M/1246M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project zeppelin-python: Compilation failure
[ERROR] /home/travis/build/apache/zeppelin/python/src/test/java/org/apache/zeppelin/python/PythonDockerInterpreterTest.java:[73,12] no suitable constructor found for InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.HashMap<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,<nulltype>,<nulltype>,<nulltype>,org.apache.zeppelin.interpreter.InterpreterOutput)
[ERROR] constructor org.apache.zeppelin.interpreter.InterpreterContext.InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.Map<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,org.apache.zeppelin.display.AngularObjectRegistry,org.apache.zeppelin.resource.ResourcePool,java.util.List<org.apache.zeppelin.interpreter.InterpreterContextRunner>,org.apache.zeppelin.interpreter.InterpreterOutput,org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient) is not applicable
[ERROR] (actual and formal argument lists differ in length)
[ERROR] constructor org.apache.zeppelin.interpreter.InterpreterContext.InterpreterContext(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.apache.zeppelin.user.AuthenticationInfo,java.util.Map<java.lang.String,java.lang.Object>,org.apache.zeppelin.display.GUI,org.apache.zeppelin.display.AngularObjectRegistry,org.apache.zeppelin.resource.ResourcePool,java.util.List<org.apache.zeppelin.interpreter.InterpreterContextRunner>,org.apache.zeppelin.interpreter.InterpreterOutput) is not applicable
[ERROR] (actual and formal argument lists differ in length)
```

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?

NO JIRA issue. (small, emergently)

### How should this be tested?

CI will do that :)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO

