### PR TITLE
Followup for ZEPPELIN-1785

### DIFF
--- a/bin/zeppelin.cmd
+++ b/bin/zeppelin.cmd
@@ -84,9 +84,4 @@ if not exist %ZEPPELIN_PID_DIR% (
     mkdir "%ZEPPELIN_PID_DIR%"
 )
 
-if not exist %ZEPPELIN_NOTEBOOK_DIR% (
-    echo Notebook dir doesn't exist, create %ZEPPELIN_NOTEBOOK_DIR%
-    mkdir "%ZEPPELIN_NOTEBOOK_DIR%"
-)
-
 "%ZEPPELIN_RUNNER%" %JAVA_OPTS% -cp %CLASSPATH% %ZEPPELIN_SERVER% "%*"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -83,9 +83,4 @@ if [[ ! -d "${ZEPPELIN_PID_DIR}" ]]; then
   $(mkdir -p "${ZEPPELIN_PID_DIR}")
 fi
 
-if [[ ! -d "${ZEPPELIN_NOTEBOOK_DIR}" ]]; then
-  echo "Pid dir doesn't exist, create ${ZEPPELIN_NOTEBOOK_DIR}"
-  $(mkdir -p "${ZEPPELIN_NOTEBOOK_DIR}")
-fi
-
 exec $ZEPPELIN_RUNNER $JAVA_OPTS -cp $ZEPPELIN_CLASSPATH_OVERRIDES:$CLASSPATH $ZEPPELIN_SERVER "$@"


### PR DESCRIPTION
### What is this PR for?
After #1745, zeppelin fail to launch in windows. https://issues.apache.org/jira/browse/ZEPPELIN-1785?focusedCommentId=15754688&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15754688

This due to the shell script difference between windows and *nix. This PR just remove the checking for ZEPPELIN_NOTEBOOK_DIR as it would be created in JVM side if the dir is not existed. I also remove it from  zeppelin.sh for *nix as well.


### What type of PR is it?
[Hot Fix |]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1785

### How should this be tested?
Tested it manually in windows and mac. Zeppelin can launch successfully on windows/mac even when the notebook dir doesn't exist. 


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
