### PR TITLE
Better output of JDBC Interpreter.

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -389,6 +389,50 @@ public class JDBCInterpreter extends Interpreter {
     return connection;
   }
 
+  private String getResults(ResultSet resultSet, boolean isTableType)
+      throws SQLException {
+    ResultSetMetaData md = resultSet.getMetaData();
+    StringBuilder msg;
+    if (isTableType) {
+      msg = new StringBuilder(TABLE_MAGIC_TAG);
+    } else {
+      msg = new StringBuilder();
+    }
+
+    for (int i = 1; i < md.getColumnCount() + 1; i++) {
+      if (i > 1) {
+        msg.append(TAB);
+      }
+      msg.append(replaceReservedChars(md.getColumnName(i)));
+    }
+    msg.append(NEWLINE);
+
+    int displayRowCount = 0;
+    while (resultSet.next() && displayRowCount < getMaxResult()) {
+      for (int i = 1; i < md.getColumnCount() + 1; i++) {
+        Object resultObject;
+        String resultValue;
+        resultObject = resultSet.getObject(i);
+        if (resultObject == null) {
+          resultValue = "null";
+        } else {
+          resultValue = resultSet.getString(i);
+        }
+        msg.append(replaceReservedChars(resultValue));
+        if (i != md.getColumnCount()) {
+          msg.append(TAB);
+        }
+      }
+      msg.append(NEWLINE);
+      displayRowCount++;
+    }
+    return msg.toString();
+  }
+
+  private boolean isDDLCommand(int updatedCount, int columnCount) throws SQLException {
+    return updatedCount < 0 && columnCount <= 0 ? true : false;
+  }
+
   private InterpreterResult executeSql(String propertyKey, String sql,
       InterpreterContext interpreterContext) {
     Connection connection;
@@ -398,6 +442,7 @@ public class JDBCInterpreter extends Interpreter {
     String user = interpreterContext.getAuthenticationInfo().getUser();
 
     try {
+      String results = null;
       connection = getConnection(propertyKey, interpreterContext);
 
       if (connection == null) {
@@ -409,61 +454,27 @@ public class JDBCInterpreter extends Interpreter {
         return new InterpreterResult(Code.ERROR, "Prefix not found.");
       }
 
-      StringBuilder msg = null;
-      boolean isTableType = false;
-
-      if (containsIgnoreCase(sql, EXPLAIN_PREDICATE)) {
-        msg = new StringBuilder();
-      } else {
-        msg = new StringBuilder(TABLE_MAGIC_TAG);
-        isTableType = true;
-      }
-
       try {
         getJDBCConfiguration(user).saveStatement(paragraphId, statement);
 
         boolean isResultSetAvailable = statement.execute(sql);
-
         if (isResultSetAvailable) {
           resultSet = statement.getResultSet();
 
-          ResultSetMetaData md = resultSet.getMetaData();
-
-          for (int i = 1; i < md.getColumnCount() + 1; i++) {
-            if (i > 1) {
-              msg.append(TAB);
-            }
-            msg.append(replaceReservedChars(isTableType, md.getColumnName(i)));
-          }
-          msg.append(NEWLINE);
-
-          int displayRowCount = 0;
-          while (resultSet.next() && displayRowCount < getMaxResult()) {
-            for (int i = 1; i < md.getColumnCount() + 1; i++) {
-              Object resultObject;
-              String resultValue;
-              resultObject = resultSet.getObject(i);
-              if (resultObject == null) {
-                resultValue = "null";
-              } else {
-                resultValue = resultSet.getString(i);
-              }
-              msg.append(replaceReservedChars(isTableType, resultValue));
-              if (i != md.getColumnCount()) {
-                msg.append(TAB);
-              }
-            }
-            msg.append(NEWLINE);
-            displayRowCount++;
+          // Regards that the command is DDL.
+          if (isDDLCommand(statement.getUpdateCount(), resultSet.getMetaData().getColumnCount())) {
+            results = "Query executed successfully.";
+          } else {
+            results = getResults(resultSet, !containsIgnoreCase(sql, EXPLAIN_PREDICATE));
           }
         } else {
           // Response contains either an update count or there are no results.
           int updateCount = statement.getUpdateCount();
-          msg.append(UPDATE_COUNT_HEADER).append(NEWLINE);
-          msg.append(updateCount).append(NEWLINE);
+          results = "Query executed successfully. Affected rows : " + updateCount;
         }
         //In case user ran an insert/update/upsert statement
         if (connection.getAutoCommit() != true) connection.commit();
+
       } finally {
         if (resultSet != null) {
           try {
@@ -482,7 +493,7 @@ public class JDBCInterpreter extends Interpreter {
         }
         getJDBCConfiguration(user).removeStatement(paragraphId);
       }
-      return new InterpreterResult(Code.SUCCESS, msg.toString());
+      return new InterpreterResult(Code.SUCCESS, results);
 
     } catch (Exception e) {
       logger.error("Cannot run " + sql, e);
@@ -504,11 +515,11 @@ public class JDBCInterpreter extends Interpreter {
   /**
    * For %table response replace Tab and Newline characters from the content.
    */
-  private String replaceReservedChars(boolean isTableResponseType, String str) {
+  private String replaceReservedChars(String str) {
     if (str == null) {
       return EMPTY_COLUMN_VALUE;
     }
-    return (!isTableResponseType) ? str : str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
+    return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
Currently, the output format of the JDBC Interpreter is the table format with all the results except EXPLAIN statement, It is better for the user experience to output only the result of the SELECT statement in table format.
This PR fixes the above issue and did some code refactoring.
Tested on mysql and aws athena.

### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1784


### How should this be tested?
 - before
<img width="1132" alt="2016-12-11 12 30 54" src="https://cloud.githubusercontent.com/assets/3348133/21074311/3bb25bd0-bf39-11e6-8cc2-c72af742c6fe.png">


<img width="1105" alt="2016-12-11 12 32 47" src="https://cloud.githubusercontent.com/assets/3348133/21074320/61b2cdd8-bf39-11e6-8be2-b02eb48b32a7.png">


 - after
<img width="1147" alt="2016-12-11 12 15 43" src="https://cloud.githubusercontent.com/assets/3348133/21074296/e349e3e6-bf38-11e6-96c2-fa7e92265e94.png">


<img width="1097" alt="2016-12-11 12 21 06" src="https://cloud.githubusercontent.com/assets/3348133/21074297/e888130a-bf38-11e6-963e-d9fbe7eafb0f.png">


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

