### PR TITLE
[HOTFIX] Removed non-string properties values since it's not used

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -92,7 +92,7 @@ public class RemoteInterpreter extends Interpreter {
    * Connect to existing process
    */
   public RemoteInterpreter(Properties property, String sessionKey, String className, String host,
-      int port, int connectTimeout, int maxPoolSize,
+      int port, String localRepoPath, int connectTimeout, int maxPoolSize,
       RemoteInterpreterProcessListener remoteInterpreterProcessListener,
       ApplicationEventListener appListener, String userName, Boolean isUserImpersonate) {
     super(property);
@@ -101,6 +101,7 @@ public class RemoteInterpreter extends Interpreter {
     initialized = false;
     this.host = host;
     this.port = port;
+    this.localRepoPath = localRepoPath;
     this.connectTimeout = connectTimeout;
     this.maxPoolSize = maxPoolSize;
     this.remoteInterpreterProcessListener = remoteInterpreterProcessListener;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -789,8 +789,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       if (option.isRemote()) {
         if (option.isExistingProcess()) {
           interpreter =
-              connectToRemoteRepl(noteId, info.getClassName(), option.getHost(), option.getPort(),
-                  properties, user, option.isUserImpersonate);
+              connectToRemoteRepl(interpreterSessionKey, info.getClassName(), option.getHost(), option.getPort(),
+                  properties, interpreterSetting.getId(), user, option.isUserImpersonate);
         } else {
           interpreter = createRemoteRepl(path, interpreterSessionKey, info.getClassName(),
               properties, interpreterSetting.getId(), user, option.isUserImpersonate(), runner);
@@ -1107,11 +1107,13 @@ public class InterpreterFactory implements InterpreterGroupFactory {
   }
 
   private Interpreter connectToRemoteRepl(String interpreterSessionKey, String className,
-      String host, int port, Properties property, String userName, Boolean isUserImpersonate) {
+      String host, int port, Properties property, String interpreterSettingId, String userName,
+      Boolean isUserImpersonate) {
     int connectTimeout = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT);
     int maxPoolSize = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE);
+    String localRepoPath = conf.getInterpreterLocalRepoPath() + "/" + interpreterSettingId;
     LazyOpenInterpreter intp = new LazyOpenInterpreter(
-        new RemoteInterpreter(property, interpreterSessionKey, className, host, port,
+        new RemoteInterpreter(property, interpreterSessionKey, className, host, port, localRepoPath,
             connectTimeout, maxPoolSize, remoteInterpreterProcessListener, appEventListener,
             userName, isUserImpersonate));
     return intp;
@@ -1435,7 +1437,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       InterpreterGroup interpreterGroup = createInterpreterGroup("dev", option);
 
       devInterpreter = connectToRemoteRepl("dev", DevInterpreter.class.getName(), "localhost",
-          ZeppelinDevServer.DEFAULT_TEST_INTERPRETER_PORT, new Properties(), "anonymous", false);
+          ZeppelinDevServer.DEFAULT_TEST_INTERPRETER_PORT, new Properties(), "dev", "anonymous",
+          false);
 
       LinkedList<Interpreter> intpList = new LinkedList<>();
       intpList.add(devInterpreter);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -758,10 +758,6 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     InterpreterGroup interpreterGroup = interpreterSetting.getInterpreterGroup(user, noteId);
     InterpreterOption option = interpreterSetting.getOption();
     Properties properties = (Properties) interpreterSetting.getProperties();
-    if (option.isExistingProcess) {
-      properties.put(Constants.ZEPPELIN_INTERPRETER_HOST, option.getHost());
-      properties.put(Constants.ZEPPELIN_INTERPRETER_PORT, option.getPort());
-    }
     // if interpreters are already there, wait until they're being removed
     synchronized (interpreterGroup) {
       long interpreterRemovalWaitStart = System.nanoTime();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -789,8 +789,9 @@ public class InterpreterFactory implements InterpreterGroupFactory {
       if (option.isRemote()) {
         if (option.isExistingProcess()) {
           interpreter =
-              connectToRemoteRepl(interpreterSessionKey, info.getClassName(), option.getHost(), option.getPort(),
-                  properties, interpreterSetting.getId(), user, option.isUserImpersonate);
+              connectToRemoteRepl(interpreterSessionKey, info.getClassName(), option.getHost(),
+                  option.getPort(), properties, interpreterSetting.getId(), user,
+                  option.isUserImpersonate);
         } else {
           interpreter = createRemoteRepl(path, interpreterSessionKey, info.getClassName(),
               properties, interpreterSetting.getId(), user, option.isUserImpersonate(), runner);


### PR DESCRIPTION
### What is this PR for?
Removing an error when users try to connect running interpreter. Zeppelin Server passes those properties into RemoteInterpreter when it starts with RemoteInterpreter. But it supports only Map<String, String> type for now, thus port information will make an error and also those information were not used in any code

### What type of PR is it?
[Hot Fix]

### Todos
* [ ] - Remove some properties

### What is the Jira issue?
N/A

### How should this be tested?
`Connect to existing process` should work well

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
