### PR TITLE
ZEPPELIN-1769. Support cancel job in SparkRInterpereter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -123,11 +123,12 @@ public class SparkRInterpreter extends Interpreter {
 
     String jobGroup = getJobGroup(interpreterContext);
     String setJobGroup = "";
+    // assign setJobGroup to dummy__, otherwise it would print NULL for this statement
     if (Utils.isSpark2()) {
-      setJobGroup = "setJobGroup(\"" + jobGroup +
+      setJobGroup = "dummy__ <- setJobGroup(\"" + jobGroup +
           "\", \"zeppelin sparkR job group description\", TRUE)";
     } else if (getSparkInterpreter().getSparkVersion().newerThanEquals(SparkVersion.SPARK_1_5_0)) {
-      setJobGroup = "setJobGroup(sc, \"" + jobGroup +
+      setJobGroup = "dummy__ <- setJobGroup(sc, \"" + jobGroup +
           "\", \"zeppelin sparkR job group description\", TRUE)";
     }
     logger.debug("set JobGroup:" + setJobGroup);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -43,6 +43,7 @@ public class SparkRInterpreter extends Interpreter {
 
   private static String renderOptions;
   private ZeppelinR zeppelinR;
+  private SparkContext sc;
 
   public SparkRInterpreter(Properties property) {
     super(property);
@@ -60,7 +61,6 @@ public class SparkRInterpreter extends Interpreter {
       // workaround to make sparkr work without SPARK_HOME
       System.setProperty("spark.test.home", System.getenv("ZEPPELIN_HOME") + "/interpreter/spark");
     }
-
     synchronized (SparkRBackend.backend()) {
       if (!SparkRBackend.isStarted()) {
         SparkRBackend.init();
@@ -71,7 +71,7 @@ public class SparkRInterpreter extends Interpreter {
     int port = SparkRBackend.port();
 
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    SparkContext sc = sparkInterpreter.getSparkContext();
+    this.sc = sparkInterpreter.getSparkContext();
     SparkVersion sparkVersion = new SparkVersion(sc.version());
     ZeppelinRContext.setSparkContext(sc);
     if (Utils.isSpark2()) {
@@ -92,6 +92,10 @@ public class SparkRInterpreter extends Interpreter {
       zeppelinR.eval("library('knitr')");
     }
     renderOptions = getProperty("zeppelin.R.render.options");
+  }
+
+  String getJobGroup(InterpreterContext context){
+    return "zeppelin-" + context.getParagraphId();
   }
 
   @Override
@@ -116,6 +120,18 @@ public class SparkRInterpreter extends Interpreter {
         lines = lines.replace(jsonConfig, "");
       }
     }
+
+    String jobGroup = getJobGroup(interpreterContext);
+    String setJobGroup = "";
+    if (Utils.isSpark2()) {
+      setJobGroup = "setJobGroup(\"" + jobGroup +
+          "\", \"zeppelin sparkR job group description\", TRUE)";
+    } else if (getSparkInterpreter().getSparkVersion().newerThanEquals(SparkVersion.SPARK_1_5_0)) {
+      setJobGroup = "setJobGroup(sc, \"" + jobGroup +
+          "\", \"zeppelin sparkR job group description\", TRUE)";
+    }
+    logger.debug("set JobGroup:" + setJobGroup);
+    lines = setJobGroup + "\n" + lines;
 
     try {
       // render output with knitr
@@ -155,7 +171,11 @@ public class SparkRInterpreter extends Interpreter {
   }
 
   @Override
-  public void cancel(InterpreterContext context) {}
+  public void cancel(InterpreterContext context) {
+    if (this.sc != null) {
+      sc.cancelJobGroup(getJobGroup(context));
+    }
+  }
 
   @Override
   public FormType getFormType() {

--- a/spark/src/main/resources/R/zeppelin_sparkr.R
+++ b/spark/src/main/resources/R/zeppelin_sparkr.R
@@ -45,6 +45,7 @@ assign("sc", get(".sc", envir = SparkR:::.sparkREnv), envir=.GlobalEnv)
 if (version >= 20000) {
   assign(".sparkRsession", SparkR:::callJStatic("org.apache.zeppelin.spark.ZeppelinRContext", "getSparkSession"), envir = SparkR:::.sparkREnv)
   assign("spark", get(".sparkRsession", envir = SparkR:::.sparkREnv), envir = .GlobalEnv)
+  assign(".sparkRjsc", get(".sc", envir = SparkR:::.sparkREnv), envir=SparkR:::.sparkREnv)
 }
 assign(".sqlc", SparkR:::callJStatic("org.apache.zeppelin.spark.ZeppelinRContext", "getSqlContext"), envir = SparkR:::.sparkREnv)
 assign("sqlContext", get(".sqlc", envir = SparkR:::.sparkREnv), envir = .GlobalEnv)


### PR DESCRIPTION
### What is this PR for?
Cancel is not supported for SparkR now, This PR is would construct a setJobGroup statement before each statement. So that we can implement the cancel feature. 



### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1769

### How should this be tested?
Manually tested for spark 1.6 & spark 2.0.2

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

