### PR TITLE
[ZEPPELIN-2072] Home Screen doesn't work on shiro.

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -93,6 +93,10 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     websocketMsgSrv.getNoteList();
   }
 
+  function getHomeNote(){
+    websocketMsgSrv.getHomeNote();
+  }
+
   function logout() {
     var logoutURL = baseUrlSrv.getRestApiBase() + '/login/logout';
 
@@ -141,6 +145,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
   $scope.$on('loginSuccess', function(event, param) {
     listConfigurations();
     loadNotes();
+    getHomeNote();
   });
 
   /*


### PR DESCRIPTION
### What is this PR for?
The home screen is a notebook for use as homepage. 
It is the zeppelin.notebook.homescreen variable in `conf/zeppelin-site.xml` or `conf/zeppelin-env.sh`. 
But currently zeppelin.notebook.homescreen variable doesn't work on shiro until refreshing window.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2072](https://issues.apache.org/jira/browse/ZEPPELIN-2072)

### How should this be tested?
1. Set zeppelin.notebook.homescreen variable in `conf/zeppelin-site.xml` or `conf/zeppelin-env.sh`.
2. Turn on shiro.
3. Start zeppelin-daemon.
4. Login your account and make sure whether homepage is changed or not.

### Screenshots (if appropriate)
[ Before ]
![z_2072_b](https://cloud.githubusercontent.com/assets/8110458/22730568/dd60512e-ee2a-11e6-8e7e-f379b1eb0e58.gif)

[ After ]
![z_2072_a](https://cloud.githubusercontent.com/assets/8110458/22730590/04482604-ee2b-11e6-9db6-d2656b252274.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
