### PR TITLE
[HOTFIX][ZEPPELIN-2011] Add lib/interpreter to classpath to fix interpreter installer

### DIFF
--- a/bin/install-interpreter.sh
+++ b/bin/install-interpreter.sh
@@ -40,6 +40,7 @@ fi
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-interpreter/target/lib"
 
 addJarInDir "${ZEPPELIN_HOME}/lib"
+addJarInDir "${ZEPPELIN_HOME}/lib/interpreter"
 
 CLASSPATH+=":${ZEPPELIN_CLASSPATH}"
 $ZEPPELIN_RUNNER $JAVA_OPTS -cp $CLASSPATH $ZEPPELIN_INSTALL_INTERPRETER_MAIN ${@}


### PR DESCRIPTION
### What is this PR for?
Interpreter installation fail with `NoClassDefFoundError` error when zeppelin is built as distribution package. This PR fixes it by adding `lib/interpreter` to classpath.

### What type of PR is it?
Bug Fix | Hot Fix

### What is the Jira issue?
[ZEPPELIN-2011](https://issues.apache.org/jira/browse/ZEPPELIN-2011)

### How should this be tested?
1. Build distribution package
```
mvn clean package -DskipTests -pl zeppelin-interpreter,zeppelin-zengine,:zeppelin-display_2.10,:zeppelin-spark-dependencies_2.10,:zeppelin-spark_2.10,zeppelin-web,zeppelin-server,zeppelin-distribution -am -Pbuild-distr
```
2. Change working directory
```
$ cd zeppelin-distribution/target/zeppelin-0.8.0-SNAPSHOT/zeppelin-0.8.0-SNAPSHOT
```
3. Run `bin/install-interpreter.sh` and see if error is gone.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
