### PR TITLE
[ZEPPELIN-1883] Can't import spark submitted packages in PySpark

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -155,12 +155,12 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     urls = urlList.toArray(urls);
     ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
     try {
-      // Get additional class paths when using SPARK_SUBMIT
-      // Should get current class Path before setting new class loader
-      // Also, add all packages to PYTHONPATH
-      // since there might be transitive dependencies
+      // get additional class paths when using SPARK_SUBMIT and not using YARN-CLIENT
+      // SHOULD get current class path before setting new class loader
+      // also, add all packages to PYTHONPATH since there might be transitive dependencies
       StringBuilder sparkSubmitPythonPaths = new StringBuilder();
-      if (SparkInterpreter.useSparkSubmit()) {
+      if (SparkInterpreter.useSparkSubmit() &&
+          !getSparkInterpreter().isYarnMode()) {
         List<File> paths = SparkInterpreter.currentClassPath();
         for (File f : paths) {
           sparkSubmitPythonPaths.append(f.getAbsolutePath()).append(":");

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -556,7 +556,7 @@ public class SparkInterpreter extends Interpreter {
     return (o instanceof String) ? (String) o : "";
   }
 
-  private boolean useSparkSubmit() {
+  public static boolean useSparkSubmit() {
     return null != System.getenv("SPARK_SUBMIT");
   }
 
@@ -726,7 +726,6 @@ public class SparkInterpreter extends Interpreter {
 
     pathSettings.v_$eq(classpath);
     settings.scala$tools$nsc$settings$ScalaSettings$_setter_$classpath_$eq(pathSettings);
-
 
     // set classloader for scala compiler
     settings.explicitParentLoader_$eq(new Some<>(Thread.currentThread()
@@ -976,7 +975,7 @@ public class SparkInterpreter extends Interpreter {
     }
   }
 
-  private List<File> currentClassPath() {
+  public static List<File> currentClassPath() {
     List<File> paths = classPath(Thread.currentThread().getContextClassLoader());
     String[] cps = System.getProperty("java.class.path").split(File.pathSeparator);
     if (cps != null) {
@@ -987,7 +986,7 @@ public class SparkInterpreter extends Interpreter {
     return paths;
   }
 
-  private List<File> classPath(ClassLoader cl) {
+  private static List<File> classPath(ClassLoader cl) {
     List<File> paths = new LinkedList<>();
     if (cl == null) {
       return paths;

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -975,7 +975,7 @@ public class SparkInterpreter extends Interpreter {
     }
   }
 
-  public static List<File> currentClassPath() {
+  public List<File> currentClassPath() {
     List<File> paths = classPath(Thread.currentThread().getContextClassLoader());
     String[] cps = System.getProperty("java.class.path").split(File.pathSeparator);
     if (cps != null) {
@@ -986,7 +986,7 @@ public class SparkInterpreter extends Interpreter {
     return paths;
   }
 
-  private static List<File> classPath(ClassLoader cl) {
+  private List<File> classPath(ClassLoader cl) {
     List<File> paths = new LinkedList<>();
     if (cl == null) {
       return paths;

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -296,7 +296,7 @@ public class SparkInterpreter extends Interpreter {
     return (DepInterpreter) p;
   }
 
-  private boolean isYarnMode() {
+  public boolean isYarnMode() {
     return getProperty("master").startsWith("yarn");
   }
 


### PR DESCRIPTION
### What is this PR for?

Fixed importing packages in pyspack requested by `SPARK_SUBMIT_OPTION`

### What type of PR is it?
[Bug Fix]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1883](https://issues.apache.org/jira/browse/ZEPPELIN-1883)

### How should this be tested?


0. Download Apache Spark 1.6.2 (since it's the most recent for pyspark-cassandra)

1. Set `SPARK_HOME` and `SPARK_SUBMIT_OPTION` in `conf/zeppelin-env.sh` like

```sh
export SPARK_HOME="~/github/apache-spark/1.6.2-bin-hadoop2.6"
export SPARK_SUBMIT_OPTIONS="--packages com.datastax.spark:spark-cassandra-connector_2.10:1.6.2,TargetHolding:pyspark-cassandra:0.3.5 --exclude-packages org.slf4j:slf4j-api"
```

2. Check before that you can run `spark-submit` or not

```
./bin/spark-submit --packages com.datastax.spark:spark-cassandra-connector_2.10:1.6.2,TargetHolding:pyspark-cassandra:0.3.5 --exclude-packages org.slf4j:slf4j-api --class org.apache.spark.examples.SparkPi lib/spark-examples-1.6.2-hadoop2.6.0.jar
```

3. Test whether submitted packages can be import or not

```
%pyspark

import pyspark_cassandra
```

### Screenshots (if appropriate)

```
import pyspark_cassandra


Traceback (most recent call last):
  File "/var/folders/lr/8g9y625n5j39rz6qhkg8s6640000gn/T/zeppelin_pyspark-5266742863961917074.py", line 267, in <module>
    raise Exception(traceback.format_exc())
Exception: Traceback (most recent call last):
  File "/var/folders/lr/8g9y625n5j39rz6qhkg8s6640000gn/T/zeppelin_pyspark-5266742863961917074.py", line 265, in <module>
    exec(code)
  File "<stdin>", line 1, in <module>
ImportError: No module named pyspark_cassandra
```

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
