### PR TITLE
[DOCS][ZEPPELIN-1586] Add 'Security' section under notebook restapi docs

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -128,6 +128,153 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   </table>
 
 <br/>
+### Get the status of all paragraphs
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets the status of all paragraphs by the given note id.
+          The body field of the returned JSON contains of the array that compose of the paragraph id, paragraph status, paragraph finish date, paragraph started date.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "OK",
+  "body": [
+    {
+      "id":"20151121-212654\_766735423",
+      "status":"FINISHED",
+      "finished":"Tue Nov 24 14:21:40 KST 2015",
+      "started":"Tue Nov 24 14:21:39 KST 2015"
+    },
+    {
+      "progress":"1",
+      "id":"20151121-212657\_730976687",
+      "status":"RUNNING",
+      "finished":"Tue Nov 24 14:21:35 KST 2015",
+      "started":"Tue Nov 24 14:21:40 KST 2015"
+    }
+  ]
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Get an existing note information
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method retrieves an existing note's information using the given id.
+          The body field of the returned JSON contain information about paragraphs in the note.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+    "paragraphs": [
+      {
+        "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age < 30 \ngroup by age \norder by age",
+        "config": {
+          "colWidth": 4,
+          "graph": {
+            "mode": "multiBarChart",
+            "height": 300,
+            "optionOpen": false,
+            "keys": [
+              {
+                "name": "age",
+                "index": 0,
+                "aggr": "sum"
+              }
+            ],
+            "values": [
+              {
+                "name": "value",
+                "index": 1,
+                "aggr": "sum"
+              }
+            ],
+            "groups": [],
+            "scatter": {
+              "xAxis": {
+                "name": "age",
+                "index": 0,
+                "aggr": "sum"
+              },
+              "yAxis": {
+                "name": "value",
+                "index": 1,
+                "aggr": "sum"
+              }
+            }
+          }
+        },
+        "settings": {
+          "params": {},
+          "forms": {}
+        },
+        "jobName": "paragraph\_1423500782552\_-1439281894",
+        "id": "20150210-015302\_1492795503",
+        "results": {
+          "code": "SUCCESS",
+          "msg": [
+            {
+              "type": "TABLE",
+              "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+            }
+          ]
+        },
+        "dateCreated": "Feb 10, 2015 1:53:02 AM",
+        "dateStarted": "Jul 3, 2015 1:43:17 PM",
+        "dateFinished": "Jul 3, 2015 1:43:23 PM",
+        "status": "FINISHED",
+        "progressUpdateIntervalMs": 500
+      }
+    ],
+    "name": "Zeppelin Tutorial",
+    "id": "2A94M5J1Z",
+    "angularObjects": {},
+    "config": {
+      "looknfeel": "default"
+    },
+    "info": {}
+  }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Delete a note
   <table class="table-configuration">
     <col width="200">
@@ -303,19 +450,64 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
   </table>
 
-<br/>
-### Get an existing note information
+### Run all paragraphs
   <table class="table-configuration">
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```GET``` method retrieves an existing note's information using the given id.
-          The body field of the returned JSON contain information about paragraphs in the note.
+      <td>
+      This ```POST``` method runs all paragraphs in the given note id. <br />
+      If you can not find Note id 404 returns.
+      If there is a problem with the interpreter returns a 412 error.
       </td>
     </tr>
     <tr>
       <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 404 or 412</td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+    <tr>
+       <td> sample JSON error response </td>
+       <td>
+         <pre>
+           {
+             "status": "NOT_FOUND",
+             "message": "note not found."
+           }
+         </pre><br />
+         <pre>
+           {
+             "status": "PRECONDITION_FAILED",
+             "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter bind"
+           }
+         </pre>
+       </td>
+    </tr>
+  </table>
+
+<br/>
+### Stop all paragraphs
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method stops all paragraphs in the given note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
     </tr>
     <tr>
       <td>Success code</td>
@@ -327,80 +519,43 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
-{
-  "status": "OK",
-  "message": "",
-  "body": {
-    "paragraphs": [
-      {
-        "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age < 30 \ngroup by age \norder by age",
-        "config": {
-          "colWidth": 4,
-          "graph": {
-            "mode": "multiBarChart",
-            "height": 300,
-            "optionOpen": false,
-            "keys": [
-              {
-                "name": "age",
-                "index": 0,
-                "aggr": "sum"
-              }
-            ],
-            "values": [
-              {
-                "name": "value",
-                "index": 1,
-                "aggr": "sum"
-              }
-            ],
-            "groups": [],
-            "scatter": {
-              "xAxis": {
-                "name": "age",
-                "index": 0,
-                "aggr": "sum"
-              },
-              "yAxis": {
-                "name": "value",
-                "index": 1,
-                "aggr": "sum"
-              }
-            }
-          }
-        },
-        "settings": {
-          "params": {},
-          "forms": {}
-        },
-        "jobName": "paragraph\_1423500782552\_-1439281894",
-        "id": "20150210-015302\_1492795503",
-        "results": {
-          "code": "SUCCESS",
-          "msg": [
-            {
-              "type": "TABLE",
-              "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
-            }
-          ]
-        },
-        "dateCreated": "Feb 10, 2015 1:53:02 AM",
-        "dateStarted": "Jul 3, 2015 1:43:17 PM",
-        "dateFinished": "Jul 3, 2015 1:43:23 PM",
-        "status": "FINISHED",
-        "progressUpdateIntervalMs": 500
-      }
-    ],
-    "name": "Zeppelin Tutorial",
-    "id": "2A94M5J1Z",
-    "angularObjects": {},
-    "config": {
-      "looknfeel": "default"
-    },
-    "info": {}
-  }
-}</pre></td>
+      <td><pre>{"status":"OK"}</pre></td>
+    </tr>
+  </table>
+
+<br />
+### Clear all paragraph result
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method clear all paragraph results from note of given id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/clear```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Forbidden code</td>
+      <td>401</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>500</td>
+    </tr>
+    <tr>
+      <td>sample JSON response</td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
     </tr>
   </table>
 
@@ -453,33 +608,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   "message": "",
   "body": "20151218-100330\_1754029574"
 }</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Delete a paragraph
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method deletes a paragraph by the given note and paragraph id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK","message": ""}</pre></td>
     </tr>
   </table>
 
@@ -555,53 +683,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
   </table>
 
-
-<br/>
-### Get the status of all paragraphs
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method gets the status of all paragraphs by the given note id.
-          The body field of the returned JSON contains of the array that compose of the paragraph id, paragraph status, paragraph finish date, paragraph started date.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>
-{
-  "status": "OK",
-  "body": [
-    {
-      "id":"20151121-212654\_766735423",
-      "status":"FINISHED",
-      "finished":"Tue Nov 24 14:21:40 KST 2015",
-      "started":"Tue Nov 24 14:21:39 KST 2015"
-    },
-    {
-      "progress":"1",
-      "id":"20151121-212657\_730976687",
-      "status":"RUNNING",
-      "finished":"Tue Nov 24 14:21:35 KST 2015",
-      "started":"Tue Nov 24 14:21:40 KST 2015"
-    }
-  ]
-}</pre></td>
-    </tr>
-  </table>
-
 <br/>
 ### Get the status of a single paragraph
   <table class="table-configuration">
@@ -636,195 +717,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "started":"Tue Nov 24 14:21:39 KST 2015"
     }
 }</pre></td>
-    </tr>
-  </table>
-
-
-### Run all paragraphs
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>
-      This ```POST``` method runs all paragraphs in the given note id. <br />
-      If you can not find Note id 404 returns.
-      If there is a problem with the interpreter returns a 412 error.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 404 or 412</td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-    <tr>
-       <td> sample JSON error response </td>
-       <td>
-         <pre>
-           {
-             "status": "NOT_FOUND",
-             "message": "note not found."
-           }
-         </pre><br />
-         <pre>
-           {
-             "status": "PRECONDITION_FAILED",
-             "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter bind"
-           }
-         </pre>
-       </td>
-    </tr>
-  </table>
-
-<br/>
-### Run a paragraph asynchronously
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```POST``` method runs the paragraph asynchronously by given note and paragraph id. This API always return SUCCESS even if the execution of the paragraph fails later because the API is asynchronous
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
-      <td><pre>
-{
-  "name": "name of new note",
-  "params": {
-    "formLabel1": "value1",
-    "formLabel2": "value2"
-  }
-}</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Run a paragraph synchronously
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```POST``` method runs the paragraph synchronously by given note and paragraph id. This API can return SUCCESS or ERROR depending on the outcome of the paragraph execution
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[noteId]/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
-      <td><pre>
-{
-  "name": "name of new note",
-  "params": {
-    "formLabel1": "value1",
-    "formLabel2": "value2"
-  }
-}</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>    
-    <tr>
-      <td> sample JSON error </td>
-      <td><pre>
-{
-   "status": "INTERNAL\_SERVER\_ERROR",
-   "body": {
-       "code": "ERROR",
-       "type": "TEXT",
-       "msg": "bash: -c: line 0: unexpected EOF while looking for matching ``'\nbash: -c: line 1: syntax error: unexpected end of file\nExitValue: 2"
-   }
-}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Stop all paragraphs
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method stops all paragraphs in the given note id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status":"OK"}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Stop a paragraph
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method stops the paragraph by given note and paragraph id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
     </tr>
   </table>
 
@@ -954,6 +846,148 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   </table>
 
 <br/>
+### Delete a paragraph
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method deletes a paragraph by the given note and paragraph id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK","message": ""}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Run a paragraph asynchronously
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method runs the paragraph asynchronously by given note and paragraph id. This API always return SUCCESS even if the execution of the paragraph fails later because the API is asynchronous
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
+      <td><pre>
+{
+  "name": "name of new note",
+  "params": {
+    "formLabel1": "value1",
+    "formLabel2": "value2"
+  }
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Run a paragraph synchronously
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method runs the paragraph synchronously by given note and paragraph id. This API can return SUCCESS or ERROR depending on the outcome of the paragraph execution
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[noteId]/[paragraphId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
+      <td><pre>
+{
+  "name": "name of new note",
+  "params": {
+    "formLabel1": "value1",
+    "formLabel2": "value2"
+  }
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>    
+    <tr>
+      <td> sample JSON error </td>
+      <td><pre>
+{
+   "status": "INTERNAL\_SERVER\_ERROR",
+   "body": {
+       "code": "ERROR",
+       "type": "TEXT",
+       "msg": "bash: -c: line 0: unexpected EOF while looking for matching ``'\nbash: -c: line 1: syntax error: unexpected end of file\nExitValue: 2"
+   }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Stop a paragraph
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method stops the paragraph by given note and paragraph id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Move a paragraph to the specific index
   <table class="table-configuration">
     <col width="200">
@@ -977,42 +1011,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     <tr>
       <td> sample JSON response </td>
       <td><pre>{"status": "OK","message": ""}</pre></td>
-    </tr>
-  </table>
-
-<br />
-### Clear all paragraph result
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```PUT``` method clear all paragraph results from note of given id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/clear```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td>Forbidden code</td>
-      <td>401</td>
-    </tr>
-    <tr>
-      <td>Not Found code</td>
-      <td>404</td>
-    </tr>
-    <tr>
-      <td>Fail code</td>
-      <td>500</td>
-    </tr>
-    <tr>
-      <td>sample JSON response</td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
     </tr>
   </table>
 
@@ -1053,7 +1051,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
 }</pre></td>
     </tr>
   </table>
-
 
 ## Cron jobs
 <br/>
@@ -1144,61 +1141,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
   </table>
 
-## Security
+## Permission
 
-### Get a ticket information 
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method gets a ticket information for the logged in user.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/security/ticket```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td>Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response <br/> for an anonymous user </td>
-      <td><pre>
-{  
-   "status":"OK",
-   "message":"",
-   "body":{  
-      "principal":"anonymous",
-      "ticket":"anonymous",
-      "roles":"[]"
-   }
-}
-      </pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON response <br/> for an authenticated user </td>
-      <td><pre>
-{  
-   "status":"OK",
-   "message":"",
-   "body":{  
-      "principal":"user2",
-      "ticket":"07db096b-6c6b-4c05-80f6-680f7f314f89",
-      "roles":"[role3]"
-   }
-}
-      </pre></td>
-    </tr>
-  </table>
 
-<br/>
 
 ### Get a note permission information
+
   <table class="table-configuration">
     <col width="200">
     <tr>
@@ -1215,20 +1163,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td>200</td>
     </tr>
     <tr>
-      <td>Bad Request code</td>
-      <td>400</td>
-    </tr>
-    <tr>
       <td>Forbidden code</td>
       <td>403</td>
     </tr>
     <tr>
-      <td>Not Found code</td>
-      <td>404</td>
-    </tr>
-    <tr>
       <td>Fail code</td>
-      <td> 500 </td>
+      <td>500</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
@@ -1270,20 +1210,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td>200</td>
     </tr>
     <tr>
-      <td>Bad Request code</td>
-      <td>400</td>
-    </tr>
-    <tr>
       <td>Forbidden code</td>
       <td>403</td>
     </tr>
     <tr>
-      <td>Not Found code</td>
-      <td>404</td>
-    </tr>
-    <tr>
       <td>Fail code</td>
-      <td> 500 </td>
+      <td>500</td>
     </tr>
     <tr>
       <td> sample JSON input </td>

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -27,14 +27,11 @@ limitations under the License.
 Apache Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
 All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. 
 Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
-
 If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
 
+Notebooks REST API supports the following operations: List, Create, Get, Delete, Clone, Run, Export, Import as detailed in the following tables.
 
-## Notebook REST API List
-
-  Notebooks REST API supports the following operations: List, Create, Get, Delete, Clone, Run, Export, Import as detailed in the following tables.
-
+## Note operations
 ### List of the notes
   <table class="table-configuration">
     <col width="200">
@@ -121,6 +118,182 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     </tr>
     <tr>
       <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "CREATED",
+  "message": "",
+  "body": "2AZPHY918"
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Delete a note
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method deletes a note by the given note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK","message": ""}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Clone a note
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method clones a note by the given id and create a new note using the given name
+          or default name if none given.
+          The body field of the returned JSON contains the new note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input </td>
+      <td><pre>{"name": "name of new note"}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "CREATED",
+  "message": "",
+  "body": "2AZPHY918"
+}</pre></td>
+    </tr>
+  </table>
+
+<br />
+### Export a note
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method exports a note by the given id and gernerates a JSON
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/export/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <td> sample JSON response </td>
+      <td><pre>{
+  "paragraphs": [
+    {
+      "text": "%md This is my new paragraph in my new note",
+      "dateUpdated": "Jan 8, 2016 4:49:38 PM",
+      "config": {
+        "enabled": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph\_1452300578795\_1196072540",
+      "id": "20160108-164938\_1685162144",
+      "dateCreated": "Jan 8, 2016 4:49:38 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "source note for export",
+  "id": "2B82H3RR1",
+  "angularObjects": {},
+  "config": {},
+  "info": {}
+}</pre></td>
+    </tr>
+  </table>
+
+<br />
+### Import a note
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method imports a note from the note JSON input
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/import```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>sample JSON input</td>
+      <td><pre>
+{
+  "paragraphs": [
+    {
+      "text": "%md This is my new paragraph in my new note",
+      "dateUpdated": "Jan 8, 2016 4:49:38 PM",
+      "config": {
+        "enabled": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "jobName": "paragraph\_1452300578795\_1196072540",
+      "id": "20160108-164938\_1685162144",
+      "dateCreated": "Jan 8, 2016 4:49:38 PM",
+      "status": "READY",
+      "progressUpdateIntervalMs": 500
+    }
+  ],
+  "name": "source note for export",
+  "id": "2B82H3RR1",
+  "angularObjects": {},
+  "config": {},
+  "info": {}
+}</pre></td>
+    </tr>
+    <tr>
+      <td>sample JSON response</td>
       <td><pre>
 {
   "status": "CREATED",
@@ -231,18 +404,70 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     </tr>
   </table>
 
+
+## Paragraph operations 
 <br/>
-### Delete a note
+### Create a new paragraph
   <table class="table-configuration">
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```DELETE``` method deletes a note by the given note id.
+      <td>This ```POST``` method create a new paragraph using JSON payload.
+          The body field of the returned JSON contain the new paragraph id.
       </td>
     </tr>
     <tr>
       <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input (add to the last) </td>
+      <td><pre>
+{
+  "title": "Paragraph insert revised",
+  "text": "%spark\nprintln(\"Paragraph insert revised\")"
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON input (add to specific index) </td>
+      <td><pre>
+{
+  "title": "Paragraph insert revised",
+  "text": "%spark\nprintln(\"Paragraph insert revised\")",
+  "index": 0
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "CREATED",
+  "message": "",
+  "body": "20151218-100330\_1754029574"
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Delete a paragraph
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method deletes a paragraph by the given note and paragraph id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
     </tr>
     <tr>
       <td>Success code</td>
@@ -259,116 +484,77 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
   </table>
 
 <br/>
-### Clone a note
+### Get a paragraph information
   <table class="table-configuration">
     <col width="200">
     <tr>
       <td>Description</td>
-      <td>This ```POST``` method clones a note by the given id and create a new note using the given name
-          or default name if none given.
-          The body field of the returned JSON contains the new note id.
+      <td>This ```GET``` method retrieves an existing paragraph's information using the given id.
+          The body field of the returned JSON contain information about paragraph.
       </td>
     </tr>
     <tr>
       <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]```</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
     </tr>
     <tr>
       <td>Success code</td>
-      <td>201</td>
+      <td>200</td>
     </tr>
     <tr>
       <td> Fail code</td>
       <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON input </td>
-      <td><pre>{"name": "name of new note"}</pre></td>
     </tr>
     <tr>
       <td> sample JSON response </td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
-  "body": "2AZPHY918"
+  "body": {
+    "title": "Paragraph2",
+    "text": "%spark\n\nprintln(\"it's paragraph2\")",
+    "dateUpdated": "Dec 18, 2015 7:33:54 AM",
+    "config": {
+      "colWidth": 12,
+      "graph": {
+        "mode": "table",
+        "height": 300,
+        "optionOpen": false,
+        "keys": [],
+        "values": [],
+        "groups": [],
+        "scatter": {}
+      },
+      "enabled": true,
+      "title": true,
+      "editorMode": "ace/mode/scala"
+    },
+    "settings": {
+      "params": {},
+      "forms": {}
+    },
+    "jobName": "paragraph\_1450391574392\_-1890856722",
+    "id": "20151218-073254\_1105602047",
+    "results": {
+      "code": "SUCCESS",
+      "msg": [
+        {
+           "type": "TEXT",
+           "data": "it's paragraph2\n"
+        }
+      ]
+    },
+    "dateCreated": "Dec 18, 2015 7:32:54 AM",
+    "dateStarted": "Dec 18, 2015 7:33:55 AM",
+    "dateFinished": "Dec 18, 2015 7:33:55 AM",
+    "status": "FINISHED",
+    "progressUpdateIntervalMs": 500
+  }
 }</pre></td>
     </tr>
   </table>
 
-<br/>
-### Run all paragraphs
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>
-      This ```POST``` method runs all paragraphs in the given note id. <br />
-      If you can not find Note id 404 returns.
-      If there is a problem with the interpreter returns a 412 error.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 404 or 412</td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-    <tr>
-       <td> sample JSON error response </td>
-       <td>
-         <pre>
-           {
-             "status": "NOT_FOUND",
-             "message": "note not found."
-           }
-         </pre><br />
-         <pre>
-           {
-             "status": "PRECONDITION_FAILED",
-             "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter bind"
-           }
-         </pre>
-       </td>
-    </tr>
-  </table>
-
-<br/>
-### Stop all paragraphs
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method stops all paragraphs in the given note id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status":"OK"}</pre></td>
-    </tr>
-  </table>
 
 <br/>
 ### Get the status of all paragraphs
@@ -450,6 +636,53 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       "started":"Tue Nov 24 14:21:39 KST 2015"
     }
 }</pre></td>
+    </tr>
+  </table>
+
+
+### Run all paragraphs
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>
+      This ```POST``` method runs all paragraphs in the given note id. <br />
+      If you can not find Note id 404 returns.
+      If there is a problem with the interpreter returns a 412 error.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 404 or 412</td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+    <tr>
+       <td> sample JSON error response </td>
+       <td>
+         <pre>
+           {
+             "status": "NOT_FOUND",
+             "message": "note not found."
+           }
+         </pre><br />
+         <pre>
+           {
+             "status": "PRECONDITION_FAILED",
+             "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter bind"
+           }
+         </pre>
+       </td>
     </tr>
   </table>
 
@@ -542,6 +775,33 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
   </table>
 
 <br/>
+### Stop all paragraphs
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method stops all paragraphs in the given note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status":"OK"}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Stop a paragraph
   <table class="table-configuration">
     <col width="200">
@@ -565,254 +825,6 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td> sample JSON response </td>
       <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Add Cron Job
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```POST``` method adds cron job by the given note id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON input </td>
-      <td><pre>{"cron": "cron expression of note"}</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-
-### Remove Cron Job
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method removes cron job by the given note id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-
-### Get Cron Job
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method gets cron job expression of given note id.
-          The body field of the returned JSON contains the cron expression.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK", "body": "* * * * * ?"}</pre></td>
-    </tr>
-  </table>
-
-<br />
-### Full text search through the paragraphs in all notes
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>```GET``` request will return list of matching paragraphs
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/search?q=[query]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td>Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td>Sample JSON response </td>
-      <td><pre>
-{
-  "status": "OK",
-  "body": [
-    {
-      "id": "<noteId>/paragraph/<paragraphId>",
-      "name":"Note Name", 
-      "snippet":"",
-      "text":""
-    }
-  ]
-}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Create a new paragraph
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```POST``` method create a new paragraph using JSON payload.
-          The body field of the returned JSON contain the new paragraph id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>201</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON input (add to the last) </td>
-      <td><pre>
-{
-  "title": "Paragraph insert revised",
-  "text": "%spark\nprintln(\"Paragraph insert revised\")"
-}</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON input (add to specific index) </td>
-      <td><pre>
-{
-  "title": "Paragraph insert revised",
-  "text": "%spark\nprintln(\"Paragraph insert revised\")",
-  "index": 0
-}</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>
-{
-  "status": "CREATED",
-  "message": "",
-  "body": "20151218-100330\_1754029574"
-}</pre></td>
-    </tr>
-  </table>
-
-<br/>
-### Get a paragraph information
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method retrieves an existing paragraph's information using the given id.
-          The body field of the returned JSON contain information about paragraph.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>
-{
-  "status": "OK",
-  "message": "",
-  "body": {
-    "title": "Paragraph2",
-    "text": "%spark\n\nprintln(\"it's paragraph2\")",
-    "dateUpdated": "Dec 18, 2015 7:33:54 AM",
-    "config": {
-      "colWidth": 12,
-      "graph": {
-        "mode": "table",
-        "height": 300,
-        "optionOpen": false,
-        "keys": [],
-        "values": [],
-        "groups": [],
-        "scatter": {}
-      },
-      "enabled": true,
-      "title": true,
-      "editorMode": "ace/mode/scala"
-    },
-    "settings": {
-      "params": {},
-      "forms": {}
-    },
-    "jobName": "paragraph\_1450391574392\_-1890856722",
-    "id": "20151218-073254\_1105602047",
-    "results": {
-      "code": "SUCCESS",
-      "msg": [
-        {
-           "type": "TEXT",
-           "data": "it's paragraph2\n"
-        }
-      ]
-    },
-    "dateCreated": "Dec 18, 2015 7:32:54 AM",
-    "dateStarted": "Dec 18, 2015 7:33:55 AM",
-    "dateFinished": "Dec 18, 2015 7:33:55 AM",
-    "status": "FINISHED",
-    "progressUpdateIntervalMs": 500
-  }
-}</pre></td>
     </tr>
   </table>
 
@@ -968,144 +980,6 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     </tr>
   </table>
 
-<br/>
-### Delete a paragraph
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```DELETE``` method deletes a paragraph by the given note and paragraph id.
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response </td>
-      <td><pre>{"status": "OK","message": ""}</pre></td>
-    </tr>
-  </table>
-
-<br />
-### Export a note
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method exports a note by the given id and gernerates a JSON
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/export/[noteId]```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>201</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <td> sample JSON response </td>
-      <td><pre>{
-  "paragraphs": [
-    {
-      "text": "%md This is my new paragraph in my new note",
-      "dateUpdated": "Jan 8, 2016 4:49:38 PM",
-      "config": {
-        "enabled": true
-      },
-      "settings": {
-        "params": {},
-        "forms": {}
-      },
-      "jobName": "paragraph\_1452300578795\_1196072540",
-      "id": "20160108-164938\_1685162144",
-      "dateCreated": "Jan 8, 2016 4:49:38 PM",
-      "status": "READY",
-      "progressUpdateIntervalMs": 500
-    }
-  ],
-  "name": "source note for export",
-  "id": "2B82H3RR1",
-  "angularObjects": {},
-  "config": {},
-  "info": {}
-}</pre></td>
-    </tr>
-  </table>
-
-<br />
-### Import a note
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```POST``` method imports a note from the note JSON input
-      </td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/import```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>201</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td>sample JSON input</td>
-      <td><pre>
-{
-  "paragraphs": [
-    {
-      "text": "%md This is my new paragraph in my new note",
-      "dateUpdated": "Jan 8, 2016 4:49:38 PM",
-      "config": {
-        "enabled": true
-      },
-      "settings": {
-        "params": {},
-        "forms": {}
-      },
-      "jobName": "paragraph\_1452300578795\_1196072540",
-      "id": "20160108-164938\_1685162144",
-      "dateCreated": "Jan 8, 2016 4:49:38 PM",
-      "status": "READY",
-      "progressUpdateIntervalMs": 500
-    }
-  ],
-  "name": "source note for export",
-  "id": "2B82H3RR1",
-  "angularObjects": {},
-  "config": {},
-  "info": {}
-}</pre></td>
-    </tr>
-    <tr>
-      <td>sample JSON response</td>
-      <td><pre>
-{
-  "status": "CREATED",
-  "message": "",
-  "body": "2AZPHY918"
-}</pre></td>
-    </tr>
-  </table>
-
 <br />
 ### Clear all paragraph result
   <table class="table-configuration">
@@ -1141,3 +1015,299 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     </tr>
     </tr>
   </table>
+
+<br />
+### Full text search through the paragraphs in all notes
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>```GET``` request will return list of matching paragraphs
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/search?q=[query]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response </td>
+      <td><pre>
+{
+  "status": "OK",
+  "body": [
+    {
+      "id": "<noteId>/paragraph/<paragraphId>",
+      "name":"Note Name", 
+      "snippet":"",
+      "text":""
+    }
+  ]
+}</pre></td>
+    </tr>
+  </table>
+
+
+## Cron jobs
+<br/>
+### Add Cron Job
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```POST``` method adds cron job by the given note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input </td>
+      <td><pre>{"cron": "cron expression of note"}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+
+### Remove Cron Job
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```DELETE``` method removes cron job by the given note id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK"}</pre></td>
+    </tr>
+  </table>
+
+<br/>
+
+### Get Cron Job
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets cron job expression of given note id.
+          The body field of the returned JSON contains the cron expression.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/[noteId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>{"status": "OK", "body": "* * * * * ?"}</pre></td>
+    </tr>
+  </table>
+
+## Security
+
+### Get a ticket information 
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets a ticket information for the logged in user.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/security/ticket```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response <br/> for an anonymous user </td>
+      <td><pre>
+{  
+   "status":"OK",
+   "message":"",
+   "body":{  
+      "principal":"anonymous",
+      "ticket":"anonymous",
+      "roles":"[]"
+   }
+}
+      </pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response <br/> for an authenticated user </td>
+      <td><pre>
+{  
+   "status":"OK",
+   "message":"",
+   "body":{  
+      "principal":"user2",
+      "ticket":"07db096b-6c6b-4c05-80f6-680f7f314f89",
+      "roles":"[role3]"
+   }
+}
+      </pre></td>
+    </tr>
+  </table>
+
+<br/>
+
+### Get a note permission information
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets a note authorization information.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/permissions```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Bad Request code</td>
+      <td>400</td>
+    </tr>
+    <tr>
+      <td>Forbidden code</td>
+      <td>403</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{  
+   "status":"OK",
+   "message":"",
+   "body":{  
+      "readers":[  
+         "user2"
+      ],
+      "owners":[  
+         "user1"
+      ],
+      "writers":[  
+         "user2"
+      ]
+   }
+}
+      </pre></td>
+    </tr>
+  </table>
+
+<br/>
+### Set note permission
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method set note authorization information.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/permissions```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Bad Request code</td>
+      <td>400</td>
+    </tr>
+    <tr>
+      <td>Forbidden code</td>
+      <td>403</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON input </td>
+      <td><pre>
+{
+  "readers": [
+    "user1"
+  ],
+  "owners": [
+    "user2"
+  ],
+  "writers": [
+    "user1"
+  ]
+}
+</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td><pre>
+{
+  "status": "OK"
+}</pre></td>
+    </tr>
+  </table>
+
+


### PR DESCRIPTION
### What is this PR for?
After #1567 merged we can get/set note permission info for a certain note. But this info is not described in anywhere for now. So I added "Security" section under [docs/rest-api/rest-notebook.md](https://github.com/apache/zeppelin/blob/master/docs/rest-api/rest-notebook.md). 

And currently so many operations are placed under one section like below.
<img src="https://cloud.githubusercontent.com/assets/10060731/21560964/c55d41cc-cea9-11e6-96ac-68f762c68bff.png" width="400px">

So I split them under each `Note opersions`, `Paragraph operations`, `Cron jobs`, and `Permission` section.
<img src="https://cloud.githubusercontent.com/assets/10060731/21799253/ca3bc596-d75b-11e6-82e5-ba440c7f0713.png" width="400px">

### What type of PR is it?
Documentation

### What is the Jira issue?
[ZEPPELIN-1877](https://issues.apache.org/jira/browse/ZEPPELIN-1877)

### How should this be tested?
Please see the below screenshots :)

### Screenshots (if appropriate)
![screen shot 2017-01-10 at 5 41 51 pm](https://cloud.githubusercontent.com/assets/10060731/21799334/22daa5f0-d75c-11e6-8ecf-6ae9c4c41e2e.png)
![screen shot 2017-01-10 at 5 41 59 pm](https://cloud.githubusercontent.com/assets/10060731/21799335/24da2740-d75c-11e6-802b-b73fbee0db57.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
