### PR TITLE
[ZEPPELIN-1724] conda run command removed in 4.1.0

### DIFF
--- a/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
@@ -49,18 +49,21 @@ public class PythonCondaInterpreterTest implements InterpreterOutputListener {
     doReturn(python).when(conda).getPythonInterpreter();
   }
 
-  @Test
-  public void testListEnv() throws IOException, InterruptedException {
-    InterpreterContext context = getInterpreterContext();
-
+  private void setCondaEnvs() throws IOException, InterruptedException {
     StringBuilder sb = new StringBuilder();
     sb.append("#comment\n\nenv1   *  /path1\nenv2\t/path2\n");
 
     doReturn(sb).when(conda).createStringBuilder();
     doReturn(0).when(conda)
-        .runCommand(any(StringBuilder.class), anyString(), anyString(), anyString());
+      .runCommand(any(StringBuilder.class), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testListEnv() throws IOException, InterruptedException {
+    setCondaEnvs();
 
     // list available env
+    InterpreterContext context = getInterpreterContext();
     InterpreterResult result = conda.interpret("", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
@@ -72,12 +75,13 @@ public class PythonCondaInterpreterTest implements InterpreterOutputListener {
   }
 
   @Test
-  public void testActivateEnv() {
+  public void testActivateEnv() throws IOException, InterruptedException {
+    setCondaEnvs();
     InterpreterContext context = getInterpreterContext();
-    conda.interpret("activate env", context);
+    conda.interpret("activate env1", context);
     verify(python, times(1)).open();
     verify(python, times(1)).close();
-    verify(python).setPythonCommand("conda run -n env \"python -iu\"");
+    verify(python).setPythonCommand("/path1/bin/python");
   }
 
   @Test
@@ -86,7 +90,7 @@ public class PythonCondaInterpreterTest implements InterpreterOutputListener {
     conda.interpret("deactivate", context);
     verify(python, times(1)).open();
     verify(python, times(1)).close();
-    verify(python).setPythonCommand(null);
+    verify(python).setPythonCommand("python");
   }
 
   private InterpreterContext getInterpreterContext() {


### PR DESCRIPTION
### What is this PR for?
Because `conda run` command removed since version `4.0.9`, PythonCondaInterpreter not working after the `conda-4.0.9`.
This PR fixes this issue.

I tested conda-4.2.12 and conda-4.0.9 .

### What type of PR is it?
Bug Fix | Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1724


### How should this be tested?
Please refer to https://github.com/apache/zeppelin/pull/1645 

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

