### PR TITLE
[ZEPPELIN-1878] added npm-debug.log on gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ zeppelin-web/src/fonts/source-code-pro*
 zeppelin-web/src/fonts/patua-one*
 zeppelin-web/src/fonts/google-fonts.css
 zeppelin-web/.sass-cache
+zeppelin-web/npm-debug.log
 zeppelin-web/bower_components
 **nbproject/
 **node/


### PR DESCRIPTION
### What is this PR for?
zeppelin-web/npm-debug.log file is only used debugging.
So, we do not tracking.

### What type of PR is it?
Improvement

### Todos
- [x] - fix .gitignore

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1878

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
