### PR TITLE
[ZEPPELIN-2099] Add NPM link for helium pkgs published in npm

### DIFF
--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -218,7 +218,7 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
 
   $scope.isLocalPackage = function(pkgSearchResult) {
     const pkg = pkgSearchResult.pkg;
-    return pkg.artifact && pkg.artifact.startsWith('/');
+    return pkg.artifact && !pkg.artifact.includes('@');
   };
 
   $scope.hasNpmLink = function(pkgSearchResult) {

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import { HeliumType, } from '../../components/helium/helium-type';
+
 angular.module('zeppelinWebApp').controller('HeliumCtrl', HeliumCtrl);
 
 HeliumCtrl.$inject = ['$scope', '$rootScope', '$sce', 'baseUrlSrv', 'ngToast', 'heliumService'];
@@ -213,4 +215,10 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
       $scope.showVersions[pkgName] = true;
     }
   };
+
+  $scope.hasNpmLink = function(pkgSearchResult) {
+    const pkg = pkgSearchResult.pkg;
+    return (pkg.type === HeliumType.SPELL || pkg.type === HeliumType.VISUALIZATION) &&
+      pkg.artifact && pkg.artifact.includes('@');
+  }
 }

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -216,9 +216,14 @@ function HeliumCtrl($scope, $rootScope, $sce, baseUrlSrv, ngToast, heliumService
     }
   };
 
+  $scope.isLocalPackage = function(pkgSearchResult) {
+    const pkg = pkgSearchResult.pkg;
+    return pkg.artifact && pkg.artifact.startsWith('/');
+  };
+
   $scope.hasNpmLink = function(pkgSearchResult) {
     const pkg = pkgSearchResult.pkg;
     return (pkg.type === HeliumType.SPELL || pkg.type === HeliumType.VISUALIZATION) &&
-      pkg.artifact && pkg.artifact.includes('@');
-  }
+      !$scope.isLocalPackage(pkgSearchResult);
+  };
 }

--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -127,3 +127,9 @@
   underline;color:#3071a9;
   display: inline-block;
 }
+
+.heliumLocalPackage {
+  color: #636363;
+}
+
+

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -54,7 +54,7 @@ limitations under the License.
           <span ng-if="hasNpmLink(pkgInfo)">
             <a target="_blank" href="https://www.npmjs.com/package/{{pkgName}}">{{pkgName}}</a>
           </span>
-          <span ng-if="!hasNpmLink(pkgInfo)">
+          <span ng-if="!hasNpmLink(pkgInfo)" ng-class="{'heliumLocalPackage': isLocalPackage(pkgInfo)}">
             {{pkgName}}
           </span>
           <span class="heliumType">{{pkgInfo.pkg.type}}</span>

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -51,7 +51,12 @@ limitations under the License.
         <div class="heliumPackageIcon"
              ng-bind-html=pkgInfo.pkg.icon></div>
         <div class="heliumPackageName">
-          {{pkgName}}
+          <span ng-if="hasNpmLink(pkgInfo)">
+            <a target="_blank" href="https://www.npmjs.com/package/{{pkgName}}">{{pkgName}}</a>
+          </span>
+          <span ng-if="!hasNpmLink(pkgInfo)">
+            {{pkgName}}
+          </span>
           <span class="heliumType">{{pkgInfo.pkg.type}}</span>
         </div>
         <div ng-show="!pkgInfo.enabled"


### PR DESCRIPTION
### What is this PR for?

Add NPM link for helium pkgs published in npm while coloring grey for local packages to distinguish easily.

### What type of PR is it?
[Improvement]

### TODOs

- [x] Add link to published npm packages
- [x] Grey color for local to distinguish

### What is the Jira issue?

[ZEPPELIN-2099](https://issues.apache.org/jira/browse/ZEPPELIN-2099)

### How should this be tested?

1. Build Zeppelin using ` mvn clean package -Phelium-dev-Pexamples -DskipTests;` for creating helium examples.
2. Open the `/helium` page

- click the name of published npm package.
- check color of local package. 

### Screenshots (if appropriate)

#### NPM Link
![npm-link](https://cloud.githubusercontent.com/assets/4968473/22859688/2d0322f6-f128-11e6-83db-b1a0013a04bf.gif)

#### Local Package Name Color
![image](https://cloud.githubusercontent.com/assets/4968473/22859724/f36866e4-f129-11e6-8bf2-dfd5a69b536e.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
