### PR TITLE
[MINOR] Supported old note format in case of not having name of note

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -144,7 +144,10 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public String getName() {
-    return isNameEmpty() ? getId() : name;
+    if (isNameEmpty()) {
+      name = getId();
+    }
+    return name;
   }
 
   public String getNameWithoutPath() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -144,7 +144,7 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public String getName() {
-    return name;
+    return isNameEmpty() ? getId() : name;
   }
 
   public String getNameWithoutPath() {
@@ -181,7 +181,7 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public boolean isNameEmpty() {
-    return getName().trim().isEmpty();
+    return this.name.trim().isEmpty();
   }
 
   private String normalizeNoteName(String name) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -203,4 +203,11 @@ public class NoteTest {
     note.setName(Folder.TRASH_FOLDER_ID + "/a/b/c");
     assertTrue(note.isTrash());
   }
+
+  @Test
+  public void getNameWithoutNameItself() {
+    Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
+
+    assertEquals("getName should return same as getId when name is empty", note.getId(), note.getName());
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Supporting old format of note which doesn't have name inside. Long time ago, when creating note without specific name, name field become empty string. but it become error while remove note for current master. It will fix this error


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Enable getName returns getId if it has empty value

### What is the Jira issue?
N/A

### How should this be tested?
See the test added

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
