### PR TITLE
[ZEPPELIN-1978] Let Zeppelin server start if authorization file is corrupt 

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -110,8 +110,13 @@ public class NotebookAuthorization {
     fis.close();
 
     String json = sb.toString();
-    NotebookAuthorizationInfoSaving info = gson.fromJson(json,
-            NotebookAuthorizationInfoSaving.class);
+    NotebookAuthorizationInfoSaving info = null;
+    try {
+      info = gson.fromJson(json, NotebookAuthorizationInfoSaving.class);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+    
     authInfo = info.authInfo;
   }
   


### PR DESCRIPTION
### What is this PR for?
This is to let Zeppelin server start even when the notebook authorization file is corrupt. Previously it would fail to start without even trace in logs, currently it starts with below logs:
```
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 2031
	at org.apache.zeppelin.notebook.NotebookAuthorization.loadFromFile(NotebookAuthorization.java:117)
	at org.apache.zeppelin.notebook.NotebookAuthorization.init(NotebookAuthorization.java:77)
	at org.apache.zeppelin.notebook.NotebookAuthorization.getInstance(NotebookAuthorization.java:89)
	at org.apache.zeppelin.notebook.repo.NotebookRepoSync.sync(NotebookRepoSync.java:220)
	at org.apache.zeppelin.notebook.repo.NotebookRepoSync.sync(NotebookRepoSync.java:274)
	at org.apache.zeppelin.notebook.repo.NotebookRepoSync.<init>(NotebookRepoSync.java:99)
	at org.apache.zeppelin.server.ZeppelinServer.<init>(ZeppelinServer.java:137)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet.createSingletonInstance(CXFNonSpringJaxrsServlet.java:382)
	at org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet.createApplicationInstance(CXFNonSpringJaxrsServlet.java:454)
	at org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet.createServerFromApplication(CXFNonSpringJaxrsServlet.java:432)
	at org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet.init(CXFNonSpringJaxrsServlet.java:93)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:616)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:396)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:871)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:298)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1349)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1342)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:505)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132)
	at org.eclipse.jetty.server.Server.start(Server.java:387)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:354)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.apache.zeppelin.server.ZeppelinServer.main(ZeppelinServer.java:178)
Caused by: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 2031
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:176)
	at com.google.gson.Gson.fromJson(Gson.java:791)
	at com.google.gson.Gson.fromJson(Gson.java:757)
	at com.google.gson.Gson.fromJson(Gson.java:706)
	at com.google.gson.Gson.fromJson(Gson.java:678)
	at org.apache.zeppelin.notebook.NotebookAuthorization.loadFromFile(NotebookAuthorization.java:115)
	... 35 more
Caused by: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BOOLEAN at line 1 column 2031
	at com.google.gson.stream.JsonReader.expect(JsonReader.java:339)
	at com.google.gson.stream.JsonReader.beginArray(JsonReader.java:306)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:79)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:60)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:188)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:146)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:188)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:146)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:93)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:172)
	... 40 more
```


### What type of PR is it?
Improvement

### Todos
* [x] - rethrow exception

### What is the Jira issue?
[ZEPPELIN-1978](https://issues.apache.org/jira/browse/ZEPPELIN-1978)

### How should this be tested?
modify `conf/notebook-authorization.json` and start zeppelin. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
