### PR TITLE
remove usage of non-standard string method

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1338,7 +1338,7 @@
         var dsvRow = '';
         for (var index in row) {
           var stringValue =  (row[index]).toString();
-          if (stringValue.contains(delimiter)) {
+          if (stringValue.indexOf(delimiter) > -1) {
             dsvRow += '"' + stringValue + '"' + delimiter;
           } else {
             dsvRow += row[index] + delimiter;


### PR DESCRIPTION
### What is this PR for?
This PR removes a non-standard string prototype method `contains` that can cause potential bugs in the future maintenance.

### What type of PR is it?
Bug Fix 

### Todos
* [x] - remove usage of non-standard string method `contains` in favor of standard `indexOf`

### How should this be tested?
Download as `csv / tsv` (graph view) should work as expected