### PR TITLE
[ZEPPELIN-965] missing lastExecuteTime function

### DIFF
--- a/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
@@ -37,6 +37,11 @@
       var result = Math.ceil(runningJobCount / totalCount * 100);
       return isNaN(result) ? 0 : result;
     };
+
+    $scope.lastExecuteTime = function(unixtime) {
+      return moment.unix(unixtime / 1000).fromNow();
+    };
+
   }
 
 })();


### PR DESCRIPTION
### What is this PR for?
Added last note run time.
This was a bug.
The function was configured, but the function to output it was missing.

### What type of PR is it?
Bug Fix

### Todos
- [x] - added print function

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-965

### How should this be tested?
execute note and check in job menu.

### Screenshots (if appropriate)
![lasttimescreen](https://cloud.githubusercontent.com/assets/10525473/20824722/5f5b12e0-b8a2-11e6-9e16-26d72ed6de59.png)
(2 hour a go)
### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

