### PR TITLE
[ZEPPELIN-1804] Added Link this paragraph to keyboard shortcut

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -556,6 +556,7 @@
         $scope.editor.commands.removeCommand('showSettingsMenu');
 
         $scope.editor.commands.bindKey('ctrl-alt-l', null);
+        $scope.editor.commands.bindKey('ctrl-alt-w', null);
 
         // autocomplete on 'ctrl+.'
         $scope.editor.commands.bindKey('ctrl-.', 'startAutocomplete');
@@ -1092,10 +1093,12 @@
           } else {
             $scope.showTitle($scope.paragraph);
           }
-        }else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 67) { // Ctrl + Alt + c
+        } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 67) { // Ctrl + Alt + c
           $scope.copyPara('below');
         } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 76) { // Ctrl + Alt + l
           $scope.clearParagraphOutput($scope.paragraph);
+        } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 87) { // Ctrl + Alt + w
+          $scope.goToSingleParagraph();
         } else {
           noShortcutDefined = true;
         }

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -202,6 +202,17 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">w</kbd>
+            </div>
+          </div>
+          <div class="col-md-8">
+            Link this paragraph
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-4">
+            <div class="keys">
               <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">-</kbd>
             </div>
           </div>


### PR DESCRIPTION
### What is this PR for?
Each paragraph menu, it has "Link this paragraph" function which is link each of the paragraph but there is not shortcut key. 

### What type of PR is it?
[ Improvement ]

### Todos
* None

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1804

### How should this be tested?
Please press Ctrl+Alt+w shortcut key and check work as expected well

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/8110458/21171777/7520eb68-c211-11e6-8498-ae22e99a547a.png)

![z1804_1](https://cloud.githubusercontent.com/assets/8110458/21171586/5b2d88d4-c210-11e6-820a-bc9d40d4a2c1.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

