### PR TITLE
[Pyspark] checking nhooks count.

### DIFF
--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -321,7 +321,9 @@ while True :
       # so that the last statement's evaluation will be printed to stdout
       sc.setJobGroup(jobGroup, "Zeppelin")
       code = compile('\n'.join(final_code), '<stdin>', 'exec', ast.PyCF_ONLY_AST, 1)
-      to_run_hooks = code.body[-nhooks:]
+      to_run_hooks = []
+      if (nhooks > 0):
+        to_run_hooks = code.body[-nhooks:]
       to_run_exec, to_run_single = (code.body[:-(nhooks + 1)],
                                     [code.body[-(nhooks + 1)]])
 

--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
@@ -213,7 +213,7 @@ public class PySparkInterpreterMatplotlibTest {
     // again but in a different color.
     ret = pyspark.interpret("plt.plot([1, 2, 3])", context);
     ret2 = pyspark.interpret("plt.show()", context);
-    assertNotSame(ret1.message().get(1).getData(), ret2.message().get(1).getData());
+    assertNotSame(ret1.message().get(0).getData(), ret2.message().get(0).getData());
   }
   
   @Test
@@ -226,7 +226,7 @@ public class PySparkInterpreterMatplotlibTest {
     ret = pyspark.interpret("plt.plot([1, 2, 3])", context);
     ret = pyspark.interpret("plt.show()", context);    
     assertEquals(ret.message().toString(), InterpreterResult.Code.SUCCESS, ret.code());
-    assertEquals(ret.message().toString(), Type.ANGULAR, ret.message().get(1).getType());
+    assertEquals(ret.message().toString(), Type.ANGULAR, ret.message().get(0).getType());
 
     // Check if the figure data is in the Angular Object Registry
     AngularObjectRegistry registry = context.getAngularObjectRegistry();


### PR DESCRIPTION
### What is this PR for?
if the `nhooks` value is `0` in this(https://github.com/apache/zeppelin/blob/master/spark/src/main/resources/python/zeppelin_pyspark.py#L324) line, python code will run twice.


### What type of PR is it?
Bug Fix | Improvement 


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2024


### How should this be tested?
- comment https://github.com/apache/zeppelin/blob/master/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java#L114 line and build.
- run pyspark code(eg, `print("hi")`), then you can see it run twice.


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
