### PR TITLE
[ZEPPELIN-1880] Fix shell interpreter output streaming result

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -20,9 +20,7 @@ package org.apache.zeppelin.shell;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -86,7 +84,8 @@ public class ShellInterpreter extends Interpreter {
 
     try {
       DefaultExecutor executor = new DefaultExecutor();
-      executor.setStreamHandler(new PumpStreamHandler(outStream, outStream));
+      executor.setStreamHandler(new PumpStreamHandler(
+        contextInterpreter.out, contextInterpreter.out));
       executor.setWatchdog(new ExecuteWatchdog(Long.valueOf(getProperty(TIMEOUT_PROPERTY))));
       executors.put(contextInterpreter.getParagraphId(), executor);
       int exitVal = executor.execute(cmdLine);
@@ -100,7 +99,7 @@ public class ShellInterpreter extends Interpreter {
       String message = outStream.toString();
       if (exitValue == 143) {
         code = Code.INCOMPLETE;
-        message += "Paragraph received a SIGTERM.\n";
+        message += "Paragraph received a SIGTERM\n";
         LOGGER.info("The paragraph " + contextInterpreter.getParagraphId() 
           + " stopped executing: " + message);
       }

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
-import org.apache.commons.exec.ExecuteException;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
@@ -33,6 +32,8 @@ import org.junit.Test;
 public class ShellInterpreterTest {
 
   private ShellInterpreter shell;
+  private InterpreterContext context;
+  private InterpreterResult result;
 
   @Before
   public void setUp() throws Exception {
@@ -40,6 +41,7 @@ public class ShellInterpreterTest {
     p.setProperty("shell.command.timeout.millisecs", "60000");
     shell = new ShellInterpreter(p);
 
+    context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
     shell.open();
   }
 
@@ -49,8 +51,6 @@ public class ShellInterpreterTest {
 
   @Test
   public void test() {
-    InterpreterContext context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
-    InterpreterResult result;
     if (System.getProperty("os.name").startsWith("Windows")) {
       result = shell.interpret("dir", context);
     } else {
@@ -65,29 +65,23 @@ public class ShellInterpreterTest {
 
   @Test
   public void testInvalidCommand(){
-    InterpreterContext context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
-    InterpreterResult result;
     if (System.getProperty("os.name").startsWith("Windows")) {
       result = shell.interpret("invalid_command\ndir", context);
     } else {
       result = shell.interpret("invalid_command\nls", context);
     }
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    assertTrue(result.message().get(0).getData().contains("invalid_command"));
+    assertEquals(Code.SUCCESS, result.code());
+    assertTrue(shell.executors.isEmpty());
   }
 
   @Test
   public void testShellTimeout() {
-    InterpreterContext context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
-    InterpreterResult result;
-
     if (System.getProperty("os.name").startsWith("Windows")) {
       result = shell.interpret("timeout 61", context);
     } else {
       result = shell.interpret("sleep 61", context);
     }
 
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertEquals(Code.INCOMPLETE, result.code());
     assertTrue(result.message().get(0).getData().contains("Paragraph received a SIGTERM"));
   }


### PR DESCRIPTION
### What is this PR for?
Shell interpreter streaming output had been available by #683, but currently it's broken after #1087 merged. This patch is for putting it back.

### What type of PR is it?
Bug Fix

### TODO
- [x] Fix test

### What is the Jira issue?
[ZEPPELIN-1880](https://issues.apache.org/jira/browse/ZEPPELIN-1880)

### How should this be tested?
```
%sh

date && sleep 3 && date
```

the each timestamp must be printed as streaming output

### Screenshots (if appropriate)
 - before 
![shellintpresultbefore](https://cloud.githubusercontent.com/assets/10060731/21585515/60c35a04-d105-11e6-8e68-853ee784e89d.gif)


 - after 
![shellintpresult](https://cloud.githubusercontent.com/assets/10060731/21585516/62142ac8-d105-11e6-8628-1d6eec35daae.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
