### PR TITLE
ZEPPELIN-2108. Livy interpreter job cancellation throws NPE

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -299,8 +299,14 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
   private InterpreterResult getResultFromStatementInfo(StatementInfo stmtInfo,
                                                        boolean displayAppInfo) {
-    if (stmtInfo.output.isError()) {
+    if (stmtInfo.output != null && stmtInfo.output.isError()) {
       return new InterpreterResult(InterpreterResult.Code.ERROR, stmtInfo.output.evalue);
+    } else if (stmtInfo.isCancelled()) {
+      // corner case, output might be null if it is cancelled.
+      return new InterpreterResult(InterpreterResult.Code.ERROR, "Job is cancelled");
+    } else if (stmtInfo.output == null) {
+      // This case should never happen, just in case
+      return new InterpreterResult(InterpreterResult.Code.ERROR, "Empty output");
     } else {
       //TODO(zjffdu) support other types of data (like json, image and etc)
       String result = stmtInfo.output.data.plain_text;
@@ -531,6 +537,10 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
     public boolean isAvailable() {
       return state.equals("available") || state.equals("cancelled");
+    }
+
+    public boolean isCancelled() {
+      return state.equals("cancelled");
     }
 
     private static class StatementOutput {


### PR DESCRIPTION
### What is this PR for?
It happens in some corner cases where output is null when statement is cancelled. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2108

### How should this be tested?
Tested manually
![livy_cancelled](https://cloud.githubusercontent.com/assets/164491/23003509/2fb0fc9c-f42c-11e6-8cba-ae654a4e5c08.png)
. 

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
