### PR TITLE
ZEPPELIN-1826. Flaky Test: ZeppelinSparkClusterTest.zRunTest

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1844,7 +1844,13 @@ public class NotebookServer extends WebSocketServlet implements
       }
 
       if (job.isTerminated()) {
-        LOG.info("Job {} is finished", job.getId());
+        if (job.getStatus() == Status.FINISHED) {
+          LOG.info("Job {} is finished successfully, status: {}", job.getId(), job.getStatus());
+        } else {
+          LOG.warn("Job {} is finished, status: {}, exception: {}, result: {}" , job.getId(),
+              job.getStatus(), job.getException(), job.getReturn());
+        }
+
         try {
           //TODO(khalid): may change interface for JobListener and pass subject from interpreter
           note.persist(job instanceof Paragraph ? ((Paragraph) job).getAuthenticationInfo() : null);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -342,6 +342,8 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p0);
         assertEquals(Status.FINISHED, p0.getStatus());
 
+        // z.run is not blocking call. So p1 may not be finished when p0 is done.
+        waitForFinish(p1);
         note.run(p2.getId());
         waitForFinish(p2);
         assertEquals(Status.FINISHED, p2.getStatus());

--- a/zeppelin-server/src/test/resources/log4j.properties
+++ b/zeppelin-server/src/test/resources/log4j.properties
@@ -43,4 +43,4 @@ log4j.logger.DataNucleus.Datastore=ERROR
 # Log all JDBC parameters
 log4j.logger.org.hibernate.type=ALL
 
-log4j.logger.org.apache.zeppelin.interpreter.remote.RemoteInterpreter=DEBUG
+log4j.logger.org.apache.zeppelin.interpreter=DEBUG


### PR DESCRIPTION
### What is this PR for?
Fix the flaky test of ZeppelinSparkClusterTest.zRunTest. The issue is that z.run is not a blocking call so we still need the check the paragraph status. (see code change for details).

Besides that, I also add more logging. This helps me a lot. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1826



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
