### PR TITLE
[ZEPPELIN-1887] fix: DON'T create new para when run all paragraphs

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileSystemException;
@@ -1562,9 +1563,11 @@ public class NotebookServer extends WebSocketServlet
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
     p.setConfig(config);
 
-    // if it's the last paragraph, let's add a new one
+    // if it's the last paragraph and empty, let's add a new one
     boolean isTheLastParagraph = note.isLastParagraph(p.getId());
-    if (isTheLastParagraph) {
+    if (!(text.trim().equals(p.getMagic()) ||
+        Strings.isNullOrEmpty(text)) &&
+        isTheLastParagraph) {
       Paragraph newPara = note.addParagraph(subject);
       broadcastNewParagraph(note, newPara);
     }


### PR DESCRIPTION
### What is this PR for?

Clicking `Run all paragraphs` adds new paragraph. This is not the intended behavior.

### What type of PR is it?
[Bug Fix]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1887](https://issues.apache.org/jira/browse/ZEPPELIN-1887)

### How should this be tested?

1. Click `Run all paragraph button` in a note
2. Check whether new paragraph is added or not.

### Screenshots (if appropriate)

![zeppelin-1887](https://cloud.githubusercontent.com/assets/4968473/21635002/56fb7ebc-d29e-11e6-9644-8f3f1c42da1a.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
