### PR TITLE
[ZEPPELIN-1723] Math formula support library path error

### DIFF
--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -104,6 +104,7 @@ limitations under the License.
 
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
+        root: ".",
         extensions: ["tex2jax.js"],
         jax: ["input/TeX", "output/HTML-CSS"],
         tex2jax: {

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -103,8 +103,7 @@ limitations under the License.
     <!-- endbuild -->
 
     <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        root: ".",
+      var config = {
         extensions: ["tex2jax.js"],
         jax: ["input/TeX", "output/HTML-CSS"],
         tex2jax: {
@@ -114,7 +113,12 @@ limitations under the License.
         },
         "HTML-CSS": { availableFonts: ["TeX"] },
         messageStyle: "none"
-      });
+      }
+      // add root only if it's not dev mode
+      if (Number(location.port) !== 9000) {
+        config.root = '.';
+      }
+      MathJax.Hub.Config(config);
     </script>
 
     <!-- build:js(.) scripts/vendor.js -->


### PR DESCRIPTION
### What is this PR for?
When user set `ZEPPELIN_SERVER_CONTEXT_PATH`, web cannot find MathJax library because root location is set to `/`.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1723](https://issues.apache.org/jira/browse/ZEPPELIN-1723)

### How should this be tested?
1. Checkout remote branch, and cherry-pick one commit from #1863 which is needed to try out this PR:
    ```
    $ ./dev/test_zeppelin_pr.py 1865
    $ git cherry-pick dbae64d
    $ mvn clean package -DskipTests -pl '!zeppelin-distribution,!alluxio,!ignite,!lens,!kylin,!scio,!hbase,!pig,!file,!flink,!cassandra,!elasticsearch,!bigquery,!postgresql,!jdbc,!python,!angular,!sh,!livy'
    ```
2. Set `ZEPPELIN_SERVER_CONTEXT_PATH` in conf/zeppelin-env.sh and start Zeppelin
3. See if error occurs in browser inspection console.
4. Test if you can use Math function with pegdown md interpreter:
   ```
   %md
   When \\(a \\ne 0\\), there are two solutions to \\(ax^2 + bx + c = 0\\) and they are
   $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
   ```
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
