### PR TITLE
[ZEPPELIN-791] Build infra: move all RAT to root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -899,6 +899,36 @@
               <exclude>**/constants.json</exclude>
               <exclude>scripts/**</exclude>
 
+              <!-- bundled from zeppelin-web -->
+              <exclude>**/test/karma.conf.js</exclude>
+              <exclude>**/test/spec/**</exclude>     
+              <exclude>**/.babelrc</exclude>
+              <exclude>**/.bowerrc</exclude>
+              <exclude>.editorconfig</exclude>
+              <exclude>.eslintrc</exclude>
+              <exclude>**/.tmp/**</exclude>
+              <exclude>**/target/**</exclude>
+              <exclude>**/node/**</exclude>
+              <exclude>**/node_modules/**</exclude>
+              <exclude>**/bower_components/**</exclude>
+              <exclude>**/dist/**</exclude>
+              <exclude>**/.buildignore</exclude>
+              <exclude>**/.npmignore</exclude>
+              <exclude>**/.jshintrc</exclude>
+              <exclude>**/yarn.lock</exclude>
+              <exclude>**/bower.json</exclude>
+              <exclude>**/src/fonts/Patua-One*</exclude>
+              <exclude>**/src/fonts/patua-one*</exclude>
+              <exclude>**/src/fonts/Roboto*</exclude>
+              <exclude>**/src/fonts/roboto*</exclude>
+              <exclude>**src/fonts/fontawesome*</exclude>
+              <exclude>**src/fonts/font-awesome*</exclude>
+              <exclude>**src/styles/font-awesome*</exclude>
+              <exclude>**src/fonts/Simple-Line*</exclude>
+              <exclude>**src/fonts/simple-line*</exclude>
+              <exclude>**src/fonts/Source-Code-Pro*</exclude>
+              <exclude>**src/fonts/source-code-pro*</exclude>
+
               <!-- bundled from bootstrap -->
               <exclude>docs/assets/themes/zeppelin/bootstrap/**</exclude>
               <exclude>docs/assets/themes/zeppelin/css/style.css</exclude>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -58,51 +58,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/.idea/</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>.git/</exclude>
-            <exclude>.gitignore</exclude>
-            <exclude>.babelrc</exclude>
-            <exclude>.bowerrc</exclude>
-            <exclude>.editorconfig</exclude>
-            <exclude>.jscsrc</exclude>
-            <exclude>.eslintrc</exclude>
-            <exclude>.tmp/**</exclude>
-            <exclude>**/.settings/*</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/.project</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>node/**</exclude>
-            <exclude>node_modules/**</exclude>
-            <exclude>bower_components/**</exclude>
-            <exclude>test/**</exclude>
-            <exclude>dist/**</exclude>
-            <exclude>src/.buildignore</exclude>
-            <exclude>src/fonts/fontawesome*</exclude>
-            <exclude>src/fonts/font-awesome*</exclude>
-            <exclude>src/styles/font-awesome*</exclude>
-            <exclude>src/fonts/Simple-Line*</exclude>
-            <exclude>src/fonts/simple-line*</exclude>
-            <exclude>src/fonts/Patua-One*</exclude>
-            <exclude>src/fonts/patua-one*</exclude>
-            <exclude>src/fonts/Roboto*</exclude>
-            <exclude>src/fonts/roboto*</exclude>
-            <exclude>src/fonts/Source-Code-Pro*</exclude>
-            <exclude>src/fonts/source-code-pro*</exclude>
-            <exclude>bower.json</exclude>
-            <exclude>**/package.json</exclude>
-            <exclude>**/.npmignore</exclude>
-            <exclude>yarn.lock</exclude>
-            <exclude>*.md</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${plugin.frontned.version}</version>


### PR DESCRIPTION
### What is this PR for?
It is better have a single place where we manage project-wise RAT exclusions for a contributions under licenses different from Apache, then let maven sub-modules have them as we do now (makes things harder to track) 


### What type of PR is it?
[Improvement]

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-791

### How should this be tested?
mvn verify -DskipTests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
