### PR TITLE
[ZEPPELIN-1747] Fix Korean notename input problem

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -15,7 +15,7 @@ limitations under the License.
   <h3>
     <div style="float: left; width: auto; max-width: 40%"
       ng-controller="ElasticInputCtrl as input">
-      <input type="text" pu-elastic-input class="form-control2" placeholder="Note {{note.id}}" style="min-width: 0px; max-width: 95%;"
+      <input type="text" pu-elastic-input class="form-control2" placeholder="New name" style="min-width: 0px; max-width: 95%;"
            ng-if="input.showEditor" ng-model="note.name" ng-blur="sendNewName();input.showEditor = false;" ng-enter="sendNewName();input.showEditor = false;" ng-escape="note.name = oldName; input.showEditor = false" focus-if="input.showEditor" />
       <p class="form-control-static2" ng-click="input.showEditor = true; oldName = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -15,7 +15,7 @@ limitations under the License.
   <h3>
     <div style="float: left; width: auto; max-width: 40%"
       ng-controller="ElasticInputCtrl as input">
-      <input type="text" pu-elastic-input class="form-control2" placeholder="{{noteName(note)}}" style="min-width: 0px; max-width: 95%;"
+      <input type="text" pu-elastic-input class="form-control2" placeholder="Note {{note.id}}" style="min-width: 0px; max-width: 95%;"
            ng-if="input.showEditor" ng-model="note.name" ng-blur="sendNewName();input.showEditor = false;" ng-enter="sendNewName();input.showEditor = false;" ng-escape="note.name = oldName; input.showEditor = false" focus-if="input.showEditor" />
       <p class="form-control-static2" ng-click="input.showEditor = true; oldName = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>


### PR DESCRIPTION
### What is this PR for?
Korean notename is incorrectly typed on Firefox.
This PR fixes the issue by changing placeholder attribute of the input field.
Getting the placeholder text from `noteName()` is unnecessary because the text is visible only when the notename is blank.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1747

### How should this be tested?
Type Korean notename in action bar using Firefox browser.

### Screenshots (if appropriate)
![korean-notename-issue](https://cloud.githubusercontent.com/assets/17305893/20859768/d7f5cf60-b9ab-11e6-926d-814b8e0cafb3.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No