### PR TITLE
[ZEPPELIN-1979] fix 'File size limit Exceeded' when importing notes

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -85,6 +85,10 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     return ($routeParams.noteId === noteId);
   }
 
+  function listConfigurations() {
+    websocketMsgSrv.listConfigurations();
+  }
+
   function loadNotes() {
     websocketMsgSrv.getNoteList();
   }
@@ -135,6 +139,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
   });
 
   $scope.$on('loginSuccess', function(event, param) {
+    listConfigurations();
     loadNotes();
   });
 
@@ -153,4 +158,3 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     });
   }
 }
-


### PR DESCRIPTION
### What is this PR for?
This is to fix the problem with import of note because of size limitations. Actually it seemed to be working in anonymous mode, and I noticed the problem only when authentication is enabled.


### What type of PR is it?
Bug Fix

### Todos
* [x] - list conf on successful login

### What is the Jira issue?
[ZEPPELIN-1979](https://issues.apache.org/jira/browse/ZEPPELIN-1979)

### How should this be tested?
1. set note msg size value in `conf/zeppelin-env.sh` e.g.
```
export ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE="4096000"
```
2.  login to Zeppelin
3. try to import note unde 4MB

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
