### PR TITLE
ZEPPELIN-1785. Remove ZEPPELIN_NOTEBOOK_DIR and ZEPPELIN_INTERPRETER_DIR from common.sh

### DIFF
--- a/bin/common.cmd
+++ b/bin/common.cmd
@@ -43,14 +43,6 @@ if not defined ZEPPELIN_WAR (
     )
 )
 
-if not defined ZEPPELIN_NOTEBOOK_DIR (
-    set ZEPPELIN_NOTEBOOK_DIR=%ZEPPELIN_HOME%\notebook
-)
-
-if not defined ZEPPELIN_INTERPRETER_DIR (
-    set ZEPPELIN_INTERPRETER_DIR=%ZEPPELIN_HOME%\interpreter
-)
-
 if exist "%ZEPPELIN_CONF_DIR%\zeppelin-env.cmd" (
     call "%ZEPPELIN_CONF_DIR%\zeppelin-env.cmd"
 )

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -48,14 +48,6 @@ if [[ -z "${ZEPPELIN_WAR}" ]]; then
   fi
 fi
 
-if [[ -z "$ZEPPELIN_NOTEBOOK_DIR" ]]; then
-  export ZEPPELIN_NOTEBOOK_DIR="${ZEPPELIN_HOME}/notebook"
-fi
-
-if [[ -z "$ZEPPELIN_INTERPRETER_DIR" ]]; then
-  export ZEPPELIN_INTERPRETER_DIR="${ZEPPELIN_HOME}/interpreter"
-fi
-
 if [[ -f "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh" ]]; then
   . "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh"
 fi


### PR DESCRIPTION
### What is this PR for?
We should remove `ZEPPELIN_NOTEBOOK_DIR` and `ZEPPELIN_INTERPRETER_DIR` from `common.sh` otherwise the corresponding property defined in `zeppelin-site.xml` won't take effect. I also check other properties like ZEPPELIN_CONF_DIR and ZEPPELIN_WAR. Although we define them explicitly in common.sh, we didn't expose them in document `install.md` and `zeppelin-site.xml.template`, so I think these are only for internal use and it is OK to keep them in common.sh although their correponding property in zeppelin-site.xml won't take effect too. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1785

### How should this be tested?
Tested manually

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

…