### PR TITLE
[MINOR] broken logo url in web dev mode

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -381,13 +381,13 @@ a.navbar-brand:hover {
 }
 
 .zeppelin {
-  background: url('../assets/images/zepLogo.png') no-repeat right;
+  background: url('/assets/images/zepLogo.png') no-repeat right;
   height: 380px;
   opacity: 0.2;
 }
 
 .zeppelin2 {
-  background: url('../assets/images/zepLogo.png') no-repeat right;
+  background: url('/assets/images/zepLogo.png') no-repeat right;
   background-position-y: 12px;
   height: 380px;
   opacity: 0.2;

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -381,13 +381,13 @@ a.navbar-brand:hover {
 }
 
 .zeppelin {
-  background: url('/assets/images/zepLogo.png') no-repeat right;
+  background: url('../assets/images/zepLogo.png') no-repeat right;
   height: 380px;
   opacity: 0.2;
 }
 
 .zeppelin2 {
-  background: url('/assets/images/zepLogo.png') no-repeat right;
+  background: url('../assets/images/zepLogo.png') no-repeat right;
   background-position-y: 12px;
   height: 380px;
   opacity: 0.2;

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -163,8 +163,7 @@ module.exports = function makeWebpackConfig () {
       // Pass along the updated reference to your code
       // You can add here any file extension you want to get copied to your output
       test: /\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)$/,
-      //loader: 'file'
-      loader: 'file-loader?name=[name].[ext]&outputPath=styles/images/'
+      loader: 'file'
     }, {
       // HTML LOADER
       // Reference: https://github.com/webpack/raw-loader

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -163,7 +163,8 @@ module.exports = function makeWebpackConfig () {
       // Pass along the updated reference to your code
       // You can add here any file extension you want to get copied to your output
       test: /\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)$/,
-      loader: 'file'
+      //loader: 'file'
+      loader: 'file-loader?name=[name].[ext]&outputPath=styles/images/'
     }, {
       // HTML LOADER
       // Reference: https://github.com/webpack/raw-loader
@@ -267,9 +268,13 @@ module.exports = function makeWebpackConfig () {
     progress: true,
     contentBase: './src',
     setup: function(app) {
-      app.use(
-        '/bower_components/',
-        require('express').static(path.join(__dirname, './bower_components/')));
+      app.use('**/bower_components/',
+        require('express').static(path.resolve(__dirname, './bower_components/')));
+      app.use('**/app/', require('express').static(path.resolve(__dirname, './src/app/')));
+      app.use('**/assets/', require('express').static(path.resolve(__dirname, './src/assets/')));
+      app.use('**/fonts/', require('express').static(path.resolve(__dirname, './src/fonts/')));
+      app.use('**/components/',
+        require('express').static(path.resolve(__dirname, './src/components/')));
     },
     stats: 'minimal',
   };

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -28,6 +28,7 @@ var InsertLiveReloadPlugin = function InsertLiveReloadPlugin(options) {
   this.port = this.options.port || 35729;
   this.hostname = this.options.hostname || 'localhost';
 }
+var express = require('express');
 
 InsertLiveReloadPlugin.prototype.autoloadJs = function autoloadJs() {
   return
@@ -267,13 +268,11 @@ module.exports = function makeWebpackConfig () {
     progress: true,
     contentBase: './src',
     setup: function(app) {
-      app.use('**/bower_components/',
-        require('express').static(path.resolve(__dirname, './bower_components/')));
-      app.use('**/app/', require('express').static(path.resolve(__dirname, './src/app/')));
-      app.use('**/assets/', require('express').static(path.resolve(__dirname, './src/assets/')));
-      app.use('**/fonts/', require('express').static(path.resolve(__dirname, './src/fonts/')));
-      app.use('**/components/',
-        require('express').static(path.resolve(__dirname, './src/components/')));
+      app.use('**/bower_components/', express.static(path.resolve(__dirname, './bower_components/')));
+      app.use('**/app/', express.static(path.resolve(__dirname, './src/app/')));
+      app.use('**/assets/', express.static(path.resolve(__dirname, './src/assets/')));
+      app.use('**/fonts/', express.static(path.resolve(__dirname, './src/fonts/')));
+      app.use('**/components/', express.static(path.resolve(__dirname, './src/components/')));
     },
     stats: 'minimal',
   };


### PR DESCRIPTION
### What is this PR for?
zeppelin logo image (zepLogo.png) is broken in `web dev` mode like below screenshot.
![screenshot from 2017-01-12 14-50-35](https://cloud.githubusercontent.com/assets/8110458/21883058/948cdd2c-d8f0-11e6-8a48-f738a811259f.png)


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1943

### How should this be tested?
1. Run front-end application in [dev mode](https://github.com/apache/zeppelin/tree/master/zeppelin-web)
2. Open console in web developer mode.
3. Connect/refresh localhost:9000 
4. Check to be shown Logo image in Zeppelin home.
![image](https://cloud.githubusercontent.com/assets/8110458/21883383/3551188a-d8f2-11e6-980e-cc4045890172.png)
5. Check errors in console.

### Screenshots (if appropriate)
![screenshot from 2017-01-12 16-58-40](https://cloud.githubusercontent.com/assets/8110458/21883263/972a2372-d8f1-11e6-82d5-543d0995bded.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
