### PR TITLE
[MINOR] fix: DON'T clean in npm run dev cause it does nothing

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -10,7 +10,7 @@
     "postinstall": "bower install --silent && grunt googlefonts",
     "prebuild": "npm-run-all clean",
     "build": "grunt pre-webpack-dist && webpack && grunt post-webpack-dist",
-    "predev": "npm-run-all clean && grunt pre-webpack-dev",
+    "predev": "grunt pre-webpack-dev",
     "dev:server": "webpack-dev-server --hot",
     "dev:watch": "grunt watch-webpack-dev",
     "dev": "npm-run-all --parallel dev:server dev:watch",


### PR DESCRIPTION
### What is this PR for?

Removed clean task in npm run dev because webpack-dev-server uses in-memory build :)
This was annoying since you have to build again after executing `npm run dev` which deleting the `zeppelin-web/dist` directory

### What type of PR is it?
[Bug Fix]

### Todos

Fixed at once

### What is the Jira issue?

MINOR

### How should this be tested?

1. Execute `npm run build && npm run dev`
2. Check whether`dist` directory exists or not

### Screenshots (if appropriate)

None

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
