### PR TITLE
[HOTFIX] Restore uninteded change of exit code in testing/dowloadSpark.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
   include:
     # Test License compliance using RAT tool
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
+      env: SCALA_VER="2.11" SPARK_VER="2.0.1" HADOOP_VER="2.3" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
     # Test all modules with spark 2.0.1 and scala 2.11
     - jdk: "oraclejdk7"

--- a/testing/downloadSpark.sh
+++ b/testing/downloadSpark.sh
@@ -19,7 +19,7 @@
 if [[ "$#" -ne 2 ]]; then
     echo "usage) $0 [spark version] [hadoop version]"
     echo "   eg) $0 1.3.1 2.6"
-    exit 0
+    exit 1
 fi
 
 SPARK_VERSION="${1}"


### PR DESCRIPTION
### What is this PR for?
This PR rollbacks unintended change of exit code in `testing/downloadSpark.sh` after #1599 which is raised by this [comments](https://github.com/apache/zeppelin/commit/b6cd47996038bafd3c05caf8f17b26f0d30f3224#commitcomment-20023614).

### What type of PR is it?
Hot Fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

