### PR TITLE
ZEPPELIN-1432. Support cancellation of paragraph execution

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -66,6 +66,11 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
     <td>Whether to display app info</td>
   </tr>
   <tr>
+    <td>zeppelin.livy.pull_status.interval.millis</td>
+    <td>1000</td>
+    <td>The interval for checking paragraph execution status</td>
+  </tr>
+  <tr>
     <td>livy.spark.driver.cores</td>
     <td></td>
     <td>Driver cores. ex) 1, 2.</td>

--- a/livy/src/main/java/org/apache/zeppelin/livy/APINotFoundException.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/APINotFoundException.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.livy;
+
+/**
+ * APINotFoundException happens because we may introduce new apis in new livy version.
+ */
+public class APINotFoundException extends LivyException {
+  public APINotFoundException() {
+  }
+
+  public APINotFoundException(String message) {
+    super(message);
+  }
+
+  public APINotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public APINotFoundException(Throwable cause) {
+    super(cause);
+  }
+
+  public APINotFoundException(String message, Throwable cause, boolean enableSuppression,
+                              boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+}

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -115,6 +115,8 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       }
       LOGGER.info("Create livy session successfully with sessionId: {}, appId: {}, webUI: {}",
           sessionInfo.id, sessionInfo.appId, sessionInfo.webUIAddress);
+    } else {
+      LOGGER.info("Create livy session successfully with sessionId: {}", this.sessionInfo.id);
     }
     // check livy version
     try {
@@ -167,12 +169,17 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   public void cancel(InterpreterContext context) {
     if (livyVersion.isCancelSupported()) {
       try {
-        cancelStatement(paragraphId2StmtIdMapping.get(context.getParagraphId()));
+        if (paragraphId2StmtIdMapping.containsKey(context.getParagraphId())) {
+          cancelStatement(paragraphId2StmtIdMapping.get(context.getParagraphId()));
+        }
       } catch (LivyException e) {
-        LOGGER.warn("Fail to cancel statement {} for paragraph {} ",
-            paragraphId2StmtIdMapping.get(context.getParagraphId()), context.getParagraphId());
+        LOGGER.error("Fail to cancel statement " +
+            paragraphId2StmtIdMapping.get(context.getParagraphId()) + " for paragraph " +
+            context.getParagraphId(), e);
       } finally {
-        paragraphId2StmtIdMapping.remove(context.getParagraphId());
+        if (paragraphId2StmtIdMapping.containsKey(context.getParagraphId())) {
+          paragraphId2StmtIdMapping.remove(context.getParagraphId());
+        }
       }
     } else {
       LOGGER.warn("cancel is not supported for this version of livy: " + livyVersion);

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -168,18 +168,16 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   @Override
   public void cancel(InterpreterContext context) {
     if (livyVersion.isCancelSupported()) {
+      String paraId = context.getParagraphId();
+      Integer stmtId = paragraphId2StmtIdMapping.get(paraId);
       try {
-        if (paragraphId2StmtIdMapping.containsKey(context.getParagraphId())) {
-          cancelStatement(paragraphId2StmtIdMapping.get(context.getParagraphId()));
+        if (stmtId != null) {
+          cancelStatement(stmtId);
         }
       } catch (LivyException e) {
-        LOGGER.error("Fail to cancel statement " +
-            paragraphId2StmtIdMapping.get(context.getParagraphId()) + " for paragraph " +
-            context.getParagraphId(), e);
+        LOGGER.error("Fail to cancel statement " + stmtId + " for paragraph " + paraId, e);
       } finally {
-        if (paragraphId2StmtIdMapping.containsKey(context.getParagraphId())) {
-          paragraphId2StmtIdMapping.remove(context.getParagraphId());
-        }
+        paragraphId2StmtIdMapping.remove(paraId);
       }
     } else {
       LOGGER.warn("cancel is not supported for this version of livy: " + livyVersion);

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -49,7 +49,8 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
   protected volatile SessionInfo sessionInfo;
   private String livyURL;
-  private long sessionCreationTimeout;
+  private int sessionCreationTimeout;
+  private int pullStatusInterval;
   protected boolean displayAppInfo;
   private AtomicBoolean sessionExpired = new AtomicBoolean(false);
   private LivyVersion livyVersion;
@@ -61,8 +62,10 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   public BaseLivyInterprereter(Properties property) {
     super(property);
     this.livyURL = property.getProperty("zeppelin.livy.url");
-    this.sessionCreationTimeout = Long.parseLong(
+    this.sessionCreationTimeout = Integer.parseInt(
         property.getProperty("zeppelin.livy.create.session.timeout", 120 + ""));
+    this.pullStatusInterval = Integer.parseInt(
+        property.getProperty("zeppelin.livy.pull_status.interval.millis", 1000 + ""));
   }
 
   public abstract String getSessionKind();
@@ -217,7 +220,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
           LOGGER.error(msg);
           throw new LivyException(msg);
         }
-        Thread.sleep(1000);
+        Thread.sleep(pullStatusInterval);
         sessionInfo = getSessionInfo(sessionInfo.id);
       }
       return sessionInfo;
@@ -259,7 +262,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       // pull the statement status
       while (!stmtInfo.isAvailable()) {
         try {
-          Thread.sleep(1000);
+          Thread.sleep(pullStatusInterval);
         } catch (InterruptedException e) {
           LOGGER.error("InterruptedException when pulling statement status.", e);
           throw new LivyException(e);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -51,7 +51,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
     // As we don't know whether livyserver use spark2 or spark1, so we will detect SparkSession
     // to judge whether it is using spark2.
     try {
-      InterpreterResult result = sparkInterpreter.interpret("spark", false, false);
+      InterpreterResult result = sparkInterpreter.interpret("spark", null, false, false);
       if (result.code() == InterpreterResult.Code.SUCCESS &&
           result.message().get(0).getData().contains("org.apache.spark.sql.SparkSession")) {
         LOGGER.info("SparkSession is detected so we are using spark 2.x for session {}",
@@ -59,7 +59,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
         isSpark2 = true;
       } else {
         // spark 1.x
-        result = sparkInterpreter.interpret("sqlContext", false, false);
+        result = sparkInterpreter.interpret("sqlContext", null, false, false);
         if (result.code() == InterpreterResult.Code.SUCCESS) {
           LOGGER.info("sqlContext is detected.");
         } else if (result.code() == InterpreterResult.Code.ERROR) {
@@ -68,7 +68,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
           LOGGER.info("sqlContext is not detected, try to create SQLContext by ourselves");
           result = sparkInterpreter.interpret(
               "val sqlContext = new org.apache.spark.sql.SQLContext(sc)\n"
-                  + "import sqlContext.implicits._", false, false);
+                  + "import sqlContext.implicits._", null, false, false);
           if (result.code() == InterpreterResult.Code.ERROR) {
             throw new LivyException("Fail to create SQLContext," +
                 result.message().get(0).getData());
@@ -113,7 +113,8 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
       } else {
         sqlQuery = "sqlContext.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ")";
       }
-      InterpreterResult result = sparkInterpreter.interpret(sqlQuery, this.displayAppInfo, true);
+      InterpreterResult result = sparkInterpreter.interpret(sqlQuery, context.getParagraphId(),
+          this.displayAppInfo, true);
 
       if (result.code() == InterpreterResult.Code.SUCCESS) {
         InterpreterResult result2 = new InterpreterResult(InterpreterResult.Code.SUCCESS);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
@@ -1,0 +1,96 @@
+package org.apache.zeppelin.livy;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provide reading comparing capability of livy version
+ */
+public class LivyVersion {
+  private static final Logger logger = LoggerFactory.getLogger(LivyVersion.class);
+
+  private static final LivyVersion LIVY_0_2_0 = LivyVersion.fromVersionString("0.2.0");
+  private static final LivyVersion LIVY_0_3_0 = LivyVersion.fromVersionString("0.3.0");
+
+  private int version;
+  private String versionString;
+
+  LivyVersion(String versionString) {
+    this.versionString = versionString;
+
+    try {
+      int pos = versionString.indexOf('-');
+
+      String numberPart = versionString;
+      if (pos > 0) {
+        numberPart = versionString.substring(0, pos);
+      }
+
+      String versions[] = numberPart.split("\\.");
+      int major = Integer.parseInt(versions[0]);
+      int minor = Integer.parseInt(versions[1]);
+      int patch = Integer.parseInt(versions[2]);
+      // version is always 5 digits. (e.g. 2.0.0 -> 20000, 1.6.2 -> 10602)
+      version = Integer.parseInt(String.format("%d%02d%02d", major, minor, patch));
+    } catch (Exception e) {
+      logger.error("Can not recognize Livy version " + versionString +
+          ". Assume it's a future release", e);
+
+      // assume it is future release
+      version = 99999;
+    }
+  }
+
+  public int toNumber() {
+    return version;
+  }
+
+  public String toString() {
+    return versionString;
+  }
+
+  public static LivyVersion fromVersionString(String versionString) {
+    return new LivyVersion(versionString);
+  }
+
+  public boolean isCancelSupported() {
+    return this.newerThanEquals(LIVY_0_3_0);
+  }
+
+  public boolean equals(Object versionToCompare) {
+    return version == ((LivyVersion) versionToCompare).version;
+  }
+
+  public boolean newerThan(LivyVersion versionToCompare) {
+    return version > versionToCompare.version;
+  }
+
+  public boolean newerThanEquals(LivyVersion versionToCompare) {
+    return version >= versionToCompare.version;
+  }
+
+  public boolean olderThan(LivyVersion versionToCompare) {
+    return version < versionToCompare.version;
+  }
+
+  public boolean olderThanEquals(LivyVersion versionToCompare) {
+    return version <= versionToCompare.version;
+  }
+}

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -77,6 +77,11 @@
         "defaultValue": "",
         "description": "Kerberos keytab to authenticate livy"
       },
+      "zeppelin.livy.pull_status.interval.millis": {
+        "propertyName": "zeppelin.livy.pull_status.interval.millis",
+        "defaultValue": "1000",
+        "description": "The interval for checking paragraph execution status"
+      },
       "livy.spark.jars.packages": {
         "propertyName": "livy.spark.jars.packages",
         "defaultValue": "",


### PR DESCRIPTION
### What is this PR for?
Livy 0.3 support cancel operation, this PR is to support cancel in livy interpreter. First we would check the livy version, then based on the livy version, we would call the livy rest api to cancel the statement. 


### What type of PR is it?
 Improvement | Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1432

### How should this be tested?
Tested manually, because cancel is only avaible in livy 0.3 which is not released yet. 

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/21712520/3ed292ec-d430-11e6-8829-581e1bba1a9c.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
