### PR TITLE
add hadoop-2.7 to available hadoop version

### DIFF
--- a/docs/install/build.md
+++ b/docs/install/build.md
@@ -124,6 +124,7 @@ Available profiles are
 -Phadoop-2.3
 -Phadoop-2.4
 -Phadoop-2.6
+-Phadoop-2.7
 ```
 
 minor version can be adjusted by `-Dhadoop.version=x.x.x`


### PR DESCRIPTION
### What is this PR for?
we can use hadoop 2.7 for spark-dependency, but building document doesn't contain that.
hadoop 2.7 should be contained to available hadoop version at document.


### What type of PR is it?
[Documentation]

### Todos


### What is the Jira issue?
ZEPPELIN-1783
