### PR TITLE
[ZEPPELIN-1727] Shift + Enter runs two paras in particular scenario

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -365,9 +365,9 @@
       _.each($scope.note.paragraphs, function(para) {
         if (para.id === paragraph.id) {
           para.focus = true;
+          $scope.$broadcast('focusParagraph', para.id, 0, false);
         }
       });
-      $scope.$broadcast('focusParagraph', paragraph.id, 0, false);
     };
 
     var removePara = function(paragraphId) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -367,6 +367,7 @@
           para.focus = true;
         }
       });
+      $scope.$broadcast('focusParagraph', paragraph.id, 0, false);
     };
 
     var removePara = function(paragraphId) {


### PR DESCRIPTION
### What is this PR for?
1. click *insert new* in p1(say code in p1 is %sh date -u )
2. New para p2 is created and cursor is on the p2 editor.
3. Type code say %sh date -u and press shift + enter.(without clicking on  p2's editor)
The output of p1 and p2 will be same, p2 run triggered p1's run as well.
This PR fixes the above scenario

### What type of PR is it?
Bug fix

### Todos
NA

### What is the Jira issue?


### How should this be tested?
The steps mentioned in description of PR need s to be tested

### Screenshots (if appropriate)
![date](https://cloud.githubusercontent.com/assets/5082742/20718785/de157348-b67f-11e6-9aef-6de085c1dcfe.gif)

### Questions:
* Does the licenses files need update? NA
* Is there breaking changes for older versions? NA
* Does this needs documentation? NA
