### PR TITLE
ZEPPELIN-1918. Fix build with Spark 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ matrix:
     - jdk: "oraclejdk7"
       env: SCALA_VER="2.11" SPARK_VER="2.0.2" HADOOP_VER="2.6" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
+    # Test all modules with spark 2.1.0 and scala 2.11
+    - jdk: "oraclejdk7"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pspark-2.1 -Phadoop-2.6 -Ppyspark -Psparkr -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" TEST_PROJECTS=""
+
     # Test all modules with spark 2.0.2 and scala 2.11
     - jdk: "oraclejdk7"
       env: SCALA_VER="2.11" SPARK_VER="2.0.2" HADOOP_VER="2.6" PROFILE="-Pspark-2.0 -Phadoop-2.6 -Ppyspark -Psparkr -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" TEST_PROJECTS=""
-
-    # Test all modules with spark 2.1.0 and scala 2.11
-    - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pspark-2.0 -Phadoop-2.6 -Ppyspark -Psparkr -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" TEST_PROJECTS=""
 
     # Test all modules with scala 2.10
     - jdk: "oraclejdk7"

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -124,8 +124,8 @@ function make_binary_release() {
 build_docker_base
 git_clone
 make_source_package
-make_binary_release all "-Pspark-2.0 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pscala-${SCALA_VERSION}"
-make_binary_release netinst "-Pspark-2.0 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pscala-${SCALA_VERSION} -pl zeppelin-interpreter,zeppelin-zengine,:zeppelin-display_${SCALA_VERSION},:zeppelin-spark-dependencies_${SCALA_VERSION},:zeppelin-spark_${SCALA_VERSION},zeppelin-web,zeppelin-server,zeppelin-distribution -am"
+make_binary_release all "-Pspark-2.1 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pscala-${SCALA_VERSION}"
+make_binary_release netinst "-Pspark-2.1 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pscala-${SCALA_VERSION} -pl zeppelin-interpreter,zeppelin-zengine,:zeppelin-display_${SCALA_VERSION},:zeppelin-spark-dependencies_${SCALA_VERSION},:zeppelin-spark_${SCALA_VERSION},zeppelin-web,zeppelin-server,zeppelin-distribution -am"
 
 # remove non release files and dirs
 rm -rf "${WORKING_DIR}/zeppelin"

--- a/dev/publish_release.sh
+++ b/dev/publish_release.sh
@@ -44,7 +44,7 @@ NC='\033[0m' # No Color
 RELEASE_VERSION="$1"
 GIT_TAG="$2"
 
-PUBLISH_PROFILES="-Ppublish-distr -Pspark-2.0 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pr"
+PUBLISH_PROFILES="-Ppublish-distr -Pspark-2.1 -Phadoop-2.6 -Pyarn -Ppyspark -Psparkr -Pr"
 PROJECT_OPTIONS="-pl !zeppelin-distribution"
 NEXUS_STAGING="https://repository.apache.org/service/local/staging"
 NEXUS_PROFILE="153446d1ac37c4"

--- a/docs/install/build.md
+++ b/docs/install/build.md
@@ -97,6 +97,7 @@ Set spark major version
 Available profiles are
 
 ```
+-Pspark-2.1
 -Pspark-2.0
 -Pspark-1.6
 -Pspark-1.5
@@ -185,6 +186,10 @@ Bulid examples under zeppelin-examples directory
 Here are some examples with several options:
 
 ```bash
+# build with spark-2.1, scala-2.11
+./dev/change_scala_version.sh 2.11
+mvn clean package -Pspark-2.1 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11 -DskipTests
+
 # build with spark-2.0, scala-2.11
 ./dev/change_scala_version.sh 2.11
 mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11 -DskipTests

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -523,13 +523,23 @@
 
     <profile>
       <id>spark-2.0</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>2.0.2</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <py4j.version>0.10.3</py4j.version>
+        <scala.version>2.11.8</scala.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.version>2.1.0</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.4</py4j.version>
         <scala.version>2.11.8</scala.version>
       </properties>
     </profile>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -515,13 +515,23 @@
 
     <profile>
       <id>spark-2.0</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>2.0.2</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <py4j.version>0.10.3</py4j.version>
+        <scala.version>2.11.8</scala.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.version>2.1.0</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.4</py4j.version>
         <scala.version>2.11.8</scala.version>
       </properties>
     </profile>

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -1498,7 +1498,6 @@ public class SparkInterpreter extends Interpreter {
           .getConstructor(new Class[]{ SparkConf.class, scala.Option.class });
       securityManager = smConstructor.newInstance(conf, null);
     } catch (NoSuchMethodException e) {
-
       Constructor<?> smConstructor = getClass().getClassLoader()
           .loadClass("org.apache.spark.SecurityManager")
           .getConstructor(new Class[]{ SparkConf.class });

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -488,8 +488,9 @@ public class SparkInterpreter extends Interpreter {
     }
 
     //Only one of py4j-0.9-src.zip and py4j-0.8.2.1-src.zip should exist
+    //TODO(zjffdu), this is not maintainable when new version is added.
     String[] pythonLibs = new String[]{"pyspark.zip", "py4j-0.9-src.zip", "py4j-0.8.2.1-src.zip",
-      "py4j-0.10.1-src.zip", "py4j-0.10.3-src.zip"};
+      "py4j-0.10.1-src.zip", "py4j-0.10.3-src.zip", "py4j-0.10.4-src.zip"};
     ArrayList<String> pythonLibUris = new ArrayList<>();
     for (String lib : pythonLibs) {
       File libFile = new File(pysparkPath, lib);
@@ -1476,8 +1477,8 @@ public class SparkInterpreter extends Interpreter {
   }
 
   /**
-   * Constructor signature of SecurityManager changes in spark 2.10, so we use this method to create
-   * Security properly for different versions of spark
+   * Constructor signature of SecurityManager changes in spark 2.1.0, so we use this method to
+   * create SecurityManager properly for different versions of spark
    *
    * @param conf
    * @return
@@ -1494,12 +1495,14 @@ public class SparkInterpreter extends Interpreter {
     try {
       Constructor<?> smConstructor = getClass().getClassLoader()
           .loadClass("org.apache.spark.SecurityManager")
-          .getConstructor(new Class[]{ SparkConf.class });
-    } catch (NoSuchMethodException e) {
-      Constructor<?> smConstructor = getClass().getClassLoader()
-          .loadClass("org.apache.spark.SecurityManager")
           .getConstructor(new Class[]{ SparkConf.class, scala.Option.class });
       securityManager = smConstructor.newInstance(conf, null);
+    } catch (NoSuchMethodException e) {
+
+      Constructor<?> smConstructor = getClass().getClassLoader()
+          .loadClass("org.apache.spark.SecurityManager")
+          .getConstructor(new Class[]{ SparkConf.class });
+      securityManager = smConstructor.newInstance(conf);
     }
     return securityManager;
   }


### PR DESCRIPTION
### What is this PR for?
It's my misunderstanding of `SPARK_VER` in travis. It is only used for downloading spark distribution. We need to specify spark profile explicitly for building with specific version of spark. This PR add new profile for spark 2.1 and fix the build issue with spark 2.1.0 because `SecurityManager` changes its constructor signature in spark 2.1 



### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1918

### How should this be tested?
Build with spark 2.1.0 and tested it manually as below screenshot.

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/164491/21797414/d586aa04-d749-11e6-8c6f-3b12e9e2ae2d.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
