### PR TITLE
[HOTFIX][branch-0.7] Show only VISUALIZATION & APPLICATION type in Helium GUI

### DIFF
--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -45,7 +45,8 @@ limitations under the License.
 
 <div class="box width-full heliumPackageContainer">
   <div class="row heliumPackageList"
-       ng-repeat="(pkgName, pkgInfo) in defaultVersions">
+       ng-repeat="(pkgName, pkgInfo) in defaultVersions"
+       ng-if="pkgInfo.pkg.type == 'VISUALIZATION' || pkgInfo.pkg.type == 'APPLICATION'">
     <div class="col-md-12">
       <div class="heliumPackageHead">
         <div class="heliumPackageIcon"


### PR DESCRIPTION
### What is this PR for?
Currently Helium online package registry file([helium.json](https://s3.amazonaws.com/helium-package/helium.json)) contains both `SPELL` and `VISUALIZATION` pkgs' info. But Zeppelin-0.7 can't include #1940 I guess. Then Zeppelin must show only available package types (`VISUALIZATION` and `APPLICATION`) in 0.7 version. So I made this PR based on `branch-0.7`. 


### What type of PR is it?
Hot Fix 

### What is the Jira issue?
[ZEPPELIN-2038](https://issues.apache.org/jira/browse/ZEPPELIN-2038)

### How should this be tested?
1. Run Zeppelin web dev mode under `zeppelin-web`  and go to [http://localhost:9000/#/helium](http://localhost:9000/#/helium).
```
$ yarn run dev
```

2. Check whether `SPELL` type package appears or not. Only `VISUALIZATION`(comes from Helium online registry [https://s3.amazonaws.com/helium-package/helium.json](https://s3.amazonaws.com/helium-package/helium.json)) or `APPLICATION`(if you put `zeppelin-example-clock.json` under `ZEPPELIN_HOME/helium/` dir) should show up with this patch.

### Screenshots (if appropriate)
**Before**
![screen shot 2017-02-01 at 5 01 06 pm](https://cloud.githubusercontent.com/assets/10060731/22499100/20529306-e8a0-11e6-9872-7e26d9dbac3f.png)

**After**
![screen shot 2017-02-01 at 5 01 35 pm](https://cloud.githubusercontent.com/assets/10060731/22499105/23f3ea6e-e8a0-11e6-81b0-810c61885337.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
