### PR TITLE
[ZEPPELIN-1983] Feedback about success/failure when interpreter is re…

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -424,8 +424,11 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
             .success(function(data, status, headers, config) {
               var index = _.findIndex($scope.interpreterSettings, {'id': settingId});
               $scope.interpreterSettings[index] = data.body;
+              ngToast.info('Interpreter stopped. Will be lazily started on next run.');
             }).error(function(data, status, headers, config) {
-            console.log('Error %o %o', status, data.message);
+              var errorMsg = (data !== null) ? data.message : 'Could not connect to server.';
+              console.log('Error %o %o', status, errorMsg);
+              ngToast.danger(errorMsg);
           });
         }
       }


### PR DESCRIPTION
### What is this PR for?
When a interpreter is restarted, there is no feedback to user whether the action is received/honoured by zeppelin. This might also lead them to click restart multiple times, before they realize it has taken affect.
Also fixed a null bug.

### What type of PR is it?
[Improvement + Bug fix]

### Todos
* None

### What is the Jira issue?
ZEPPELIN-1983

### How should this be tested?
Restart a interpreter to test the positive case. The message should disappers on its own after sometime if not closed. A simple way to test the negative case is to stop the server and then try restarting.

### Screenshots (if appropriate)
#### Positive case
![positive case](https://cloud.githubusercontent.com/assets/4542030/22111327/fa675304-de84-11e6-9323-da49f2f70902.png)

#### Negative case
![negative case](https://cloud.githubusercontent.com/assets/4542030/22111326/fa31bd84-de84-11e6-8a2e-07aaf0179275.png)



### Questions:
* Does the licenses files need update?
-No
* Is there breaking changes for older versions?
-No
* Does this needs documentation?
-No
