### PR TITLE
[ZEPPELIN-1810] Removed incorrect usage of getString

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -291,7 +291,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
       return getRelativeDir(
           String.format("%s/%s",
               getConfDir(),
-              getString(path)));
+              path));
     }
   }
 
@@ -320,7 +320,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
       return getRelativeDir(
           String.format("%s/%s",
               getConfDir(),
-              getString(path)));
+              path));
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
The changes in the fix for https://issues.apache.org/jira/browse/ZEPPELIN-1319 introduced a bug which makes setting path to keystore and truststore impossible from zeppelin-site.xml.
The reason seems to be an incorrect use of getString() here
https://github.com/apache/zeppelin/pull/1319/files#diff-69b17249ac9d265091d730130d973f4aR282 
and here
https://github.com/apache/zeppelin/pull/1319/files#diff-69b17249ac9d265091d730130d973f4aR311
There should be no getString there, just "path" as it is.


### What type of PR is it?
Hot Fix

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1810

### How should this be tested?
Before this fix:
In `zeppelin-site.xml`
* setting `zeppelin.ssl` to `true`
* setting `zeppelin.ssl.keystore.path` to a relative path to a keystore (technically it doens't have to exist at all)
* setting `zeppelin.ssl.truststore.path` to a relative path to a truststore Zeppelin 

Now Zeppelin won't start. In the log you can read something like
```WARN [2016-12-14 13:55:45,522] ({main} AbstractLifeCycle.java[setFailed]:212) - FAILED SslContextFactory@8f2098e(/home/firearrow/zeppelin/incubator-zeppelin/conf/null,/home/firearrow/zeppelin/incubator-zeppelin/conf/null): java.io.FileNotFoundException: /home/firearrow/zeppelin/incubator-zeppelin/conf/null (No such file or directory)```

With this fix the correct path is resolved

Edit: Proof reading and formatting fixes
### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

