### PR TITLE
[Hot Fix] Fix deadlink in writingzeppelinvisualization.md

### DIFF
--- a/docs/development/writingzeppelinvisualization.md
+++ b/docs/development/writingzeppelinvisualization.md
@@ -61,7 +61,7 @@ Click 'enable' button.
 
 #### 3. Create and load visualization bundle on the fly
 
-Once a Visualization package is enabled, [HeliumVisualizationFactory](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationPackage.java) creates a js bundle. The js bundle is served by `helium/visualization/load` rest api endpoint.
+Once a Visualization package is enabled, [HeliumVisualizationFactory](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java) creates a js bundle. The js bundle is served by `helium/visualization/load` rest api endpoint.
 
 
 #### 4. Run visualization


### PR DESCRIPTION
### What is this PR for?
It should point [HeliumVisualizationFactory.java](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java) not [HeliumVisualizationPackage.java](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationPackage.java)

### What type of PR is it?
Documentation | HotFix

### What is the Jira issue?
N/A

### How should this be tested?
click `HeliumVisualizationFactory` link in [this section](https://zeppelin.apache.org/docs/0.7.0-SNAPSHOT/development/writingzeppelinvisualization.html#3-create-and-load-visualization-bundle-on-the-fly) :)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
