### PR TITLE
[ZEPPELIN-1298] Address invalid ticket warnings when server restarted

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -171,8 +171,11 @@ public class NotebookServer extends WebSocketServlet implements
           LOG.debug("{} message: invalid ticket {} != {}", messagereceived.op,
               messagereceived.ticket, ticket);
         } else {
-          LOG.warn("{} message: invalid ticket {} != {}", messagereceived.op,
-              messagereceived.ticket, ticket);
+          if (!messagereceived.op.equals(OP.PING)) {
+            conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
+                "Your ticket is invalid possibly due to server restart. "
+                + "Please refresh the page and login again.")));
+          }
         }
         return;
       }


### PR DESCRIPTION
### What is this PR for?
When Zeppelin server restarted then all previously open tab tickets will be invalidated. It causes execessive `PING` logs and requires user to refresh the page. More details in comments of the issue. 

### What type of PR is it?
Bug Fix | Improvement

### Todos
* [x] - remove ping warning
* [x] - add popup

### What is the Jira issue?
[ZEPPELIN-1298](https://issues.apache.org/jira/browse/ZEPPELIN-1298)

### How should this be tested?
1. start Zeppelin server and login
2. restart server
3. try to do something in previously open window

### Screenshots (if appropriate)
Before:
![ping_stack_before](https://cloud.githubusercontent.com/assets/1642088/21128483/b50a9400-c13e-11e6-84af-2384cdde7efc.gif)

After:
![ping_stack_after](https://cloud.githubusercontent.com/assets/1642088/21128484/bd49f76e-c13e-11e6-86a6-f6ec944d927c.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

