### PR TITLE
Fix Travis build error with ls command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1024M -Xmx2048M -XX:MaxPermSize=1024m -XX:-UseGCOverheadLimit'" >> ~/.mavenrc
-  - "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin" || true
+  - ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin || true
   - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || echo "node_modules are not cached"
   - mkdir -p ~/R
   - echo 'R_LIBS=~/R' > ~/.Renviron

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1024M -Xmx2048M -XX:MaxPermSize=1024m -XX:-UseGCOverheadLimit'" >> ~/.mavenrc
-  - "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin"
+  - "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin" || true
   - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || echo "node_modules are not cached"
   - mkdir -p ~/R
   - echo 'R_LIBS=~/R' > ~/.Renviron


### PR DESCRIPTION
### What is this PR for?
Fix error with

```
$ ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin
ls: cannot access /home/travis/.m2/repository/.cache/maven-download-plugin: No such file or directory
.spark-dist:
total 4
drwxr-xr-x  2 travis travis    6 Nov 25 19:27 .
drwxr-xr-x 47 travis travis 4096 Nov 25 19:27 ..
The command "ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin" failed and exited with 2 during .
Your build has been stopped.
```
https://travis-ci.org/apache/zeppelin/jobs/178918031

### What type of PR is it?
Bug Fix

### How should this be tested?
CI

### Questions:
* Does the licenses files need update? None
* Is there breaking changes for older versions? None
* Does this needs documentation? None

