### PR TITLE
[ZEPPELIN-1808] disable shortcut key of window created by link this paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -979,15 +979,20 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
       $location.path('/');
     }
 
+    $scope.note = note;
+
     $scope.paragraphUrl = $routeParams.paragraphId;
     $scope.asIframe = $routeParams.asIframe;
     if ($scope.paragraphUrl) {
-      note = cleanParagraphExcept($scope.paragraphUrl, note);
+      $scope.note = cleanParagraphExcept($scope.paragraphUrl, $scope.note);
+      $scope.$broadcast('$unBindKeyEvent', $scope.$unBindKeyEvent);
       $rootScope.$broadcast('setIframe', $scope.asIframe);
+      initializeLookAndFeel();
+      return;
     }
 
-    $scope.note = note;
     initializeLookAndFeel();
+
     //open interpreter binding setting when there're none selected
     getInterpreterBindings();
     getPermissions();
@@ -1001,6 +1006,11 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     $scope.killSaveTimer();
     $scope.saveNote();
 
+    document.removeEventListener('click', $scope.focusParagraphOnClick);
+    document.removeEventListener('keydown', $scope.keyboardShortcut);
+  });
+
+  $scope.$on('$unBindKeyEvent', function() {
     document.removeEventListener('click', $scope.focusParagraphOnClick);
     document.removeEventListener('keydown', $scope.keyboardShortcut);
   });

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -118,7 +118,7 @@ table.dataTable.table-condensed .sorting_desc:after {
 .paragraphAsIframe {
   padding: 0;
   margin-top: -79px;
-  margin-left: -10px;
+  margin-left: 0px;
   margin-right: -10px;
 }
 
@@ -150,12 +150,20 @@ table.dataTable.table-condensed .sorting_desc:after {
   display: block;
   unicode-bidi: embed;
   display: block !important;
-  margin: 0 0 10px!important;
+  margin: 0 10px 5px!important;
   font-size: 12px!important;
   line-height: 1.42857143!important;
   word-break: break-all!important;
   word-wrap: break-word!important;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+}
+
+.paragraphAsIframe .title {
+  width: 80%;
+  font-weight: bold;
+  font-family: 'Roboto', sans-serif;
+  font-size: 17px !important;
+  margin: 0 10px !important;
 }
 
 /*


### PR DESCRIPTION
### What is this PR for?
If using a `Link this paragraph`, new window works the keyboard shortcut. 
Keyboard shortcut should not work in "Link this paragraph" URL.

### What type of PR is it?
[ Improvement ]

### What is the Jira issue?
[ZEPPELIN-1808](https://issues.apache.org/jira/browse/ZEPPELIN-1808)

### How should this be tested?
1. Click `Link this paragraph` or Use `Ctrl+Alt(command)+w` in a paragraph.
2. Use some keyboard shortcut in new window which is created by `Link this paragraph`.
3. Check text and title shape of the paragraph.

### Screenshots (if appropriate)
[ Before ]
* When trying to use keyboard shortcut`(Ctrl+Alt/Command+t)` in paragraph of new window.
![1808_b](https://cloud.githubusercontent.com/assets/8110458/22680039/6020a24a-ed49-11e6-9d52-accfa4982252.gif)

* Text and title are misaligned
![1808_b](https://cloud.githubusercontent.com/assets/8110458/22680223/3ac4f090-ed4a-11e6-972d-e863ce81a187.png)


[ After ]
![image](https://cloud.githubusercontent.com/assets/8110458/22680134/dc18169e-ed49-11e6-9190-f5a9ae20c745.png)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
