### PR TITLE
Change gitignore for font files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,10 @@ reports
 zeppelin-web/node_modules
 zeppelin-web/dist
 zeppelin-web/.tmp
-zeppelin-web/src/fonts/Roboto*
-zeppelin-web/src/fonts/Source-Code-Pro*
-zeppelin-web/src/fonts/Patua-One*
+zeppelin-web/src/fonts/roboto*
+zeppelin-web/src/fonts/source-code-pro*
+zeppelin-web/src/fonts/patua-one*
+zeppelin-web/src/fonts/google-fonts.css
 zeppelin-web/.sass-cache
 zeppelin-web/bower_components
 **nbproject/


### PR DESCRIPTION
### What is this PR for?
Some web fonts were changed by 5552319378e8361a16c91df2ba3cdf5519b74d58 but `.gitignore` was not changed accordingly.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?

### How should this be tested?
Build zeppelin and check `git status` whether there are untracked files.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No