### PR TITLE
[ZEPPELIN-1736] Introduce trash & enable removing folder

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1051,7 +1051,7 @@ public class NotebookServer extends WebSocketServlet
 
   private void restoreFolder(NotebookSocket conn, HashSet<String> userAndRoles,
                             Notebook notebook, Message fromMessage)
-          throws SchedulerException, IOException {
+      throws SchedulerException, IOException {
     String folderId = (String) fromMessage.get("id");
 
     if (folderId == null) {
@@ -1079,7 +1079,7 @@ public class NotebookServer extends WebSocketServlet
 
   private void emptyTrash(NotebookSocket conn, HashSet<String> userAndRoles,
                           Notebook notebook, Message fromMessage)
-    throws SchedulerException, IOException {
+      throws SchedulerException, IOException {
     fromMessage.data = new HashMap<>();
     fromMessage.put("id", Folder.TRASH_FOLDER_ID);
     removeFolder(conn, userAndRoles, notebook, fromMessage);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -29,6 +29,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -1060,25 +1062,12 @@ public class NotebookServer extends WebSocketServlet
 
     Folder folder = notebook.getFolder(folderId);
     if (folder != null && folder.isTrash()) {
-      String restoreName = folder.getId().replaceFirst(Folder.TRASH_FOLDER_ID + "/", "");
+      String restoreName = folder.getId().replaceFirst(Folder.TRASH_FOLDER_ID + "/", "").trim();
 
       // if the folder had conflict when it had moved to trash before
-      if (folder.getId().indexOf(Folder.TRASH_FOLDER_CONFLICT_INFIX) > 0) {
-        String[] splits = restoreName.split(Folder.TRASH_FOLDER_CONFLICT_INFIX);
-        String nameWithoutInfix = splits[0];
-        String removedDateString = splits[1];
-        boolean isDateString;
-
-        try {
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").parseDateTime(removedDateString);
-          isDateString = true;
-        } catch (IllegalArgumentException e) {
-          isDateString = false;
-        }
-
-        if (isDateString)
-          restoreName = nameWithoutInfix;
-      }
+      Pattern p = Pattern.compile("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$");
+      Matcher m = p.matcher(restoreName);
+      restoreName = m.replaceAll("").trim();
 
       fromMessage.put("name", restoreName);
       renameFolder(conn, userAndRoles, notebook, fromMessage, "restore");

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1072,7 +1072,7 @@ public class NotebookServer extends WebSocketServlet
         try {
           DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").parseDateTime(removedDateString);
           isDateString = true;
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
           isDateString = false;
         }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -119,10 +119,10 @@ abstract public class AbstractZeppelinIT {
   }
 
   protected void deleteTestNotebook(final WebDriver driver) {
-    driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']"))
+    driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='moveNoteToTrash(note.id)']"))
         .sendKeys(Keys.ENTER);
     ZeppelinITUtils.sleep(1000, true);
-    driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this note')]" +
+    driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'This note will be moved to trash')]" +
         "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
     ZeppelinITUtils.sleep(100, true);
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -179,10 +179,10 @@ public class ZeppelinIT extends AbstractZeppelinIT {
       waitForText("BindingTest_1_",
           By.xpath(getParagraphXPath(1) + "//div[@id=\"angularTestButton\"]"));
 
-      driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']"))
+      driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='moveNoteToTrash(note.id)']"))
           .sendKeys(Keys.ENTER);
       ZeppelinITUtils.sleep(1000, true);
-      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'delete this note')]" +
+      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'This note will be moved to trash')]" +
           "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
       ZeppelinITUtils.sleep(100, true);
 

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -101,7 +101,8 @@
             combineDuplications: true,
             timeout: 6000
           });
-        });
+        })
+        .constant('TRASH_FOLDER_ID', '~Trash');
 
   function auth() {
     var $http = angular.injector(['ng']).get('$http');

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -22,11 +22,12 @@
     '$rootScope',
     'arrayOrderingSrv',
     'ngToast',
-    'noteActionSrv'
+    'noteActionSrv',
+    'TRASH_FOLDER_ID'
   ];
 
   function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv,
-                    ngToast, noteActionSrv) {
+                    ngToast, noteActionSrv, TRASH_FOLDER_ID) {
     ngToast.dismiss();
     var vm = this;
     vm.notes = noteListDataFactory;
@@ -41,6 +42,7 @@
     }
 
     $scope.isReloading = false;
+    $scope.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
 
     var initHome = function() {
       websocketMsgSrv.getHomeNote();

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -91,12 +91,40 @@
       noteActionSrv.renameNote(node.id, node.path);
     };
 
+    $scope.moveNoteToTrash = function(noteId) {
+      noteActionSrv.moveNoteToTrash(noteId, false);
+    };
+
+    $scope.moveFolderToTrash = function(folderId) {
+      noteActionSrv.moveFolderToTrash(folderId);
+    };
+
+    $scope.restoreNote = function(noteId) {
+      websocketMsgSrv.restoreNote(noteId);
+    };
+
+    $scope.restoreFolder = function(folderId) {
+      websocketMsgSrv.restoreFolder(folderId);
+    };
+
+    $scope.restoreAll = function() {
+      noteActionSrv.restoreAll();
+    };
+
     $scope.renameFolder = function(node) {
       noteActionSrv.renameFolder(node.id);
     };
 
     $scope.removeNote = function(noteId) {
       noteActionSrv.removeNote(noteId, false);
+    };
+
+    $scope.removeFolder = function(folderId) {
+      noteActionSrv.removeFolder(folderId);
+    };
+
+    $scope.emptyTrash = function() {
+      noteActionSrv.emptyTrash();
     };
 
     $scope.clearAllParagraphOutput = function(noteId) {

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -51,6 +51,13 @@ body .navbar {
   width: auto;
 }
 
+.notebook-list-btn {
+  font-size: 13px;
+  margin-left: 2px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
 .navbar-inverse {
   background: #3071a9;
   color: #fff;

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -21,30 +21,29 @@ limitations under the License.
       <i style="font-size: 10px;" class="icon-doc"/> {{noteName(node)}}
     </a>
     <a style="text-decoration: none;">
-      <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
-         class="fa fa-pencil" ng-show="showNoteButton" ng-click="renameNote(node)"
+      <i style="margin-left: 10px;"
+         class="fa fa-pencil notebook-list-btn" ng-show="showNoteButton" ng-click="renameNote(node)"
          tooltip-placement="bottom" tooltip="Rename note">
       </i>
     </a>
     <a style="text-decoration: none;">
-      <i style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-         class="fa fa-eraser" ng-show="showNoteButton" ng-click="clearAllParagraphOutput(node.id)"
+      <i class="fa fa-eraser notebook-list-btn" ng-show="showNoteButton" ng-click="clearAllParagraphOutput(node.id)"
          tooltip-placement="bottom" tooltip="Clear output">
       </i>
     </a>
     <a style="text-decoration: none;">
       <!-- if note is not in trash -->
-      <i ng-if="!node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-         class="fa fa-trash-o" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
+      <i ng-if="!node.isTrash"
+         class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
          tooltip-placement="bottom" tooltip="Move note to Trash">
       </i>
       <!-- if note is in trash -->
-      <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-         class="fa fa-trash-o" ng-show="showNoteButton" ng-click="removeNote(node.id)"
+      <i ng-if="node.isTrash"
+         class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
          tooltip-placement="bottom" tooltip="Remove note permanently">
       </i>
-      <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-         class="fa fa-undo" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
+      <i ng-if="node.isTrash"
+         class="fa fa-undo notebook-list-btn" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
          tooltip-placement="bottom" tooltip="Restore note">
       </i>
     </a>
@@ -57,22 +56,22 @@ limitations under the License.
         <i style="font-size: 10px;" ng-class="node.hidden ? 'icon-folder' : 'icon-folder-alt'" /> {{noteName(node)}}
       </a>
       <a style="text-decoration: none;">
-        <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
-           class="fa fa-pencil" ng-show="showFolderButton" ng-click="renameFolder(node)"
+        <i style="margin-left: 10px;"
+           class="fa fa-pencil notebook-list-btn" ng-show="showFolderButton" ng-click="renameFolder(node)"
            tooltip-placement="bottom" tooltip="Rename folder">
         </i>
         <!-- if folder is not in trash -->
-        <i ng-if="!node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
+        <i ng-if="!node.isTrash"
+           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
            tooltip-placement="bottom" tooltip="Move folder to Trash">
         </i>
         <!-- if folder is in trash -->
-        <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
+        <i ng-if="node.isTrash"
+           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
            tooltip-placement="bottom" tooltip="Remove folder permanently">
         </i>
-        <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-           class="fa fa-undo" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
+        <i ng-if="node.isTrash"
+           class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
            tooltip-placement="bottom" tooltip="Restore folder">
         </i>
       </a>
@@ -91,12 +90,11 @@ limitations under the License.
         <i style="font-size: 10px;" class="fa fa-trash-o" /> Trash
       </a>
       <a style="text-decoration: none;">
-        <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
-           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="emptyTrash()"
+        <i style="margin-left: 10px;"
+           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="emptyTrash()"
            tooltip-placement="bottom" tooltip="Empty trash">
         </i>
-        <i style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
-           class="fa fa-undo" ng-show="showFolderButton" ng-click="restoreAll()"
+        <i class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreAll()"
            tooltip-placement="bottom" tooltip="Restore all">
         </i>
       </a>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -50,7 +50,7 @@ limitations under the License.
     </a>
   </div>
   <!-- folder -->
-  <div ng-if="node.children != null && node.id !== '~Trash'">
+  <div ng-if="node.children != null && node.id !== TRASH_FOLDER_ID">
     <div ng-mouseenter="showFolderButton=true"
          ng-mouseleave="showFolderButton=false">
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
@@ -84,7 +84,7 @@ limitations under the License.
     </div>
   </div>
   <!-- trash folder -->
-  <div ng-if="node.id === '~Trash'">
+  <div ng-if="node.id === TRASH_FOLDER_ID">
     <div ng-mouseenter="showFolderButton=true"
          ng-mouseleave="showFolderButton=false">
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -41,7 +41,7 @@ limitations under the License.
       <!-- if note is in trash -->
       <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
          class="fa fa-trash-o" ng-show="showNoteButton" ng-click="removeNote(node.id)"
-         tooltip-placement="bottom" tooltip="Remove note for good">
+         tooltip-placement="bottom" tooltip="Remove note permanently">
       </i>
       <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
          class="fa fa-undo" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
@@ -69,7 +69,7 @@ limitations under the License.
         <!-- if folder is in trash -->
         <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
            class="fa fa-trash-o" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
-           tooltip-placement="bottom" tooltip="Remove folder for good">
+           tooltip-placement="bottom" tooltip="Remove folder permanently">
         </i>
         <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
            class="fa fa-undo" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -39,12 +39,12 @@ limitations under the License.
       </i>
       <!-- if note is in trash -->
       <i ng-if="node.isTrash"
-         class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
-         tooltip-placement="bottom" tooltip="Remove note permanently">
-      </i>
-      <i ng-if="node.isTrash"
          class="fa fa-undo notebook-list-btn" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
          tooltip-placement="bottom" tooltip="Restore note">
+      </i>
+      <i ng-if="node.isTrash" style="font-size: 16px;"
+         class="fa fa-times notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
+         tooltip-placement="bottom" tooltip="Remove note permanently">
       </i>
     </a>
   </div>
@@ -67,12 +67,12 @@ limitations under the License.
         </i>
         <!-- if folder is in trash -->
         <i ng-if="node.isTrash"
-           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
-           tooltip-placement="bottom" tooltip="Remove folder permanently">
-        </i>
-        <i ng-if="node.isTrash"
            class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
            tooltip-placement="bottom" tooltip="Restore folder">
+        </i>
+        <i ng-if="node.isTrash" style="font-size: 16px"
+           class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
+           tooltip-placement="bottom" tooltip="Remove folder permanently">
         </i>
       </a>
     </div>
@@ -87,15 +87,16 @@ limitations under the License.
     <div ng-mouseenter="showFolderButton=true"
          ng-mouseleave="showFolderButton=false">
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
-        <i style="font-size: 10px;" class="fa fa-trash-o" /> Trash
+        <i style="font-size: 14px;" class="fa fa-trash-o" /> Trash
       </a>
       <a style="text-decoration: none;">
-        <i style="margin-left: 10px;"
-           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="emptyTrash()"
-           tooltip-placement="bottom" tooltip="Empty trash">
-        </i>
-        <i class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreAll()"
+        <i style="margin-left: 10px"
+           class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreAll()"
            tooltip-placement="bottom" tooltip="Restore all">
+        </i>
+        <i style="font-size: 16px;"
+           class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="emptyTrash()"
+           tooltip-placement="bottom" tooltip="Empty trash">
         </i>
       </a>
     </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -13,6 +13,7 @@ limitations under the License.
 -->
 
 <script type="text/ng-template" id="notebook_folder_renderer.html">
+  <!-- note -->
   <div ng-if="node.children == null"
        ng-mouseenter="showNoteButton=true"
        ng-mouseleave="showNoteButton=false">
@@ -32,13 +33,24 @@ limitations under the License.
       </i>
     </a>
     <a style="text-decoration: none;">
-      <i style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+      <!-- if note is not in trash -->
+      <i ng-if="!node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+         class="fa fa-trash-o" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
+         tooltip-placement="bottom" tooltip="Move note to Trash">
+      </i>
+      <!-- if note is in trash -->
+      <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
          class="fa fa-trash-o" ng-show="showNoteButton" ng-click="removeNote(node.id)"
-         tooltip-placement="bottom" tooltip="Remove note">
+         tooltip-placement="bottom" tooltip="Remove note for good">
+      </i>
+      <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+         class="fa fa-undo" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
+         tooltip-placement="bottom" tooltip="Restore note">
       </i>
     </a>
   </div>
-  <div ng-if="node.children != null">
+  <!-- folder -->
+  <div ng-if="node.children != null && node.id !== '~Trash'">
     <div ng-mouseenter="showFolderButton=true"
          ng-mouseleave="showFolderButton=false">
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
@@ -48,6 +60,44 @@ limitations under the License.
         <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
            class="fa fa-pencil" ng-show="showFolderButton" ng-click="renameFolder(node)"
            tooltip-placement="bottom" tooltip="Rename folder">
+        </i>
+        <!-- if folder is not in trash -->
+        <i ng-if="!node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
+           tooltip-placement="bottom" tooltip="Move folder to Trash">
+        </i>
+        <!-- if folder is in trash -->
+        <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
+           tooltip-placement="bottom" tooltip="Remove folder for good">
+        </i>
+        <i ng-if="node.isTrash" style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+           class="fa fa-undo" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
+           tooltip-placement="bottom" tooltip="Restore folder">
+        </i>
+      </a>
+    </div>
+    <div ng-if="!node.hidden">
+      <ul style="list-style-type: none; padding-left:15px;">
+        <li ng-repeat="node in node.children" ng-include="'notebook_folder_renderer.html'" />
+      </ul>
+    </div>
+  </div>
+  <!-- trash folder -->
+  <div ng-if="node.id === '~Trash'">
+    <div ng-mouseenter="showFolderButton=true"
+         ng-mouseleave="showFolderButton=false">
+      <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
+        <i style="font-size: 10px;" class="fa fa-trash-o" /> Trash
+      </a>
+      <a style="text-decoration: none;">
+        <i style="font-size: 13px; margin-left: 10px; cursor: pointer; text-decoration: none;"
+           class="fa fa-trash-o" ng-show="showFolderButton" ng-click="emptyTrash()"
+           tooltip-placement="bottom" tooltip="Empty trash">
+        </i>
+        <i style="font-size: 13px; margin-left: 2px; cursor: pointer; text-decoration: none;"
+           class="fa fa-undo" ng-show="showFolderButton" ng-click="restoreAll()"
+           tooltip-placement="bottom" tooltip="Restore all">
         </i>
       </a>
     </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -146,7 +146,8 @@ limitations under the License.
               </div>
               <div ng-if="query && query.name !== ''">
                 <li ng-repeat="note in home.notes.flatList | filter:query.q | orderBy:home.arrayOrderingSrv.noteListOrdering track by $index">
-                  <i style="font-size: 10px;" class="icon-doc"></i>
+                  <i ng-if="!note.isTrash" style="font-size: 10px;" class="icon-doc"></i>
+                  <i ng-if="note.isTrash" style="font-size: 12px;" class="fa fa-trash-o"></i>
                   <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
                 </li>
               </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -20,13 +20,13 @@ limitations under the License.
     <a style="text-decoration: none;" href="#/notebook/{{node.id}}">
       <i style="font-size: 10px;" class="icon-doc"/> {{noteName(node)}}
     </a>
-    <a style="text-decoration: none;">
+    <a ng-if="!node.isTrash" style="text-decoration: none;">
       <i style="margin-left: 10px;"
          class="fa fa-pencil notebook-list-btn" ng-show="showNoteButton" ng-click="renameNote(node)"
          tooltip-placement="bottom" tooltip="Rename note">
       </i>
     </a>
-    <a style="text-decoration: none;">
+    <a ng-if="!node.isTrash" style="text-decoration: none;">
       <i class="fa fa-eraser notebook-list-btn" ng-show="showNoteButton" ng-click="clearAllParagraphOutput(node.id)"
          tooltip-placement="bottom" tooltip="Clear output">
       </i>
@@ -56,7 +56,7 @@ limitations under the License.
         <i style="font-size: 10px;" ng-class="node.hidden ? 'icon-folder' : 'icon-folder-alt'" /> {{noteName(node)}}
       </a>
       <a style="text-decoration: none;">
-        <i style="margin-left: 10px;"
+        <i ng-if="!node.isTrash" style="margin-left: 10px;"
            class="fa fa-pencil notebook-list-btn" ng-show="showFolderButton" ng-click="renameFolder(node)"
            tooltip-placement="bottom" tooltip="Rename folder">
         </i>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -158,7 +158,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
                 ng-hide="viewOnly"
-                tooltip-placement="bottom" tooltip="Remove this note for good">
+                tooltip-placement="bottom" tooltip="Remove this note permanently">
           <i class="icon-trash"></i>
         </button>
         <button ng-if="note.name.split('/')[0] !== TRASH_FOLDER_ID"

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -155,9 +155,9 @@ limitations under the License.
       <span class="labelBtn" style="vertical-align:middle; display:inline-block;">
         <button type="button"
                 class="btn btn-default btn-xs"
-                ng-click="removeNote(note.id)"
+                ng-click="moveNoteToTrash(note.id)"
                 ng-hide="viewOnly"
-                tooltip-placement="bottom" tooltip="Remove this note">
+                tooltip-placement="bottom" tooltip="Move this note to trash">
           <i class="icon-trash"></i>
         </button>
       </span>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -153,7 +153,7 @@ limitations under the License.
 
 <!-- put the delete action by itself for your protection -->
       <span class="labelBtn" style="vertical-align:middle; display:inline-block;">
-        <button ng-if="note.name.split('/')[0] === '~Trash'"
+        <button ng-if="note.name.split('/')[0] === TRASH_FOLDER_ID"
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
@@ -161,7 +161,7 @@ limitations under the License.
                 tooltip-placement="bottom" tooltip="Remove this note for good">
           <i class="icon-trash"></i>
         </button>
-        <button ng-if="note.name.split('/')[0] !== '~Trash'"
+        <button ng-if="note.name.split('/')[0] !== TRASH_FOLDER_ID"
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -153,7 +153,8 @@ limitations under the License.
 
 <!-- put the delete action by itself for your protection -->
       <span class="labelBtn" style="vertical-align:middle; display:inline-block;">
-        <button ng-if="note.name.split('/')[0] === TRASH_FOLDER_ID"
+        <!-- if the note is in the trash, remove note permanently -->
+        <button ng-if="isTrash(note)"
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
@@ -161,7 +162,8 @@ limitations under the License.
                 tooltip-placement="bottom" tooltip="Remove this note permanently">
           <i class="icon-trash"></i>
         </button>
-        <button ng-if="note.name.split('/')[0] !== TRASH_FOLDER_ID"
+        <!-- if the note is not in the trash, move to trash -->
+        <button ng-if="!isTrash(note)"
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -153,7 +153,16 @@ limitations under the License.
 
 <!-- put the delete action by itself for your protection -->
       <span class="labelBtn" style="vertical-align:middle; display:inline-block;">
-        <button type="button"
+        <button ng-if="note.name.split('/')[0] === '~Trash'"
+                type="button"
+                class="btn btn-default btn-xs"
+                ng-click="removeNote(note.id)"
+                ng-hide="viewOnly"
+                tooltip-placement="bottom" tooltip="Remove this note for good">
+          <i class="icon-trash"></i>
+        </button>
+        <button ng-if="note.name.split('/')[0] !== '~Trash'"
+                type="button"
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"
                 ng-hide="viewOnly"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -187,6 +187,11 @@
       noteActionSrv.moveNoteToTrash(noteId, true);
     };
 
+    // Remove the note for good if it's in the trash
+    $scope.removeNote = function(noteId) {
+      noteActionSrv.removeNote(noteId, true);
+    };
+
     //Export notebook
     $scope.exportNote = function() {
       var jsonContent = JSON.stringify($scope.note);

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -45,7 +45,6 @@
     $scope.viewOnly = false;
     $scope.showSetting = false;
     $scope.looknfeelOption = ['default', 'simple', 'report'];
-    $scope.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
     $scope.cronOption = [
       {name: 'None', value: undefined},
       {name: '1m', value: '0 0/1 * * * ?'},
@@ -192,6 +191,10 @@
     // Remove the note permanently if it's in the trash
     $scope.removeNote = function(noteId) {
       noteActionSrv.removeNote(noteId, true);
+    };
+
+    $scope.isTrash = function(note) {
+      return note ? note.name.split('/')[0] === TRASH_FOLDER_ID : false;
     };
 
     //Export notebook

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -189,7 +189,7 @@
       noteActionSrv.moveNoteToTrash(noteId, true);
     };
 
-    // Remove the note for good if it's in the trash
+    // Remove the note permanently if it's in the trash
     $scope.removeNote = function(noteId) {
       noteActionSrv.removeNote(noteId, true);
     };

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -28,12 +28,13 @@
     'saveAsService',
     'ngToast',
     'noteActionSrv',
-    'noteVarShareService'
+    'noteVarShareService',
+    'TRASH_FOLDER_ID'
   ];
 
   function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
                         $http, websocketMsgSrv, baseUrlSrv, $timeout, saveAsService,
-                        ngToast, noteActionSrv, noteVarShareService) {
+                        ngToast, noteActionSrv, noteVarShareService, TRASH_FOLDER_ID) {
 
     ngToast.dismiss();
 
@@ -44,6 +45,7 @@
     $scope.viewOnly = false;
     $scope.showSetting = false;
     $scope.looknfeelOption = ['default', 'simple', 'report'];
+    $scope.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
     $scope.cronOption = [
       {name: 'None', value: undefined},
       {name: '1m', value: '0 0/1 * * * ?'},

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -182,9 +182,9 @@
       $scope.$broadcast('doubleClickParagraph', paragraphId);
     };
 
-    // Remove the note and go back to the main page
-    $scope.removeNote = function(noteId) {
-      noteActionSrv.removeNote(noteId, true);
+    // Move the note to trash and go back to the main page
+    $scope.moveNoteToTrash = function(noteId) {
+      noteActionSrv.moveNoteToTrash(noteId, true);
     };
 
     //Export notebook

--- a/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
+++ b/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
@@ -15,10 +15,15 @@
 
   angular.module('zeppelinWebApp').service('arrayOrderingSrv', arrayOrderingSrv);
 
-  function arrayOrderingSrv() {
+  arrayOrderingSrv.$inject = ['TRASH_FOLDER_ID'];
+
+  function arrayOrderingSrv(TRASH_FOLDER_ID) {
     var arrayOrderingSrv = this;
 
     this.noteListOrdering = function(note) {
+      if (note.id === TRASH_FOLDER_ID) {
+        return '\uFFFF';
+      }
       return arrayOrderingSrv.getNoteName(note);
     };
 

--- a/zeppelin-web/src/components/expandCollapse/expandCollapse.directive.js
+++ b/zeppelin-web/src/components/expandCollapse/expandCollapse.directive.js
@@ -25,7 +25,10 @@
             angular.element(element).find('i.icon-folder-alt').toggleClass('icon-folder icon-folder-alt');
           } else {
             angular.element(element).find('.expandable').first().slideToggle('200',function() {
-              angular.element(element).find('i').first().toggleClass('icon-folder icon-folder-alt');
+              // do not toggle trash folder
+              if (angular.element(element).find('.fa-trash-o').length === 0) {
+                angular.element(element).find('i').first().toggleClass('icon-folder icon-folder-alt');
+              }
             });
           }
           event.stopPropagation();

--- a/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
+++ b/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
@@ -20,8 +20,14 @@ limitations under the License.
   <expand-collapse>
       <div>
         <a class="notebook-list-item" href="javascript:void(0)">
-          <i style="font-size: 10px; margin-right: 5px;" class="icon-folder"></i>
-          <span>{{noteName(note)}}</span>
+          <div ng-if="note.id !== navbar.TRASH_FOLDER_ID">
+            <i style="font-size: 10px; margin-right: 5px;" class="icon-folder"></i>
+            <span>{{noteName(note)}}</span>
+          </div>
+          <div ng-if="note.id === navbar.TRASH_FOLDER_ID">
+            <i style="font-size: 12px; margin-right: 5px;" class="fa fa-trash-o"></i>
+            <span>Trash</span>
+          </div>
         </a>
       </div>
       <div class="expandable" style="color: black;">

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -25,12 +25,13 @@
     'baseUrlSrv',
     'websocketMsgSrv',
     'arrayOrderingSrv',
-    'searchService'
+    'searchService',
+    'TRASH_FOLDER_ID'
   ];
 
   function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
                    noteListDataFactory, baseUrlSrv, websocketMsgSrv,
-                   arrayOrderingSrv, searchService) {
+                   arrayOrderingSrv, searchService, TRASH_FOLDER_ID) {
     var vm = this;
     vm.arrayOrderingSrv = arrayOrderingSrv;
     vm.connected = websocketMsgSrv.isConnected();
@@ -40,6 +41,7 @@
     vm.search = search;
     vm.searchForm = searchService;
     vm.showLoginWindow = showLoginWindow;
+    vm.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
 
     $scope.query = {q: ''};
 

--- a/zeppelin-web/src/components/noteAction/noteAction.service.js
+++ b/zeppelin-web/src/components/noteAction/noteAction.service.js
@@ -18,17 +18,89 @@
   noteActionSrv.$inject = ['websocketMsgSrv', '$location', 'renameSrv', 'noteListDataFactory'];
 
   function noteActionSrv(websocketMsgSrv, $location, renameSrv, noteListDataFactory) {
-    this.removeNote = function(noteId, redirectToHome) {
+    this.moveNoteToTrash = function(noteId, redirectToHome) {
       BootstrapDialog.confirm({
         closable: true,
-        title: '',
-        message: 'Do you want to delete this note?',
+        title: 'Move this note to trash?',
+        message: 'This note will be moved to <strong>trash</strong>.',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.moveNoteToTrash(noteId);
+            if (redirectToHome) {
+              $location.path('/');
+            }
+          }
+        }
+      });
+    };
+
+    this.moveFolderToTrash = function(folderId) {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: 'Move this folder to trash?',
+        message: 'This folder will be moved to <strong>trash</strong>.',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.moveFolderToTrash(folderId);
+          }
+        }
+      });
+    };
+
+    this.removeNote = function(noteId, redirectToHome) {
+      BootstrapDialog.confirm({
+        type: BootstrapDialog.TYPE_WARNING,
+        closable: true,
+        title: 'WARNING! This note will be removed permanently',
+        message: 'This cannot be undone. Are you sure?',
         callback: function(result) {
           if (result) {
             websocketMsgSrv.deleteNote(noteId);
             if (redirectToHome) {
               $location.path('/');
             }
+          }
+        }
+      });
+    };
+
+    this.removeFolder = function(folderId) {
+      BootstrapDialog.confirm({
+        type: BootstrapDialog.TYPE_WARNING,
+        closable: true,
+        title: 'WARNING! This folder will be removed permanently',
+        message: 'This cannot be undone. Are you sure?',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.removeFolder(folderId);
+          }
+        }
+      });
+    };
+
+    this.restoreAll = function() {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: 'Are you sure want to restore all notes in the trash?',
+        message: 'Folders and notes in the trash will be ' +
+          '<strong>merged</strong> into their original position.',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.restoreAll();
+          }
+        }
+      });
+    };
+
+    this.emptyTrash = function() {
+      BootstrapDialog.confirm({
+        type: BootstrapDialog.TYPE_WARNING,
+        closable: true,
+        title: 'WARNING! Notes under trash will be removed permanently',
+        message: 'This cannot be undone. Are you sure?',
+        callback: function(result) {
+          if (result) {
+            websocketMsgSrv.emptyTrash();
           }
         }
       });

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -25,7 +25,10 @@
 
       setNotes: function(notesList) {
         // a flat list to boost searching
-        notes.flatList = angular.copy(notesList);
+        notes.flatList = _.map(angular.copy(notesList), (note) => {
+          note.isTrash = note.name.split('/')[0] === TRASH_FOLDER_ID;
+          return note;
+        });
 
         // construct the folder-based tree
         notes.root = {children: []};

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -15,7 +15,9 @@
 
   angular.module('zeppelinWebApp').factory('noteListDataFactory', noteListDataFactory);
 
-  function noteListDataFactory() {
+  noteListDataFactory.$inject = ['TRASH_FOLDER_ID'];
+
+  function noteListDataFactory(TRASH_FOLDER_ID) {
     var notes = {
       root: {children: []},
       flatList: [],
@@ -46,7 +48,7 @@
           name: nodes[0],
           id: noteId,
           path: curDir.id ? curDir.id + '/' + nodes[0] : nodes[0],
-          isTrash: curDir.id ? curDir.id.split('/')[0] === '~Trash' : false
+          isTrash: curDir.id ? curDir.id.split('/')[0] === TRASH_FOLDER_ID : false
         });
       } else {  // a folder node
         var node = nodes.shift();
@@ -60,7 +62,7 @@
             name: node,
             hidden: true,
             children: [],
-            isTrash: curDir.id ? curDir.id.split('/')[0] === '~Trash' : false
+            isTrash: curDir.id ? curDir.id.split('/')[0] === TRASH_FOLDER_ID : false
           };
 
           // add the folder to flat folder map

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -45,7 +45,8 @@
         curDir.children.push({
           name: nodes[0],
           id: noteId,
-          path: curDir.id ? curDir.id + '/' + nodes[0] : nodes[0]
+          path: curDir.id ? curDir.id + '/' + nodes[0] : nodes[0],
+          isTrash: curDir.id ? curDir.id.split('/')[0] === '~Trash' : false
         });
       } else {  // a folder node
         var node = nodes.shift();
@@ -58,7 +59,8 @@
             id: curDir.id ? curDir.id + '/' + node : node,
             name: node,
             hidden: true,
-            children: []
+            children: [],
+            isTrash: curDir.id ? curDir.id.split('/')[0] === '~Trash' : false
           };
 
           // add the folder to flat folder map

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -26,7 +26,8 @@
       setNotes: function(notesList) {
         // a flat list to boost searching
         notes.flatList = _.map(notesList, (note) => {
-          note.isTrash = note.name.split('/')[0] === TRASH_FOLDER_ID;
+          note.isTrash = note.name ?
+            note.name.split('/')[0] === TRASH_FOLDER_ID : false;
           return note;
         });
 

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -25,7 +25,7 @@
 
       setNotes: function(notesList) {
         // a flat list to boost searching
-        notes.flatList = _.map(angular.copy(notesList), (note) => {
+        notes.flatList = _.map(notesList, (note) => {
           note.isTrash = note.name.split('/')[0] === TRASH_FOLDER_ID;
           return note;
         });

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -34,8 +34,36 @@
         });
       },
 
+      moveNoteToTrash: function(noteId) {
+        websocketEvents.sendNewEvent({op: 'MOVE_NOTE_TO_TRASH', data: {id: noteId}});
+      },
+
+      moveFolderToTrash: function(folderId) {
+        websocketEvents.sendNewEvent({op: 'MOVE_FOLDER_TO_TRASH', data: {id: folderId}});
+      },
+
+      restoreNote: function(noteId) {
+        websocketEvents.sendNewEvent({op: 'RESTORE_NOTE', data: {id: noteId}});
+      },
+
+      restoreFolder: function(folderId) {
+        websocketEvents.sendNewEvent({op: 'RESTORE_FOLDER', data: {id: folderId}});
+      },
+
+      restoreAll: function() {
+        websocketEvents.sendNewEvent({op: 'RESTORE_ALL'});
+      },
+
       deleteNote: function(noteId) {
         websocketEvents.sendNewEvent({op: 'DEL_NOTE', data: {id: noteId}});
+      },
+
+      removeFolder: function(folderId) {
+        websocketEvents.sendNewEvent({op: 'REMOVE_FOLDER', data: {id: folderId}});
+      },
+
+      emptyTrash: function() {
+        websocketEvents.sendNewEvent({op: 'EMPTY_TRASH'});
       },
 
       cloneNote: function(noteIdToClone, newNoteName) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
@@ -31,6 +31,7 @@ import java.util.*;
 public class Folder {
   public static final String ROOT_FOLDER_ID = "/";
   public static final String TRASH_FOLDER_ID = "~Trash";
+  public static final String TRASH_FOLDER_CONFLICT_INFIX = " removed at ";
 
   private String id;
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
@@ -30,6 +30,7 @@ import java.util.*;
  */
 public class Folder {
   public static final String ROOT_FOLDER_ID = "/";
+  public static final String TRASH_FOLDER_ID = "~Trash";
 
   private String id;
 
@@ -52,7 +53,7 @@ public class Folder {
   }
 
   public String getName() {
-    if (getId().equals(ROOT_FOLDER_ID))
+    if (isRoot())
       return ROOT_FOLDER_ID;
 
     String path = getId();
@@ -66,7 +67,7 @@ public class Folder {
   }
 
   public String getParentFolderId() {
-    if (getId().equals(ROOT_FOLDER_ID))
+    if (isRoot())
       return ROOT_FOLDER_ID;
 
     int lastSlashIndex = getId().lastIndexOf("/");
@@ -106,7 +107,7 @@ public class Folder {
    * @param newId
    */
   public void rename(String newId) {
-    if (getId().equals(ROOT_FOLDER_ID))   // root folder cannot be renamed
+    if (isRoot())   // root folder cannot be renamed
       return;
 
     String oldId = getId();
@@ -220,5 +221,16 @@ public class Folder {
 
   public boolean hasChild() {
     return children.size() > 0;
+  }
+
+  boolean isRoot() {
+    return getId().equals(ROOT_FOLDER_ID);
+  }
+
+  public boolean isTrash() {
+    if (isRoot())
+      return false;
+
+    return getId().split("/")[0].equals(TRASH_FOLDER_ID);
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
@@ -31,7 +31,7 @@ import java.util.*;
 public class Folder {
   public static final String ROOT_FOLDER_ID = "/";
   public static final String TRASH_FOLDER_ID = "~Trash";
-  public static final String TRASH_FOLDER_CONFLICT_INFIX = " removed at ";
+  public static final String TRASH_FOLDER_CONFLICT_INFIX = " ";
 
   private String id;
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FolderView.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FolderView.java
@@ -99,6 +99,8 @@ public class FolderView implements NoteNameListener, FolderListener {
   }
 
   private Folder createFolder(String folderId) {
+    folderId = Folder.normalizeFolderId(folderId);
+
     Folder newFolder = new Folder(folderId);
     newFolder.addFolderListener(this);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -596,6 +596,14 @@ public class Note implements Serializable, ParagraphJobListener {
     return true;
   }
 
+  public boolean isTrash() {
+    String path = getName();
+    if (path.charAt(0) == '/') {
+      path = path.substring(1);
+    }
+    return path.split("/")[0].equals(Folder.TRASH_FOLDER_ID);
+  }
+
   public List<InterpreterCompletion> completion(String paragraphId, String buffer, int cursor) {
     Paragraph p = getParagraph(paragraphId);
     p.setListener(jobListenerFactory.getParagraphJobListener(this));

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -307,6 +307,18 @@ public class Notebook implements NoteEventListener {
     }
   }
 
+  public Folder getFolder(String folderId) {
+    synchronized (folders) {
+      return folders.getFolder(folderId);
+    }
+  }
+
+  public boolean hasFolder(String folderId) {
+    synchronized (folders) {
+      return folders.hasFolder(folderId);
+    }
+  }
+
   public void removeNote(String id, AuthenticationInfo subject) {
     Preconditions.checkNotNull(subject, "AuthenticationInfo should not be null");
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -46,6 +46,13 @@ public class Message {
     NEW_NOTE,         // [c-s] create new notebook
     DEL_NOTE,         // [c-s] delete notebook
                       // @param id note id
+    REMOVE_FOLDER,
+    MOVE_NOTE_TO_TRASH,
+    MOVE_FOLDER_TO_TRASH,
+    RESTORE_FOLDER,
+    RESTORE_NOTE,
+    RESTORE_ALL,
+    EMPTY_TRASH,
     CLONE_NOTE,       // [c-s] clone new notebook
                       // @param id id of note to clone
                       // @param name name for the cloned note

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/FolderTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/FolderTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FolderTest {
@@ -185,5 +187,24 @@ public class FolderTest {
     assertEquals("/", rootFolder.getName());
     assertEquals("a", aFolder.getName());
     assertEquals("b", abFolder.getName());
+  }
+
+  @Test
+  public void isTrashTest() {
+    Folder folder;
+    // Not trash
+    folder = new Folder(Folder.ROOT_FOLDER_ID);
+    assertFalse(folder.isTrash());
+    folder = new Folder("a");
+    assertFalse(folder.isTrash());
+    folder = new Folder("a/b");
+    assertFalse(folder.isTrash());
+    // trash
+    folder = new Folder(Folder.TRASH_FOLDER_ID);
+    assertTrue(folder.isTrash());
+    folder = new Folder(Folder.TRASH_FOLDER_ID + "/a");
+    assertTrue(folder.isTrash());
+    folder = new Folder(Folder.TRASH_FOLDER_ID + "/a/b");
+    assertTrue(folder.isTrash());
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -175,4 +175,28 @@ public class NoteTest {
     note.setName("a/b/note");
     assertEquals("note", note.getNameWithoutPath());
   }
+
+  @Test
+  public void isTrashTest() {
+    Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
+    // Notes in the root folder
+    note.setName("noteOnRootFolder");
+    assertFalse(note.isTrash());
+    note.setName("/noteOnRootFolderStartsWithSlash");
+    assertFalse(note.isTrash());
+
+    // Notes in subdirectories
+    note.setName("/a/b/note");
+    assertFalse(note.isTrash());
+    note.setName("a/b/note");
+    assertFalse(note.isTrash());
+
+    // Notes in trash
+    note.setName(Folder.TRASH_FOLDER_ID + "/a");
+    assertTrue(note.isTrash());
+    note.setName("/" + Folder.TRASH_FOLDER_ID + "/a");
+    assertTrue(note.isTrash());
+    note.setName(Folder.TRASH_FOLDER_ID + "/a/b/c");
+    assertTrue(note.isTrash());
+  }
 }


### PR DESCRIPTION
### What is this PR for?
![image](https://cloud.githubusercontent.com/assets/8201019/20925378/03a722f8-bbfa-11e6-9afc-c62cfe6b0e2a.png)
This PR introduces the trash! (which is essential, I think ^^;)

I added basic operations of the trash:
#### Added operations of trash
* `Move` a folder to the trash
* `Move` a note to the trash
* `Restore` a folder
* `Restore` a note
* `Remove` a folder in the trash for good
* `Remove` a note in the trash for good
* `Empty` the trash
* `Restore all` in the trash
* `Move` a note to the trash from the notebook view
* `Remove` a note to the trash for good from the notebook view
* If there is a folder that has the same name, suffix current data rather than just merging(please see screenshot below!)


### What type of PR is it?
[Feature]

### Future work
Maybe it would be better if notebook view notices that a note is in the trash.

### What is the Jira issue?
[ZEPPELIN-1736](https://issues.apache.org/jira/browse/ZEPPELIN-1736)

### How should this be tested?
* Build this PR
* Move some folders or notes to the trash
* Restore them
* Empty the trash
* Restore all notes in the trash
* Remove folders or notes in the trash
* Remove a folder which has the same folder name in the trash

### Screenshots (if appropriate)
## Move, restore, remove a note from the main page
![note_from_main](https://cloud.githubusercontent.com/assets/8201019/20925760/13b0d91c-bbfc-11e6-94c5-2211c9d9a282.gif)

## Move, restore, remove a folder from the main page
![folder_test](https://cloud.githubusercontent.com/assets/8201019/20925774/2884abde-bbfc-11e6-9ba9-7b1f8a935a41.gif)

## Move, remove a note from the notebook view
![noteview_test](https://cloud.githubusercontent.com/assets/8201019/20925837/83564162-bbfc-11e6-9a92-c6bc1984b30d.gif)

## Restore, empty the trash
![restore_empty_trash](https://cloud.githubusercontent.com/assets/8201019/20925841/8f6d78d0-bbfc-11e6-90a9-6f67c95371a5.gif)

## Suffix current date if the folder exists in the trash
![same_folder_name_test](https://cloud.githubusercontent.com/assets/8201019/20926085/e8cb6954-bbfd-11e6-9cdf-acf9b785d833.gif)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO

