### PR TITLE
[ZEPPELIN-2084] z.show doesn't show dataframe

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -36,21 +36,17 @@ export default class TableVisualization extends Visualization {
     var container = this.targetEl.css('height', height).get(0);
     var resultRows = tableData.rows;
     var columnNames = _.pluck(tableData.columns, 'name');
+    var columns = Array.apply(null, Array(tableData.columns.length)).map(function() {
+      return {type: 'text'};
+    });
 
     if (this.hot) {
       this.hot.destroy();
     }
 
-    if (!this.columns) {
-      this.columns = Array.apply(null, Array(tableData.columns.length)).map(function() {
-        return {type: 'text'};
-      });
-    }
-
     var handsonHelper = new HandsonHelper();
-
     this.hot = new Handsontable(container, handsonHelper.getHandsonTableConfig(
-      this.columns, columnNames, resultRows));
+      columns, columnNames, resultRows));
     this.hot.validateCells(null);
   };
 


### PR DESCRIPTION
### What is this PR for?

following may/may not display the result
```
z.show(sc.parallelize((1 to 1000000).toList).toDF, 1000000)
```

it was because of column information is not refreshed as data refresh in TableVisualization.

### What type of PR is it?
Bug Fix

### Todos
* [x] - fix bug

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2084

### How should this be tested?

run followings multiple times. and see if it displays result every time.
```
z.show(sc.parallelize((1 to 1000000).toList).toDF, 1000000)
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
