### PR TITLE
[ZEPPELIN-1931] add yarn_error.log in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ zeppelin-web/src/fonts/patua-one*
 zeppelin-web/src/fonts/google-fonts.css
 zeppelin-web/.sass-cache
 zeppelin-web/npm-debug.log
+zeppelin-web/yarn-error.log
 zeppelin-web/bower_components
 zeppelin-web/yarn.lock
 **nbproject/


### PR DESCRIPTION
### What is this PR for?
Currently zeppelin is built from yarn.
Therefore, we need to add a log to gitignore.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1931

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
