### PR TITLE
[HOTFIX] [ZEPPELIN-1863] Travis Selenium CI fail

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -289,7 +289,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
       // Get 2nd paragraph id
       final String secondParagraphId = driver.findElement(By.xpath(getParagraphXPath(2)
-              + "//div[@class=\"control ng-scope\"]//ul[@class=\"dropdown-menu\"]/li[1]"))
+              + "//div[@class=\"control ng-scope\"]//ul[@class=\"dropdown-menu dropdown-menu-right\"]/li[1]"))
               .getAttribute("textContent");
 
       assertTrue("Cannot find paragraph id for the 2nd paragraph", isNotBlank(secondParagraphId));


### PR DESCRIPTION
### What is this PR for?
Currently, the Selenium CI test of Travis regarding every PR is failing. 
I think because it is after merging #1777 PR. 

Here is error log.
```
Caused by: org.openqa.selenium.NoSuchElementException: Unable to locate element: {"method":"xpath","selector":"(//div[@ng-controller=\"ParagraphCtrl\"])[2]//div[@class=\"control ng-scope\"]//ul[@class=\"dropdown-menu\"]/li[1]"}


Results :
Tests in error: 
  ZeppelinIT.testAngularRunParagraph:291 » NoSuchElement Unable to locate elemen...
```

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos
* [x] fix code regarding this problem 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1863

### How should this be tested?
- None

### Screenshots (if appropriate)
- None

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
