### PR TITLE
[ZEPPELIN-1976] Text-Output too large, causing crash

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -219,7 +219,7 @@
 <property>
   <name>zeppelin.interpreter.output.limit</name>
   <value>102400</value>
-  <description>Output message from interpreter exceed the limit will be truncated</description>
+  <description>Output message from interpreter exceeding the limit will be truncated</description>
 </property>
 
 <property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -216,6 +216,11 @@
   <description>Interpreter process connect timeout in msec.</description>
 </property>
 
+<property>
+  <name>zeppelin.interpreter.output.limit</name>
+  <value>102400</value>
+  <description>Output message from interpreter exceed the limit will be truncated</description>
+</property>
 
 <property>
   <name>zeppelin.ssl</name>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -249,6 +249,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Interpreter directory</td>
   </tr>
   <tr>
+    <td>ZEPPELIN_INTERPRETER_OUTPUT_LIMIT</td>
+    <td>zeppelin.interpreter.output.limit</td>
+    <td>102400</td>
+    <td>Output message from interpreter exceed the limit will be truncated</td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>
     <td>zeppelin.websocket.max.text.message.size</td>
     <td>1024000</td>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -252,7 +252,7 @@ If both are defined, then the **environment variables** will take priority.
     <td>ZEPPELIN_INTERPRETER_OUTPUT_LIMIT</td>
     <td>zeppelin.interpreter.output.limit</td>
     <td>102400</td>
-    <td>Output message from interpreter exceed the limit will be truncated</td>
+    <td>Output message from interpreter exceeding the limit will be truncated</td>
   </tr>
   <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Constants.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Constants.java
@@ -30,4 +30,6 @@ public class Constants {
 
   public static final int ZEPPELIN_INTERPRETER_DEFAUlT_PORT = 29914;
 
+  public static final int ZEPPELIN_INTERPRETER_OUTPUT_LIMIT = 1024 * 100;
+
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -63,6 +63,7 @@ public class RemoteInterpreter extends Interpreter {
   private int port;
   private String userName;
   private Boolean isUserImpersonate;
+  private int outputLimit = Constants.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT;
 
   /**
    * Remote interpreter and manage interpreter process
@@ -70,7 +71,8 @@ public class RemoteInterpreter extends Interpreter {
   public RemoteInterpreter(Properties property, String sessionKey, String className,
       String interpreterRunner, String interpreterPath, String localRepoPath, int connectTimeout,
       int maxPoolSize, RemoteInterpreterProcessListener remoteInterpreterProcessListener,
-      ApplicationEventListener appListener, String userName, Boolean isUserImpersonate) {
+      ApplicationEventListener appListener, String userName, Boolean isUserImpersonate,
+      int outputLimit) {
     super(property);
     this.sessionKey = sessionKey;
     this.className = className;
@@ -85,6 +87,7 @@ public class RemoteInterpreter extends Interpreter {
     this.applicationEventListener = appListener;
     this.userName = userName;
     this.isUserImpersonate = isUserImpersonate;
+    this.outputLimit = outputLimit;
   }
 
 
@@ -94,7 +97,8 @@ public class RemoteInterpreter extends Interpreter {
   public RemoteInterpreter(Properties property, String sessionKey, String className, String host,
       int port, String localRepoPath, int connectTimeout, int maxPoolSize,
       RemoteInterpreterProcessListener remoteInterpreterProcessListener,
-      ApplicationEventListener appListener, String userName, Boolean isUserImpersonate) {
+      ApplicationEventListener appListener, String userName, Boolean isUserImpersonate,
+      int outputLimit) {
     super(property);
     this.sessionKey = sessionKey;
     this.className = className;
@@ -108,6 +112,7 @@ public class RemoteInterpreter extends Interpreter {
     this.applicationEventListener = appListener;
     this.userName = userName;
     this.isUserImpersonate = isUserImpersonate;
+    this.outputLimit = outputLimit;
   }
 
 
@@ -217,6 +222,8 @@ public class RemoteInterpreter extends Interpreter {
         if (localRepoPath != null) {
           property.put("zeppelin.interpreter.localRepo", localRepoPath);
         }
+
+        property.put("zeppelin.interpreter.output.limit", Integer.toString(outputLimit));
         client.createInterpreter(groupId, sessionKey,
             getClassName(), (Map) property, userName);
         // Push angular object loaded from JSON file to remote interpreter

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -162,6 +162,11 @@ public class RemoteInterpreterServer
       interpreterGroup.setResourcePool(resourcePool);
 
       String localRepoPath = properties.get("zeppelin.interpreter.localRepo");
+      if (properties.containsKey("zeppelin.interpreter.output.limit")) {
+        InterpreterOutput.limit = Integer.parseInt(
+            properties.get("zeppelin.interpreter.output.limit"));
+      }
+
       depLoader = new DependencyResolver(localRepoPath);
       appLoader = new ApplicationLoader(resourcePool, depLoader);
     }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputTest.java
@@ -162,6 +162,33 @@ public class InterpreterOutputTest implements InterpreterOutputListener {
     assertEquals("val1\tval2\n", new String(out.getOutputAt(1).toByteArray()));
   }
 
+  @Test
+  public void testTruncate() throws IOException {
+    // output is truncated after the new line
+    InterpreterOutput.limit = 3;
+    out = new InterpreterOutput(this);
+
+    // truncate text
+    out.write("%text hello\nworld\n");
+    assertEquals("hello", new String(out.getOutputAt(0).toByteArray()));
+    assertTrue(new String(out.getOutputAt(1).toByteArray()).contains("Truncated"));
+
+    // truncate table
+    out = new InterpreterOutput(this);
+    out.write("%table key\tvalue\nhello\t100\nworld\t200\n");
+    assertEquals("key\tvalue", new String(out.getOutputAt(0).toByteArray()));
+    assertTrue(new String(out.getOutputAt(1).toByteArray()).contains("Truncated"));
+
+    // does not truncate html
+    out = new InterpreterOutput(this);
+    out.write("%html hello\nworld\n");
+    out.flush();
+    assertEquals("hello\nworld\n", new String(out.getOutputAt(0).toByteArray()));
+
+    // restore default
+    InterpreterOutput.limit = Constants.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT;
+  }
+
 
   @Override
   public void onUpdateAll(InterpreterOutput out) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -37,6 +37,7 @@ import org.apache.zeppelin.helium.Helium;
 import org.apache.zeppelin.helium.HeliumApplicationFactory;
 import org.apache.zeppelin.helium.HeliumVisualizationFactory;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
@@ -97,6 +98,8 @@ public class ZeppelinServer extends Application {
 
     this.depResolver = new DependencyResolver(
         conf.getString(ConfVars.ZEPPELIN_INTERPRETER_LOCALREPO));
+
+    InterpreterOutput.limit = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT);
 
     HeliumApplicationFactory heliumApplicationFactory = new HeliumApplicationFactory();
     HeliumVisualizationFactory heliumVisualizationFactory;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -572,6 +572,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_GROUP_ORDER("zeppelin.interpreter.group.order", "spark,md,angular,sh,"
         + "livy,alluxio,file,psql,flink,python,ignite,lens,cassandra,geode,kylin,elasticsearch,"
         + "scalding,jdbc,hbase,bigquery,beam,pig,scio"),
+    ZEPPELIN_INTERPRETER_OUTPUT_LIMIT("zeppelin.interpreter.output.limit", 1024 * 100),
     ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
     ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),
     // use specified notebook (id) as homescreen

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -1150,7 +1150,7 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     LazyOpenInterpreter intp = new LazyOpenInterpreter(
         new RemoteInterpreter(property, interpreterSessionKey, className, host, port, localRepoPath,
             connectTimeout, maxPoolSize, remoteInterpreterProcessListener, appEventListener,
-            userName, isUserImpersonate));
+            userName, isUserImpersonate, conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT)));
     return intp;
   }
 
@@ -1175,7 +1175,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     RemoteInterpreter remoteInterpreter =
         new RemoteInterpreter(property, interpreterSessionKey, className,
             interpreterRunnerPath, interpreterPath, localRepoPath, connectTimeout, maxPoolSize,
-            remoteInterpreterProcessListener, appEventListener, userName, isUserImpersonate);
+            remoteInterpreterProcessListener, appEventListener, userName, isUserImpersonate,
+            conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT));
     remoteInterpreter.addEnv(env);
 
     return new LazyOpenInterpreter(remoteInterpreter);


### PR DESCRIPTION
### What is this PR for?
This PR implements interpreter output message limit.

`ZEPPELIN_INTERPRETER_OUTPUT_LIMIT` env variable or `zeppelin.interpreter.output.limit` jvm property can set limit of the interpreter output message in byte.

The limit applied to only TEXT and TABLE type output, not in HTML or other types.


### What type of PR is it?
Improvement

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1976

### How should this be tested?

try to print more than the limit
```
%spark
(1 to 10000).foreach(i=>
    println(s"Print line ${i} times")
)
```

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/1540981/22035334/6c17ff9a-dca4-11e6-89b0-51b9340856b0.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
