### PR TITLE
[ZEPPELIN-1731] Fix unexpected EditOnDoubleClick

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -584,7 +584,8 @@
       console.log('Interpreter bindings %o saved', selectedSettingIds);
 
       _.forEach($scope.note.paragraphs, function(n, key) {
-        if (n.text && !n.text.startsWith('%')) {
+        var regExp = /^\s*%/g;
+        if (n.text && !regExp.exec(n.text)) {
           $scope.$broadcast('saveInterpreterBindings', n.id);
         }
       });

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -582,6 +582,13 @@
       }
       websocketMsgSrv.saveInterpreterBindings($scope.note.id, selectedSettingIds);
       console.log('Interpreter bindings %o saved', selectedSettingIds);
+
+      _.forEach($scope.note.paragraphs, function(n, key) {
+        if (n.text && !n.text.startsWith('%')) {
+          $scope.$broadcast('saveInterpreterBindings', n.id);
+        }
+      });
+
       $scope.showSetting = false;
     };
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -43,7 +43,10 @@
     $scope.editor = null;
 
     var editorSetting = {};
+    // flag that is used to set editor setting on paste percent sign
     var pastePercentSign = false;
+    // flag that is used to set editor setting on save interpreter bindings
+    var setInterpreterBindings = false;
     var paragraphScope = $rootScope.$new(true, $rootScope);
 
     // to keep backward compatibility
@@ -661,7 +664,8 @@
       if ((typeof pos === 'undefined') || (pos.row === 0 && pos.column < 30) ||
           (pos.row === 1 && pos.column === 0) || pastePercentSign) {
         // If paragraph loading, use config value if exists
-        if ((typeof pos === 'undefined') && $scope.paragraph.config.editorMode) {
+        if ((typeof pos === 'undefined') && $scope.paragraph.config.editorMode &&
+            !setInterpreterBindings) {
           session.setMode($scope.paragraph.config.editorMode);
         } else {
           var magic = getInterpreterName(paragraphText);
@@ -676,6 +680,7 @@
         }
       }
       pastePercentSign = false;
+      setInterpreterBindings = false;
     };
 
     var getInterpreterName = function(paragraphText) {
@@ -1151,6 +1156,13 @@
         $scope.editor.blur();
         var isDigestPass = true;
         $scope.handleFocus(false, isDigestPass);
+      }
+    });
+
+    $scope.$on('saveInterpreterBindings', function(event, paragraphId) {
+      if ($scope.paragraph.id === paragraphId) {
+        setInterpreterBindings = true;
+        setParagraphMode($scope.editor.getSession(), $scope.editor.getSession().getValue());
       }
     });
 


### PR DESCRIPTION
### What is this PR for?
This PR fixes wrong `EditOnDoubleClick` value in editor setting when default bound interpreter has changed.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1731](https://issues.apache.org/jira/browse/ZEPPELIN-1731)

### How should this be tested?
1. Set default interpreter to `md`.
2. Write below code in first paragraph and execute the paragraph. The editor should be hidden when you run.
```
## abc
pwd
```
3. Double click the result to make editor to be shown.
4. Change default interpreter to `sh`. At this point syntax highlight on `## abc` should be changed from blue to green.
5. Execute paragraph and see if editor stays displayed.

### Screenshots (if appropriate)
**Before**
![jan-05-2017 21-39-46](https://cloud.githubusercontent.com/assets/8503346/21681060/c69c68f6-d390-11e6-87fe-aebebb5244d7.gif)


**After**
![jan-05-2017 21-38-57](https://cloud.githubusercontent.com/assets/8503346/21681101/fbcd19ee-d390-11e6-98ff-296eb679677e.gif)




### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
