### PR TITLE
[ZEPPELIN-2101] Add zeppelin bump up and git tag script for release

### DIFF
--- a/dev/change_zeppelin_version.sh
+++ b/dev/change_zeppelin_version.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+usage() {
+  echo "usage) $0 [Old version] [New version]"
+  echo "   ex. $0 0.7.0-SNAPSHOT 0.7.0"
+  exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+fi
+
+FROM_VERSION="$1"
+TO_VERSION="$2"
+
+is_dev_version() {
+  if [[ "$1" == *"SNAPSHOT" ]]; then
+    return 0
+  else
+    return 1
+  fi
+} 
+
+is_maintenance_version() {
+  local version="$1"
+  if [[ "${version}" == *"SNAPSHOT" ]]; then
+    version = $(echo ${1} | cut -d'-' -f 1)
+  fi 
+  if [[ "${version}" == *".0" ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+# Change version in pom.xml
+mvn versions:set -DnewVersion="${TO_VERSION}" -DgenerateBackupPoms=false > /dev/null 2>&1 
+
+# Change version in example and package files
+sed -i '' 's/-'"${FROM_VERSION}"'.jar",/-'"${TO_VERSION}"'.jar",/g' zeppelin-examples/zeppelin-example-clock/zeppelin-example-clock.json
+sed -i '' 's/"version": "'"${FROM_VERSION}"'",/"version": "'"${TO_VERSION}"'",/g' zeppelin-web/src/app/tabledata/package.json
+sed -i '' 's/"version": "'"${FROM_VERSION}"'",/"version": "'"${TO_VERSION}"'",/g' zeppelin-web/src/app/visualization/package.json
+
+# When preparing new dev version from release tag, doesn't need to change docs version
+if is_dev_version "${FROM_VERSION}" || ! is_dev_version "${TO_VERSION}"; then
+  # When prepare new rc for the maintenance release
+  if is_dev_version "${FROM_VERSION}" && is_maintenance_version "${TO_VERSION}" \
+     && [[ "${FROM_VERSION}" == "${TO_VERSION}"* ]]; then
+    FROM_VERSION=$(echo "${TO_VERSION}" | awk -F. '{ printf("%d.%d.%d", $1, $2, $3-1) }')
+  fi
+
+  # Change zeppelin version in docs config
+  sed -i '' 's/ZEPPELIN_VERSION : '"${FROM_VERSION}"'$/ZEPPELIN_VERSION : '"$TO_VERSION"'/g' docs/_config.yml
+  sed -i '' 's/BASE_PATH : \/docs\/'"${FROM_VERSION}"'$/BASE_PATH : \/docs\/'"$TO_VERSION"'/g' docs/_config.yml
+
+  # Change interpreter's maven version in docs and interpreter-list
+  sed -i '' 's/:'"${FROM_VERSION}"'/:'"${TO_VERSION}"'/g' conf/interpreter-list
+  sed -i '' 's/:'"${FROM_VERSION}"'/:'"${TO_VERSION}"'/g' docs/manual/interpreterinstallation.md 
+fi

--- a/dev/tag_release.sh
+++ b/dev/tag_release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+WORKING_DIR="/tmp/apache-zeppelin"
+
+for var in CURRENT_VERSION RELEASE_VERSION NEXT_DEV_VERSION RC_TAG GIT_BRANCH; do
+  if [[ -z "${!var}" ]]; then
+    echo "You need ${var} variable set"
+    exit 1
+  fi
+done
+
+set -e
+
+git clone https://git-wip-us.apache.org/repos/asf/zeppelin.git "${WORKING_DIR}"
+pushd "${WORKING_DIR}" 
+
+git checkout "${GIT_BRANCH}"
+
+# Create release version
+./dev/change_zeppelin_version.sh "${CURRENT_VERSION}" "${RELEASE_VERSION}"
+git commit -a -m "Preparing Apache Zeppelin release ${RELEASE_VERSION}"
+echo "Creating tag ${RC_TAG} at the head of ${GIT_BRANCH}"
+git tag "${RC_TAG}"
+
+# Create next dev version
+./dev/change_zeppelin_version.sh "${RELEASE_VERSION}" "${NEXT_DEV_VERSION}"
+git commit -a -m "Preparing development version ${NEXT_DEV_VERSION}"
+
+git push origin "${RC_TAG}"
+git push origin HEAD:"${BRANCH}" 
+
+popd
+rm -rf "${WORKING_DIR}"


### PR DESCRIPTION
### What is this PR for?
There are several files that needs to be changed as mentioned in [wiki](https://cwiki.apache.org/confluence/display/ZEPPELIN/Preparing+Zeppelin+Release#PreparingZeppelinRelease-Bumpupversion,createtaganduploadmavenartifacttostagingrepo).
This PR provides script for this to automate these file bump up as well as creating release tag mentioned in wiki page.

### What type of PR is it?
Build infra

### What is the Jira issue?
[ZEPPELIN-2101](https://issues.apache.org/jira/browse/ZEPPELIN-2101)

### How should this be tested?
This script will be used only by release manager.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? [wiki page](https://cwiki.apache.org/confluence/display/ZEPPELIN/Preparing+Zeppelin+Release) will be updated once this PR merged.
