### PR TITLE
[ZEPPELIN-2026] Flaky Test: WebDriverManager.getWebDriver() fails with Unable to locate element 'WebSocket Connected'

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -122,7 +122,7 @@ public class WebDriverManager {
     while (System.currentTimeMillis() - start < 60 * 1000) {
       // wait for page load
       try {
-        (new WebDriverWait(driver, 5)).until(new ExpectedCondition<Boolean>() {
+        (new WebDriverWait(driver, 30)).until(new ExpectedCondition<Boolean>() {
           @Override
           public Boolean apply(WebDriver d) {
             return d.findElement(By.xpath("//i[@tooltip='WebSocket Connected']"))


### PR DESCRIPTION
### What is this PR for?
Selenium test sometimes fails with 

```
Caused by: org.openqa.selenium.NoSuchElementException: Unable to locate element: {"method":"xpath","selector":"//i[@tooltip='WebSocket Connected']"}
```

This PR gives enough timeout (30s) for waiting 'WebSocket Connected' element.

Tested in my travis account 5 times and they're all green.
https://travis-ci.org/Leemoonsoo/zeppelin/builds/196428795
https://travis-ci.org/Leemoonsoo/zeppelin/builds/196429337
https://travis-ci.org/Leemoonsoo/zeppelin/builds/196429559
https://travis-ci.org/Leemoonsoo/zeppelin/builds/196429593
https://travis-ci.org/Leemoonsoo/zeppelin/builds/196430020

However, I'm not 100% sure if it really fixes the flaky test.
So, I'd like to merge this PR but keep ZEPPELIN-2026 open for next 1 week.
And then see if no selenium test fails with the error for next 1 week to close ZEPPELIN-2026.

### What type of PR is it?
Improvement

### Todos
* [x] - Increase timeout of detecting 'connected'

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2026

### How should this be tested?
CI green on Selenium test profile

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
