### PR TITLE
[MINOR][ZEPPELIN-2100] Enable to go back to zeppelin.apache.org in docs site 

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -7,11 +7,15 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{BASE_PATH}}">
-            <img src="/assets/themes/zeppelin/img/zeppelin_logo.png" width="50" alt="I'm zeppelin">
-            <span style="vertical-align:middle">Zeppelin</span>
-            <span style="vertical-align:baseline"><small>{{site.ZEPPELIN_VERSION}}</small></span>
-          </a>
+          <div class="navbar-brand">
+            <a class="navbar-brand-main" href="{{site.production_url}}">
+              <img src="/assets/themes/zeppelin/img/zeppelin_logo.png" width="50" alt="I'm zeppelin">
+              <span style="vertical-align:middle">Zeppelin</span>
+            </a>
+            <a class="navbar-brand-version" href="{{BASE_PATH}}">
+              <span><small>{{site.ZEPPELIN_VERSION}}</small></span>
+            </a>
+          </div>
         </div>
         <nav class="navbar-collapse collapse" role="navigation">
           <ul class="nav navbar-nav">

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -646,8 +646,8 @@ and (max-width: 1024px) {
 
 #menu .navbar-brand-version span {
   float: none;
-    display: inline-block;
-    vertical-align: bottom;
+  display: inline-block;
+  vertical-align: bottom;
 }
 
 #menu .navbar-brand-version small {

--- a/docs/assets/themes/zeppelin/css/style.css
+++ b/docs/assets/themes/zeppelin/css/style.css
@@ -79,7 +79,7 @@ body {
   padding-bottom: 10px;
 }
 
-.navbar-brand img {
+.navbar-brand-main img {
   margin: 0;
 }
 
@@ -124,7 +124,7 @@ body {
   background: #265380;
 }
 
-.navbar-inverse .navbar-brand {
+.navbar-inverse .navbar-brand-main {
   color: white;
   text-decoration: none;
   font-size: 32px;
@@ -523,15 +523,8 @@ a.anchor {
   color: white;
 }
 
-.navbar-brand {
+.navbar-brand-main {
   font-family: 'Patua One', cursive;
-}
-
-.navbar-brand small {
-  font-size: 14px;
-  font-family: 'Open Sans', 'Helvetica Neue', Helvetica;
-  color: white;
-  vertical-align: bottom;
 }
 
 .navbar-collapse.collapse {
@@ -597,14 +590,14 @@ a.anchorjs-link:hover { text-decoration: none; }
   .jumbotron h1 {
     display: none;
   }
-  .navbar-brand small {
+  .navbar-brand-version small {
     display: none;
     color: white;
   }
 }
 
 @media only screen and (max-width: 768px) {
-  .navbar .navbar-brand {
+  .navbar .navbar-brand-main {
     padding-bottom: 0;
   }
 }
@@ -612,7 +605,7 @@ a.anchorjs-link:hover { text-decoration: none; }
 @media only screen
 and (min-width: 768px)
 and (max-width: 1024px) {
-  .navbar-brand small {
+  .navbar-brand-version small {
     display: none;
   }
 
@@ -646,8 +639,21 @@ and (max-width: 1024px) {
   border-bottom-color: #428bca;
 }
 
-#menu .navbar-brand {
+#menu .navbar-brand-version {
   margin-right: 50px;
+  text-decoration: none !important;
+}
+
+#menu .navbar-brand-version span {
+  float: none;
+    display: inline-block;
+    vertical-align: bottom;
+}
+
+#menu .navbar-brand-version small {
+  font-size: 14px;
+  font-family: 'Open Sans', 'Helvetica Neue', Helvetica;
+  color: white;
 }
 
 /* gh-pages branch docs dropdown menu */


### PR DESCRIPTION
### What is this PR for?
Currently there is no link to go back to [zeppelin.apache.org](https://zeppelin.apache.org) in each docs site. It's a bit inconvenient. 

e.g. In [https://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/](https://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/), if I click Zeppelin main logo, it keeps me staying in docs main page not the root: [zeppelin.apache.org](https://zeppelin.apache.org).

So I separated main logo in navbar to "Zeppelin" and "version". And linked [production_url](https://github.com/apache/zeppelin/blob/master/docs/_config.yml#L34) and [BASE_PATH](https://github.com/apache/zeppelin/blob/master/docs/_config.yml#L62) to each of them. Please see the below screenshot img.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-2100](https://issues.apache.org/jira/browse/ZEPPELIN-2100)

### How should this be tested?
Run docs site locally under `ZEPPELIN_HOME/docs` as described in here: [Run website locally](https://github.com/apache/zeppelin/blob/master/docs/README.md#run-website-locally)

### Screenshots (if appropriate)
In [https://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/](https://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/),

 - Before 
<img width="400px" src="https://cloud.githubusercontent.com/assets/10060731/22860466/6064c964-f142-11e6-9bc1-bbd34fa42c18.png">

 - After
<img width="500px" src="https://cloud.githubusercontent.com/assets/10060731/22860469/69364568-f142-11e6-963d-7b6ab33330c3.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
