### PR TITLE
[ZEPPELIN-2069] Helium Package Configuration

### DIFF
--- a/zeppelin-examples/zeppelin-example-spell-echo/index.js
+++ b/zeppelin-examples/zeppelin-example-spell-echo/index.js
@@ -26,7 +26,28 @@ export default class EchoSpell extends SpellBase {
         super("%echo");
     }
 
-    interpret(paragraphText) {
-        return new SpellResult(paragraphText);
+    /**
+     * Consumes text and return `SpellResult`.
+     *
+     * @param paragraphText {string} which doesn't include magic
+     * @param config {Object}
+     * @return {SpellResult}
+     */
+    interpret(paragraphText, config) {
+        let repeat = 1;
+
+        try {
+            repeat = parseFloat(config.repeat);
+        } catch (error) {
+            /** ignore, use default value */
+        }
+
+        let repeated = "";
+
+        for (let i = 0; i < repeat; i++) {
+            repeated += `${paragraphText}\n`;
+        }
+
+        return new SpellResult(repeated);
     }
 }

--- a/zeppelin-examples/zeppelin-example-spell-echo/zeppelin-example-spell-echo.json
+++ b/zeppelin-examples/zeppelin-example-spell-echo/zeppelin-example-spell-echo.json
@@ -17,7 +17,6 @@
 {
   "type" : "SPELL",
   "name" : "echo-spell",
-  "version": "local",
   "description" : "Return just what receive (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-echo",
   "license" : "Apache-2.0",

--- a/zeppelin-examples/zeppelin-example-spell-echo/zeppelin-example-spell-echo.json
+++ b/zeppelin-examples/zeppelin-example-spell-echo/zeppelin-example-spell-echo.json
@@ -17,10 +17,18 @@
 {
   "type" : "SPELL",
   "name" : "echo-spell",
+  "version": "local",
   "description" : "Return just what receive (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-echo",
   "license" : "Apache-2.0",
   "icon" : "<i class='fa fa-repeat'></i>",
+  "config": {
+    "repeat": {
+      "type": "number",
+      "description": "How many times to repeat",
+      "defaultValue": 1
+    }
+  },
   "spell": {
     "magic": "%echo",
     "usage": "%echo <TEXT>"

--- a/zeppelin-examples/zeppelin-example-spell-flowchart/zeppelin-example-spell-flowchart.json
+++ b/zeppelin-examples/zeppelin-example-spell-flowchart/zeppelin-example-spell-flowchart.json
@@ -17,7 +17,6 @@
 {
   "type" : "SPELL",
   "name" : "flowchart-spell",
-  "version": "local",
   "description" : "Draw flowchart using http://flowchart.js.org (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-flowchart",
   "license" : "Apache-2.0",

--- a/zeppelin-examples/zeppelin-example-spell-flowchart/zeppelin-example-spell-flowchart.json
+++ b/zeppelin-examples/zeppelin-example-spell-flowchart/zeppelin-example-spell-flowchart.json
@@ -17,6 +17,7 @@
 {
   "type" : "SPELL",
   "name" : "flowchart-spell",
+  "version": "local",
   "description" : "Draw flowchart using http://flowchart.js.org (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-flowchart",
   "license" : "Apache-2.0",

--- a/zeppelin-examples/zeppelin-example-spell-markdown/zeppelin-example-spell-markdown.json
+++ b/zeppelin-examples/zeppelin-example-spell-markdown/zeppelin-example-spell-markdown.json
@@ -17,6 +17,7 @@
 {
   "type" : "SPELL",
   "name" : "markdown-spell",
+  "version": "local",
   "description" : "Parse markdown using https://github.com/evilstreak/markdown-js (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-markdown",
   "license" : "Apache-2.0",

--- a/zeppelin-examples/zeppelin-example-spell-markdown/zeppelin-example-spell-markdown.json
+++ b/zeppelin-examples/zeppelin-example-spell-markdown/zeppelin-example-spell-markdown.json
@@ -17,7 +17,6 @@
 {
   "type" : "SPELL",
   "name" : "markdown-spell",
-  "version": "local",
   "description" : "Parse markdown using https://github.com/evilstreak/markdown-js (example)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-markdown",
   "license" : "Apache-2.0",

--- a/zeppelin-examples/zeppelin-example-spell-translator/index.js
+++ b/zeppelin-examples/zeppelin-example-spell-translator/index.js
@@ -28,11 +28,18 @@ export default class TranslatorSpell extends SpellBase {
         super("%translator");
     }
 
-    interpret(paragraphText) {
+    /**
+     * Consumes text and return `SpellResult`.
+     *
+     * @param paragraphText {string} which doesn't include magic
+     * @param config {Object}
+     * @return {SpellResult}
+     */
+    interpret(paragraphText, config) {
         const parsed = this.parseConfig(paragraphText);
+        const auth = config['access-token'];
         const source = parsed.source;
         const target = parsed.target;
-        const auth = parsed.auth;
         const text = parsed.text;
 
         /**
@@ -49,7 +56,7 @@ export default class TranslatorSpell extends SpellBase {
     }
 
     parseConfig(text) {
-        const pattern = /^\s*(\S+)-(\S+)\s*(\S+)([\S\s]*)/g;
+        const pattern = /^\s*(\S+)-(\S+)\s*([\S\s]*)/g;
         const match = pattern.exec(text);
 
         if (!match) {
@@ -59,8 +66,7 @@ export default class TranslatorSpell extends SpellBase {
         return {
             source: match[1],
             target: match[2],
-            auth: match[3],
-            text: match[4],
+            text: match[3],
         }
     }
 

--- a/zeppelin-examples/zeppelin-example-spell-translator/zeppelin-example-spell-translator.json
+++ b/zeppelin-examples/zeppelin-example-spell-translator/zeppelin-example-spell-translator.json
@@ -17,10 +17,18 @@
 {
   "type" : "SPELL",
   "name" : "translator-spell",
+  "version": "local",
   "description" : "Translate langauges using Google API (examaple)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-translator",
   "license" : "Apache-2.0",
   "icon" : "<i class='fa fa-globe '></i>",
+  "config": {
+    "access-token": {
+      "type": "string",
+      "description": "access token for Google Translation API",
+      "defaultValue": "EXAMPLE-TOKEN"
+    }
+  },
   "spell": {
     "magic": "%translator",
     "usage": "%translator <source>-<target> <access-key> <TEXT>"

--- a/zeppelin-examples/zeppelin-example-spell-translator/zeppelin-example-spell-translator.json
+++ b/zeppelin-examples/zeppelin-example-spell-translator/zeppelin-example-spell-translator.json
@@ -17,7 +17,6 @@
 {
   "type" : "SPELL",
   "name" : "translator-spell",
-  "version": "local",
   "description" : "Translate langauges using Google API (examaple)",
   "artifact" : "./zeppelin-examples/zeppelin-example-spell-translator",
   "license" : "Apache-2.0",

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
@@ -18,6 +18,8 @@ package org.apache.zeppelin.helium;
 
 import org.apache.zeppelin.annotation.Experimental;
 
+import java.util.Map;
+
 /**
  * Helium package definition
  */
@@ -25,6 +27,7 @@ import org.apache.zeppelin.annotation.Experimental;
 public class HeliumPackage {
   private HeliumType type;
   private String name;           // user friendly name of this application
+  private String version;
   private String description;    // description
   private String artifact;       // artifact name e.g) groupId:artifactId:versionId
   private String className;      // entry point
@@ -33,7 +36,8 @@ public class HeliumPackage {
   private String license;
   private String icon;
 
-  public SpellPackageInfo spell;
+  private SpellPackageInfo spell;
+  private Map<String, Object> config;
 
   public HeliumPackage(HeliumType type,
                        String name,
@@ -81,6 +85,10 @@ public class HeliumPackage {
     return name;
   }
 
+  public String getVersion() {
+    return version;
+  }
+
   public String getDescription() {
     return description;
   }
@@ -100,6 +108,7 @@ public class HeliumPackage {
   public String getLicense() {
     return license;
   }
+
   public String getIcon() {
     return icon;
   }
@@ -107,4 +116,6 @@ public class HeliumPackage {
   public SpellPackageInfo getSpellInfo() {
     return spell;
   }
+
+  public Map<String, Object> getConfig() { return config; }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/HeliumPackage.java
@@ -27,7 +27,6 @@ import java.util.Map;
 public class HeliumPackage {
   private HeliumType type;
   private String name;           // user friendly name of this application
-  private String version;
   private String description;    // description
   private String artifact;       // artifact name e.g) groupId:artifactId:versionId
   private String className;      // entry point
@@ -83,10 +82,6 @@ public class HeliumPackage {
 
   public String getName() {
     return name;
-  }
-
-  public String getVersion() {
-    return version;
   }
 
   public String getDescription() {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/helium/HeliumPackageTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/helium/HeliumPackageTest.java
@@ -20,6 +20,8 @@ package org.apache.zeppelin.helium;
 import com.google.gson.Gson;
 import org.junit.Test;
 
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 public class HeliumPackageTest {
@@ -28,7 +30,7 @@ public class HeliumPackageTest {
 
   @Test
   public void parseSpellPackageInfo() {
-    String exampleSpell = "{\n" +
+    String examplePackage = "{\n" +
         "  \"type\" : \"SPELL\",\n" +
         "  \"name\" : \"echo-spell\",\n" +
         "  \"description\" : \"'%echo' - return just what receive (example)\",\n" +
@@ -41,8 +43,41 @@ public class HeliumPackageTest {
         "  }\n" +
         "}";
 
-    HeliumPackage p = gson.fromJson(exampleSpell, HeliumPackage.class);
+    HeliumPackage p = gson.fromJson(examplePackage, HeliumPackage.class);
     assertEquals(p.getSpellInfo().getMagic(), "%echo");
     assertEquals(p.getSpellInfo().getUsage(), "%echo <TEXT>");
+  }
+
+  @Test
+  public void parseConfig() {
+    String examplePackage = "{\n" +
+        "  \"type\" : \"SPELL\",\n" +
+        "  \"name\" : \"translator-spell\",\n" +
+        "  \"description\" : \"Translate langauges using Google API (examaple)\",\n" +
+        "  \"artifact\" : \"./zeppelin-examples/zeppelin-example-spell-translator\",\n" +
+        "  \"license\" : \"Apache-2.0\",\n" +
+        "  \"icon\" : \"<i class='fa fa-globe '></i>\",\n" +
+        "  \"config\": {\n" +
+        "    \"access-token\": {\n" +
+        "      \"type\": \"string\",\n" +
+        "      \"description\": \"access token for Google Translation API\",\n" +
+        "      \"defaultValue\": \"EXAMPLE-TOKEN\"\n" +
+        "    }\n" +
+        "  },\n" +
+        "  \"spell\": {\n" +
+        "    \"magic\": \"%translator\",\n" +
+        "    \"usage\": \"%translator <source>-<target> <access-key> <TEXT>\"\n" +
+        "  }\n" +
+        "}";
+
+    HeliumPackage p = gson.fromJson(examplePackage, HeliumPackage.class);
+    Map<String, Object> config = p.getConfig();
+    Map<String, Object> accessToken = (Map<String, Object>) config.get("access-token");
+
+    assertEquals((String) accessToken.get("type"),"string");
+    assertEquals((String) accessToken.get("description"),
+        "access token for Google Translation API");
+    assertEquals((String) accessToken.get("defaultValue"),
+        "EXAMPLE-TOKEN");
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -195,7 +195,7 @@ public class HeliumRestApi {
   @Path("config")
   public Response getAllPackageConfigs() {
     try {
-      Map<String, Map<String, Map<String, Object>>> config = helium.getAllPackageConfig();
+      Map<String, Map<String, Object>> config = helium.getAllPackageConfig();
       return new JsonResponse(Response.Status.OK, config).build();
     } catch (RuntimeException e) {
       logger.error(e.getMessage(), e);
@@ -204,18 +204,17 @@ public class HeliumRestApi {
   }
 
   @GET
-  @Path("config/{packageName}/{packageVersion}")
-  public Response getPackageConfig(@PathParam("packageName") String packageName,
-                                   @PathParam("packageVersion") String packageVersion) {
+  @Path("config/{artifact}")
+  public Response getPackageConfig(@PathParam("artifact") String artifact) {
 
-    if (StringUtils.isEmpty(packageName) || StringUtils.isEmpty(packageVersion)) {
+    if (StringUtils.isEmpty(artifact)) {
       return new JsonResponse(Response.Status.BAD_REQUEST,
           "package name or version is empty"
       ).build();
     }
 
     try {
-      Map<String, Object> config = helium.getPackageConfig(packageName, packageVersion);
+      Map<String, Object> config = helium.getPackageConfig(artifact);
       return new JsonResponse(Response.Status.OK, config).build();
     } catch (RuntimeException e) {
       logger.error(e.getMessage(), e);
@@ -224,9 +223,8 @@ public class HeliumRestApi {
   }
 
   @POST
-  @Path("config/{packageName}/{packageVersion}")
-  public Response updatePackageConfig(@PathParam("packageName") String packageName,
-                                      @PathParam("packageVersion") String packageVersion,
+  @Path("config/{artifact}")
+  public Response updatePackageConfig(@PathParam("artifact") String artifact,
                                       String rawConfig) {
 
     Map<String, Object> packageConfig = null;
@@ -234,7 +232,7 @@ public class HeliumRestApi {
     try {
       packageConfig = gson.fromJson(
           rawConfig, new TypeToken<Map<String, Object>>(){}.getType());
-      helium.updatePackageConfig(packageName, packageVersion, packageConfig);
+      helium.updatePackageConfig(artifact, packageConfig);
     } catch (JsonParseException e) {
       logger.error(e.getMessage(), e);
       return new JsonResponse(Response.Status.BAD_REQUEST,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -18,8 +18,12 @@
 package org.apache.zeppelin.rest;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.helium.Helium;
 import org.apache.zeppelin.helium.HeliumPackage;
 import org.apache.zeppelin.notebook.Note;
@@ -34,6 +38,7 @@ import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Helium Rest Api
@@ -56,13 +61,34 @@ public class HeliumRestApi {
   }
 
   /**
-   * Get all packages
-   * @return
+   * Get all package infos
    */
   @GET
-  @Path("all")
-  public Response getAll() {
-    return new JsonResponse(Response.Status.OK, "", helium.getAllPackageInfo()).build();
+  @Path("package")
+  public Response getAllPackageInfo() {
+    return new JsonResponse(
+        Response.Status.OK, "", helium.getAllPackageInfo()).build();
+  }
+
+  /**
+   * Get single package info
+   */
+  @GET
+  @Path("package/{packageName}")
+  public Response getSinglePackageInfo(@PathParam("packageName") String packageName) {
+    if (StringUtils.isEmpty(packageName)) {
+      return new JsonResponse(
+          Response.Status.BAD_REQUEST,
+          "Can't get package info for empty name").build();
+    }
+
+    try {
+      return new JsonResponse(
+          Response.Status.OK, "", helium.getSinglePackageInfo(packageName)).build();
+    } catch (RuntimeException e) {
+      logger.error(e.getMessage(), e);
+      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
+    }
   }
 
   @GET
@@ -163,6 +189,62 @@ public class HeliumRestApi {
   public Response getVisualizationPackageOrder() {
     List<String> order = helium.setVisualizationPackageOrder();
     return new JsonResponse(Response.Status.OK, order).build();
+  }
+
+  @GET
+  @Path("config")
+  public Response getAllPackageConfigs() {
+    try {
+      Map<String, Map<String, Map<String, Object>>> config = helium.getAllPackageConfig();
+      return new JsonResponse(Response.Status.OK, config).build();
+    } catch (RuntimeException e) {
+      logger.error(e.getMessage(), e);
+      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
+    }
+  }
+
+  @GET
+  @Path("config/{packageName}/{packageVersion}")
+  public Response getPackageConfig(@PathParam("packageName") String packageName,
+                                   @PathParam("packageVersion") String packageVersion) {
+
+    if (StringUtils.isEmpty(packageName) || StringUtils.isEmpty(packageVersion)) {
+      return new JsonResponse(Response.Status.BAD_REQUEST,
+          "package name or version is empty"
+      ).build();
+    }
+
+    try {
+      Map<String, Object> config = helium.getPackageConfig(packageName, packageVersion);
+      return new JsonResponse(Response.Status.OK, config).build();
+    } catch (RuntimeException e) {
+      logger.error(e.getMessage(), e);
+      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
+    }
+  }
+
+  @POST
+  @Path("config/{packageName}/{packageVersion}")
+  public Response updatePackageConfig(@PathParam("packageName") String packageName,
+                                      @PathParam("packageVersion") String packageVersion,
+                                      String rawConfig) {
+
+    Map<String, Object> packageConfig = null;
+
+    try {
+      packageConfig = gson.fromJson(
+          rawConfig, new TypeToken<Map<String, Object>>(){}.getType());
+      helium.updatePackageConfig(packageName, packageVersion, packageConfig);
+    } catch (JsonParseException e) {
+      logger.error(e.getMessage(), e);
+      return new JsonResponse(Response.Status.BAD_REQUEST,
+          e.getMessage()).build();
+    } catch (IOException | RuntimeException e) {
+      return new JsonResponse(Response.Status.INTERNAL_SERVER_ERROR,
+          e.getMessage()).build();
+    }
+
+    return new JsonResponse(Response.Status.OK, packageConfig).build();
   }
 
   @POST

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -126,7 +126,7 @@ public class ZeppelinServer extends Application {
           new File(conf.getRelativeDir("zeppelin-web/src/app/spell")));
     }
 
-    this.helium = new Helium(
+    ZeppelinServer.helium = new Helium(
         conf.getHeliumConfPath(),
         conf.getHeliumRegistry(),
         new File(conf.getRelativeDir(ConfVars.ZEPPELIN_DEP_LOCALREPO),
@@ -177,7 +177,7 @@ public class ZeppelinServer extends Application {
     // Web UI
     final WebAppContext webApp = setupWebAppContext(contexts, conf);
 
-    // REST api
+    // Create `ZeppelinServer` using reflection and setup REST Api
     setupRestApiContextHandler(webApp, conf);
 
     // Notebook server

--- a/zeppelin-web/src/app/helium/helium.config.js
+++ b/zeppelin-web/src/app/helium/helium.config.js
@@ -41,36 +41,24 @@ export function mergePersistedConfWithSpec(persisted, spec) {
   return confs;
 }
 
-export function createSinglePackageConfig(pkg, persistedConf) {
-  const spec = pkg.config;
-  if (!spec) { return; }
-
-  const version = pkg.version;
-  if (!version) { return; }
-
-  if (!persistedConf) { persistedConf = {}; }
-
-  return mergePersistedConfWithSpec(persistedConf, spec);
-}
-
-export function createAllPackageConfigs(defaultPackages, persistedConfs) {
+export function createPackageConf(defaultPackages, persistedPackacgeConfs) {
   let packageConfs = {};
 
   for (let name in defaultPackages) {
-    const pkgSearchResult = defaultPackages[name];
+    const pkgInfo = defaultPackages[name];
 
-    const spec = pkgSearchResult.pkg.config;
-    if (!spec) { continue; }
+    const configSpec = pkgInfo.pkg.config;
+    if (!configSpec) { continue; }
 
-    const version = pkgSearchResult.pkg.version;
+    const version = pkgInfo.pkg.version;
     if (!version) { continue; }
 
-    let persistedConf = {};
-    if (persistedConfs[name] && persistedConfs[name][version]) {
-      persistedConf = persistedConfs[name][version];
+    let config = {};
+    if (persistedPackacgeConfs[name] && persistedPackacgeConfs[name][version]) {
+      config = persistedPackacgeConfs[name][version];
     }
 
-    const confs = mergePersistedConfWithSpec(persistedConf, spec);
+    const confs = mergePersistedConfWithSpec(config, configSpec);
     packageConfs[name] = confs;
   }
 
@@ -95,12 +83,14 @@ export function parseConfigValue(type, stringified) {
 }
 
 /**
- * persist key-value only
- * since other info (e.g type, desc) can be provided by default config
+ * create persistable config object
  */
 export function createPersistableConfig(currentConf) {
+  // persist key-value only
+  // since other info (e.g type, desc) can be provided by default config
   const filtered = currentConf.reduce((acc, c) => {
-    acc[c.name] = parseConfigValue(c.type, c.value);
+    let value = parseConfigValue(c.type, c.value);
+    acc[c.name] = value;
     return acc;
   }, {});
 

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -218,7 +218,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
       return;
     }
 
-    heliumService.getSinglePackageConfig(pkgName, pkgVersion)
+    heliumService.getSinglePackageConfigs(pkgName, pkgVersion)
       .then(conf => {
         $scope.defaultPackageConfigs[pkgName] = conf;
         pkgSearchResult.configOpened = true;

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -14,61 +14,36 @@
 
 import { HeliumType, } from '../../components/helium/helium-type';
 
-angular.module('zeppelinWebApp').controller('HeliumCtrl', HeliumCtrl);
-
-function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService) {
+export default function HeliumCtrl($scope, $rootScope, $sce,
+                                   baseUrlSrv, ngToast, heliumService) {
   'ngInject';
 
-  $scope.packageInfos = {};
-  $scope.defaultVersions = {};
+  $scope.pkgSearchResults = {};
+  $scope.defaultPackages = {};
   $scope.showVersions = {};
   $scope.bundleOrder = [];
   $scope.bundleOrderChanged = false;
+  $scope.defaultPackageConfigs = {}; // { pkgName, [{name, type, desc, value, defaultValue}] }
 
-  var buildDefaultVersionListToDisplay = function(packageInfos) {
-    var defaultVersions = {};
-    // show enabled version if any version of package is enabled
-    for (var name in packageInfos) {
-      var pkgs = packageInfos[name];
-      for (var pkgIdx in pkgs) {
-        var pkg = pkgs[pkgIdx];
-        pkg.pkg.icon = $sce.trustAsHtml(pkg.pkg.icon);
-        if (pkg.enabled) {
-          defaultVersions[name] = pkg;
-          pkgs.splice(pkgIdx, 1);
-          break;
-        }
-      }
+  function init() {
+    // get all package info and set config
+    heliumService.getAllPackageInfoAndDefaultPackages()
+      .then(({ pkgSearchResults, defaultPackages }) => {
+        $scope.pkgSearchResults = pkgSearchResults;
+        $scope.defaultPackages = defaultPackages;
+        return heliumService.getAllPackageConfigs()
+      })
+      .then(defaultPackageConfigs => {
+        $scope.defaultPackageConfigs = defaultPackageConfigs;
+      });
 
-      // show first available version if package is not enabled
-      if (!defaultVersions[name]) {
-        defaultVersions[name] = pkgs[0];
-        pkgs.splice(0, 1);
-      }
-    }
-    $scope.defaultVersions = defaultVersions;
-  };
-
-  var getAllPackageInfo = function() {
-    heliumService.getAllPackageInfo().
-    success(function(data, status) {
-      $scope.packageInfos = data.body;
-      buildDefaultVersionListToDisplay($scope.packageInfos);
-    }).
-    error(function(data, status) {
-      console.log('Can not load package info %o %o', status, data);
-    });
-  };
-
-  var getBundleOrder = function() {
-    heliumService.getVisualizationPackageOrder().
-    success(function(data, status) {
-      $scope.bundleOrder = data.body;
-    }).
-    error(function(data, status) {
-      console.log('Can not get bundle order %o %o', status, data);
-    });
-  };
+    // 2. get vis package order
+    heliumService.getVisualizationPackageOrder()
+      .then(visPackageOrder => {
+        $scope.bundleOrder = visPackageOrder;
+        $scope.bundleOrderChanged = false;
+      });
+  }
 
   $scope.bundleOrderListeners = {
     accept: function(sourceItemHandleScope, destSortableScope) {return true;},
@@ -77,14 +52,6 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
       $scope.bundleOrderChanged = true;
     }
   };
-
-  var init = function() {
-    getAllPackageInfo();
-    getBundleOrder();
-    $scope.bundleOrderChanged = false;
-  };
-
-  init();
 
   $scope.saveBundleOrder = function() {
     var confirm = BootstrapDialog.confirm({
@@ -115,24 +82,24 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
         }
       }
     });
-  }
+  };
 
   var getLicense = function(name, artifact) {
-    var pkg = _.filter($scope.defaultVersions[name], function(p) {
+    var filteredPkgSearchResults = _.filter($scope.defaultPackages[name], function(p) {
       return p.artifact === artifact;
     });
 
     var license;
-    if (pkg.length === 0) {
-      pkg = _.filter($scope.packageInfos[name], function(p) {
+    if (filteredPkgSearchResults.length === 0) {
+      filteredPkgSearchResults = _.filter($scope.pkgSearchResults[name], function(p) {
         return p.pkg.artifact === artifact;
       });
 
-      if (pkg.length > 0) {
-        license  = pkg[0].pkg.license;
+      if (filteredPkgSearchResults.length > 0) {
+        license  = filteredPkgSearchResults[0].pkg.license;
       }
     } else {
-      license = pkg[0].license;
+      license = filteredPkgSearchResults[0].license;
     }
 
     if (!license) {
@@ -226,4 +193,46 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
     return (pkg.type === HeliumType.SPELL || pkg.type === HeliumType.VISUALIZATION) &&
       !$scope.isLocalPackage(pkgSearchResult);
   };
+
+  $scope.configExists = function(pkgSearchResult) {
+    // helium package config is persisted per version
+    return pkgSearchResult.pkg.config && pkgSearchResult.pkg.version;
+  };
+
+  $scope.configOpened = function(pkgSearchResult) {
+    return pkgSearchResult.configOpened;
+  };
+
+  $scope.toggleConfigButton = function(pkgSearchResult) {
+    if (pkgSearchResult.configOpened) {
+      pkgSearchResult.configOpened = false;
+      return;
+    }
+
+    const pkg = pkgSearchResult.pkg;
+    const pkgName = pkg.name;
+    const pkgVersion = pkg.version;
+
+    if (!pkgName || !pkgVersion) {
+      console.error(`Failed to fetch config for '${pkgSearchResult}@${pkgVersion}'`);
+      return;
+    }
+
+    heliumService.getSinglePackageConfig(pkgName, pkgVersion)
+      .then(conf => {
+        $scope.defaultPackageConfigs[pkgName] = conf;
+        pkgSearchResult.configOpened = true;
+        $scope.$digest(); // to trigger view update
+      });
+  };
+
+  $scope.saveConfig = function(pkgSearchResult) {
+    const pkgName = pkgSearchResult.pkg.name;
+    const pkgVersion = pkgSearchResult.pkg.version;
+    const currentConf = $scope.defaultPackageConfigs[pkgName];
+
+    heliumService.saveConfig(pkgName, pkgVersion, currentConf);
+  };
+
+  init();
 }

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -200,8 +200,13 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
   };
 
   $scope.configOpened = function(pkgSearchResult) {
-    return pkgSearchResult.configOpened;
+    return pkgSearchResult.configOpened && !pkgSearchResult.configFetching;
   };
+
+  $scope.getConfigButtonClass = function(pkgSearchResult) {
+    return (pkgSearchResult.configOpened && pkgSearchResult.configFetching) ?
+      'disabled' : '';
+  }
 
   $scope.toggleConfigButton = function(pkgSearchResult) {
     if (pkgSearchResult.configOpened) {
@@ -211,11 +216,13 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
     const pkg = pkgSearchResult.pkg;
     const pkgName = pkg.name;
+    pkgSearchResult.configFetching = true;
+    pkgSearchResult.configOpened = true;
 
     heliumService.getSinglePackageConfigs(pkg)
       .then(confs => {
         $scope.defaultPackageConfigs[pkgName] = confs;
-        pkgSearchResult.configOpened = true;
+        pkgSearchResult.configFetching = false;
         $scope.$digest(); // to trigger view update
       });
   };

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -211,16 +211,10 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
     const pkg = pkgSearchResult.pkg;
     const pkgName = pkg.name;
-    const pkgVersion = pkg.version;
 
-    if (!pkgName || !pkgVersion) {
-      console.error(`Failed to fetch config for '${pkgSearchResult}@${pkgVersion}'`);
-      return;
-    }
-
-    heliumService.getSinglePackageConfigs(pkgName, pkgVersion)
-      .then(conf => {
-        $scope.defaultPackageConfigs[pkgName] = conf;
+    heliumService.getSinglePackageConfigs(pkg)
+      .then(confs => {
+        $scope.defaultPackageConfigs[pkgName] = confs;
         pkgSearchResult.configOpened = true;
         $scope.$digest(); // to trigger view update
       });
@@ -228,10 +222,9 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
   $scope.saveConfig = function(pkgSearchResult) {
     const pkgName = pkgSearchResult.pkg.name;
-    const pkgVersion = pkgSearchResult.pkg.version;
     const currentConf = $scope.defaultPackageConfigs[pkgName];
 
-    heliumService.saveConfig(pkgName, pkgVersion, currentConf);
+    heliumService.saveConfig(pkgSearchResult.pkg, currentConf);
   };
 
   init();

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -230,7 +230,10 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
     const pkgName = pkgSearchResult.pkg.name;
     const currentConf = $scope.defaultPackageConfigs[pkgName];
 
-    heliumService.saveConfig(pkgSearchResult.pkg, currentConf);
+    heliumService.saveConfig(pkgSearchResult.pkg, currentConf, () => {
+      // close after config is saved
+      pkgSearchResult.configOpened = false;
+    });
   };
 
   init();

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -223,7 +223,6 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
       .then(confs => {
         $scope.defaultPackageConfigs[pkgName] = confs;
         pkgSearchResult.configFetching = false;
-        $scope.$digest(); // to trigger view update
       });
   };
 

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -196,7 +196,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
   $scope.configExists = function(pkgSearchResult) {
     // helium package config is persisted per version
-    return pkgSearchResult.pkg.config && pkgSearchResult.pkg.version;
+    return pkgSearchResult.pkg.config && pkgSearchResult.pkg.artifact;
   };
 
   $scope.configOpened = function(pkgSearchResult) {

--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -79,6 +79,10 @@
   width: 500px;
 }
 
+.spellConfigButton {
+  background-color: #FEFEFE;
+}
+
 .heliumPackageList .heliumPackageDisabledArtifact {
   color:gray;
 }
@@ -132,4 +136,21 @@
   color: #636363;
 }
 
+.heliumConfig {
+  margin-top: 30px;
+  margin-bottom: 10px;
+}
 
+.heliumConfigTable {
+  margin-top: 15px;
+  vertical-align:middle;
+  margin-bottom: 15px;
+}
+
+.heliumConfigValueInput {
+
+}
+
+.heliumConfigValueText {
+  vertical-align: top;
+}

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -29,7 +29,7 @@ limitations under the License.
         <div class="btn-group" data-ng-repeat="pkgName in bundleOrder"
              as-sortable-item>
           <div class="btn btn-default btn-sm"
-               ng-bind-html='defaultVersions[pkgName].pkg.icon'
+               ng-bind-html='defaultPackages[pkgName].pkg.icon'
                as-sortable-item-handle>
           </div>
         </div>
@@ -45,32 +45,37 @@ limitations under the License.
 
 <div class="box width-full heliumPackageContainer">
   <div class="row heliumPackageList"
-       ng-repeat="(pkgName, pkgInfo) in defaultVersions">
+       ng-repeat="(pkgName, pkgSearchResult) in defaultPackages">
+
     <div class="col-md-12">
       <div class="heliumPackageHead">
         <div class="heliumPackageIcon"
-             ng-bind-html=pkgInfo.pkg.icon></div>
+             ng-bind-html=pkgSearchResult.pkg.icon></div>
         <div class="heliumPackageName">
-          <span ng-if="hasNpmLink(pkgInfo)">
+          <span ng-if="hasNpmLink(pkgSearchResult)">
             <a target="_blank" href="https://www.npmjs.com/package/{{pkgName}}">{{pkgName}}</a>
           </span>
-          <span ng-if="!hasNpmLink(pkgInfo)" ng-class="{'heliumLocalPackage': isLocalPackage(pkgInfo)}">
+          <span ng-if="!hasNpmLink(pkgSearchResult)" ng-class="{'heliumLocalPackage': isLocalPackage(pkgSearchResult)}">
             {{pkgName}}
           </span>
-          <span class="heliumType">{{pkgInfo.pkg.type}}</span>
+          <span class="heliumType">{{pkgSearchResult.pkg.type}}</span>
         </div>
-        <div ng-show="!pkgInfo.enabled"
-             ng-click="enable(pkgName, pkgInfo.pkg.artifact)"
+        <div ng-show="!pkgSearchResult.enabled"
+             ng-click="enable(pkgName, pkgSearchResult.pkg.artifact)"
              class="btn btn-success btn-xs"
              style="float:right">Enable</div>
-        <div ng-show="pkgInfo.enabled"
+        <div ng-show="pkgSearchResult.enabled"
              ng-click="disable(pkgName)"
              class="btn btn-info btn-xs"
              style="float:right">Disable</div>
+        <div ng-show="configExists(pkgSearchResult)"
+             ng-click="toggleConfigButton(pkgSearchResult)"
+             class="btn btn-default btn-xs spellConfigButton"
+             style="float:right; margin-right:5px;">Config</div>
       </div>
-      <div ng-class="{heliumPackageDisabledArtifact: !pkgInfo.enabled, heliumPackageEnabledArtifact: pkgInfo.enabled}">
-        {{pkgInfo.pkg.artifact}}
-        <span ng-show="packageInfos[pkgName].length > 0"
+      <div ng-class="{heliumPackageDisabledArtifact: !pkgSearchResult.enabled, heliumPackageEnabledArtifact: pkgSearchResult.enabled}">
+        {{pkgSearchResult.pkg.artifact}}
+        <span ng-show="pkgSearchResults[pkgName].length > 0"
               ng-click="toggleVersions(pkgName)">
           versions
         </span>
@@ -78,28 +83,64 @@ limitations under the License.
       <ul class="heliumPackageVersions"
            ng-show="showVersions[pkgName]">
         <li class="heliumPackageDisabledArtifact"
-             ng-repeat="pkg in packageInfos[pkgName]">
-          {{pkg.pkg.artifact}} -
-          <span ng-click="enable(pkgName, pkg.pkg.artifact)"
+             ng-repeat="pkgSearchResult in pkgSearchResults[pkgName]">
+          {{pkgSearchResult.pkg.artifact}} -
+          <span ng-click="enable(pkgName, pkgSearchResult.pkg.artifact)"
                 style="margin-left:3px;cursor:pointer;text-decoration: underline;color:#3071a9">
             enable
           </span>
         </li>
       </ul>
       <div class="heliumPackageDescription">
-        {{pkgInfo.pkg.description}}
+        {{pkgSearchResult.pkg.description}}
       </div>
-      <div ng-if="pkgInfo.pkg.type === 'SPELL' && pkgInfo.pkg.spell"
+      <div ng-if="pkgSearchResult.pkg.type === 'SPELL' && pkgSearchResult.pkg.spell"
            class="spellInfo">
         <div>
           <span class="spellInfoDesc">MAGIC</span>
-          <span class="spellInfoValue">{{pkgInfo.pkg.spell.magic}} </span>
+          <span class="spellInfoValue">{{pkgSearchResult.pkg.spell.magic}} </span>
         </div>
         <div>
           <span class="spellInfoDesc">USAGE</span>
-          <pre class="spellUsage">{{pkgInfo.pkg.spell.usage}} </pre>
+          <pre class="spellUsage">{{pkgSearchResult.pkg.spell.usage}} </pre>
         </div>
       </div>
+
+      <!--start: config-->
+      <div class="heliumConfig" ng-if="configOpened(pkgSearchResult)">
+        <h5>Configuration</h5>
+        <table class="heliumConfigTable table table-striped">
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Value</th>
+          </tr>
+          <tr>
+          </tr>
+          <tr data-ng-repeat="cfg in defaultPackageConfigs[pkgSearchResult.pkg.name]">
+            <td style="vertical-align: middle;">{{cfg.name}}</td>
+            <td style="vertical-align: middle;">{{cfg.type}}</td>
+            <td style="vertical-align: middle;">{{cfg.description}}</td>
+            <td>
+              <div class="input-group">
+                <input type="text" class="form-control" style="border-radius: 5px;"
+                       data-ng-model="cfg.value" placeholder="{{cfg.defaultValue}}" />
+              </div>
+            </td>
+          </tr>
+        </table>
+
+        <div>
+          <button class="btn btn-primary"
+                  ng-click="saveConfig(pkgSearchResult)">Save</button>
+          <button class="btn btn-default"
+                  ng-click="toggleConfigButton(pkgSearchResult)">Close</button>
+        </div>
+      </div>
+      <!--end: config-->
+
     </div>
+
   </div>
 </div>

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -70,6 +70,7 @@ limitations under the License.
              style="float:right">Disable</div>
         <div ng-show="configExists(pkgSearchResult)"
              ng-click="toggleConfigButton(pkgSearchResult)"
+             ng-class="getConfigButtonClass(pkgSearchResult)"
              class="btn btn-default btn-xs spellConfigButton"
              style="float:right; margin-right:5px;">Config</div>
       </div>

--- a/zeppelin-web/src/app/helium/index.js
+++ b/zeppelin-web/src/app/helium/index.js
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import HeliumController from './helium.controller';
+
+angular.module('zeppelinWebApp')
+  .controller('HeliumCtrl', HeliumController);
+

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -249,31 +249,28 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       // remove leading spaces
       const textWithoutMagic = splited[1].replace(/^\s+/g, '');
 
-      const spell = heliumService.getSpellByMagic(magic);
-      const spellResult = spell.interpret(textWithoutMagic);
-      const parsed = spellResult.getAllParsedDataWithTypes(
-        heliumService.getAllSpells(), magic, textWithoutMagic);
-
       // handle actual result message in promise
-      parsed.then(resultsMsg => {
-        const status = 'FINISHED';
-        $scope.paragraph.status = status;
-        $scope.paragraph.results.code = status;
-        $scope.paragraph.results.msg = resultsMsg;
-        $scope.paragraph.config.tableHide = false;
-        if (digestRequired) { $scope.$digest(); }
+      heliumService.executeSpell(magic, textWithoutMagic)
+        .then(resultsMsg => {
+          const status = 'FINISHED';
+          $scope.paragraph.status = status;
+          $scope.paragraph.results.code = status;
+          $scope.paragraph.results.msg = resultsMsg;
+          $scope.paragraph.config.tableHide = false;
+          if (digestRequired) { $scope.$digest(); }
 
-        if (!propagated) {
-          const propagable = SpellResult.createPropagable(resultsMsg);
-          $scope.propagateSpellResult(
-            $scope.paragraph.id, $scope.paragraph.title,
-            paragraphText, propagable, status, '',
-            $scope.paragraph.config, $scope.paragraph.settings.params);
-        }
-      }).catch(error => {
-        $scope.handleSpellError(paragraphText, error,
-          digestRequired, propagated);
-      });
+          if (!propagated) {
+            const propagable = SpellResult.createPropagable(resultsMsg);
+            $scope.propagateSpellResult(
+              $scope.paragraph.id, $scope.paragraph.title,
+              paragraphText, propagable, status, '',
+              $scope.paragraph.config, $scope.paragraph.settings.params);
+          }
+        })
+        .catch(error => {
+          $scope.handleSpellError(paragraphText, error,
+            digestRequired, propagated);
+        });
     } catch (error) {
       $scope.handleSpellError(paragraphText, error,
         digestRequired, propagated);
@@ -311,9 +308,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     }
 
     const magic = SpellResult.extractMagic(paragraphText);
-    const spell = heliumService.getSpellByMagic(magic);
 
-    if (spell) {
+    if (heliumService.getSpellByMagic(magic)) {
       $scope.runParagraphUsingSpell(paragraphText, magic, digestRequired, propagated);
     } else {
       $scope.runParagraphUsingBackendInterpreter(paragraphText);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -237,7 +237,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     }
   };
 
-  $scope.runParagraphUsingSpell = function(spell, paragraphText,
+  $scope.runParagraphUsingSpell = function(paragraphText,
                                            magic, digestRequired, propagated) {
     $scope.paragraph.results = {};
     $scope.paragraph.errorMessage = '';
@@ -248,6 +248,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       const splited = paragraphText.split(magic);
       // remove leading spaces
       const textWithoutMagic = splited[1].replace(/^\s+/g, '');
+
+      const spell = heliumService.getSpellByMagic(magic);
       const spellResult = spell.interpret(textWithoutMagic);
       const parsed = spellResult.getAllParsedDataWithTypes(
         heliumService.getAllSpells(), magic, textWithoutMagic);
@@ -312,8 +314,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     const spell = heliumService.getSpellByMagic(magic);
 
     if (spell) {
-      $scope.runParagraphUsingSpell(
-        spell, paragraphText, magic, digestRequired, propagated);
+      $scope.runParagraphUsingSpell(paragraphText, magic, digestRequired, propagated);
     } else {
       $scope.runParagraphUsingBackendInterpreter(paragraphText);
     }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -227,7 +227,6 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     $scope.paragraph.status = 'ERROR';
     $scope.paragraph.errorMessage = errorMessage;
     console.error('Failed to execute interpret() in spell\n', error);
-    if (digestRequired) { $scope.$digest(); }
 
     if (!propagated) {
       $scope.propagateSpellResult(
@@ -240,6 +239,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.runParagraphUsingSpell = function(paragraphText,
                                            magic, digestRequired, propagated) {
     $scope.paragraph.results = {};
+    $scope.paragraph.status = 'PENDING';
     $scope.paragraph.errorMessage = '';
     if (digestRequired) { $scope.$digest(); }
 
@@ -257,7 +257,6 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
           $scope.paragraph.results.code = status;
           $scope.paragraph.results.msg = resultsMsg;
           $scope.paragraph.config.tableHide = false;
-          if (digestRequired) { $scope.$digest(); }
 
           if (!propagated) {
             const propagable = SpellResult.createPropagable(resultsMsg);

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -294,12 +294,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       renderApp(`p${appState.id}`, appState);
     } else {
       if (!DefaultDisplayType[type]) {
-        const spell = heliumService.getSpellByMagic(type);
-        if (!spell) {
-          console.error(`Can't execute spell due to unknown display type: ${type}`);
-          return;
-        }
-        $scope.renderCustomDisplay(type, data, spell);
+        $scope.renderCustomDisplay(type, data);
       } else {
         const targetElemId = $scope.createDisplayDOMId(`p${$scope.id}`, type);
         $scope.renderDefaultDisplay(targetElemId, type, data, refresh);
@@ -314,38 +309,40 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
   /**
    * Render multiple sub results for custom display
    */
-  $scope.renderCustomDisplay = function(type, data, spell) {
+  $scope.renderCustomDisplay = function(type, data) {
     // get result from intp
-
-    const spellResult = spell.interpret(data.trim());
-    const parsed = spellResult.getAllParsedDataWithTypes(
-      heliumService.getAllSpells());
+    if (!heliumService.getSpellByMagic(type)) {
+      console.error(`Can't execute spell due to unknown display type: ${type}`);
+      return;
+    }
 
     // custom display result can include multiple subset results
-    parsed.then(dataWithTypes => {
-      const containerDOMId = `p${$scope.id}_custom`;
-      const afterLoaded = () => {
-        const containerDOM = angular.element(`#${containerDOMId}`);
-        // Spell.interpret() can create multiple outputs
-        for(let i = 0; i < dataWithTypes.length; i++) {
-          const dt = dataWithTypes[i];
-          const data = dt.data;
-          const type = dt.type;
+    heliumService.executeSpellAsDisplaySystem(type, data)
+      .then(dataWithTypes => {
+        const containerDOMId = `p${$scope.id}_custom`;
+        const afterLoaded = () => {
+          const containerDOM = angular.element(`#${containerDOMId}`);
+          // Spell.interpret() can create multiple outputs
+          for(let i = 0; i < dataWithTypes.length; i++) {
+            const dt = dataWithTypes[i];
+            const data = dt.data;
+            const type = dt.type;
 
-          // prepare each DOM to be filled
-          const subResultDOMId = $scope.createDisplayDOMId(`p${$scope.id}_custom_${i}`, type);
-          const subResultDOM = document.createElement('div');
-          containerDOM.append(subResultDOM);
-          subResultDOM.setAttribute('id', subResultDOMId);
+            // prepare each DOM to be filled
+            const subResultDOMId = $scope.createDisplayDOMId(`p${$scope.id}_custom_${i}`, type);
+            const subResultDOM = document.createElement('div');
+            containerDOM.append(subResultDOM);
+            subResultDOM.setAttribute('id', subResultDOMId);
 
-          $scope.renderDefaultDisplay(subResultDOMId, type, data, true);
-        }
-      };
+            $scope.renderDefaultDisplay(subResultDOMId, type, data, true);
+          }
+        };
 
-      retryUntilElemIsLoaded(containerDOMId, afterLoaded);
-    }).catch(error => {
-      console.error(`Failed to render custom display: ${$scope.type}\n` + error);
-    });
+        retryUntilElemIsLoaded(containerDOMId, afterLoaded);
+      })
+      .catch(error => {
+        console.error(`Failed to render custom display: ${$scope.type}\n` + error);
+      });
   };
 
   /**

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -279,6 +279,10 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
     } else {
       console.error(`Unknown Display Type: ${type}`);
     }
+
+    // send message to parent that this result is rendered
+    const paragraphId = $scope.$parent.paragraph.id;
+    $scope.$emit('resultRendered', paragraphId);
   };
 
   const renderResult = function(type, refresh) {

--- a/zeppelin-web/src/app/spell/spell-base.js
+++ b/zeppelin-web/src/app/spell/spell-base.js
@@ -31,9 +31,10 @@ export class SpellBase {
    * Consumes text and return `SpellResult`.
    *
    * @param paragraphText {string} which doesn't include magic
+   * @param config {Object}
    * @return {SpellResult}
    */
-  interpret(paragraphText) {
+  interpret(paragraphText, config) {
     throw new Error('SpellBase.interpret() should be overrided');
   }
 

--- a/zeppelin-web/src/components/helium/helium-conf.js
+++ b/zeppelin-web/src/components/helium/helium-conf.js
@@ -50,9 +50,6 @@ export function createAllPackageConfigs(defaultPackages, persistedConfs) {
     const spec = pkgSearchResult.pkg.config;
     if (!spec) { continue; }
 
-    const version = pkgSearchResult.pkg.version;
-    if (!version) { continue; }
-
     const artifact = pkgSearchResult.pkg.artifact;
     if (!artifact) { continue; }
 

--- a/zeppelin-web/src/components/helium/helium-conf.js
+++ b/zeppelin-web/src/components/helium/helium-conf.js
@@ -41,12 +41,12 @@ export function mergePersistedConfWithSpec(persisted, spec) {
   return confs;
 }
 
-export function createSinglePackageConfig(pkg, persistedConf) {
+export function createSinglePackageConfigs(pkg, persistedConf) {
   const spec = pkg.config;
-  if (!spec) { return; }
+  if (!spec) { return []; }
 
   const version = pkg.version;
-  if (!version) { return; }
+  if (!version) { return []; }
 
   if (!persistedConf) { persistedConf = {}; }
 
@@ -98,8 +98,8 @@ export function parseConfigValue(type, stringified) {
  * persist key-value only
  * since other info (e.g type, desc) can be provided by default config
  */
-export function createPersistableConfig(currentConf) {
-  const filtered = currentConf.reduce((acc, c) => {
+export function createPersistableConfig(currentConfs) {
+  const filtered = currentConfs.reduce((acc, c) => {
     acc[c.name] = parseConfigValue(c.type, c.value);
     return acc;
   }, {});

--- a/zeppelin-web/src/components/helium/helium-conf.js
+++ b/zeppelin-web/src/components/helium/helium-conf.js
@@ -41,18 +41,6 @@ export function mergePersistedConfWithSpec(persisted, spec) {
   return confs;
 }
 
-export function createSinglePackageConfigs(pkg, persistedConf) {
-  const spec = pkg.config;
-  if (!spec) { return []; }
-
-  const version = pkg.version;
-  if (!version) { return []; }
-
-  if (!persistedConf) { persistedConf = {}; }
-
-  return mergePersistedConfWithSpec(persistedConf, spec);
-}
-
 export function createAllPackageConfigs(defaultPackages, persistedConfs) {
   let packageConfs = {};
 

--- a/zeppelin-web/src/components/helium/helium-conf.js
+++ b/zeppelin-web/src/components/helium/helium-conf.js
@@ -65,9 +65,12 @@ export function createAllPackageConfigs(defaultPackages, persistedConfs) {
     const version = pkgSearchResult.pkg.version;
     if (!version) { continue; }
 
+    const artifact = pkgSearchResult.pkg.artifact;
+    if (!artifact) { continue; }
+
     let persistedConf = {};
-    if (persistedConfs[name] && persistedConfs[name][version]) {
-      persistedConf = persistedConfs[name][version];
+    if (persistedConfs[artifact]) {
+      persistedConf = persistedConfs[artifact];
     }
 
     const confs = mergePersistedConfWithSpec(persistedConf, spec);
@@ -106,5 +109,3 @@ export function createPersistableConfig(currentConfs) {
 
   return filtered;
 }
-
-

--- a/zeppelin-web/src/components/helium/helium-package.js
+++ b/zeppelin-web/src/components/helium/helium-package.js
@@ -56,7 +56,8 @@ export function createDefaultPackages(pkgSearchResults, sce) {
 export function findPackageByMagic(defaultPackages, magic) {
   for (let name in defaultPackages) {
     const pkgSearchResult = defaultPackages[name];
-    if (pkgSearchResult.pkg.type === HeliumType.SPELL &&
+    if (pkgSearchResult.enabled &&
+      pkgSearchResult.pkg.type === HeliumType.SPELL &&
       pkgSearchResult.pkg.spell.magic === magic) {
       return pkgSearchResult;
     }

--- a/zeppelin-web/src/components/helium/helium-package.js
+++ b/zeppelin-web/src/components/helium/helium-package.js
@@ -48,12 +48,28 @@ export function createDefaultPackages(pkgSearchResults, sce) {
   return defaultPackages;
 }
 
-export function findPackageByMagic(pkgSearchResults, magic) {
-  return pkgSearchResults.find(psr => {
-    psr.pkg.type === HeliumType.SPELL && psr.pkg.spell.magic === magic;
-  });
+/**
+ * @param defaultPackages {name, pkgSearchResult}
+ * @param magic
+ * @returns {pkgSearchResult}
+ */
+export function findPackageByMagic(defaultPackages, magic) {
+  for (let name in defaultPackages) {
+    const pkgSearchResult = defaultPackages[name];
+    if (pkgSearchResult.pkg.type === HeliumType.SPELL &&
+      pkgSearchResult.pkg.spell.magic === magic) {
+      return pkgSearchResult;
+    }
+  }
+
+  return undefined;
 }
 
+/**
+ * @param singlePkgSearchResults list of PkgSearchResult for a single package
+ * @param version
+ * @returns {T} found PkgSearchResult otherwise returns `undefined`
+ */
 export function findPackageByVersion(singlePkgSearchResults, version) {
   return singlePkgSearchResults.find(psr => {
     return psr.pkg.version === version;

--- a/zeppelin-web/src/components/helium/helium-package.js
+++ b/zeppelin-web/src/components/helium/helium-package.js
@@ -12,8 +12,6 @@
  * limitations under the License.
  */
 
-import { HeliumType, } from './helium-type';
-
 export function createDefaultPackage(pkgSearchResult, sce) {
   for (let pkgIdx in pkgSearchResult) {
     const pkg = pkgSearchResult[pkgIdx];
@@ -46,33 +44,4 @@ export function createDefaultPackages(pkgSearchResults, sce) {
   }
 
   return defaultPackages;
-}
-
-/**
- * @param defaultPackages {name, pkgSearchResult}
- * @param magic
- * @returns {pkgSearchResult}
- */
-export function findPackageByMagic(defaultPackages, magic) {
-  for (let name in defaultPackages) {
-    const pkgSearchResult = defaultPackages[name];
-    if (pkgSearchResult.enabled &&
-      pkgSearchResult.pkg.type === HeliumType.SPELL &&
-      pkgSearchResult.pkg.spell.magic === magic) {
-      return pkgSearchResult;
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * @param singlePkgSearchResults list of PkgSearchResult for a single package
- * @param version
- * @returns {T} found PkgSearchResult otherwise returns `undefined`
- */
-export function findPackageByVersion(singlePkgSearchResults, version) {
-  return singlePkgSearchResults.find(psr => {
-    return psr.pkg.version === version;
-  });
 }

--- a/zeppelin-web/src/components/helium/helium-package.js
+++ b/zeppelin-web/src/components/helium/helium-package.js
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HeliumType, } from './helium-type';
+
+export function createDefaultPackage(pkgSearchResult, sce) {
+  for (let pkgIdx in pkgSearchResult) {
+    const pkg = pkgSearchResult[pkgIdx];
+    pkg.pkg.icon = sce.trustAsHtml(pkg.pkg.icon);
+    if (pkg.enabled) {
+      pkgSearchResult.splice(pkgIdx, 1);
+      return pkg;
+    }
+  }
+
+  // show first available version if package is not enabled
+  const result = pkgSearchResult[0];
+  pkgSearchResult.splice(0, 1);
+  return result;
+}
+
+/**
+ * create default packages based on `enabled` field and `latest` version.
+ *
+ * @param pkgSearchResults
+ * @param sce angular `$sce` object
+ * @returns {Object} including {name, pkgInfo}
+ */
+export function createDefaultPackages(pkgSearchResults, sce) {
+  const defaultPackages = {};
+  // show enabled version if any version of package is enabled
+  for (let name in pkgSearchResults) {
+    const pkgSearchResult = pkgSearchResults[name];
+    defaultPackages[name] = createDefaultPackage(pkgSearchResult, sce)
+  }
+
+  return defaultPackages;
+}
+
+export function findPackageByMagic(pkgSearchResults, magic) {
+  return pkgSearchResults.find(psr => {
+    psr.pkg.type === HeliumType.SPELL && psr.pkg.spell.magic === magic;
+  });
+}
+
+export function findPackageByVersion(singlePkgSearchResults, version) {
+  return singlePkgSearchResults.find(psr => {
+    return psr.pkg.version === version;
+  });
+}

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -13,16 +13,27 @@
  */
 
 import { HeliumType, } from './helium-type';
+import {
+  createAllPackageConfigs,
+  createSinglePackageConfig,
+  createPersistableConfig,
+} from './helium-conf';
+import {
+  createDefaultPackages,
+  findPackageByVersion,
+  findPackageByMagic,
+} from './helium-package';
 
 angular.module('zeppelinWebApp').service('heliumService', heliumService);
 
-function heliumService($http, baseUrlSrv, ngToast) {
+export default function heliumService($http, $sce, baseUrlSrv) {
   'ngInject';
 
   var url = baseUrlSrv.getRestApiBase() + '/helium/bundle/load';
   if (process.env.HELIUM_BUNDLE_DEV) {
     url = url + '?refresh=true';
   }
+
   // name `heliumBundles` should be same as `HelumBundleFactory.HELIUM_BUNDLES_VAR`
   var heliumBundles = [];
   // map for `{ magic: interpreter }`
@@ -68,16 +79,21 @@ function heliumService($http, baseUrlSrv, ngToast) {
     return visualizationBundles;
   };
 
+  /**
+   * @returns {Promise} which returns bundleOrder
+   */
   this.getVisualizationPackageOrder = function() {
-    return $http.get(baseUrlSrv.getRestApiBase() + '/helium/order/visualization');
+    return $http.get(baseUrlSrv.getRestApiBase() + '/helium/order/visualization')
+      .then(function(response, status) {
+        return response.data.body;
+      })
+      .catch(function(error) {
+        console.error('Can not get bundle order', error);
+      });
   };
 
   this.setVisualizationPackageOrder = function(list) {
     return $http.post(baseUrlSrv.getRestApiBase() + '/helium/order/visualization', list);
-  };
-
-  this.getAllPackageInfo = function() {
-    return $http.get(baseUrlSrv.getRestApiBase() + '/helium/all');
   };
 
   this.enable = function(name, artifact) {
@@ -86,5 +102,128 @@ function heliumService($http, baseUrlSrv, ngToast) {
 
   this.disable = function(name) {
     return $http.post(baseUrlSrv.getRestApiBase() + '/helium/disable/' + name);
+  };
+
+  this.saveConfig = function(pkgName, pkgVersion, defaultPackageConfig) {
+    const filtered = createPersistableConfig(defaultPackageConfig);
+
+    if (!pkgName || !pkgVersion || !filtered) {
+      console.error(
+        `Can't save helium package '${pkgName}@${pkgVersion}' config`, filtered);
+      return;
+    }
+
+    const url = `${baseUrlSrv.getRestApiBase()}/helium/config/${pkgName}/${pkgVersion}`;
+    return $http.post(url, filtered);
+  };
+
+  /**
+   * @returns {Promise<Object>} which including {name, Array<package info for version>}
+   */
+  this.getAllPackageInfo = function() {
+    return $http.get(`${baseUrlSrv.getRestApiBase()}/helium/package`)
+      .then(function(response, status) {
+        return response.data.body;
+      })
+      .catch(function(error) {
+        console.error('Failed to get all package infos', error);
+      });
+  };
+
+  /**
+   * @returns {Promise<Array>} which including package info list for all versions
+   */
+  this.getSinglePackageInfo = function(pkgName, pkgVersion) {
+    return $http.get(`${baseUrlSrv.getRestApiBase()}/helium/package/${pkgName}`)
+      .then(response => {
+        return response.data.body;
+      })
+      .then(singlePkgSearchResults => {
+        const found = findPackageByVersion(singlePkgSearchResults, pkgVersion);
+
+        if (!found) {
+          throw new Error(`Could not find package info for '${pkgName}@${pkgVersion}'`);
+        }
+
+        return found;
+      });
+  };
+
+  this.getDefaultPackages = function() {
+    return this.getAllPackageInfo()
+      .then(pkgSearchResults => {
+        return createDefaultPackages(pkgSearchResults, $sce);
+      });
+  };
+
+  this.getAllPackageInfoAndDefaultPackages = function() {
+    return this.getAllPackageInfo()
+      .then(pkgSearchResults => {
+        return {
+          pkgSearchResults: pkgSearchResults,
+          defaultPackages: createDefaultPackages(pkgSearchResults, $sce),
+        };
+      });
+  };
+
+  /**
+   * get all package configs.
+   * @return Promise<{name, {version, {confKey, confVal}}}>
+   */
+  this.getAllPackageConfigs = function() {
+    const promisedDefaultPackages = this.getDefaultPackages();
+    const promisedPersistedConfs =
+      $http.get(`${baseUrlSrv.getRestApiBase()}/helium/config`)
+      .then(function(response, status) {
+        return response.data.body;
+      });
+
+    return Promise.all([promisedDefaultPackages, promisedPersistedConfs])
+      .then(values => {
+        const defaultPackages = values[0];
+        const persistedConfs = values[1];
+
+        return createAllPackageConfigs(defaultPackages, persistedConfs);
+      })
+      .catch(function(error) {
+        console.error('Failed to get all package configs', error);
+      });
+  };
+
+  /**
+   * get the package config which is persisted in server.
+   * @return Promise<{confKey, confVal}>
+   */
+  this.getSinglePackageConfig = function(pkgName, pkgVersion) {
+    const promisedPkgSearchResult = this.getSinglePackageInfo(pkgName, pkgVersion);
+
+    const confUrl = `${baseUrlSrv.getRestApiBase()}/helium/config/${pkgName}/${pkgVersion}`;
+    const promisedConf = $http.get(confUrl)
+      .then(function(response, status) {
+        return response.data.body;
+      });
+
+    return Promise.all([promisedPkgSearchResult, promisedConf])
+      .then(values => {
+        const pkgSearchResult = values[0];
+        const persistedConf = values[1];
+
+        const merged = createSinglePackageConfig(pkgSearchResult.pkg, persistedConf);
+        return merged;
+      })
+      .catch(function(error) {
+        console.error(`Failed to get package config for '${pkgName}@${pkgVersion}'`, error);
+      });
+  };
+
+  this.getSinglePackageConfigUsingMagic = function(magic) {
+    this.getDefaultPackages()
+      .then(defaultPackages => {
+        const pkgSearchResult = findPackageByMagic(defaultPackages, magic)
+        const pkgVersion = pkgSearchResult.pkg.version;
+        const pkgName = pkgSearchResult.pkg.name;
+
+        return this.getSinglePackageConfig(pkgName, pkgVersion);
+      })
   };
 }

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -70,9 +70,7 @@ export default function heliumService($http, $sce, baseUrlSrv) {
 
   this.executeSpell = function(magic, textWithoutMagic) {
     const promisedConf = this.getSinglePackageConfigUsingMagic(magic)
-      .then(confs => {
-        return createPersistableConfig(confs);
-      });
+      .then(confs => createPersistableConfig(confs));
 
     return promisedConf.then(conf => {
       const spell = this.getSpellByMagic(magic);
@@ -84,16 +82,13 @@ export default function heliumService($http, $sce, baseUrlSrv) {
     });
   };
 
-  this.executeSpellAsDisplaySystem = function(type, data) {
-    const promisedConf = this.getSinglePackageConfigUsingMagic(type)
-      .then(confs => {
-        return createPersistableConfig(confs);
-      });
+  this.executeSpellAsDisplaySystem = function(magic, textWithoutMagic) {
+    const promisedConf = this.getSinglePackageConfigUsingMagic(magic)
+      .then(confs => createPersistableConfig(confs));
 
     return promisedConf.then(conf => {
-
-      const spell = this.getSpellByMagic(type);
-      const spellResult = spell.interpret(data.trim(), conf);
+      const spell = this.getSpellByMagic(magic);
+      const spellResult = spell.interpret(textWithoutMagic.trim(), conf);
       const parsed = spellResult.getAllParsedDataWithTypes(spellPerMagic);
 
       return parsed;

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -69,10 +69,22 @@ export default function heliumService($http, $sce, baseUrlSrv) {
   };
 
   /**
-   * @returns {Object} map for `{ magic : spell }`
    */
-  this.getAllSpells = function() {
-    return spellPerMagic;
+  this.executeSpell = function(magic, textWithoutMagic) {
+    const spell = this.getSpellByMagic(magic);
+    const spellResult = spell.interpret(textWithoutMagic);
+    const parsed = spellResult.getAllParsedDataWithTypes(
+      spellPerMagic, magic, textWithoutMagic);
+
+    return parsed;
+  };
+
+  this.executeSpellAsDisplaySystem = function(type, data) {
+    const spell = this.getSpellByMagic(type);
+    const spellResult = spell.interpret(data.trim());
+    const parsed = spellResult.getAllParsedDataWithTypes(spellPerMagic);
+
+    return parsed;
   };
 
   this.getVisualizationBundles = function() {

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -32,13 +32,13 @@ export default function heliumService($http, $sce, baseUrlSrv) {
     url = url + '?refresh=true';
   }
 
+  let visualizationBundles = [];
   // name `heliumBundles` should be same as `HelumBundleFactory.HELIUM_BUNDLES_VAR`
-  var heliumBundles = [];
+  let heliumBundles = [];
   // map for `{ magic: interpreter }`
   let spellPerMagic = {};
   // map for `{ magic: package-name }`
   let pkgNamePerMagic = {}
-  let visualizationBundles = [];
 
   // load should be promise
   this.load = $http.get(url).success(function(response) {

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -148,7 +148,7 @@ export default function heliumService($http, $sce, baseUrlSrv) {
   };
 
   /**
-   * @returns {Promise<Object>} which including {name, Array<package info for version>}
+   * @returns {Promise<Object>} which including {name, Array<package info for artifact>}
    */
   this.getAllPackageInfo = function() {
     return $http.get(`${baseUrlSrv.getRestApiBase()}/helium/package`)
@@ -207,11 +207,10 @@ export default function heliumService($http, $sce, baseUrlSrv) {
    */
   this.getSinglePackageConfigs = function(pkg) {
     const pkgName = pkg.name;
-    const pkgVersion = pkg.version;
     // in case of local package, it will include `/`
     const pkgArtifact = encodeURIComponent(pkg.artifact);
 
-    if (!pkgName || !pkgVersion || !pkgArtifact) {
+    if (!pkgName || !pkgArtifact) {
       console.error('Failed to fetch config for\n', pkg);
       return Promise.resolve([]);
     }

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -126,7 +126,7 @@ export default function heliumService($http, $sce, baseUrlSrv) {
     return $http.post(baseUrlSrv.getRestApiBase() + '/helium/disable/' + name);
   };
 
-  this.saveConfig = function(pkg , defaultPackageConfig) {
+  this.saveConfig = function(pkg , defaultPackageConfig, closeConfigPanelCallback) {
     // in case of local package, it will include `/`
     const pkgArtifact = encodeURIComponent(pkg.artifact);
     const pkgName = pkg.name;
@@ -139,7 +139,12 @@ export default function heliumService($http, $sce, baseUrlSrv) {
     }
 
     const url = `${baseUrlSrv.getRestApiBase()}/helium/config/${pkgName}/${pkgArtifact}`;
-    return $http.post(url, filtered);
+    return $http.post(url, filtered)
+      .then(() => {
+        if (closeConfigPanelCallback) { closeConfigPanelCallback(); }
+      }).catch((error) => {
+        console.error(`Failed to save config for ${pkgArtifact}`, error);
+      });
   };
 
   /**

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -224,8 +224,8 @@ export default function heliumService($http, $sce, baseUrlSrv) {
     let pkgArtifact = pkg.artifact;
 
     if (!pkgName || !pkgVersion || !pkgArtifact) {
-      console.error(`Failed to fetch config for \n`, pkg);
-      return;
+      console.error('Failed to fetch config for\n', pkg);
+      return Promise.resolve([]);
     }
 
     const promisedPkgSearchResult = this.getSinglePackageInfo(pkgName, pkgVersion);

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -166,6 +166,8 @@ function websocketEvents($rootScope, $websocket, $location, baseUrlSrv) {
       $rootScope.$broadcast('setNoteRevisionResult', data);
     } else if (op === 'PARAS_INFO') {
       $rootScope.$broadcast('updateParaInfos', data);
+    } else {
+      console.error(`unknown websocket op: ${op}`);
     }
   });
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -334,7 +334,7 @@ function websocketMsgSrv($rootScope, websocketEvents) {
 
     getInterpreterSettings: function() {
       websocketEvents.sendNewEvent({op: 'GET_INTERPRETER_SETTINGS'});
-    }
+    },
 
   };
 }

--- a/zeppelin-web/src/index.js
+++ b/zeppelin-web/src/index.js
@@ -18,7 +18,6 @@ import './app/home/home.controller.js';
 import './app/handsontable/handsonHelper.js';
 import './app/notebook/notebook.controller.js';
 
-/** start: global variable `zeppelin` related files */
 import './app/tabledata/tabledata.js';
 import './app/tabledata/transformation.js';
 import './app/tabledata/pivot.js';
@@ -32,7 +31,6 @@ import './app/visualization/builtins/visualization-piechart.js';
 import './app/visualization/builtins/visualization-areachart.js';
 import './app/visualization/builtins/visualization-linechart.js';
 import './app/visualization/builtins/visualization-scatterchart.js';
-/** end: global variable `zeppelin` related files */
 
 import './app/jobmanager/jobmanager.controller.js';
 import './app/jobmanager/jobs/job.controller.js';
@@ -45,7 +43,7 @@ import './app/notebook/paragraph/paragraph.controller.js';
 import './app/notebook/paragraph/result/result.controller.js';
 import './app/search/result-list.controller.js';
 import './app/notebookRepos/notebookRepos.controller.js';
-import './app/helium/helium.controller.js';
+import './app/helium';
 import './components/arrayOrderingSrv/arrayOrdering.service.js';
 import './components/clipboard/clipboard.controller.js';
 import './components/navbar/navbar.controller.js';

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -145,7 +145,7 @@ public class Helium {
   }
 
   private void clearNotExistsPackages() {
-    Map<String, List<HeliumPackageSearchResult>> all = getAllPackageInfo(false, null);
+    Map<String, List<HeliumPackageSearchResult>> all = getAllPackageInfoWithoutRefresh();
 
     // clear visualization display order
     List<String> packageOrder = heliumConf.getBundleDisplayOrder();
@@ -164,6 +164,10 @@ public class Helium {
         heliumConf.disablePackage(pkgName);
       }
     }
+  }
+
+  public Map<String, List<HeliumPackageSearchResult>> getAllPackageInfoWithoutRefresh() {
+    return getAllPackageInfo(false, null);
   }
 
   public Map<String, List<HeliumPackageSearchResult>> getAllPackageInfo() {
@@ -249,7 +253,7 @@ public class Helium {
   }
 
   public HeliumPackageSearchResult getEnabledPackageInfo(String packageName) {
-    Map<String, List<HeliumPackageSearchResult>> infos = getAllPackageInfo();
+    Map<String, List<HeliumPackageSearchResult>> infos = getAllPackageInfoWithoutRefresh();
     List<HeliumPackageSearchResult> packages = infos.get(packageName);
 
     for (HeliumPackageSearchResult pkgSearchResult : packages) {
@@ -353,7 +357,7 @@ public class Helium {
       allResources = ResourcePoolUtils.getAllResources();
     }
 
-    for (List<HeliumPackageSearchResult> pkgs : getAllPackageInfo(false, null).values()) {
+    for (List<HeliumPackageSearchResult> pkgs : getAllPackageInfoWithoutRefresh().values()) {
       for (HeliumPackageSearchResult pkg : pkgs) {
         if (pkg.getPkg().getType() == HeliumType.APPLICATION && pkg.isEnabled()) {
           ResourceSet resources = ApplicationLoader.findRequiredResourceSet(
@@ -381,7 +385,7 @@ public class Helium {
    * @return ordered list of enabled buildBundle package
    */
   public List<HeliumPackage> getBundlePackagesToBundle() {
-    Map<String, List<HeliumPackageSearchResult>> allPackages = getAllPackageInfo(false, null);
+    Map<String, List<HeliumPackageSearchResult>> allPackages = getAllPackageInfoWithoutRefresh();
     List<String> visOrder = heliumConf.getBundleDisplayOrder();
 
     List<HeliumPackage> orderedBundlePackages = new LinkedList<>();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -304,19 +304,19 @@ public class Helium {
     save();
   }
 
-  public void updatePackageConfig(String pkgName, String pkgVersion,
-                                  Map<String, Object> pkgConfig) throws IOException {
-    heliumConf.updatePackageConfig(pkgName, pkgVersion, pkgConfig);
+  public void updatePackageConfig(String artifact, Map<String, Object> pkgConfig)
+      throws IOException {
 
+    heliumConf.updatePackageConfig(artifact, pkgConfig);
     save();
   }
 
-  public Map<String, Map<String, Map<String, Object>>> getAllPackageConfig() {
+  public Map<String, Map<String, Object>> getAllPackageConfig() {
     return heliumConf.getAllPackageConfigs();
   }
 
-  public Map<String, Object> getPackageConfig(String pkgName, String pkgVersion) {
-    return heliumConf.getPackageConfig(pkgName, pkgVersion);
+  public Map<String, Object> getPackageConfig(String artifact) {
+    return heliumConf.getPackageConfig(artifact);
   }
 
   public HeliumPackageSuggestion suggestApp(Paragraph paragraph) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
@@ -25,10 +25,10 @@ public class HeliumConf {
   // enabled packages {name, version}
   private Map<String, String> enabled = Collections.synchronizedMap(new HashMap<String, String>());
 
-  // config for versioned package {name {version {configKey configValue}}}
-  private Map<String, Map<String, Map<String, Object>>> packageConfig =
+  // {artifact, {configKey, configValue}}
+  private Map<String, Map<String, Object>> packageConfig =
       Collections.synchronizedMap(
-          new HashMap<String, Map<String, Map<String, Object>>>());
+          new HashMap<String, Map<String, Object>>());
 
   // enabled visualization package display order
   private List<String> bundleDisplayOrder = new LinkedList<>();
@@ -45,41 +45,30 @@ public class HeliumConf {
     enabled.put(name, artifact);
   }
 
-  public void updatePackageConfig(String pkgName, String pkgVersion,
+  public void updatePackageConfig(String artifact,
                                   Map<String, Object> newConfig) {
-    if (!packageConfig.containsKey(pkgName)) {
-      packageConfig.put(pkgName,
-          Collections.synchronizedMap(new HashMap<String, Map<String, Object>>()));
-    }
-
-    Map<String, Map<String, Object>> versionedConfig = packageConfig.get(pkgName);
-
-    versionedConfig.put(pkgVersion, newConfig);
-  }
-
-  /**
-   * @return versioned package config `{name, {version, {configKey, configVal}}}`
-   */
-  public Map<String, Map<String, Map<String, Object>>> getAllPackageConfigs () {
-    return packageConfig;
-  }
-
-  public Map<String, Object> getPackageConfig (String pkgName, String pkgVersion) {
-    if (!packageConfig.containsKey(pkgName)) {
-      packageConfig.put(pkgName,
-          Collections.synchronizedMap(new HashMap<String, Map<String, Object>>()));
-    }
-
-    Map<String, Map<String, Object>> versionedConfig = packageConfig.get(pkgName);
-
-    if (!versionedConfig.containsKey(pkgVersion)) {
-      versionedConfig.put(pkgVersion,
+    if (!packageConfig.containsKey(artifact)) {
+      packageConfig.put(artifact,
           Collections.synchronizedMap(new HashMap<String, Object>()));
     }
 
-    Map<String, Object> config = versionedConfig.get(pkgVersion);
+    packageConfig.put(artifact, newConfig);
+  }
 
-    return config;
+  /**
+   * @return versioned package config `{artifact, {configKey, configVal}}`
+   */
+  public Map<String, Map<String, Object>> getAllPackageConfigs () {
+    return packageConfig;
+  }
+
+  public Map<String, Object> getPackageConfig (String artifact) {
+    if (!packageConfig.containsKey(artifact)) {
+      packageConfig.put(artifact,
+          Collections.synchronizedMap(new HashMap<String, Object>()));
+    }
+
+    return packageConfig.get(artifact);
   }
 
   public void disablePackage(HeliumPackage pkg) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
@@ -62,7 +62,7 @@ public class HeliumConf {
     return packageConfig;
   }
 
-  public Map<String, Object> getPackageConfig (String artifact) {
+  public Map<String, Object> getPackagePersistedConfig(String artifact) {
     if (!packageConfig.containsKey(artifact)) {
       packageConfig.put(artifact,
           Collections.synchronizedMap(new HashMap<String, Object>()));

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
@@ -122,7 +122,7 @@ public class HeliumTest {
         ""));
 
     // then
-    assertEquals(1, helium.getAllPackageInfo(false, null).size());
+    assertEquals(1, helium.getAllPackageInfoWithoutRefresh().size());
 
     // when
     registry1.add(new HeliumPackage(
@@ -136,7 +136,7 @@ public class HeliumTest {
         ""));
 
     // then
-    assertEquals(1, helium.getAllPackageInfo(false, null).size());
+    assertEquals(1, helium.getAllPackageInfoWithoutRefresh().size());
     assertEquals(2, helium.getAllPackageInfo(true, null).size());
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
@@ -122,7 +122,7 @@ public class HeliumTest {
         ""));
 
     // then
-    assertEquals(1, helium.getAllPackageInfo(false).size());
+    assertEquals(1, helium.getAllPackageInfo(false, null).size());
 
     // when
     registry1.add(new HeliumPackage(
@@ -136,7 +136,7 @@ public class HeliumTest {
         ""));
 
     // then
-    assertEquals(1, helium.getAllPackageInfo(false).size());
-    assertEquals(2, helium.getAllPackageInfo(true).size());
+    assertEquals(1, helium.getAllPackageInfo(false, null).size());
+    assertEquals(2, helium.getAllPackageInfo(true, null).size());
   }
 }


### PR DESCRIPTION
### What is this PR for?

Supporting helium package configurations. I attached screenshots.

#### Implementation details.

In case of spell, spell developer can create config spec in their `package.json` and it will be part of `helium.json` which is consumed by Zeppelin.

```
  "config": {
    "repeat": {
      "type": "number",
      "description": "How many times to repeat",
      "defaultValue": 1
    }
  },
```

1. Persists conf per `package name@package version` since each version can require different configs even if they are the same package.
2. Saves key-value config only. Since config spec (e.g `type`, `desc`, `defaultValue`) can be provided. So it's not efficient save both of them. 
3. Extracts config related functions to `helium.service.js` since it can be used not only in `helium.controller.js` for view but also should be used in `paragraph.controller.js`, `result.controller.js` for executing spell. 

### What type of PR is it?
[Feature]

### Todos
* [x] - create config view in `/helium`
* [x] - persist config per `package@version`
* [x] - pass config to spell

### What is the Jira issue?

[ZEPPELIN-2069](https://issues.apache.org/jira/browse/ZEPPELIN-2069)

### How should this be tested?

- Build with examples `mvn clean package -Phelium-dev -Pexamples -DskipTests;`
- Open `/helium` page
- Update the `echo-spell` config
- Execute the spell like the screenshot below. (you don't need to refresh the page, since executing spell will fetch config from server)

### Screenshots (if appropriate)

![config](https://cloud.githubusercontent.com/assets/4968473/22678867/a66db8ae-ed40-11e6-910b-f81e50a62ba4.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
