### PR TITLE
Can't remove interpreter repository.

### DIFF
--- a/zeppelin-web/src/components/repository-create/repository-dialog.html
+++ b/zeppelin-web/src/components/repository-create/repository-dialog.html
@@ -28,7 +28,7 @@ limitations under the License.
             <div class="form-group">
               <label class="control-label col-sm-2" for="repoId">ID</label>
               <div class="col-sm-10">
-                <input type="text" class="form-control" id="repoId" ng-model="newRepoSetting.id"
+                <input type="text" pattern="^[a-zA-Z0-9]*$" class="form-control" id="repoId" ng-model="newRepoSetting.id"
                        placeholder="Repository id" required />
               </div>
             </div>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -1402,6 +1404,13 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
   public void addRepository(String id, String url, boolean snapshot, Authentication auth,
       Proxy proxy) throws IOException {
+
+    Pattern r = Pattern.compile("^[a-zA-Z0-9]*$");
+    Matcher m = r.matcher(id);
+    if (!m.find()) {
+      throw new IOException("id is not allow the special characters.");
+    }
+
     depResolver.addRepo(id, url, snapshot, auth, proxy);
     saveToFile();
   }


### PR DESCRIPTION
### What is this PR for?
It can't be delete the `interpreter repository`(http://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/manual/dependencymanagement.html) when name has include special characters.

### What type of PR is it?
Bug Fix 


### How should this be tested?
please refer to screenshot.


### Screenshots (if appropriate)
- before
![2017-01-12 18_29_47](https://cloud.githubusercontent.com/assets/3348133/21916407/3acdb540-d8f5-11e6-9a4b-c550e41b4d94.gif)


- after
![image](https://cloud.githubusercontent.com/assets/3348133/21916280/622ab986-d8f4-11e6-963f-f7c9e4e4f2f5.png)


### Questions: 
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
