### PR TITLE
ZEPPELIN-1716. Error of interpreter not found is not propagated to fr…

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -593,7 +593,12 @@ public class Paragraph extends Job implements Serializable, Cloneable {
   }
 
   private boolean isValidInterpreter(String replName) {
-    return factory.getInterpreter(user,
-        note.getId(), replName) != null;
+    try {
+      return factory.getInterpreter(user,
+          note.getId(), replName) != null;
+    } catch (InterpreterException e) {
+      // ignore this exception, it would be recaught when running paragraph.
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### What is this PR for?
It is introduced in ZEPPELIN-1399, we call `InterpreterFactory.getInterpreter` before calling `Paragraph.jobRun`. This PR would ignore the `InterpreterException` in `Paragraph.isValidIntepreter`


### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1716

### How should this be tested?
Tested manually, see the following screenshot

### Screenshots (if appropriate)

Before this PR, only see the following error in log, but not in frontend
```
ERROR [2016-11-28 15:16:47,378] ({qtp1471868639-17} NotebookServer.java[onMessage]:303) - Can't handle message
org.apache.zeppelin.interpreter.InterpreterException: spark.sparkr interpreter not found
    at org.apache.zeppelin.interpreter.InterpreterFactory.getInterpreter(InterpreterFactory.java:1302)
    at org.apache.zeppelin.notebook.Paragraph.isValidInterpreter(Paragraph.java:596)
    at org.apache.zeppelin.notebook.Paragraph.getMagic(Paragraph.java:586)
    at org.apache.zeppelin.socket.NotebookServer.runParagraph(NotebookServer.java:1337)
    at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:226)
    at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:59)
```
After this PR
![2016-11-28_1514](https://cloud.githubusercontent.com/assets/164491/20659318/e8d00a58-b57d-11e6-854d-899614c4ca87.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

