### PR TITLE
[ZEPPELIN-1754] PING request stacking on websocket reconnect

### DIFF
--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -20,6 +20,7 @@
 
   function websocketEvents($rootScope, $websocket, $location, baseUrlSrv) {
     var websocketCalls = {};
+    var pingIntervalId;
 
     websocketCalls.ws = $websocket(baseUrlSrv.getWebsocketUrl());
     websocketCalls.ws.reconnectIfNotNormalClose = true;
@@ -27,7 +28,7 @@
     websocketCalls.ws.onOpen(function() {
       console.log('Websocket created');
       $rootScope.$broadcast('setConnectedStatus', true);
-      setInterval(function() {
+      pingIntervalId = setInterval(function() {
         websocketCalls.sendNewEvent({op: 'PING'});
       }, 10000);
     });
@@ -158,6 +159,10 @@
 
     websocketCalls.ws.onClose(function(event) {
       console.log('close message: ', event);
+      if (pingIntervalId !== undefined) {
+        clearInterval(pingIntervalId);
+        pingIntervalId = undefined;
+      }
       $rootScope.$broadcast('setConnectedStatus', false);
     });
 


### PR DESCRIPTION
### What is this PR for?
Fixes a bug when PING requests are stacking when server restarted.

### What type of PR is it?
[Bug Fix]

### Todos
No

### What is the Jira issue?
[ZEPPELIN-1754]

### How should this be tested?
1) build Zeppelin leaving console.log enabled
2) start ZeppelinServer, open any notebook in browser
3) open console with timestamps and check that PING request repeats exactly once in every 10 second
4) restart ZeppelinServer but do not close or refresh the notebook page
5) wait for websocket connection reopened
6) check PING request frequency in console
PING requests should repeat not often than once per 10 seconds.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
No

* Is there breaking changes for older versions?
No

* Does this needs documentation?
No