### PR TITLE
[ZEPPELIN-1847] fix: Copy only html when html file changed

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -559,7 +559,7 @@ module.exports = function(grunt) {
           dot: true,
           cwd: '<%= yeoman.app %>',
           dest: '.tmp',
-          src: [ '*.html', ]
+          src: ['*.html']
         }]
       },
     },

--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
         files: [
           '<%= yeoman.app %>/**/*.html'
         ],
-        tasks: ['newer:htmlhint', 'newer:copy:dev']
+        tasks: ['newer:htmlhint', 'newer:copy:html']
       },
       jsTest: {
         files: ['test/spec/{,*/}*.js'],
@@ -552,7 +552,16 @@ module.exports = function(grunt) {
         cwd: '<%= yeoman.app %>',
         dest: '.tmp/styles/',
         src: '{fonts,components,app}/**/*.css'
-      }
+      },
+      html: {
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '.tmp',
+          src: [ '*.html', ]
+        }]
+      },
     },
 
     // Run some tasks in parallel to speed up the build process


### PR DESCRIPTION
### What is this PR for?

Reduce build time by avoiding to copy non-related files. Approx 3~4 secs as you can see below.

### What type of PR is it?
[Improvement]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1847](https://issues.apache.org/jira/browse/ZEPPELIN-1847)

### How should this be tested?

1. `cd zeppelin-web`
2. `npm install` && `npm run start`
3. change any html file in `src/` and see log. 
4. compare the result with master branch's

### Screenshots (if appropriate)


```
Running "watch" task
Waiting...
>> File "src/app/home/home.html" changed.


## before

Execution Time (2016-12-22 08:13:35 UTC)
loading tasks   130ms  ▇▇▇ 3%
htmlhint:src     84ms  ▇▇ 2%
newer:copy:dev   3.6s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 93%
Total 3.9s
Completed in 5.953s at Thu Dec 22 2016 17:13:39 GMT+0900 (KST) - Waiting…

## after

Execution Time (2016-12-22 08:14:27 UTC)
loading tasks       137ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 52%
newer:htmlhint        3ms  ▇ 1%
newer:htmlhint:src   25ms  ▇▇▇▇▇▇▇ 10%
htmlhint:src         89ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 34%
newer:copy:html       5ms  ▇▇ 2%
Total 261ms

Completed in 2.447s at Thu Dec 22 2016 17:14:27 GMT+0900 (KST) - Waiting…
```

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
