### PR TITLE
[ZEPPELIN-1686] Added clear output to keyboard shortcut

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1850,6 +1850,8 @@
           } else {
             $scope.showTitle();
           }
+        } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 67) { // Ctrl + shift + c
+          $scope.clearParagraphOutput();
         } else {
           noShortcutDefined = true;
         }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -762,6 +762,8 @@
         $scope.editor.commands.bindKey('ctrl-alt-n.', null);
         $scope.editor.commands.removeCommand('showSettingsMenu');
 
+        $scope.editor.commands.bindKey('ctrl-alt-l', null);
+
         // autocomplete on 'ctrl+.'
         $scope.editor.commands.bindKey('ctrl-.', 'startAutocomplete');
         $scope.editor.commands.bindKey('ctrl-space', null);
@@ -1850,7 +1852,7 @@
           } else {
             $scope.showTitle();
           }
-        } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 67) { // Ctrl + shift + c
+        } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 76) { // Ctrl + Alt + l
           $scope.clearParagraphOutput();
         } else {
           noShortcutDefined = true;

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -180,6 +180,17 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">c</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Clear output
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">-</kbd>
             </div>
           </div>
@@ -198,6 +209,7 @@ limitations under the License.
             Increase paragraph width
           </div>
         </div>
+
 
         <h4>Editor Shortcuts</h4>
 

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -180,6 +180,17 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">l</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Clear output
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">c</kbd>
             </div>
           </div>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -191,17 +191,6 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">c</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Clear output
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">-</kbd>
             </div>
           </div>


### PR DESCRIPTION
### What is this PR for?
This PR Added "Clear output" of paragraph to the keyboard shortcut.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1686

### How should this be tested?
Click in paragraph and press Ctrl+Shift+c

### Screenshots (if appropriate)
![screenshot from 2016-11-27 06-29-27](https://cloud.githubusercontent.com/assets/8110458/20644011/e8d8f370-b46a-11e6-83cd-2d2fffc10a77.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no