### PR TITLE
[ZEPPELIN-1729] With CRLF line endings, Livy gets HTTP 500 errors

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyHelper.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.livy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -212,16 +213,6 @@ public class LivyHelper {
                                      final InterpreterContext context,
                                      final Map<String, Integer> userSessionMap)
       throws Exception {
-    stringLines = stringLines
-        //for "\n" present in string
-        .replaceAll("\\\\n", "\\\\\\\\n")
-        //for new line present in string
-        .replaceAll("\\n", "\\\\n")
-        // for \" present in string
-        .replaceAll("\\\\\"", "\\\\\\\\\"")
-        // for " present in string
-        .replaceAll("\"", "\\\\\"");
-
     if (stringLines.trim().equals("")) {
       return new InterpreterResult(Code.SUCCESS, "");
     }
@@ -288,7 +279,7 @@ public class LivyHelper {
             + userSessionMap.get(context.getAuthenticationInfo().getUser())
             + "/statements",
         "POST",
-        "{\"code\": \"" + lines + "\" }",
+        "{\"code\": \"" + StringEscapeUtils.escapeJson(lines) + "\"}",
         context.getParagraphId());
     if (json.matches("^(\")?Session (\'[0-9]\' )?not found(.?\"?)$")) {
       throw new Exception("Exception: Session not found, Livy server would have restarted, " +

--- a/livy/src/main/test/org/apache/zeppelin/livy/LivyHelperTest.java
+++ b/livy/src/main/test/org/apache/zeppelin/livy/LivyHelperTest.java
@@ -111,4 +111,28 @@ public class LivyHelperTest {
     }
   }
 
+  @Test
+  public void checkInterpretMultilineUnix() {
+    try {
+      InterpreterResult result = livyHelper.interpret("print(1)\nprint(2)", interpreterContext, interpreter.userSessionMap);
+
+      collector.checkThat("check sessionId", InterpreterResult.Code.SUCCESS, CoreMatchers.equalTo(result.code()));
+
+    } catch (Exception e) {
+      collector.addError(e);
+    }
+  }
+
+  @Test
+  public void checkInterpretMultilineWindows() {
+    try {
+      InterpreterResult result = livyHelper.interpret("print(1)\r\nprint(2)", interpreterContext, interpreter.userSessionMap);
+
+      collector.checkThat("check sessionId", InterpreterResult.Code.SUCCESS, CoreMatchers.equalTo(result.code()));
+
+    } catch (Exception e) {
+      collector.addError(e);
+    }
+  }
+
 }


### PR DESCRIPTION
### What is this PR for?
When you paste text on Windows, you may inadvertedly add some Carriage Return control characters along with it. When this happens in a Livy paragraph in Zeppelin 0.6.0, execution of that paragraph will fail with a "500 Internal Server Error" message. This is because `LivyHelper` does not properly sanitise its input when generating a JSON payload for the Livy server. This PR takes the subset for the resolution of [ZEPPELIN-1430](https://issues.apache.org/jira/browse/ZEPPELIN-1430/) that should resolve this issue.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
<https://issues.apache.org/jira/browse/ZEPPELIN-1729>

### How should this be tested?

Paste the following code in a new paragraph, ensuring that lines are ended by CRLF rather than LF:

    %livy.pyspark
    import datetime
    import json

This can be easily realised on Windows, by copy-pasting this code from Notepad. Then, try to execute the paragraph. Without the fix, a "500 Internal Server Error" message should appear. With the fix, the paragraph will successfully execute (and do nothing interesting).

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.