### PR TITLE
ZEPPELIN-2006. Livy interpreter doesn't work in anonymous mode

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -206,7 +206,8 @@ public abstract class BaseLivyInterprereter extends Interpreter {
           conf.put(entry.getKey().toString().substring(5), entry.getValue().toString());
       }
 
-      CreateSessionRequest request = new CreateSessionRequest(kind, user, conf);
+      CreateSessionRequest request = new CreateSessionRequest(kind,
+          user.equals("anonymous") ? null : user, conf);
       SessionInfo sessionInfo = SessionInfo.fromJson(
           callRestAPI("/sessions", "POST", request.toJson()));
       long start = System.currentTimeMillis();


### PR DESCRIPTION
### What is this PR for?
We should not pass proxy-user to livy server in anonymous mode, otherwise the livy session will be started as user anonymous. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2006

### How should this be tested?
Tested manually in anonymous mode.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
