### PR TITLE
[ZEPPELIN-1837] Fix possible reason of DepInterpreterTest failure

### DIFF
--- a/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/DepInterpreterTest.java
@@ -19,7 +19,7 @@ package org.apache.zeppelin.spark;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Properties;
@@ -31,28 +31,27 @@ import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class DepInterpreterTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
   private DepInterpreter dep;
   private InterpreterContext context;
-  private File tmpDir;
-  private SparkInterpreter repl;
 
-  private Properties getTestProperties() {
+  private Properties getTestProperties() throws IOException {
     Properties p = new Properties();
-    p.setProperty("zeppelin.dep.localrepo", "local-repo");
+    p.setProperty("zeppelin.dep.localrepo", tmpDir.newFolder().getAbsolutePath());
     p.setProperty("zeppelin.dep.additionalRemoteRepository", "spark-packages,http://dl.bintray.com/spark-packages/maven,false;");
     return p;
   }
 
   @Before
   public void setUp() throws Exception {
-    tmpDir = new File(System.getProperty("java.io.tmpdir") + "/ZeppelinLTest_" + System.currentTimeMillis());
-    System.setProperty("zeppelin.dep.localrepo", tmpDir.getAbsolutePath() + "/local-repo");
-
-    tmpDir.mkdirs();
-
     Properties p = getTestProperties();
 
     dep = new DepInterpreter(p);
@@ -74,20 +73,6 @@ public class DepInterpreterTest {
   @After
   public void tearDown() throws Exception {
     dep.close();
-    delete(tmpDir);
-  }
-
-  private void delete(File file) {
-    if (file.isFile()) file.delete();
-    else if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null && files.length > 0) {
-        for (File f : files) {
-          delete(f);
-        }
-      }
-      file.delete();
-    }
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
Fix possible reason of DepInterpreterTest failure

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-1837](https://issues.apache.org/jira/browse/ZEPPELIN-1837)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

DepInterpreterTest will use random temporary folder for repo

`DefaultRepositorySystem.resolveDependencies` throws NPE at line 352
if `ArtifactResolutionException` is thrown during `collectDependencies`.
Artifact is found but it is impossible to download it (for example folder
can't be created)

I think the reason is that several tests use "local-repo" folder for repository.
While one test tries to download artifact, another deletes repository
(or some another distructive thing)