### PR TITLE
[ZEPPELIN-1842] sync on start when anonymous allowed

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -93,6 +93,14 @@ public class NotebookRepoSync implements NotebookRepo {
       LOG.info("No storage could be initialized, using default {} storage", defaultStorage);
       initializeDefaultStorage(conf);
     }
+    // sync for anonymous mode on start
+    if (getRepoCount() > 1 && conf.getBoolean(ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED)) {
+      try {
+        sync(AuthenticationInfo.ANONYMOUS);
+      } catch (IOException e) {
+        LOG.error("Couldn't sync on start ", e);
+      }
+    }
   }
 
   @SuppressWarnings("static-access")


### PR DESCRIPTION
### What is this PR for?
this is to keep backward compatibility when it's possible to sync on start in anonymous mode.


### What type of PR is it?
Bug Fix | Improvement

### Todos
* [x] - add sync call with condition

### What is the Jira issue?
[ZEPPELIN-1842](https://issues.apache.org/jira/browse/ZEPPELIN-1842)

### How should this be tested?
1. enable secondary storage (e.g. s3, azure, [here](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/storage/storage.html#notebook-storage-in-s3))
2. keep anonymous mode without authentication
3. start zeppelin -> notes should be synced

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? no
