### PR TITLE
ZEPPELIN-1903. ZeppelinContext can not display pandas DataFrame in PySparkInterpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,8 @@ before_install:
 
 install:
   - mvn $BUILD_FLAG $MODULES $PROFILE -B
+  - pip install --user -U pip
+  - pip install --user pandas
 
 before_script:
   - if [[ -n $SPARK_VER ]]; then travis_retry ./testing/downloadSpark.sh $SPARK_VER $HADOOP_VER; fi

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -52,13 +52,18 @@ class PyZeppelinContext(dict):
     self.max_result = 1000
     self._displayhook = lambda *args: None
 
+  def _isPandas(self, obj):
+    try:
+      from pandas.core.frame import DataFrame
+      return isinstance(obj, DataFrame)
+    except ImportError:
+      return false
+
   def show(self, obj):
     from pyspark.sql import DataFrame
     if isinstance(obj, DataFrame):
       print(self.z.showData(obj._jdf))
-    elif type(obj).__name__ == "DataFrame": # does not play well with sub-classes
-      # `isinstance(obj, DataFrame)` would req `import pandas.core.frame.DataFrame`
-      # and so a dependency on pandas
+    elif self._isPandas(obj):
       self.show_dataframe(obj)
     else:
       print(str(obj))

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -232,6 +232,23 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             waitForFinish(p);
             assertEquals(Status.FINISHED, p.getStatus());
             assertEquals("55\n", p.getResult().message().get(0).getData());
+
+            // display pandas data frame
+            p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            config = p.getConfig();
+            config.put("enabled", true);
+            p.setConfig(config);
+            p.setText("%pyspark data = {'id':[1,2], 'name':['alice', 'bob']}\n"
+                + "import pandas as pd\n"
+                + "df = pd.DataFrame(data)\n"
+                + "z.show(df)");
+            p.setAuthenticationInfo(anonymous);
+            note.run(p.getId());
+            waitForFinish(p);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals(InterpreterResult.Type.TABLE, p.getResult().message().get(0).getType());
+            assertEquals("id\tname\n1\talice\n2\tbob\n", p.getResult().message().get(0).getData());
+
             if (sparkVersion >= 13) {
                 // run sqlContext test
                 p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -234,7 +234,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             assertEquals("55\n", p.getResult().message().get(0).getData());
 
             // display pandas data frame
-            p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);


### PR DESCRIPTION
### What is this PR for?
I copy some code from `PythonInterpreter` to `PySparkInterpreter` to enable display pandas DataFrame in `PySparkInterpreter`. Ideally IMO all the features in PythonInterpreter should be available in `PySparkInterpeter`. `PySparkInterpreter` should be an extension of PythonInterpreter.  After refactoring of PythonInterpreter is done, we can consider about it.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1903

### How should this be tested?
Unit test is added and also manually tested. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/21637701/17a68a22-d2a3-11e6-9a5c-4ec2183b5951.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
