### PR TITLE
[ZEPPELIN-1239] Google WebFont: goog-webfont-dl Grunt task warning and build error

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: './src/',
           src: ['**/*.js'],
-          dest: '.tmp'
+          dest: '.tmp',
         }]
       },
       dist: {
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: '.tmp/concat/scripts',
           src: ['scripts.js'],
-          dest: '.tmp/concat/scripts'
+          dest: '.tmp/concat/scripts',
         }]
       }
     },
@@ -197,7 +197,7 @@ module.exports = function(grunt) {
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
         livereload: 35729,
-        base: '.tmp'
+        base: '.tmp',
       },
       livereload: {
         options: {

--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -606,7 +606,6 @@ module.exports = function(grunt) {
     'htmlhint',
     'clean:dist',
     'wiredep',
-    'googlefonts',
     'useminPrepare',
     'concurrent:dist',
     'postcss',

--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: './src/',
           src: ['**/*.js'],
-          dest: '.tmp',
+          dest: '.tmp'
         }]
       },
       dist: {
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: '.tmp/concat/scripts',
           src: ['scripts.js'],
-          dest: '.tmp/concat/scripts',
+          dest: '.tmp/concat/scripts'
         }]
       }
     },
@@ -103,50 +103,32 @@ module.exports = function(grunt) {
       }
     },
 
-    'goog-webfont-dl': {
-      patuaOne: {
+    googlefonts: {
+      build: {
         options: {
-          ttf: true,
-          eot: true,
-          woff: true,
-          woff2: true,
-          svg: true,
-          fontname: 'Patua One',
-          fontstyles: '400',
-          fontdest: '<%= yeoman.app %>/fonts/',
-          cssdest: '<%= yeoman.app %>/fonts/Patua-One.css',
-          cssprefix: '',
-          subset: ''
-        }
-      },
-      sourceCodePro: {
-        options: {
-          ttf: true,
-          eot: true,
-          woff: true,
-          woff2: true,
-          svg: true,
-          fontname: 'Source Code Pro',
-          fontstyles: '300, 400, 500',
-          fontdest: '<%= yeoman.app %>/fonts/',
-          cssdest: '<%= yeoman.app %>/fonts/Source-Code-Pro.css',
-          cssprefix: '',
-          subset: ''
-        }
-      },
-      roboto: {
-        options: {
-          ttf: true,
-          eot: true,
-          woff: true,
-          woff2: true,
-          svg: true,
-          fontname: 'Roboto',
-          fontstyles: '300, 400, 500',
-          fontdest: '<%= yeoman.app %>/fonts/',
-          cssdest: '<%= yeoman.app %>/fonts/Roboto.css',
-          cssprefix: '',
-          subset: ''
+          fontPath: '<%= yeoman.app %>/fonts/',
+          httpPath: '../fonts/',
+          cssFile: '<%= yeoman.app %>/fonts/google-fonts.css',
+          formats: {
+            eot: true,
+            ttf: true,
+            woff: true,
+            svg: true
+          },
+          fonts: [
+            {
+              family: 'Patua One',
+              styles: [400]
+            },
+            {
+              family: 'Source Code Pro',
+              styles: [300, 400, 500]
+            },
+            {
+              family: 'Roboto',
+              styles: [300, 400, 500]
+            }
+          ]
         }
       }
     },
@@ -215,7 +197,7 @@ module.exports = function(grunt) {
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
         livereload: 35729,
-        base: '.tmp',
+        base: '.tmp'
       },
       livereload: {
         options: {
@@ -624,7 +606,7 @@ module.exports = function(grunt) {
     'htmlhint',
     'clean:dist',
     'wiredep',
-    'goog-webfont-dl',
+    'googlefonts',
     'useminPrepare',
     'concurrent:dist',
     'postcss',

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^18.1.0",
     "grunt-filerev": "^0.2.1",
-    "grunt-goog-webfont-dl": "^0.1.2",
+    "grunt-google-fonts": "^0.4.0",
     "grunt-htmlhint": "^0.9.13",
     "grunt-jscs": "^2.1.0",
     "grunt-karma": "~2.0.0",

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "engines" : { "node" : ">=6.0.0" },
   "scripts": {
-    "postinstall": "node_modules/.bin/bower install --silent",
-    "build": "./node_modules/.bin/grunt build",
-    "start": "./node_modules/.bin/grunt serve",
-    "test": "./node_modules/.bin/grunt test",
-    "pretest": "./node_modules/.bin/npm install karma-phantomjs-launcher"
+    "postinstall": "bower install --silent && grunt googlefonts",
+    "build": "grunt build",
+    "start": "grunt serve",
+    "test": "grunt test",
+    "pretest": "npm install karma-phantomjs-launcher"
   },
   "dependencies": {
     "grunt-angular-templates": "^0.5.7",

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -86,9 +86,10 @@
             <exclude>src/styles/font-awesome*</exclude>
             <exclude>src/fonts/Simple-Line*</exclude>
             <exclude>src/fonts/simple-line*</exclude>
-            <exclude>src/fonts/Patua-One*</exclude>
-            <exclude>src/fonts/Roboto*</exclude>
-            <exclude>src/fonts/Source-Code-Pro*</exclude>
+            <exclude>src/fonts/patua-one*</exclude>
+            <exclude>src/fonts/roboto*</exclude>
+            <exclude>src/fonts/source-code-pro*</exclude>
+            <exclude>src/fonts/google-fonts.css</exclude>
             <exclude>bower.json</exclude>
             <exclude>package.json</exclude>
             <exclude>*.md</exclude>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -65,9 +65,7 @@ limitations under the License.
     <link rel="stylesheet" href="fonts/font-awesome.min.css" />
     <link rel="stylesheet" href="fonts/simple-line-icons.css" />
     <link rel="stylesheet" href="fonts/custom-font.css" />
-    <link rel="stylesheet" href="fonts/Patua-One.css" />
-    <link rel="stylesheet" href="fonts/Source-Code-Pro.css" />
-    <link rel="stylesheet" href="fonts/Roboto.css" />
+    <link rel="stylesheet" href="fonts/google-fonts.css" />
     <!-- endbuild -->
     <link rel="stylesheet" ng-href="assets/styles/looknfeel/{{looknfeel}}.css" />
     <link rel="stylesheet" href="assets/styles/printMode.css" />


### PR DESCRIPTION
### What is this PR for?
It is to fix a zeppelin-web build error in Windows 10.
To fix it, I changed google webfont download module of grunt.

### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
[ZEPPELIN-1239](https://issues.apache.org/jira/browse/ZEPPELIN-1239)

### How should this be tested?
zeppelin-web build in Windows 10

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

'spawn UNKNOWN' error occurs on zeppelin-web build processing in windows 10.
It due to the function 'grunt.util.spawn()' which is called by the module 'grunt-goog-webfont-dl'.
So I changed this module to 'grunt-google-fonts'.