### PR TITLE
[ZEPPELIN-1840] Allow fully qualified username when principalSuffix is used

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -156,7 +156,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
       if (userPrincipalName == null) {
         return null;
       }
-      if (this.principalSuffix != null) {
+      if (this.principalSuffix != null && userPrincipalName.indexOf('@') < 0) {
         userPrincipalName = upToken.getUsername() + this.principalSuffix;
       }
       ctx = ldapContextFactory.getLdapContext(
@@ -254,7 +254,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     SearchControls searchCtls = new SearchControls();
     searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
     String userPrincipalName = username;
-    if (principalSuffix != null) {
+    if (this.principalSuffix != null && userPrincipalName.indexOf('@') < 0) {
       userPrincipalName += principalSuffix;
     }
 


### PR DESCRIPTION
### What is this PR for?
When principalSuffix is defined in shiro.ini, only the short username are allowed and any attempt with fully qualified user name will result in the login error.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-1840](https://issues.apache.org/jira/browse/ZEPPELIN-1840)

### How should this be tested?
1. Configure Zeppelin for Active Directory user authentication by using ActiveDirectoryGroupRealm in shiro.ini
2. Define activeDirectoryGroupRealm.principalSuffix = @DOMAIN.COM in shiro.ini
3. Restart Zeppelin and try to login via short username i.e. "user1" and fully qualified username i.e. "user1@DOMAIN.COM".
4. Expected Result: Login should be permitted for both type of user names

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
