### PR TITLE
[ZEPPELIN-1854] make Per User mode in interpreter setting visible even if there is no role assigned to a user

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -59,7 +59,7 @@ limitations under the License.
                     Per Note
                   </a>
                 </li>
-                <li ng-if="ticket.ticket !== 'anonymous'">
+                <li ng-if="ticket.principal !== 'anonymous'">
                   <a style="cursor:pointer"
                      ng-click="setInterpreterRunningOption(setting.id, 'shared', 'scoped')">
                     Per User
@@ -126,7 +126,7 @@ limitations under the License.
               </ul>
             </span>
               process.
-            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous'">
+            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.principal !== 'anonymous'">
               <span ng-if="getPerNoteOption(setting.id) === 'shared'">
                 <button type="button" class="btn btn-default btn-xs"
                         ng-click="setPerNoteOption(setting.id, 'scoped')"
@@ -143,7 +143,7 @@ limitations under the License.
           <div class="row interpreter"
                style="margin-top: 6px;"
                ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
-                      && ticket.ticket !== 'anonymous'
+                      && ticket.principal !== 'anonymous'
                       && getPerNoteOption(setting.id) !== 'shared'">
             <div class="col-md-12">
               <span>

--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -59,7 +59,7 @@ limitations under the License.
                     Per Note
                   </a>
                 </li>
-                <li ng-if="ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+                <li ng-if="ticket.ticket !== 'anonymous'">
                   <a style="cursor:pointer"
                      ng-click="setInterpreterRunningOption(setting.id, 'shared', 'scoped')">
                     Per User
@@ -126,7 +126,7 @@ limitations under the License.
               </ul>
             </span>
               process.
-            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous'">
               <span ng-if="getPerNoteOption(setting.id) === 'shared'">
                 <button type="button" class="btn btn-default btn-xs"
                         ng-click="setPerNoteOption(setting.id, 'scoped')"
@@ -144,7 +144,6 @@ limitations under the License.
                style="margin-top: 6px;"
                ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
                       && ticket.ticket !== 'anonymous'
-                      && ticket.roles !== '[]'
                       && getPerNoteOption(setting.id) !== 'shared'">
             <div class="col-md-12">
               <span>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -171,7 +171,7 @@ limitations under the License.
                     Per Note
                   </a>
                 </li>
-                <li ng-if="ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+                <li ng-if="ticket.ticket !== 'anonymous'">
                   <a style="cursor:pointer"
                      ng-click="setInterpreterRunningOption(setting.id, 'shared', 'scoped')">
                     Per User
@@ -239,7 +239,7 @@ limitations under the License.
               </ul>
             </span>
             process.
-            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous' && ticket.roles !== '[]'">
+            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous'">
               <span ng-if="getPerNoteOption(setting.id) === 'shared'">
                 <button type="button" class="btn btn-default btn-xs"
                         ng-click="setPerNoteOption(setting.id, 'scoped')"
@@ -258,7 +258,6 @@ limitations under the License.
              style="margin-top: 6px;"
              ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
                     && ticket.ticket !== 'anonymous'
-                    && ticket.roles !== '[]'
                     && getPerNoteOption(setting.id) !== 'shared'">
           <div class="col-md-12">
             <span>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -171,7 +171,7 @@ limitations under the License.
                     Per Note
                   </a>
                 </li>
-                <li ng-if="ticket.ticket !== 'anonymous'">
+                <li ng-if="ticket.principal !== 'anonymous'">
                   <a style="cursor:pointer"
                      ng-click="setInterpreterRunningOption(setting.id, 'shared', 'scoped')">
                     Per User
@@ -239,7 +239,7 @@ limitations under the License.
               </ul>
             </span>
             process.
-            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.ticket !== 'anonymous'">
+            <span ng-if="getInterpreterRunningOption(setting.id) === 'Per User' && ticket.principal !== 'anonymous'">
               <span ng-if="getPerNoteOption(setting.id) === 'shared'">
                 <button type="button" class="btn btn-default btn-xs"
                         ng-click="setPerNoteOption(setting.id, 'scoped')"
@@ -257,7 +257,7 @@ limitations under the License.
         <div class="row interpreter"
              style="margin-top: 6px;"
              ng-if="getInterpreterRunningOption(setting.id) === 'Per User'
-                    && ticket.ticket !== 'anonymous'
+                    && ticket.principal !== 'anonymous'
                     && getPerNoteOption(setting.id) !== 'shared'">
           <div class="col-md-12">
             <span>


### PR DESCRIPTION
### What is this PR for?
There can be a case where user may have enabled shiro authentication, but may not have configured role based mapping.
In such a scenarios "Per User" mode in interpreter setting should be visible even if there are no role assigned to a user.

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-1854](https://issues.apache.org/jira/browse/ZEPPELIN-1854)

### How should this be tested?
Enable authentication via shiro.ini, and in that remove "[roles]" block, now after restarting zeppelin server "Per User" should be visible when user edits any interpreter setting.

### Screenshots (if appropriate)
Before:
<img width="1439" alt="screen shot 2016-12-23 at 12 10 58 pm" src="https://cloud.githubusercontent.com/assets/674497/21448469/019f4456-c909-11e6-8222-62c74e78e6f8.png">

After:
<img width="1440" alt="screen shot 2016-12-23 at 12 11 28 pm" src="https://cloud.githubusercontent.com/assets/674497/21448470/01a36b76-c909-11e6-89fa-b3492a3331d8.png">


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
