### PR TITLE
[ZEPPELIN-1874] fix: sparkR doens't render output properly

### DIFF
--- a/spark/src/main/scala/org/apache/zeppelin/spark/ZeppelinRDisplay.scala
+++ b/spark/src/main/scala/org/apache/zeppelin/spark/ZeppelinRDisplay.scala
@@ -18,15 +18,15 @@
 package org.apache.zeppelin.spark
 
 import org.apache.zeppelin.interpreter.InterpreterResult.Code
-import org.apache.zeppelin.interpreter.InterpreterResult.Code.{SUCCESS, ERROR}
+import org.apache.zeppelin.interpreter.InterpreterResult.Code.{SUCCESS}
 import org.apache.zeppelin.interpreter.InterpreterResult.Type
 import org.apache.zeppelin.interpreter.InterpreterResult.Type.{TEXT, HTML, TABLE, IMG}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.Document.OutputSettings
+import org.jsoup.safety.Whitelist
 
 import scala.collection.JavaConversions._
-
 import scala.util.matching.Regex
 
 case class RDisplay(content: String, `type`: Type, code: Code)
@@ -64,11 +64,13 @@ object ZeppelinRDisplay {
     }
 
     return htmlDisplay(body, imageWidth)
-
   }
 
   private def textDisplay(body: Element): RDisplay = {
-    RDisplay(body.getElementsByTag("p").first().html(), TEXT, SUCCESS)
+    // remove HTML tag while preserving whitespaces and newlines
+    val text = Jsoup.clean(body.html(), "",
+      Whitelist.none(), new OutputSettings().prettyPrint(false))
+    RDisplay(text, TEXT, SUCCESS)
   }
 
   private def tableDisplay(body: Element): RDisplay = {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -183,7 +183,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         waitForFinish(p);
         System.err.println("sparkRTest=" + p.getResult().message().get(0).getData());
         assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals("[1] 3", p.getResult().message().get(0).getData());
+        assertEquals("[1] 3", p.getResult().message().get(0).getData().trim());
       }
       ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
     }


### PR DESCRIPTION
### What is this PR for?

Zeppelin sparkr only shows first element of all outputs due to invalid implementation

```scala
// https://github.com/apache/zeppelin/blob/master/spark/src/main/scala/org/apache/zeppelin/spark/ZeppelinRDisplay.scala#L71

private def textDisplay(body: Element): RDisplay = {
  // we are extracting only the first element. it shouldn't
  RDisplay(body.getElementsByTag("p").first().html(), TEXT, SUCCESS)
}
```

#### FYI

SparkR interpreter sends message which containing multiple whitespaces, newlines. But zeppelin frontend breaks the space characters. This should be handled by other issue ([ZEPPELIN-1914](https://issues.apache.org/jira/browse/ZEPPELIN-1914)). As you can see the screenshot below, the paragraph result sent from websocket keeps consequent whitespaces and newlines until rendering.

<img width="716" alt="screen shot 2017-01-06 at 4 50 06 pm" src="https://cloud.githubusercontent.com/assets/4968473/21711367/f11d7c72-d431-11e6-8b6b-e4b7cc603afb.png">


### What type of PR is it?
[Bug Fix]

### Todos

N/A

### What is the Jira issue?

[ZEPPELIN-1874](https://issues.apache.org/jira/browse/ZEPPELIN-1874)

### How should this be tested?

1. Build Zeppelin with Spark 2.0+, R, sparkR
2. Execute this paragraph

```
%spark.r
mtcarsDF <- createDataFrame(mtcars)
model <- glm(vs ~ mpg + disp + hp + wt , data = mtcarsDF, family = "binomial")
summary(model)
``` 

3. Check you can get all result. 

```
Deviance Residuals:
(Note: These are approximate quantiles with relative error &lt;= 0.01)
Min 1Q Median 3Q Max
-2.11025 -0.08567 -0.00069 0.13214 1.10483
Coefficients:
Estimate Std. Error t value Pr(&gt;|t|)
(Intercept) -23.623 23.144 -1.0207 0.30739
mpg 0.78475 0.65026 1.2068 0.2275
disp -0.031549 0.027342 -1.1539 0.24854
hp -0.072188 0.045509 -1.5862 0.11269
wt 7.335 5.2336 1.4015 0.16105
(Dispersion parameter for binomial family taken to be 1)
Null deviance: 43.860 on 31 degrees of freedom
Residual deviance: 12.873 on 27 degrees of freedom
AIC: 22.87
Number of Fisher Scoring iterations: 9
```

### Screenshots (if appropriate)

Buggy (doesn't show full result)

<img width="714" alt="buggy" src="https://cloud.githubusercontent.com/assets/4968473/21711437/723f00be-d432-11e6-9701-1bcd81f86fb7.png">


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
