### PR TITLE
ZEPPELIN-1770. Restart only the client user's interpreter when restarting interpreter setting

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.Response.Status;
 import com.google.gson.Gson;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.zeppelin.rest.message.RestartInterpreterRequest;
+import org.apache.zeppelin.utils.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.repository.RemoteRepository;
@@ -178,12 +179,11 @@ public class InterpreterRestApi {
   @ZeppelinApi
   public Response restartSetting(String message, @PathParam("settingId") String settingId) {
     logger.info("Restart interpreterSetting {}, msg={}", settingId, message);
-
     try {
       RestartInterpreterRequest request = gson.fromJson(message, RestartInterpreterRequest.class);
 
       String noteId = request == null ? null : request.getNoteId();
-      interpreterFactory.restart(settingId, noteId);
+      interpreterFactory.restart(settingId, noteId, SecurityUtils.getPrincipal());
 
     } catch (InterpreterException e) {
       logger.error("Exception in InterpreterRestApi while restartSetting ", e);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -739,7 +739,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       String noteId) {
     InterpreterOption option = interpreterSetting.getOption();
     if (option.isProcess()) {
-      interpreterSetting.closeAndRemoveInterpreterGroup(noteId);
+      interpreterSetting.closeAndRemoveInterpreterGroupByNoteId(noteId);
     } else if (option.isSession()) {
       InterpreterGroup interpreterGroup = interpreterSetting.getInterpreterGroup(user, noteId);
       String key = getInterpreterSessionKey(user, noteId, interpreterSetting);
@@ -973,18 +973,23 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     return noteId == null ? false : true;
   }
 
-  public void restart(String settingId, String noteId) {
+  public void restart(String settingId, String noteId, String user) {
     InterpreterSetting intpSetting = interpreterSettings.get(settingId);
     Preconditions.checkNotNull(intpSetting);
 
+    // restart interpreter setting in note page
     if (noteIdIsExist(noteId) && intpSetting.getOption().isProcess()) {
-      intpSetting.closeAndRemoveInterpreterGroup(noteId);
+      intpSetting.closeAndRemoveInterpreterGroupByNoteId(noteId);
       return;
+    } else {
+      // restart interpreter setting in interpreter setting page
+      restart(settingId, user);
     }
-    restart(settingId);
+
+
   }
 
-  public void restart(String id) {
+  public void restart(String id, String user) {
     synchronized (interpreterSettings) {
       InterpreterSetting intpSetting = interpreterSettings.get(id);
       // Check if dependency in specified path is changed
@@ -995,13 +1000,20 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         copyDependenciesFromLocalPath(intpSetting);
 
         stopJobAllInterpreter(intpSetting);
-
-        intpSetting.closeAndRemoveAllInterpreterGroups();
+        if (user.equals("anonymous")) {
+          intpSetting.closeAndRemoveAllInterpreterGroups();
+        } else {
+          intpSetting.closeAndRemoveInterpreterGroupByUser(user);
+        }
 
       } else {
         throw new InterpreterException("Interpreter setting id " + id + " not found");
       }
     }
+  }
+
+  public void restart(String id) {
+    restart(id, "anonymous");
   }
 
   private void stopJobAllInterpreter(InterpreterSetting intpSetting) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -173,8 +173,28 @@ public class InterpreterSetting {
     }
   }
 
-  void closeAndRemoveInterpreterGroup(String noteId) {
+  void closeAndRemoveInterpreterGroupByNoteId(String noteId) {
     String key = getInterpreterProcessKey("", noteId);
+
+    InterpreterGroup groupToRemove = null;
+    for (String intpKey : new HashSet<>(interpreterGroupRef.keySet())) {
+      if (intpKey.contains(key)) {
+        interpreterGroupWriteLock.lock();
+        groupToRemove = interpreterGroupRef.remove(intpKey);
+        interpreterGroupWriteLock.unlock();
+      }
+    }
+
+    if (groupToRemove != null) {
+      groupToRemove.close();
+    }
+  }
+
+  void closeAndRemoveInterpreterGroupByUser(String user) {
+    if (user.equals("anonymous")) {
+      user = "";
+    }
+    String key = getInterpreterProcessKey(user, "");
 
     InterpreterGroup groupToRemove = null;
     for (String intpKey : new HashSet<>(interpreterGroupRef.keySet())) {
@@ -193,7 +213,7 @@ public class InterpreterSetting {
   void closeAndRemoveAllInterpreterGroups() {
     HashSet<String> groupsToRemove = new HashSet<>(interpreterGroupRef.keySet());
     for (String key : groupsToRemove) {
-      closeAndRemoveInterpreterGroup(key);
+      closeAndRemoveInterpreterGroupByNoteId(key);
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterFactoryTest.java
@@ -167,6 +167,79 @@ public class InterpreterFactoryTest {
     assertEquals("value_2", remoteInterpreter.getProperty("property_2"));
   }
 
+  /**
+   * 2 users' interpreters in scoped mode. Each user has one session. Restarting user1's interpreter
+   * won't affect user2's interpreter
+   * @throws Exception
+   */
+  @Test
+  public void testRestartInterpreterInScopedMode() throws Exception {
+    factory = new InterpreterFactory(conf, new InterpreterOption(true), null, null, null, depResolver, false);
+    List<InterpreterSetting> all = factory.get();
+    InterpreterSetting mock1Setting = null;
+    for (InterpreterSetting setting : all) {
+      if (setting.getName().equals("mock1")) {
+        mock1Setting = setting;
+        break;
+      }
+    }
+    mock1Setting.getOption().setPerUser("scoped");
+    mock1Setting.getOption().setPerNote("shared");
+    // set remote as false so that we won't create new remote interpreter process
+    mock1Setting.getOption().setRemote(false);
+    mock1Setting.getOption().setHost("localhost");
+    mock1Setting.getOption().setPort(2222);
+    InterpreterGroup interpreterGroup = mock1Setting.getInterpreterGroup("user1", "sharedProcess");
+    factory.createInterpretersForNote(mock1Setting, "user1", "sharedProcess", "user1");
+    factory.createInterpretersForNote(mock1Setting, "user2", "sharedProcess", "user2");
+
+    LazyOpenInterpreter interpreter1 = (LazyOpenInterpreter)interpreterGroup.get("user1").get(0);
+    interpreter1.open();
+    LazyOpenInterpreter interpreter2 = (LazyOpenInterpreter)interpreterGroup.get("user2").get(0);
+    interpreter2.open();
+
+    mock1Setting.closeAndRemoveInterpreterGroupByUser("user1");
+    assertFalse(interpreter1.isOpen());
+    assertTrue(interpreter2.isOpen());
+  }
+
+  /**
+   * 2 users' interpreters in isolated mode. Each user has one interpreterGroup. Restarting user1's interpreter
+   * won't affect user2's interpreter
+   * @throws Exception
+   */
+  @Test
+  public void testRestartInterpreterInIsolatedMode() throws Exception {
+    factory = new InterpreterFactory(conf, new InterpreterOption(true), null, null, null, depResolver, false);
+    List<InterpreterSetting> all = factory.get();
+    InterpreterSetting mock1Setting = null;
+    for (InterpreterSetting setting : all) {
+      if (setting.getName().equals("mock1")) {
+        mock1Setting = setting;
+        break;
+      }
+    }
+    mock1Setting.getOption().setPerUser("isolated");
+    mock1Setting.getOption().setPerNote("shared");
+    // set remote as false so that we won't create new remote interpreter process
+    mock1Setting.getOption().setRemote(false);
+    mock1Setting.getOption().setHost("localhost");
+    mock1Setting.getOption().setPort(2222);
+    InterpreterGroup interpreterGroup1 = mock1Setting.getInterpreterGroup("user1", "note1");
+    InterpreterGroup interpreterGroup2 = mock1Setting.getInterpreterGroup("user2", "note2");
+    factory.createInterpretersForNote(mock1Setting, "user1", "note1", "shared_session");
+    factory.createInterpretersForNote(mock1Setting, "user2", "note2", "shared_session");
+
+    LazyOpenInterpreter interpreter1 = (LazyOpenInterpreter)interpreterGroup1.get("shared_session").get(0);
+    interpreter1.open();
+    LazyOpenInterpreter interpreter2 = (LazyOpenInterpreter)interpreterGroup2.get("shared_session").get(0);
+    interpreter2.open();
+
+    mock1Setting.closeAndRemoveInterpreterGroupByUser("user1");
+    assertFalse(interpreter1.isOpen());
+    assertTrue(interpreter2.isOpen());
+  }
+
   @Test
   public void testFactoryDefaultList() throws IOException, RepositoryException {
     // get default settings
@@ -364,10 +437,5 @@ public class InterpreterFactoryTest {
     i = factory.createRemoteRepl("path1", "sessionKey", "className", new Properties(), "settingId", "userName", false, mockInterpreterRunner);
     interpreterRunner = ((RemoteInterpreter) ((LazyOpenInterpreter) i).getInnerInterpreter()).getInterpreterRunner();
     assertEquals(interpreterRunner, testInterpreterRunner);
-  }
-
-  @Test
-  public void interpreterRunnerAsAbsolutePathTest() {
-
   }
 }


### PR DESCRIPTION

### What is this PR for?
This PR would only restart the trigger user's interpreter rather than all the interpreter. So that restarting won't affect other users. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1770

### How should this be tested?
Tested manually.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
