### PR TITLE
[HOTFIX] Exclude org/apache/zeppelin/scio/avro/* once at pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
             </goals>
             <configuration>
               <failOnViolation>true</failOnViolation>
-              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*,org/apache/zeppelin/scio/avro/*</excludes>
+              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*</excludes>
             </configuration>
           </execution>
           <execution>
@@ -271,7 +271,7 @@
               <goal>checkstyle-aggregate</goal>
             </goals>
             <configuration>
-              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*,org/apache/zeppelin/scio/avro/*</excludes>
+              <excludes>org/apache/zeppelin/interpreter/thrift/*,org/apache/zeppelin/scio/avro/*</excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### What is this PR for?
Previously on #1676, I excluded path **twice**. It's my mistake! @khalidhuseynov pointed that out (Thanks!).

### What type of PR is it?
Hot Fix

### How should this be tested?
Build with command `mvn clean package install -DskipTests -DskipRat`

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

