### PR TITLE
[ZEPPELIN-1905] fix: "Clear All Paragraphs" doens't work in a note

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -973,11 +973,7 @@
         $rootScope.$broadcast('setIframe', $scope.asIframe);
       }
 
-      if ($scope.note === null) {
-        $scope.note = note;
-      } else {
-        $scope.note.config.personalizedMode = note.config.personalizedMode;
-      }
+      $scope.note = note;
       initializeLookAndFeel();
       //open interpreter binding setting when there're none selected
       getInterpreterBindings();

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -715,7 +715,7 @@
      * lastCursorMove : 1(down), 0, -1(up) last cursor move event
      **/
     $scope.scrollToCursor = function(paragraphId, lastCursorMove) {
-      if (!$scope.editor.isFocused()) {
+      if (!$scope.editor || !$scope.editor.isFocused()) {
         // only make sense when editor is focused
         return;
       }


### PR DESCRIPTION
### What is this PR for?

Fixed **Clear all paragraphs** button in a note (I attached a screenshot)

### Details

- `NotebookServer.java` sends the `NOTE` websocket message
- But `notebook.controller.js` doens't apply the result properly since it has invalid impl

```javascript
  $scope.$on('setNoteContent', function(event, note) {
      ....

      if ($scope.note === null) { // only set if the note is empty? what if already created?
        $scope.note = note;
      } else {
        $scope.note.config.personalizedMode = note.config.personalizedMode;
      }
```

- The reason I fixed `if (!$scope.editor || !$scope.editor.isFocused())` (in `paragraph.controll.js`) is because i am getting this type error whenever i click `Run all paragraphs` button after commit 7f95b9b (in this PR)

```javascript
angular.js:13236 TypeError: Cannot read property 'isFocused' of null
    at ChildScope.ParagraphCtrl.$scope.scrollToCursor (paragraph.controller.js:718)
    at paragraph.controller.js:708
    at Scope.$broadcast (angular.js:17143)
    at paragraph.controller.js:1052
```

### What type of PR is it?
[Bug Fix]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1905](https://issues.apache.org/jira/browse/ZEPPELIN-1905)

### How should this be tested?

1. Open a note
2. Run some paragraphs.
3. Click the **Run all paragraphs** button.

### Screenshots (if appropriate)

![clear-all-output-bug](https://cloud.githubusercontent.com/assets/4968473/21660976/391d5010-d315-11e6-9ad0-c4feff32eee6.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
