### PR TITLE
[ZEPPELIN-1820] Fix action bar layout broken issue

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -910,6 +910,11 @@
       document.removeEventListener('click', $scope.focusParagraphOnClick);
       document.removeEventListener('keydown', $scope.keyboardShortcut);
     });
+
+    angular.element(window).bind('resize', function() {
+      const actionbarHeight = document.getElementById('actionbar').lastElementChild.clientHeight;
+      angular.element(document.getElementById('content')).css('padding-top', actionbarHeight - 20);
+    });
   }
 
 })();

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -133,7 +133,7 @@
   position: fixed;
   top: 50px;
   width: 100%;
-  height: 54px;
+  min-height: 54px;
   z-index: 10001;
 }
 

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -12,8 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <!-- Here the controller <NotebookCtrl> is not needed because explicitly set in the app.js (route) -->
-<div ng-include src="'app/notebook/notebook-actionBar.html'"></div>
-<div class="notebookContent">
+<div id="actionbar" ng-include src="'app/notebook/notebook-actionBar.html'"></div>
+<div id="content" class="notebookContent">
   <!-- settings -->
   <div ng-if="showSetting" class="setting">
     <div>


### PR DESCRIPTION
### What is this PR for?
Action bar buttons and paragraph are overlapped when the browser width is small.
To fix this issue, this PR replaces `height` css property for action bar with `min-height` and adds a binding code for `window resize` to dynamically change the paragraph position based on the height of action bar.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1820

### How should this be tested?
Change browser width

### Screenshots (if appropriate)
[Before]
![actionbar-layout-broken](https://cloud.githubusercontent.com/assets/17305893/21232567/68bf764a-c32f-11e6-846a-f476abeaee13.png)

[After]
![actionbar-layout-broken](https://cloud.githubusercontent.com/assets/17305893/21232529/5078d194-c32f-11e6-94a8-4698fc8d63d2.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No