### PR TITLE
[ZEPPELIN-1850] Remove grunt-contrib-clean (grunt)

### DIFF
--- a/zeppelin-web/Gruntfile.js
+++ b/zeppelin-web/Gruntfile.js
@@ -212,21 +212,6 @@ module.exports = function(grunt) {
       }
     },
 
-    // Empties folders to start fresh
-    clean: {
-      dist: {
-        files: [{
-          dot: true,
-          src: [
-            '.tmp',
-            '<%= yeoman.dist %>/{,*/}*',
-            '!<%= yeoman.dist %>/.git*'
-          ]
-        }]
-      },
-      tmp: '.tmp'
-    },
-
     // Add vendor prefixed styles
     postcss: {
       options: {
@@ -461,7 +446,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('pre-webpack-dev', 'Compile then start a connect web server', function(target) {
     grunt.task.run([
-      'clean:tmp',
       'wiredep',
     ]);
   });
@@ -474,7 +458,6 @@ module.exports = function(grunt) {
     'jscs',
     'eslint',
     'htmlhint',
-    'clean:dist',
     'wiredep',
   ]);
 

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -6,11 +6,13 @@
     "node": ">=0.10.0"
   },
   "scripts": {
+    "clean": "rimraf dist && rimraf .tmp",
     "postinstall": "bower install --silent && grunt googlefonts",
+    "prebuild": "npm-run-all clean",
     "build": "grunt pre-webpack-dist && webpack && grunt post-webpack-dist",
+    "predev": "npm-run-all clean && grunt pre-webpack-dev",
     "dev:server": "webpack-dev-server --hot",
     "dev:watch": "grunt watch-webpack-dev",
-    "prestart": "grunt pre-webpack-dev",
     "dev": "npm-run-all --parallel dev:server dev:watch",
     "pretest": "npm install karma-phantomjs-launcher",
     "test": "karma start test/karma.conf.js"
@@ -36,7 +38,6 @@
     "grunt-cache-bust": "1.3.0",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^0.5.0",
-    "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
@@ -66,6 +67,7 @@
     "npm-run-all": "^3.1.2",
     "postcss-loader": "^1.2.1",
     "raw-loader": "^0.5.1",
+    "rimraf": "^2.5.4",
     "strip-loader": "^0.1.2",
     "style-loader": "^0.13.1",
     "time-grunt": "^0.3.1",

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -146,6 +146,17 @@
             </configuration>
           </execution>
 
+          <execution>
+            <id>npm clean</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>clean</phase>
+            <configuration>
+              <arguments>run clean</arguments>
+            </configuration>
+          </execution>
+
         </executions>
       </plugin>
 
@@ -173,14 +184,8 @@
       </plugin>
 
       <plugin>
+        <!-- clean task will be executed by front-end-maven plugin -->
         <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>bower_components</directory>
-            </fileset>
-          </filesets>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### What is this PR for?

Replaced `grunt-contrib-clean` to [rimraf](https://github.com/isaacs/rimraf) 

- to remove `Gruntfile.js`
- to have npm managed scripts in `package.json` for running `rm -rf` in multiple platforms including windows
- Also, fixed invalid `prestart` npm command to `predev`

This PR related to

- https://github.com/apache/zeppelin/pull/1812 (Using yarn)
- https://github.com/apache/zeppelin/pull/1818 (Removing jscs)

### What type of PR is it?

[Improvement]

### Todos

Done at once

### What is the Jira issue?

[ZEPPELIN-1850](https://issues.apache.org/jira/browse/ZEPPELIN-1850)

### How should this be tested?

- `npm run test`, `npm run build`, `npm run dev` should work

### Screenshots (if appropriate)

None

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
