### PR TITLE
[ZEPPELIN-1930](HotFix) PythonInterpreter syntax error.

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -72,9 +72,9 @@ public class PythonInterpreter extends Interpreter {
     // Add matplotlib display hook
     InterpreterGroup intpGroup = getInterpreterGroup();
     if (intpGroup != null && intpGroup.getInterpreterHookRegistry() != null) {
-      registerHook(HookType.POST_EXEC_DEV, "z._displayhook()");
+      registerHook(HookType.POST_EXEC_DEV, "\nz._displayhook()");
     }
-    
+
     // Add zeppelin-bundled libs to PYTHONPATH
     setPythonPath("../interpreter/lib/python:$PYTHONPATH");
     LOG.info("Starting Python interpreter ---->");

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -182,7 +182,7 @@ public class PythonInterpreterTest {
   }
 
   @Test
-  public void testInterpret2() {
+  public void testInterpretInvalidSyntax() {
     zeppelinPythonInterpreter.open();
     InterpreterResult result = zeppelinPythonInterpreter.interpret("for x in range(0,3):  print (\"hi\")\n\nz._displayhook()", null);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -45,6 +45,7 @@ import org.apache.zeppelin.interpreter.ClassloaderInterpreter;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -62,6 +63,7 @@ import org.slf4j.LoggerFactory;
 public class PythonInterpreterTest {
   private static final Logger LOG = LoggerFactory.getLogger(PythonProcess.class);
 
+  PythonInterpreter zeppelinPythonInterpreter = null;
   PythonInterpreter pythonInterpreter = null;
   PythonProcess mockPythonProcess;
   String cmdHistory;
@@ -88,6 +90,7 @@ public class PythonInterpreterTest {
 
     // python interpreter
     pythonInterpreter = spy(new PythonInterpreter(getPythonTestProperties()));
+    zeppelinPythonInterpreter = new PythonInterpreter(getPythonTestProperties());
 
     // create interpreter group
     InterpreterGroup group = new InterpreterGroup();
@@ -97,6 +100,12 @@ public class PythonInterpreterTest {
 
     when(pythonInterpreter.getPythonProcess()).thenReturn(mockPythonProcess);
     when(mockPythonProcess.sendAndGetResult(eq("\n\nimport py4j\n"))).thenReturn("ImportError");
+  }
+
+  @After
+  public void afterTest() throws IOException {
+    pythonInterpreter.close();
+    zeppelinPythonInterpreter.close();
   }
 
   @Test
@@ -170,6 +179,18 @@ public class PythonInterpreterTest {
     InterpreterResult result = pythonInterpreter.interpret("print a", null);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertEquals("%text print a", result.message().get(0).toString());
+  }
+
+  @Test
+  public void testInterpret2() {
+    zeppelinPythonInterpreter.open();
+    InterpreterResult result = zeppelinPythonInterpreter.interpret("for x in range(0,3):  print (\"hi\")\n\nz._displayhook()", null);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertTrue(result.message().get(0).toString().contains("hi\nhi\nhi"));
+
+    result = zeppelinPythonInterpreter.interpret("for x in range(0,3):  print (\"hi\")\nz._displayhook()", null);
+    assertEquals(InterpreterResult.Code.ERROR, result.code());
+    assertTrue(result.message().get(0).toString().contains("SyntaxError: invalid syntax"));
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
This PR fixes syntax error of PythonInterpreter.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1930

### How should this be tested?
Please run following code on the paragraph of PythonInterpreter.
```
for x in range(0,3):  print ("hi")
```

### Screenshots (if appropriate)
- before
![image](https://cloud.githubusercontent.com/assets/3348133/21763102/fdf3fada-d610-11e6-8e92-310aec1968ad.png)

- after
![image](https://cloud.githubusercontent.com/assets/3348133/21763159/4a0aec26-d611-11e6-955b-be0b86455a34.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
