### PR TITLE
[ZEPPELIN-2081] Prettify input, textarea in interpreter setting page

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.css
+++ b/zeppelin-web/src/app/interpreter/interpreter.css
@@ -39,6 +39,14 @@
   display: block;
   height: 23px;
   border: 1px solid #CCCCCC;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.interpreter textarea {
+  min-height: 23px;
+  border-radius: 3px;
+  vertical-align: middle;
 }
 
 .interpreter .interpreter-title {

--- a/zeppelin-web/src/app/interpreter/interpreter.css
+++ b/zeppelin-web/src/app/interpreter/interpreter.css
@@ -41,6 +41,7 @@
   border: 1px solid #CCCCCC;
   border-radius: 3px;
   vertical-align: middle;
+  font-size: 12px;
 }
 
 .interpreter textarea {

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -400,28 +400,27 @@ limitations under the License.
             </tr>
           </thead>
           <tr ng-repeat="key in setting.properties | sortByKey" >
-            <td>{{key}}</td>
-            <td>
+            <td style="vertical-align: middle;">{{key}}</td>
+            <td style="vertical-align: middle;">
               <span editable-textarea="setting.properties[key]" e-form="valueform" e-msd-elastic>
                 {{setting.properties[key] | breakFilter}}
               </span>
             </td>
-            <td ng-if="valueform.$visible">
+            <td style="vertical-align: middle;" ng-if="valueform.$visible">
               <button class="btn btn-default btn-sm fa fa-remove"
                    ng-click="removeInterpreterProperty(key, setting.id)">
               </button>
             </td>
           </tr>
           <tr ng-if="valueform.$visible">
-            <td>
+            <td style="vertical-align: middle;">
               <input ng-model="setting.propertyKey"
-                     pu-elastic-input
-                     pu-elastic-input-minwidth="180px" />
+                     pu-elastic-input pu-elastic-input-minwidth="180px" />
             </td>
-            <td>
+            <td style="vertical-align: middle;">
               <textarea msd-elastic ng-model="setting.propertyValue"></textarea>
             </td>
-            <td>
+            <td style="vertical-align: middle;">
               <button class="btn btn-default btn-sm fa fa-plus"
                    ng-click="addNewInterpreterProperty(setting.id)">
               </button>


### PR DESCRIPTION
### What is this PR for?

Fix small details in interpreter setting page about inputboxes, textareas

- Set align middle for `td`
- Keep same min-height between input and textarea
- Add border-radius 3px;

### What type of PR is it?
[Improvement]

### What is the Jira issue?

[ZEPPELIN-2081](https://issues.apache.org/jira/browse/ZEPPELIN-2081)

### How should this be tested?

Open the browser and check manually.

### Screenshots (if appropriate)

#### Before: Invalid align

![image](https://cloud.githubusercontent.com/assets/4968473/22731438/06a84124-ee2e-11e6-9367-96d59a2dbc2a.png)

#### Before: Inconsistent min-height

![image](https://cloud.githubusercontent.com/assets/4968473/22731449/0bdab870-ee2e-11e6-9ee3-450e1b1508bf.png)

#### After: align

![image](https://cloud.githubusercontent.com/assets/4968473/22731451/11a303f2-ee2e-11e6-9ed4-708ca01e637d.png)

#### After: min-height

![image](https://cloud.githubusercontent.com/assets/4968473/22731456/15f295ee-ee2e-11e6-915d-e9d7d6236bbd.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
