### PR TITLE
[ZEPPELIN-2078] bug fix in get project name in Kylin interpreter

### DIFF
--- a/kylin/src/main/java/org/apache/zeppelin/kylin/KylinInterpreter.java
+++ b/kylin/src/main/java/org/apache/zeppelin/kylin/KylinInterpreter.java
@@ -100,10 +100,11 @@ public class KylinInterpreter extends Interpreter {
   }
 
   public HttpResponse prepareRequest(String sql) throws IOException {
-    String kylinProject = getProject(KYLIN_QUERY_PROJECT);
+    String kylinProject = getProject(sql);
+    String kylinSql = getSQL(sql);
 
     logger.info("project:" + kylinProject);
-    logger.info("sql:" + sql);
+    logger.info("sql:" + kylinSql);
     logger.info("acceptPartial:" + getProperty(KYLIN_QUERY_ACCEPT_PARTIAL));
     logger.info("limit:" + getProperty(KYLIN_QUERY_LIMIT));
     logger.info("offset:" + getProperty(KYLIN_QUERY_OFFSET));
@@ -111,7 +112,7 @@ public class KylinInterpreter extends Interpreter {
         + ":" + getProperty(KYLIN_PASSWORD)).getBytes("UTF-8"));
 
     String postContent = new String("{\"project\":" + "\"" + kylinProject + "\""
-        + "," + "\"sql\":" + "\"" + sql + "\""
+        + "," + "\"sql\":" + "\"" + kylinSql + "\""
         + "," + "\"acceptPartial\":" + "\"" + getProperty(KYLIN_QUERY_ACCEPT_PARTIAL) + "\""
         + "," + "\"offset\":" + "\"" + getProperty(KYLIN_QUERY_OFFSET) + "\""
         + "," + "\"limit\":" + "\"" + getProperty(KYLIN_QUERY_LIMIT) + "\"" + "}");
@@ -132,18 +133,34 @@ public class KylinInterpreter extends Interpreter {
   }
 
   public String getProject(String cmd) {
-    boolean firstLineIndex = cmd.startsWith("(");
+    boolean isFirstLineProject = cmd.startsWith("(");
 
-    if (firstLineIndex) {
-      int configStartIndex = cmd.indexOf("(");
-      int configLastIndex = cmd.indexOf(")");
-      if (configStartIndex != -1 && configLastIndex != -1) {
-        return cmd.substring(configStartIndex + 1, configLastIndex);
+    if (isFirstLineProject) {
+      int projectStartIndex = cmd.indexOf("(");
+      int projectEndIndex = cmd.indexOf(")");
+      if (projectStartIndex != -1 && projectEndIndex != -1) {
+        return cmd.substring(projectStartIndex + 1, projectEndIndex);
       } else {
         return getProperty(KYLIN_QUERY_PROJECT);
       }
     } else {
       return getProperty(KYLIN_QUERY_PROJECT);
+    }
+  }
+
+  public String getSQL(String cmd) {
+    boolean isFirstLineProject = cmd.startsWith("(");
+
+    if (isFirstLineProject) {
+      int projectStartIndex = cmd.indexOf("(");
+      int projectEndIndex = cmd.indexOf(")");
+      if (projectStartIndex != -1 && projectEndIndex != -1) {
+        return cmd.substring(projectEndIndex + 1);
+      } else {
+        return cmd;
+      }
+    } else {
+      return cmd;
     }
   }
 

--- a/kylin/src/test/java/KylinInterpreterTest.java
+++ b/kylin/src/test/java/KylinInterpreterTest.java
@@ -64,6 +64,13 @@ public class KylinInterpreterTest {
             "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
     assertEquals("", t.getProject("()\n select a.date,sum(b.measure) as measure " +
             "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
+    assertEquals("\n select a.date,sum(b.measure) as measure from kylin_fact_table a inner join " +
+            "kylin_lookup_table b on a.date=b.date group by a.date", t.getSQL("(project2)\n select a.date," +
+            "sum(b.measure) as measure from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date " +
+            "group by a.date"));
+    assertEquals("\n select a.date,sum(b.measure) as measure from kylin_fact_table a inner join kylin_lookup_table b " +
+            "on a.date=b.date group by a.date", t.getSQL("()\n select a.date,sum(b.measure) as measure " +
+            "from kylin_fact_table a inner join kylin_lookup_table b on a.date=b.date group by a.date"));
   }
 
   private Properties getDefaultProperties(){


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/zeppelin/blob/master/kylin/src/main/java/org/apache/zeppelin/kylin/KylinInterpreter.java line 103, the getProject's input should be sql, not const string KYLIN_QUERY_PROJECT. Otherwise no project name could be retrieved. And also the SQL should exclude the project part.

public HttpResponse prepareRequest(String sql) throws IOException {
String kylinProject = getProject(KYLIN_QUERY_PROJECT);


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2078

### How should this be tested?
Has unit test.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
