### PR TITLE
[ZEPPELIN-1766] Improve Interpreter Binding UI better (frontend)

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -199,7 +199,8 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
     try {
       // restart spark interpreter before running %dep
       clickAndWait(By.xpath("//span[@tooltip='Interpreter binding']"));
-      clickAndWait(By.xpath("//div[font[contains(text(), 'spark')]]/preceding-sibling::a[@tooltip='Restart']"));
+      clickAndWait(By.xpath("//button[span[contains(text(), 'spark')]]/following-sibling::button[contains(@data-toggle, 'dropdown')]"));
+      clickAndWait(By.xpath("//button[span[contains(text(), 'spark')]]/following-sibling::ul[contains(@class, 'dropdown-menu')]//a[span[contains(text(), 'restart')]]"));
       clickAndWait(By.xpath("//button[contains(.,'OK')]"));
 
       setTextOfParagraph(1,"%dep z.load(\"org.apache.commons:commons-csv:1.1\")");

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -58,6 +58,7 @@
 
     $scope.interpreterSettings = [];
     $scope.interpreterBindings = [];
+    $scope.interpreterBindingsOrig = [];
     $scope.bindingFilterKeyword = '';
     $scope.isNoteDirty = null;
     $scope.saveTimer = null;
@@ -411,6 +412,19 @@
 
     var getInterpreterBindings = function() {
       websocketMsgSrv.getInterpreterBindings($scope.note.id);
+    };
+
+    $scope.isDefaultInterpreterBinding = function(first, binding, filterKeyword) {
+      if (!first || !binding || $scope.interpreterBindings.length === 0) {
+        return false;
+      }
+
+      if (filterKeyword === '') {
+        return (first && binding.selected);
+      } else {
+        return (first && binding.selected &&
+        $scope.interpreterBindings[0].id === binding.id);
+      }
     };
 
     $scope.$on('interpreterBindings', function(event, data) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -58,6 +58,7 @@
 
     $scope.interpreterSettings = [];
     $scope.interpreterBindings = [];
+    $scope.bindingFilterKeyword = '';
     $scope.isNoteDirty = null;
     $scope.saveTimer = null;
 

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -28,12 +28,27 @@ limitations under the License.
         The first interpreter on the list becomes default. To create/remove interpreters, go to <a href="#/interpreter">Interpreter</a> menu.
       </p>
 
-      <br/>
+      <div class="interpreterSearchBox" style="margin: 15px 0px 15px 0px;">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="input-group pull-left" style="width:300px">
+              <input type="text" placeholder="Search interpreter Bindings"
+                     ng-model="bindingFilterKeyword"
+                     class="form-control ng-pristine ng-untouched ng-valid ng-empty" />
+              <span class="input-group-btn">
+            <button type="submit" class="btn btn-default">
+              <i class="glyphicon glyphicon-search"></i>
+            </button>
+          </span>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div class="interpreterSettings"
            as-sortable="interpreterSelectionListeners" data-ng-model="interpreterBindings">
         <div style="display:inline-block; margin: 0px 3px 0px 3px"
-             data-ng-repeat="item in interpreterBindings" as-sortable-item>
+             data-ng-repeat="item in interpreterBindings | filter: {name:bindingFilterKeyword}" as-sortable-item>
           <div>
             <div class="btn-group">
               <button type="button" class="btn" as-sortable-item-handle

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -16,10 +16,9 @@ limitations under the License.
 <div class="notebookContent">
   <!-- settings -->
   <div ng-if="showSetting" class="setting">
-    <div>
-      <h4>Settings</h4>
-    </div>
+    <div><h4>Settings</h4></div>
     <hr />
+
     <div>
       <h5>Interpreter binding</h5>
       <p>
@@ -29,33 +28,48 @@ limitations under the License.
         The first interpreter on the list becomes default. To create/remove interpreters, go to <a href="#/interpreter">Interpreter</a> menu.
       </p>
 
+      <br/>
+
       <div class="interpreterSettings"
            as-sortable="interpreterSelectionListeners" data-ng-model="interpreterBindings">
-        <div data-ng-repeat="item in interpreterBindings" as-sortable-item>
+        <div style="display:inline-block; margin: 0px 3px 0px 3px"
+             data-ng-repeat="item in interpreterBindings" as-sortable-item>
           <div>
-            <a ng-click="restartInterpreter(item)"
-               ng-class="{'inactivelink': !item.selected}"
-               tooltip="Restart">
-              <span class="glyphicon glyphicon-refresh btn-md"></span>
-            </a>&nbsp
-            <div as-sortable-item-handle
-                 ng-click="item.selected = !item.selected"
-                 class="btn"
-                 ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
-              <font style="font-size:16px">{{item.name}}</font>
-              <small>
-                <span style="display:inline-block" ng-repeat="intp in item.interpreters">
-                  <span ng-show="!$first">, </span>
-                  %<span ng-show="!$parent.$first || $first">{{item.name}}</span
-                  ><span ng-show="(!$parent.$first || $first) && !$first">.</span
-                  ><span ng-show="!$first">{{intp.name}}</span>
-                  <span ng-show="$parent.$first && $first">(default)</span>
-                </span>
-              </small>
+            <div class="btn-group">
+              <button type="button" class="btn" as-sortable-item-handle
+                      ng-click="item.selected = !item.selected"
+                      ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
+                <span style="font-weight: bold; font-size: 14px; margin-right: 5px;">{{item.name}}</span>
+                <small>
+                  <span style="display:inline-block" ng-repeat="intp in item.interpreters">
+                    <span ng-show="!$first">, </span>
+                    %<span ng-show="!$parent.$first || $first">{{item.name}}</span
+                    ><span ng-show="(!$parent.$first || $first) && !$first">.</span
+                    ><span ng-show="!$first">{{intp.name}}</span>
+                    <span ng-show="$parent.$first && $first">(default)</span>
+                  </span>
+                </small>
+              </button>
+              <button type="button" class="btn"
+                      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                      ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
+                <span class="caret"></span>
+                <span class="sr-only">Toggle Dropdown</span>
+              </button>
+              <ul class="dropdown-menu">
+                <li>
+                  <a ng-click="restartInterpreter(item)" ng-class="{'inactivelink': !item.selected}"
+                     tooltip="Restart">
+                    <span class="glyphicon glyphicon-refresh btn-sm"></span>
+                    <span style="margin-left: 3px">Restart</span>
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
       </div>
+
     </div>
     <br />
     <div>
@@ -127,5 +141,5 @@ limitations under the License.
       <h4 class="plus-sign">&#43;</h4>
     </div>
   </div>
-  <div style="clear:both;height:10px"></div>
 </div>
+<div style="clear:both;height:10px"></div>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -16,16 +16,16 @@ limitations under the License.
 <div class="notebookContent">
   <!-- settings -->
   <div ng-if="showSetting" class="setting">
-    <div><h4>Settings</h4></div>
+    <div><h4>Interpreter Binding</h4></div>
     <hr />
 
     <div>
-      <h5>Interpreter binding</h5>
       <p>
         Bind interpreter for this note.
         Click to Bind/Unbind interpreter.
         Drag and drop to reorder interpreters. <br />
-        The first interpreter on the list becomes default. To create/remove interpreters, go to <a href="#/interpreter">Interpreter</a> menu.
+        <strong>The first interpreter on the list becomes default.</strong>
+        To create/remove interpreters, go to <a href="#/interpreter">Interpreter</a> menu.
       </p>
 
       <div class="interpreterSearchBox" style="margin: 15px 0px 15px 0px;">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -33,7 +33,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-12">
             <div class="input-group pull-left" style="width:300px">
-              <input type="text" placeholder="Search interpreter Bindings"
+              <input type="text" placeholder="Search bindable interpreters"
                      ng-model="bindingFilterKeyword"
                      class="form-control ng-pristine ng-untouched ng-valid ng-empty" />
               <span class="input-group-btn">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -72,11 +72,12 @@ limitations under the License.
                 <span class="caret"></span>
                 <span class="sr-only">Toggle Dropdown</span>
               </button>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu" style="padding-top: 2px; padding-bottom: 2px;">
                 <li>
-                  <a ng-click="restartInterpreter(item)" ng-class="{'inactivelink': !item.selected}">
+                  <a ng-click="restartInterpreter(item)" ng-class="{'inactivelink': !item.selected}"
+                     style="padding: 0px 0px 0px 5px;">
                     <span class="glyphicon glyphicon-refresh btn-sm"></span>
-                    <span style="margin-left: 3px">Restart</span>
+                    <span style="margin-left: 3px; font-size: 13px;">restart</span>
                   </a>
                 </li>
               </ul>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -53,7 +53,7 @@ limitations under the License.
             <div class="btn-group">
               <button type="button" class="btn" as-sortable-item-handle
                       ng-click="item.selected = !item.selected"
-                      ng-class="{'btn-success': $first && item.selected, 'btn-info': !$first && item.selected, 'btn-default': !item.selected}">
+                      ng-class="$first && item.selected && bindingFilterKeyword === '' ? 'btn-success' : (item.selected ? 'btn-info' : 'btn-default')">
                 <span style="font-weight: bold; font-size: 14px; margin-right: 5px;">{{item.name}}</span>
                 <small>
                   <span style="display:inline-block" ng-repeat="intp in item.interpreters">
@@ -61,13 +61,13 @@ limitations under the License.
                     %<span ng-show="!$parent.$first || $first">{{item.name}}</span
                     ><span ng-show="(!$parent.$first || $first) && !$first">.</span
                     ><span ng-show="!$first">{{intp.name}}</span>
-                    <span ng-show="$parent.$first && $first">(default)</span>
+                    <span ng-show="$parent.$first && $first && bindingFilterKeyword === ''">(default)</span>
                   </span>
                 </small>
               </button>
               <button type="button" class="btn"
                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                      ng-class="{'btn-success': $first && item.selected, 'btn-info': !$first && item.selected, 'btn-default': !item.selected}">
+                      ng-class="$first && item.selected && bindingFilterKeyword === '' ? 'btn-success' : (item.selected ? 'btn-info' : 'btn-default')">
                 <span class="caret"></span>
                 <span class="sr-only">Toggle Dropdown</span>
               </button>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -47,7 +47,7 @@ limitations under the License.
 
       <div class="interpreterSettings"
            as-sortable="interpreterSelectionListeners" data-ng-model="interpreterBindings">
-        <div style="display:inline-block; margin: 0px 3px 0px 3px"
+        <div style="margin: 0px 3px 0px 3px"
              data-ng-repeat="item in interpreterBindings | filter: {name:bindingFilterKeyword}" as-sortable-item>
           <div>
             <div class="btn-group">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -45,7 +45,7 @@ limitations under the License.
         </div>
       </div>
 
-      <div class="interpreterSettings"
+      <div class="interpreterSettings" style="overflow-y:auto; height:320px;"
            as-sortable="interpreterSelectionListeners" data-ng-model="interpreterBindings">
         <div style="margin: 0px 3px 0px 3px"
              data-ng-repeat="item in interpreterBindings | filter: {name:bindingFilterKeyword}" as-sortable-item>
@@ -84,8 +84,8 @@ limitations under the License.
           </div>
         </div>
       </div>
-
     </div>
+
     <br />
     <div>
       <button class="btn btn-primary" ng-click="saveSetting()">Save</button>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -15,8 +15,7 @@ limitations under the License.
 <div ng-include src="'app/notebook/notebook-actionBar.html'"></div>
 <div class="notebookContent">
   <!-- settings -->
-  <div ng-if="true" class="setting">
-  <!--<div ng-if="showSetting" class="setting">-->
+  <div ng-if="showSetting" class="setting">
     <div><h4>Interpreter Binding</h4></div>
     <hr />
 
@@ -54,7 +53,7 @@ limitations under the License.
             <div class="btn-group">
               <button type="button" class="btn" as-sortable-item-handle
                       ng-click="item.selected = !item.selected"
-                      ng-class="$first && item.selected && bindingFilterKeyword === '' ? 'btn-success' : (item.selected ? 'btn-info' : 'btn-default')">
+                      ng-class="isDefaultInterpreterBinding($first, item, bindingFilterKeyword) ? 'btn-success' : item.selected ? 'btn-info' : 'btn-default'">
                 <span style="font-weight: bold; font-size: 14px; margin-right: 5px;">{{item.name}}</span>
                 <small>
                   <span style="display:inline-block" ng-repeat="intp in item.interpreters">
@@ -62,13 +61,13 @@ limitations under the License.
                     %<span ng-show="!$parent.$first || $first">{{item.name}}</span
                     ><span ng-show="(!$parent.$first || $first) && !$first">.</span
                     ><span ng-show="!$first">{{intp.name}}</span>
-                    <span ng-show="$parent.$first && $first && bindingFilterKeyword === ''">(default)</span>
+                    <span ng-show="isDefaultInterpreterBinding($parent.$first && $first, item, bindingFilterKeyword)">(default)</span>
                   </span>
                 </small>
               </button>
               <button type="button" class="btn"
                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                      ng-class="$first && item.selected && bindingFilterKeyword === '' ? 'btn-success' : (item.selected ? 'btn-info' : 'btn-default')">
+                      ng-class="isDefaultInterpreterBinding($first, item, bindingFilterKeyword) ? 'btn-success' : item.selected ? 'btn-info' : 'btn-default'">
                 <span class="caret"></span>
                 <span class="sr-only">Toggle Dropdown</span>
               </button>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -53,7 +53,7 @@ limitations under the License.
             <div class="btn-group">
               <button type="button" class="btn" as-sortable-item-handle
                       ng-click="item.selected = !item.selected"
-                      ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
+                      ng-class="{'btn-success': $first && item.selected, 'btn-info': !$first && item.selected, 'btn-default': !item.selected}">
                 <span style="font-weight: bold; font-size: 14px; margin-right: 5px;">{{item.name}}</span>
                 <small>
                   <span style="display:inline-block" ng-repeat="intp in item.interpreters">
@@ -67,7 +67,7 @@ limitations under the License.
               </button>
               <button type="button" class="btn"
                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                      ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
+                      ng-class="{'btn-success': $first && item.selected, 'btn-info': !$first && item.selected, 'btn-default': !item.selected}">
                 <span class="caret"></span>
                 <span class="sr-only">Toggle Dropdown</span>
               </button>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -15,7 +15,8 @@ limitations under the License.
 <div ng-include src="'app/notebook/notebook-actionBar.html'"></div>
 <div class="notebookContent">
   <!-- settings -->
-  <div ng-if="showSetting" class="setting">
+  <div ng-if="true" class="setting">
+  <!--<div ng-if="showSetting" class="setting">-->
     <div><h4>Interpreter Binding</h4></div>
     <hr />
 
@@ -73,8 +74,7 @@ limitations under the License.
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a ng-click="restartInterpreter(item)" ng-class="{'inactivelink': !item.selected}"
-                     tooltip="Restart">
+                  <a ng-click="restartInterpreter(item)" ng-class="{'inactivelink': !item.selected}">
                     <span class="glyphicon glyphicon-refresh btn-sm"></span>
                     <span style="margin-left: 3px">Restart</span>
                   </a>


### PR DESCRIPTION
### What is this PR for?

Current Interpreter Binding UI

- *is too long so that users should scroll down to just close binding UI*
- *doesn't have filter*
- *hard to find the default interpreter*
- *has restart button which can be designed better*

As the result of this PR the, binding UI would be better due to

- **small size, not distracted UI**
- **well noticed the default binding (green color)**
- **simplicity by hiding restart button. even we can utilise the dropbox buttons to add more features for bindings** (e.g adding link to go to a specific interpreter)


### What type of PR is it?
[Improvement | Feature]

### Todos
* [x] - Improve binding UI
* [x] - Add binding filter
* [x] - Highlight default binding
* [x] - Remove useless text and stress important message in binding usage
* [x] - DON'T Highlight when filtering bindings

### What is the Jira issue?

[ZEPPELIN-1766](https://issues.apache.org/jira/browse/ZEPPELIN-1766)

### How should this be tested?

Open interpreter binding UI and manipulate it. 

- insert filter keyword
- click restart buttons

### Screenshots (if appropriate)

![feature](https://cloud.githubusercontent.com/assets/4968473/20995441/72caa830-bd3a-11e6-8465-762a27ba08ec.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
