### PR TITLE
[ZEPPELIN-1841] Some of shortcut key is not working

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -556,6 +556,10 @@
 
         $scope.editor.commands.bindKey('ctrl-alt-l', null);
         $scope.editor.commands.bindKey('ctrl-alt-w', null);
+        $scope.editor.commands.bindKey('ctrl-alt-a', null);
+        $scope.editor.commands.bindKey('ctrl-alt-k', null);
+        $scope.editor.commands.bindKey('ctrl-alt-e', null);
+        $scope.editor.commands.bindKey('ctrl-alt-t', null);
 
         // autocomplete on 'ctrl+.'
         $scope.editor.commands.bindKey('ctrl-.', 'startAutocomplete');


### PR DESCRIPTION
### What is this PR for?
Some of note shortcut key is not working on Ubuntu.

### What type of PR is it?
[ Bug Fix ]

### Todos
* N/A

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1841

### How should this be tested?
If you don't have keyboard shortcut in your OS system, please test shortcut key in paragraph like the following key and check work well.

```
Ctrl + Alt + a : Insert new paragraph above
Ctrl + Alt + k : Move paragraph Up
Ctrl + Alt + e : Toggle editor
Ctrl + Alt + t : Toggle title
```

### Screenshots (if appropriate)
 - Ctrl + Alt + a : Insert new paragraph above
![z1841_a](https://cloud.githubusercontent.com/assets/8110458/21543796/ea98a83e-ce0c-11e6-84b6-bab09964d40a.gif)

 - Ctrl + Alt + k : Move paragraph Up
![z1841_k](https://cloud.githubusercontent.com/assets/8110458/21543837/41158fc4-ce0d-11e6-8338-102a28b816bf.gif)

 - Ctrl + Alt + e : Toggle editor
![z1841_e](https://cloud.githubusercontent.com/assets/8110458/21543845/57cc980c-ce0d-11e6-86d6-9f232ee336f9.gif)

 - Ctrl + Alt + t : Toggle title
![z1841_t](https://cloud.githubusercontent.com/assets/8110458/21543849/5c2d6282-ce0d-11e6-9b73-ce1df437b87d.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
