### PR TITLE
Hive proxy user doesn't work if interpreter name is not JDBC

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -375,7 +375,7 @@ public class JDBCInterpreter extends Interpreter {
             if (user == null) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
-              if (url.trim().indexOf("jdbc:hive") == 0) {
+              if (url.trim().startsWith("jdbc:hive")) {
                 StringBuilder connectionUrl = new StringBuilder(url);
                 Integer lastIndexOfUrl = connectionUrl.indexOf("?");
                 if (lastIndexOfUrl == -1) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -375,7 +375,7 @@ public class JDBCInterpreter extends Interpreter {
             if (user == null) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
-              if ("hive".equalsIgnoreCase(propertyKey)) {
+              if (url.trim().indexOf("jdbc:hive") == 0) {
                 StringBuilder connectionUrl = new StringBuilder(url);
                 Integer lastIndexOfUrl = connectionUrl.indexOf("?");
                 if (lastIndexOfUrl == -1) {


### PR DESCRIPTION
### What is this PR for?
Hive proxy user doesn't work if interpreter name is not JDBC

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-2062](https://issues.apache.org/jira/browse/ZEPPELIN-2062)

### How should this be tested?
Create a new interpreter named "hive" and run a hive query in a Kerberos environment.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
