### PR TITLE
[ZEPPELIN-1818] Absolute local repo path in dependency downloader

### DIFF
--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
@@ -16,20 +16,18 @@
  */
 
 package org.apache.zeppelin.spark;
+
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import org.apache.zeppelin.resource.LocalResourcePool;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -40,10 +38,13 @@ import static org.junit.Assert.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class PySparkInterpreterMatplotlibTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
   public static SparkInterpreter sparkInterpreter;
   public static PySparkInterpreter pyspark;
   public static InterpreterGroup intpGroup;
-  private File tmpDir;
   public static Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreterTest.class);
   private InterpreterContext context;
   
@@ -79,7 +80,7 @@ public class PySparkInterpreterMatplotlibTest {
     }
   }
 
-  public static Properties getPySparkTestProperties() {
+  private Properties getPySparkTestProperties() throws IOException {
     Properties p = new Properties();
     p.setProperty("master", "local[*]");
     p.setProperty("spark.app.name", "Zeppelin Test");
@@ -87,6 +88,7 @@ public class PySparkInterpreterMatplotlibTest {
     p.setProperty("zeppelin.spark.maxResult", "1000");
     p.setProperty("zeppelin.spark.importImplicit", "true");
     p.setProperty("zeppelin.pyspark.python", "python");
+    p.setProperty("zeppelin.dep.localrepo", tmpDir.newFolder().getAbsolutePath());
     return p;
   }
 
@@ -106,10 +108,6 @@ public class PySparkInterpreterMatplotlibTest {
 
   @Before
   public void setUp() throws Exception {
-    tmpDir = new File(System.getProperty("java.io.tmpdir") + "/ZeppelinLTest_" + System.currentTimeMillis());
-    System.setProperty("zeppelin.dep.localrepo", tmpDir.getAbsolutePath() + "/local-repo");
-    tmpDir.mkdirs();
-
     intpGroup = new InterpreterGroup();
     intpGroup.put("note", new LinkedList<Interpreter>());
 
@@ -135,24 +133,6 @@ public class PySparkInterpreterMatplotlibTest {
       new LocalResourcePool("id"),
       new LinkedList<InterpreterContextRunner>(),
       new InterpreterOutput(null));
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    delete(tmpDir);
-  }
-
-  private void delete(File file) {
-    if (file.isFile()) file.delete();
-    else if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null && files.length > 0) {
-        for (File f : files) {
-          delete(f);
-        }
-      }
-      file.delete();
-    }
   }
 
   @Test

--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
@@ -16,20 +16,22 @@
  */
 
 package org.apache.zeppelin.spark;
+
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.resource.LocalResourcePool;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,14 +41,17 @@ import static org.junit.Assert.*;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class PySparkInterpreterTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
   public static SparkInterpreter sparkInterpreter;
   public static PySparkInterpreter pySparkInterpreter;
   public static InterpreterGroup intpGroup;
-  private File tmpDir;
   public static Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreterTest.class);
   private InterpreterContext context;
 
-  public static Properties getPySparkTestProperties() {
+  private Properties getPySparkTestProperties() throws IOException {
     Properties p = new Properties();
     p.setProperty("master", "local[*]");
     p.setProperty("spark.app.name", "Zeppelin Test");
@@ -54,6 +59,7 @@ public class PySparkInterpreterTest {
     p.setProperty("zeppelin.spark.maxResult", "1000");
     p.setProperty("zeppelin.spark.importImplicit", "true");
     p.setProperty("zeppelin.pyspark.python", "python");
+    p.setProperty("zeppelin.dep.localrepo", tmpDir.newFolder().getAbsolutePath());
     return p;
   }
 
@@ -73,10 +79,6 @@ public class PySparkInterpreterTest {
 
   @Before
   public void setUp() throws Exception {
-    tmpDir = new File(System.getProperty("java.io.tmpdir") + "/ZeppelinLTest_" + System.currentTimeMillis());
-    System.setProperty("zeppelin.dep.localrepo", tmpDir.getAbsolutePath() + "/local-repo");
-    tmpDir.mkdirs();
-
     intpGroup = new InterpreterGroup();
     intpGroup.put("note", new LinkedList<Interpreter>());
 
@@ -102,24 +104,6 @@ public class PySparkInterpreterTest {
       new LocalResourcePool("id"),
       new LinkedList<InterpreterContextRunner>(),
       new InterpreterOutput(null));
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    delete(tmpDir);
-  }
-
-  private void delete(File file) {
-    if (file.isFile()) file.delete();
-    else if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null && files.length > 0) {
-        for (File f : files) {
-          delete(f);
-        }
-      }
-      file.delete();
-    }
   }
 
   @Test

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.zeppelin.spark;
 
-import static org.junit.Assert.*;
-
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Properties;
@@ -29,25 +27,28 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SparkSqlInterpreterTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
 
   private SparkSqlInterpreter sql;
   private SparkInterpreter repl;
   private InterpreterContext context;
   private InterpreterGroup intpGroup;
 
-  Logger LOGGER = LoggerFactory.getLogger(SparkSqlInterpreterTest.class);
-
   @Before
   public void setUp() throws Exception {
     Properties p = new Properties();
-    p.putAll(SparkInterpreterTest.getSparkTestProperties());
+    p.putAll(SparkInterpreterTest.getSparkTestProperties(tmpDir));
     p.setProperty("zeppelin.spark.maxResult", "1000");
     p.setProperty("zeppelin.spark.concurrentSQL", "false");
     p.setProperty("zeppelin.spark.sql.stacktrace", "false");
@@ -80,10 +81,6 @@ public class SparkSqlInterpreterTest {
         new AngularObjectRegistry(intpGroup.getId(), null),
         new LocalResourcePool("id"),
         new LinkedList<InterpreterContextRunner>(), new InterpreterOutput(null));
-  }
-
-  @After
-  public void tearDown() throws Exception {
   }
 
   boolean isDataFrameSupported() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.dep;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;
@@ -35,6 +36,8 @@ public class Booter {
 
   public static RepositorySystemSession newRepositorySystemSession(
       RepositorySystem system, String localRepoPath) {
+    Validate.notNull(localRepoPath, "localRepoPath should have a value");
+
     MavenRepositorySystemSession session = new MavenRepositorySystemSession();
 
     LocalRepository localRepo = new LocalRepository(resolveLocalRepoPath(localRepoPath));

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -17,13 +17,13 @@
 
 package org.apache.zeppelin.dep;
 
-import java.io.File;
-
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.repository.LocalRepository;
 import org.sonatype.aether.repository.RemoteRepository;
+
+import java.nio.file.Paths;
 
 /**
  * Manage mvn repository.
@@ -37,19 +37,7 @@ public class Booter {
       RepositorySystem system, String localRepoPath) {
     MavenRepositorySystemSession session = new MavenRepositorySystemSession();
 
-    // find homedir
-    String home = System.getenv("ZEPPELIN_HOME");
-    if (home == null) {
-      home = System.getProperty("zeppelin.home");
-    }
-    if (home == null) {
-      home = "..";
-    }
-
-    String path = home + "/" + localRepoPath;
-
-    LocalRepository localRepo =
-        new LocalRepository(new File(path).getAbsolutePath());
+    LocalRepository localRepo = new LocalRepository(resolveLocalRepoPath(localRepoPath));
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(localRepo));
 
     // session.setTransferListener(new ConsoleTransferListener());
@@ -61,10 +49,24 @@ public class Booter {
     return session;
   }
 
+  static String resolveLocalRepoPath(String localRepoPath) {
+    // todo decouple home folder resolution
+    // find homedir
+    String home = System.getenv("ZEPPELIN_HOME");
+    if (home == null) {
+      home = System.getProperty("zeppelin.home");
+    }
+    if (home == null) {
+      home = "..";
+    }
+
+    return Paths.get(home).resolve(localRepoPath).toAbsolutePath().toString();
+  }
+
   public static RemoteRepository newCentralRepository() {
     return new RemoteRepository("central", "default", "http://repo1.maven.org/maven2/");
   }
-  
+
   public static RemoteRepository newLocalRepository() {
     return new RemoteRepository("local",
         "default", "file://" + System.getProperty("user.home") + "/.m2/repository");

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/BooterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/BooterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.dep;
+
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class BooterTest {
+
+  @Test
+  public void should_return_absolute_path() {
+    String resolvedPath = Booter.resolveLocalRepoPath("path");
+    assertTrue(Paths.get(resolvedPath).isAbsolute());
+  }
+
+  @Test
+  public void should_not_change_absolute_path() {
+    String absolutePath
+        = Paths.get("first", "second").toAbsolutePath().toString();
+    String resolvedPath = Booter.resolveLocalRepoPath(absolutePath);
+
+    assertThat(resolvedPath, equalTo(absolutePath));
+  }
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/BooterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/BooterTest.java
@@ -41,4 +41,9 @@ public class BooterTest {
 
     assertThat(resolvedPath, equalTo(absolutePath));
   }
+
+  @Test(expected = NullPointerException.class)
+  public void should_throw_exception_for_null() {
+    Booter.resolveLocalRepoPath(null);
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Allow dependency resolver to use absolute path for local repo

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1818](https://issues.apache.org/jira/browse/ZEPPELIN-1818)

### How should this be tested?
Outline the steps to test the PR here.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

Old implementation expected localRepoPath to be relative to ZEPPELIN_HOME.
It created broken path with absolute localRepoPath
(e.g. C:\Users\User\AppData\Local\Temp\..\C:\......)

Huge amount of tests passed absolute path to newRepositorySystemSession.

Path.resolve(...) works fine if parameter is absolute path