### PR TITLE
ZEPPELIN-1977. spark 2.1 uses a more recent commons-lang3

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -20,7 +20,7 @@ package org.apache.zeppelin.livy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -17,7 +17,7 @@
 
 package org.apache.zeppelin.livy;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -33,6 +33,7 @@
   <name>Zeppelin: Markdown interpreter</name>
 
   <properties>
+    <commons.lang3.version>3.4</commons.lang3.version>
     <markdown4j.version>2.2-cj-1.0</markdown4j.version>
     <pegdown.version>1.6.0</pegdown.version>
   </properties>
@@ -65,6 +66,12 @@
       <groupId>org.pegdown</groupId>
       <artifactId>pegdown</artifactId>
       <version>${pegdown.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang3.version}</version>
     </dependency>
 
     <dependency>

--- a/pig/src/main/java/org/apache/zeppelin/pig/BasePigInterpreter.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/BasePigInterpreter.java
@@ -17,7 +17,7 @@
 
 package org.apache.zeppelin.pig;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.pig.PigServer;
 import org.apache.pig.backend.BackendException;

--- a/pig/src/main/java/org/apache/zeppelin/pig/PigInterpreter.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/PigInterpreter.java
@@ -18,8 +18,8 @@
 package org.apache.zeppelin.pig;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.pig.PigServer;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.tools.pigstats.*;

--- a/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
@@ -19,8 +19,8 @@
 package org.apache.zeppelin.pig;
 
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.pig.PigServer;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.FrontendException;
@@ -114,7 +114,7 @@ public class PigQueryInterpreter extends BasePigInterpreter {
           resultBuilder.append("\n");
           firstRow = false;
         }
-        resultBuilder.append(StringUtils.join(tuple, "\t"));
+        resultBuilder.append(StringUtils.join(tuple.iterator(), "\t"));
         resultBuilder.append("\n");
       }
       if (index >= maxResult && iter.hasNext()) {

--- a/pig/src/main/java/org/apache/zeppelin/pig/PigUtils.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/PigUtils.java
@@ -19,8 +19,8 @@ package org.apache.zeppelin.pig;
 
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.pig.PigRunner;
 import org.apache.pig.backend.hadoop.executionengine.tez.TezExecType;
 import org.apache.pig.tools.pigstats.InputStats;

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <!--library versions -->
+    <commons.lang3.version>3.4</commons.lang3.version>
     <commons.exec.version>1.3</commons.exec.version>
   </properties>
 
@@ -59,6 +60,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>${commons.exec.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang3.version}</version>
     </dependency>
 
     <dependency>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -37,7 +37,6 @@
 
   <properties>
     <!--library versions-->
-    <commons.lang3.version>3.4</commons.lang3.version>
     <commons.pool2.version>2.3</commons.pool2.version>
     <commons.exec.version>1.3</commons.exec.version>
     <maven.plugin.api.version>3.0</maven.plugin.api.version>
@@ -86,12 +85,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
-    <dependency>
-    	<groupId>org.apache.commons</groupId>
-    	<artifactId>commons-lang3</artifactId>
-        <version>${commons.lang3.version}</version>
     </dependency>
 
     <!-- Aether :: maven dependency resolution -->

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -17,7 +17,7 @@
 
 package org.apache.zeppelin.dep;
 
-import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang.Validate;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Repository.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Repository.java
@@ -16,7 +16,7 @@
  */
 
 package org.apache.zeppelin.dep;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 import org.sonatype.aether.repository.Authentication;
 import org.sonatype.aether.repository.Proxy;

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -380,6 +380,10 @@
           <groupId>net.java.dev.jna</groupId>
           <artifactId>jna</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -36,6 +36,7 @@
 
   <properties>
     <!--library versions-->
+    <commons.lang3.version>3.4</commons.lang3.version>
     <commons.vfs2.version>2.0</commons.vfs2.version>
     <aws.sdk.s3.version>1.10.62</aws.sdk.s3.version>
     <azure.storage.version>4.0.0</azure.storage.version>
@@ -276,6 +277,12 @@
       <artifactId>websocket-server</artifactId>
       <version>${jetty.version}</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang3.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What is this PR for?
The issue is that spark 2.1 use `commons-lang3` 3.5 while `zeppelin-interpreter` use 3.4. We can not just upgrade `commons-lang3` to 3.5, as it just make spark 2.1 work, but would fail other versions of spark. This PR remove `commons-lang3` from zeppelin-interpreter. We should keep zeppelin-interpreter's dependencies as minimum as possible. We can remove other dependencies (like `commons-lang`) from `zeppelin-interpreter` in a followup PR. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-1977

### How should this be tested?
Tested manually
![2017-01-18_1448](https://cloud.githubusercontent.com/assets/164491/22054522/f125e836-dd90-11e6-9acf-d73541046d95.png)
 on 3 versions of spark (2.1, 2.0.2, 1.6.2)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
