### PR TITLE
[MINOR] Prevent log NPE in ResourcePoolUtils.getAllResourcesExcept()

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourcePoolUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourcePoolUtils.java
@@ -55,6 +55,10 @@ public class ResourcePoolUtils {
         boolean broken = false;
         try {
           client = remoteInterpreterProcess.getClient();
+          if (client == null) {
+            // remote interpreter may not started yet or terminated.
+            continue;
+          }
           List<String> resourceList = client.resourcePoolGetAll();
           Gson gson = new Gson();
           for (String res : resourceList) {


### PR DESCRIPTION
### What is this PR for?

ResourcePoolUtils.getAllResourcesExcept() sometimes throws NPE. Which doesn't really need to be logged.

```
ResourcePoolUtils.java[getAllResourcesExcept]:64) - 
java.lang.NullPointerException
	at org.apache.zeppelin.resource.ResourcePoolUtils.getAllResourcesExcept(ResourcePoolUtils.java:58)
	at org.apache.zeppelin.resource.ResourcePoolUtils.getAllResources(ResourcePoolUtils.java:36)
	at org.apache.zeppelin.helium.Helium.suggestApp(Helium.java:264)
	at org.apache.zeppelin.rest.HeliumRestApi.suggest(HeliumRestApi.java:84)
```


### What type of PR is it?
Improvement

### Todos
* [x] - handle null thrift client

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no
