### PR TITLE
[ZEPPELIN-2007] Fix flaky test: ShellInterpreterTest#testShellTimeout

### DIFF
--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -38,7 +38,7 @@ public class ShellInterpreterTest {
   @Before
   public void setUp() throws Exception {
     Properties p = new Properties();
-    p.setProperty("shell.command.timeout.millisecs", "60000");
+    p.setProperty("shell.command.timeout.millisecs", "2000");
     shell = new ShellInterpreter(p);
 
     context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
@@ -77,9 +77,9 @@ public class ShellInterpreterTest {
   @Test
   public void testShellTimeout() {
     if (System.getProperty("os.name").startsWith("Windows")) {
-      result = shell.interpret("timeout 61", context);
+      result = shell.interpret("timeout 4", context);
     } else {
-      result = shell.interpret("sleep 61", context);
+      result = shell.interpret("sleep 4", context);
     }
 
     assertEquals(Code.INCOMPLETE, result.code());


### PR DESCRIPTION
### What is this PR for?
Fix flaky test ShellInterpreterTest#testShellTimeout https://issues.apache.org/jira/browse/ZEPPELIN-2007

this PR makes sure `testShellTimeout()` produce timeout error by increase gap between timeout and test value (from `61-60 = 1`  to `4-2 = 2`).

### What type of PR is it?
Hot Fix

### Todos
* [x] - Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2007

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
