### PR TITLE
[HOTFIX][MINOR] Change the scope of httpclient to runtime from test

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -343,17 +343,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <version>${selenium.java.version}</version>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -345,7 +345,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>


### PR DESCRIPTION
### What is this PR for?
When IDE runs ZeppelinServer in debugging mode, it doesn't load httpclient because its scope is test but it needs zeppelin-zengine that zeppelin-server depends on. ZeppelinServer cannot run itself successfully while loading libraries.

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos
* [x] - Change the scope

### What is the Jira issue?
N/A

### How should this be tested?
Run ZeppelinServer in IntelliJ

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
