### PR TITLE
[ZEPPELIN-2000] Run paragraph on enter when select dynamic form value changed

### DIFF
--- a/docs/manual/dynamicform.md
+++ b/docs/manual/dynamicform.md
@@ -56,6 +56,8 @@ Also you can separate option's display name and value, using `${formName=default
 
 <img src="../assets/themes/zeppelin/img/screenshots/form_select_displayname.png" />
 
+Hit enter after selecting option to run the paragraph with new value.
+
 ### Checkbox form
 
 For multi-selection, you can create a checkbox form using `${checkbox:formName=defaultValue1|defaultValue2...,option1|option2...}`. The variable will be substituted by a comma-separated string based on the selected items. For example:

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -29,6 +29,7 @@ limitations under the License.
 
       <select class="form-control input-sm"
              ng-if="paragraph.settings.forms[formulaire.name].options && paragraph.settings.forms[formulaire.name].type != 'checkbox'"
+             ng-enter="runParagraph(getEditorValue())"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
              name="{{formulaire.name}}"


### PR DESCRIPTION
### What is this PR for?
Run paragraph on enter when select dynamic form value changed to make paragraph runnable in report mode.

### What type of PR is it?
Bug Fix | Hot Fix

### What is the Jira issue?
[ZEPPELIN-2000](https://issues.apache.org/jira/browse/ZEPPELIN-2000)

### How should this be tested?
1. Go to `Zeppelin Tutorial/Basic Features (Spark)` notebook
2. Change view mode to `report`.
3. Change selected value from `married` to `single` in 5th paragraph and hit enter.
4. See if paragraph runs

### Screenshots (if appropriate)
![jan-23-2017 14-14-05](https://cloud.githubusercontent.com/assets/8503346/22192310/460d713c-e176-11e6-96d4-96d25eb029c0.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes. docs update included.
