### PR TITLE
[HOTFIX : ZEPPELIN-1932] paragraph blur error

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -270,7 +270,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.copyPara = function(position) {
-    var editorValue = $scope.editor.getValue();
+    var editorValue = $scope.getEditorValue();
     if (editorValue) {
       $scope.copyParagraph(editorValue, position);
     }
@@ -398,15 +398,19 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.showLineNumbers = function(paragraph) {
-    paragraph.config.lineNumbers = true;
-    $scope.editor.renderer.setShowGutter(true);
-    commitParagraph(paragraph);
+    if ($scope.editor) {
+      paragraph.config.lineNumbers = true;
+      $scope.editor.renderer.setShowGutter(true);
+      commitParagraph(paragraph);
+    }
   };
 
   $scope.hideLineNumbers = function(paragraph) {
-    paragraph.config.lineNumbers = false;
-    $scope.editor.renderer.setShowGutter(false);
-    commitParagraph(paragraph);
+    if ($scope.editor) {
+      paragraph.config.lineNumbers = false;
+      $scope.editor.renderer.setShowGutter(false);
+      commitParagraph(paragraph);
+    }
   };
 
   $scope.columnWidthClass = function(n) {
@@ -764,7 +768,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.getEditorValue = function() {
-    return $scope.editor.getValue();
+    return !$scope.editor ? $scope.paragraph.text : $scope.editor.getValue();
   };
 
   $scope.getProgress = function() {
@@ -1086,7 +1090,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         // move focus to next paragraph
         $scope.$emit('moveFocusToNextParagraph', paragraphId);
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
-        $scope.run($scope.paragraph, $scope.editor.getValue());
+        $scope.run($scope.paragraph, $scope.getEditorValue());
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c
         $scope.cancelParagraph($scope.paragraph);
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 68) { // Ctrl + Alt + d
@@ -1167,7 +1171,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   });
 
   $scope.$on('saveInterpreterBindings', function(event, paragraphId) {
-    if ($scope.paragraph.id === paragraphId) {
+    if ($scope.paragraph.id === paragraphId && $scope.editor) {
       setInterpreterBindings = true;
       setParagraphMode($scope.editor.getSession(), $scope.editor.getSession().getValue());
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1133,6 +1133,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   });
 
   $scope.$on('focusParagraph', function(event, paragraphId, cursorPos, mouseEvent) {
+    if (!$scope.editor) {
+      return;
+    }
     if ($scope.paragraph.id === paragraphId) {
       // focus editor
       if (!$scope.paragraph.config.editorHide) {
@@ -1177,8 +1180,10 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         ), 1000);
 
       deferred.promise.then(function(data) {
-        $scope.editor.focus();
-        $scope.goToEnd($scope.editor);
+        if ($scope.editor) {
+          $scope.editor.focus();
+          $scope.goToEnd($scope.editor);
+        }
       });
     }
   });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -192,6 +192,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.$watch($scope.getEditor, function(newValue, oldValue) {
+    if (!$scope.editor) {
+      return;
+    }
     if (newValue === null || newValue === undefined) {
       console.log('editor isnt loaded yet, returning');
       return;
@@ -1035,7 +1038,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       $scope.paragraph.status = data.paragraph.status;
       $scope.paragraph.results = data.paragraph.results;
       $scope.paragraph.settings = data.paragraph.settings;
-      $scope.editor.setReadOnly($scope.isRunning(data.paragraph));
+      if ($scope.editor) {
+        $scope.editor.setReadOnly($scope.isRunning(data.paragraph));
+      }
 
       if (!$scope.asIframe) {
         $scope.paragraph.config = data.paragraph.config;


### PR DESCRIPTION
### What is this PR for?
When one or more hidden editors are present, clicking on the editor will cause a blur error.
This means that when a paragraph is hidden through ng-if,
Caused by calling the blur method in the absence of an editor object.

### What type of PR is it?
Hot Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1932

### How should this be tested?
1. create paragraph and open debug console.
2. enable hide paragraph.
3. page refresh
4. click to anywhere paragraph.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
