### PR TITLE
[ZEPPELIN-2103] Unnecessary read to Helium registry

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumTest.java
@@ -100,4 +100,43 @@ public class HeliumTest {
     // then
     assertEquals(2, helium.getAllPackageInfo().size());
   }
+
+
+  @Test
+  public void testRefresh() throws IOException, URISyntaxException, TaskRunnerException {
+    File heliumConf = new File(tmpDir, "helium.conf");
+    Helium helium = new Helium(
+        heliumConf.getAbsolutePath(), localRegistryPath.getAbsolutePath(), null, null, null);
+    HeliumTestRegistry registry1 = new HeliumTestRegistry("r1", "r1");
+    helium.addRegistry(registry1);
+
+    // when
+    registry1.add(new HeliumPackage(
+        HeliumType.APPLICATION,
+        "name1",
+        "desc1",
+        "artifact1",
+        "className1",
+        new String[][]{},
+        "",
+        ""));
+
+    // then
+    assertEquals(1, helium.getAllPackageInfo(false).size());
+
+    // when
+    registry1.add(new HeliumPackage(
+        HeliumType.APPLICATION,
+        "name2",
+        "desc2",
+        "artifact2",
+        "className2",
+        new String[][]{},
+        "",
+        ""));
+
+    // then
+    assertEquals(1, helium.getAllPackageInfo(false).size());
+    assertEquals(2, helium.getAllPackageInfo(true).size());
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Every `Helium.getAllPackageInfo()` call read helium package information from all registry configured (both local registry, online registry by default).
Problem is, `Helium.getAllPackageInfo()` is used inside of many other methods. like `Helium.suggestApp()`, `Helium.enable()`, `Helium.disable()`, `Helium.recreateBundle()`, `Helium.getPackageInfo()`.
So local/remote registry is unnecessarily accessed more than it should do.


### What type of PR is it?
Bug Fix

### Todos
* [x] - Hold the result and reuse it
* [x] - Unit test

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2103

### How should this be tested?
Unittest included

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
