### PR TITLE
remove org.apache.spark.sql.hive.HiveSharedState class check

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -205,7 +205,6 @@ public class SparkInterpreter extends Interpreter {
   private boolean hiveClassesArePresent() {
     try {
       this.getClass().forName("org.apache.spark.sql.hive.HiveSessionState");
-      this.getClass().forName("org.apache.spark.sql.hive.HiveSharedState");
       this.getClass().forName("org.apache.hadoop.hive.conf.HiveConf");
       return true;
     } catch (ClassNotFoundException | NoClassDefFoundError e) {
@@ -355,7 +354,7 @@ public class SparkInterpreter extends Interpreter {
             new Class[]{ String.class, String.class},
             new Object[]{ "spark.sql.catalogImplementation", "in-memory"});
         sparkSession = Utils.invokeMethod(builder, "getOrCreate");
-        logger.info("Created Spark session with Hive support");
+        logger.info("Created Spark session with Hive support use in-memory catalogImplementation");
       }
     } else {
       sparkSession = Utils.invokeMethod(builder, "getOrCreate");


### PR DESCRIPTION
### What is this PR for?
remove org.apache.spark.sql.hive.HiveSharedState class check
because it has been removed since spark 2.1.x

### What type of PR is it?
[Bug Fix ]


### What is the Jira issue?
[ZEPPELIN-1909](https://issues.apache.org/jira/browse/ZEPPELIN-1909)

