### PR TITLE
[ZEPPELIN-2114]: Adding an endpoint in NotebookRepoRestApi to reload note list

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -17,6 +17,7 @@ package org.apache.zeppelin.jdbc;
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
+import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import com.google.common.base.Throwables;
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
@@ -46,6 +48,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.apache.thrift.transport.TTransportException;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
@@ -565,6 +568,7 @@ public class JDBCInterpreter extends Interpreter {
           getJDBCConfiguration(user).saveStatement(paragraphId, statement);
 
           boolean isResultSetAvailable = statement.execute(sqlToExecute);
+          getJDBCConfiguration(user).setConnectionInDBDriverPoolSuccessful(propertyKey);
           if (isResultSetAvailable) {
             resultSet = statement.getResultSet();
 
@@ -608,21 +612,49 @@ public class JDBCInterpreter extends Interpreter {
       }
       getJDBCConfiguration(user).removeStatement(paragraphId);
     } catch (Exception e) {
-      logger.error("Cannot run " + sql, e);
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      PrintStream ps = new PrintStream(baos);
-      e.printStackTrace(ps);
-      String errorMsg = new String(baos.toByteArray(), StandardCharsets.UTF_8);
-
-      try {
-        closeDBPool(user, propertyKey);
-      } catch (SQLException e1) {
-        e1.printStackTrace();
+      if (e.getCause() instanceof TTransportException &&
+          Throwables.getStackTraceAsString(e).contains("GSS") &&
+          getJDBCConfiguration(user).isConnectionInDBDriverPoolSuccessful(propertyKey)) {
+        return reLoginFromKeytab(propertyKey, sql, interpreterContext, interpreterResult);
+      } else {
+        logger.error("Cannot run " + sql, e);
+        String errorMsg = Throwables.getStackTraceAsString(e);
+        try {
+          closeDBPool(user, propertyKey);
+        } catch (SQLException e1) {
+          logger.error("Cannot close DBPool for user, propertyKey: " + user + propertyKey, e1);
+        }
+        interpreterResult.add(errorMsg);
+        return new InterpreterResult(Code.ERROR, interpreterResult.message());
       }
-      interpreterResult.add(errorMsg);
-      return new InterpreterResult(Code.ERROR, interpreterResult.message());
     }
     return interpreterResult;
+  }
+
+  private InterpreterResult reLoginFromKeytab(String propertyKey, String sql,
+     InterpreterContext interpreterContext, InterpreterResult interpreterResult) {
+    String user = interpreterContext.getAuthenticationInfo().getUser();
+    try {
+      closeDBPool(user, propertyKey);
+    } catch (SQLException e) {
+      logger.error("Error, could not close DB pool in reLoginFromKeytab ", e);
+    }
+    UserGroupInformation.AuthenticationMethod authType =
+        JDBCSecurityImpl.getAuthtype(property);
+    if (authType.equals(KERBEROS)) {
+      try {
+        if (UserGroupInformation.isLoginKeytabBased()) {
+          UserGroupInformation.getLoginUser().reloginFromKeytab();
+        } else if (UserGroupInformation.isLoginTicketBased()) {
+          UserGroupInformation.getLoginUser().reloginFromTicketCache();
+        }
+      } catch (IOException e) {
+        logger.error("Cannot reloginFromKeytab " + sql, e);
+        interpreterResult.add(e.getMessage());
+        return new InterpreterResult(Code.ERROR, interpreterResult.message());
+      }
+    }
+    return executeSql(propertyKey, sql, interpreterContext);
   }
 
   /**

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
@@ -31,11 +31,13 @@ public class JDBCUserConfigurations {
   private final Map<String, Statement> paragraphIdStatementMap;
   private final Map<String, PoolingDriver> poolingDriverMap;
   private final HashMap<String, Properties> propertiesMap;
+  private HashMap<String, Boolean> isSuccessful;
 
   public JDBCUserConfigurations() {
     paragraphIdStatementMap = new HashMap<>();
     poolingDriverMap = new HashMap<>();
     propertiesMap = new HashMap<>();
+    isSuccessful = new HashMap<>();
   }
 
   public void initStatementMap() throws SQLException {
@@ -53,6 +55,7 @@ public class JDBCUserConfigurations {
       it.remove();
     }
     poolingDriverMap.clear();
+    isSuccessful.clear();
   }
 
   public void setPropertyMap(String key, Properties properties) {
@@ -88,13 +91,26 @@ public class JDBCUserConfigurations {
 
   public void saveDBDriverPool(String key, PoolingDriver driver) throws SQLException {
     poolingDriverMap.put(key, driver);
+    isSuccessful.put(key, false);
   }
   public PoolingDriver removeDBDriverPool(String key) throws SQLException {
+    isSuccessful.remove(key);
     return poolingDriverMap.remove(key);
   }
 
   public boolean isConnectionInDBDriverPool(String key) {
     return poolingDriverMap.containsKey(key);
+  }
+
+  public void setConnectionInDBDriverPoolSuccessful(String key) {
+    isSuccessful.put(key, true);
+  }
+
+  public boolean isConnectionInDBDriverPoolSuccessful(String key) {
+    if (isSuccessful.containsKey(key)) {
+      return isSuccessful.get(key);
+    }
+    return false;
   }
 
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -76,6 +76,18 @@ public class NotebookRepoRestApi {
   }
 
   /**
+   * Reload notebook repository
+   */
+  @GET
+  @Path("reload")
+  @ZeppelinApi
+  public Response refreshRepo(){
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    notebookWsServer.broadcastReloadedNoteList(subject, null);
+    return new JsonResponse<>(Status.OK, "", null).build();
+  }
+
+  /**
    * Update a specific note repo.
    *
    * @param message

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -76,18 +76,6 @@ public class NotebookRepoRestApi {
   }
 
   /**
-   * Reload notebook repository
-   */
-  @GET
-  @Path("reload")
-  @ZeppelinApi
-  public Response refreshRepo(){
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
-    notebookWsServer.broadcastReloadedNoteList(subject, null);
-    return new JsonResponse<>(Status.OK, "", null).build();
-  }
-
-  /**
    * Update a specific note repo.
    *
    * @param message

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
@@ -80,13 +80,16 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
     assertThat(listOfRepositories.size(), is(not(0)));
   }
+<<<<<<< HEAD
 
   @Test public void reloadRepositories() throws IOException {
-    GetMethod get = httGet("/notebook-repositories/reload");
+    GetMethod get = httpGet("/notebook-repositories/reload");
     int status = get.getStatusCode();
     get.releaseConnection();
     assertThat(status, is(200)); 
   }
+=======
+>>>>>>> parent of 064eee8... [ZEPPELIN-2114]: Adding a call in NotebookRepoRestApi to reload note
   
   @Test public void setNewDirectoryForLocalDirectory() throws IOException {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
@@ -102,7 +105,7 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     }
 
     if (StringUtils.isBlank(localVfs)) {
-      // no local VFS set...
+      // no loval VFS set...
       return;
     }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
@@ -80,6 +80,13 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
     assertThat(listOfRepositories.size(), is(not(0)));
   }
+
+  @Test public void reloadRepositories() throws IOException {
+    GetMethod get = httGet("/notebook-repositories/reload");
+    int status = get.getStatusCode();
+    get.releaseConnection();
+    assertThat(status, is(200)); 
+  }
   
   @Test public void setNewDirectoryForLocalDirectory() throws IOException {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
@@ -95,7 +102,7 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     }
 
     if (StringUtils.isBlank(localVfs)) {
-      // no loval VFS set...
+      // no local VFS set...
       return;
     }
 


### PR DESCRIPTION
### What is this PR for?
Adding endpoint in NotebookRepoRestApi to trigger reload and broadcast of the note list.
Sending a GET request to /api/notebook-repositories/reload will trigger a reload of the note list, just like the reload button does on the homepage.
Q: If you think this endpoint belongs to another API (NotebookRestApi?), let me know.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
<https://issues.apache.org/jira/browse/ZEPPELIN-2114>

### How should this be tested?
0. add (or remove) a note in the notebook repository
1. curl -x GET http://HOST:PORT/api/notebook-repository/reload
2. verify that you the note list in Zeppelin's home page now contains (or does not contain anymore) the note.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NotebookRepoRestApi does not have documentation yet. Could add it in another PR if needed.
