### PR TITLE
[HOTFIX][ZEPPELIN-2013] Exceeded size of logs makes CI failed

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -99,7 +99,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
         File destFile = new File(destPath, srcFile.getName());
         if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
           FileUtils.copyFile(srcFile, destFile);
-          logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
+          logger.debug("copy {} to {}", srcFile.getAbsolutePath(), destPath);
         }
       }
     }
@@ -117,7 +117,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
 
     if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
       FileUtils.copyFile(srcFile, destFile);
-      logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
+      logger.debug("copy {} to {}", srcFile.getAbsolutePath(), destPath);
     }
   }
 
@@ -145,7 +145,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
     List<File> files = new LinkedList<>();
     for (ArtifactResult artifactResult : listOfArtifact) {
       files.add(artifactResult.getArtifact().getFile());
-      logger.info("load {}", artifactResult.getArtifact().getFile().getAbsolutePath());
+      logger.debug("load {}", artifactResult.getArtifact().getFile().getAbsolutePath());
     }
 
     return files;


### PR DESCRIPTION
### What is this PR for?
avoiding failure of CI due to exceeded limit of log size. https://s3.amazonaws.com/archive.travis-ci.org/jobs/195087823/log.txt

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Changed level of logs 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2013

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
