### PR TITLE
[ZEPPELIN-1920] Fail to load app.js when ZEPPELIN_SERVER_CONTEXT_PATH is set

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -381,13 +381,13 @@ a.navbar-brand:hover {
 }
 
 .zeppelin {
-  background: url('/assets/images/zepLogo.png') no-repeat right;
+  background: url('../assets/images/zepLogo.png') no-repeat right;
   height: 380px;
   opacity: 0.2;
 }
 
 .zeppelin2 {
-  background: url('/assets/images/zepLogo.png') no-repeat right;
+  background: url('../assets/images/zepLogo.png') no-repeat right;
   background-position-y: 12px;
   height: 380px;
   opacity: 0.2;

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = function makeWebpackConfig () {
 
     // Output path from the view of the page
     // Uses webpack-dev-server in development
-    publicPath: isProd ? '/' : 'http://localhost:9000/',
+    publicPath: isProd ? '' : 'http://localhost:9000/',
 
     // Filename for entry points
     // Only adds hash in build mode


### PR DESCRIPTION
### What is this PR for?
If user set env variable `ZEPPELIN_SERVER_CONTEXT_PATH`, web fails to load `app.xxxxx.js` because `webpack.config.js` configures root path to be `/`.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1920](https://issues.apache.org/jira/browse/ZEPPELIN-1920)

### How should this be tested?
1. open `conf/zeppelin-env.sh` and paste below:
```
export ZEPPELIN_SERVER_CONTEXT_PATH="/zeppelin/"
```
2. start zeppelin
3. see if you can load `localhost:8080/zeppelin` in browser

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
