### PR TITLE
[DOCS] Remove outdated 'Security Setup' section in SECURITY-README

### DIFF
--- a/SECURITY-README.md
+++ b/SECURITY-README.md
@@ -16,7 +16,7 @@ limitations under the License.
 To connect to Zeppelin, users will be asked to enter their credentials. Once logged, a user has access to all notes including other users notes.
 This a a first step toward full security as implemented by this pull request (https://github.com/apache/zeppelin/pull/53).
 
-Please check [Shiro authentication in Apache Zeppelin](https://zeppelin.apache.org/docs/snapshot/security/shiroauthentication.html) in our official website for more detailed information(e.g. [How to setup](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html#security-setup), [How to configure user groups and permissions](https://zeppelin.apache.org/docs/snapshot/security/shiroauthentication.html#groups-and-permissions-optional), etc)
+Please check [Shiro authentication in Apache Zeppelin](https://zeppelin.apache.org/docs/snapshot/security/shiroauthentication.html) in our official website for more detailed information(e.g. How to setup the security, How to configure user groups and permissions, and etc).
 
 # Implementation notes
 ## Vocabulary

--- a/SECURITY-README.md
+++ b/SECURITY-README.md
@@ -16,12 +16,7 @@ limitations under the License.
 To connect to Zeppelin, users will be asked to enter their credentials. Once logged, a user has access to all notes including other users notes.
 This a a first step toward full security as implemented by this pull request (https://github.com/apache/zeppelin/pull/53).
 
-# Security setup
-1. Secure the HTTP channel: Comment the line "/** = anon" and uncomment the line "/** = authc" in the file conf/shiro.ini. Read more about he shiro.ini file format at the following URL http://shiro.apache.org/configuration.html#Configuration-INISections.  
-2. Secure the Websocket channel : Set to property "zeppelin.anonymous.allowed" to "false" in the file conf/zeppelin-site.xml. You can start by renaming conf/zeppelin-site.xml.template to conf/zeppelin-site.xml
-3. Start Zeppelin : bin/zeppelin.sh
-4. point your browser to http://localhost:8080
-5. Login using one of the user/password combinations defined in the conf/shiro.ini file.
+Please check [Shiro authentication in Apache Zeppelin](https://zeppelin.apache.org/docs/snapshot/security/shiroauthentication.html) in our official website for more detailed information(e.g. [How to setup](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html#security-setup), [How to configure user groups and permissions](https://zeppelin.apache.org/docs/snapshot/security/shiroauthentication.html#groups-and-permissions-optional), etc)
 
 # Implementation notes
 ## Vocabulary

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -180,7 +180,7 @@ In this case, only who have `admin` role can see **Interpreter Setting**, **Cred
 If you want to grant this permission to other users, you can change **roles[ ]** as you defined at `[users]` section.
 
 <br/>
-> **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file. This documentation is originally from [SECURITY-README.md](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md).
+> **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file.
 
 
 ## Other authentication methods

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -41,10 +41,10 @@ cp conf/shiro.ini.template conf/shiro.ini
 
 For the further information about  `shiro.ini` file format, please refer to [Shiro Configuration](http://shiro.apache.org/configuration.html#Configuration-INISections).
 
-### 3. Secure the Websocket channel
+### 2. Secure the Websocket channel
 Set to property **zeppelin.anonymous.allowed** to **false** in `conf/zeppelin-site.xml`. If you don't have this file yet, just copy `conf/zeppelin-site.xml.template` to `conf/zeppelin-site.xml`.
 
-### 4. Start Zeppelin
+### 3. Start Zeppelin
 
 ```
 bin/zeppelin-daemon.sh start (or restart)
@@ -52,7 +52,7 @@ bin/zeppelin-daemon.sh start (or restart)
 
 Then you can browse Zeppelin at [http://localhost:8080](http://localhost:8080).
 
-### 5. Login
+### 4. Login
 Finally, you can login using one of the below **username/password** combinations.
 
 <center><img src="../assets/themes/zeppelin/img/docs-img/zeppelin-login.png"></center>
@@ -161,7 +161,7 @@ zeppelinHubRealm.zeppelinhubUrl = https://www.zeppelinhub.com
 securityManager.realms = $zeppelinHubRealm
 ```
 
-> Note: ZeppelinHub is not releated to apache Zeppelin project.
+> Note: ZeppelinHub is not releated to Apache Zeppelin project.
 
 ## Secure your Zeppelin information (optional)
 By default, anyone who defined in `[users]` can share **Interpreter Setting**, **Credential** and **Configuration** information in Apache Zeppelin.


### PR DESCRIPTION
### What is this PR for?
[SECURITY-README.md](https://github.com/apache/zeppelin/blob/master/SECURITY-README.md) was added by #53 when Shiro auth was implemented for the first time. But I think we need to keep "Security Setup" information in one source; [Official docs website](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html#security-setup) and guide ppl to see this official docs page so that `SECURITY-README.md` can only contain dev related contents (not step by step setup guide).

### What type of PR is it?
Documentation

### What is the Jira issue?
N/A

### How should this be tested?
Just clicking "View" would be enough I guess :)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
