### PR TITLE
ZEPPELIN-1834 Deadlock in Zeppelin when running multiple notes via sc…

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -514,21 +514,19 @@ public class Note implements Serializable, ParagraphJobListener {
   /**
    * Run all paragraphs sequentially.
    */
-  public void runAll() {
+  public synchronized void runAll() {
     String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
     if (null == cronExecutingUser) {
       cronExecutingUser = "anonymous";
     }
-    synchronized (paragraphs) {
-      for (Paragraph p : paragraphs) {
-        if (!p.isEnabled()) {
-          continue;
-        }
-        AuthenticationInfo authenticationInfo = new AuthenticationInfo();
-        authenticationInfo.setUser(cronExecutingUser);
-        p.setAuthenticationInfo(authenticationInfo);
-        run(p.getId());
+    for (Paragraph p : getParagraphs()) {
+      if (!p.isEnabled()) {
+        continue;
       }
+      AuthenticationInfo authenticationInfo = new AuthenticationInfo();
+      authenticationInfo.setUser(cronExecutingUser);
+      p.setAuthenticationInfo(authenticationInfo);
+      run(p.getId());
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

To prevent deadlock when different notes are run simultaneously by the scheduler.

### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1834
[ZEPPELIN-1834]

### How should this be tested?
Manual testing steps:
*  Create 2 notes.
* Set a scheduler on each of them to run at the same time.
* Deadlock will occur and Zeppelin hangs.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
