### PR TITLE
[ZEPPELIN-1922] Exclude jackson-core and jackson-databind from aws dep

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -45,6 +45,16 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.10.62</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
Fix jar hell around jackson. aws-java-sdk-s3 braings 2.5.3

### What type of PR is it?
Bug Fix 

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1922

### How should this be tested?
Just use docker conrainer https://github.com/epahomov/docker-zeppelin/blob/master/Dockerfile  against a yarn cluster. Now it's not working becuase of this issue.

### Screenshots (if appropriate)

### Questions: