### PR TITLE
[HOTFIX][ZEPPELIN-1779]Flaky test: PySparkInterpreterMatplotlibTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1024M -Xmx2048M -XX:MaxPermSize=1024m -XX:-UseGCOverheadLimit -Dorg.slf4j.simpleLogger.defaultLogLevel=warn'" >> ~/.mavenrc
-  - ./testing/install_external_dependencies.sh > /dev/null 2>&1
+  - ./testing/install_external_dependencies.sh
   - ls -la .spark-dist ${HOME}/.m2/repository/.cache/maven-download-plugin || true
   - ls .node_modules && cp -r .node_modules zeppelin-web/node_modules || echo "node_modules are not cached"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1600x1024x16"

--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -27,7 +27,7 @@ if [[ ${PROFILE/"-Pr "} != $PROFILE ]] || [[ ${PROFILE/"-Psparkr "} != $PROFILE 
   source ~/.environ
   if [[ ! -d "$HOME/R/knitr" ]] ; then
     mkdir -p ~/R
-    R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org', lib='~/R')"
+    R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org', lib='~/R')"  > /dev/null 2>&1
   fi
 fi
 
@@ -42,5 +42,5 @@ if [[ -n "$PYTHON" ]] ; then
   conda update -q conda
   conda info -a
   conda config --add channels conda-forge
-  conda install -q matplotlib pandasql
+  conda install -q matplotlib=1.5.3 pandasql
 fi


### PR DESCRIPTION
### What is this PR for?
The matplotlib tests have stalled as a result of conda downloading version 2.0.0b1. While this was an old beta version and the issue has been fixed upstream (https://github.com/conda-forge/matplotlib-feedstock/issues/86), we still have not tested the inline backend for 2.0.0 which will be a release with a lot of major changes, hence this PR should be made anyway. I am also partially undoing one of the changes made in #1709 which suppressed the output of the dependency installation from conda. This change was very puzzling to me since dependency info isn't that verbose. I ended up determining the cause of this issue because I reverted this change and was then able to see the dependency versions in the log. I could see suppressing this being necessary for the R packages in case they aren't cached and a wall of compiler output gets printed out, but I see no real justification to mute it for python packages, especially given that they will only be installed for two short profiles.

### What type of PR is it?
Hot Fix 

### What is the Jira issue?
[ZEPPELIN-1779](https://issues.apache.org/jira/browse/ZEPPELIN-1779)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

