### PR TITLE
[ZEPPELIN-2091] Disable add/remove operations in the window of Link this paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -481,10 +481,16 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   $scope.$on('addParagraph', function(event, paragraph, index) {
+    if ($scope.paragraphUrl) {
+      return;
+    }
     addPara(paragraph, index);
   });
 
   $scope.$on('removeParagraph', function(event, paragraphId) {
+    if ($scope.paragraphUrl) {
+      return;
+    }
     removePara(paragraphId);
   });
 


### PR DESCRIPTION
### What is this PR for?
When a paragraph is added or deleted from a note, the window which is created by `Link this paragraph` does unnecessary work.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2091](https://issues.apache.org/jira/browse/ZEPPELIN-2091)

### How should this be tested?
Here is the test way.
1. click "Link this paragraph" of a paragraph menu.
2. click `Insert New` or `remove`.
3. check the window made by "Link this paragraph". 

### Screenshots (if appropriate)
[ Before ]
* When clicking `Insert New` in a paragraph menu, it appears new paragraph in the window of `Link this paragraph`.
![z_2091_b](https://cloud.githubusercontent.com/assets/8110458/22874942/29993076-f20c-11e6-827f-01afe1189744.gif)
* When click `remove` in a paragraph menu, the window of `Link this paragraph` appears empty screen.
![z_2091_b_remove](https://cloud.githubusercontent.com/assets/8110458/22874973/5fcab71e-f20c-11e6-9415-22f3fe84456e.png)


[ After ]
* It doesn't work in the window of 'Link this paragraph`
![z_2091_a](https://cloud.githubusercontent.com/assets/8110458/22875086/1c3530f0-f20d-11e6-98a8-6eca2e56ce1c.png)

 * _Note that text and title shape of the paragraph in window is covering https://github.com/apache/zeppelin/pull/1983._

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
