### PR TITLE
[ZEPPELIN-1740] Focus next paragraph after paragraph deletion

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -265,7 +265,12 @@
       if (paragraphs[paragraphs.length - 1].id.startsWith($scope.paragraph.id)) {
         BootstrapDialog.alert({
           closable: true,
-          message: 'The last paragraph can\'t be deleted.'
+          message: 'The last paragraph can\'t be deleted.',
+          callback: function(result) {
+            if (result) {
+              $scope.editor.focus();
+            }
+          }
         });
       } else {
         BootstrapDialog.confirm({
@@ -275,8 +280,8 @@
           callback: function(result) {
             if (result) {
               console.log('Remove paragraph');
-              $scope.$emit('moveFocusToNextParagraph', $scope.paragraph.id);
               websocketMsgSrv.removeParagraph($scope.paragraph.id);
+              $scope.$emit('moveFocusToNextParagraph', $scope.paragraph.id);
             }
           }
         });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -275,6 +275,7 @@
           callback: function(result) {
             if (result) {
               console.log('Remove paragraph');
+              $scope.$emit('moveFocusToNextParagraph', $scope.paragraph.id);
               websocketMsgSrv.removeParagraph($scope.paragraph.id);
             }
           }


### PR DESCRIPTION
### What is this PR for?
This PR is for moving focus next paragraph after paragraph deletion using Ctrl-Alt-D.
After paragraph is removed by keyboard shortcut Ctrl-Alt-D, focus is gone.
We have to move mouse and click the next paragraph to get focus.

### What type of PR is it?
[Improvement]

### Todos
* None

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1740

### How should this be tested?
Check the focus after pressing Ctrl-Alt-D in paragraph.

### Screenshots (if appropriate)
![z1740_1](https://cloud.githubusercontent.com/assets/8110458/20823489/c7ba83d0-b897-11e6-81a4-16f61434582c.gif)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

