### PR TITLE
[ZEPPELIN-1982] When using the 'Select * ...' statement doesn't show …

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -293,7 +293,9 @@ public class ZeppelinContext {
     }
 
     if (rows.length > maxResult) {
-      msg.append("\n<font color=red>Results are limited by " + maxResult + ".</font>");
+      msg.append("<!--TABLE_COMMENT-->");
+      msg.append("\n");
+      msg.append("<font color=red>Results are limited by " + maxResult + ".</font>");
     }
     sc.clearJobGroup();
     return msg.toString();

--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -37,6 +37,10 @@ export default class TableData {
 
     for (var i = 0; i < textRows.length; i++) {
       var textRow = textRows[i];
+      if (textRow === '') {
+        continue;
+      }
+
       if (commentRow) {
         comment += textRow;
         continue;

--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -42,7 +42,7 @@ export default class TableData {
         continue;
       }
 
-      if (textRow === '') {
+      if (textRow === '<!--TABLE_COMMENT-->') {
         if (rows.length > 0) {
           commentRow = true;
         }

--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -37,16 +37,13 @@ export default class TableData {
 
     for (var i = 0; i < textRows.length; i++) {
       var textRow = textRows[i];
-      if (textRow === '') {
-        continue;
-      }
 
       if (commentRow) {
         comment += textRow;
         continue;
       }
 
-      if (textRow === '<!--TABLE_COMMENT-->') {
+      if (textRow === '' || textRow === '<!--TABLE_COMMENT-->') {
         if (rows.length > 0) {
           commentRow = true;
         }


### PR DESCRIPTION
### What is this PR for?
In this ticket [ZEPPELIN-212](https://issues.apache.org/jira/browse/ZEPPELIN-212)，``InterpreterOutput.java`` will filter out '\n'.
It causes ``tabledata.js`` couldn't recognize the comment in the paragraphResult. If column number of sql query exceed 2 columns and row number over ``maxResult`` will show nothing.
Therefore, I suppose to modify comment statement from ''  to ``TABLE_COMMENT``for this issue.


### What type of PR is it?
Bug Fix

### Todos
* None

### What is the Jira issue?
[ZEPPELIN-1982](https://issues.apache.org/jira/browse/ZEPPELIN-1982)


### How should this be tested?
try  to execute ``%sql  SELECT * FROM bank`` on  tutorial

### Screenshots (if appropriate)
Before
![2017-01-25 14 49 40](https://cloud.githubusercontent.com/assets/3747345/22279334/8b3e6642-e30d-11e6-9e20-d6da015f016b.png)

After
![2017-01-25 14 48 59](https://cloud.githubusercontent.com/assets/3747345/22279909/da0922fa-e310-11e6-9c3e-34ef75b2ac81.png)



### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
