### PR TITLE
[ZEPPELIN-2000][HOTFIX] Run paragraph on ng-change when select value changed.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -30,6 +30,7 @@ limitations under the License.
       <select class="form-control input-sm"
              ng-if="paragraph.settings.forms[formulaire.name].options && paragraph.settings.forms[formulaire.name].type != 'checkbox'"
              ng-enter="runParagraphFromButton(getEditorValue())"
+             ng-change="runParagraphFromButton(getEditorValue())"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
              name="{{formulaire.name}}"


### PR DESCRIPTION
### What is this PR for?
Run paragraph on ng-change when select value changed.


### What type of PR is it?
[Bug Fix | Hot Fix]

### What is the Jira issue?
* [ZEPPELIN-2000](https://issues.apache.org/jira/browse/ZEPPELIN-2000)

### How should this be tested?
 - Go to Zeppelin Tutorial/Basic Features (Spark) notebook
 - Change selected value from married to single in 5th paragraph and hit enter.
 - Change view mode to report and check step 2.
 - See if paragraph runs

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
