### PR TITLE
When gear icon is clicked, scroll the page to the top to show the interpreter bindings

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -614,6 +614,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     } else {
       $scope.openSetting();
       $scope.closePermissions();
+      window.scroll(0,0);
     }
   };
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -614,7 +614,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     } else {
       $scope.openSetting();
       $scope.closePermissions();
-      window.scroll(0,0);
+      angular.element('html, body').animate({ scrollTop: 0 }, 'slow');
     }
   };
 


### PR DESCRIPTION

### What is this PR for?
When someone is browsing a notebook and they click the *gear* button of interpreter bindings, the bindings do come up, but the person might not realize since it opens on the top of the page, and they don't get any feedback that the bindings have opened. We should scroll up the page to show the bindings. This will also act as the feedback of clicking the *gear* button.

### What type of PR is it?
[Improvement]

### Todos
* None

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2047

### How should this be tested?
Create few (say 10) paragraphs and scroll down to the last paragraph. Now click the *gear* icon meant to open the interpreter bindings. The view should have scrolled up to show the bindings.

### Screenshots (if appropriate)


![zeppelin-2047](https://cloud.githubusercontent.com/assets/4542030/22618870/e724a1f8-eb0d-11e6-9395-949791469659.gif)



### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No. Its a usability improvement.
