### PR TITLE
[MINOR][DOCS] Add troubleshooting section to spark_cluster_mode.md

### DIFF
--- a/docs/install/spark_cluster_mode.md
+++ b/docs/install/spark_cluster_mode.md
@@ -208,3 +208,30 @@ Don't forget to set Spark `master` as `mesos://127.0.1.1:5050` in Zeppelin **Int
 After running a single paragraph with Spark interpreter in Zeppelin, browse `http://<hostname>:5050/#/frameworks` and check Zeppelin application is running well or not.
 
 <img src="../assets/themes/zeppelin/img/docs-img/mesos_frameworks.png" />
+
+### Troubleshooting for Spark on Mesos
+
+- If you have problem with hostname, use `--add-host` option when executing `dockerrun`
+
+```
+## use `--add-host=moby:127.0.0.1` option to resolve
+## since docker container couldn't resolve `moby`
+
+: java.net.UnknownHostException: moby: moby: Name or service not known
+        at java.net.InetAddress.getLocalHost(InetAddress.java:1496)
+        at org.apache.spark.util.Utils$.findLocalInetAddress(Utils.scala:789)
+        at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress$lzycompute(Utils.scala:782)
+        at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress(Utils.scala:782)
+```
+
+- If you have problem with mesos master, try `mesos://127.0.0.1` instead of `mesos://127.0.1.1`
+
+```
+I0103 20:17:22.329269   340 sched.cpp:330] New master detected at master@127.0.1.1:5050
+I0103 20:17:22.330749   340 sched.cpp:341] No credentials provided. Attempting to register without authentication
+W0103 20:17:22.333531   340 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
+W0103 20:17:24.040252   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
+W0103 20:17:26.150250   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
+W0103 20:17:26.737604   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
+W0103 20:17:35.241714   336 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
+```


### PR DESCRIPTION
### What is this PR for?

I faced a few problems while executing docker image described in [Spark on Mesos mode](http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/install/spark_cluster_mode.html#spark-on-mesos-mode). Thus I updated doc.

FYI, I am using

- Docker version 1.12.5, build 7392c3b
- OSX 10.11.6

### What type of PR is it?
[Documentation]

### Todos

Nothing

### What is the Jira issue?

MINOR, DOCS

### How should this be tested?

DOCS

### Screenshots (if appropriate)

Error 1

```
: java.net.UnknownHostException: moby: moby: Name or service not known
        at java.net.InetAddress.getLocalHost(InetAddress.java:1496)
        at org.apache.spark.util.Utils$.findLocalInetAddress(Utils.scala:789)
        at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress$lzycompute(Utils.scala:782)
        at org.apache.spark.util.Utils$.org$apache$spark$util$Utils$$localIpAddress(Utils.scala:782)
```

Error 2

```
I0103 20:17:22.329269   340 sched.cpp:330] New master detected at master@127.0.1.1:5050
I0103 20:17:22.330749   340 sched.cpp:341] No credentials provided. Attempting to register without authentication
W0103 20:17:22.333531   340 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
W0103 20:17:24.040252   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
W0103 20:17:26.150250   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
W0103 20:17:26.737604   339 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
W0103 20:17:35.241714   336 sched.cpp:736] Ignoring framework registered message because it was sentfrom 'master@127.0.0.1:5050' instead of the leading master 'master@127.0.1.1:5050'
```

### Questions:
* Does the licenses files need update - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation - YES, I updated
