### PR TITLE
[ZEPPELIN-1969] Can not change visualization package version.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
@@ -145,7 +145,8 @@ public class HeliumVisualizationFactory {
     pkgJson = pkgJson.replaceFirst("DEPENDENCIES", dependencies.toString());
 
     // check if we can use previous bundle or not
-    if (cacheKeyBuilder.toString().equals(bundleCacheKey) && currentBundle.isFile() && !forceRefresh) {
+    if (cacheKeyBuilder.toString().equals(bundleCacheKey)
+        && currentBundle.isFile() && !forceRefresh) {
       return currentBundle;
     }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
@@ -104,6 +104,7 @@ public class HeliumVisualizationFactory {
     URL pkgUrl = Resources.getResource("helium/package.json");
     String pkgJson = Resources.toString(pkgUrl, Charsets.UTF_8);
     StringBuilder dependencies = new StringBuilder();
+    StringBuilder cacheKeyBuilder = new StringBuilder();
 
     FileFilter npmPackageCopyFilter = new FileFilter() {
       @Override
@@ -127,18 +128,24 @@ public class HeliumVisualizationFactory {
         dependencies.append(",\n");
       }
       dependencies.append("\"" + moduleNameVersion[0] + "\": \"" + moduleNameVersion[1] + "\"");
+      cacheKeyBuilder.append(pkg.getName() + pkg.getArtifact());
+
+      File pkgInstallDir = new File(workingDirectory, "node_modules/" + pkg.getName());
+      if (pkgInstallDir.exists()) {
+        FileUtils.deleteDirectory(pkgInstallDir);
+      }
 
       if (isLocalPackage(pkg)) {
         FileUtils.copyDirectory(
             new File(pkg.getArtifact()),
-            new File(workingDirectory, "node_modules/" + pkg.getName()),
+            pkgInstallDir,
             npmPackageCopyFilter);
       }
     }
     pkgJson = pkgJson.replaceFirst("DEPENDENCIES", dependencies.toString());
 
     // check if we can use previous bundle or not
-    if (dependencies.toString().equals(bundleCacheKey) && currentBundle.isFile() && !forceRefresh) {
+    if (cacheKeyBuilder.toString().equals(bundleCacheKey) && currentBundle.isFile() && !forceRefresh) {
       return currentBundle;
     }
 
@@ -177,7 +184,10 @@ public class HeliumVisualizationFactory {
     // install tabledata module
     File tabledataModuleInstallPath = new File(workingDirectory,
         "node_modules/zeppelin-tabledata");
-    if (tabledataModulePath != null && !tabledataModuleInstallPath.exists()) {
+    if (tabledataModulePath != null) {
+      if (tabledataModuleInstallPath.exists()) {
+        FileUtils.deleteDirectory(tabledataModuleInstallPath);
+      }
       FileUtils.copyDirectory(
           tabledataModulePath,
           tabledataModuleInstallPath,
@@ -187,7 +197,17 @@ public class HeliumVisualizationFactory {
     // install visualization module
     File visModuleInstallPath = new File(workingDirectory,
         "node_modules/zeppelin-vis");
-    if (visualizationModulePath != null && !visModuleInstallPath.exists()) {
+    if (visualizationModulePath != null) {
+      if (visModuleInstallPath.exists()) {
+        // when zeppelin-vis and zeppelin-table package is published to npm repository
+        // we don't need to remove module because npm install command will take care
+        // dependency version change. However, when two dependencies are copied manually
+        // into node_modules directory, changing vis package version results inconsistent npm
+        // install behavior.
+        //
+        // Remote vis package everytime and let npm download every time bundle as a workaround
+        FileUtils.deleteDirectory(visModuleInstallPath);
+      }
       FileUtils.copyDirectory(visualizationModulePath, visModuleInstallPath, npmPackageCopyFilter);
     }
 
@@ -210,7 +230,7 @@ public class HeliumVisualizationFactory {
     synchronized (this) {
       currentBundle.delete();
       FileUtils.moveFile(visBundleJs, currentBundle);
-      bundleCacheKey = dependencies.toString();
+      bundleCacheKey = cacheKeyBuilder.toString();
     }
     return currentBundle;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumVisualizationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumVisualizationFactoryTest.java
@@ -30,9 +30,7 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class HeliumVisualizationFactoryTest {
   private File tmpDir;
@@ -153,5 +151,43 @@ public class HeliumVisualizationFactoryTest {
       assertTrue(e.getMessage().contains("error in the package"));
     }
     assertNull(bundle);
+  }
+
+  @Test
+  public void switchVersion() throws IOException, TaskRunnerException {
+    URL res = Resources.getResource("helium/webpack.config.js");
+    String resDir = new File(res.getFile()).getParent();
+
+    HeliumPackage pkgV1 = new HeliumPackage(
+        HeliumPackage.Type.VISUALIZATION,
+        "zeppelin-bubblechart",
+        "zeppelin-bubblechart",
+        "zeppelin-bubblechart@0.0.3",
+        "",
+        null,
+        "license",
+        "icon"
+    );
+
+    HeliumPackage pkgV2 = new HeliumPackage(
+        HeliumPackage.Type.VISUALIZATION,
+        "zeppelin-bubblechart",
+        "zeppelin-bubblechart",
+        "zeppelin-bubblechart@0.0.1",
+        "",
+        null,
+        "license",
+        "icon"
+    );
+    List<HeliumPackage> pkgsV1 = new LinkedList<>();
+    pkgsV1.add(pkgV1);
+
+    List<HeliumPackage> pkgsV2 = new LinkedList<>();
+    pkgsV2.add(pkgV2);
+
+    File bundle1 = hvf.bundle(pkgsV1);
+    File bundle2 = hvf.bundle(pkgsV2);
+
+    assertNotSame(bundle1.lastModified(), bundle2.lastModified());
   }
 }


### PR DESCRIPTION
### What is this PR for?
Changing visualization package version from helium menu, sometimes fail.
This PR fixes the problem and providing a unittest.


### What type of PR is it?
Bug Fix

### Todos
* [x] - remove package from node_module and let npm download again before bundle the package.
* [x] - add unittest.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1969

### How should this be tested?
Unittest HeliumVisualizationFactoryTest.switchVersion() ensure the fix.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
