### PR TITLE
[HOTFIX] CAN'T install cran packages using apt in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ addons:
     - r-packages-precise
     packages:
     - r-base-dev
-    - r-cran-evaluate
-    - r-cran-base64enc
 
 matrix:
   include:

--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -27,6 +27,8 @@ if [[ ${PROFILE/"-Pr "} != $PROFILE ]] || [[ ${PROFILE/"-Psparkr "} != $PROFILE 
   source ~/.environ
   if [[ ! -d "$HOME/R/knitr" ]] ; then
     mkdir -p ~/R
+    R -e "install.packages('evaluate', repos = 'http://cran.us.r-project.org', lib='~/R')"  > /dev/null 2>&1
+    R -e "install.packages('base64enc', repos = 'http://cran.us.r-project.org', lib='~/R')"  > /dev/null 2>&1
     R -e "install.packages('knitr', repos = 'http://cran.us.r-project.org', lib='~/R')"  > /dev/null 2>&1
   fi
 fi


### PR DESCRIPTION
### What is this PR for?

[CRAN repository](https://cran.rstudio.com/bin/linux/ubuntu/precise/) for precise doens't have `r-cran-evaluate`, `r-cran-base64enc`. This cause the whole build failure. (even in the [ubuntu precise repo](http://packages.ubuntu.com/search?section=all&arch=any&keywords=r-cran-base64enc&searchon=names))

```
E: Unable to locate package r-cran-evaluate
E: Unable to locate package r-cran-base64enc
apt-get.diagnostics
apt-get install failed
```

You can see those errors in

- (master:HEAD) https://travis-ci.org/apache/zeppelin/builds/184428876
- (master:HEAD~1) https://travis-ci.org/apache/zeppelin/builds/184428084
- (recent 1773 PR) https://travis-ci.org/apache/zeppelin/builds/184435284

### What type of PR is it?
[Hot Fix]

### Todos
* [X] - NOTHING

### What is the Jira issue?

NO. This is hotfix

### How should this be tested?

I tested this in my own travis CI. 

- https://travis-ci.org/1ambda/zeppelin/builds/184455104

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO

