### PR TITLE
[MINOR] Set default interpreter \w first intp

### DIFF
--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -34,7 +34,6 @@ limitations under the License.
                       name="defaultInterpreter"
                       id="defaultInterpreter"
                       ng-options="option.name for option in interpreterSettings">
-                <option value="">--Select--</option>
               </select>
             </div>
           </div>

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -39,7 +39,7 @@
           defaultInterpreterId = $scope.note.defaultInterpreter.id;
         }
         vm.websocketMsgSrv.createNotebook($scope.note.notename, defaultInterpreterId);
-        $scope.note.defaultInterpreter = null;
+        $scope.note.defaultInterpreter = $scope.interpreterSettings[0];
       } else {
         var noteId = $routeParams.noteId;
         vm.websocketMsgSrv.cloneNote(noteId, $scope.note.notename);
@@ -104,6 +104,9 @@
 
     $scope.$on('interpreterSettings', function(event, data) {
       $scope.interpreterSettings = data.interpreterSettings;
+
+      //initialize default interpreter with Spark interpreter
+      $scope.note.defaultInterpreter = data.interpreterSettings[0];
     });
 
     var init = function() {


### PR DESCRIPTION
### What is this PR for?
Currently we can select default interpreter when we create a new note like below.
![screen shot 2016-12-15 at 4 41 15 pm](https://cloud.githubusercontent.com/assets/10060731/21215571/56bf4078-c2e5-11e6-8455-b2cb0e126007.png)

However, even if we don't set the default interpreter(don't select any interpreters) in this dialog and just create new note, the default interpreter is automatically set as `Spark` interpreter. This can be checked in the interpreter binding page. It doesn't make sense I think. 
So I removed `--select--` and set the default option in the select box with `Spark` as the interpreter binding page does. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
N/A

### How should this be tested?
1. Build only web \w `npm run build` under `zeppelin-web/` and run `npm run start` for dev mode. 
2. Create a new note and see the select box 

or just see the below screenshots :)

### Screenshots (if appropriate)
 - Before 
![before](https://cloud.githubusercontent.com/assets/10060731/21215524/1b3f9886-c2e5-11e6-9947-e9186e087b54.gif)

 - After
![default_intp](https://cloud.githubusercontent.com/assets/10060731/21215526/1cc8d258-c2e5-11e6-9a71-504f7164078b.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

