### PR TITLE
[ZEPPELIN-1465] Add an option to allow S3 server-side encryption

### DIFF
--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -34,6 +34,7 @@ REM set ZEPPELIN_NOTEBOOK_S3_USER              REM User in bucket where notebook
 REM set ZEPPELIN_NOTEBOOK_S3_ENDPOINT          REM Endpoint of the bucket
 REM set ZEPPELIN_NOTEBOOK_S3_KMS_KEY_ID        REM AWS KMS key ID
 REM set ZEPPELIN_NOTEBOOK_S3_KMS_KEY_REGION    REM AWS KMS key region
+REM set ZEPPELIN_NOTEBOOK_S3_SSE               REM Server-side encryption enabled for notebooks
 REM set ZEPPELIN_IDENT_STRING   		REM A string representing this instance of zeppelin. $USER by default.
 REM set ZEPPELIN_NICENESS       		REM The scheduling priority for daemons. Defaults to 0.
 REM set ZEPPELIN_INTERPRETER_LOCALREPO         REM Local repository for interpreter's additional dependency loading

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -35,6 +35,7 @@
 # export ZEPPELIN_NOTEBOOK_S3_USER          # User in bucket where notebook saved. For example bucket/user/notebook/2A94M5J1Z/note.json
 # export ZEPPELIN_NOTEBOOK_S3_KMS_KEY_ID    # AWS KMS key ID
 # export ZEPPELIN_NOTEBOOK_S3_KMS_KEY_REGION      # AWS KMS key region
+# export ZEPPELIN_NOTEBOOK_S3_SSE      # Server-side encryption enabled for notebooks
 # export ZEPPELIN_IDENT_STRING   		# A string representing this instance of zeppelin. $USER by default.
 # export ZEPPELIN_NICENESS       		# The scheduling priority for daemons. Defaults to 0.
 # export ZEPPELIN_INTERPRETER_LOCALREPO         # Local repository for interpreter's additional dependency loading

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -129,6 +129,14 @@
 </property>
 -->
 
+<!-- Server-side encryption enabled for notebooks -->
+<!--
+<property>
+  <name>zeppelin.notebook.s3.sse</name>
+  <value>true</value>
+  <description>Server-side encryption enabled for notebooks</description>
+</property>
+-->
 
 <!-- If using Azure for storage use the following settings -->
 <!--

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -195,6 +195,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Class name of a custom S3 encryption materials provider implementation to use for encrypting data in S3 (optional)</td>
   </tr>
   <tr>
+    <td>ZEPPELIN_NOTEBOOK_S3_SSE</td>
+    <td>zeppelin.notebook.s3.sse</td>
+    <td>false</td>
+    <td>Save notebooks to S3 with server-side encryption enabled</td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING</td>
     <td>zeppelin.notebook.azure.connectionString</td>
     <td></td>

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -165,6 +165,24 @@ Or using the following setting in **zeppelin-site.xml**:
   <description>Custom encryption materials provider used to encrypt notebook data in S3</description>
 ```   
 
+#### Enable server-side encryption
+
+To request server-side encryption of notebooks, set the following environment variable in the file **zeppelin-env.sh**:
+
+```
+export ZEPPELIN_NOTEBOOK_S3_SSE = true
+```
+
+Or using the following setting in **zeppelin-site.xml**:
+
+```
+<property>
+  <name>zeppelin.notebook.s3.sse</name>
+  <value>true</value>
+  <description>Server-side encryption enabled for notebooks</description>
+</property>
+```
+
 </br>
 ## Notebook Storage  in Azure <a name="Azure"></a>
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -381,7 +381,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
   public boolean isS3ServerSideEncryption() {
-	  return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_S3_SSE);
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_S3_SSE);
   }
 
   public String getInterpreterListPath() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -380,6 +380,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_S3_EMP);
   }
 
+  public boolean isS3ServerSideEncryption() {
+	  return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_S3_SSE);
+  }
+
   public String getInterpreterListPath() {
     return getRelativeDir(String.format("%s/interpreter-list", getConfDir()));
   }
@@ -588,6 +592,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_S3_EMP("zeppelin.notebook.s3.encryptionMaterialsProvider", null),
     ZEPPELIN_NOTEBOOK_S3_KMS_KEY_ID("zeppelin.notebook.s3.kmsKeyID", null),
     ZEPPELIN_NOTEBOOK_S3_KMS_KEY_REGION("zeppelin.notebook.s3.kmsKeyRegion", null),
+    ZEPPELIN_NOTEBOOK_S3_SSE("zeppelin.notebook.s3.sse", false),
     ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING("zeppelin.notebook.azure.connectionString", null),
     ZEPPELIN_NOTEBOOK_AZURE_SHARE("zeppelin.notebook.azure.share", "zeppelin"),
     ZEPPELIN_NOTEBOOK_AZURE_USER("zeppelin.notebook.azure.user", "user"),


### PR DESCRIPTION
### What is this PR for?
Provide a configuration option that will cause the S3 Notebook repo to request server-side encryption of saved notebooks.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1465

### How should this be tested?
Enable the configuration option, save a notebook in zeppelin, and confirm in the AWS S3 Console that the related file was saved with AES-256 encryption on the server-side.  (Properties tab, Detail section)

### Questions:
* Does the licenses files need update?
No

* Is there breaking changes for older versions?
No.

* Does this needs documentation?
I added mentions of the new option in existing documentation.

Thank you!