### PR TITLE
[ZEPPELIN-1714] Build error of scio Intepreter on Centos

### DIFF
--- a/scio/src/main/scala/org/apache/zeppelin/scio/ScioInterpreter.scala
+++ b/scio/src/main/scala/org/apache/zeppelin/scio/ScioInterpreter.scala
@@ -161,7 +161,7 @@ class ScioInterpreter(property: Properties) extends Interpreter(property) {
     innerOut.setInterpreterOutput(context.out)
 
     try {
-      import tools.nsc.interpreter.Results._
+      import scala.tools.nsc.interpreter.Results._
       REPL.interpret(code) match {
         case Success => {
           logger.debug(s"Successfully executed `$code` in $paragraphId")


### PR DESCRIPTION
### What is this PR for?
This PR fixes build error of scio Intepreter on CentOS.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1714

### How should this be tested?
Run `mvn clean package -DskipTest' on CentOS

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

