### PR TITLE
[ZEPPELIN-2004] List all helium packages in Zeppelin GUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ before_script:
   - travis_retry ./testing/downloadSpark.sh $SPARK_VER $HADOOP_VER
   - ./testing/setupLivy.sh
   - echo "export SPARK_HOME=`pwd`/spark-$SPARK_VER-bin-hadoop$HADOOP_VER" > conf/zeppelin-env.sh
+  - echo "export ZEPPELIN_HELIUM_REGISTRY=helium" >> conf/zeppelin-env.sh
   - tail conf/zeppelin-env.sh
 
 script:

--- a/docs/development/writingzeppelinvisualization.md
+++ b/docs/development/writingzeppelinvisualization.md
@@ -32,27 +32,12 @@ Apache Zeppelin Visualization is a pluggable package that can be loaded/unloaded
 
 
 #### 1. Load Helium package files from registry
-Zeppelin needs to know what Visualization packages are available. Zeppelin searches _Helium package file_ from local registry (by default helium/ directory) by default.
-_Helium package file_ provides informations like name, artifact, and so on. It's similar to _package.json_ in npm package.
 
-Here's an example `helium/zeppelin-example-horizontalbar.json`
-
-```
-{
-  "type" : "VISUALIZATION",
-  "name" : "zeppelin_horizontalbar",
-  "description" : "Horizontal Bar chart (example)",
-  "artifact" : "./zeppelin-examples/zeppelin-example-horizontalbar",
-  "license" : "Apache-2.0",
-  "icon" : "<i class='fa fa-bar-chart rotate90flipX'></i>"
-}
-```
-
-Check [Create helium package file](#3-create-helium-package-file) section to learn about it.
-
+Zeppelin needs to know what Visualization packages are available. Zeppelin will read information of packages from both online and local registry.
+Registries are configurable through `ZEPPELIN_HELIUM_LOCALREGISTRY_DEFAULT` env variable or `zeppelin.helium.localregistry.default` property.
 
 #### 2. Enable packages
-Once Zeppelin loads _Helium package files_ from local registry, available packages are displayed in Helium menu.
+Once Zeppelin loads _Helium package files_ from registries, available packages are displayed in Helium menu.
 
 Click 'enable' button.
 
@@ -129,7 +114,7 @@ You can check complete visualization package example [here](https://github.com/a
 Zeppelin's built-in visualization uses the same API, so you can check [built-in visualizations](https://github.com/apache/zeppelin/tree/master/zeppelin-web/src/app/visualization/builtins) as additional examples.
 
 
-#### 3. Create __Helium package file__
+#### 3. Create __Helium package file__ and locally deploy
 
 __Helium Package file__ is a json file that provides information about the application.
 Json file contains the following information
@@ -144,6 +129,9 @@ Json file contains the following information
   "icon" : "<i class='fa fa-bar-chart rotate90flipX'></i>"
 }
 ```
+
+Place file in your local registry directory (default `./helium`).
+
 
 ##### type
 
@@ -210,3 +198,9 @@ yarn run visdev
 ```
 
 You can browse localhost:9000. Everytime refresh your browser, Zeppelin will rebuild your visualization and reload changes.
+
+
+#### 5. Publish your visualization
+
+Once it's done, publish your visualization package using `npm publish`.
+That's it. With in an hour, your visualization will be available in Zeppelin's helium menu.

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -123,7 +123,7 @@ public class ZeppelinServer extends Application {
 
     this.helium = new Helium(
         conf.getHeliumConfPath(),
-        conf.getHeliumDefaultLocalRegistryPath(),
+        conf.getHeliumRegistry(),
         heliumVisualizationFactory,
         heliumApplicationFactory);
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -124,6 +124,8 @@ public class ZeppelinServer extends Application {
     this.helium = new Helium(
         conf.getHeliumConfPath(),
         conf.getHeliumRegistry(),
+        new File(
+            conf.getRelativeDir(ConfVars.ZEPPELIN_DEP_LOCALREPO), "helium_registry_cache"),
         heliumVisualizationFactory,
         heliumApplicationFactory);
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -41,6 +41,9 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   private static final String ZEPPELIN_SITE_XML = "zeppelin-site.xml";
   private static final long serialVersionUID = 4749305895693848035L;
   private static final Logger LOG = LoggerFactory.getLogger(ZeppelinConfiguration.class);
+
+  private static final String HELIUM_PACKAGE_DEFAULT_URL =
+      "https://s3.amazonaws.com/helium-package/helium.json";
   private static ZeppelinConfiguration conf;
 
   public ZeppelinConfiguration(URL url) throws ConfigurationException {
@@ -397,8 +400,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getRelativeDir(String.format("%s/helium.json", getConfDir()));
   }
 
-  public String getHeliumDefaultLocalRegistryPath() {
-    return getRelativeDir(ConfVars.ZEPPELIN_HELIUM_LOCALREGISTRY_DEFAULT);
+  public String getHeliumRegistry() {
+    return getRelativeDir(ConfVars.ZEPPELIN_HELIUM_REGISTRY);
   }
 
   public String getNotebookAuthorizationPath() {
@@ -599,7 +602,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_AUTO_INTERPRETER_BINDING("zeppelin.notebook.autoInterpreterBinding", true),
     ZEPPELIN_CONF_DIR("zeppelin.conf.dir", "conf"),
     ZEPPELIN_DEP_LOCALREPO("zeppelin.dep.localrepo", "local-repo"),
-    ZEPPELIN_HELIUM_LOCALREGISTRY_DEFAULT("zeppelin.helium.localregistry.default", "helium"),
+    ZEPPELIN_HELIUM_REGISTRY("zeppelin.helium.registry", "helium," + HELIUM_PACKAGE_DEFAULT_URL),
     // Allows a way to specify a ',' separated list of allowed origins for rest and websockets
     // i.e. http://localhost:8080
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -42,6 +42,8 @@ public class Helium {
   private final HeliumConf heliumConf;
   private final String heliumConfPath;
   private final String registryPaths;
+  private final File registryCacheDir;
+
   private final Gson gson;
   private final HeliumVisualizationFactory visualizationFactory;
   private final HeliumApplicationFactory applicationFactory;
@@ -49,11 +51,13 @@ public class Helium {
   public Helium(
       String heliumConfPath,
       String registryPaths,
+      File registryCacheDir,
       HeliumVisualizationFactory visualizationFactory,
       HeliumApplicationFactory applicationFactory)
       throws IOException {
     this.heliumConfPath = heliumConfPath;
     this.registryPaths = registryPaths;
+    this.registryCacheDir = registryCacheDir;
     this.visualizationFactory = visualizationFactory;
     this.applicationFactory = applicationFactory;
 
@@ -102,7 +106,7 @@ public class Helium {
       for (String uri : paths) {
         if (uri.startsWith("http://") || uri.startsWith("https://")) {
           logger.info("Add helium online registry {}", uri);
-          registry.add(new HeliumOnlineRegistry(uri, uri));
+          registry.add(new HeliumOnlineRegistry(uri, uri, registryCacheDir));
         } else {
           logger.info("Add helium local registry {}", uri);
           registry.add(new HeliumLocalRegistry(uri, uri));

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
@@ -22,22 +22,11 @@ import java.util.*;
  * Helium config. This object will be persisted to conf/heliumc.conf
  */
 public class HeliumConf {
-  List<HeliumRegistry> registry = new LinkedList<>();
-
   // enabled packages {name, version}
   Map<String, String> enabled = Collections.synchronizedMap(new HashMap<String, String>());
 
   // enabled visualization package display order
   List<String> visualizationDisplayOrder = new LinkedList<>();
-
-
-  public List<HeliumRegistry> getRegistry() {
-    return registry;
-  }
-
-  public void setRegistry(List<HeliumRegistry> registry) {
-    this.registry = registry;
-  }
 
   public Map<String, String> getEnabledPackages() {
     return new HashMap<>(enabled);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.helium;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This registry reads helium package json data
+ * from specified url.
+ *
+ * File should be look like
+ * [
+ *    "packageName": {
+ *       "0.0.1": json serialized HeliumPackage class,
+ *       "0.0.2": json serialized HeliumPackage class,
+ *       ...
+ *    },
+ *    ...
+ * ]
+ */
+public class HeliumOnlineRegistry extends HeliumRegistry {
+  Logger logger = LoggerFactory.getLogger(HeliumOnlineRegistry.class);
+  private final Gson gson;
+
+  public HeliumOnlineRegistry(String name, String uri) {
+    super(name, uri);
+    gson = new Gson();
+  }
+
+  @Override
+  public List<HeliumPackage> getAll() throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(uri()).openStream()));
+    List<Map<String, Map<String, HeliumPackage>>> packages = gson.fromJson(
+        reader,
+        new TypeToken<List<Map<String, Map<String, HeliumPackage>>>>() {
+        }.getType());
+    reader.close();
+
+    List<HeliumPackage> packageList = new LinkedList<>();
+
+    for (Map<String, Map<String, HeliumPackage>> pkg : packages) {
+      for (Map<String, HeliumPackage> versions : pkg.values()) {
+        packageList.addAll(versions.values());
+      }
+    }
+
+    return packageList;
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
@@ -53,7 +53,7 @@ public class HeliumTest {
     // given
     File heliumConf = new File(tmpDir, "helium.conf");
     Helium helium = new Helium(heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(),
-        null, null);
+        null, null, null);
     assertFalse(heliumConf.exists());
     HeliumTestRegistry registry1 = new HeliumTestRegistry("r1", "r1");
     helium.addRegistry(registry1);
@@ -68,7 +68,7 @@ public class HeliumTest {
 
     // then
     Helium heliumRestored = new Helium(
-        heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null);
+        heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null, null);
     assertEquals(2, heliumRestored.getAllRegistry().size());
   }
 
@@ -76,7 +76,7 @@ public class HeliumTest {
   public void testRestoreRegistryInstances() throws IOException, URISyntaxException, TaskRunnerException {
     File heliumConf = new File(tmpDir, "helium.conf");
     Helium helium = new Helium(
-        heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null);
+        heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null, null);
     HeliumTestRegistry registry1 = new HeliumTestRegistry("r1", "r1");
     HeliumTestRegistry registry2 = new HeliumTestRegistry("r2", "r2");
     helium.addRegistry(registry1);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
@@ -55,10 +55,6 @@ public class HeliumTest {
     Helium helium = new Helium(heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(),
         null, null, null);
     assertFalse(heliumConf.exists());
-    HeliumTestRegistry registry1 = new HeliumTestRegistry("r1", "r1");
-    helium.addRegistry(registry1);
-    assertEquals(2, helium.getAllRegistry().size());
-    assertEquals(0, helium.getAllPackageInfo().size());
 
     // when
     helium.save();
@@ -66,10 +62,9 @@ public class HeliumTest {
     // then
     assertTrue(heliumConf.exists());
 
-    // then
+    // then load without exception
     Helium heliumRestored = new Helium(
         heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null, null);
-    assertEquals(2, heliumRestored.getAllRegistry().size());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
ZEPPELIN-1973 will provides catalogue for all available helium (visualization) packages in npm registry. And https://github.com/apache/zeppelin/pull/1935 shows available packages in Zeppelin website.

This PR make Zeppelin reads package information and display in Zeppelin's helium gui menu.

To do that, this PR changes configuration environment variable (java property) from

```
ZEPPELIN_HELIUM_LOCALREGISTRY_DEFAULT (zeppelin.helium.localregistry.default)
```

to

```
ZEPPELIN_HELIUM_REGISTRY (zeppelin.helium.registry)
```

and allow multiple comma separated items.
Registry is either filesystem directory (e.g. `/helium`) or http location.

default value is `helium,https://s3.amazonaws.com/helium-package/helium.json`


### What type of PR is it?
Feature

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2004

### How should this be tested?
Go to helium menu and check if you can see packages available.

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/1540981/22234465/43251c9a-e1ad-11e6-8f2d-6bbdac632f9d.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? yes
`ZEPPELIN_HELIUM_LOCALREGISTRY_DEFAULT` changed to `ZEPPELIN_HELIUM_REGISTRY`
* Does this needs documentation? no
