### PR TITLE
ZEPPELIN-1816. Implement getProgress in SparkRInterpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -42,6 +42,7 @@ public class SparkRInterpreter extends Interpreter {
   private static final Logger logger = LoggerFactory.getLogger(SparkRInterpreter.class);
 
   private static String renderOptions;
+  private SparkInterpreter sparkInterpreter;
   private ZeppelinR zeppelinR;
   private SparkContext sc;
 
@@ -70,7 +71,7 @@ public class SparkRInterpreter extends Interpreter {
 
     int port = SparkRBackend.port();
 
-    SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    this.sparkInterpreter = getSparkInterpreter();
     this.sc = sparkInterpreter.getSparkContext();
     SparkVersion sparkVersion = new SparkVersion(sc.version());
     ZeppelinRContext.setSparkContext(sc);
@@ -185,7 +186,11 @@ public class SparkRInterpreter extends Interpreter {
 
   @Override
   public int getProgress(InterpreterContext context) {
-    return 0;
+    if (sparkInterpreter != null) {
+      return sparkInterpreter.getProgress(context);
+    } else {
+      return 0;
+    }
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
Since I add jobGroup in ZEPPELIN-1769, it is easy to implement getProgress as well. It could be delegated to `SparkInterpreter` in the same session.


### What type of PR is it?
 Improvement | Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1816

### How should this be tested?
Tested manually, see screenshot

### Screenshots (if appropriate)
![sparkr_progress](https://cloud.githubusercontent.com/assets/164491/21212236/aeadd22e-c2c5-11e6-8a16-ba3f940aee39.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

