### PR TITLE
[HOTFIX] fix: DON'T run npm clean in maven clean phase (CI related, Build failure in web)

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -146,17 +146,6 @@
             </configuration>
           </execution>
 
-          <execution>
-            <id>npm clean</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>clean</phase>
-            <configuration>
-              <arguments>run clean</arguments>
-            </configuration>
-          </execution>
-
         </executions>
       </plugin>
 
@@ -186,6 +175,19 @@
       <plugin>
         <!-- clean task will be executed by front-end-maven plugin -->
         <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>bower_components</directory>
+            </fileset>
+            <fileset>
+              <directory>node</directory>
+            </fileset>
+            <fileset>
+              <directory>node_modules</directory>
+            </fileset>
+          </filesets>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
### What is this PR for?

maven clean executes `npm run clean` after #1824. but running npm commands requires installing, it's impossible to clean before installing it. 

**This PR resolve CI break** (see broken RAT build profiles)

- https://travis-ci.org/apache/zeppelin/builds/188895921
- https://travis-ci.org/apache/zeppelin/builds/188782988

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1850](https://issues.apache.org/jira/browse/ZEPPELIN-1850)

### How should this be tested?

The first build profile (RAT) should pass CI.

### Screenshots (if appropriate)

```
[INFO] --- frontend-maven-plugin:1.3:npm (npm clean) @ zeppelin-web ---
...
[INFO] Running 'npm run clean' in /Users/lambda/github/apache-zeppelin/zeppelin-bug/zeppelin-web
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.701 s
[INFO] Finished at: 2017-01-05T03:55:32+09:00
[INFO] Final Memory: 21M/982M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.3:npm (npm clean) on project zeppelin-web: Failed to run task: 'npm run clean' failed. java.io.IOException: Cannot run program"/Users/lambda/github/apache-zeppelin/zeppelin-bug/zeppelin-web/node/node" (in directory "/Users/lambda/github/apache-zeppelin/zeppelin-bug/zeppelin-web"): error=2, No such file or directory -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.3:npm (npm clean) on project zeppelin-web: Failed to run task
...
 
[ERROR]
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
