### PR TITLE
[ZEPPELIN-1912] fix: Improve perosnalized mode tooltip text

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -77,7 +77,7 @@ limitations under the License.
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode !== 'true'"
               ng-click="toggleNotePersonalizedMode()"
-              tooltip-placement="bottom" tooltip="Personal mode {{isOwner ? '' : '(owner can change)'}}"
+              tooltip-placement="bottom" tooltip="Switch to collaboration mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
         <i class="fa fa-user"></i>
       </button>
@@ -86,7 +86,7 @@ limitations under the License.
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"
-              tooltip-placement="bottom" tooltip="Collaboration mode {{isOwner ? '' : '(owner can change)'}}"
+              tooltip-placement="bottom" tooltip="Switch to personal mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
         <i class="fa fa-users"></i>
       </button>
@@ -258,7 +258,7 @@ limitations under the License.
           <i class="fa fa-lock" ng-style="{color: showPermissions ? '#3071A9' : 'black' }"></i>
         </span>
       </span>
-      
+
       <span class="btn-group">
         <button type="button" class="btn btn-default btn-xs dropdown-toggle"
                 data-toggle="dropdown">


### PR DESCRIPTION
### What is this PR for?

Currently the tooltip for personalized mode is quite confusing. Since

- tooltip text is {{Collaboration mode}}
- and when i click the icon, dialog tell me {{Do you want to personalized your analysis?}}

**Tooltips should tell us what we can do instead of just stating current state as other tooltips do**

<img width="211" alt="confusing-1" src="https://cloud.githubusercontent.com/assets/4968473/21708295/6ae778e0-d41a-11e6-8aa6-a30a3cebec74.png">

<img width="472" alt="confusing-2" src="https://cloud.githubusercontent.com/assets/4968473/21708297/6e30f01c-d41a-11e6-991e-504aadfa5dc9.png">


### What type of PR is it?
[Improvement]

### Todos

Nothing

### What is the Jira issue?

[ZEPPELIN-1912](https://issues.apache.org/jira/browse/ZEPPELIN-1912)

### How should this be tested?

1. Enable shiro and login
2. Check the tooltip text while switching modes

### Screenshots (if appropriate)

#### After

<img width="154" alt="switch-2" src="https://cloud.githubusercontent.com/assets/4968473/21708341/d869d6c4-d41a-11e6-808f-5eadd6f7727a.png">

<img width="234" alt="switch-1" src="https://cloud.githubusercontent.com/assets/4968473/21708305/7c5cef24-d41a-11e6-8524-993a880300f2.png">


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
