### PR TITLE
[ZEPPELIN-2014] Jetty Directory Listing on app, assets, components, and scripts

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -304,4 +304,10 @@
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>
 </property>
 
+<property>
+  <name>zeppelin.server.default.dir.allowed</name>
+  <value>false</value>
+  <description>Enable directory listings on server.</description>
+</property>
+
 </configuration>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -260,6 +260,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>1024000</td>
     <td>Size (in characters) of the maximum text message that can be received by websocket.</td>
   </tr>
+  <tr>
+    <td>ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED</td>
+    <td>zeppelin.server.default.dir.allowed</td>
+    <td>false</td>
+    <td>Enable directory listings on server.</td>
+  </tr>
 </table>
 
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -346,6 +346,9 @@ public class ZeppelinServer extends Application {
     webApp.addFilter(new FilterHolder(CorsFilter.class), "/*",
         EnumSet.allOf(DispatcherType.class));
 
+    webApp.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed",
+            Boolean.toString(conf.getBoolean(ConfVars.ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED)));
+
     return webApp;
 
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.security;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.junit.Test;
+
+public class DirAccessTest extends AbstractTestRestApi {
+
+  @Test
+  public void testDirAccessForbidden() throws Exception {
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED.getVarName(), "false");
+    AbstractTestRestApi.startUpWithAuthenticationEnable();
+    HttpClient httpClient = new HttpClient();
+    GetMethod getMethod = new GetMethod(getUrlToTest() + "/app/");
+    httpClient.executeMethod(getMethod);
+    AbstractTestRestApi.shutDown();
+    assert getMethod.getStatusCode() == HttpStatus.SC_FORBIDDEN;
+  }
+
+  @Test
+  public void testDirAccessOk() throws Exception {
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED.getVarName(), "true");
+    AbstractTestRestApi.startUpWithAuthenticationEnable();
+    HttpClient httpClient = new HttpClient();
+    GetMethod getMethod = new GetMethod(getUrlToTest() + "/app/");
+    httpClient.executeMethod(getMethod);
+    AbstractTestRestApi.shutDown();
+    assert getMethod.getStatusCode() == HttpStatus.SC_OK;
+  }
+
+  protected static String getUrlToTest() {
+    String url = "http://localhost:8080";
+    if (System.getProperty("url") != null) {
+      url = System.getProperty("url");
+    }
+    return url;
+  }
+}
+

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -607,7 +607,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
     ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
     ZEPPELIN_CREDENTIALS_PERSIST("zeppelin.credentials.persist", true),
-    ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000");
+    ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),
+    ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false);
 
     private String varName;
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
### What is this PR for?
Added property for enable/disable public access to directories on server from Web

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2014

### How should this be tested?
Run application and try get list of files in app directory from web.
You will see a response with the code 403. Previously, we saw all files in the directory.
Change property "zeppelin.server.default.dir.allowed" to true and restart server.
Try again, all files should be visible.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
