### PR TITLE
User Impersonation fails on setting hive_conf_list in hive interpreter (JDBC)

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -376,8 +376,14 @@ public class JDBCInterpreter extends Interpreter {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
               if ("hive".equalsIgnoreCase(propertyKey)) {
-                connection = getConnectionFromPool(url + ";hive.server2.proxy.user=" + user,
-                  user, propertyKey, properties);
+                StringBuilder connectionUrl = new StringBuilder(url);
+                Integer lastIndexOfUrl = connectionUrl.indexOf("?");
+                if (lastIndexOfUrl == -1) {
+                  lastIndexOfUrl = connectionUrl.length();
+                }
+                connectionUrl.insert(lastIndexOfUrl, ";hive.server2.proxy.user=" + user + ";");
+                connection = getConnectionFromPool(connectionUrl.toString(),
+                    user, propertyKey, properties);
               } else {
                 UserGroupInformation ugi = null;
                 try {


### PR DESCRIPTION
### What is this PR for?
This is how a sample `jdbc:hive2://<host1>:<port1>,<host2>:<port2>/dbName;initFile=<file>;sess_var_list?hive_conf_list#hive_var_list` looks like. And when "hive_conf_list" is set then, User Impersonation which is passed via "sess_var_list" fails.

Ref: https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-ConnectionURLFormat

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2023](https://issues.apache.org/jira/browse/ZEPPELIN-2023)

### How should this be tested?
Try setting tez.queue.name=someQueueName so the JDBC url, like following
```
jdbc:hive2://sameple-custer-3.novalocal:2181,sameple-custer-2.novalocal:2181,sameple-custer-4.novalocal:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2?tez.queue.name=someQueueName
````
 and now execute some query like 
```
select count(*) from table_name
```
 and check resource manager UI, this should show up on the designated queue with the webUi logged-in user.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
