### PR TITLE
[ZEPPELIN-2114]: adding reload endpoint + fixing test

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -76,6 +76,18 @@ public class NotebookRepoRestApi {
   }
 
   /**
+   * Reload notebook repository
+   */
+  @GET
+  @Path("reload")
+  @ZeppelinApi
+  public Response refreshRepo(){
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    notebookWsServer.broadcastReloadedNoteList(subject, null);
+    return new JsonResponse<>(Status.OK, "", null).build();
+  }
+
+  /**
    * Update a specific note repo.
    *
    * @param message

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRepoRestApiTest.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.rest;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -80,6 +81,13 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
     assertThat(listOfRepositories.size(), is(not(0)));
   }
+
+  @Test public void reloadRepositories() throws IOException {
+    GetMethod get = httpGet("/notebook-repositories/reload");
+    int status = get.getStatusCode();
+    get.releaseConnection();
+    assertThat(status, is(200)); 
+  }
   
   @Test public void setNewDirectoryForLocalDirectory() throws IOException {
     List<Map<String, Object>> listOfRepositories = getListOfReposotiry();
@@ -95,7 +103,7 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
     }
 
     if (StringUtils.isBlank(localVfs)) {
-      // no loval VFS set...
+      // no local VFS set...
       return;
     }
 
@@ -111,7 +119,7 @@ public class NotebookRepoRestApiTest extends AbstractTestRestApi {
         break;
       }
     }
-    assertThat(updatedPath, is("/tmp/newDir"));
+    assertThat(updatedPath, anyOf(is("/tmp/newDir"),is("/tmp/newDir/")));
     
     // go back to normal
     payload = "{ \"name\": \"" + className + "\", \"settings\" : { \"Notebook Path\" : \"" + localVfs + "\" } }";


### PR DESCRIPTION
### What is this PR for?
Adding endpoint in NotebookRepoRestApi to trigger reload and broadcast of the note list.
Sending a GET request to /api/notebook-repositories/reload will trigger a reload of the note list, just like the reload button does on the homepage.
Q: If you think this endpoint belongs to another API (NotebookRestApi?), let me know.

### What type of PR is it?
Improvement

### Todos


### What is the Jira issue?
<https://issues.apache.org/jira/browse/ZEPPELIN-2114>

### How should this be tested?
0. add (or remove) a note in the notebook repository
1. curl -X GET http://HOST:PORT/api/notebook-repository/reload
2. verify that you the note list in Zeppelin's home page now contains (or does not contain anymore) the note.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NotebookRepoRestApi does not have documentation yet. Could add it in another PR if needed.
