### PR TITLE
ZEPPELIN-1901. Output schema might be null for PigQueryInterpreter

### DIFF
--- a/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
@@ -93,7 +93,7 @@ public class PigQueryInterpreter extends BasePigInterpreter {
       if (schemaKnown) {
         for (int i = 0; i < schema.size(); ++i) {
           Schema.FieldSchema field = schema.getField(i);
-          resultBuilder.append(field.alias);
+          resultBuilder.append(field.alias != null ? field.alias : "col_" + i);
           if (i != schema.size() - 1) {
             resultBuilder.append("\t");
           }

--- a/pig/src/test/java/org/apache/zeppelin/pig/PigQueryInterpreterTest.java
+++ b/pig/src/test/java/org/apache/zeppelin/pig/PigQueryInterpreterTest.java
@@ -108,6 +108,13 @@ public class PigQueryInterpreterTest {
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertEquals("gender\tcount\nmale\t2\nfemale\t1\n", result.message().get(0).getData());
 
+    // generate alias with unknown schema
+    query = "b = group a by gender;\nforeach b generate group, COUNT($1);";
+    result = pigQueryInterpreter.interpret(query, context);
+    assertEquals(InterpreterResult.Type.TABLE, result.message().get(0).getType());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals("group\tcol_1\nmale\t2\nfemale\t1\n", result.message().get(0).getData());
+
     // syntax error in PigQueryInterpereter
     query = "b = group a by invalid_column;\nforeach b generate group as gender, COUNT($1) as count;";
     result = pigQueryInterpreter.interpret(query, context);


### PR DESCRIPTION
### What is this PR for?
The output schema might be null if user doesn't specify it explicitly. In this PR, I will use 'col_{pos}' to replace the column name if it is null. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1901

### How should this be tested?
Unit test is added.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
