### PR TITLE
[ZEPPELIN-1934] maven-assembly-plugin fails make-assembly if executing user's ID is "too big"

### DIFF
--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -95,6 +95,7 @@
           <finalName>${project.parent.artifactId}-${project.version}</finalName>
           <appendAssemblyId>false</appendAssemblyId>
           <attach>false</attach>
+          <tarLongFileMode>posix</tarLongFileMode>
           <descriptors>
             <descriptor>src/assemble/distribution.xml</descriptor>
           </descriptors>
@@ -157,6 +158,9 @@
           </plugin>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <configuration>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
             <executions>
               <execution>
                 <id>make-assembly</id>


### PR DESCRIPTION
### What is this PR for?
maven-assembly-plugin fails make-assembly execution when the executing user's ID is "too big."
If domain account, managed by Active Directory or Os X, it assigned very large user IDs that inconsistent with GNU tar archiver and maven-assembly-plugin's configuration property tarLongFileMode  should be set to posix value.
See proof links below:
http://maven.apache.org/plugins-archives/maven-assembly-plugin-2.6/assembly-mojo.html
http://stackoverflow.com/questions/30246705/mvn-failure-on-build
 
### What type of PR is it?
Improvement

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1934

### How should this be tested?
Manually

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
