### PR TITLE
[ZEPPELIN-1974] Remove extension from webpack config for visualization bundle

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -144,9 +144,6 @@ public class HeliumRestApi {
     } catch (IOException e) {
       logger.error(e.getMessage(), e);
       return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
-    } catch (TaskRunnerException e) {
-      logger.error(e.getMessage(), e);
-      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
 
@@ -157,9 +154,6 @@ public class HeliumRestApi {
       helium.disable(packageName);
       return new JsonResponse(Response.Status.OK).build();
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
-    } catch (TaskRunnerException e) {
       logger.error(e.getMessage(), e);
       return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
@@ -180,7 +174,7 @@ public class HeliumRestApi {
 
     try {
       helium.setVisualizationPackageOrder(orderedList);
-    } catch (IOException | TaskRunnerException e) {
+    } catch (IOException e) {
       logger.error(e.getMessage(), e);
       return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -16,7 +16,6 @@
  */
 package org.apache.zeppelin.helium;
 
-import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.io.FileUtils;
@@ -31,8 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.*;
 
 /**
@@ -54,7 +51,7 @@ public class Helium {
       String defaultLocalRegistryPath,
       HeliumVisualizationFactory visualizationFactory,
       HeliumApplicationFactory applicationFactory)
-      throws IOException, TaskRunnerException {
+      throws IOException {
     this.heliumConfPath = heliumConfPath;
     this.defaultLocalRegistryPath = defaultLocalRegistryPath;
     this.visualizationFactory = visualizationFactory;
@@ -206,11 +203,11 @@ public class Helium {
     return null;
   }
 
-  public File recreateVisualizationBundle() throws IOException, TaskRunnerException {
+  public File recreateVisualizationBundle() throws IOException {
     return visualizationFactory.bundle(getVisualizationPackagesToBundle(), true);
   }
 
-  public void enable(String name, String artifact) throws IOException, TaskRunnerException {
+  public void enable(String name, String artifact) throws IOException {
     HeliumPackageSearchResult pkgInfo = getPackageInfo(name, artifact);
 
     // no package found.
@@ -229,7 +226,7 @@ public class Helium {
     save();
   }
 
-  public void disable(String name) throws IOException, TaskRunnerException {
+  public void disable(String name) throws IOException {
     String artifact = heliumConf.getEnabledPackages().get(name);
 
     if (artifact == null) {
@@ -344,7 +341,7 @@ public class Helium {
   }
 
   public void setVisualizationPackageOrder(List<String> orderedPackageList)
-      throws IOException, TaskRunnerException {
+      throws IOException {
     heliumConf.setVisualizationDisplayOrder(orderedPackageList);
 
     // if package is visualization, rebuild bundle

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
@@ -94,12 +94,12 @@ public class HeliumVisualizationFactory {
     return new ProxyConfig(proxy);
   }
 
-  public File bundle(List<HeliumPackage> pkgs) throws IOException, TaskRunnerException {
+  public File bundle(List<HeliumPackage> pkgs) throws IOException {
     return bundle(pkgs, false);
   }
 
   public synchronized File bundle(List<HeliumPackage> pkgs, boolean forceRefresh)
-      throws IOException, TaskRunnerException {
+      throws IOException {
     // package.json
     URL pkgUrl = Resources.getResource("helium/package.json");
     String pkgJson = Resources.toString(pkgUrl, Charsets.UTF_8);
@@ -213,8 +213,12 @@ public class HeliumVisualizationFactory {
     }
 
     out.reset();
-    npmCommand("install");
-    npmCommand("run bundle");
+    try {
+      npmCommand("install");
+      npmCommand("run bundle");
+    } catch (TaskRunnerException e) {
+      throw new IOException(new String(out.toByteArray()));
+    }
 
     File visBundleJs = new File(workingDirectory, "vis.bundle.js");
     if (!visBundleJs.isFile()) {

--- a/zeppelin-zengine/src/main/resources/helium/webpack.config.js
+++ b/zeppelin-zengine/src/main/resources/helium/webpack.config.js
@@ -21,8 +21,7 @@ module.exports = {
         filename: 'vis.bundle.js',
     },
     resolve: {
-        root: __dirname + "/node_modules",
-        extensions: [".js"]
+        root: __dirname + "/node_modules"
     },
     module: {
         loaders: [{


### PR DESCRIPTION
### What is this PR for?
webpack.config.js for creating visualization bundle has unnecessary extension configuration, which makes unable to import some libraries.

This PR removes the unnecessary configuration and propagate 'npm install' error message to front-end.

### What type of PR is it?
Bug Fix

### Todos
* [x] - exclude 'extensions' from webpack.config.js for visualization bundle
* [x] - propagate 'npm install' error to front-end 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1974

### Screenshots (if appropriate)

Before propagate error message to front-end
![image](https://cloud.githubusercontent.com/assets/1540981/21994155/2095e554-dbd3-11e6-8923-8deafecd350b.png)

After propagate error message to front-end
![image](https://cloud.githubusercontent.com/assets/1540981/21994317/f8ffdcec-dbd3-11e6-8bec-156aa2d5bdf7.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
