### PR TITLE
[ZEPPELIN-1700] Update docs for ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -261,6 +261,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Output message from interpreter exceeding the limit will be truncated</td>
   </tr>
   <tr>
+    <td>ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT</td>
+    <td>zeppelin.interpreter.connect.timeout</td>
+    <td>30000</td>
+    <td>Output message from interpreter exceeding the limit will be truncated</td>
+  </tr>
+  <tr>
     <td>ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE</td>
     <td>zeppelin.websocket.max.text.message.size</td>
     <td>1024000</td>


### PR DESCRIPTION

### What is this PR for?
Update docs to let devs know about [ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT](https://github.com/apache/zeppelin/blob/5bb38c89ae67f95858547f73d0e833ef91b3d6ee/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L576)

Some use cases are such that this value would need to be quite a bit higher, e.g., exceed the time required to create the spark executors in a mesos cluster. Developers may not know about this var until after they see the error [ZEPPELIN-1700].

### What type of PR is it?
Documentation

### Todos
* [ ] - Review and merge

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1700

### How should this be tested?
Review that the documented values reflect code reality https://github.com/apache/zeppelin/blob/5bb38c89ae67f95858547f73d0e833ef91b3d6ee/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java#L576

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes; it is documentation.
