### PR TITLE
[ZEPPELIN-1742] send error info to popup when commit fails

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1401,6 +1401,10 @@ public class NotebookServer extends WebSocketServlet implements
       List<Revision> revisions = notebook.listRevisionHistory(noteId, subject);
       conn.send(serializeMessage(new Message(OP.LIST_REVISION_HISTORY)
         .put("revisionList", revisions)));
+    } else {
+      conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
+          "Couldn't checkpoint note revision: possibly storage doesn't support versioning. "
+          + "Please check the logs for more details.")));
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
To notify user when commit of note revision have failed.


### What type of PR is it?
Bug Fix | Improvement

### Todos
* [x] - send error

### What is the Jira issue?
[ZEPPELIN-1742](https://issues.apache.org/jira/browse/ZEPPELIN-1742)

### How should this be tested?
try to commit note with default storage

### Screenshots (if appropriate)
failure case before:
![commit error before](https://cloud.githubusercontent.com/assets/1642088/20796541/e91c3d76-b819-11e6-9d73-aaa6708b8a2d.gif)


failure case after:
![commit error](https://cloud.githubusercontent.com/assets/1642088/20796103/faf4c33a-b817-11e6-849a-75401a96b6cb.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

