### PR TITLE
[ZEPPELIN-1876] smart psql autocomplition

### DIFF
--- a/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
+++ b/postgresql/src/main/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreter.java
@@ -315,7 +315,6 @@ public class PostgreSqlInterpreter extends Interpreter {
 
     // It's strange, but here cursor comes with +1 extra
     cursor = cursor - 1;
-    logger.info("CURSOR = " + cursor);
 
     List<CharSequence> candidates = new ArrayList<>();
     if (sqlCompleter != null && sqlCompleter.complete(buf, cursor, candidates) >= 0) {

--- a/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
+++ b/postgresql/src/test/java/org/apache/zeppelin/postgresql/PostgreSqlInterpreterTest.java
@@ -254,9 +254,8 @@ public class PostgreSqlInterpreterTest extends BasicJDBCTestCaseAdapter {
   @Test
   public void testAutoCompletion() throws SQLException {
     psqlInterpreter.open();
-    assertEquals(1, psqlInterpreter.completion("SEL", 0).size());
+    assertEquals(1, psqlInterpreter.completion("SEL", 1).size());
     InterpreterCompletion selectCompletion = new InterpreterCompletion("SELECT ", "SELECT ");
-    assertEquals(selectCompletion, psqlInterpreter.completion("SEL", 0).iterator().next());
-    assertEquals(0, psqlInterpreter.completion("SEL", 100).size());
+    assertEquals(selectCompletion, psqlInterpreter.completion("SEL", 1).iterator().next());
   }
 }

--- a/postgresql/src/test/java/org/apache/zeppelin/postgresql/SqlCompleterTest.java
+++ b/postgresql/src/test/java/org/apache/zeppelin/postgresql/SqlCompleterTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
+import jline.console.completer.ArgumentCompleter;
 import jline.console.completer.Completer;
 
 import org.junit.Before;
@@ -43,76 +42,207 @@ public class SqlCompleterTest extends BasicJDBCTestCaseAdapter {
 
   private CompleterTester tester;
 
-  private SqlCompleter sqlCompleter;
+  private ArgumentCompleter.WhitespaceArgumentDelimiter delimiter =
+          new ArgumentCompleter.WhitespaceArgumentDelimiter();
+
+  private SqlCompleter sqlCompleter = new SqlCompleter();
 
   @Before
   public void beforeTest() throws IOException, SQLException {
-    Set<String> keywordsCompletions =
-        SqlCompleter.getSqlKeywordsCompletions(getJDBCMockObjectFactory().getMockConnection());
-    Set<String> dataModelCompletions =
-        SqlCompleter
-            .getDataModelMetadataCompletions(getJDBCMockObjectFactory().getMockConnection());
 
-    sqlCompleter =
-        new SqlCompleter(Sets.union(keywordsCompletions, dataModelCompletions),
-            dataModelCompletions);
+    Map<String, Set<String>> tables = new HashMap<>();
+    Map<String, Set<String>> columns = new HashMap<>();
+    Set<String> schemas = new HashSet<>();
+    Set<String> keywords = new HashSet<>();
+
+    keywords.add("SUM");
+    keywords.add("SUBSTRING");
+    keywords.add("SUBCLASS_ORIGIN");
+    keywords.add("ORDER");
+    keywords.add("SELECT");
+    keywords.add("LIMIT");
+    keywords.add("FROM");
+
+    schemas.add("prod_dds");
+    schemas.add("prod_emart");
+
+    Set<String> prod_dds_tables = new HashSet<>();
+    prod_dds_tables.add("financial_account");
+    prod_dds_tables.add("customer");
+
+    Set<String> prod_emart_tables = new HashSet<>();
+    prod_emart_tables.add("financial_account");
+
+    tables.put("prod_dds", prod_dds_tables);
+    tables.put("prod_emart", prod_emart_tables);
+
+    Set<String> prod_dds_financial_account_columns = new HashSet<>();
+    prod_dds_financial_account_columns.add("account_rk");
+    prod_dds_financial_account_columns.add("account_id");
+
+    Set<String> prod_dds_customer_columns = new HashSet<>();
+    prod_dds_customer_columns.add("customer_rk");
+    prod_dds_customer_columns.add("name");
+    prod_dds_customer_columns.add("birth_dt");
+
+    Set<String> prod_emart_financial_account_columns = new HashSet<>();
+    prod_emart_financial_account_columns.add("account_rk");
+    prod_emart_financial_account_columns.add("balance_amt");
+
+    columns.put("prod_dds.financial_account", prod_dds_financial_account_columns);
+    columns.put("prod_dds.customer", prod_dds_customer_columns);
+    columns.put("prod_emart.financial_account", prod_emart_financial_account_columns);
+
+    sqlCompleter.init(schemas, tables, columns, keywords);
+
     tester = new CompleterTester(sqlCompleter);
   }
 
   @Test
-  public void testAfterBufferEnd() {
-    String buffer = "ORDER";
-    // Up to 2 white spaces after the buffer end, the completer still uses the last argument
-    tester.buffer(buffer).from(0).to(buffer.length() + 1).expect(newHashSet("ORDER ")).test();
-    // 2 white spaces or more behind the buffer end the completer returns empty result
-    tester.buffer(buffer).from(buffer.length() + 2).to(buffer.length() + 5).expect(EMPTY).test();
+  public void testFindAliasesInSQL_Simple(){
+    String sql = "select * from prod_emart.financial_account a";
+    Map<String, String> res = sqlCompleter.findAliasesInSQL(delimiter.delimit(sql, 0).getArguments());
+    assertEquals(1, res.size());
+    assertTrue(res.get("a").equals("prod_emart.financial_account"));
+  }
+
+  @Test
+  public void testFindAliasesInSQL_Two(){
+    String sql = "select * from prod_dds.financial_account a, prod_dds.customer b";
+    Map<String, String> res = sqlCompleter.findAliasesInSQL(sqlCompleter.getSqlDelimiter().delimit(sql, 0).getArguments());
+    assertEquals(2, res.size());
+    assertTrue(res.get("a").equals("prod_dds.financial_account"));
+    assertTrue(res.get("b").equals("prod_dds.customer"));
+  }
+
+  @Test
+  public void testFindAliasesInSQL_WrongTables(){
+    String sql = "select * from prod_ddsxx.financial_account a, prod_dds.customerxx b";
+    Map<String, String> res = sqlCompleter.findAliasesInSQL(sqlCompleter.getSqlDelimiter().delimit(sql, 0).getArguments());
+    assertEquals(0, res.size());
+  }
+
+  @Test
+  public void testCompleteName_Empty() {
+    String buffer = "";
+    int cursor = 0;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, false);
+    assertEquals(9, candidates.size());
+    assertTrue(candidates.contains("prod_dds"));
+    assertTrue(candidates.contains("prod_emart"));
+    assertTrue(candidates.contains("SUM"));
+    assertTrue(candidates.contains("SUBSTRING"));
+    assertTrue(candidates.contains("SUBCLASS_ORIGIN"));
+    assertTrue(candidates.contains("SELECT"));
+    assertTrue(candidates.contains("ORDER"));
+    assertTrue(candidates.contains("LIMIT"));
+    assertTrue(candidates.contains("FROM"));
+  }
+
+  @Test
+  public void testCompleteName_SimpleSchema() {
+    String buffer = "prod_";
+    int cursor = 3;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, false);
+    assertEquals(2, candidates.size());
+    assertTrue(candidates.contains("prod_dds"));
+    assertTrue(candidates.contains("prod_emart"));
+  }
+
+  @Test
+  public void testCompleteName_SimpleTable() {
+    String buffer = "prod_dds.fin";
+    int cursor = 11;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, false);
+    assertEquals(1, candidates.size());
+    assertTrue(candidates.contains("financial_account "));
+  }
+
+  @Test
+  public void testCompleteName_SimpleColumn() {
+    String buffer = "prod_dds.financial_account.acc";
+    int cursor = 30;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, true);
+    assertEquals(2, candidates.size());
+    assertTrue(candidates.contains("account_rk"));
+    assertTrue(candidates.contains("account_id"));
+  }
+
+  @Test
+  public void testCompleteName_WithAlias() {
+    String buffer = "a.acc";
+    int cursor = 4;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    aliases.put("a", "prod_dds.financial_account");
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, true);
+    assertEquals(2, candidates.size());
+    assertTrue(candidates.contains("account_rk"));
+    assertTrue(candidates.contains("account_id"));
+  }
+
+  @Test
+  public void testCompleteName_WithAliasAndPoint() {
+    String buffer = "a.";
+    int cursor = 2;
+    List<CharSequence> candidates = new ArrayList<>();
+    Map<String, String> aliases = new HashMap<>();
+    aliases.put("a", "prod_dds.financial_account");
+    sqlCompleter.completeName(buffer, cursor, candidates, aliases, true);
+    assertEquals(2, candidates.size());
+    assertTrue(candidates.contains("account_rk"));
+    assertTrue(candidates.contains("account_id"));
+  }
+
+  public void testSchemaAndTable() {
+    String buffer = "select * from prod_v_emart.fi";
+    tester.buffer(buffer).from(15).to(26).expect(newHashSet("prod_v_emart ")).test();
+    tester.buffer(buffer).from(27).to(29).expect(newHashSet("financial_account ")).test();
   }
 
   @Test
   public void testEdges() {
     String buffer = "  ORDER  ";
-    tester.buffer(buffer).from(0).to(8).expect(newHashSet("ORDER ")).test();
-    tester.buffer(buffer).from(9).to(15).expect(EMPTY).test();
+    tester.buffer(buffer).from(0).to(7).expect(newHashSet("ORDER ")).test();
+    tester.buffer(buffer).from(8).to(15).expect(newHashSet("ORDER", "SUBCLASS_ORIGIN", "SUBSTRING",
+            "prod_emart", "LIMIT", "SUM", "prod_dds", "SELECT", "FROM")).test();
   }
 
   @Test
   public void testMultipleWords() {
-    String buffer = "  SELE  fro    LIM";
-    tester.buffer(buffer).from(0).to(6).expect(newHashSet("SELECT ")).test();
-    tester.buffer(buffer).from(7).to(11).expect(newHashSet("from ")).test();
-    tester.buffer(buffer).from(12).to(19).expect(newHashSet("LIMIT ")).test();
-    tester.buffer(buffer).from(20).to(24).expect(EMPTY).test();
+    String buffer = "SELE FRO LIM";
+    tester.buffer(buffer).from(0).to(4).expect(newHashSet("SELECT ")).test();
+    tester.buffer(buffer).from(5).to(8).expect(newHashSet("FROM ")).test();
+    tester.buffer(buffer).from(9).to(12).expect(newHashSet("LIMIT ")).test();
   }
 
   @Test
   public void testMultiLineBuffer() {
-    String buffer = " \n SELE \n fro";
+    String buffer = " \n SELE\nFRO";
     tester.buffer(buffer).from(0).to(7).expect(newHashSet("SELECT ")).test();
-    tester.buffer(buffer).from(8).to(14).expect(newHashSet("from ")).test();
-    tester.buffer(buffer).from(15).to(17).expect(EMPTY).test();
+    tester.buffer(buffer).from(8).to(11).expect(newHashSet("FROM ")).test();
   }
 
   @Test
   public void testMultipleCompletionSuggestions() {
-    String buffer = "  SU";
-    tester.buffer(buffer).from(0).to(5).expect(newHashSet("SUBCLASS_ORIGIN", "SUM", "SUBSTRING"))
+    String buffer = "SU";
+    tester.buffer(buffer).from(0).to(2).expect(newHashSet("SUBCLASS_ORIGIN", "SUM", "SUBSTRING"))
         .test();
-    tester.buffer(buffer).from(6).to(7).expect(EMPTY).test();
-  }
-
-  @Test
-  public void testDotDelimiter() {
-    String buffer = "  order.select  ";
-    tester.buffer(buffer).from(4).to(7).expect(newHashSet("order ")).test();
-    tester.buffer(buffer).from(8).to(15).expect(newHashSet("select ")).test();
-    tester.buffer(buffer).from(16).to(17).expect(EMPTY).test();
   }
 
   @Test
   public void testSqlDelimiterCharacters() {
-    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar("r.", 1));
-    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar("SS;", 2));
-    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar(":", 0));
+    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar("r,", 1));
+    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar("SS,", 2));
+    assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar(",", 0));
     assertTrue(sqlCompleter.getSqlDelimiter().isDelimiterChar("ttt,", 3));
   }
 


### PR DESCRIPTION
### What is this PR for?
This PR changes autocompletion behaviour in postgresql interpeter.
There are some changes:
* [main change] autocompletion now depends on what are you typing. Now there are four types of competion: schema, table, column and keywords. If you typing new word then autocompetion suggests only keywords and schema names. If you are typing after schema name with point then you get list of tables in that schema. Also if you typing a name after point after a table name you will get a list of column names of this table.
* autocomption now supports aliases in sql. If you write alias for a table you will get a list of columns of an aliased table if you write down the alias and a point.
* new option are availble for postgresql interpreter: postgresql.completer.schema.filter. It allows filter schema names loaded into autocompletion (no more garbage schema names).
* autocompletion now load keywords only in low case (otherwise there are so many keywords in a list of autocompletion that it is becomes uncomfortable)

### What type of PR is it?
Improvement

### Todos
* [ ] - sort names in the output of autocompletion
* [ ] - list only schema names if we are typing a schema name (for example after keywork FROM)
* [ ] - add description in autocompletion list for schema names - schema, for table names - table and so

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1876

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
https://issues.apache.org/jira/secure/attachment/12845228/auto1.JPG
https://issues.apache.org/jira/secure/attachment/12845229/auto2.JPG
https://issues.apache.org/jira/secure/attachment/12845230/auto3.JPG

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
