### PR TITLE
[ZEPPELIN-1789] Make exported data file name more explicit

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -580,8 +580,8 @@ import zeppelin from '../../../zeppelin';
 
     $scope.exportToDSV = function(delimiter) {
       var dsv = '';
-      var currentTime = moment().format('YYYY-MM-DD hh:mm:ss A');
-      var exportedFileName = paragraph.title ? paragraph.title + '_' + currentTime : 'Exported data_' + currentTime;
+      var dateFinished = moment(paragraph.dateFinished).format('YYYY-MM-DD hh:mm:ss A');
+      var exportedFileName = paragraph.title ? paragraph.title + '_' + dateFinished : 'Exported data_' + dateFinished;
 
       for (var titleIndex in tableData.columns) {
         dsv += tableData.columns[titleIndex].name + delimiter;

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -581,7 +581,7 @@ import zeppelin from '../../../zeppelin';
     $scope.exportToDSV = function(delimiter) {
       var dsv = '';
       var dateFinished = moment(paragraph.dateFinished).format('YYYY-MM-DD hh:mm:ss A');
-      var exportedFileName = paragraph.title ? paragraph.title + '_' + dateFinished : 'Exported data_' + dateFinished;
+      var exportedFileName = paragraph.title ? paragraph.title + '_' + dateFinished : 'data_' + dateFinished;
 
       for (var titleIndex in tableData.columns) {
         dsv += tableData.columns[titleIndex].name + delimiter;

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -580,6 +580,9 @@ import zeppelin from '../../../zeppelin';
 
     $scope.exportToDSV = function(delimiter) {
       var dsv = '';
+      var currentTime = moment().format('YYYY-MM-DD hh:mm:ss A');
+      var exportedFileName = paragraph.title ? paragraph.title + '_' + currentTime : 'Exported data_' + currentTime;
+
       for (var titleIndex in tableData.columns) {
         dsv += tableData.columns[titleIndex].name + delimiter;
       }
@@ -603,7 +606,7 @@ import zeppelin from '../../../zeppelin';
       } else if (delimiter === ',') {
         extension = 'csv';
       }
-      saveAsService.saveAs(dsv, 'data', extension);
+      saveAsService.saveAs(dsv, exportedFileName, extension);
     };
 
     $scope.getBase64ImageSrc = function(base64Data) {


### PR DESCRIPTION
### What is this PR for?
Currently we can download table data set as `.csv` or `.tsv` format in Zeppelin note. But since the exported file name is always set as `data.csv`, it will be difficult to distinguish the each file if user tries to export it several times. So I changed the naming rule like below. 

1. if the paragraph has title e.g. `this is title`, then the exported csv file name will be 
`this is title_YYYY-MM-DD hh:mm:ss a.csv` .

2. if not, the file name will be `data_YYYY-MM-DD hh:mm:ss a.csv` .

Please see the short discussion in [ZEPPELIN-1789](https://issues.apache.org/jira/browse/ZEPPELIN-1789) for the more details. I just made this PR by following one person's opinion who raised this issue (_Ruslan Dautkhanov_ ). So if anyone has better idea, please feel free to share :)

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1789](https://issues.apache.org/jira/browse/ZEPPELIN-1789)

### How should this be tested?
1. run Zeppelin web dev mode under `zeppelin-web` 

```
$ npm run dev
```

2. browse `http://localhost:9000` and go to Zeppelin-Spark tutorial note
3. click ![screen shot 2016-12-30 at 2 26 32 pm](https://cloud.githubusercontent.com/assets/10060731/21560080/fcf86cdc-ce9b-11e6-8fe3-a8ea0bd9141d.png) 

If the paragraph has title, then the exported file name will be `"paragraph_title_YYYY-MM-DD hh:mm:ss a".csv`, if not, will be `"data_YYYY-MM-DD hh:mm:ss a".csv`.

> The timestamp is not current time but paragraph finished time


### Screenshots (if appropriate)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
