### PR TITLE
[ZEPPELIN-1994] bugfix of streaming output.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1040,7 +1040,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       $scope.paragraph.title = data.paragraph.title;
       $scope.paragraph.lineNumbers = data.paragraph.lineNumbers;
       $scope.paragraph.status = data.paragraph.status;
-      $scope.paragraph.results = data.paragraph.results;
+      if (data.paragraph.status !== 'RUNNING') {
+        $scope.paragraph.results = data.paragraph.results;
+      }
       $scope.paragraph.settings = data.paragraph.settings;
       if ($scope.editor) {
         $scope.editor.setReadOnly($scope.isRunning(data.paragraph));


### PR DESCRIPTION
### What is this PR for?
If you run the following code, then streaming output doesn't work properly from the second run.
```
%spark.pyspark
import time
print("1")
time.sleep(2)
print("2")
time.sleep(2)
print("3")
time.sleep(2)
print("4")
```
This problem comes from the order of `paragraph update` event timing and `paragraph update-append` event timing is incorrect.
and This PR will fix also https://github.com/apache/zeppelin/pull/1833 too.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1994


### How should this be tested?
- run several times pyspark interpreter with above code.


### Screenshots (if appropriate)
- before
![2017-01-21 00_55_25](https://cloud.githubusercontent.com/assets/3348133/22173437/bfa48e64-df77-11e6-9625-ab44dedee395.gif)


- after
![2017-01-21 00_59_12](https://cloud.githubusercontent.com/assets/3348133/22173438/c21820ac-df77-11e6-87dc-07970fca13ca.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions?no
* Does this needs documentation?no
