### PR TITLE
[ZEPPELIN-1988] precode execution in JDBCInterpreter

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -31,7 +31,7 @@
   <packaging>jar</packaging>
   <version>0.7.0-SNAPSHOT</version>
   <name>Zeppelin: JDBC interpreter</name>
-  
+
   <properties>
     <!--library versions-->
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>


### PR DESCRIPTION
### What is this PR for?
PR adds new parameter in JDBC interpreter which allows to execute some SQL while opening connection.

Parameter: default.precode
Value examples:
"select 1;"
"set application_name=zeppelin;"

If parameter is null then precode is ignored.

### What type of PR is it?
Feature

### Todos
* [ ] - ZEPPELIN-1988

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1988

### How should this be tested?
* Use %jdbc interpreter with DB user with create schema grants
* Set %jdbc interpreter property name / value to "default.precode" / "create schema zeppelin1988;"
* Check if schema has been created

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
