### PR TITLE
[ZEPPELIN-1997] Added derbylog in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ zeppelin-server/derby.log
 
 lens/lens-cli-hist.log
 
+# bin file
+bin/derby.log
+
 # conf file
 conf/zeppelin-env.sh
 conf/zeppelin-env.cmd
@@ -69,8 +72,7 @@ zeppelin-web/yarn.lock
 /local-repo/
 
 **/sessions/
-**/data/
-**/build/
+**/data/ **/build/
 **/testing/
 !/testing/
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,16 +11,13 @@
 !/interpreter/lib
 
 # interpreter temp files
-spark/derby.log
+derby.log
 spark/metastore_db
 spark-1.*-bin-hadoop*
 .spark-dist
-zeppelin-server/derby.log
 
 lens/lens-cli-hist.log
 
-# bin file
-bin/derby.log
 
 # conf file
 conf/zeppelin-env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,8 @@ zeppelin-web/yarn.lock
 /local-repo/
 
 **/sessions/
-**/data/ **/build/
+**/data/ 
+**/build/
 **/testing/
 !/testing/
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ zeppelin-web/yarn.lock
 /local-repo/
 
 **/sessions/
-**/data/ 
+**/data/
 **/build/
 **/testing/
 !/testing/


### PR DESCRIPTION
### What is this PR for?
Added derbylog in .gitignore
Sometime created derby.log in bin directory.
We should stop tracking derbylog
derby.log
```
1 ----------------------------------------------------------------
2 Thu Jan 19 23:45:08 PST 2017:
3 Booting Derby version The Apache Software Foundation - Apache Derby - 10.10.2.0 - (1582446): instance a816c00e-0159-bad6-0f44-000030e6b528
4 on database directory /Users/cloverhearts/Source/nflabs/zeppelin/bin/metastore_db with class loader org.apache.spark.sql.hive.client.IsolatedClientLoader$$anon$1@74101877
5 Loaded from file:/Users/cloverhearts/Source/nflabs/zeppelin/interpreter/spark/dep/zeppelin-spark-dependencies_2.10-0.7.0-SNAPSHOT.jar
6 java.vendor=Oracle Corporation
7 java.runtime.version=1.8.0_101-b13
8 user.dir=/Users/cloverhearts/Source/nflabs/zeppelin/bin
9 os.name=Mac OS X
10 os.arch=x86_64
11 os.version=10.12.2
12 derby.system.home=null
13 Database Class Loader started - derby.database.classpath=''
```

### What type of PR is it?
 Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1997

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
