### PR TITLE
[ZEPPELIN-1560] avoid generating minus sign in package name

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -745,8 +745,12 @@ public class SparkInterpreter extends Interpreter {
      *
      * In Spark 2.x, REPL generated wrapper class name should compatible with the pattern
      * ^(\$line(?:\d+)\.\$read)(?:\$\$iw)+$
+     *
+     * As hashCode() can return a negative integer value and the minus character '-' is invalid
+     * in a package name we change it to a numeric value '0' which still conforms to the regexp.
+     * 
      */
-    System.setProperty("scala.repl.name.line", "$line" + this.hashCode());
+    System.setProperty("scala.repl.name.line", ("$line" + this.hashCode()).replace('-', '0'));
 
     // To prevent 'File name too long' error on some file system.
     MutableSettings.IntSetting numClassFileSetting = settings.maxClassfileName();


### PR DESCRIPTION
### What is this PR for?
using Object.hashCode() as part of the REPL wrapper class name can cause a compilation error as hashCode can validly return a negative integer.

We would like this fix backported to 0.6 and later streams.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1560

### How should this be tested?
regression tests with openJdk + tests with IBM jvm

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO 
* Does this needs documentation? NO
