### PR TITLE
ZEPPELIN-1773. Remove method destroy() in Interpreter

### DIFF
--- a/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
+++ b/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
@@ -226,10 +226,4 @@ public class CassandraInterpreter extends Interpreter {
             .createOrGetParallelScheduler(CassandraInterpreter.class.getName() + this.hashCode(),
                     parseInt(getProperty(CASSANDRA_INTERPRETER_PARALLELISM)));
   }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-    this.close();
-  }
 }

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
@@ -46,7 +46,6 @@ public class FlinkInterpreterTest {
   @AfterClass
   public static void tearDown() {
     flink.close();
-    flink.destroy();
   }
 
   @Test

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -131,13 +131,6 @@ public abstract class Interpreter {
     return SchedulerFactory.singleton().createOrGetFIFOScheduler("interpreter_" + this.hashCode());
   }
 
-  /**
-   * Called when interpreter is no longer used.
-   */
-  @ZeppelinApi
-  public void destroy() {
-  }
-
   public static Logger logger = LoggerFactory.getLogger(Interpreter.class);
   private InterpreterGroup interpreterGroup;
   private URL [] classloaderUrls;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -106,7 +106,6 @@ public class RemoteInterpreterServer
     eventClient.waitForEventQueueBecomesEmpty();
     if (interpreterGroup != null) {
       interpreterGroup.close();
-      interpreterGroup.destroy();
     }
 
     server.stop();

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectTest.java
@@ -103,7 +103,6 @@ public class RemoteAngularObjectTest implements AngularObjectRegistryListener {
   public void tearDown() throws Exception {
     intp.close();
     intpGroup.close();
-    intpGroup.destroy();
   }
 
   @Test

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterOutputTestStream.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterOutputTestStream.java
@@ -58,7 +58,6 @@ public class RemoteInterpreterOutputTestStream implements RemoteInterpreterProce
   @After
   public void tearDown() throws Exception {
     intpGroup.close();
-    intpGroup.destroy();
   }
 
   private RemoteInterpreter createMockInterpreter() {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -73,7 +73,6 @@ public class RemoteInterpreterTest {
   @After
   public void tearDown() throws Exception {
     intpGroup.close();
-    intpGroup.destroy();
   }
 
   private RemoteInterpreter createMockInterpreterA(Properties p) {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/DistributedResourcePoolTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/resource/DistributedResourcePoolTest.java
@@ -134,11 +134,9 @@ public class DistributedResourcePoolTest {
     eventPoller1.shutdown();
     intp1.close();
     intpGroup1.close();
-    intpGroup1.destroy();
     eventPoller2.shutdown();
     intp2.close();
     intpGroup2.close();
-    intpGroup2.destroy();
   }
 
   @Test

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -745,7 +745,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       InterpreterGroup interpreterGroup = interpreterSetting.getInterpreterGroup(user, noteId);
       String key = getInterpreterSessionKey(user, noteId, interpreterSetting);
       interpreterGroup.close(key);
-      interpreterGroup.destroy(key);
       synchronized (interpreterGroup) {
         interpreterGroup.remove(key);
         interpreterGroup.notifyAll(); // notify createInterpreterForNote()

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -178,7 +178,6 @@ public class InterpreterSetting {
 
     if (groupToRemove != null) {
       groupToRemove.close();
-      groupToRemove.destroy();
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
IMHO `destroy` is a little functional duplicated with `close`. And it seems currently only cassandra use destroy and it just calls `close()` https://github.com/apache/zeppelin/blob/master/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java#L231. So IMO, we could delete destroy method, also we can delete the destroy method in `InterpreterGroup`.  Besides, I move the terminate remoteInterpreterProcess in `close`.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1773

### How should this be tested?
Just remove something so the existing test pass should be sufficient. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

