### PR TITLE
[MINOR][ZEPPELIN-2090] Remove "zeppelin.interpreters" property related guide msg

### DIFF
--- a/docs/manual/interpreterinstallation.md
+++ b/docs/manual/interpreterinstallation.md
@@ -113,9 +113,7 @@ You can also install 3rd party interpreters located in the maven repository by u
 
 The above command will download maven artifact `groupId1:artifact1:version1` and all of it's transitive dependencies into `interpreter/interpreter1` directory.
 
-Once you have installed interpreters, you'll need to add interpreter class name into `zeppelin.interpreters` property in [configuration](../install/configuration.html).
-And then restart Zeppelin, [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
-
+After restart Zeppelin, then [create interpreter setting](../manual/interpreters.html#what-is-zeppelin-interpreter) and [bind it with your notebook](../manual/interpreters.html#what-is-zeppelin-interpreter-setting).
 
 #### Install multiple 3rd party interpreters at once
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java
@@ -159,7 +159,9 @@ public class InstallInterpreter {
 
     File installDir = new File(interpreterBaseDir, name);
     if (installDir.exists()) {
-      System.err.println("Directory " + installDir.getAbsolutePath() + " already exists. Skipping");
+      System.err.println("Directory " + installDir.getAbsolutePath()
+        + " already exists"
+        + "\n\nSkipped");
       return;
     }
 
@@ -170,6 +172,7 @@ public class InstallInterpreter {
       depResolver.load(artifact, installDir);
       System.out.println("Interpreter " + name + " installed under " +
           installDir.getAbsolutePath() + ".");
+      startTip();
     } catch (RepositoryException e) {
       e.printStackTrace();
     } catch (IOException e) {
@@ -273,29 +276,15 @@ public class InstallInterpreter {
     if (names != null) {
       if (artifacts != null) {
         installer.install(names.split(","), artifacts.split(","));
-        startTip();
-        configurationTip();
-        interpreterSettingTip();
       } else {
         installer.install(names.split(","));
-        startTip();
-        interpreterSettingTip();
       }
     }
   }
 
   private static void startTip() {
-    System.out.println("");
-  }
-
-  private static void configurationTip() {
-    System.out.println("Add interpreter class name to '"
-        + ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETERS.getVarName() + "' property "
-        + "in your conf/zeppelin-site.xml file");
-  }
-
-  private static void interpreterSettingTip() {
-    System.out.println("Create interpreter setting in 'Interpreter' menu on GUI."
-        + " And then you can bind interpreter on your notebook");
+    System.out.println("\n1. Restart Zeppelin"
+      + "\n2. Create interpreter setting in 'Interpreter' menu on Zeppelin GUI"
+      + "\n3. Then you can bind the interpreter on your note");
   }
 }


### PR DESCRIPTION
### What is this PR for?
As we won't support `zeppelin.interpreters` property anymore (from `0.7.0`), the related msg should be removed accordingly. So I removed it from [docs/manual/interpreterinstallation.md#install-3rd-party-interpreters](https://github.com/apache/zeppelin/blob/master/docs/manual/interpreterinstallation.md#install-3rd-party-interpreters) & [InstallInterpreter.java#L291](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/install/InstallInterpreter.java#L291). And rewrite some guide msg like below.

1. After successful installation
 - Before 
```
Interpreter spark installed under /Users/ahyoungryu/Dev/zeppelin-bin/zeppelin-0.7.0-bin-netinst/interpreter/spark.

Add interpreter class name to 'zeppelin.interpreters' property in your conf/zeppelin-site.xml file
Create interpreter setting in 'Interpreter' menu on GUI. And then you can bind interpreter on your notebook
```

 - After 
```
Interpreter spark installed under /Users/ahyoungryu/Dev/zeppelin-development/zeppelin/interpreter/spark.

1. Restart Zeppelin
2. Create interpreter setting in 'Interpreter' menu on Zeppelin GUI
3. Then you can bind the interpreter on your note
```

2. If it's skipped (since the interpreter dir already existed)
 - Before
```
Directory /Users/ahyoungryu/Dev/zeppelin-bin/zeppelin-0.7.0-bin-netinst/interpreter/flink already exists. Skipping

Create interpreter setting in 'Interpreter' menu on GUI. And then you can bind interpreter on your notebook
```
 - After 
```
Directory /Users/ahyoungryu/Dev/zeppelin-development/zeppelin/interpreter/flink already exists

Skipped
```

### What type of PR is it?
just removed unnecessary message :)

### What is the Jira issue?
[ZEPPELIN-2090](https://issues.apache.org/jira/browse/ZEPPELIN-2090)

### How should this be tested?
1. Apply this patch and build with 
```
$ mvn clean package -DskipTests -pl 'zeppelin-interpreter, zeppelin-zengine, zeppelin-server'
```

2. Remove `interpreter/spark`
```
$ rm -r interpreter/spark
```

3. Install Spark using `install-interpreter.sh`
```
$ ./bin/install-interpreter.sh --name spark --artifact org.apache.zeppelin:zeppelin-spark_2.10:0.7.0
```

Then the msg should be like 
<img width="866" alt="screen shot 2017-02-09 at 5 06 27 pm" src="https://cloud.githubusercontent.com/assets/10060731/22774373/1fc93e9e-eeea-11e6-8055-3594e18c7d96.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
