### PR TITLE
[ZEPPELIN-1455] Fix flaky test: AbstractAngularElemTest

### DIFF
--- a/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularElemTest.scala
+++ b/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularElemTest.scala
@@ -23,6 +23,7 @@ import org.apache.zeppelin.display.{AngularObject, AngularObjectRegistry, GUI}
 import org.apache.zeppelin.interpreter._
 import org.apache.zeppelin.user.AuthenticationInfo
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach, FlatSpec, Matchers}
 
 /**
@@ -61,12 +62,12 @@ trait AbstractAngularElemTest
     // click create thread for callback function to run. So it'll may not immediately invoked
     // after click. therefore eventually should be
     click(elem)
-    eventually {
+    eventually (timeout(Span(5, Seconds))) {
       a should be(1)
     }
 
     click(elem)
-    eventually {
+    eventually (timeout(Span(5, Seconds))) {
       a should be(2)
     }
 
@@ -120,7 +121,7 @@ trait AbstractAngularElemTest
 
     click(elem)
 
-    eventually { modelValue should be("value")}
+    eventually (timeout(Span(5, Seconds))) { modelValue should be("value")}
   }
 
 


### PR DESCRIPTION
### What is this PR for?
This PR fix flaky test [ZEPPELIN-1455](https://issues.apache.org/jira/browse/ZEPPELIN-1455).

According to http://doc.scalatest.org/1.8/org/scalatest/concurrent/Eventually.html, default timeout of eventually is 150millisecond. Set enough timeout for the test.

### What type of PR is it?
Hot Fix

### Todos
* [x] - increase timeout

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1455

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
