### PR TITLE
[ZEPPELIN-2117] jdbc autocomplete for exasol database

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -202,7 +202,7 @@ public class JDBCInterpreter extends Interpreter {
   private SqlCompleter createSqlCompleter(Connection jdbcConnection) {
 
     SqlCompleter completer = new SqlCompleter();
-    completer.initFromConnection(jdbcConnection, "");
+    completer.initFromConnection(jdbcConnection, "%");
     return completer;
   }
 


### PR DESCRIPTION
### What is this PR for?
Adds support for jdbc autocompletion for exasol database. W/o this PR for exasol there'are no tables in schemas in autocompletion.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2117

### How should this be tested?
try "select * from <schema_name>. " for exasol jdbc connection

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
