### PR TITLE
[ZEPPELIN-1924] Fix "this._isNumeric is not a function" error 

### DIFF
--- a/zeppelin-web/src/app/handsontable/handsonHelper.js
+++ b/zeppelin-web/src/app/handsontable/handsonHelper.js
@@ -20,6 +20,7 @@ export default class HandsonHelper {
     this.columns = columns || [];
     this.rows = rows || [];
     this.comment = comment || '';
+    this._numericValidator = this._numericValidator.bind(this);
   };
 
   getHandsonTableConfig(columns, columnNames, resultRows) {


### PR DESCRIPTION
### What is this PR for?
After #1815 was merged, 
```
uncaught TypeError: this._isNumeric is not a function
    at ColumnSettings._numericValidator [as validator] (handsonHelper.js:172)
    at handsontable.js:5181
```
is shown when click "Numeric" in the result table like below. 
<img src="https://cloud.githubusercontent.com/assets/10060731/21749365/d1d700ee-d5e0-11e6-9f25-65ebb3ea313a.gif" width="450px">

Since ES6 no longer supports autobind for `this`, seems it needs to be bound in the constructor.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-1924](https://issues.apache.org/jira/browse/ZEPPELIN-1924)

### How should this be tested?
**To reproduce**
In master, go to Spark tutorial note and click 
<img width="230" alt="screen shot 2017-01-08 at 8 32 05 pm" src="https://cloud.githubusercontent.com/assets/10060731/21749412/8a123318-d5e1-11e6-9a65-a84e443c385c.png"> 
`Numeric`. Then the error msg will be shown in browser dev console. 

With this patch, this error msg won't be shown up anymore :)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
