### PR TITLE
ZEPPELIN-1293. Livy Interpreter: Automatically attach or create to a new session

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -259,7 +259,8 @@ public abstract class BaseLivyInterprereter extends Interpreter {
     if (sessionExpired) {
       InterpreterResult result2 = new InterpreterResult(result.code());
       result2.add(InterpreterResult.Type.HTML,
-          "<font color=\"red\">Previous session is expired, new session is created.</font>");
+          "<font color=\"red\">Previous livy session is expired, new livy session is created. " +
+              "Paragraphs that depend on this paragraph need to be re-executed!" + "</font>");
       for (InterpreterResultMessage message : result.message()) {
         result2.add(message.getType(), message.getData());
       }


### PR DESCRIPTION
### What is this PR for?
By default, livy session will expire after one hour. This PR would create session automatically for user if session is expired, and would also display the session expire information in frontend. The expire message would only display at the first time of session recreation, after that the message won't be displayed. 


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1293

### How should this be tested?
Tested manually. 
![image](https://cloud.githubusercontent.com/assets/164491/21761175/2473c0c0-d68c-11e6-8f39-9e87333c6168.png)




### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
