### PR TITLE
[ZEPPELIN-2067] SparkInterpreter prints unnecessary newline

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -993,6 +993,7 @@ public class SparkInterpreter extends Interpreter {
   }
 
   private Results.Result interpret(String line) {
+    out.ignoreLeadingNewLinesFromScalaReporter();
     return (Results.Result) Utils.invokeMethod(
         intp,
         "interpret",
@@ -1261,7 +1262,6 @@ public class SparkInterpreter extends Interpreter {
     if (varName == null || varName.isEmpty()) {
       return;
     }
-
     Object lastObj = null;
     try {
       if (Utils.isScala2_10()) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 public class InterpreterOutputStream extends LogOutputStream {
   public static Logger logger;
   InterpreterOutput interpreterOutput;
+  boolean ignoreLeadingNewLinesFromScalaReporter = false;
 
   public InterpreterOutputStream(Logger logger) {
     this.logger = logger;
@@ -45,6 +46,18 @@ public class InterpreterOutputStream extends LogOutputStream {
 
   @Override
   public void write(int b) throws IOException {
+    if (ignoreLeadingNewLinesFromScalaReporter && b == '\n') {
+      StackTraceElement[] stacks = Thread.currentThread().getStackTrace();
+      for (StackTraceElement stack : stacks) {
+        if (stack.getClassName().equals("scala.tools.nsc.interpreter.ReplReporter") &&
+            stack.getMethodName().equals("error")) {
+          // ignore
+          return;
+        }
+      }
+    } else {
+      ignoreLeadingNewLinesFromScalaReporter = false;
+    }
     super.write(b);
     if (interpreterOutput != null) {
       interpreterOutput.write(b);
@@ -53,17 +66,13 @@ public class InterpreterOutputStream extends LogOutputStream {
 
   @Override
   public void write(byte [] b) throws IOException {
-    super.write(b);
-    if (interpreterOutput != null) {
-      interpreterOutput.write(b);
-    }
+    write(b, 0, b.length);
   }
 
   @Override
-  public void write(byte [] b, int offset, int len) throws IOException {
-    super.write(b, offset, len);
-    if (interpreterOutput != null) {
-      interpreterOutput.write(b, offset, len);
+  public void write(byte [] b, int off, int len) throws IOException {
+    for (int i = off; i < len; i++) {
+      write(b[i]);
     }
   }
 
@@ -80,12 +89,15 @@ public class InterpreterOutputStream extends LogOutputStream {
     }
   }
 
-
   @Override
   public void flush() throws IOException {
     super.flush();
     if (interpreterOutput != null) {
       interpreterOutput.flush();
     }
+  }
+
+  public void ignoreLeadingNewLinesFromScalaReporter() {
+    ignoreLeadingNewLinesFromScalaReporter = true;
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
@@ -51,7 +51,7 @@ public class InterpreterOutputStream extends LogOutputStream {
       for (StackTraceElement stack : stacks) {
         if (stack.getClassName().equals("scala.tools.nsc.interpreter.ReplReporter") &&
             stack.getMethodName().equals("error")) {
-          // ignore
+          // ignore. Please see ZEPPELIN-2067
           return;
         }
       }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -76,6 +76,30 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
 
     @Test
+    public void scalaOutputTest() throws IOException {
+        // create new note
+        Note note = ZeppelinServer.notebook.createNote(anonymous);
+        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Map config = p.getConfig();
+        config.put("enabled", true);
+        p.setConfig(config);
+        p.setText("%spark import java.util.Date\n" +
+            "import java.net.URL\n" +
+            "println(\"hello\")\n"
+        );
+        p.setAuthenticationInfo(anonymous);
+        note.run(p.getId());
+        waitForFinish(p);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals("import java.util.Date\n" +
+            "import java.net.URL\n" +
+            "hello\n", p.getResult().message().get(0).getData());
+        ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
+    }
+
+
+
+    @Test
     public void basicRDDTransformationAndActionTest() throws IOException {
         // create new note
         Note note = ZeppelinServer.notebook.createNote(anonymous);


### PR DESCRIPTION
### What is this PR for?
Spark interpreter prints unnecessary new line before the evaluation output is printed.
See https://github.com/apache/zeppelin/pull/1975#issuecomment-277581660.

This PR make SparkInterpreter ignores unnecessary preceding newline from ReplReporter.error()


### What type of PR is it?
Bug Fix

### Todos
* [x] - Ignore unnecessary preceding newline
* [x] - unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2067

### How should this be tested?
run
```
%spark
import java.util.Date
import java.net.URL
```

and see if result looks like (no new line in front of each lines)

```
import java.util.Date
import java.net.URL
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
