### PR TITLE
Search for interpreter-settings in several jars in folder

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -311,16 +312,19 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     URL[] urls = recursiveBuildLibList(new File(interpreterDir));
     ClassLoader tempClassLoader = new URLClassLoader(urls, cl);
 
-    InputStream inputStream = tempClassLoader.getResourceAsStream(interpreterJson);
-
-    if (null != inputStream) {
-      logger.debug("Reading {} from resources in {}", interpreterJson, interpreterDir);
-      List<RegisteredInterpreter> registeredInterpreterList =
-          getInterpreterListFromJson(inputStream);
-      registerInterpreters(registeredInterpreterList, interpreterDir);
-      return true;
+    Enumeration<URL> interpreterSettings = tempClassLoader.getResources(interpreterJson);
+    if (!interpreterSettings.hasMoreElements()) {
+      return false;
     }
-    return false;
+    for (URL url : Collections.list(interpreterSettings)) {
+      try (InputStream inputStream = url.openStream()) {
+        logger.debug("Reading {} from {}", interpreterJson, url);
+        List<RegisteredInterpreter> registeredInterpreterList =
+            getInterpreterListFromJson(inputStream);
+        registerInterpreters(registeredInterpreterList, interpreterDir);
+      }
+    }
+    return true;
   }
 
   private boolean registerInterpreterFromPath(String interpreterDir, String interpreterJson)


### PR DESCRIPTION
### What is this PR for?
`InterpreterFactory` searches for single `interpreter-settings.json` in some jar in folder. This PR allows us to have `interpreter-settings.json` in several jar in one interpreter folder.

For example, we can have `zeppelin-spark.jar` and `zeppelin-zrinterpreter.jar` in interpreter/spark folder, both with interpreter-settings.json. Zeppelin will load R settings only when `zeppelin-zrinterpreter.jar` exists.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
