### PR TITLE
[ZEPPELIN-2046] The final output is a little inconsistent with the streaming output

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -76,6 +76,10 @@ table.dataTable.table-condensed .sorting_desc:after {
   white-space:pre-wrap; /** to preserve white-space and newlines of result */
 }
 
+.plainTextContent div {
+  min-height:17px;
+}
+
 .graphContainer {
   position: relative;
   margin-bottom: 5px;

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -488,12 +488,8 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
 
     // pop all stacked data and append to the DOM
     while (textResultQueueForAppend.length > 0) {
-      const stacked = textResultQueueForAppend.pop();
-
-      const lines = stacked.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        elem.append(angular.element('<div></div>').text(lines[i]));
-      }
+      const line = textResultQueueForAppend.pop();
+      elem.append(angular.element('<div></div>').text(line));
 
       if ($scope.keepScrollDown) {
         const doc = angular.element(`#${elemId}`);


### PR DESCRIPTION
### What is this PR for?
he final output is not consistent with the streaming output. The final output has one extra blank lines between outputs.

### What type of PR is it?
Bug Fix

### Todos
* [x] - make streaming output and static output the same

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2046

### How should this be tested?
run 

```
%sh echo hello && echo "" && sleep 1 && echo world && sleep 1
```
and see if streaming output is the same to final output

### Screenshots (if appropriate)
before
![output_append_fix_before](https://cloud.githubusercontent.com/assets/1540981/22631180/7ac842c4-ec4a-11e6-8d70-6f710f9b850e.gif)

after
![output_append_fix](https://cloud.githubusercontent.com/assets/1540981/22631178/77596f46-ec4a-11e6-90f0-335d911a9091.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
