### PR TITLE
[ZEPPELIN-1845] InterpreterFactory.createOrGetInterpreterList fails when interpreter mode is "perUser": "scoped"

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -326,12 +326,12 @@ public class NotebookRestApi {
     List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
     if (initialParagraphs != null) {
       for (NewParagraphRequest paragraphRequest : initialParagraphs) {
-        Paragraph p = note.addParagraph();
+        Paragraph p = note.addParagraph(subject);
         p.setTitle(paragraphRequest.getTitle());
         p.setText(paragraphRequest.getText());
       }
     }
-    note.addParagraph(); // add one paragraph to the last
+    note.addParagraph(subject); // add one paragraph to the last
     String noteName = request.getName();
     if (noteName.isEmpty()) {
       noteName = "Note " + note.getId();
@@ -414,18 +414,17 @@ public class NotebookRestApi {
     checkIfUserCanWrite(noteId, "Insufficient privileges you cannot add paragraph to this note");
 
     NewParagraphRequest request = gson.fromJson(message, NewParagraphRequest.class);
-
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     Paragraph p;
     Double indexDouble = request.getIndex();
     if (indexDouble == null) {
-      p = note.addParagraph();
+      p = note.addParagraph(subject);
     } else {
-      p = note.insertParagraph(indexDouble.intValue());
+      p = note.insertParagraph(indexDouble.intValue(), subject);
     }
     p.setTitle(request.getTitle());
     p.setText(request.getText());
 
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     note.persist(subject);
     notebookServer.broadcastNote(note);
     return new JsonResponse<>(Status.CREATED, "", p.getId()).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -854,7 +854,7 @@ public class NotebookServer extends WebSocketServlet implements
         note = notebook.createNote(subject);
       }
 
-      note.addParagraph(); // it's an empty note. so add one paragraph
+      note.addParagraph(subject); // it's an empty note. so add one paragraph
       if (message != null) {
         String noteName = (String) message.get("name");
         if (StringUtils.isEmpty(noteName)) {
@@ -1327,7 +1327,7 @@ public class NotebookServer extends WebSocketServlet implements
       return null;
     }
 
-    Paragraph newPara = note.insertParagraph(index);
+    Paragraph newPara = note.insertParagraph(index, subject);
     note.persist(subject);
     broadcastNewParagraph(note, newPara);
 
@@ -1386,9 +1386,9 @@ public class NotebookServer extends WebSocketServlet implements
     String text = (String) fromMessage.get("paragraph");
     p.setText(text);
     p.setTitle((String) fromMessage.get("title"));
-    AuthenticationInfo authenticationInfo =
+    AuthenticationInfo subject =
         new AuthenticationInfo(fromMessage.principal, fromMessage.ticket);
-    p.setAuthenticationInfo(authenticationInfo);
+    p.setAuthenticationInfo(subject);
 
     Map<String, Object> params = (Map<String, Object>) fromMessage
        .get("params");
@@ -1400,11 +1400,9 @@ public class NotebookServer extends WebSocketServlet implements
     // if it's the last paragraph, let's add a new one
     boolean isTheLastParagraph = note.isLastParagraph(p.getId());
     if (isTheLastParagraph) {
-      Paragraph newPara = note.addParagraph();
+      Paragraph newPara = note.addParagraph(subject);
       broadcastNewParagraph(note, newPara);
     }
-
-    AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
 
     try {
       note.persist(subject);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -242,7 +242,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   public void testInterpreterRestart() throws IOException, InterruptedException {
     // when: create new note
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    note.addParagraph();
+    note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();
     config.put("enabled", true);
@@ -269,7 +269,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
     }
 
     // when: run markdown paragraph, again
-    p = note.addParagraph();
+    p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setConfig(config);
     p.setText("%md markdown restarted");
     p.setAuthenticationInfo(anonymous);
@@ -287,7 +287,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   public void testRestartInterpreterPerNote() throws IOException, InterruptedException {
     // when: create new note
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    note.addParagraph();
+    note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();
     config.put("enabled", true);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -136,7 +136,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   @Test
   public void testGetNoteParagraphJobStatus() throws IOException {
     Note note1 = ZeppelinServer.notebook.createNote(anonymous);
-    note1.addParagraph();
+    note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     String paragraphId = note1.getLastParagraph().getId();
 
@@ -158,9 +158,9 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   @Test
   public void testRunParagraphJob() throws IOException {
     Note note1 = ZeppelinServer.notebook.createNote(anonymous);
-    note1.addParagraph();
+    note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Paragraph p = note1.addParagraph();
+    Paragraph p = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // run blank paragraph
     PostMethod post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
@@ -214,7 +214,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   public void testUpdateParagraphConfig() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     String noteId = note.getId();
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     assertNull(p.getConfig().get("colWidth"));
     String paragraphId = p.getId();
     String jsonRequest = "{\"colWidth\": 6.0}";
@@ -240,11 +240,11 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   public void testClearAllParagraphOutput() throws IOException {
     // Create note and set result explicitly
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
     p1.setResult(result);
 
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setReturn(result, new Throwable());
 
     // clear paragraph result

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -88,7 +88,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -218,7 +218,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -251,7 +251,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName(noteName);
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -313,7 +313,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("source note for clone");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -364,7 +364,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -419,7 +419,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -473,7 +473,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -517,7 +517,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("%md This is test paragraph.");
     
     Map config = paragraph.getConfig();
@@ -566,7 +566,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph();
+    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
 
     note.persist(anonymous);
@@ -627,7 +627,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testGetParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("hello");
     p.setText("world");
     note.persist(anonymous);
@@ -656,11 +656,11 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testMoveParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("title1");
     p.setText("text1");
 
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setTitle("title2");
     p2.setText("text2");
 
@@ -688,7 +688,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testDeleteParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("title1");
     p.setText("text1");
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -81,7 +81,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         Note note = ZeppelinServer.notebook.createNote(anonymous);
 
         // run markdown paragraph, again
-        Paragraph p = note.addParagraph();
+        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config = p.getConfig();
         config.put("enabled", true);
         p.setConfig(config);
@@ -102,7 +102,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         // DataFrame API is available from spark 1.3
         if (sparkVersion >= 13) {
             // test basic dataframe api
-            Paragraph p = note.addParagraph();
+            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -116,7 +116,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                     "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
 
             // test display DataFrame
-            p = note.addParagraph();
+            p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -131,7 +131,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
             // test display DataSet
             if (sparkVersion >= 20) {
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -170,7 +170,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         if (sparkVersion >= 20) {
           sqlContextName = "spark";
         }
-        Paragraph p = note.addParagraph();
+        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config = p.getConfig();
         config.put("enabled", true);
         p.setConfig(config);
@@ -197,7 +197,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
         if (isPyspark() && sparkVersion >= 12) {   // pyspark supported from 1.2.1
             // run markdown paragraph, again
-            Paragraph p = note.addParagraph();
+            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -209,7 +209,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             assertEquals("55\n", p.getResult().message().get(0).getData());
             if (sparkVersion >= 13) {
                 // run sqlContext test
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -223,7 +223,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("[Row(age=20, id=1)]\n", p.getResult().message().get(0).getData());
 
                 // test display Dataframe
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -239,7 +239,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("age\tid\n20\t1\n", p.getResult().message().get(0).getData());
 
                 // test udf
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -253,7 +253,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             }
             if (sparkVersion >= 20) {
                 // run SparkSession test
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -267,7 +267,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("[Row(age=20, id=1)]\n", p.getResult().message().get(0).getData());
 
                 // test udf
-                p = note.addParagraph();
+                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -294,7 +294,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
         if (isPyspark() && sparkVersionNumber >= 14) {   // auto_convert enabled from spark 1.4
             // run markdown paragraph, again
-            Paragraph p = note.addParagraph();
+            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -319,19 +319,19 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     public void zRunTest() throws IOException {
         // create new note
         Note note = ZeppelinServer.notebook.createNote(anonymous);
-        Paragraph p0 = note.addParagraph();
+        Paragraph p0 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config0 = p0.getConfig();
         config0.put("enabled", true);
         p0.setConfig(config0);
         p0.setText("%spark z.run(1)");
         p0.setAuthenticationInfo(anonymous);
-        Paragraph p1 = note.addParagraph();
+        Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config1 = p1.getConfig();
         config1.put("enabled", true);
         p1.setConfig(config1);
         p1.setText("%spark val a=10");
         p1.setAuthenticationInfo(anonymous);
-        Paragraph p2 = note.addParagraph();
+        Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config2 = p2.getConfig();
         config2.put("enabled", true);
         p2.setConfig(config2);
@@ -347,7 +347,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         assertEquals(Status.FINISHED, p2.getStatus());
         assertEquals("10", p2.getResult().message().get(0).getData());
 
-        Paragraph p3 = note.addParagraph();
+        Paragraph p3 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         Map config3 = p3.getConfig();
         config3.put("enabled", true);
         p3.setConfig(config3);
@@ -397,7 +397,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             }
 
             // load dep
-            Paragraph p0 = note.addParagraph();
+            Paragraph p0 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p0.getConfig();
             config.put("enabled", true);
             p0.setConfig(config);
@@ -412,7 +412,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             FileUtils.write(tmpFile, "a,b\n1,2");
 
             // load data using libraries from dep loader
-            Paragraph p1 = note.addParagraph();
+            Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
             p1.setConfig(config);
 
             String sqlContextName = "sqlContext";
@@ -438,7 +438,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
      * eg. 1.1.x => 11, 1.2.x => 12, 1.3.x => 13 ...
      */
     private int getSparkVersionNumber(Note note) {
-        Paragraph p = note.addParagraph();
+        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
         note.setName("note");
         Map config = p.getConfig();
         config.put("enabled", true);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -110,7 +110,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     }
 
     // start interpreter process
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%md start remote interpreter process");
     p1.setAuthenticationInfo(anonymous);
     note1.run(p1.getId());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -255,8 +255,9 @@ public class Note implements Serializable, ParagraphJobListener {
   /**
    * Add paragraph last.
    */
-  public Paragraph addParagraph() {
+  public Paragraph addParagraph(AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory);
+    p.setAuthenticationInfo(authenticationInfo);
     setParagraphMagic(p, paragraphs.size());
     synchronized (paragraphs) {
       paragraphs.add(p);
@@ -311,8 +312,9 @@ public class Note implements Serializable, ParagraphJobListener {
    *
    * @param index index of paragraphs
    */
-  public Paragraph insertParagraph(int index) {
+  public Paragraph insertParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory);
+    p.setAuthenticationInfo(authenticationInfo);
     setParagraphMagic(p, index);
     synchronized (paragraphs) {
       paragraphs.add(index, p);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -139,7 +139,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     factory.setInterpreters("user", note1.getId(),factory.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -184,7 +184,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     factory.setInterpreters("user", note1.getId(), factory.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -223,7 +223,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     notebook.bindInterpretersToNote("user", note1.getId(), factory.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -254,7 +254,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
 
     // add paragraph with invalid magic
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%fake ");
 
     // make sure that p1's repl is null
@@ -290,7 +290,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
       }
     }
 
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -70,7 +70,7 @@ public class NoteTest {
     String pText = "%spark sc.version";
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(pText);
     p.setAuthenticationInfo(anonymous);
     note.run(p.getId());
@@ -86,7 +86,7 @@ public class NoteTest {
   public void addParagraphWithEmptyReplNameTest() {
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     assertNull(p.getText());
   }
 
@@ -95,9 +95,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%spark ");
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     assertEquals("%spark\n", p2.getText());
   }
@@ -107,9 +107,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%spark ");
-    Paragraph p2 = note.insertParagraph(note.getParagraphs().size());
+    Paragraph p2 = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
 
     assertEquals("%spark\n", p2.getText());
   }
@@ -119,9 +119,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("invalid"))).thenReturn(null);
 
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%invalid ");
-    Paragraph p2 = note.insertParagraph(note.getParagraphs().size());
+    Paragraph p2 = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
 
     assertNull(p2.getText());
   }
@@ -132,11 +132,11 @@ public class NoteTest {
     when(interpreter.getScheduler()).thenReturn(scheduler);
 
     Note note = new Note(repo, interpreterFactory, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
     p1.setResult(result);
 
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setReturn(result, new Throwable());
 
     note.clearAllParagraphOutput();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -111,7 +111,7 @@ public class NotebookTest implements JobListenerFactory{
     factory.setInterpreters(anonymous.getUser(), note.getId(), factory.getDefaultInterpreterSettingList());
 
     // run with default repl
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -122,7 +122,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals("repl1: hello world", p1.getResult().message().get(0).getData());
 
     // run with specific repl
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setConfig(config);
     p2.setText("%mock2 hello world");
     p2.setAuthenticationInfo(anonymous);
@@ -202,7 +202,7 @@ public class NotebookTest implements JobListenerFactory{
     try {
       assertEquals(0, notebook.getAllNotes().size());
       note = notebook.createNote(anonymous);
-      Paragraph p1 = note.addParagraph();
+      Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
       Map config = p1.getConfig();
       config.put("enabled", true);
       p1.setConfig(config);
@@ -225,7 +225,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
 
     // run with default repl
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -256,7 +256,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException{
     Note note = notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -276,7 +276,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testRunBlankParagraph() throws IOException, SchedulerException, InterruptedException {
     Note note = notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("");
     p1.setAuthenticationInfo(anonymous);
     note.run(p1.getId());
@@ -293,21 +293,21 @@ public class NotebookTest implements JobListenerFactory{
     factory.setInterpreters("user", note.getId(), factory.getDefaultInterpreterSettingList());
 
     // p1
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config1 = p1.getConfig();
     config1.put("enabled", true);
     p1.setConfig(config1);
     p1.setText("p1");
 
     // p2
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config2 = p2.getConfig();
     config2.put("enabled", false);
     p2.setConfig(config2);
     p2.setText("p2");
 
     // p3
-    Paragraph p3 = note.addParagraph();
+    Paragraph p3 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p3.setText("p3");
 
     // when
@@ -331,7 +331,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters("user", note.getId(), factory.getDefaultInterpreterSettingList());
 
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = new HashMap<>();
     p.setConfig(config);
     p.setText("p1");
@@ -364,12 +364,12 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters(anonymous.getUser(), note.getId(), factory.getDefaultInterpreterSettingList());
     
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = new HashMap<>();
     p.setConfig(config);
     p.setText("sleep 1000");
 
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setConfig(config);
     p2.setText("%mock2 sleep 500");
 
@@ -417,7 +417,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters("user", note.getId(), factory.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph();
+    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     String simpleText = "hello world";
     p.setText(simpleText);
 
@@ -456,7 +456,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters("user", note.getId(), factory.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph();
+    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
     note.runAll();
     while(p.isTerminated()==false || p.getResult()==null) Thread.yield();
@@ -502,7 +502,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters(anonymous.getUser(), note.getId(), factory.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph();
+    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
     note.runAll();
     while (p.isTerminated() == false || p.getResult() == null) {
@@ -529,9 +529,9 @@ public class NotebookTest implements JobListenerFactory{
     for (InterpreterGroup intpGroup : InterpreterGroup.getAll()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
     }
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("hello");
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setText("%mock2 world");
 
     note.runAll();
@@ -560,7 +560,7 @@ public class NotebookTest implements JobListenerFactory{
         .getInterpreterSettings(note.getId()).get(0).getInterpreterGroup(anonymous.getUser(), "sharedProcess")
         .getAngularObjectRegistry();
 
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // add paragraph scope object
     registry.add("o1", "object1", note.getId(), p1.getId());
@@ -593,7 +593,7 @@ public class NotebookTest implements JobListenerFactory{
         .getInterpreterSettings(note.getId()).get(0).getInterpreterGroup(anonymous.getUser(), "sharedProcess")
         .getAngularObjectRegistry();
 
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     // add paragraph scope object
     registry.add("o1", "object1", note.getId(), p1.getId());
@@ -738,7 +738,7 @@ public class NotebookTest implements JobListenerFactory{
 
     ArrayList<Paragraph> paragraphs = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
-      Paragraph tmp = note.addParagraph();
+      Paragraph tmp = note.addParagraph(AuthenticationInfo.ANONYMOUS);
       tmp.setText("p" + tmp.getId());
       paragraphs.add(tmp);
     }
@@ -772,7 +772,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException {
     // create a notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
 
@@ -789,7 +789,7 @@ public class NotebookTest implements JobListenerFactory{
     // remove note and recreate
     notebook.removeNote(note1.getId(), anonymous);
     note1 = notebook.createNote(anonymous);
-    p1 = note1.addParagraph();
+    p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
 
@@ -804,10 +804,10 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreter() throws IOException {
     // create two notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     Note note2  = notebook.createNote(anonymous);
-    Paragraph p2 = note2.addParagraph();
+    Paragraph p2 = note2.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
@@ -848,10 +848,10 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerNoteSessionInterpreter() throws IOException {
     // create two notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     Note note2  = notebook.createNote(anonymous);
-    Paragraph p2 = note2.addParagraph();
+    Paragraph p2 = note2.addParagraph(AuthenticationInfo.ANONYMOUS);
 
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
@@ -907,7 +907,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException {
     // create a notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setAuthenticationInfo(anonymous);
     p1.setText("getId");
 
@@ -977,7 +977,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note1 = notebook.createNote(anonymous);
     assertEquals(1, onNoteCreate.get());
 
-    Paragraph p1 = note1.addParagraph();
+    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
     assertEquals(1, onParagraphCreate.get());
 
     note1.addCloneParagraph(p1);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -34,6 +34,7 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
@@ -144,7 +145,7 @@ public class GitNotebookRepoTest {
 
     //modify, save and checkpoint first note
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -159,7 +160,7 @@ public class GitNotebookRepoTest {
 
     //modify, save and checkpoint second note
     note = notebookRepo.get(TEST_NOTE_ID2, null);
-    p = note.addParagraph();
+    p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     config = p.getConfig();
     config.put("enabled", false);
     p.setConfig(config);
@@ -185,7 +186,7 @@ public class GitNotebookRepoTest {
     
     // add changes to note
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -224,7 +225,7 @@ public class GitNotebookRepoTest {
 
     // add paragraph and save
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -246,7 +247,7 @@ public class GitNotebookRepoTest {
     assertThat(note.getParagraphs().size()).isEqualTo(paragraphCount_2);
 
     // add one more paragraph and save
-    Paragraph p2 = note.addParagraph();
+    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     config.put("enabled", false);
     p2.setConfig(config);
     p2.setText("get revision when modified note test text");
@@ -282,7 +283,7 @@ public class GitNotebookRepoTest {
     assertThat(note.getParagraphs().size()).isEqualTo(paragraphCount_1);
 
     // add one more paragraph and save
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -324,7 +325,7 @@ public class GitNotebookRepoTest {
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null).size()).isEqualTo(1);
     
     // add one more paragraph and save
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -168,7 +168,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     /* create note */
     Note note = notebookSync.createNote(anonymous);
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -305,7 +305,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     int vCount = gitRepo.revisionHistory(noteId, anonymous).size();
     assertThat(vCount).isEqualTo(1);
     
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -339,7 +339,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(0, authInfo.getWriters(note.getId()).size());
     
     /* update note and save on secondary storage */
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("hello world");
     assertEquals(1, note.getParagraphs().size());
     notebookRepoSync.save(1, note, null);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -120,7 +120,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     Note note = notebook.createNote(anonymous);
     factory.setInterpreters("user", note.getId(), factory.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note.addParagraph();
+    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -275,13 +275,13 @@ public class LuceneSearchTest {
   }
 
   private Paragraph addParagraphWithText(Note note, String text) {
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(text);
     return p;
   }
 
   private Paragraph addParagraphWithTextAndTitle(Note note, String text, String title) {
-    Paragraph p = note.addParagraph();
+    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(text);
     p.setTitle(title);
     return p;


### PR DESCRIPTION
### What is this PR for?
When trying to add a paragraph, whose default interpreter is running in mode `"perUser": "scoped"` fails with following exception

```
ERROR [2016-12-22 11:52:18,784] ({qtp112466394-59} NotebookServer.java[onMessage]:318) - Can't handle message
java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964)
	at org.apache.zeppelin.interpreter.InterpreterFactory.createOrGetInterpreterList(InterpreterFactory.java:1219)
	at org.apache.zeppelin.interpreter.InterpreterFactory.getInterpreter(InterpreterFactory.java:1333)
	at org.apache.zeppelin.notebook.Paragraph.isValidInterpreter(Paragraph.java:598)
	at org.apache.zeppelin.notebook.Paragraph.getMagic(Paragraph.java:587)
	at org.apache.zeppelin.notebook.Note.setParagraphMagic(Note.java:506)
	at org.apache.zeppelin.notebook.Note.insertParagraph(Note.java:316)
	at org.apache.zeppelin.socket.NotebookServer.insertParagraph(NotebookServer.java:1330)
	at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:241)
	at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:59)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:128)
	at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:65)
	at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextFrame(JettyListenerEventDriver.java:122)
	at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.incomingFrame(AbstractEventDriver.java:161)
	at org.eclipse.jetty.websocket.common.WebSocketSession.incomingFrame(WebSocketSession.java:309)
	at org.eclipse.jetty.websocket.common.extensions.ExtensionStack.incomingFrame(ExtensionStack.java:214)
	at org.eclipse.jetty.websocket.common.Parser.notifyFrame(Parser.java:220)
	at org.eclipse.jetty.websocket.common.Parser.parse(Parser.java:258)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.readParse(AbstractWebSocketConnection.java:632)
	at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable(AbstractWebSocketConnection.java:480)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
```

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-1845](https://issues.apache.org/jira/browse/ZEPPELIN-1845)

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
Before:
![before](https://cloud.githubusercontent.com/assets/674497/21417398/4d7535da-c840-11e6-81aa-42290ff75617.gif)

After:
![after](https://cloud.githubusercontent.com/assets/674497/21417399/4d7554f2-c840-11e6-951c-44c7a23e191b.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
