### PR TITLE
[ZEPPELIN-2116]. livy interpreter needs to restart after previous session timeout in secured cluster

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -413,7 +413,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       // Exception happens when kerberos is enabled.
       if (e.getCause() instanceof HttpClientErrorException) {
         HttpClientErrorException cause = (HttpClientErrorException) e.getCause();
-        if (cause.getMessage().matches(SessionNotFound_Pattern)) {
+        if (cause.getResponseBodyAsString().matches(SessionNotFound_Pattern)) {
           throw new SessionNotFoundException(cause.getResponseBodyAsString());
         }
       }

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.kerberos.client.KerberosRestTemplate;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
@@ -407,6 +408,13 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       response = new ResponseEntity(e.getResponseBodyAsString(), e.getStatusCode());
       LOGGER.error(String.format("Error with %s StatusCode: %s",
           response.getStatusCode().value(), e.getResponseBodyAsString()));
+    } catch (RestClientException e) {
+      // Exception happens when kerberos is enabled.
+      if (e.getMessage().contains("404 Not Found")) {
+        throw new SessionNotFoundException("Session not found when kerberos is enabled ");
+      } else {
+        throw new LivyException(e);
+      }
     }
     if (response == null) {
       throw new LivyException("No http response returned");

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -47,7 +47,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterprereter.class);
   private static Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-  private static String SessionNotFound_Pattern = "\"Session '\\d+' not found.\"";
+  private static String SESSION_NOT_FOUND_PATTERN = "\"Session '\\d+' not found.\"";
 
   protected volatile SessionInfo sessionInfo;
   private String livyURL;
@@ -413,7 +413,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       // Exception happens when kerberos is enabled.
       if (e.getCause() instanceof HttpClientErrorException) {
         HttpClientErrorException cause = (HttpClientErrorException) e.getCause();
-        if (cause.getResponseBodyAsString().matches(SessionNotFound_Pattern)) {
+        if (cause.getResponseBodyAsString().matches(SESSION_NOT_FOUND_PATTERN)) {
           throw new SessionNotFoundException(cause.getResponseBodyAsString());
         }
       }
@@ -428,7 +428,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
         || response.getStatusCode().value() == 201) {
       return response.getBody();
     } else if (response.getStatusCode().value() == 404) {
-      if (response.getBody().matches(SessionNotFound_Pattern)) {
+      if (response.getBody().matches(SESSION_NOT_FOUND_PATTERN)) {
         throw new SessionNotFoundException(response.getBody());
       } else {
         throw new APINotFoundException("No rest api found for " + targetURL +


### PR DESCRIPTION
What is this PR for?

It throw different exception in secured cluster. This PR fix the issue in secured cluster

What type of PR is it?

[Bug Fix]

Todos

 - Task
What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-2116
How should this be tested?

Tested manually.

Questions:

Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? no