### PR TITLE
[ZEPPELIN-1984] Zeppelin Server doesn't catch all exceptions when launching interpreter.sh

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -214,7 +214,7 @@ eval $INTERPRETER_RUN_COMMAND &
 
 pid=$!
 if [[ -z "${pid}" ]]; then
-  return 1;
+  exit 1;
 else
   echo ${pid} > ${ZEPPELIN_PID}
 fi


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ZEPPELIN-1984

> DEBUG [2017-01-20 13:56:37,688] ({Exec Stream Pumper} RemoteInterpreterManagedProcess.java[processLine]:189) - /opt/zeppelin/zeppelin-active/bin/interpreter.sh: line 207: return: can only `return' from a function or sourced script
>  INFO [2017-01-20 13:56:37,690] ({Exec Default Executor} RemoteInterpreterManagedProcess.java[onProcessComplete]:164) - Interpreter process exited 0

So `return 1` outside of function is not correct and gets ignored by shell interpreters, also it causes 
Zeppelin to not catch situations when interpreter hasn't started, as shown in ZEPPELIN-1984.
As you can see Zeppelin got exit status of interpreter.sh as 0 when it had to be 1 (error). Zeppelin then starts a loop to try to connect interpreter process, and fails half a minute later with `connection refused`

### What is this PR for?
Fix for https://issues.apache.org/jira/browse/ZEPPELIN-1984


### What type of PR is it?
Bug Fix 

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1984

### How should this be tested?
On example of Spark interpreter, remove keytab file and keep --keytab reference to it in SPARK_SUBMIT_OPTIONS. Try to use Spark interpreter. spark-submit will fail with `Exception in thread "main" org.apache.spark.SparkException: Keytab file: /home/someuser/.kt does not exist` but Zeppelin (around [RemoteInterpreterManagedProcess.java](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java#L121) ) wouldn't capture this problem (or many other problems starting interpreter process [as indicated here](https://issues.apache.org/jira/browse/ZEPPELIN-1984?focusedCommentId=15831000&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15831000) )

This fix for ZEPPELIN-1984 would allow for error to be captured by RemoteInterpreterManagedProcess.java. 

A future improvement could be made, to carry forward exception from interpreter to RemoteInterpreterManagedProcess.java so end user could clearly see what's the problem, not just that the interpreter could not be started.

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No

