### PR TITLE
ZEPPELIN-1851. LazyOpenInterpreter would open interpreter multiple times when open fails

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -31,7 +31,7 @@ public class LazyOpenInterpreter
     extends Interpreter
     implements WrappedInterpreter {
   private Interpreter intp;
-  boolean opened = false;
+  volatile boolean opened = false;
 
   public LazyOpenInterpreter(Interpreter intp) {
     super(new Properties());
@@ -59,7 +59,7 @@ public class LazyOpenInterpreter
   }
 
   @Override
-  public void open() {
+  public synchronized void open() {
     if (opened == true) {
       return;
     }
@@ -107,8 +107,11 @@ public class LazyOpenInterpreter
 
   @Override
   public int getProgress(InterpreterContext context) {
-    open();
-    return intp.getProgress(context);
+    if (opened) {
+      return intp.getProgress(context);
+    } else {
+      return 0;
+    }
   }
 
   @Override


### PR DESCRIPTION

### What is this PR for?
Change `opened` to be `volatile` as it would be accessed by multiple threads. And check `opened` in `getProgress` rather than call `open()`


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1851

### How should this be tested?
Tested manually on livy interpreter (change the livy configuration to make livy fails to create session).

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
