### PR TITLE
Fix case where user use zeppelin in normal mode with token

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepo.java
@@ -186,8 +186,14 @@ public class ZeppelinHubRepo implements NotebookRepo {
 
   /**
    * For a given user logged in is zeppelin (via zeppelinhub notebook repo), get default token.
-   *  */
+   *
+   */
   private String getUserToken(String principal) {
+    // Case of user use token instead of authentication.
+    if (!StringUtils.isBlank(token)) {
+      return token;
+    }
+
     String token = usersToken.get(principal);
     if (StringUtils.isBlank(token)) {
       String ticket = UserSessionContainer.instance.getSession(principal);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/zeppelinhub/ZeppelinHubRepoTest.java
@@ -42,11 +42,13 @@ public class ZeppelinHubRepoTest {
   private ZeppelinhubRestApiHandler getMockedZeppelinHandler() throws HttpException, IOException {
     ZeppelinhubRestApiHandler mockedZeppelinhubHandler = mock(ZeppelinhubRestApiHandler.class);
 
-    byte[] response = Files.toByteArray(pathOfNotebooks);
-    when(mockedZeppelinhubHandler.get("", "")).thenReturn(new String(response));
+    byte[] listOfNotesResponse = Files.toByteArray(pathOfNotebooks);
+    when(mockedZeppelinhubHandler.get("AAA-BBB-CCC-00", ""))
+      .thenReturn(new String(listOfNotesResponse));
 
-    response =  Files.toByteArray(pathOfNotebook);
-    when(mockedZeppelinhubHandler.get("", "AAAAA")).thenReturn(new String(response));
+    byte[] noteResponse =  Files.toByteArray(pathOfNotebook);
+    when(mockedZeppelinhubHandler.get("AAA-BBB-CCC-00", "AAAAA"))
+      .thenReturn(new String(noteResponse));
 
     return mockedZeppelinhubHandler;
   }


### PR DESCRIPTION
### What is this PR for?
Fix the case where user use zeppelin in normal mode (doesnt use authentication) and set zeppelinhub token in zeppelin-env.sh.

### What type of PR is it?
[Bug Fix | Hot Fix]

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

