### PR TITLE
remove usage of non-standard string method

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -589,7 +589,7 @@ import zeppelin from '../../../zeppelin';
         var dsvRow = '';
         for (var index in row) {
           var stringValue =  (row[index]).toString();
-          if (stringValue.contains(delimiter)) {
+          if (stringValue.indexOf(delimiter) > -1) {
             dsvRow += '"' + stringValue + '"' + delimiter;
           } else {
             dsvRow += row[index] + delimiter;

--- a/zeppelin-web/src/components/noteAction/noteAction.service.js
+++ b/zeppelin-web/src/components/noteAction/noteAction.service.js
@@ -85,11 +85,11 @@
     function normalizeFolderId(folderId) {
       folderId = folderId.trim();
 
-      while (folderId.contains('\\')) {
+      while (folderId.indexOf('\\') > -1) {
         folderId = folderId.replace('\\', '/');
       }
 
-      while (folderId.contains('///')) {
+      while (folderId.indexOf('///') > -1) {
         folderId = folderId.replace('///', '/');
       }
 


### PR DESCRIPTION
### What is this PR for?
Recreating #1701 that was lost in refactoring.
This PR removes a non-standard string prototype method `contains` that can cause potential bugs in the future maintenance.

### What type of PR is it?
Bug Fix 

### Todos
* [x] - remove usage of non-standard string method `contains` in favor of standard `indexOf`

### How should this be tested?
Download as `csv / tsv` (graph view) should work as expected