### PR TITLE
[HOTFIX][ZEPPELIN-1980] - Test and update CI for matplotlib 2.0.0

### DIFF
--- a/interpreter/lib/python/mpl_config.py
+++ b/interpreter/lib/python/mpl_config.py
@@ -50,8 +50,12 @@ def get(key):
 def _on_config_change():
     # dpi
     dpi = _config['dpi']
-    matplotlib.rcParams['savefig.dpi'] = dpi
+    
+    # For older versions of matplotlib, savefig.dpi is not synced with
+    # figure.dpi by default
     matplotlib.rcParams['figure.dpi'] = dpi
+    if matplotlib.__version__ < '2.0.0':
+        matplotlib.rcParams['savefig.dpi'] = dpi
     
     # Width and height
     width = float(_config['width']) / dpi
@@ -75,7 +79,7 @@ def _on_config_change():
     
     
 def _init_config():
-    dpi = matplotlib.rcParams['savefig.dpi']
+    dpi = matplotlib.rcParams['figure.dpi']
     fmt = matplotlib.rcParams['savefig.format']
     width, height = matplotlib.rcParams['figure.figsize']
     fontsize = matplotlib.rcParams['font.size']

--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -44,5 +44,5 @@ if [[ -n "$PYTHON" ]] ; then
   conda update -q conda
   conda info -a
   conda config --add channels conda-forge
-  conda install -q matplotlib=1.5.3 pandasql
+  conda install -q matplotlib pandasql
 fi


### PR DESCRIPTION
### What is this PR for?
Matplotlib 2.0.0 was just released. It has introduced some major changes including some to the `rcParams` which makes it incompatible with Zeppelin's built-in plotting backend. This PR updates the backend config for 2.0.0 as well as the CI tests.

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-1980](https://issues.apache.org/jira/browse/ZEPPELIN-1980)

### How should this be tested?
Run the matplotlib tutorial notebook with matplotlib 2.0.0 installed.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

If possible, this should be included as a hotfix for 0.7.0.