### PR TITLE
[ZEPPELIN-1917] Improve python.conda interpreter

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -45,6 +45,7 @@ public class PythonCondaInterpreter extends Interpreter {
   private Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   private Pattern deactivatePattern = Pattern.compile("deactivate");
   private Pattern installPattern = Pattern.compile("install\\s*(.*)");
+  private Pattern uninstallPattern = Pattern.compile("[uninstall|remove]\\s*(.*)");
   private Pattern helpPattern = Pattern.compile("help");
   private Pattern infoPattern = Pattern.compile("info");
 
@@ -68,6 +69,7 @@ public class PythonCondaInterpreter extends Interpreter {
     Matcher activateMatcher = activatePattern.matcher(st);
     Matcher createMatcher = createPattern.matcher(st);
     Matcher installMatcher = installPattern.matcher(st);
+    Matcher uninstallMatcher = uninstallPattern.matcher(st);
 
     try {
       if (st == null || listEnvPattern.matcher(st).matches()) {
@@ -91,6 +93,9 @@ public class PythonCondaInterpreter extends Interpreter {
         return new InterpreterResult(Code.SUCCESS, "Deactivated");
       } else if (installMatcher.matches()) {
         String result = runCondaInstall(getRestArgsFromMatcher(installMatcher));
+        return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
+      } else if (uninstallMatcher.matches()) {
+        String result = runCondaUninstall(getRestArgsFromMatcher(uninstallMatcher));
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
       } else if (helpPattern.matcher(st).matches()) {
         runCondaHelp(out);
@@ -234,6 +239,24 @@ public class PythonCondaInterpreter extends Interpreter {
     }
 
     return wrapCondaBasicOutputStyle("Package Installation", sb.toString());
+  }
+
+  private String runCondaUninstall(List<String> restArgs)
+      throws IOException, InterruptedException {
+
+    restArgs.add(0, "conda");
+    restArgs.add(1, "uninstall");
+    restArgs.add(2, "--yes");
+
+    StringBuilder sb = new StringBuilder();
+    int exit = runCommand(sb, restArgs);
+    if (exit != 0) {
+      throw new RuntimeException("Failed to execute `" +
+          StringUtils.join(restArgs, " ") +
+          "` exited with " + exit);
+    }
+
+    return wrapCondaBasicOutputStyle("Package Uninstallation", sb.toString());
   }
 
   private String wrapCondaBasicOutputStyle(String title, String content) {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -60,12 +60,9 @@ public class PythonCondaInterpreter extends Interpreter {
   public InterpreterResult interpret(String st, InterpreterContext context) {
     InterpreterOutput out = context.out;
 
-    Matcher listEnvMatcher = listEnvPattern.matcher(st);
     Matcher activateMatcher = activatePattern.matcher(st);
-    Matcher deactivateMatcher = deactivatePattern.matcher(st);
-    Matcher helpMatcher = helpPattern.matcher(st);
 
-    if (st == null || listEnvMatcher.matches()) {
+    if (st == null || listEnvPattern.matcher(st).matches()) {
       listEnv(out, getCondaEnvs());
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     } else if (activateMatcher.matches()) {
@@ -73,11 +70,11 @@ public class PythonCondaInterpreter extends Interpreter {
       changePythonEnvironment(envName);
       restartPythonProcess();
       return new InterpreterResult(InterpreterResult.Code.SUCCESS, "\"" + envName + "\" activated");
-    } else if (deactivateMatcher.matches()) {
+    } else if (deactivatePattern.matcher(st).matches()) {
       changePythonEnvironment(null);
       restartPythonProcess();
       return new InterpreterResult(InterpreterResult.Code.SUCCESS, "Deactivated");
-    } else if (helpMatcher.matches()) {
+    } else if (helpPattern.matcher(st).matches()) {
       printUsage(out);
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     } else {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -17,6 +17,8 @@
 package org.apache.zeppelin.python;
 
 import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,26 +67,25 @@ public class PythonCondaInterpreter extends Interpreter {
     try {
       if (st == null || listEnvPattern.matcher(st).matches()) {
         runCondaEnvList(out, getCondaEnvs());
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS);
+        return new InterpreterResult(Code.SUCCESS);
       } else if (activateMatcher.matches()) {
         String envName = activateMatcher.group(1);
         changePythonEnvironment(envName);
         restartPythonProcess();
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS,
+        return new InterpreterResult(Code.SUCCESS,
             "\"" + envName + "\" activated");
       } else if (deactivatePattern.matcher(st).matches()) {
         changePythonEnvironment(null);
         restartPythonProcess();
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS, "Deactivated");
+        return new InterpreterResult(Code.SUCCESS, "Deactivated");
       } else if (helpPattern.matcher(st).matches()) {
         printCondaUsage(out);
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS);
+        return new InterpreterResult(Code.SUCCESS);
       } else if (infoPattern.matcher(st).matches()) {
         String result = runCondaInfo();
-        return new InterpreterResult(InterpreterResult.Code.SUCCESS,
-            InterpreterResult.Type.TEXT, result);
+        return new InterpreterResult(Code.SUCCESS, Type.TEXT, result);
       } else {
-        return new InterpreterResult(InterpreterResult.Code.ERROR, "Not supported command: " + st);
+        return new InterpreterResult(Code.ERROR, "Not supported command: " + st);
       }
     } catch (RuntimeException | IOException | InterruptedException e) {
       throw new InterpreterException(e);
@@ -121,7 +122,8 @@ public class PythonCondaInterpreter extends Interpreter {
   protected PythonInterpreter getPythonInterpreter() {
     LazyOpenInterpreter lazy = null;
     PythonInterpreter python = null;
-    Interpreter p = getInterpreterInTheSameSessionByClassName(PythonInterpreter.class.getName());
+    Interpreter p =
+        getInterpreterInTheSameSessionByClassName(PythonInterpreter.class.getName());
 
     while (p instanceof WrappedInterpreter) {
       if (p instanceof LazyOpenInterpreter) {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -45,7 +45,7 @@ public class PythonCondaInterpreter extends Interpreter {
   private Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   private Pattern deactivatePattern = Pattern.compile("deactivate");
   private Pattern installPattern = Pattern.compile("install\\s*(.*)");
-  private Pattern uninstallPattern = Pattern.compile("[uninstall|remove]\\s*(.*)");
+  private Pattern uninstallPattern = Pattern.compile("uninstall\\s*(.*)");
   private Pattern helpPattern = Pattern.compile("help");
   private Pattern infoPattern = Pattern.compile("info");
 

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -40,6 +40,7 @@ public class PythonCondaInterpreter extends Interpreter {
 
   private Pattern condaEnvListPattern = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
   private Pattern listEnvPattern = Pattern.compile("env\\s*list\\s?");
+  private Pattern listPattern = Pattern.compile("list");
   private Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   private Pattern deactivatePattern = Pattern.compile("deactivate");
   private Pattern helpPattern = Pattern.compile("help");
@@ -68,6 +69,9 @@ public class PythonCondaInterpreter extends Interpreter {
       if (st == null || listEnvPattern.matcher(st).matches()) {
         runCondaEnvList(out, getCondaEnvs());
         return new InterpreterResult(Code.SUCCESS);
+      } else if (listPattern.matcher(st).matches()) {
+        String result = runCondaList();
+        return new InterpreterResult(Code.SUCCESS, Type.TEXT, result);
       } else if (activateMatcher.matches()) {
         String envName = activateMatcher.group(1);
         changePythonEnvironment(envName);
@@ -183,6 +187,16 @@ public class PythonCondaInterpreter extends Interpreter {
     out.write("<small><code>%python.conda help</code> for the usage</small>\n");
   }
 
+  private String runCondaList() throws IOException, InterruptedException {
+    StringBuilder out = createStringBuilder();
+    int exit = runCommand(out, "conda", "list");
+    if (exit != 0) {
+      throw new RuntimeException("Failed to execute conda list. exited with " + exit);
+    }
+
+    return out.toString();
+  }
+
   private String runCondaInfo() throws IOException, InterruptedException {
     StringBuilder out = createStringBuilder();
     int exit = runCommand(out, "conda", "info");
@@ -248,6 +262,7 @@ public class PythonCondaInterpreter extends Interpreter {
   }
 
   protected StringBuilder createStringBuilder() {
+    // to support mocking in test
     return new StringBuilder();
   }
 }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -63,7 +63,7 @@ public class PythonCondaInterpreter extends Interpreter {
     Matcher activateMatcher = activatePattern.matcher(st);
 
     if (st == null || listEnvPattern.matcher(st).matches()) {
-      listEnv(out, getCondaEnvs());
+      runCondaEnvList(out, getCondaEnvs());
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     } else if (activateMatcher.matches()) {
       String envName = activateMatcher.group(1);
@@ -75,10 +75,10 @@ public class PythonCondaInterpreter extends Interpreter {
       restartPythonProcess();
       return new InterpreterResult(InterpreterResult.Code.SUCCESS, "Deactivated");
     } else if (helpPattern.matcher(st).matches()) {
-      printUsage(out);
+      printCondaUsage(out);
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     } else if (infoPattern.matcher(st).matches()) {
-      String result = getCondaInfoCommand();
+      String result = runCondaInfo();
       return new InterpreterResult(InterpreterResult.Code.SUCCESS,
           InterpreterResult.Type.TEXT, result);
     } else {
@@ -158,7 +158,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return envList;
   }
 
-  private void listEnv(InterpreterOutput out, HashMap<String, String> envList) {
+  private void runCondaEnvList(InterpreterOutput out, HashMap<String, String> envList) {
     try {
       out.setType(InterpreterResult.Type.HTML);
       out.write("<h4>Conda environments</h4>\n");
@@ -182,7 +182,7 @@ public class PythonCondaInterpreter extends Interpreter {
     }
   }
 
-  private String getCondaInfoCommand() {
+  private String runCondaInfo() {
     StringBuilder out = createStringBuilder();
     try {
       int exit = runCommand(out, "conda", "info");
@@ -196,7 +196,7 @@ public class PythonCondaInterpreter extends Interpreter {
     }
   }
 
-  private void printUsage(InterpreterOutput out) {
+  private void printCondaUsage(InterpreterOutput out) {
     try {
       out.setType(InterpreterResult.Type.HTML);
       out.writeResource("output_templates/conda_usage.html");

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -82,15 +82,10 @@ public class PythonCondaInterpreter extends Interpreter {
         String result = runCondaCreate(getRestArgsFromMatcher(createMatcher));
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
       } else if (activateMatcher.matches()) {
-        String envName = activateMatcher.group(1);
-        changePythonEnvironment(envName);
-        restartPythonProcess();
-        return new InterpreterResult(Code.SUCCESS,
-            "\"" + envName + "\" activated");
+        String envName = activateMatcher.group(1).trim();
+        return runCondaActivate(envName);
       } else if (deactivatePattern.matcher(st).matches()) {
-        changePythonEnvironment(null);
-        restartPythonProcess();
-        return new InterpreterResult(Code.SUCCESS, "Deactivated");
+        return runCondaDeactivate();
       } else if (installMatcher.matches()) {
         String result = runCondaInstall(getRestArgsFromMatcher(installMatcher));
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
@@ -201,6 +196,27 @@ public class PythonCondaInterpreter extends Interpreter {
 
   private String runCondaEnvList() throws IOException, InterruptedException {
     return wrapCondaTableOutputStyle("Environment List", getCondaEnvs());
+  }
+
+  private InterpreterResult runCondaActivate(String envName)
+      throws IOException, InterruptedException {
+
+    if (null == envName || envName.isEmpty()) {
+      return new InterpreterResult(Code.ERROR, "Env name should be specified");
+    }
+
+    changePythonEnvironment(envName);
+    restartPythonProcess();
+
+    return new InterpreterResult(Code.SUCCESS, "'" + envName + "' is activated");
+  }
+
+  private InterpreterResult runCondaDeactivate()
+      throws IOException, InterruptedException {
+
+    changePythonEnvironment(null);
+    restartPythonProcess();
+    return new InterpreterResult(Code.SUCCESS, "Deactivated");
   }
 
   private String runCondaList() throws IOException, InterruptedException {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -276,9 +276,12 @@ public class PythonCondaInterpreter extends Interpreter {
   public static String wrapCondaBasicOutputStyle(String title, String content) {
     StringBuilder sb = new StringBuilder();
     if (null != title && !title.isEmpty()) {
-      sb.append("<h4>").append(title).append("</h4>\n");
+      sb.append("<h4>").append(title).append("</h4>\n")
+          .append("</div><br />\n");
     }
-    sb.append("</div><br />\n").append(content);
+    sb.append("<div style=\"white-space:pre-wrap;\">\n")
+        .append(content)
+        .append("</div>");
 
     return sb.toString();
   }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -37,7 +37,7 @@ public class PythonCondaInterpreter extends Interpreter {
   public static final String DEFAULT_ZEPPELIN_PYTHON = "python";
 
   Pattern condaEnvListPattern = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
-  Pattern listPattern = Pattern.compile("env\\s*list\\s?");
+  Pattern listEnvPattern = Pattern.compile("env\\s*list\\s?");
   Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   Pattern deactivatePattern = Pattern.compile("deactivate");
   Pattern helpPattern = Pattern.compile("help");
@@ -60,12 +60,12 @@ public class PythonCondaInterpreter extends Interpreter {
   public InterpreterResult interpret(String st, InterpreterContext context) {
     InterpreterOutput out = context.out;
 
-    Matcher listMatcher = listPattern.matcher(st);
+    Matcher listEnvMatcher = listEnvPattern.matcher(st);
     Matcher activateMatcher = activatePattern.matcher(st);
     Matcher deactivateMatcher = deactivatePattern.matcher(st);
     Matcher helpMatcher = helpPattern.matcher(st);
 
-    if (st == null || st.isEmpty() || listMatcher.matches()) {
+    if (st == null || listEnvMatcher.matches()) {
       listEnv(out, getCondaEnvs());
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
     } else if (activateMatcher.matches()) {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -36,12 +36,12 @@ public class PythonCondaInterpreter extends Interpreter {
   public static final String CONDA_PYTHON_PATH = "/bin/python";
   public static final String DEFAULT_ZEPPELIN_PYTHON = "python";
 
-  Pattern condaEnvListPattern = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
-  Pattern listEnvPattern = Pattern.compile("env\\s*list\\s?");
-  Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
-  Pattern deactivatePattern = Pattern.compile("deactivate");
-  Pattern helpPattern = Pattern.compile("help");
-  Pattern infoPattern = Pattern.compile("info");
+  private Pattern condaEnvListPattern = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
+  private Pattern listEnvPattern = Pattern.compile("env\\s*list\\s?");
+  private Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
+  private Pattern deactivatePattern = Pattern.compile("deactivate");
+  private Pattern helpPattern = Pattern.compile("help");
+  private Pattern infoPattern = Pattern.compile("info");
 
   public PythonCondaInterpreter(Properties property) {
     super(property);

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -38,17 +38,17 @@ public class PythonCondaInterpreter extends Interpreter {
   public static final String CONDA_PYTHON_PATH = "/bin/python";
   public static final String DEFAULT_ZEPPELIN_PYTHON = "python";
 
-  private Pattern condaEnvListPattern = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
-  private Pattern listEnvPattern = Pattern.compile("env\\s*list\\s?");
-  private Pattern envPattern = Pattern.compile("env\\s*(.*)");
-  private Pattern listPattern = Pattern.compile("list");
-  private Pattern createPattern = Pattern.compile("create\\s*(.*)");
-  private Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
-  private Pattern deactivatePattern = Pattern.compile("deactivate");
-  private Pattern installPattern = Pattern.compile("install\\s*(.*)");
-  private Pattern uninstallPattern = Pattern.compile("uninstall\\s*(.*)");
-  private Pattern helpPattern = Pattern.compile("help");
-  private Pattern infoPattern = Pattern.compile("info");
+  public static final Pattern PATTERN_OUTPUT_ENV_LIST = Pattern.compile("([^\\s]*)[\\s*]*\\s(.*)");
+  public static final Pattern PATTERN_COMMAND_ENV_LIST = Pattern.compile("env\\s*list\\s?");
+  public static final Pattern PATTERN_COMMAND_ENV = Pattern.compile("env\\s*(.*)");
+  public static final Pattern PATTERN_COMMAND_LIST = Pattern.compile("list");
+  public static final Pattern PATTERN_COMMAND_CREATE = Pattern.compile("create\\s*(.*)");
+  public static final Pattern PATTERN_COMMAND_ACTIVATE = Pattern.compile("activate\\s*(.*)");
+  public static final Pattern PATTERN_COMMAND_DEACTIVATE = Pattern.compile("deactivate");
+  public static final Pattern PATTERN_COMMAND_INSTALL = Pattern.compile("install\\s*(.*)");
+  public static final Pattern PATTERN_COMMAND_UNINSTALL = Pattern.compile("uninstall\\s*(.*)");
+  public static final Pattern PATTERN_COMMAND_HELP = Pattern.compile("help");
+  public static final Pattern PATTERN_COMMAND_INFO = Pattern.compile("info");
 
   public PythonCondaInterpreter(Properties property) {
     super(property);
@@ -67,21 +67,21 @@ public class PythonCondaInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     InterpreterOutput out = context.out;
-    Matcher activateMatcher = activatePattern.matcher(st);
-    Matcher createMatcher = createPattern.matcher(st);
-    Matcher installMatcher = installPattern.matcher(st);
-    Matcher uninstallMatcher = uninstallPattern.matcher(st);
-    Matcher envMatcher = envPattern.matcher(st);
+    Matcher activateMatcher = PATTERN_COMMAND_ACTIVATE.matcher(st);
+    Matcher createMatcher = PATTERN_COMMAND_CREATE.matcher(st);
+    Matcher installMatcher = PATTERN_COMMAND_INSTALL.matcher(st);
+    Matcher uninstallMatcher = PATTERN_COMMAND_UNINSTALL.matcher(st);
+    Matcher envMatcher = PATTERN_COMMAND_ENV.matcher(st);
 
     try {
-      if (listEnvPattern.matcher(st).matches()) {
+      if (PATTERN_COMMAND_ENV_LIST.matcher(st).matches()) {
         String result = runCondaEnvList();
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
       } else if (envMatcher.matches()) {
         // `envMatcher` should be used after `listEnvMatcher`
         String result = runCondaEnv(getRestArgsFromMatcher(envMatcher));
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
-      } else if (listPattern.matcher(st).matches()) {
+      } else if (PATTERN_COMMAND_LIST.matcher(st).matches()) {
         String result = runCondaList();
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
       } else if (createMatcher.matches()) {
@@ -90,7 +90,7 @@ public class PythonCondaInterpreter extends Interpreter {
       } else if (activateMatcher.matches()) {
         String envName = activateMatcher.group(1).trim();
         return runCondaActivate(envName);
-      } else if (deactivatePattern.matcher(st).matches()) {
+      } else if (PATTERN_COMMAND_DEACTIVATE.matcher(st).matches()) {
         return runCondaDeactivate();
       } else if (installMatcher.matches()) {
         String result = runCondaInstall(getRestArgsFromMatcher(installMatcher));
@@ -98,10 +98,10 @@ public class PythonCondaInterpreter extends Interpreter {
       } else if (uninstallMatcher.matches()) {
         String result = runCondaUninstall(getRestArgsFromMatcher(uninstallMatcher));
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
-      } else if (st == null || helpPattern.matcher(st).matches()) {
+      } else if (st == null || PATTERN_COMMAND_HELP.matcher(st).matches()) {
         runCondaHelp(out);
         return new InterpreterResult(Code.SUCCESS);
-      } else if (infoPattern.matcher(st).matches()) {
+      } else if (PATTERN_COMMAND_INFO.matcher(st).matches()) {
         String result = runCondaInfo();
         return new InterpreterResult(Code.SUCCESS, Type.HTML, result);
       } else {
@@ -159,7 +159,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return python;
   }
 
-  private String runCondaCommandForTextOutput(String title, List<String> commands)
+  public static String runCondaCommandForTextOutput(String title, List<String> commands)
       throws IOException, InterruptedException {
 
     StringBuilder sb = new StringBuilder();
@@ -289,7 +289,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return runCondaCommandForTextOutput("Package Uninstallation", restArgs);
   }
 
-  private String wrapCondaBasicOutputStyle(String title, String content) {
+  public static String wrapCondaBasicOutputStyle(String title, String content) {
     StringBuilder sb = new StringBuilder();
     if (null != title && !title.isEmpty()) {
       sb.append("<h4>").append(title).append("</h4>\n");
@@ -299,7 +299,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return sb.toString();
   }
 
-  private String wrapCondaTableOutputStyle(String title, Map<String, String> kv) {
+  public static String wrapCondaTableOutputStyle(String title, Map<String, String> kv) {
     StringBuilder sb = new StringBuilder();
 
     if (null != title && !title.isEmpty()) {
@@ -321,7 +321,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return sb.toString();
   }
 
-  private Map<String, String> parseCondaCommonStdout(String out)
+  public static Map<String, String> parseCondaCommonStdout(String out)
       throws IOException, InterruptedException {
 
     Map<String, String> kv = new LinkedHashMap<String, String>();
@@ -330,7 +330,7 @@ public class PythonCondaInterpreter extends Interpreter {
       if (s == null || s.isEmpty() || s.startsWith("#")) {
         continue;
       }
-      Matcher match = condaEnvListPattern.matcher(s);
+      Matcher match = PATTERN_OUTPUT_ENV_LIST.matcher(s);
 
       if (!match.matches()) {
         continue;
@@ -370,7 +370,7 @@ public class PythonCondaInterpreter extends Interpreter {
     }
   }
 
-  protected int runCommand(StringBuilder sb, List<String> command)
+  public static int runCommand(StringBuilder sb, List<String> command)
       throws IOException, InterruptedException {
 
     ProcessBuilder builder = new ProcessBuilder(command);
@@ -387,7 +387,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return r;
   }
 
-  protected int runCommand(StringBuilder sb, String ... command)
+  public static int runCommand(StringBuilder sb, String ... command)
       throws IOException, InterruptedException {
 
     List<String> list = new ArrayList<>(command.length);
@@ -398,7 +398,7 @@ public class PythonCondaInterpreter extends Interpreter {
     return runCommand(sb, list);
   }
 
-  private List<String> getRestArgsFromMatcher(Matcher m) {
+  public static List<String> getRestArgsFromMatcher(Matcher m) {
     // Arrays.asList just returns fixed-size, so we should use ctor instead of
     return new ArrayList<>(Arrays.asList(m.group(1).split(" ")));
   }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -178,7 +178,6 @@ public class PythonCondaInterpreter extends Interpreter {
     }
   }
 
-
   private void printUsage(InterpreterOutput out) {
     try {
       out.setType(InterpreterResult.Type.HTML);
@@ -202,7 +201,6 @@ public class PythonCondaInterpreter extends Interpreter {
   public int getProgress(InterpreterContext context) {
     return 0;
   }
-
 
   /**
    * Use python interpreter's scheduler.

--- a/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java
@@ -110,10 +110,13 @@ public class PythonProcess {
     writer.println("\"" + STATEMENT_END + "\"");
     StringBuilder output = new StringBuilder();
     String line = null;
-    while (!(line = reader.readLine()).contains(STATEMENT_END)) {
+
+    while ((line = reader.readLine()) != null &&
+        !line.contains(STATEMENT_END)) {
       logger.debug("Read line from python shell : " + line);
       output.append(line + "\n");
     }
+
     return output.toString();
   }
 

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -40,3 +40,7 @@ limitations under the License.
   Install
   <pre>%python.conda install [PACKAGE NAME]</pre>
 </div>
+<div>
+  Uninstall
+  <pre>%python.conda uninstall [PACKAGE NAME]</pre>
+</div>

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -36,3 +36,7 @@ limitations under the License.
   Get installed package list inside the current environment
   <pre>%python.conda list</pre>
 </div>
+<div>
+  Install
+  <pre>%python.conda install [PACKAGE NAME]</pre>
+</div>

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -24,4 +24,7 @@ limitations under the License.
   List the Conda environments
   <pre>%python.conda env list</pre>
 </div>
-
+<div>
+  Get the Conda Infomation
+  <pre>%python.conda info</pre>
+</div>

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -13,6 +13,14 @@ limitations under the License.
 -->
 <h4>Usage</h4>
 <div>
+  Get the Conda Infomation
+  <pre>%python.conda info</pre>
+</div>
+<div>
+  List the Conda environments
+  <pre>%python.conda env list</pre>
+</div>
+<div>
   Activate an environment (python interpreter will be restarted)
   <pre>%python.conda activate [ENV NAME]</pre>
 </div>
@@ -21,10 +29,6 @@ limitations under the License.
   <pre>%python.conda deactivate</pre>
 </div>
 <div>
-  List the Conda environments
-  <pre>%python.conda env list</pre>
-</div>
-<div>
-  Get the Conda Infomation
-  <pre>%python.conda info</pre>
+  Get installed package list inside the current environment
+  <pre>%python.conda list</pre>
 </div>

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -37,10 +37,10 @@ limitations under the License.
   <pre>%python.conda list</pre>
 </div>
 <div>
-  Install
+  Install Package
   <pre>%python.conda install [PACKAGE NAME]</pre>
 </div>
 <div>
-  Uninstall
+  Uninstall Package
   <pre>%python.conda uninstall [PACKAGE NAME]</pre>
 </div>

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -22,6 +22,6 @@ limitations under the License.
 </div>
 <div>
   List the Conda environments
-  <pre>%python.conda</pre>
+  <pre>%python.conda env list</pre>
 </div>
 

--- a/python/src/main/resources/output_templates/conda_usage.html
+++ b/python/src/main/resources/output_templates/conda_usage.html
@@ -21,6 +21,10 @@ limitations under the License.
   <pre>%python.conda env list</pre>
 </div>
 <div>
+  Create a conda enviornment
+  <pre>%python.conda create --name [ENV NAME]</pre>
+</div>
+<div>
   Activate an environment (python interpreter will be restarted)
   <pre>%python.conda activate [ENV NAME]</pre>
 </div>

--- a/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
@@ -49,10 +49,8 @@ public class PythonCondaInterpreterTest {
 
   private void setMockCondaEnvList() throws IOException, InterruptedException {
     Map<String, String> envList = new LinkedHashMap<String, String>();
-
     envList.put("env1", "/path1");
     envList.put("env2", "/path2");
-
     doReturn(envList).when(conda).getCondaEnvs();
   }
 
@@ -74,6 +72,7 @@ public class PythonCondaInterpreterTest {
   @Test
   public void testActivateEnv() throws IOException, InterruptedException {
     setMockCondaEnvList();
+
     InterpreterContext context = getInterpreterContext();
     conda.interpret("activate env1", context);
     verify(python, times(1)).open();

--- a/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Matcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -87,6 +88,34 @@ public class PythonCondaInterpreterTest {
     verify(python, times(1)).open();
     verify(python, times(1)).close();
     verify(python).setPythonCommand("python");
+  }
+
+  @Test
+  public void testParseCondaCommonStdout()
+      throws IOException, InterruptedException {
+
+    StringBuilder sb = new StringBuilder()
+        .append("# comment1\n")
+        .append("# comment2\n")
+        .append("env1     /location1\n")
+        .append("env2     /location2\n");
+
+    Map<String, String> locationPerEnv =
+        PythonCondaInterpreter.parseCondaCommonStdout(sb.toString());
+
+    assertEquals("/location1", locationPerEnv.get("env1"));
+    assertEquals("/location2", locationPerEnv.get("env2"));
+  }
+
+  @Test
+  public void testGetRestArgsFromMatcher() {
+    Matcher m =
+        PythonCondaInterpreter.PATTERN_COMMAND_ENV.matcher("env remove --name test --yes");
+    m.matches();
+
+    List<String> restArgs = PythonCondaInterpreter.getRestArgsFromMatcher(m);
+    List<String> expected = Arrays.asList(new String[]{"remove", "--name", "test", "--yes"});
+    assertEquals(expected, restArgs);
   }
 
   private InterpreterContext getInterpreterContext() {

--- a/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
@@ -64,7 +64,7 @@ public class PythonCondaInterpreterTest {
 
     // list available env
     InterpreterContext context = getInterpreterContext();
-    InterpreterResult result = conda.interpret("", context);
+    InterpreterResult result = conda.interpret("env list", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
     context.out.flush();


### PR DESCRIPTION
### What is this PR for?

Add missing commands to the `python.conda` interpreter

- `conda info`
- `conda list`
- `conda create`
- `conda install`
- `conda uninstall (alias of remove)`
- `conda env *`

#### Implementation Detail

The reason I modified `PythonProcess` is due to NPE

```java
// https://github.com/apache/zeppelin/blob/master/python/src/main/java/org/apache/zeppelin/python/PythonProcess.java#L107-L118


  public String sendAndGetResult(String cmd) throws IOException {
    writer.println(cmd);
    writer.println();
    writer.println("\"" + STATEMENT_END + "\"");
    StringBuilder output = new StringBuilder();
    String line = null;

    // NPE when line is null
    while (!(line = reader.readLine()).contains(STATEMENT_END)) {
      logger.debug("Read line from python shell : " + line);
      output.append(line + "\n");
    }
    return output.toString();
  }
```

```
java.lang.NullPointerException
at org.apache.zeppelin.python.PythonProcess.sendAndGetResult(PythonProcess.java:113)
at org.apache.zeppelin.python.PythonInterpreter.sendCommandToPython(PythonInterpreter.java:250)
at org.apache.zeppelin.python.PythonInterpreter.bootStrapInterpreter(PythonInterpreter.java:272)
at org.apache.zeppelin.python.PythonInterpreter.open(PythonInterpreter.java:100)
at org.apache.zeppelin.python.PythonCondaInterpreter.restartPythonProcess(PythonCondaInterpreter.java:139)
at org.apache.zeppelin.python.PythonCondaInterpreter.interpret(PythonCondaInterpreter.java:88)
at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:94)
at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer$InterpretJob.jobRun(RemoteInterpreterServer.java:494)
at org.apache.zeppelin.scheduler.Job.run(Job.java:175)
at org.apache.zeppelin.scheduler.FIFOScheduler$1.run(FIFOScheduler.java:139)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
```

### What type of PR is it?
[Improvement | Refactoring]

### Todos
* [x] - info
* [x] - list
* [x] - create
* [x] - install
* [x] - uninstall (= remove)
* [x] - env *

### What is the Jira issue?

[ZEPPELIN-1917](https://issues.apache.org/jira/browse/ZEPPELIN-1917)

### How should this be tested?

1. Install [miniconda](http://conda.pydata.org/miniconda.html)
2. Make sure that your python interpreter can use `conda` (check the Interpreter Binding page)
3. Remove `test` conda env since we will create in the following section

```sh
$ conda env remove --yes --name test
```

4. Run these commands with `%python.conda`

```
%python.conda info
%python.conda env list
%python.conda create --name test

# you should be able to see `test` in the list
%python.conda env list
%python.conda activate pymysql
%python.conda install pymysql

# you should be able to import
%python
import pymysql.cursors

%python.conda uninstall pymysql
%python.conda deactivate pymysql

# you should be able to see `No module named pymysql.cursor` since we deactivated
%python
import pymysql.cursors
```

### Screenshots (if appropriate)

![conda-screenshot](https://cloud.githubusercontent.com/assets/4968473/21747565/98c0e366-d5ad-11e6-8000-e293996089fa.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
