### PR TITLE
[ZEPPELIN-1843] Error on invoking the REST API to run paragraph synchronously

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -222,7 +222,7 @@ public class Note implements Serializable, ParagraphJobListener {
 
   public void initializeJobListenerForParagraph(Paragraph paragraph) {
     final Note paragraphNote = paragraph.getNote();
-    if (paragraphNote.getId().equals(this.getId())) {
+    if (!paragraphNote.getId().equals(this.getId())) {
       throw new IllegalArgumentException(
           format("The paragraph %s from note %s " + "does not belong to note %s", paragraph.getId(),
               paragraphNote.getId(), this.getId()));


### PR DESCRIPTION

### What is this PR for?
This fixes the validation check of paragraph's note id to match with the Note instance id.

### What type of PR is it?
Bug Fix

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1843

### How should this be tested?
The run para synchronous REST API should be successful.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
