### PR TITLE
[ZEPPELIN-1695] Use shared versions in test libraries (maven)

### DIFF
--- a/alluxio/pom.xml
+++ b/alluxio/pom.xml
@@ -34,9 +34,8 @@
 
     <properties>
         <alluxio.version>1.0.0</alluxio.version>
-        <powermock.version>1.6.1</powermock.version>
-        <mockito.version>1.10.8</mockito.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.zeppelin</groupId>
@@ -76,35 +75,30 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -43,8 +43,6 @@
 
         <!-- test library versions -->
         <achilles.version>3.2.4-Zeppelin</achilles.version>
-        <assertj.version>1.7.0</assertj.version>
-        <mockito.version>1.9.5</mockito.version>
         <jna.version>4.2.0</jna.version>
 
         <!-- plugin versions -->
@@ -167,14 +165,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -42,7 +42,6 @@
         <cassandra.guava.version>16.0.1</cassandra.guava.version>
 
         <!-- test library versions -->
-        <junit.version>4.12</junit.version>
         <achilles.version>3.2.4-Zeppelin</achilles.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.9.5</mockito.version>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -36,9 +36,6 @@
     <!--library versions-->
     <geode.version>1.0.0-incubating-SNAPSHOT</geode.version>
     <commons.exec.version>1.3</commons.exec.version>
-
-    <!--test library versions-->
-    <mockito.all.version>1.9.5</mockito.all.version>
   </properties>
 
   <dependencies>
@@ -80,7 +77,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -41,7 +41,6 @@
     <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
 
     <!--test library versions-->
-    <mockito.all.version>1.9.5</mockito.all.version>
     <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
   </properties>
   
@@ -109,7 +108,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -42,7 +42,6 @@
         <spring.security.kerberosclient>1.0.1.RELEASE</spring.security.kerberosclient>
 
         <!--test library versions-->
-        <junit.version>4.12</junit.version>
         <achilles.version>3.2.4-Zeppelin</achilles.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.9.5</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,9 @@
 
     <!-- test library versions -->
     <junit.version>4.12</junit.version>
+    <mockito.version>1.10.19</mockito.version>
+    <assertj.version>1.7.0</assertj.version>
+    <powermock.version>1.6.4</powermock.version>
 
     <!-- plugin versions -->
     <plugin.compiler.version>3.1</plugin.compiler.version>
@@ -218,13 +221,6 @@
         <version>${guava.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-
       <!-- Apache Shiro -->
       <dependency>
         <groupId>org.apache.shiro</groupId>
@@ -241,6 +237,64 @@
         <artifactId>shiro-config-core</artifactId>
         <version>${shiro.version}</version>
       </dependency>
+
+      <!-- Test libraries -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-all</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-core</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-reflect</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,10 @@
     <commons.io.version>2.4</commons.io.version>
     <commons.collections.version>3.2.1</commons.collections.version>
     <commons.logging.version>1.1.1</commons.logging.version>
-    <junit.version>4.11</junit.version>
     <shiro.version>1.2.3</shiro.version>
+
+    <!-- test library versions -->
+    <junit.version>4.12</junit.version>
 
     <!-- plugin versions -->
     <plugin.compiler.version>3.1</plugin.compiler.version>

--- a/postgresql/pom.xml
+++ b/postgresql/pom.xml
@@ -38,7 +38,6 @@
     <jline.version>2.12.1</jline.version>
 
     <!--test library versions-->
-    <mockito.all.version>1.9.5</mockito.all.version>
     <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
 
   </properties>
@@ -87,7 +86,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -61,7 +61,6 @@
       <version>${py4j.version}</version>
     </dependency>
 
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -72,6 +71,7 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
+    <!-- test libraries -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -81,13 +81,9 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-
-
 
   <build>
     <plugins>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -45,9 +45,6 @@
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
     <wagon.version>1.0</wagon.version>
 
-    <!--test library versions-->
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.4</powermock.version>
     <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
     <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
     <datanucleus.core.version>3.2.10</datanucleus.core.version>
@@ -305,21 +302,18 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -368,7 +368,7 @@ The following components are provided under the EPL License.
     (EPL 1.0) Sisu Inject Plexus 2.2.2 (org.sonatype.sisu:sisu-inject-plexus:2.2.2 - https://github.com/sonatype/sisu)
     (EPL 1.0) Sisu Inject Bean 2.2.2 (org.sonatype.sisu:sisu-inject-bean:2.2.2 - https://github.com/sonatype/sisu)
     (EPL 1.0) Sisu Inject Guice (org.sonatype.sisu:sisu-inject-guice:no_aop- https://github.com/sonatype/sisu)
-    (EPL 1.0) JUnit 4.11 (junit:junit:4.11 - https://github.com/junit-team/junit4)
+    (EPL 1.0) JUnit 4.12 (junit:junit:4.12 - https://github.com/junit-team/junit4)
 
 
 

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -45,9 +45,6 @@
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
     <wagon.version>1.0</wagon.version>
 
-    <!--test library versions-->
-    <mockito.all.version>1.9.0</mockito.all.version>
-
     <!--plugin versions-->
     <plugin.shade.version>2.3</plugin.shade.version>
   </properties>
@@ -223,7 +220,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -43,7 +43,6 @@
     <jna.version>4.1.0</jna.version>
 
     <!--test library versions-->
-    <mockito.all.version>1.9.0</mockito.all.version>
     <selenium.java.version>2.48.2</selenium.java.version>
     <xml.apis.version>1.4.01</xml.apis.version>
 
@@ -330,7 +329,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -47,7 +47,6 @@
     <eclipse.jgit.version>4.1.1.201511131810-r</eclipse.jgit.version>
 
     <!--test library versions-->
-    <mockito.all.version>1.9.0</mockito.all.version>
     <google.truth.version>0.27</google.truth.version>
   </properties>
 
@@ -221,7 +220,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>${mockito.all.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
### What is this PR for?

Use shared test library versions in maven config so that lib versions do mot be fragmented. 
Previously we used multiple versions of 

- Junit (4.11, 4.12)
- mockito (1.9.0, 1.10.8, ...)
- powermock (...)

### What type of PR is it?
[Improvement]

### What is the Jira issue?

[ZEPPELIN-1695](https://issues.apache.org/jira/browse/ZEPPELIN-1695)

### How should this be tested?

Use this command to see test libraries share versions or not

```
$ mvn org.apache.maven.plugins:maven-help-plugin:2.2:effective-pom | vim -
```

### Questions:
* Does the licenses files need update? - YES, I updated JUnit version to 4.12 from 4.11
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
