### PR TITLE
[MINOR] Fix broken CSS for plain text paragraph result

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -67,6 +67,11 @@ table.dataTable.table-condensed .sorting_desc:after {
   right: 12px;
 }
 
+.plainTextContainer {
+  font-family: "Monaco","Menlo","Ubuntu Mono","Consolas","source-code-pro",monospace;
+  font-size: 12px !important;
+}
+
 .graphContainer {
   position: relative;
   margin-bottom: 5px;

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -52,7 +52,8 @@ limitations under the License.
     </div>
 
     <div id="p{{id}}_text"
-         ng-if="type == 'TEXT'">
+         ng-if="type == 'TEXT'"
+         class="plainTextContainer">
       <div class="fa fa-level-down scroll-paragraph-down"
            ng-show="showScrollDownIcon()"
            ng-click="scrollParagraphDown()"


### PR DESCRIPTION
### What is this PR for?
After #1711 merged, plain text paragraph result CSS is broken now. Originally the text result like below (it's `0.6.2`). The font was `Monaco` applied by `.paragraph .text` class. 
![result1](https://cloud.githubusercontent.com/assets/10060731/21538417/421bdb76-cde0-11e6-901e-8fd79c0cb69a.png)
<img width="213" alt="screen shot 2016-12-29 at 2 58 14 pm" src="https://cloud.githubusercontent.com/assets/10060731/21538419/44d4f0e6-cde0-11e6-9707-227ee4b95446.png">


But now  bootstrap default font `Helvetica` is used. 
![result2](https://cloud.githubusercontent.com/assets/10060731/21538421/47f72794-cde0-11e6-877c-4b43ae4f217f.png)
<img width="245" alt="screen shot 2016-12-29 at 2 58 07 pm" src="https://cloud.githubusercontent.com/assets/10060731/21538424/49824ec2-cde0-11e6-8a07-c893eb31a12e.png">

So I bring it back by adding new class `.plainTextContainer`.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
No Jira issue for this 

### How should this be tested?
 1. See the current text paragraph result (e.g. Zeppelin tutorial: Spark)
 2. Apply this patch and start dev mode under `zeppelin-web` \w `npm run dev` -> browse `http://localhost:9000`
 3. Compare the text paragraph result 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
