### PR TITLE
[ZEPPELIN-2039] Upgrade safe_yaml version in gh-page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,4 +58,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.14.3
+   1.10.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       maruku (~> 0.6.0)
       pygments.rb (~> 0.5.0)
       redcarpet (~> 2.3.0)
-      safe_yaml (~> 0.9.7)
+      safe_yaml (~> 1.0.4)
     kramdown (1.2.0)
     liquid (2.5.4)
     listen (1.3.1)
@@ -47,7 +47,7 @@ GEM
       ffi (>= 0.5.0)
     rdiscount (2.1.7)
     redcarpet (2.3.0)
-    safe_yaml (0.9.7)
+    safe_yaml (1.0.4)
     syntax (1.0.0)
     yajl-ruby (1.1.0)
 
@@ -58,4 +58,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.10.4
+   1.14.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Zeppelin project website
+## Apache Zeppelin project website
 
-This readme will walk you through building the Zeppelin website
+This readme will walk you through building the Apache Zeppelin website
 
 
 ## Build website
@@ -8,7 +8,7 @@ See https://help.github.com/articles/using-jekyll-with-pages#installing-jekyll
 
 **tl;dr version:**
 
-    ruby --version >= 1.9.3
+    ruby --version >= 2.0.0
     gem install bundler
     bundle install
 


### PR DESCRIPTION
### What is this PR for?
This PR will fix some problem which I faced when starting the gh-page server like the following code.
```
$ bundle exec jekyll serve --watch
/var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/user_interaction.rb:328: warning: constant ::TimeoutError is deprecated
/var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:365:in `block in require_program': program version required (Commander::Runner::CommandError)
	from /var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `each'
	from /var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:364:in `require_program'
	from /var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/runner.rb:52:in `run!'
	from /var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/delegates.rb:7:in `run!'
	from /var/lib/gems/2.3.0/gems/commander-4.1.5/lib/commander/import.rb:10:in `block in <top (required)>'
/var/lib/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml/syck_node_monkeypatch.rb:42:in `<top (required)>': uninitialized constant Syck (NameError)
	from /var/lib/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:200:in `require'
	from /var/lib/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:200:in `<module:YAML>'
	from /var/lib/gems/2.3.0/gems/safe_yaml-0.9.7/lib/safe_yaml.rb:132:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/jekyll-1.3.0/lib/jekyll.rb:21:in `require'
	from /var/lib/gems/2.3.0/gems/jekyll-1.3.0/lib/jekyll.rb:21:in `<top (required)>'
	from /var/lib/gems/2.3.0/gems/jekyll-1.3.0/bin/jekyll:7:in `require'
	from /var/lib/gems/2.3.0/gems/jekyll-1.3.0/bin/jekyll:7:in `<top (required)>'
	from /usr/local/bin/jekyll:23:in `load'
	from /usr/local/bin/jekyll:23:in `<main>'
```
This issue is similar with [ZEPPELIN-813](https://issues.apache.org/jira/browse/ZEPPELIN-813) and it was solved by [PR #1167](https://github.com/apache/zeppelin/pull/1167).

### What type of PR is it?
[Bug Fix | Improvement | Documentation(`README.md`)]

### What is the Jira issue?
[ZEPPELIN-2039](https://issues.apache.org/jira/browse/ZEPPELIN-2039)

### How should this be tested?
**Please read `README.md` if you didn't installed dependencies ever.**

1. If you already installed dependencies before, you need
```
$ bundle update safe_yaml
```
2. Check what version of safe_yaml is installed and then run this command
```
$ bundle exec jekyll serve --watch
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
