### PR TITLE
[ZEPPELIN-914] Apply new mechanism to IgniteInterpreter

### DIFF
--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteInterpreter.java
@@ -76,23 +76,6 @@ public class IgniteInterpreter extends Interpreter {
 
   static final String IGNITE_CFG_URL = "ignite.config.url";
 
-  static {
-    Interpreter.register(
-            "ignite",
-            "ignite",
-            IgniteInterpreter.class.getName(),
-            true,
-            new InterpreterPropertyBuilder()
-                    .add(IGNITE_ADDRESSES, "127.0.0.1:47500..47509",
-                            "Coma separated list of addresses "
-                                    + "(e.g. 127.0.0.1:47500 or 127.0.0.1:47500..47509)")
-                    .add(IGNITE_CLIENT_MODE, "true", "Client mode. true or false")
-                    .add(IGNITE_CFG_URL, "", "Configuration URL. Overrides all other settings.")
-                    .add(IGNITE_PEER_CLASS_LOADING_ENABLED, "true",
-                            "Peer class loading enabled. true or false")
-                    .build());
-  }
-
   private Logger logger = LoggerFactory.getLogger(IgniteInterpreter.class);
   private Ignite ignite;
   private ByteArrayOutputStream out;

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
@@ -57,17 +57,6 @@ public class IgniteSqlInterpreter extends Interpreter {
 
   static final String IGNITE_JDBC_URL = "ignite.jdbc.url";
 
-  static {
-    Interpreter.register(
-        "ignitesql",
-        "ignite",
-        IgniteSqlInterpreter.class.getName(),
-        new InterpreterPropertyBuilder()
-            .add(IGNITE_JDBC_URL,
-                "jdbc:ignite:cfg://default-ignite-jdbc.xml", "Ignite JDBC connection URL.")
-            .build());
-  }
-
   private Logger logger = LoggerFactory.getLogger(IgniteSqlInterpreter.class);
 
   private Connection conn;

--- a/ignite/src/main/resources/interpreter-setting.json
+++ b/ignite/src/main/resources/interpreter-setting.json
@@ -1,0 +1,47 @@
+[
+  {
+    "group": "ignite",
+    "name": "ignite",
+    "className": "org.apache.zeppelin.ignite.IgniteInterpreter",
+    "properties": {
+      "ignite.addresses": {
+        "envName": null,
+        "propertyName": "ignite.addresses",
+        "defaultValue": "127.0.0.1:47500..47509,Comma separated list of addresses",
+        "description": "(e.g. 127.0.0.1:47500 or 127.0.0.1:47500..47509)"
+      },
+      "ignite.clientMode": {
+        "envName": null,
+        "propertyName": "ignite.clientMode",
+        "defaultValue": "true",
+        "description": "Client mode. true or false"
+      },
+      "ignite.config.url": {
+        "envName": null,
+        "propertyName": "ignite.config.url",
+        "defaultValue": "",
+        "description": "Configuration URL. Overrides all other settings."
+      },
+      "ignite.peerClassLoadingEnabled": {
+        "envName": null,
+        "propertyName": "ignite.peerClassLoadingEnabled",
+        "defaultValue": "true",
+        "description": "Peer class loading enabled. True or false"
+      }
+    }
+    
+  },
+  { 
+    "group": "ignite",
+    "name": "ignitesql",
+    "className": "org.apache.zeppelin.ignite.IgniteSqlInterpreter",
+    "properties": {
+      "ignite.jdbc.url": {
+        "envName": null,
+        "propertyName": "ignite.jdbc.url",
+        "defaultValue": "jdbc:ignite:cfg://default-ignite-jdbc.xml",
+        "description": "Ignite JDBC connection URL."
+        }
+    }   
+  }
+]

--- a/ignite/src/main/resources/interpreter-setting.json
+++ b/ignite/src/main/resources/interpreter-setting.json
@@ -7,8 +7,8 @@
       "ignite.addresses": {
         "envName": null,
         "propertyName": "ignite.addresses",
-        "defaultValue": "127.0.0.1:47500..47509,Comma separated list of addresses",
-        "description": "(e.g. 127.0.0.1:47500 or 127.0.0.1:47500..47509)"
+        "defaultValue": "127.0.0.1:47500..47509",
+        "description": "Comma separated list of addresses (e.g. 127.0.0.1:47500 or 127.0.0.1:47500..47509)"
       },
       "ignite.clientMode": {
         "envName": null,
@@ -29,7 +29,6 @@
         "description": "Peer class loading enabled. True or false"
       }
     }
-    
   },
   { 
     "group": "ignite",

--- a/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
+++ b/ignite/src/test/java/org/apache/zeppelin/ignite/IgniteInterpreterTest.java
@@ -64,6 +64,7 @@ public class IgniteInterpreterTest {
     props.setProperty(IgniteSqlInterpreter.IGNITE_JDBC_URL, "jdbc:ignite:cfg://cache=person@default-ignite-jdbc.xml");
     props.setProperty(IgniteInterpreter.IGNITE_CLIENT_MODE, "false");
     props.setProperty(IgniteInterpreter.IGNITE_PEER_CLASS_LOADING_ENABLED, "false");
+    props.setProperty(IgniteInterpreter.IGNITE_ADDRESSES, HOST);
 
     intp = new IgniteInterpreter(props);
     intp.open();


### PR DESCRIPTION
### What is this PR for?
This handles replacing the registration of interpreter with static block by the interpreter-setting.json file

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-914](https://issues.apache.org/jira/browse/ZEPPELIN-914)

### How should this be tested?
There shouldn't be any warning like below on starting the server
```
INFO 2016-09-29 00:25:46,247 - Bootstrapping Ignite Interpreter
WARN 2016-09-29 00:25:46,250 - Static initialization is deprecated for interpreter Ignite, You should change it to use interpreter-setting.json in your jar or interpreter/{interpreter}/interpreter-setting.json
INFO 2016-09-29 00:25:46,250 - Inclass=org.apache.zeppelin.ignite
```

And ensure that the Ignite related paragraphs run without any error

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
