### PR TITLE
Downloading dependency/changing version for an interpreter results in error sometimes

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -466,7 +466,11 @@ public class InterpreterFactory implements InterpreterGroupFactory {
             File localRepoDir = new File(conf.getInterpreterLocalRepoPath() + "/" +
                 setting.getId());
             if (localRepoDir.exists()) {
-              FileUtils.cleanDirectory(localRepoDir);
+              try {
+                FileUtils.cleanDirectory(localRepoDir);
+              } catch (FileNotFoundException e) {
+                logger.info("A file that does not exist cannot be deleted, nothing to worry", e);
+              }
             }
 
             // load dependencies


### PR DESCRIPTION
### What is this PR for?
At times on downloading dependency/changing version for an interpreter results in error

```
 INFO [2016-11-29 11:16:52,998] ({qtp60559178-18} InterpreterRestApi.java[updateSetting]:137) - Update interpreterSetting 2C2ENJBEV
ERROR [2016-11-29 11:16:53,047] ({Thread-61} InterpreterFactory.java[run]:494) - Error while downloading repos for interpreter group : jdbc, go to interpreter setting page click on edit and save it again to make this interpreter work properly. : File does not exist: /Users/xxx/local-repo/2C2ENJBEV/twill-zookeeper-0.6.0-incubating.jar
java.io.FileNotFoundException: File does not exist: /Users/xxx/local-repo/2C2ENJBEV/twill-zookeeper-0.6.0-incubating.jar
	at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2275)
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
	at org.apache.zeppelin.interpreter.InterpreterFactory$3.run(InterpreterFactory.java:470)
ERROR [2016-11-29 11:16:53,047] ({Thread-64} InterpreterFactory.java[run]:494) - Error while downloading repos for interpreter group : jdbc, go to interpreter setting page click on edit and save it again to make this interpreter work properly. : File does not exist: /Users/xxx/local-repo/2C2ENJBEV/zookeeper-3.4.6.jar
java.io.FileNotFoundException: File does not exist: /Users/xxx/local-repo/2C2ENJBEV/zookeeper-3.4.6.jar
	at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2275)
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
	at org.apache.zeppelin.interpreter.InterpreterFactory$3.run(InterpreterFactory.java:470)
```

but on re-saving it works fine.



### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
* [ZEPPELIN-1725](https://issues.apache.org/jira/browse/ZEPPELIN-1725)

### How should this be tested?
Configure following as dependencies in JDBC 
```
org.apache.hive:hive-jdbc:2.0.1	
org.apache.hadoop:hadoop-common:2.7.1	
org.apache.hive.shims:hive-shims-0.23:2.1.0	
org.apache.phoenix:phoenix-core:4.7.0-HBase-1.1
```
now try changing one of it, say "org.apache.hadoop:hadoop-common:2.7.1" to "org.apache.hadoop:hadoop-common:2.6.0"

Save should happen all the time. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a