### PR TITLE
[MINOR] Rename Pig tutorial note to consider priority

### DIFF
--- a/notebook/2C57UKYWR/note.json
+++ b/notebook/2C57UKYWR/note.json
@@ -286,7 +286,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Zeppelin Tutorial/Basic Features (Pig)",
+  "name": "Zeppelin Tutorial/Using Pig for querying data",
   "id": "2C57UKYWR",
   "angularObjects": {
     "2C3DR183X:shared_process": [],


### PR DESCRIPTION
### What is this PR for?
After #1830 merged, Pig tutorial note placed as a first under `Zeppelin Tutorial` folder. I told to @zjffdu, I thought the note name should be same with Spark ("Basic Feature (Spark)") in [this comment](https://github.com/apache/zeppelin/pull/1830#discussion_r95522394) (because they have same contents). 

<img src="https://cloud.githubusercontent.com/assets/10060731/21879248/a6d9b88a-d8da-11e6-8f43-5ef192e5895c.png" width="300px">

But considering the number of Spark and Pig users, the Spark tutorial note needs to be placed as first I think.

<img src="https://cloud.githubusercontent.com/assets/10060731/21879244/a488e3d0-d8da-11e6-9e0b-c91ca890c611.png" width="300px">
 
### What type of PR is it?
Rename Pig tutorial note 

### What is the Jira issue?
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
