### PR TITLE
[ZEPPELIN-1906] Use multiple InterpreterResult for displaying multiple JDBC queries

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -443,11 +443,8 @@ public class JDBCInterpreter extends Interpreter {
 
     InterpreterResult interpreterResult = new InterpreterResult(InterpreterResult.Code.SUCCESS);
 
-
     try {
-
       connection = getConnection(propertyKey, interpreterContext);
-
       if (connection == null) {
         return new InterpreterResult(Code.ERROR, "Prefix not found.");
       }
@@ -462,7 +459,6 @@ public class JDBCInterpreter extends Interpreter {
 
         try {
           getJDBCConfiguration(user).saveStatement(paragraphId, statement);
-
 
           boolean isResultSetAvailable = statement.execute(sqlToExecute);
           if (isResultSetAvailable) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -433,22 +433,23 @@ public class JDBCInterpreter extends Interpreter {
     return updatedCount < 0 && columnCount <= 0 ? true : false;
   }
 
+  //inspired from https://github.com/postgres/pgadmin3/blob/794527d97e2e3b01399954f3b79c8e2585b908dd/pgadmin/dlg/dlgProperty.cpp#L999-L1045
   protected String[] splitSqlQueries(String sql) {
     ArrayList<String> queries = new ArrayList<>();
     StringBuilder query = new StringBuilder();
-    Character c;
+    Character character;
 
     Boolean antiSlash = false;
     Boolean quoteString = false;
     Boolean doubleQuoteString = false;
 
     for (int item = 0; item < sql.length(); item++) {
-      c = sql.charAt(item);
+      character = sql.charAt(item);
 
-      if (c.equals('\\')) {
+      if (character.equals('\\')) {
         antiSlash = true;
       }
-      if (c.equals('\'')) {
+      if (character.equals('\'')) {
         if (antiSlash) {
           antiSlash = false;
         } else if (quoteString) {
@@ -457,7 +458,7 @@ public class JDBCInterpreter extends Interpreter {
           quoteString = true;
         }
       }
-      if (c.equals('"')) {
+      if (character.equals('"')) {
         if (antiSlash) {
           antiSlash = false;
         } else if (doubleQuoteString) {
@@ -467,11 +468,11 @@ public class JDBCInterpreter extends Interpreter {
         }
       }
 
-      if (c.equals(';') && !antiSlash && !quoteString && !doubleQuoteString) {
+      if (character.equals(';') && !antiSlash && !quoteString && !doubleQuoteString) {
         queries.add(query.toString());
         query = new StringBuilder();
       } else {
-        query.append(c);
+        query.append(character);
       }
     }
     if (queries.size() == 0) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -474,12 +474,12 @@ public class JDBCInterpreter extends Interpreter {
       if (character.equals(';') && !antiSlash && !quoteString && !doubleQuoteString) {
         queries.add(query.toString());
         query = new StringBuilder();
+      } else if (item == sql.length() - 1) {
+        query.append(character);
+        queries.add(query.toString());
       } else {
         query.append(character);
       }
-    }
-    if (queries.size() == 0) {
-      queries.add(query.toString());
     }
     return queries.toArray(new String[queries.size()]);
   }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -433,6 +433,10 @@ public class JDBCInterpreter extends Interpreter {
     return updatedCount < 0 && columnCount <= 0 ? true : false;
   }
 
+  protected String[] splitSqlQuery(String query) {
+    return query.split("\\s*;\\s*(?=([^'\"`]*['\"`][^'\"`]*['\"`])*[^'\"`]*$)");
+  }
+
   private InterpreterResult executeSql(String propertyKey, String sql,
       InterpreterContext interpreterContext) {
     Connection connection;
@@ -449,7 +453,7 @@ public class JDBCInterpreter extends Interpreter {
         return new InterpreterResult(Code.ERROR, "Prefix not found.");
       }
 
-      String[] multipleSqlArray = sql.split("\\s*;\\s*(?=([^'\"`]*'[^'\"`]*')*[^'\"`]*$)");
+      String[] multipleSqlArray = splitSqlQuery(sql);
       for (int i = 0; i < multipleSqlArray.length; i++) {
         String sqlToExecute = multipleSqlArray[i];
         statement = connection.createStatement();

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -433,7 +433,10 @@ public class JDBCInterpreter extends Interpreter {
     return updatedCount < 0 && columnCount <= 0 ? true : false;
   }
 
-  //inspired from https://github.com/postgres/pgadmin3/blob/794527d97e2e3b01399954f3b79c8e2585b908dd/pgadmin/dlg/dlgProperty.cpp#L999-L1045
+  /*
+  inspired from https://github.com/postgres/pgadmin3/blob/794527d97e2e3b01399954f3b79c8e2585b908dd/
+    pgadmin/dlg/dlgProperty.cpp#L999-L1045
+   */
   protected String[] splitSqlQueries(String sql) {
     ArrayList<String> queries = new ArrayList<>();
     StringBuilder query = new StringBuilder();

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -175,12 +176,12 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     Properties properties = new Properties();
     JDBCInterpreter t = new JDBCInterpreter(properties);
     t.open();
-    String[] multipleSqlArray = t.splitSqlQueries(sqlQuery);
-    assertEquals(4, multipleSqlArray.length);
-    assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray[0]);
-    assertEquals("select * from test_table", multipleSqlArray[1]);
-    assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray[2]);
-    assertEquals("select * from test_table WHERE ID = ';'", multipleSqlArray[3]);
+    ArrayList<String> multipleSqlArray = t.splitSqlQueries(sqlQuery);
+    assertEquals(4, multipleSqlArray.size());
+    assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray.get(0));
+    assertEquals("select * from test_table", multipleSqlArray.get(1));
+    assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray.get(2));
+    assertEquals("select * from test_table WHERE ID = ';'", multipleSqlArray.get(3));
   }
 
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -15,7 +15,6 @@
 package org.apache.zeppelin.jdbc;
 
 import static java.lang.String.format;
-import static org.apache.zeppelin.interpreter.Interpreter.register;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_DRIVER;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_PASSWORD;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_USER;
@@ -171,7 +170,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     String sqlQuery = "insert into test_table(id, name) values ('a', ';\"');" +
         "select * from test_table;" +
         "select * from test_table WHERE ID = \";'\";" +
-        "select * from test_table WHERE ID = ';';";
+        "select * from test_table WHERE ID = ';'";
 
     Properties properties = new Properties();
     JDBCInterpreter t = new JDBCInterpreter(properties);

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -15,9 +15,7 @@
 package org.apache.zeppelin.jdbc;
 
 import static java.lang.String.format;
-import static org.apache.zeppelin.interpreter.Interpreter.logger;
 import static org.apache.zeppelin.interpreter.Interpreter.register;
-import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_KEY;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_DRIVER;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_PASSWORD;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_USER;
@@ -29,19 +27,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.*;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.jdbc.JDBCInterpreter;
 import org.apache.zeppelin.scheduler.FIFOScheduler;
 import org.apache.zeppelin.scheduler.ParallelScheduler;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.user.UserCredentials;
 import org.apache.zeppelin.user.UsernamePassword;
 import org.junit.Before;
@@ -173,19 +168,19 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
   @Test
   public void testSplitSqlQuery() throws SQLException, IOException {
-    String sqlQuery = "select * from test_table;" +
-        "select * from test_table WHERE ID = `;`;" +
-        "select * from test_table WHERE ID = \";\";" +
+    String sqlQuery = "insert into test_table(id, name) values ('a', ';\"');" +
+        "select * from test_table;" +
+        "select * from test_table WHERE ID = \";'\";" +
         "select * from test_table WHERE ID = ';';";
 
     Properties properties = new Properties();
     JDBCInterpreter t = new JDBCInterpreter(properties);
     t.open();
-    String[] multipleSqlArray = t.splitSqlQuery(sqlQuery);
+    String[] multipleSqlArray = t.splitSqlQueries(sqlQuery);
     assertEquals(4, multipleSqlArray.length);
-    assertEquals("select * from test_table", multipleSqlArray[0]);
-    assertEquals("select * from test_table WHERE ID = `;`", multipleSqlArray[1]);
-    assertEquals("select * from test_table WHERE ID = \";\"", multipleSqlArray[2]);
+    assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray[0]);
+    assertEquals("select * from test_table", multipleSqlArray[1]);
+    assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray[2]);
     assertEquals("select * from test_table WHERE ID = ';'", multipleSqlArray[3]);
   }
 


### PR DESCRIPTION
### What is this PR for?
Use multiple InterpreterResult for displaying multiple JDBC queries. 
IMO since other sql editors allows to execute multiple sql separated with ";" and ours display mechanism being more powerful, hence, it should also allow the same.

### What type of PR is it?
[Improvement]


### What is the Jira issue?
* [ZEPPELIN-1906](https://issues.apache.org/jira/browse/ZEPPELIN-1906)

### How should this be tested?
Try running following in a paragraph (with Postgres setting) and check for output. 

```
%jdbc
create table test_temp_table (id int);
select column_name, data_type, character_maximum_length from INFORMATION_SCHEMA.COLUMNS where table_name = 'test_temp_table';
SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';
drop table test_temp_table;
SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
