### PR TITLE
[ZEPPELIN-1961] Improve stability of sync when get fails

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -330,8 +330,7 @@ public class NotebookRepoSync implements NotebookRepo {
 
   private Map<String, List<String>> notesCheckDiff(List<NoteInfo> sourceNotes,
       NotebookRepo sourceRepo, List<NoteInfo> destNotes, NotebookRepo destRepo,
-      AuthenticationInfo subject)
-      throws IOException {
+      AuthenticationInfo subject) {
     List <String> pushIDs = new ArrayList<>();
     List <String> pullIDs = new ArrayList<>();
     List <String> delDstIDs = new ArrayList<>();
@@ -341,9 +340,14 @@ public class NotebookRepoSync implements NotebookRepo {
     for (NoteInfo snote : sourceNotes) {
       dnote = containsID(destNotes, snote.getId());
       if (dnote != null) {
-        /* note exists in source and destination storage systems */
-        sdate = lastModificationDate(sourceRepo.get(snote.getId(), subject));
-        ddate = lastModificationDate(destRepo.get(dnote.getId(), subject));
+        try {
+          /* note exists in source and destination storage systems */
+          sdate = lastModificationDate(sourceRepo.get(snote.getId(), subject));
+          ddate = lastModificationDate(destRepo.get(dnote.getId(), subject));
+        } catch (IOException e) {
+          LOG.error("Cannot access previously listed note {} from storage ", dnote.getId(), e);
+          continue;
+        }
 
         if (sdate.compareTo(ddate) != 0) {
           if (sdate.after(ddate) || oneWaySync) {


### PR DESCRIPTION
### What is this PR for?
This is to improve the stability of sync mechanism when `get` from some backend storage fails (e.g. corrupt file, network issues).


### What type of PR is it?
Bug Fix |  Hot Fix

### Todos
* [x] - handle exception

### What is the Jira issue?
[ZEPPELIN-1961](https://issues.apache.org/jira/browse/ZEPPELIN-1961)

### How should this be tested?
CI green

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
