### PR TITLE
ZEPPELIN-2083: default interpreter list should honour order of zeppelin.interpreters property in zeppelin-site.xml

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -843,11 +843,11 @@ public class InterpreterFactory implements InterpreterGroupFactory {
 
       Map<String, List<InterpreterSetting>> nameInterpreterSettingMap = new HashMap<>();
       for (InterpreterSetting interpreterSetting : interpreterSettings.values()) {
-        String name = interpreterSetting.getName();
-        if (!nameInterpreterSettingMap.containsKey(name)) {
-          nameInterpreterSettingMap.put(name, new ArrayList<InterpreterSetting>());
+        String group = interpreterSetting.getGroup();
+        if (!nameInterpreterSettingMap.containsKey(group)) {
+          nameInterpreterSettingMap.put(group, new ArrayList<InterpreterSetting>());
         }
-        nameInterpreterSettingMap.get(name).add(interpreterSetting);
+        nameInterpreterSettingMap.get(group).add(interpreterSetting);
       }
 
       for (String groupName : interpreterGroupOrderList) {


### PR DESCRIPTION
### What is this PR for?
Default interpreter list should honour order of zeppelin.interpreters property in zeppelin-site.xml

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2083](https://issues.apache.org/jira/browse/ZEPPELIN-2083)

### How should this be tested?
Remove default spark interpreter, and and another with a different name say "spark2". This newly created interpreter should show up on top.

### Screenshots (if appropriate)

Before:
<img width="1439" alt="screen shot 2017-02-08 at 6 58 09 pm" src="https://cloud.githubusercontent.com/assets/674497/22739380/66c50e72-ee31-11e6-83cc-07669d292a12.png">

After:
<img width="1434" alt="screen shot 2017-02-08 at 6 56 42 pm" src="https://cloud.githubusercontent.com/assets/674497/22739379/66c377d8-ee31-11e6-965c-f9f61b288d99.png">




### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
