### PR TITLE
[ZEPPELIN-1875] permission dialog code is not stable

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -95,7 +95,7 @@ public class NotebookRestApi {
   @ZeppelinApi
   public Response getNotePermissions(@PathParam("noteId") String noteId) throws IOException {
 
-    checkIfUserIsAnon(blockNotAuthenticatedUserError());
+    checkIfUserIsAnon(getBlockNotAuthenticatedUserErrorMsg());
     checkIfUserCanRead(noteId,
         "Insufficient privileges you cannot get the list of permissions for this note");
     HashMap<String, Set<String>> permissionsMap = new HashMap<>();
@@ -113,8 +113,7 @@ public class NotebookRestApi {
         "User belongs to: " + current.toString();
   }
 
-  private String blockNotAuthenticatedUserError() throws IOException {
-    LOG.info("Anonymous user cannot set any permissions for this note.");
+  private String getBlockNotAuthenticatedUserErrorMsg() throws IOException {
     return  "Only authenticated user can set the permission.";
   }
 
@@ -129,7 +128,8 @@ public class NotebookRestApi {
    */
   private void checkIfUserIsAnon(String errorMsg) {
     boolean isAuthenticated = SecurityUtils.isAuthenticated();
-    if (!isAuthenticated) {
+    if (isAuthenticated && SecurityUtils.getPrincipal().equals("anonymous")) {
+      LOG.info("Anonymous user cannot set any permissions for this note.");
       throw new ForbiddenException(errorMsg);
     }
   }
@@ -196,7 +196,7 @@ public class NotebookRestApi {
     userAndRoles.add(principal);
     userAndRoles.addAll(roles);
 
-    checkIfUserIsAnon(blockNotAuthenticatedUserError());
+    checkIfUserIsAnon(getBlockNotAuthenticatedUserErrorMsg());
     checkIfUserIsOwner(noteId,
         ownerPermissionError(userAndRoles, notebookAuthorization.getOwners(noteId)));
     

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -91,27 +91,25 @@
     };
 
     $scope.blockAnonUsers = function() {
-      if ($scope.isAnonymous) {
-        var zeppelinVersion = $rootScope.zeppelinVersion;
-        var url = 'https://zeppelin.apache.org/docs/' + zeppelinVersion + '/security/notebook_authorization.html';
-        var content = 'Only authenticated user can set the permission.' +
-          '<a data-toggle="tooltip" data-placement="top" title="Learn more" target="_blank" href=' + url + '>' +
-          '<i class="icon-question" />' +
-          '</a>';
-        BootstrapDialog.show({
-          closable: false,
-          closeByBackdrop: false,
-          closeByKeyboard: false,
-          title: 'No permission',
-          message: content,
-          buttons: [{
-            label: 'Close',
-            action: function(dialog) {
-              dialog.close();
-            }
-          }]
-        });
-      }
+      var zeppelinVersion = $rootScope.zeppelinVersion;
+      var url = 'https://zeppelin.apache.org/docs/' + zeppelinVersion + '/security/notebook_authorization.html';
+      var content = 'Only authenticated user can set the permission.' +
+        '<a data-toggle="tooltip" data-placement="top" title="Learn more" target="_blank" href=' + url + '>' +
+        '<i class="icon-question" />' +
+        '</a>';
+      BootstrapDialog.show({
+        closable: false,
+        closeByBackdrop: false,
+        closeByKeyboard: false,
+        title: 'No permission',
+        message: content,
+        buttons: [{
+          label: 'Close',
+          action: function(dialog) {
+            dialog.close();
+          }
+        }]
+      });
     };
 
     /** Init the new controller */
@@ -770,7 +768,7 @@
     $scope.togglePermissions = function() {
       var principal = $rootScope.ticket.principal;
       $scope.isAnonymous = principal === 'anonymous' ? true : false;
-      if (!!principal) {
+      if (!!principal && $scope.isAnonymous) {
         $scope.blockAnonUsers();
       } else {
         if ($scope.showPermissions) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -91,30 +91,26 @@
     };
 
     $scope.blockAnonUsers = function() {
-      var principal = $rootScope.ticket.principal;
-      if (principal) {
-        $scope.isAnonymous = principal === 'anonymous' ? true : false;
-        if ($scope.isAnonymous) {
-          var zeppelinVersion = $rootScope.zeppelinVersion;
-          var url = 'https://zeppelin.apache.org/docs/' + zeppelinVersion + '/security/notebook_authorization.html';
-          var content = 'Only authenticated user can set the permission.' +
-            '<a data-toggle="tooltip" data-placement="top" title="Learn more" target="_blank" href=' + url + '>' +
-            '<i class="icon-question" />' +
-            '</a>';
-          BootstrapDialog.show({
-            closable: false,
-            closeByBackdrop: false,
-            closeByKeyboard: false,
-            title: 'No permission',
-            message: content,
-            buttons: [{
-              label: 'Close',
-              action: function(dialog) {
-                dialog.close();
-              }
-            }]
-          });
-        }
+      if ($scope.isAnonymous) {
+        var zeppelinVersion = $rootScope.zeppelinVersion;
+        var url = 'https://zeppelin.apache.org/docs/' + zeppelinVersion + '/security/notebook_authorization.html';
+        var content = 'Only authenticated user can set the permission.' +
+          '<a data-toggle="tooltip" data-placement="top" title="Learn more" target="_blank" href=' + url + '>' +
+          '<i class="icon-question" />' +
+          '</a>';
+        BootstrapDialog.show({
+          closable: false,
+          closeByBackdrop: false,
+          closeByKeyboard: false,
+          title: 'No permission',
+          message: content,
+          buttons: [{
+            label: 'Close',
+            action: function(dialog) {
+              dialog.close();
+            }
+          }]
+        });
       }
     };
 
@@ -772,15 +768,20 @@
     };
 
     $scope.togglePermissions = function() {
-      $scope.blockAnonUsers();
-      if ($scope.showPermissions) {
-        $scope.closePermissions();
-        angular.element('#selectOwners').select2({});
-        angular.element('#selectReaders').select2({});
-        angular.element('#selectWriters').select2({});
+      var principal = $rootScope.ticket.principal;
+      $scope.isAnonymous = principal === 'anonymous' ? true : false;
+      if (!!principal) {
+        $scope.blockAnonUsers();
       } else {
-        $scope.openPermissions();
-        $scope.closeSetting();
+        if ($scope.showPermissions) {
+          $scope.closePermissions();
+          angular.element('#selectOwners').select2({});
+          angular.element('#selectReaders').select2({});
+          angular.element('#selectWriters').select2({});
+        } else {
+          $scope.openPermissions();
+          $scope.closeSetting();
+        }
       }
     };
 


### PR DESCRIPTION
### What is this PR for?
The code for the notification pop-up is not stable.
Sometime when response to slow for backend.
Then the permission box and the dialogue open together.


### What type of PR is it?
Bug Fix , Improvement

### Todos
- [x] changed method name  (getBlockNotAuthenticatedUserErrorMsg)
- [x] permission dialog pop-up change logic.
- [x] added check logic for anonymous user in checkIfUserIsAnon method

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1875

### How should this be tested?
1. when you do have turn on the shiro and login and click to note permission button.
2. or turn off the shiro.
### Screenshots (if appropriate)
![dialog](https://cloud.githubusercontent.com/assets/10525473/21549451/141cca5c-cda7-11e6-9c4b-94cbf882face.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
