### PR TITLE
[HOT FIX] Fix broken display_formula.png by using relative path

### DIFF
--- a/docs/displaysystem/basicdisplaysystem.md
+++ b/docs/displaysystem/basicdisplaysystem.md
@@ -27,37 +27,37 @@ limitations under the License.
 
 By default, Apache Zeppelin prints interpreter response as a plain text using `text` display system.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_text.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_text.png" />
 
 You can explicitly say you're using `text` display system.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_text1.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_text1.png" />
 
 ## Html
 
 With `%html` directive, Zeppelin treats your output as HTML
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_html.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_html.png" />
 
 ### Mathematical expressions
 HTML display system automatically formats mathematical expression using [MathJax](https://www.mathjax.org/). You can use
 `\\( INLINE EXPRESSION \\)` and `$$ EXPRESSION $$` to format. For example
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_formula.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_formula.png" />
 
 
 ## Table
 
-If you have data that row separated by '\n' (newline) and column separated by '\t' (tab) with first row as header row, for example
+If you have data that row separated by `\n` (newline) and column separated by `\t` (tab) with first row as header row, for example
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_table.png" />
 
 You can simply use `%table` display system to leverage Zeppelin's built in visualization.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table1.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_table1.png" />
 
 If table contents start with `%html`, it is interpreted as an HTML.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table_html.png" />
+<img src="../assets/themes/zeppelin/img/screenshots/display_table_html.png" />
 
 > **Note :** Display system is backend independent.


### PR DESCRIPTION
### What is this PR for?
Currently `display_formula.png` (added by #1606) is broken in here: http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/displaysystem/basicdisplaysystem.html#mathematical-expressions

Fixed it by using relative path for the image. But have no idea why the other image files are not broken in that page. 

### What type of PR is it?
Documentation | Hot Fix

### Todos
* [ ] - Task

### What is the Jira issue?
N/A

### How should this be tested?
It can't be reproduced using docs dev mode. Needs to be tested with below steps. 

```
1) build gh-pages (website) branch
JEKYLL_ENV=production bundle exec jekyll build
cp -r _site/ /tmp/zeppelin_website/
mkdir -p /tmp/zeppelin_website/docs/0.7.0-SNAPSHOT

2) build this patch (docs) and copy it under docs/0.7.0-SNAPSHOT of website
cd docs
bundle exec jekyll build --safe
cp -r _site/ /tmp/zeppelin_website/0.7.0-SNAPSHOT/

3) start httpserver and browse http://localhost:8000/docs/0.7.0-SNAPSHOT/
cd /tmp/zeppelin_website
python -m SimpleHTTPServer
```

### Screenshots (if appropriate)
**Before**
 - In the official website 
<img width="938" alt="screen shot 2016-12-13 at 7 07 27 pm" src="https://cloud.githubusercontent.com/assets/10060731/21136061/72c230b6-c167-11e6-9805-12d6f11f3270.png">

```
GET http://zeppelin.apache.org/assets/themes/zeppelin/img/screenshots/display_formula.png 404 (Not Found)
```

**After**
 - test locally using same with production path
<img width="877" alt="screen shot 2016-12-13 at 7 09 42 pm" src="https://cloud.githubusercontent.com/assets/10060731/21136136/bbff660e-c167-11e6-9ed3-384e609886fe.png">

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

