### PR TITLE
[MINOR] Fix paragraph id misalignment in dropdown menu

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -41,6 +41,7 @@ limitations under the License.
     <ul class="dropdown-menu dropdown-menu-right" role="menu" style="width:200px;z-index:1002">
       <li ng-controller="clipboardCtrl" ng-click="$event.stopPropagation()" style="text-align:center;margin-top:4px;">
         <a  ngclipboard
+            class="clipboard"
             ngclipboard-success="complete($event)"
             ngclipboard-error="clipError($event)"
             data-clipboard-text="{{paragraph.id}}"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -202,6 +202,12 @@ table.dataTable.table-condensed .sorting_desc:after {
   cursor: pointer;
 }
 
+.dropdown-menu > li > a.clipboard {
+  padding: 3px 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /*
   Paragraph Title
 */


### PR DESCRIPTION
### What is this PR for?
Fix paragraph id misalignment in dropdown menu at Chrome/Firefox browser.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
N/A

### How should this be tested?
Open the dropdown menu of a paragraph at Chrome/Firefox browser.

### Screenshots (if appropriate)
* before
![before](https://cloud.githubusercontent.com/assets/8870299/21526341/cbc8d57e-cd66-11e6-8379-d95914139310.png)
* after
![after](https://cloud.githubusercontent.com/assets/8870299/21526378/095d732c-cd67-11e6-87b7-fb4b1e509a30.png)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
