### PR TITLE
[ZEPPELIN-1753] Fix blank notename issue

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -16,8 +16,9 @@ limitations under the License.
     <div style="float: left; width: auto; max-width: 40%"
       ng-controller="ElasticInputCtrl as input">
       <input type="text" pu-elastic-input class="form-control2" placeholder="New name" style="min-width: 0px; max-width: 95%;"
-           ng-if="input.showEditor" ng-model="note.name" ng-blur="sendNewName();input.showEditor = false;" ng-enter="sendNewName();input.showEditor = false;" ng-escape="note.name = oldName; input.showEditor = false" focus-if="input.showEditor" />
-      <p class="form-control-static2" ng-click="input.showEditor = true; oldName = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
+           ng-if="input.showEditor" ng-model="input.value" ng-escape="input.showEditor = false" focus-if="input.showEditor"
+           ng-blur="updateNoteName(input.value);input.showEditor = false;" ng-enter="updateNoteName(input.value);input.showEditor = false;" />
+      <p class="form-control-static2" ng-click="input.showEditor = true; input.value = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -325,8 +325,10 @@
     };
 
     /** Update the note name */
-    $scope.sendNewName = function() {
-      if ($scope.note.name) {
+    $scope.updateNoteName = function(newName) {
+      const trimmedNewName = newName.trim();
+      if (trimmedNewName.length > 0 && $scope.note.name !== trimmedNewName) {
+        $scope.note.name = trimmedNewName;
         websocketMsgSrv.updateNote($scope.note.id, $scope.note.name, $scope.note.config);
       }
     };

--- a/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
+++ b/zeppelin-web/src/components/elasticInputCtrl/elasticInput.controller.js
@@ -19,6 +19,7 @@
   function ElasticInputCtrl() {
     var vm = this;
     vm.showEditor = false;
+    vm.value = '';
   }
 
 })();

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -8,7 +8,8 @@ describe('Controller: NotebookCtrl', function() {
   var websocketMsgSrvMock = {
     getNote: function() {},
     listRevisionHistory: function() {},
-    getInterpreterBindings: function() {}
+    getInterpreterBindings: function() {},
+    updateNote: function() {}
   };
 
   var baseUrlSrvMock = {
@@ -38,7 +39,7 @@ describe('Controller: NotebookCtrl', function() {
 
   var functions = ['getCronOptionNameFromValue', 'removeNote', 'runNote', 'saveNote', 'toggleAllEditor',
     'showAllEditor', 'hideAllEditor', 'toggleAllTable', 'hideAllTable', 'showAllTable', 'isNoteRunning',
-    'killSaveTimer', 'startSaveTimer', 'setLookAndFeel', 'setCronScheduler', 'setConfig', 'sendNewName',
+    'killSaveTimer', 'startSaveTimer', 'setLookAndFeel', 'setCronScheduler', 'setConfig', 'updateNoteName',
     'openSetting', 'closeSetting', 'saveSetting', 'toggleSetting'];
 
   functions.forEach(function(fn) {
@@ -100,4 +101,24 @@ describe('Controller: NotebookCtrl', function() {
     expect(scope.saveTimer).toEqual(null);
   });
 
+  it('should NOT update note name when updateNoteName() is called with an invalid name', function() {
+    spyOn(websocketMsgSrvMock, 'updateNote');
+    scope.updateNoteName('');
+    expect(scope.note.name).toEqual(noteMock.name);
+    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+    scope.updateNoteName(' ');
+    expect(scope.note.name).toEqual(noteMock.name);
+    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+    scope.updateNoteName(scope.note.name);
+    expect(scope.note.name).toEqual(noteMock.name);
+    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+  });
+
+  it('should update note name when updateNoteName() is called with a valid name', function() {
+    spyOn(websocketMsgSrvMock, 'updateNote');
+    var newName = 'Your Note';
+    scope.updateNoteName(newName);
+    expect(scope.note.name).toEqual(newName);
+    expect(websocketMsgSrvMock.updateNote).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### What is this PR for?
Note ID is displayed on action bar after pressing enter key with blank notename.
This is because the scope variable for notename is used directly as the model of input field and it doesn't revert the blank notename back to its existing name even though the notename was actually not updated to the blank value. (Temporarily lost notename from scope)
To resolve this issue, I added a variable to `ElasticInputCtrl` for the model of input field.
This change can always make the notename valid.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1753

### How should this be tested?
Input blank notename on action bar and..
- Check the notename on action bar
- Click 'Export this note' button and check the downloaded json filename.

### Screenshots (if appropriate)
![blank-notename](https://cloud.githubusercontent.com/assets/17305893/20969808/07b6a970-bcce-11e6-9457-e264a2bb0f92.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No