### PR TITLE
[ZEPPELIN-1908] Invalid Typo Method name

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1035,7 +1035,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       for (final InterpreterSetting intpSetting : intpSettings) {
         Thread t = new Thread() {
           public void run() {
-            intpSetting.closeAndRmoveAllInterpreterGroups();
+            intpSetting.closeAndRemoveAllInterpreterGroups();
           }
         };
         t.start();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -825,7 +825,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     synchronized (interpreterSettings) {
       if (interpreterSettings.containsKey(id)) {
         InterpreterSetting intp = interpreterSettings.get(id);
-        intp.closeAndRmoveAllInterpreterGroups();
+        intp.closeAndRemoveAllInterpreterGroups();
 
         interpreterSettings.remove(id);
         for (List<String> settings : interpreterBindings.values()) {
@@ -954,7 +954,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
         try {
           stopJobAllInterpreter(intpSetting);
 
-          intpSetting.closeAndRmoveAllInterpreterGroups();
+          intpSetting.closeAndRemoveAllInterpreterGroups();
           intpSetting.setOption(option);
           intpSetting.setProperties(properties);
           intpSetting.setDependencies(dependencies);
@@ -999,7 +999,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
         stopJobAllInterpreter(intpSetting);
 
-        intpSetting.closeAndRmoveAllInterpreterGroups();
+        intpSetting.closeAndRemoveAllInterpreterGroups();
 
       } else {
         throw new InterpreterException("Interpreter setting id " + id + " not found");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -190,7 +190,7 @@ public class InterpreterSetting {
     }
   }
 
-  void closeAndRmoveAllInterpreterGroups() {
+  void closeAndRemoveAllInterpreterGroups() {
     HashSet<String> groupsToRemove = new HashSet<>(interpreterGroupRef.keySet());
     for (String key : groupsToRemove) {
       closeAndRemoveInterpreterGroup(key);


### PR DESCRIPTION
### What is this PR for?
Invalid Typo Method name

closeAndRmoveAllInterpreterGroups -> closeAndRemoveAllInterpreterGroups

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1908

### Questions: no
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
