### PR TITLE
[ZEPPELIN-2068] Change interpreter.json & credentials.json permission to 600

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -24,9 +24,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 /**
  * Class defining credentials for data source authorization
@@ -131,6 +138,9 @@ public class Credentials {
     try {
       if (!credentialsFile.exists()) {
         credentialsFile.createNewFile();
+
+        Set<PosixFilePermission> permissions = EnumSet.of(OWNER_READ, OWNER_WRITE);
+        Files.setPosixFilePermissions(credentialsFile.toPath(), permissions);
       }
 
       FileOutputStream fos = new FileOutputStream(credentialsFile, false);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -38,18 +38,8 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.*;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -81,6 +71,9 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 /**
  * Manage interpreters.
@@ -554,6 +547,9 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     File settingFile = new File(conf.getInterpreterSettingPath());
     if (!settingFile.exists()) {
       settingFile.createNewFile();
+
+      Set<PosixFilePermission> permissions = EnumSet.of(OWNER_READ, OWNER_WRITE);
+      Files.setPosixFilePermissions(settingFile.toPath(), permissions);
     }
 
     FileOutputStream fos = new FileOutputStream(settingFile, false);


### PR DESCRIPTION
### What is this PR for?
As @Tagar reported in [ZEPPELIN-2068](https://issues.apache.org/jira/browse/ZEPPELIN-2068), `conf/interpreter.json` & `conf/credentials.json` can store passwords. For the sake of any security issues, we should set the permission of those files to `600` not default one `644`. 

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-2068](https://issues.apache.org/jira/browse/ZEPPELIN-2068)

### How should this be tested?
1. rm both `conf/interpreter.json` & `conf/credentials.json`
2. apply this patch -> build 
```
$ mvn clean package -DskipTests -pl 'zeppelin-interpreter, zeppelin-server, zeppelin-zengine'
```

3. restart Zeppelin server 
4. check the permission of `conf/interpreter.json`. It should be 
```
-rw-------   interpreter.json
```

5. To check the `credentials.json`, open `http://localhost:8080/#/credential` and create new credential set. Then new `credentials.json` will be created under `conf/`. 
 ```
-rw-------   credentials.json
```

### Screenshots (if appropriate)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
