### PR TITLE
[ZEPPELIN-2033] Handle focus/blur of paragraph with hidden editor

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -532,23 +532,12 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         enableLiveAutocompletion: false
       });
 
-      $scope.handleFocus = function(value, isDigestPass) {
-        $scope.paragraphFocused = value;
-        if (isDigestPass === false || isDigestPass === undefined) {
-          // Protect against error in case digest is already running
-          $timeout(function() {
-            // Apply changes since they come from 3rd party library
-            $scope.$digest();
-          });
-        }
-      };
-
       $scope.editor.on('focus', function() {
-        $scope.handleFocus(true);
+        handleFocus(true);
       });
 
       $scope.editor.on('blur', function() {
-        $scope.handleFocus(false);
+        handleFocus(false);
       });
 
       $scope.editor.on('paste', function(e) {
@@ -640,6 +629,17 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         }
         this.origOnCommandKey(e, hashId, keyCode);
       };
+    }
+  };
+
+  var handleFocus = function(value, isDigestPass) {
+    $scope.paragraphFocused = value;
+    if (isDigestPass === false || isDigestPass === undefined) {
+      // Protect against error in case digest is already running
+      $timeout(function() {
+        // Apply changes since they come from 3rd party library
+        $scope.$digest();
+      });
     }
   };
 
@@ -1144,9 +1144,6 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   });
 
   $scope.$on('focusParagraph', function(event, paragraphId, cursorPos, mouseEvent) {
-    if (!$scope.editor) {
-      return;
-    }
     if ($scope.paragraph.id === paragraphId) {
       // focus editor
       if (!$scope.paragraph.config.editorHide) {
@@ -1164,11 +1161,13 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
           $scope.scrollToCursor($scope.paragraph.id, 0);
         }
       }
-      $scope.handleFocus(true);
+      handleFocus(true);
     } else {
-      $scope.editor.blur();
+      if ($scope.editor !== undefined && $scope.editor !== null) {
+        $scope.editor.blur();
+      }
       var isDigestPass = true;
-      $scope.handleFocus(false, isDigestPass);
+      handleFocus(false, isDigestPass);
     }
   });
 


### PR DESCRIPTION
### What is this PR for?
#1879 check if `$scope.editor` is null on `focusParagraph` message, and if it is, just return without handling focus/blur.
Instead of doing null check in the beginning of `$scope.on(focusParagraph)`, I made null check to be scoped only to `$scope.editor`'s method invocation.
FYI, when I say focus/blur, it means paragraph focus. Focused paragraph has different css style from blurred paragraph.

### What type of PR is it?
Bug Fix | Hot Fix

### What is the Jira issue?
[ZEPPELIN-2033](https://issues.apache.org/jira/browse/ZEPPELIN-2033)

### How should this be tested?
Go to `Zeppelin Tutorial/Matplotlib (Python • PySpark)` notebook and see:
 - if first paragraph is blurred, when you click second paragraph.
 - if first paragraph is not run when you run second paragraph with shift + enter. In current master, first editor is not blurred even if you click second paragraph, which makes both first and second paragraph to be focused. This will make both paragraphs to be run.
 - if it is focused when you click third paragraph whose editor is hidden. In current master, it won't work.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
