### PR TITLE
[ZEPPELIN-1763] Prevent duplicate $scope.$on('setNoteMenu') calls

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -112,11 +112,6 @@
               var top = $id.offset().top - 103;
               angular.element('html, body').scrollTo({top: top, left: 0});
             }
-
-            // force notebook reload on user change
-            $scope.$on('setNoteMenu', function(event, note) {
-              initNotebook();
-            });
           },
           1000
         );
@@ -124,6 +119,11 @@
     };
 
     initNotebook();
+
+    // force notebook reload on user change
+    $scope.$on('setNoteMenu', function(event, note) {
+      initNotebook();
+    });
 
     $scope.focusParagraphOnClick = function(clickEvent) {
       if (!$scope.note) {

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -101,6 +101,7 @@ describe('Controller: NotebookCtrl', function() {
     expect(scope.saveTimer).toEqual(null);
   });
 
+
   it('should NOT update note name when updateNoteName() is called with an invalid name', function() {
     spyOn(websocketMsgSrvMock, 'updateNote');
     scope.updateNoteName('');
@@ -120,5 +121,21 @@ describe('Controller: NotebookCtrl', function() {
     scope.updateNoteName(newName);
     expect(scope.note.name).toEqual(newName);
     expect(websocketMsgSrvMock.updateNote).toHaveBeenCalled();
+  });
+
+  it('should reload note info once per one "setNoteMenu" event', function() {
+    spyOn(websocketMsgSrvMock, 'getNote');
+    spyOn(websocketMsgSrvMock, 'listRevisionHistory');
+
+    scope.$broadcast('setNoteMenu');
+    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(1);
+    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(1);
+
+    websocketMsgSrvMock.getNote.calls.reset();
+    websocketMsgSrvMock.listRevisionHistory.calls.reset();
+
+    scope.$broadcast('setNoteMenu');
+    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(1);
+    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(1);
   });
 });

--- a/zeppelin-web/test/spec/controllers/notebook.js
+++ b/zeppelin-web/test/spec/controllers/notebook.js
@@ -101,7 +101,6 @@ describe('Controller: NotebookCtrl', function() {
     expect(scope.saveTimer).toEqual(null);
   });
 
-
   it('should NOT update note name when updateNoteName() is called with an invalid name', function() {
     spyOn(websocketMsgSrvMock, 'updateNote');
     scope.updateNoteName('');


### PR DESCRIPTION
### What is this PR for?
It's to fix the issue 'ZEPPELIN-1763' (Zeppelin hangs if I repeatedly select and deselect note name).
When the note name was changed, there was a problem that the 'setNoteName' listener was registered in duplicate and occupied resources. 
To fix it, I moved the function that registers the listener out of initNoteBook()

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[ZEPPELIN-1763](https://issues.apache.org/jira/browse/ZEPPELIN-1763?filter=-2)

### How should this be tested?
Repeat changing note name.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

The listners are added in duplicate on $scope.$on('setNoteMenu') calls.