### PR TITLE
ZEPPELIN-1852. Use multiple InterpreterResult for displaying appInfo

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -61,6 +61,11 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
     <td>Max number of Spark SQL result to display.</td>
   </tr>
   <tr>
+    <td>zeppelin.livy.session.create_timeout</td>
+    <td>120</td>
+    <td>Timeout in seconds for session creation</td>
+  </tr>
+  <tr>
     <td>zeppelin.livy.displayAppInfo</td>
     <td>false</td>
     <td>Whether to display app info</td>

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -62,8 +62,10 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   public BaseLivyInterprereter(Properties property) {
     super(property);
     this.livyURL = property.getProperty("zeppelin.livy.url");
+    this.displayAppInfo = Boolean.parseBoolean(
+        property.getProperty("zeppelin.livy.displayAppInfo", "false"));
     this.sessionCreationTimeout = Integer.parseInt(
-        property.getProperty("zeppelin.livy.create.session.timeout", 120 + ""));
+        property.getProperty("zeppelin.livy.session.create_timeout", 120 + ""));
     this.pullStatusInterval = Integer.parseInt(
         property.getProperty("zeppelin.livy.pull_status.interval.millis", 1000 + ""));
   }
@@ -77,7 +79,6 @@ public abstract class BaseLivyInterprereter extends Interpreter {
     } catch (LivyException e) {
       String msg = "Fail to create session, please check livy interpreter log and " +
           "livy server log";
-      LOGGER.error(msg);
       throw new RuntimeException(msg, e);
     }
   }
@@ -102,10 +103,11 @@ public abstract class BaseLivyInterprereter extends Interpreter {
                 .get(0).getData());
       }
 
-      interpret(
-          "val webui=sc.getClass.getMethod(\"ui\").invoke(sc).asInstanceOf[Some[_]].get",
-          null, false, false);
-      if (StringUtils.isEmpty(sessionInfo.appInfo.get("sparkUiUrl"))) {
+      if (sessionInfo.appInfo == null ||
+          StringUtils.isEmpty(sessionInfo.appInfo.get("sparkUiUrl"))) {
+        interpret(
+            "val webui=sc.getClass.getMethod(\"ui\").invoke(sc).asInstanceOf[Some[_]].get",
+            null, false, false);
         sessionInfo.webUIAddress = extractStatementResult(
             interpret(
                 "webui.getClass.getMethod(\"appUIAddress\").invoke(webui)", null, false, false)
@@ -215,14 +217,12 @@ public abstract class BaseLivyInterprereter extends Interpreter {
         if (sessionInfo.isFinished()) {
           String msg = "Session " + sessionInfo.id + " is finished, appId: " + sessionInfo.appId
               + ", log: " + sessionInfo.log;
-          LOGGER.error(msg);
           throw new LivyException(msg);
         }
         if ((System.currentTimeMillis() - start) / 1000 > sessionCreationTimeout) {
           String msg = "The creation of session " + sessionInfo.id + " is timeout within "
               + sessionCreationTimeout + " seconds, appId: " + sessionInfo.appId
               + ", log: " + sessionInfo.log;
-          LOGGER.error(msg);
           throw new LivyException(msg);
         }
         Thread.sleep(pullStatusInterval);
@@ -361,16 +361,14 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
       if (displayAppInfo) {
         //TODO(zjffdu), use multiple InterpreterResult to display appInfo
-        StringBuilder outputBuilder = new StringBuilder();
-        outputBuilder.append("%angular ");
-        outputBuilder.append("<pre><code>");
-        outputBuilder.append(result);
-        outputBuilder.append("</code></pre>");
-        outputBuilder.append("<hr/>");
-        outputBuilder.append("Spark Application Id:" + sessionInfo.appId + "<br/>");
-        outputBuilder.append("Spark WebUI: <a href=" + sessionInfo.webUIAddress + ">"
-            + sessionInfo.webUIAddress + "</a>");
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS, outputBuilder.toString());
+        InterpreterResult interpreterResult = new InterpreterResult(InterpreterResult.Code.SUCCESS);
+        interpreterResult.add(InterpreterResult.Type.TEXT, result);
+        String appInfoHtml = "<hr/>Spark Application Id: " + sessionInfo.appId + "<br/>"
+            + "Spark WebUI: <a href=\"" + sessionInfo.webUIAddress + "\">"
+            + sessionInfo.webUIAddress + "</a>";
+        LOGGER.info("appInfoHtml:" + appInfoHtml);
+        interpreterResult.add(InterpreterResult.Type.HTML, appInfoHtml);
+        return interpreterResult;
       } else {
         return new InterpreterResult(InterpreterResult.Code.SUCCESS, result);
       }

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -11,9 +11,9 @@
         "defaultValue": "http://localhost:8998",
         "description": "The URL for Livy Server."
       },
-      "zeppelin.livy.create.session.retries": {
-        "envName": "ZEPPELIN_LIVY_CREATE_SESSION_RETRIES",
-        "propertyName": "zeppelin.livy.create.session.timeout",
+      "zeppelin.livy.session.create_timeout": {
+        "envName": "ZEPPELIN_LIVY_SESSION_CREATE_TIMEOUT",
+        "propertyName": "zeppelin.livy.session.create_timeout",
         "defaultValue": "120",
         "description": "Livy Server create session timeout (seconds)."
       },
@@ -87,7 +87,7 @@
         "defaultValue": "",
         "description": "Adding extra libraries to livy interpreter"
       },
-      "livy.spark.displayAppInfo": {
+      "zeppelin.livy.displayAppInfo": {
         "propertyName": "zeppelin.livy.displayAppInfo",
         "defaultValue": "false",
         "description": "Whether display app info"


### PR DESCRIPTION
### What is this PR for?
Refactor the livy interpreter to use multiple `InterpreterResult` for displaying appInfo. 


### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1852

### How should this be tested?
Add integration test and also test it manually

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/21446774/691b84fe-c905-11e6-91a1-9dcc57c75f3c.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
