### PR TITLE
[ZEPPELIN-1812] Ace editor show/hide problem.

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -463,7 +463,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       collector.checkThat("Markdown editor is hidden after run ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(false));
 
       collector.checkThat("Markdown editor is shown after run ",
@@ -477,7 +477,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       action.doubleClick(driver.findElement(By.xpath(getParagraphXPath(1)))).perform();
       ZeppelinITUtils.sleep(1000, false);
       collector.checkThat("Markdown editor is shown after double click ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(true));
 
       collector.checkThat("Markdown editor is hidden after double click ",

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -463,8 +463,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       collector.checkThat("Markdown editor is hidden after run ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")),
-          null);
+          driver.findElements(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).size(),
+          CoreMatchers.equalTo(0));
 
       collector.checkThat("Markdown editor is shown after run ",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.tableHide')]")).isDisplayed(),

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -463,8 +463,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       collector.checkThat("Markdown editor is hidden after run ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
-          CoreMatchers.equalTo(false));
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
+          CoreMatchers.equalTo(null));
 
       collector.checkThat("Markdown editor is shown after run ",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.tableHide')]")).isDisplayed(),
@@ -477,7 +477,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       action.doubleClick(driver.findElement(By.xpath(getParagraphXPath(1)))).perform();
       ZeppelinITUtils.sleep(1000, false);
       collector.checkThat("Markdown editor is shown after double click ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(true));
 
       collector.checkThat("Markdown editor is hidden after double click ",

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -463,8 +463,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       collector.checkThat("Markdown editor is hidden after run ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
-          CoreMatchers.equalTo(null));
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")),
+          null);
 
       collector.checkThat("Markdown editor is shown after run ",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.tableHide')]")).isDisplayed(),

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -463,7 +463,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
 
       collector.checkThat("Markdown editor is hidden after run ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(false));
 
       collector.checkThat("Markdown editor is shown after run ",
@@ -477,7 +477,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       action.doubleClick(driver.findElement(By.xpath(getParagraphXPath(1)))).perform();
       ZeppelinITUtils.sleep(1000, false);
       collector.checkThat("Markdown editor is shown after double click ",
-          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-show, 'paragraph.config.editorHide')]")).isDisplayed(),
+          driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@ng-if, 'paragraph.config.editorHide')]")).isDisplayed(),
           CoreMatchers.equalTo(true));
 
       collector.checkThat("Markdown editor is hidden after double click ",

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -36,7 +36,7 @@ limitations under the License.
   </div>
 
   <div>
-    <div ng-show="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">
+    <div ng-if="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">
       <code-editor
         paragraph-id="paragraph.id"
         paragraph-context="paragraph"


### PR DESCRIPTION
### What is this PR for?
When editor hide is on and page refresh then editor is gone.
I was solve this problem.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1812

### How should this be tested?
1. hide to editor mode on in paragraph configure.
2. page refresh (f5)
3. enable to show editor mode in paragraph configure.
4. if show editor then is correct.
### Screenshots (if appropriate)
#### before
![badeditor](https://cloud.githubusercontent.com/assets/10525473/21677078/62136de2-d2ed-11e6-9418-0be4453fd839.gif)

#### after
![goodeditor](https://cloud.githubusercontent.com/assets/10525473/21677092/6c8d97e8-d2ed-11e6-8966-a3b7af60c231.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
