### PR TITLE
[ZEPPELIN-1833] Fix bug in ClientFactory.destroyObject that does not close socket connections

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
@@ -70,9 +70,9 @@ public class ClientFactory extends BasePooledObjectFactory<Client>{
   @Override
   public void destroyObject(PooledObject<Client> p) {
     synchronized (clientSocketMap) {
-      if (clientSocketMap.containsKey(p)) {
-        clientSocketMap.get(p).close();
-        clientSocketMap.remove(p);
+      if (clientSocketMap.containsKey(p.getObject())) {
+        clientSocketMap.get(p.getObject()).close();
+        clientSocketMap.remove(p.getObject());
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Fix bug in ClientFactory.destroyObject that does not close socket connections

### What type of PR is it?
Bug Fix

### Todos
NA

### What is the Jira issue?
[ZEPPELIN-1833](https://issues.apache.org/jira/browse/ZEPPELIN-1833)

### How should this be tested?
* Create multiple paragraphs and execute them in parallel. This will create multiple thrift clients and active connections.
* When the clients are returned to the object pool, verify that the destroyObject correctly closes connections. Use the netstat command to get number of active connections.

### Screenshots (if appropriate)
NA

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
