### PR TITLE
[HOTFIX] Change the screenshot path in custom page document

### DIFF
--- a/docs/manual/notebookashomepage.md
+++ b/docs/manual/notebookashomepage.md
@@ -82,7 +82,7 @@ println(
 
 After running the paragraph, you will see output similar to this one:
 
-<img src="/assets/themes/zeppelin/img/docs-img/homepage_custom_notebook_list.png" />
+<img src="../assets/themes/zeppelin/img/docs-img/homepage_custom_notebook_list.png" />
 
 That's it! Voila! You have your note list.
 


### PR DESCRIPTION
### What is this PR for?
After merging [PR1804](https://github.com/apache/zeppelin/pull/1804), the following screenshot path is fault.
![image](https://cloud.githubusercontent.com/assets/8110458/22681668/cb9184c4-ed51-11e6-8984-e8811f81e9aa.png)
![image](https://cloud.githubusercontent.com/assets/8110458/22681769/627c22ea-ed52-11e6-9bf9-b1c2080d0a25.png)

I fixed to change from absolute path to relative path.

### What type of PR is it?
[Bug Fix | Hot Fix]

### What is the Jira issue?
* None

### How should this be tested?
1. Run website locally
2. Please check [Show note list in your custom homepage](http://localhost:4000/manual/notebookashomepage.html#show-note-list-in-your-custom-homepage)
![image](https://cloud.githubusercontent.com/assets/8110458/22681862/eceef222-ed52-11e6-9ff9-9a2560c54e45.png)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
