### PR TITLE
[ZEPPELIN-525] Test failing in zeppelin-interpreter

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
@@ -307,10 +307,10 @@ public class RemoteScheduler implements Scheduler {
     @Override
     public void run() {
       if (job.isAborted()) {
-        job.setStatus(Status.ABORT);
-        job.aborted = false;
-
         synchronized (queue) {
+          job.setStatus(Status.ABORT);
+          job.aborted = false;
+
           running.remove(job);
           queue.notify();
         }
@@ -350,16 +350,16 @@ public class RemoteScheduler implements Scheduler {
         lastStatus = Status.ERROR;
       }
 
-      job.setStatus(lastStatus);
-
-      if (listener != null) {
-        listener.jobFinished(scheduler, job);
-      }
-
-      // reset aborted flag to allow retry
-      job.aborted = false;
-
       synchronized (queue) {
+        job.setStatus(lastStatus);
+
+        if (listener != null) {
+          listener.jobFinished(scheduler, job);
+        }
+
+        // reset aborted flag to allow retry
+        job.aborted = false;
+
         running.remove(job);
         queue.notify();
       }


### PR DESCRIPTION
`RemoteSchedulerTest.test` was fall when CPU switched `RemoteScheduler` execution (which executes a job in a separate thread) back to test main thread execution after changing job status to `Status.FINISHED` but before updating running jobs list:
```
job.setStatus(lastStatus);

// if thread execution is switched here to the main thread test will fall

synchronized (queue) {
    running.remove(job);
    queue.notify();
}
```
Test checked job status, saw that job was terminated and expected to see an empty jobs runing list. 
```
while (!job.isTerminated() && cycles < MAX_WAIT_CYCLES) {
    Thread.sleep(TICK_WAIT);
    cycles++;
}

// this assert will fail because a job was not removed from running list yet
assertEquals(0, scheduler.getJobsRunning().size());
```
But `scheduler.running` list still contained the last job and the assertion failed.

### What is this PR for?
The goal is to synchronize updating of a job status and a scheduler running jobs list when a job is terminated.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-525](https://issues.apache.org/jira/browse/ZEPPELIN-525)

### How should this be tested?
You may place a `Thread.sleep(1000);` code to the `RemoteScheduler.java` class after the `job.setStatus(lastStatus);` (line number 354). This will increase probability of threads switching after this line. Test should not fail.

### Questions:
* Does the licenses files need update? **no**
* Is there breaking changes for older versions? **no**
* Does this needs documentation? **no**
