### PR TITLE
ZEPPELIN-2045. Pass interpreter properties with "spark." as prefix to SparkConf

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -332,7 +332,7 @@ public class SparkInterpreter extends Interpreter {
     for (Object k : intpProperty.keySet()) {
       String key = (String) k;
       String val = toString(intpProperty.get(key));
-      if (!key.startsWith("spark.") || !val.trim().isEmpty()) {
+      if (key.startsWith("spark.") && !val.trim().isEmpty()) {
         logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, val));
         conf.set(key, val);
       }
@@ -463,7 +463,7 @@ public class SparkInterpreter extends Interpreter {
     for (Object k : intpProperty.keySet()) {
       String key = (String) k;
       String val = toString(intpProperty.get(key));
-      if (!key.startsWith("spark.") || !val.trim().isEmpty()) {
+      if (key.startsWith("spark.") && !val.trim().isEmpty()) {
         logger.debug(String.format("SparkConf: key = [%s], value = [%s]", key, val));
         conf.set(key, val);
       }


### PR DESCRIPTION
### What is this PR for?
Minor change to only pass interpreter properties with "spark." as prefix to SparkConf. Other properties is used by zeppelin interpreter process, so don't need to be passed to SparkConf.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2045

### How should this be tested?
Tested manually, this is the log after this PR
```
 INFO [2017-02-03 09:05:33,664] ({pool-2-thread-2} SparkInterpreter.java[createSparkContext_1]:384) - ------ Create new SparkContext yarn-client -------
DEBUG [2017-02-03 09:05:33,668] ({pool-2-thread-2} SparkInterpreter.java[createSparkContext_1]:467) - SparkConf: key = [spark.cores.max], value = [2]
DEBUG [2017-02-03 09:05:33,668] ({pool-2-thread-2} SparkInterpreter.java[createSparkContext_1]:467) - SparkConf: key = [spark.app.name], value = [Zeppelin]
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
