### PR TITLE
[MINOR] Remove redundant log4j license

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -17,7 +17,6 @@ The following components are provided under Apache License.
     (Apache 2.0) Apache Commons Lang 3 (org.apache.commons:commons-lang3:3.4 - http://commons.apache.org/proper/commons-lang/)
     (Apache 2.0) Apache Commons Math 3 (org.apache.commons:commons-math3:3.6.1 - http://commons.apache.org/proper/commons-math/)
     (Apache 2.0) Apache Commons Net (commons-net:commons-net:2.2 - http://commons.apache.org/proper/commons-net/)
-    (Apache 2.0) Apache log4j (log4j:log4j:1.2.17 - http://logging.apache.org/log4j/1.2/)
     (Apache 2.0) Apache Commons Pool2 (commons-exec:commons-pool2:2.3 - https://commons.apache.org/proper/commons-pool/)
     (Apache 2.0) Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.3.1 - http://commons.apache.org/fileupload/)
     (Apache 2.0) Apache Commons IO (commons-io:commons-io:2.4 - http://commons.apache.org/io/)


### PR DESCRIPTION
### What is this PR for?
Remove redundant log4j license: [L20](https://github.com/apache/zeppelin/blob/master/zeppelin-distribution/src/bin_license/LICENSE#L20), [L148](https://github.com/apache/zeppelin/blob/master/zeppelin-distribution/src/bin_license/LICENSE#L148)

### What type of PR is it?
License

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
