### PR TITLE
[ZEPPELIN-1551] Remove the "default" text against interpreters on interpreters screen as it is providing incorrect semantics

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -103,7 +103,6 @@ limitations under the License.
               %<span ng-show="!$parent.$first || $first">{{setting.name}}</span
               ><span ng-show="(!$parent.$first || $first) && !$first">.</span
               ><span ng-show="!$first">{{interpreter.name}}</span>
-              <span ng-show="$parent.$first && $first">(default)</span>
             </span>
           </small>
 


### PR DESCRIPTION

### What is this PR for?
This PR addresses the incorrect semantics and confusion caused by the "default" text against an interpreter group on interpreters page. 
The intent of of this tag seems to be informing the user which of the interpreters among a particular group will be used by default if the user doesn't specify any %<interpreter> tag. However, the "default" tag is always tied to the first interpreter of the first interpreter group on the page and isn't displayed for any other interpreter groups; therefore not serving any purpose. It also leads to confusion with the default interpreter bound to a notebook on bindings page.

It would be better to remove this default tag from interpreters in order to avoid the confusion.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1551

### How should this be tested?
Run Zeppelin server. Open Interpreters menu. "default" shouldn't be visible against any interpreter group.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

### Screenshots (if appropriate)
![zeppelin-1551](https://cloud.githubusercontent.com/assets/6438072/22550188/f0efe0d4-e974-11e6-82a4-722b9662e5db.png)
