### PR TITLE
[ZEPPELIN-1864] Improvement to show folder and note after searching note

### DIFF
--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -42,6 +42,7 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
 
   $scope.isReloading = false;
   $scope.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
+  $scope.query = {q: ''};
 
   var initHome = function() {
     websocketMsgSrv.getHomeNote();
@@ -124,6 +125,7 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
     noteActionSrv.removeFolder(folderId);
   };
 
+<<<<<<< c41d4682afdce3bb5fb491229ec442e2617b6ca4
   $scope.emptyTrash = function() {
     noteActionSrv.emptyTrash();
   };
@@ -132,3 +134,22 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
     noteActionSrv.clearAllParagraphOutput(noteId);
   };
 }
+=======
+    $scope.clearAllParagraphOutput = function(noteId) {
+      noteActionSrv.clearAllParagraphOutput(noteId);
+    };
+
+    $scope.isFilterNote = function(note) {
+      if (!$scope.query.q) {
+        return true;
+      }
+
+      var noteName = note.name;
+      if (noteName.toLowerCase().indexOf($scope.query.q.toLowerCase()) > -1) {
+        return true;
+      }
+      return false;
+    };
+  }
+})();
+>>>>>>> fix for that filter of navbar and home don't work

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -88,8 +88,8 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
     }
   });
 
-  $scope.renameNote = function(node) {
-    noteActionSrv.renameNote(node.id, node.path);
+  $scope.renameNote = function(nodeId, nodePath) {
+    noteActionSrv.renameNote(nodeId, nodePath);
   };
 
   $scope.moveNoteToTrash = function(noteId) {

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -125,7 +125,6 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
     noteActionSrv.removeFolder(folderId);
   };
 
-<<<<<<< c41d4682afdce3bb5fb491229ec442e2617b6ca4
   $scope.emptyTrash = function() {
     noteActionSrv.emptyTrash();
   };
@@ -133,23 +132,16 @@ function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arra
   $scope.clearAllParagraphOutput = function(noteId) {
     noteActionSrv.clearAllParagraphOutput(noteId);
   };
+
+  $scope.isFilterNote = function(note) {
+    if (!$scope.query.q) {
+      return true;
+    }
+
+    var noteName = note.name;
+    if (noteName.toLowerCase().indexOf($scope.query.q.toLowerCase()) > -1) {
+      return true;
+    }
+    return false;
+  };
 }
-=======
-    $scope.clearAllParagraphOutput = function(noteId) {
-      noteActionSrv.clearAllParagraphOutput(noteId);
-    };
-
-    $scope.isFilterNote = function(note) {
-      if (!$scope.query.q) {
-        return true;
-      }
-
-      var noteName = note.name;
-      if (noteName.toLowerCase().indexOf($scope.query.q.toLowerCase()) > -1) {
-        return true;
-      }
-      return false;
-    };
-  }
-})();
->>>>>>> fix for that filter of navbar and home don't work

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -11,18 +11,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-<script type="text/ng-template" id="notebook_folder_renderer.html">
+<!-- Template of Home -->
+<script type="text/ng-template" id="note_renderer.html">
   <!-- note -->
-  <div ng-if="node.children == null"
-       ng-mouseenter="showNoteButton=true"
+  <div ng-if="node.children == null" ng-mouseenter="showNoteButton=true"
        ng-mouseleave="showNoteButton=false">
     <a style="text-decoration: none;" href="#/notebook/{{node.id}}">
-      <i style="font-size: 10px;" class="icon-doc"/> {{noteName(node)}}
+      <i style="font-size: 10px;"
+         ng-class="query.q && node.isTrash ? 'fa fa-trash-o' : 'icon-doc'" /> {{noteName(node)}}
     </a>
+    <!-- if note is not in trash -->
     <a ng-if="!node.isTrash" style="text-decoration: none;">
       <i style="margin-left: 10px;"
-         class="fa fa-pencil notebook-list-btn" ng-show="showNoteButton" ng-click="renameNote(node)"
+         class="fa fa-pencil notebook-list-btn" ng-show="showNoteButton"
+         ng-click="node.path ? renameNote(node.id, node.path) : renameNote(node.id, node.name)"
          tooltip-placement="bottom" tooltip="Rename note">
       </i>
     </a>
@@ -31,23 +33,24 @@ limitations under the License.
          tooltip-placement="bottom" tooltip="Clear output">
       </i>
     </a>
-    <a style="text-decoration: none;">
-      <!-- if note is not in trash -->
-      <i ng-if="!node.isTrash"
-         class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
+    <a ng-if="!node.isTrash" style="text-decoration: none;">
+      <i class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
          tooltip-placement="bottom" tooltip="Move note to Trash">
       </i>
+    </a>
       <!-- if note is in trash -->
-      <i ng-if="node.isTrash"
-         class="fa fa-undo notebook-list-btn" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
+    <a ng-if="node.isTrash">
+      <i class="fa fa-undo notebook-list-btn" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
          tooltip-placement="bottom" tooltip="Restore note">
       </i>
-      <i ng-if="node.isTrash" style="font-size: 16px;"
-         class="fa fa-times notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
+    </a>
+    <a ng-if="node.isTrash" style="font-size: 16px;">
+      <i class="fa fa-times notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
          tooltip-placement="bottom" tooltip="Remove note permanently">
       </i>
     </a>
   </div>
+
   <!-- folder -->
   <div ng-if="node.children != null && node.id !== TRASH_FOLDER_ID">
     <div ng-mouseenter="showFolderButton=true"
@@ -55,30 +58,33 @@ limitations under the License.
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
         <i style="font-size: 10px;" ng-class="node.hidden ? 'icon-folder' : 'icon-folder-alt'" /> {{noteName(node)}}
       </a>
-      <a style="text-decoration: none;">
-        <i ng-if="!node.isTrash" style="margin-left: 10px;"
+      <a ng-if="!node.isTrash" style="text-decoration: none;">
+        <i style="margin-left: 10px;"
            class="fa fa-pencil notebook-list-btn" ng-show="showFolderButton" ng-click="renameFolder(node)"
            tooltip-placement="bottom" tooltip="Rename folder">
         </i>
+      </a>
         <!-- if folder is not in trash -->
-        <i ng-if="!node.isTrash"
-           class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
+      <a ng-if="!node.isTrash">
+        <i class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
            tooltip-placement="bottom" tooltip="Move folder to Trash">
         </i>
+      </a>
         <!-- if folder is in trash -->
-        <i ng-if="node.isTrash"
-           class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
+      <a ng-if="node.isTrash">
+        <i class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
            tooltip-placement="bottom" tooltip="Restore folder">
         </i>
-        <i ng-if="node.isTrash" style="font-size: 16px"
-           class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
+      </a>
+      <a ng-if="node.isTrash" style="font-size: 16px">
+        <i class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
            tooltip-placement="bottom" tooltip="Remove folder permanently">
         </i>
       </a>
     </div>
     <div ng-if="!node.hidden">
       <ul style="list-style-type: none; padding-left:15px;">
-        <li ng-repeat="node in node.children" ng-include="'notebook_folder_renderer.html'" />
+        <li ng-repeat="node in node.children" ng-include="'note_renderer.html'" />
       </ul>
     </div>
   </div>
@@ -99,15 +105,16 @@ limitations under the License.
            tooltip-placement="bottom" tooltip="Empty trash">
         </i>
       </a>
-    </div>
+      </div>
     <div ng-if="!node.hidden">
       <ul style="list-style-type: none; padding-left:15px;">
-        <li ng-repeat="node in node.children" ng-include="'notebook_folder_renderer.html'" />
+        <li ng-repeat="node in node.children" ng-include="'note_renderer.html'" />
       </ul>
     </div>
   </div>
 </script>
 
+<!-- HomeCtrl -->
 <div ng-controller="HomeCtrl as home">
   <div ng-show="home.staticHome" class="box width-full home">
     <div class="zeppelin">
@@ -141,16 +148,14 @@ limitations under the License.
                 <i style="font-size: 10px;" class="icon-doc"></i>
                 <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
               </li>
-              <div ng-if="!query || query.name === ''">
-                <li ng-repeat="node in home.notes.root.children | orderBy:home.arrayOrderingSrv.noteListOrdering track by $index" ng-include="'notebook_folder_renderer.html'" />
+              <div ng-if="!query.q || query.q === ''">
+                <li ng-repeat="node in home.notes.root.children | orderBy:home.arrayOrderingSrv.noteListOrdering track by $index"
+                    ng-include="'note_renderer.html'" />
               </div>
-              <div ng-if="query && query.name !== ''">
-                <li ng-repeat="note in home.notes.flatList | filter:query.q | orderBy:home.arrayOrderingSrv.noteListOrdering track by $index">
-                  <i ng-if="!note.isTrash" style="font-size: 10px;" class="icon-doc"></i>
-                  <i ng-if="note.isTrash" style="font-size: 12px;" class="fa fa-trash-o"></i>
-                  <a style="text-decoration: none;" href="#/notebook/{{note.id}}">{{noteName(note)}}</a>
-                </li>
-              </div>
+              <div ng-if="query.q">
+                <li ng-repeat="node in home.notes.flatList| filter:query.q | orderBy:home.arrayOrderingSrv.noteListOrdering track by $index"
+                    ng-include="'note_renderer.html'" />
+             </div>
             </ul>
           </div>
         </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -14,7 +14,7 @@ limitations under the License.
 <!-- Template of Home -->
 <script type="text/ng-template" id="note_renderer.html">
   <!-- note -->
-  <div ng-if="node.children == null" ng-mouseenter="showNoteButton=true"
+  <div ng-if="node.children == null && isFilterNote(node)" ng-mouseenter="showNoteButton=true"
        ng-mouseleave="showNoteButton=false">
     <a style="text-decoration: none;" href="#/notebook/{{node.id}}">
       <i style="font-size: 10px;"

--- a/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
+++ b/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
@@ -12,4 +12,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()"
-       placeholder="&#xf002 Filter by Note" ng-model="$parent.query.q" />
+       placeholder="&#xf002 Filter" ng-model="$parent.query.q" />

--- a/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
+++ b/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
@@ -12,4 +12,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()"
-       placeholder="&#xf002 Filter" ng-model="$parent.query.q" />
+       placeholder="&#xf002 Filter by Note" ng-model="$parent.query.q" />

--- a/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
+++ b/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
@@ -12,16 +12,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<a class="notebook-list-item" ng-if="!note.children" href="#/notebook/{{note.id}}">
-  <i style="font-size: 10px; margin-right: 5px;" class="icon-doc"></i>
+<a class="notebook-list-item" ng-if="navbar.isFilterNote(note) && !note.children" href="#/notebook/{{note.id}}">
+  <i style="font-size: 10px; margin-right: 5px;" ng-class="query.q && note.isTrash ? 'fa fa-trash-o' : 'icon-doc'" ></i>
   <span>{{noteName(note)}}</span>
 </a>
+
 <li ng-if="note.children" ng-click="$event.stopPropagation()">
   <expand-collapse>
       <div>
         <a class="notebook-list-item" href="javascript:void(0)">
           <div ng-if="note.id !== navbar.TRASH_FOLDER_ID">
-            <i style="font-size: 10px; margin-right: 5px;" class="icon-folder"></i>
+            <i style="font-size: 10px; margin-right: 5px;"  class="icon-folder"></i>
             <span>{{noteName(note)}}</span>
           </div>
           <div ng-if="note.id === navbar.TRASH_FOLDER_ID">

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -68,6 +68,18 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     loadNotes();
   }
 
+  function isFilterNote(note) {
+    if (!$scope.query.q) {
+      return true;
+    }
+
+    var noteName = note.name;
+    if (noteName.toLowerCase().indexOf($scope.query.q.toLowerCase()) > -1) {
+      return true;
+    }
+    return false;
+  }
+
   function isActive(noteId) {
     return ($routeParams.noteId === noteId);
   }

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -41,6 +41,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
   vm.searchForm = searchService;
   vm.showLoginWindow = showLoginWindow;
   vm.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
+  vm.isFilterNote = isFilterNote;
 
   $scope.query = {q: ''};
 

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -32,9 +32,16 @@ limitations under the License.
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container" ng-if="isDrawNavbarNoteList">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>
-              <li ng-repeat="note in navbar.notes.root.children | filter:query.q | orderBy:navbar.arrayOrderingSrv.noteListOrdering track by $index"
+              <div ng-if="!query.q || query.q === ''">
+              <li ng-repeat="note in navbar.notes.root.children | orderBy:navbar.arrayOrderingSrv.noteListOrdering track by note.id"
                   ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'components/navbar/navbar-noteList-elem.html'">
               </li>
+            </div>
+            <div ng-if="query.q">
+              <li ng-repeat="note in navbar.notes.flatList | filter : query.q | orderBy:navbar.arrayOrderingSrv.noteListOrdering track by note.id"
+                  ng-class="{'active' : navbar.isActive(note.id)}" ng-include="'components/navbar/navbar-noteList-elem.html'">
+              </li>
+            </div>
             </div>
           </ul>
         </li>


### PR DESCRIPTION
### What is this PR for?
This PR is for improvement to show folder and note after using the filter. And I found some bugs and fixed like this.

the following list is improvement and bug fixed.
1. After using the filter in Zeppelin Home, every note is shown by the form [FolderName/NoteName] like below. It would be nice to show folder icon and note icon as previous status.
![z1864_f_b](https://cloud.githubusercontent.com/assets/8110458/21604777/79dbb228-d1e8-11e6-974d-737520729d68.gif)
 
2. When using the filter, some functions and icons next to note and folder are disappeared.
![z1864_f_2_b](https://cloud.githubusercontent.com/assets/8110458/21605057/f5a0143e-d1e9-11e6-86f3-ebff5be4c41d.gif)

3. When using the filter, the `Rename Note` function doesn't work. ( When I was handling this PR, this bug was discovered.)
![z1864_f_4_b](https://cloud.githubusercontent.com/assets/8110458/21606384/71305796-d1f2-11e6-91a4-2ec14b8b4959.gif)


### What type of PR is it?
[ Bug Fix | Improvement ]

### Todos
* [x] - improve to show folder and note when finishing to use filter.
* [x] - some functions and icons next to note and folder are appeared when using filter.
* [x] - fix `Rename Note` function when using the filter.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1864

### How should this be tested?
 - **[Test 1]** Before/After using the filter, check the list structure of your notes. It must be same appearance.

 - **[Test 2]** When using the filter, check the notes. Some icons and functions next to note and folder must be appeared.

 - **[Test 3]** When using the filter, click `Rename Note`. It must be appeared the path of Note.

### Screenshots (if appropriate)
**Test 1**.
![z1864_f_1_a](https://cloud.githubusercontent.com/assets/8110458/21606849/a79dbf82-d1f5-11e6-8d48-3a1977099ab1.gif)

**Test 2**.
![z1864_f_2_a](https://cloud.githubusercontent.com/assets/8110458/21606880/d1cf9550-d1f5-11e6-9311-ee54424d7e76.gif)

**Test 3**.
![z1864_f_4_a](https://cloud.githubusercontent.com/assets/8110458/21606272/9e0b096a-d1f1-11e6-8bfb-ab1ea1a30b88.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
