### PR TITLE
[MINOR][ZEPPELIN-1919] Reduce markdown intp's plain text font size

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -478,7 +478,7 @@ table.dataTable.table-condensed .sorting_desc:after {
 }
 
 /*
-  Paragaph Font CSS
+  Paragraph Font CSS
 */
 
 .lightBold {
@@ -560,4 +560,34 @@ table.table-striped {
 }
 .changeTypeMenu li:hover {
   background: #eee;
+}
+
+/*
+  Overwrite github-markdown-css for Markdown interpreter
+*/
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.markdown-body {
+  font-size: 14px;
+}
+
+.markdown-body h2 {
+  font-size: 26px;
+}
+
+.markdown-body h3 {
+  font-size: 20px;
+}
+
+.markdown-body h4 {
+  font-size: 16px;
 }


### PR DESCRIPTION
### What is this PR for?
Currently Zeppelin `%md` result style is using [`github-markdown-css`](https://github.com/sindresorhus/github-markdown-css). But the plain text's font-size a bit bigger than any other interpreter's. And the margin between the text paragraph is also wider than before. So I reduced them. 

### What type of PR is it?
Improvement


### What is the Jira issue?
[ZEPPELIN-1919](https://issues.apache.org/jira/browse/ZEPPELIN-1919)

### How should this be tested?
 - After applying this patch, run dev mode under `zeppelin-web` \w `npm run dev`
 - Compare the font size using `%md` interpreter

### Screenshots (if appropriate)
 - Before 
![before](https://cloud.githubusercontent.com/assets/10060731/21746484/116d9986-d58a-11e6-878c-40b84c488020.png)



 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/21746486/16ff6514-d58a-11e6-9800-3b0193dcc694.png)




### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
