### PR TITLE
[MINOR] fix: Initialize zeppelin var in visualization/builtin/*.js

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in area chart
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-barchart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-barchart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in bar char
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in line chart
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in table format
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in pie chart
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in scatter char
  */

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+var zeppelin = zeppelin || {};
+
 /**
  * Visualize data in table format
  */


### PR DESCRIPTION
### What is this PR for?

Fixed fragile code in src/app/visualization/bulitin This code causes loading errors as u can see the screenshot above. Especially in different loading system (e.g es6 import, require, webpack)

Let's initialize `zeppelin` var like other files do

- [visualization.js#L17](https://github.com/apache/zeppelin/blob/6808bdc6966d6be5085003b47296bdc9917fd0a3/zeppelin-web/src/app/visualization/visualization.js#L17)
- [tabledata.js#L17](https://github.com/apache/zeppelin/blob/6808bdc6966d6be5085003b47296bdc9917fd0a3/zeppelin-web/src/app/tabledata/tabledata.js#L17)

### What type of PR is it?
[Bug Fix]

### Todos

Nothing

### What is the Jira issue?

MINOR

### How should this be tested?

It's trivial. 

### Screenshots (if appropriate)

<img width="1439" alt="screen shot 2016-12-24 at 12 34 35 am" src="https://cloud.githubusercontent.com/assets/4968473/21457826/602cf11e-c975-11e6-9974-bce5370a3833.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
