### PR TITLE
[ZEPPELIN-2009] Cron job isn't executed after couple of times

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -105,7 +105,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     }.getType());
     assertEquals(resp.get("status"), "OK");
     post.releaseConnection();
-    assertEquals(p.getStatus(), Job.Status.READY);
+    assertEquals(p.getStatus(), Job.Status.FINISHED);
 
     // run non-blank paragraph
     p.setText("test");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -555,13 +555,14 @@ public class Note implements Serializable, ParagraphJobListener {
    */
   public void run(String paragraphId) {
     Paragraph p = getParagraph(paragraphId);
-
+    p.setListener(jobListenerFactory.getParagraphJobListener(this));
+    
     if (p.isBlankParagraph()) {
       logger.info("skip to run blank paragraph. {}", p.getId());
+      p.setStatus(Job.Status.FINISHED);
       return;
     }
 
-    p.setListener(jobListenerFactory.getParagraphJobListener(this));
     String requiredReplName = p.getRequiredReplName();
     Interpreter intp = factory.getInterpreter(p.getUser(), getId(), requiredReplName);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -282,7 +282,7 @@ public class NotebookTest implements JobListenerFactory{
     note.run(p1.getId());
 
     Thread.sleep(2 * 1000);
-    assertEquals(p1.getStatus(), Status.READY);
+    assertEquals(p1.getStatus(), Status.FINISHED);
     assertNull(p1.getDateStarted());
     notebook.removeNote(note.getId(), anonymous);
   }


### PR DESCRIPTION
### What is this PR for?
This is to solve the problem with cron job scheduling. basically after https://github.com/apache/zeppelin/commit/6177c819b1edb76cfaa8f6249dc9041771ce6da9 all empty paragraphs are skipped when executing, but if the paragraph had status `READY` that status will be stayed same and then the note won't be considered as terminated in [here](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java#L866) resulting on keeping cron threads up running. So after all 10 threads in the threadpool are exhausted, new jobs are not scheduled. Here i change the status of paragraph to `FINISHED` when it's empty and skipping run.

### What type of PR is it?
Bug Fix

### Todos
* [x] - set status to `FINISHED`

### What is the Jira issue?
[ZEPPELIN-2009](https://issues.apache.org/jira/browse/ZEPPELIN-2009)

### How should this be tested?
try to schedule note using cron expression (e.g. `0/5 * * * * ?` every 5 secs) before and after this PR

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
