### PR TITLE
[ZEPPELIN-1963] set cron job executor to current user by default 

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -401,6 +401,13 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
 
   /** Set cron expression for this note **/
   $scope.setCronScheduler = function(cronExpr) {
+    if (cronExpr) {
+      if (!$scope.note.config.cronExecutingUser) {
+        $scope.note.config.cronExecutingUser = $rootScope.ticket.principal;
+      }
+    } else {
+      $scope.note.config.cronExecutingUser = '';
+    }
     $scope.note.config.cron = cronExpr;
     $scope.setConfig();
   };
@@ -1011,4 +1018,3 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     angular.element(document.getElementById('content')).css('padding-top', actionbarHeight - 20);
   });
 }
-


### PR DESCRIPTION
### What is this PR for?
currently when executing cron job, backend doesn't know who initiated cron job (with subsequent save) unless user puts his name. This PR adds user name by default by keeping compatibility with current workflow. 


### What type of PR is it?
Improvement

### Todos
* [x] - add user on front

### What is the Jira issue?
[ZEPPELIN-1963](https://issues.apache.org/jira/browse/ZEPPELIN-1963)

### How should this be tested?
go and set cron job

### Screenshots (if appropriate)
![cron_user](https://cloud.githubusercontent.com/assets/1642088/21919566/25330daa-d910-11e6-9373-aa3c44064f39.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
