### PR TITLE
[MINOR] Replace angular inject with ngInject

### DIFF
--- a/zeppelin-web/src/app/app.controller.js
+++ b/zeppelin-web/src/app/app.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('MainCtrl', MainCtrl);
 
-MainCtrl.$inject = ['$scope', '$rootScope', '$window', 'arrayOrderingSrv'];
-
 function MainCtrl($scope, $rootScope, $window, arrayOrderingSrv) {
+  'ngInject';
+
   $scope.looknfeel = 'default';
 
   var init = function() {

--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('ConfigurationCtrl', ConfigurationCtrl);
 
-ConfigurationCtrl.$inject = ['$scope', '$rootScope', '$http', 'baseUrlSrv', 'ngToast'];
-
 function ConfigurationCtrl($scope, $rootScope, $http, baseUrlSrv, ngToast) {
+  'ngInject';
+
   $scope.configrations = [];
   $scope._ = _;
   ngToast.dismiss();

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('CredentialCtrl', CredentialCtrl);
 
-CredentialCtrl.$inject = ['$scope', '$rootScope', '$http', 'baseUrlSrv', 'ngToast'];
-
 function CredentialCtrl($scope, $rootScope, $http, baseUrlSrv, ngToast) {
+  'ngInject';
+
   $scope._ = _;
   ngToast.dismiss();
 

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('HeliumCtrl', HeliumCtrl);
 
-HeliumCtrl.$inject = ['$scope', '$rootScope', '$sce', 'baseUrlSrv', 'ngToast', 'heliumService'];
-
 function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService) {
+  'ngInject';
+
   $scope.packageInfos = {};
   $scope.defaultVersions = {};
   $scope.showVersions = {};

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -14,19 +14,10 @@
 
 angular.module('zeppelinWebApp').controller('HomeCtrl', HomeCtrl);
 
-HomeCtrl.$inject = [
-  '$scope',
-  'noteListDataFactory',
-  'websocketMsgSrv',
-  '$rootScope',
-  'arrayOrderingSrv',
-  'ngToast',
-  'noteActionSrv',
-  'TRASH_FOLDER_ID'
-];
-
 function HomeCtrl($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv,
                   ngToast, noteActionSrv, TRASH_FOLDER_ID) {
+  'ngInject';
+
   ngToast.dismiss();
   var vm = this;
   vm.notes = noteListDataFactory;

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('InterpreterCtrl', InterpreterCtrl);
 
-InterpreterCtrl.$inject = ['$rootScope', '$scope', '$http', 'baseUrlSrv', 'ngToast', '$timeout', '$route'];
-
 function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeout, $route) {
+  'ngInject';
+
   var interpreterSettingsTmp = [];
   $scope.interpreterSettings = [];
   $scope.availableInterpreters = {};

--- a/zeppelin-web/src/app/jobmanager/jobmanager.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobmanager.controller.js
@@ -15,9 +15,9 @@
 angular.module('zeppelinWebApp')
   .controller('JobmanagerCtrl', JobmanagerCtrl);
 
-JobmanagerCtrl.$inject = ['$scope', 'websocketMsgSrv', '$interval', 'ngToast', '$q', '$timeout', 'jobManagerFilter'];
-
 function JobmanagerCtrl($scope, websocketMsgSrv, $interval, ngToast, $q, $timeout, jobManagerFilter) {
+  'ngInject';
+
   ngToast.dismiss();
   var asyncNotebookJobFilter = function(jobInfomations, filterConfig) {
     return $q(function(resolve, reject) {

--- a/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('JobCtrl', JobCtrl);
 
-JobCtrl.$inject = ['$scope', '$http', 'baseUrlSrv'];
-
 function JobCtrl($scope, $http, baseUrlSrv) {
+  'ngInject';
+
   $scope.init = function(jobInformation) {
     $scope.progressValue = 0;
   };

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -14,28 +14,11 @@
 
 angular.module('zeppelinWebApp').controller('NotebookCtrl', NotebookCtrl);
 
-NotebookCtrl.$inject = [
-  '$scope',
-  '$route',
-  '$routeParams',
-  '$location',
-  '$rootScope',
-  '$http',
-  'websocketMsgSrv',
-  'baseUrlSrv',
-  '$timeout',
-  'saveAsService',
-  'ngToast',
-  'noteActionSrv',
-  'noteVarShareService',
-  'TRASH_FOLDER_ID',
-  'heliumService',
-];
-
 function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
                       $http, websocketMsgSrv, baseUrlSrv, $timeout, saveAsService,
                       ngToast, noteActionSrv, noteVarShareService, TRASH_FOLDER_ID,
                       heliumService) {
+  'ngInject';
 
   ngToast.dismiss();
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -18,29 +18,12 @@ import {
 
 angular.module('zeppelinWebApp').controller('ParagraphCtrl', ParagraphCtrl);
 
-ParagraphCtrl.$inject = [
-  '$scope',
-  '$rootScope',
-  '$route',
-  '$window',
-  '$routeParams',
-  '$location',
-  '$timeout',
-  '$compile',
-  '$http',
-  '$q',
-  'websocketMsgSrv',
-  'baseUrlSrv',
-  'ngToast',
-  'saveAsService',
-  'noteVarShareService',
-  'heliumService'
-];
-
 function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $location,
                        $timeout, $compile, $http, $q, websocketMsgSrv,
                        baseUrlSrv, ngToast, saveAsService, noteVarShareService,
                        heliumService) {
+  'ngInject';
+
   var ANGULAR_FUNCTION_OBJECT_NAME_PREFIX = '_Z_ANGULAR_FUNC_';
   $scope.parentNote = null;
   $scope.paragraph = {};

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -26,30 +26,10 @@ import {
 
 angular.module('zeppelinWebApp').controller('ResultCtrl', ResultCtrl);
 
-ResultCtrl.$inject = [
-  '$scope',
-  '$rootScope',
-  '$route',
-  '$window',
-  '$routeParams',
-  '$location',
-  '$timeout',
-  '$compile',
-  '$http',
-  '$q',
-  '$templateRequest',
-  '$sce',
-  'websocketMsgSrv',
-  'baseUrlSrv',
-  'ngToast',
-  'saveAsService',
-  'noteVarShareService',
-  'heliumService'
-];
-
 function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location,
                     $timeout, $compile, $http, $q, $templateRequest, $sce, websocketMsgSrv,
                     baseUrlSrv, ngToast, saveAsService, noteVarShareService, heliumService) {
+  'ngInject';
 
   /**
    * Built-in visualizations

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('NotebookReposCtrl', NotebookReposCtrl);
 
-NotebookReposCtrl.$inject = ['$http', 'baseUrlSrv', 'ngToast'];
-
 function NotebookReposCtrl($http, baseUrlSrv, ngToast) {
+  'ngInject';
+
   var vm = this;
   vm.notebookRepos = [];
   vm.showDropdownSelected = showDropdownSelected;

--- a/zeppelin-web/src/app/search/result-list.controller.js
+++ b/zeppelin-web/src/app/search/result-list.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('SearchResultCtrl', SearchResultCtrl);
 
-SearchResultCtrl.$inject = ['$scope', '$routeParams', 'searchService'];
-
 function SearchResultCtrl($scope, $routeParams, searchService) {
+  'ngInject';
+
   $scope.isResult = true ;
   $scope.searchTerm = $routeParams.searchTerm;
   var results = searchService.search({'q': $routeParams.searchTerm}).query();

--- a/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
+++ b/zeppelin-web/src/components/arrayOrderingSrv/arrayOrdering.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('arrayOrderingSrv', arrayOrderingSrv);
 
-arrayOrderingSrv.$inject = ['TRASH_FOLDER_ID'];
-
 function arrayOrderingSrv(TRASH_FOLDER_ID) {
+  'ngInject';
+
   var arrayOrderingSrv = this;
 
   this.noteListOrdering = function(note) {

--- a/zeppelin-web/src/components/clipboard/clipboard.controller.js
+++ b/zeppelin-web/src/components/clipboard/clipboard.controller.js
@@ -12,9 +12,10 @@
  * limitations under the License.
  */
 angular.module('zeppelinWebApp').controller('clipboardCtrl', clipboardCtrl);
-clipboardCtrl.$inject = ['$scope'];
 
 function clipboardCtrl($scope) {
+  'ngInject';
+
   $scope.complete = function(e) {
     $scope.copied = true;
     $scope.tooltip = 'Copied!';

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -16,9 +16,8 @@ import { HeliumType, } from './helium-type';
 
 angular.module('zeppelinWebApp').service('heliumService', heliumService);
 
-heliumService.$inject = ['$http', 'baseUrlSrv', 'ngToast'];
-
 function heliumService($http, baseUrlSrv, ngToast) {
+  'ngInject';
 
   var url = baseUrlSrv.getRestApiBase() + '/helium/bundle/load';
   if (process.env.HELIUM_BUNDLE_DEV) {

--- a/zeppelin-web/src/components/interpreter/interpreter.directive.js
+++ b/zeppelin-web/src/components/interpreter/interpreter.directive.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').directive('interpreterDirective', interpreterDirective);
 
-interpreterDirective.$inject = ['$timeout'];
-
 function interpreterDirective($timeout) {
+  'ngInject';
+
   return {
     restrict: 'A',
     link: function(scope, element, attr) {

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -14,8 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('LoginCtrl', LoginCtrl);
 
-LoginCtrl.$inject = ['$scope', '$rootScope', '$http', '$httpParamSerializer', 'baseUrlSrv'];
 function LoginCtrl($scope, $rootScope, $http, $httpParamSerializer, baseUrlSrv) {
+  'ngInject';
+
   $scope.SigningIn = false;
   $scope.loginParams = {};
   $scope.login = function() {

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -14,23 +14,11 @@
 
 angular.module('zeppelinWebApp').controller('NavCtrl', NavCtrl);
 
-NavCtrl.$inject = [
-  '$scope',
-  '$rootScope',
-  '$http',
-  '$routeParams',
-  '$location',
-  'noteListDataFactory',
-  'baseUrlSrv',
-  'websocketMsgSrv',
-  'arrayOrderingSrv',
-  'searchService',
-  'TRASH_FOLDER_ID'
-];
-
 function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
                  noteListDataFactory, baseUrlSrv, websocketMsgSrv,
                  arrayOrderingSrv, searchService, TRASH_FOLDER_ID) {
+  'ngInject';
+
   var vm = this;
   vm.arrayOrderingSrv = arrayOrderingSrv;
   vm.connected = websocketMsgSrv.isConnected();

--- a/zeppelin-web/src/components/noteAction/noteAction.service.js
+++ b/zeppelin-web/src/components/noteAction/noteAction.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('noteActionSrv', noteActionSrv);
 
-noteActionSrv.$inject = ['websocketMsgSrv', '$location', 'renameSrv', 'noteListDataFactory'];
-
 function noteActionSrv(websocketMsgSrv, $location, renameSrv, noteListDataFactory) {
+  'ngInject';
+
   this.moveNoteToTrash = function(noteId, redirectToHome) {
     BootstrapDialog.confirm({
       closable: true,

--- a/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
+++ b/zeppelin-web/src/components/noteListDataFactory/noteList.datafactory.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').factory('noteListDataFactory', noteListDataFactory);
 
-noteListDataFactory.$inject = ['TRASH_FOLDER_ID'];
-
 function noteListDataFactory(TRASH_FOLDER_ID) {
+  'ngInject';
+
   var notes = {
     root: {children: []},
     flatList: [],

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -14,14 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('NotenameCtrl', NotenameCtrl);
 
-NotenameCtrl.$inject = [
-  '$scope',
-  'noteListDataFactory',
-  '$routeParams',
-  'websocketMsgSrv'
-];
-
 function NotenameCtrl($scope, noteListDataFactory, $routeParams, websocketMsgSrv) {
+  'ngInject';
+
   var vm = this;
   vm.clone = false;
   vm.notes = noteListDataFactory;

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('NoteImportCtrl', NoteImportCtrl);
 
-NoteImportCtrl.$inject = ['$scope', '$timeout', 'websocketMsgSrv'];
-
 function NoteImportCtrl($scope, $timeout, websocketMsgSrv) {
+  'ngInject';
+  
   var vm = this;
   $scope.note = {};
   $scope.note.step1 = true;

--- a/zeppelin-web/src/components/notevarshareService/notevarshare.service.js
+++ b/zeppelin-web/src/components/notevarshareService/notevarshare.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('noteVarShareService', noteVarShareService);
 
-noteVarShareService.$inject = [];
-
 function noteVarShareService() {
+  'ngInject';
+
   var store = {};
 
   this.clear = function() {

--- a/zeppelin-web/src/components/popover-html-unsafe/popover-html-unsafe.directive.js
+++ b/zeppelin-web/src/components/popover-html-unsafe/popover-html-unsafe.directive.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').directive('popoverHtmlUnsafe', popoverHtmlUnsafe);
 
-popoverHtmlUnsafe.$inject = ['$tooltip'];
-
 function popoverHtmlUnsafe($tooltip) {
+  'ngInject';
+
   return $tooltip('popoverHtmlUnsafe', 'popover', 'click');
 }
 

--- a/zeppelin-web/src/components/rename/rename.controller.js
+++ b/zeppelin-web/src/components/rename/rename.controller.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').controller('RenameCtrl', RenameCtrl);
 
-RenameCtrl.$inject = ['$scope'];
-
 function RenameCtrl($scope) {
+  'ngInject';
+
   var self = this;
 
   $scope.params = {newName: ''};

--- a/zeppelin-web/src/components/rename/rename.service.js
+++ b/zeppelin-web/src/components/rename/rename.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('renameSrv', renameSrv);
 
-renameSrv.$inject = ['$rootScope'];
-
 function renameSrv($rootScope) {
+  'ngInject';
+
   var self = this;
 
   /**

--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('saveAsService', saveAsService);
 
-saveAsService.$inject = ['browserDetectService'];
-
 function saveAsService(browserDetectService) {
+  'ngInject';
+
   this.saveAs = function(content, filename, extension) {
     var BOM = '\uFEFF';
     if (browserDetectService.detectIE()) {

--- a/zeppelin-web/src/components/searchService/search.service.js
+++ b/zeppelin-web/src/components/searchService/search.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('searchService', searchService);
 
-searchService.$inject = ['$resource', 'baseUrlSrv'];
-
 function searchService($resource, baseUrlSrv) {
+  'ngInject';
+
   this.search = function(term) {
     this.searchTerm = term.q;
     console.log('Searching for: %o', term.q);

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').factory('websocketEvents', websocketEvents);
 
-websocketEvents.$inject = ['$rootScope', '$websocket', '$location', 'baseUrlSrv'];
-
 function websocketEvents($rootScope, $websocket, $location, baseUrlSrv) {
+  'ngInject';
+
   var websocketCalls = {};
   var pingIntervalId;
 

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -14,9 +14,9 @@
 
 angular.module('zeppelinWebApp').service('websocketMsgSrv', websocketMsgSrv);
 
-websocketMsgSrv.$inject = ['$rootScope', 'websocketEvents'];
-
 function websocketMsgSrv($rootScope, websocketEvents) {
+  'ngInject';
+
   return {
 
     getHomeNote: function() {


### PR DESCRIPTION
### What is this PR for?

Replaced angular inject with ngInject to reduce duplication and keep simple. There is no reason to use angular inject since

- it can make human-error (e.g. fixing only inject while doesn't modify function args.)
- ngInject is a way to enforce single source of truth (function args)
- we are already applying [ng-annotate](https://github.com/olov/ng-annotate) in webpack. (https://github.com/apache/zeppelin/blob/0589e27e7bb84ec81e1438bcbf3f2fd80ee5a963/zeppelin-web/webpack.config.js#L142)

```javascript
ParagraphCtrl.$inject = [		
  '$scope',		
  '$rootScope',		
  '$route',		
  '$window',		
  '$routeParams',		
  '$location',		
  '$timeout',		
  '$compile',		
  '$http',		
  '$q',		
  'websocketMsgSrv',		
  'baseUrlSrv',		
  'ngToast',		
  'saveAsService',		
  'noteVarShareService',		
  'heliumService'		
 ];		

// can be replaced with one line
'ngInject';
```

### What type of PR is it?
[Improvement]

### What is the Jira issue?

MINOR

### How should this be tested?

will be tested by CI

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
