### PR TITLE
[ZEPPELIN-2063] Hive Jdbc interpreter does not relogin if kerberos ticket expired when hive.server2.transport.mode is http

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -647,7 +647,9 @@ public class JDBCInterpreter extends Interpreter {
     String user = interpreterContext.getAuthenticationInfo().getUser();
     try {
       closeDBPool(user, propertyKey);
-    } catch (SQLException e) {/*ignored*/}
+    } catch (SQLException e) {
+      logger.error("Error, could not close DB pool in reLoginFromKeytab ", e);
+    }
     UserGroupInformation.AuthenticationMethod authType =
         JDBCSecurityImpl.getAuthtype(property);
     if (authType.equals(KERBEROS)) {
@@ -659,11 +661,7 @@ public class JDBCInterpreter extends Interpreter {
         }
       } catch (IOException e) {
         logger.error("Cannot reloginFromKeytab " + sql, e);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-        e.printStackTrace(ps);
-        String errorMsg = new String(baos.toByteArray(), StandardCharsets.UTF_8);
-        interpreterResult.add(errorMsg);
+        interpreterResult.add(e.getMessage());
         return new InterpreterResult(Code.ERROR, interpreterResult.message());
       }
     }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
@@ -31,11 +31,13 @@ public class JDBCUserConfigurations {
   private final Map<String, Statement> paragraphIdStatementMap;
   private final Map<String, PoolingDriver> poolingDriverMap;
   private final HashMap<String, Properties> propertiesMap;
+  private HashMap<String, Boolean> isSuccessful;
 
   public JDBCUserConfigurations() {
     paragraphIdStatementMap = new HashMap<>();
     poolingDriverMap = new HashMap<>();
     propertiesMap = new HashMap<>();
+    isSuccessful = new HashMap<>();
   }
 
   public void initStatementMap() throws SQLException {
@@ -53,6 +55,7 @@ public class JDBCUserConfigurations {
       it.remove();
     }
     poolingDriverMap.clear();
+    isSuccessful.clear();
   }
 
   public void setPropertyMap(String key, Properties properties) {
@@ -88,13 +91,26 @@ public class JDBCUserConfigurations {
 
   public void saveDBDriverPool(String key, PoolingDriver driver) throws SQLException {
     poolingDriverMap.put(key, driver);
+    isSuccessful.put(key, false);
   }
   public PoolingDriver removeDBDriverPool(String key) throws SQLException {
+    isSuccessful.remove(key);
     return poolingDriverMap.remove(key);
   }
 
   public boolean isConnectionInDBDriverPool(String key) {
     return poolingDriverMap.containsKey(key);
+  }
+
+  public void setConnectionInDBDriverPoolSuccessful(String key) {
+    isSuccessful.put(key, true);
+  }
+
+  public boolean isConnectionInDBDriverPoolSuccessful(String key) {
+    if (isSuccessful.containsKey(key)) {
+      return isSuccessful.get(key);
+    }
+    return false;
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
Hadoop Client will re-login once the ticket expired in case of RPC and so when hive.server2.transport.mode is binary, Hive Jdbc interpreter does a relogin and works fine. But when Rest API is used i.e when hive.server2.transport.mode is http, it is not doing a re-login and so fails with GSS exception.

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2063](https://issues.apache.org/jira/browse/ZEPPELIN-2063)

### How should this be tested?
Run hive in http mode i.e. hive.server2.transport.mode is http. Run any query say `show tables` now wait for key to expire (usually its 24hrs), now try to run the same paragraph again without restarting zeppelin-server or jdbc interpreter. It should not fail with `GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)
` exception

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
