### PR TITLE
[ZEPPELIN-1902] Fix blank default intp select box after Zeppelin started when Shiro on

### DIFF
--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -133,7 +133,7 @@ limitations under the License.
           <div>
             <h5><a href="" data-toggle="modal" data-target="#noteImportModal" style="text-decoration: none;">
               <i style="font-size: 15px;" class="fa fa-upload"></i> Import note</a></h5>
-            <h5><a href="" data-toggle="modal" data-target="#noteNameModal" style="text-decoration: none;">
+            <h5 ng-controller="NotenameCtrl as notenamectrl"><a href="" data-toggle="modal" data-target="#noteNameModal" style="text-decoration: none;" ng-click="notenamectrl.getInterpreterSettings()">
               <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
             <ul id="notebook-names">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -28,7 +28,7 @@ limitations under the License.
         <li class="dropdown notebook-list-dropdown" dropdown>
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" dropdown-toggle>Notebook <span class="caret"></span></a>
           <ul class="dropdown-menu navbar-dropdown-maxHeight" role="menu">
-            <li><a href="" data-toggle="modal" data-target="#noteNameModal"><i class="fa fa-plus"></i> Create new note</a></li>
+            <li ng-controller="NotenameCtrl as notenamectrl"><a href="" data-toggle="modal" data-target="#noteNameModal" ng-click="notenamectrl.getInterpreterSettings()"><i class="fa fa-plus"></i> Create new note</a></li>
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container" ng-if="isDrawNavbarNoteList">
               <li class="filter-names" ng-include="'components/filterNoteNames/filter-note-names.html'"></li>

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -100,6 +100,7 @@
     vm.getInterpreterSettings = function() {
       vm.websocketMsgSrv.getInterpreterSettings();
     };
+    
 
     $scope.$on('interpreterSettings', function(event, data) {
       $scope.interpreterSettings = data.interpreterSettings;
@@ -108,13 +109,6 @@
       $scope.note.defaultInterpreter = data.interpreterSettings[0];
     });
 
-    var init = function() {
-      if (!vm.clone) {
-        vm.getInterpreterSettings();
-      }
-    };
-
-    init();
   }
 
 })();


### PR DESCRIPTION
### What is this PR for?
After #1520 we can set default interpreter when we create new note. Currently this feature is implemented to get `interpreterSetting` list when Zeppelin is initiated (can be checked in dev console). And it needs user's info. So there can be two cases like below.

 - Shiro off 
It tries to get interpreter setting lists as `anonymous` user
![shirooff](https://cloud.githubusercontent.com/assets/10060731/21676394/cce513d8-d378-11e6-9645-99255882b664.png)
In this case, the problem is not happened. If we don't turn Shiro on, it doesn't need user's info and Zeppelin automatically creates fake user(?) info as `anonymous`. So there is no problem to get the interpreter setting lists. 

 - Shiro on
tries to get interpreter setting lists as '  ' user since we're not loggined yet. 
![shiroon](https://cloud.githubusercontent.com/assets/10060731/21676414/db03515a-d378-11e6-99c9-34775e07a2e8.png) 
So it's failed to get interpreter setting lists since it doesn't have any user info. It needs reloading to get it. 
![whenshiroon](https://cloud.githubusercontent.com/assets/10060731/21676657/e08ee03e-d379-11e6-8844-6baa673e0308.gif)


Actually we don't need to send `GET_INTERPRETER_SETTINGS` msg when Zeppelin started. It would be fine when we click "Create new note" button. So I removed `init()` (it's used only for getting interpreter settings) and made `getInterpreterSettings` called only when user clicks "Create new note" in both Zeppelin home and Navbar. 


### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1902](https://issues.apache.org/jira/browse/ZEPPELIN-1902)

### How should this be tested?
In master (not this branch)
1. [Turn Shiro on](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/security/shiroauthentication.html#1-enable-shiro) and start(restart) Zeppelin 
2. Click "Create new note" in home (or Navbar)
3. the default interpreter select box will be like 
![screen shot 2017-01-05 at 7 16 08 pm](https://cloud.githubusercontent.com/assets/10060731/21676986/7a005a80-d37b-11e6-80d9-1597914c4b05.png)

but it'll be okay after reloading. It shouldn't be like that with this patch. 


### Screenshots (if appropriate)
after fixing this problem
![whenshiroonafter](https://cloud.githubusercontent.com/assets/10060731/21676678/08a2360c-d37a-11e6-9a9b-03457b88a4fb.gif)
 

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no
