### PR TITLE
[ZEPPELIN-1984] Capture stdin/stdout on interpreter process creation and propagate to front-end when error

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -202,7 +202,11 @@ public abstract class Job {
     }
 
     Throwable cause = ExceptionUtils.getRootCause(e);
-    return ExceptionUtils.getFullStackTrace(cause);
+    if (cause != null) {
+      return ExceptionUtils.getFullStackTrace(cause);
+    } else {
+      return ExceptionUtils.getFullStackTrace(e);
+    }
   }
 
   public Throwable getException() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
@@ -346,6 +346,10 @@ public class RemoteScheduler implements Scheduler {
           lastStatus = Status.ERROR;
         }
       }
+      if (job.getException() != null) {
+        lastStatus = Status.ERROR;
+      }
+
       job.setStatus(lastStatus);
 
       if (listener != null) {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcessTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcessTest.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.zeppelin.interpreter.Constants;
+import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService.Client;
 import org.junit.Test;
@@ -108,5 +109,22 @@ public class RemoteInterpreterProcessTest {
     assertEquals(0, rip.referenceCount());
     assertEquals(1, rip.reference(intpGroup, "anonymous", false));
     assertEquals(true, rip.isRunning());
+  }
+
+
+  @Test
+  public void testPropagateError() throws TException, InterruptedException {
+    InterpreterGroup intpGroup = new InterpreterGroup();
+    RemoteInterpreterManagedProcess rip = new RemoteInterpreterManagedProcess(
+        "echo hello_world", "nonexists", "fakeRepo", new HashMap<String, String>(),
+        10 * 1000, null, null);
+    assertFalse(rip.isRunning());
+    assertEquals(0, rip.referenceCount());
+    try {
+      assertEquals(1, rip.reference(intpGroup, "anonymous", false));
+    } catch (InterpreterException e) {
+      e.getMessage().contains("hello_world");
+    }
+    assertEquals(0, rip.referenceCount());
   }
 }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -831,8 +831,8 @@ public class RemoteInterpreterTest {
 
 
     assertEquals("env value 1", intp.interpret("getEnv MY_ENV1", context).message().get(0).getData());
-    assertEquals(0, intp.interpret("getProperty MY_ENV1", context).message().size());
-    assertEquals(0, intp.interpret("getEnv my.property.1", context).message().size());
+    assertEquals(Code.ERROR, intp.interpret("getProperty MY_ENV1", context).code());
+    assertEquals(Code.ERROR, intp.interpret("getEnv my.property.1", context).code());
     assertEquals("property value 1", intp.interpret("getProperty my.property.1", context).message().get(0).getData());
 
     intp.close();


### PR DESCRIPTION
### What is this PR for?
This PR captures stdin/stdout on interpreter process creation and propagate to front-end when error.

### What type of PR is it?
Improvement

### Todos
* [x] - Capture and propagate stdin/stdout
* [x] - unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1984

### How should this be tested?
Outline the steps to test the PR here.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
