### PR TITLE
[HOTFIX][ZEPPELIN-1970] Use relative path for broken screenshot imgs

### DIFF
--- a/docs/development/writingzeppelinvisualization.md
+++ b/docs/development/writingzeppelinvisualization.md
@@ -56,7 +56,7 @@ Once Zeppelin loads _Helium package files_ from local registry, available packag
 
 Click 'enable' button.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_visualization_helium_menu.png" />
+<img class="img-responsive" style="width:70%" src="../assets/themes/zeppelin/img/docs-img/writing_visualization_helium_menu.png" />
 
 
 #### 3. Create and load visualization bundle on the fly
@@ -69,7 +69,7 @@ Once a Visualization package is enabled, [HeliumVisualizationFactory](https://gi
 Zeppelin shows additional button for loaded Visualizations.
 User can use just like any other built-in visualizations.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_visualization_example.png" />
+<img class="img-responsive" style="width:70%" src="../assets/themes/zeppelin/img/docs-img/writing_visualization_example.png" />
 
 
 


### PR DESCRIPTION
### What is this PR for?
Two screenshot imgs in [Writing a new visualization](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/development/writingzeppelinvisualization.html) page are broken after deployed. It can be fixed by using relative path like other images. (e.g. [shiroauthentication.md](https://github.com/apache/zeppelin/blob/master/docs/security/shiroauthentication.md#4-login))

### What type of PR is it? 
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1970](https://issues.apache.org/jira/browse/ZEPPELIN-1970)

### How should this be tested?
It can't be reproduced using docs dev mode. Needs to be tested with below steps. 

```
1) build gh-pages (website) branch
JEKYLL_ENV=production bundle exec jekyll build
cp -r _site/ /tmp/zeppelin_website/
mkdir -p /tmp/zeppelin_website/docs/0.7.0-SNAPSHOT

2) build this patch (docs) and copy it under docs/0.7.0-SNAPSHOT of website
cd docs
bundle exec jekyll build --safe
cp -r _site/ /tmp/zeppelin_website/0.7.0-SNAPSHOT/

3) start httpserver and browse http://localhost:8000/docs/0.7.0-SNAPSHOT/
cd /tmp/zeppelin_website
python -m SimpleHTTPServer
```

### Screenshots (if appropriate)
 - before 
<img width="809" alt="screen shot 2017-01-15 at 3 10 53 pm" src="https://cloud.githubusercontent.com/assets/10060731/21960655/a73ee658-db35-11e6-8e4d-7702adb1ab19.png">

 - after 
<img width="751" alt="screen shot 2017-01-15 at 3 10 13 pm" src="https://cloud.githubusercontent.com/assets/10060731/21960650/a23348a2-db35-11e6-80a4-a6bc9b9b188c.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no

