### PR TITLE
[ZEPPELIN-1728] Add an example configuring classpath for hive-site.xml

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -146,11 +146,17 @@ For example,
 export SPARK_HOME=/usr/lib/spark
 ```
 
-You can optionally export `HADOOP_CONF_DIR` and `SPARK_SUBMIT_OPTIONS`
+You can optionally set more environment variables
 
 ```bash
+# set hadoop conf dir
 export HADOOP_CONF_DIR=/usr/lib/hadoop
+
+# set options to pass spark-submit command
 export SPARK_SUBMIT_OPTIONS="--packages com.databricks:spark-csv_2.10:1.2.0"
+
+# extra classpath. e.g. set classpath for hive-site.xml
+export ZEPPELIN_INTP_CLASSPATH_OVERRIDES=/etc/hive/conf
 ```
 
 For Windows, ensure you have `winutils.exe` in `%HADOOP_HOME%\bin`. Please see [Problems running Hadoop on Windows](https://wiki.apache.org/hadoop/WindowsProblems) for the details.


### PR DESCRIPTION
### What is this PR for?
hive-site.xml is required to configure HiveContext in SparkInterpreter.
So it'll be helpful if document provide at least simple example that can help user get some idea.

### What type of PR is it?
Improvement

### Todos
* [x] - Add simple example

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1728

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

