### PR TITLE
[ZEPPELIN-2105] yarn installed by frontend-maven-plugin causes build failure (BUG)

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -40,6 +40,7 @@
   <properties>
     <node.version>v6.9.1</node.version>
     <yarn.version>v0.18.1</yarn.version>
+    <npm.version>4.2.0</npm.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--plugin versions-->
@@ -112,10 +113,12 @@
             <id>install node and yarn</id>
             <goals>
               <goal>install-node-and-yarn</goal>
+              <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
               <nodeVersion>${node.version}</nodeVersion>
               <yarnVersion>${yarn.version}</yarnVersion>
+              <npmVersion>${npm.version}</npmVersion>
             </configuration>
           </execution>
 


### PR DESCRIPTION
### What is this PR for?

yarn installed by frontend-maven-plugin causes build failure **when there is no nodeJS in local system**

To reproduce this bug

- Remove system nodejs
- Execute `mvn -X clean package -pl 'zeppelin-web' -DskipTests;`

#### Details.

- yarn installed by frontend-maven-plugin can't run commands described in scripts tag (`package.json`)
- it's due to yarn uses npm when run script tags.
- so we need to npm as well

#### See also

https://github.com/apache/zeppelin/pull/2002
https://github.com/eirslett/frontend-maven-plugin/issues/562

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Rollback yarn to npm
* [x] - Update README.md for zeppelin-web

### What is the Jira issue?

[ZEPPELIN-2105](https://issues.apache.org/jira/browse/ZEPPELIN-2105)

### How should this be tested?

- Remove system nodejs
- `mvn -X clean package -pl 'zeppelin-web' -DskipTests;`


### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
