### PR TITLE
[ZEPPELIN-1695] chore: Set xml plugin phase to verify (minor)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
           <version>1.0.1</version>
           <executions>
             <execution>
-              <phase>validate</phase>
+              <phase>verify</phase>
               <goals>
                 <goal>validate</goal>
               </goals>


### PR DESCRIPTION
### What is this PR for?

Changed the phase of xml validation plugin from validate to verify so that developers can use `mvn test` in submodule dirctories
(**this PR doesn't affect on runtime application behaivor.**)

```
[INFO] --- xml-maven-plugin:1.0.1:validate (default) @ zeppelin-markdown ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.643 s
[INFO] Finished at: 2016-11-28T17:53:47+09:00
[INFO] Final Memory: 17M/307M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.0.1:validate (default) on project zeppelin-markdown: Failed to load schema with public ID null, system ID _tools/maven-4.0.0.xsd: /Users/lambda/github/apache-zeppelin/zeppelin-feature/markdown/_tools/maven-4.0.0.xsd (No such file or directory) -> [Help 1]
[ERROR]
```

### What type of PR is it?
[Improvement]

### Todos


### What is the Jira issue?

[ZEPPELIN-1695](https://issues.apache.org/jira/browse/ZEPPELIN-1695?filter=-3)

### How should this be tested?

```
$ cd markdown
$ mvn test
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO

