### PR TITLE
[ZEPPELIN-1991] Can't get the PARAGRAPH_APPEND_OUTPUT from the Interpreter.

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
@@ -41,7 +41,7 @@ public class AppendOutputRunner implements Runnable {
   private static final Long SAFE_PROCESSING_TIME = new Long(10);
   private static final Long SAFE_PROCESSING_STRING_SIZE = new Long(100000);
 
-  private final BlockingQueue<AppendOutputBuffer> queue = new LinkedBlockingQueue<>();
+  private static final BlockingQueue<AppendOutputBuffer> queue = new LinkedBlockingQueue<>();
   private final RemoteInterpreterProcessListener listener;
 
   public AppendOutputRunner(RemoteInterpreterProcessListener listener) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
@@ -41,7 +41,7 @@ public class AppendOutputRunner implements Runnable {
   private static final Long SAFE_PROCESSING_TIME = new Long(10);
   private static final Long SAFE_PROCESSING_STRING_SIZE = new Long(100000);
 
-  private static final BlockingQueue<AppendOutputBuffer> queue = new LinkedBlockingQueue<>();
+  private final BlockingQueue<AppendOutputBuffer> queue = new LinkedBlockingQueue<>();
   private final RemoteInterpreterProcessListener listener;
 
   public AppendOutputRunner(RemoteInterpreterProcessListener listener) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class RemoteInterpreterEventPoller extends Thread {
   private static final Logger logger = LoggerFactory.getLogger(RemoteInterpreterEventPoller.class);
-  private static final ScheduledExecutorService appendService =
+  private final ScheduledExecutorService appendService =
       Executors.newSingleThreadScheduledExecutor();
   private final RemoteInterpreterProcessListener listener;
   private final ApplicationEventListener appListener;


### PR DESCRIPTION
### What is this PR for?
This PR fixes the problem of streaming events(PARAGRAPH_APPEND_OUTPUT).
It's because of the queue was not thread safe.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1991


### How should this be tested?
1. make a spark paragraph

2. run following code on spark paragraph.
```
%spark
(1 to 5).foreach{ i=>
    Thread.sleep(1000)
    println("Hello " + i)
}

```
3. make a python paragraph

4. run following code on python paragraph.
```
%python.python

print("hi1")
```

5. retry run step 2, and check if streaming working.

### Screenshots (if appropriate)
- before
![2017-01-20 13_36_02](https://cloud.githubusercontent.com/assets/3348133/22166640/edb9f610-df16-11e6-926c-c781f618e6cf.gif)


- after
![2017-01-20 13_52_53](https://cloud.githubusercontent.com/assets/3348133/22166840/efd855e4-df17-11e6-816c-17e069cd6a04.gif)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
