### PR TITLE
[MINOR] Improve travis_check.py script

### DIFF
--- a/travis_check.py
+++ b/travis_check.py
@@ -17,6 +17,18 @@
 #
 # This script checks build status of given pullrequest identified by author and commit hash.
 #
+# usage)
+#   python travis_check.py [author] [commit hash] [check interval (optional)]
+#
+# example)
+#   # full hash
+#   python travis_check.py Leemoonsoo 1f2549a38f440ebfbfe2d32a041684e3e39b496c
+#
+#   # with short hash
+#   python travis_check.py Leemoonsoo 1f2549a
+#
+#   # with custom check interval
+#   python travis_check.py Leemoonsoo 1f2549a 5,60,60
 
 import os, sys, getopt, traceback, json, requests, time
 
@@ -25,6 +37,9 @@ commit = sys.argv[2]
 
 # check interval in sec
 check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300, 600, 600, 600, 600, 600, 600]
+
+if len(sys.argv) > 3:
+    check = map(lambda x: int(x), sys.argv[3].split(","))
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)

--- a/travis_check.py
+++ b/travis_check.py
@@ -28,7 +28,7 @@ check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
-
+    sys.stdout.flush()
 
 info("Author: " + author + ", commit: " + commit)
 

--- a/travis_check.py
+++ b/travis_check.py
@@ -64,12 +64,12 @@ def getBuildStatus(author, commit):
 
     return build
 
+def status(index, msg, jobId):
+    return '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
 
 def printBuildStatus(build):
     failure = 0
     running = 0
-
-    status = lambda idx, msg, jobId: '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
 
     for index, job in enumerate(build["matrix"]):
         result = job["result"]
@@ -97,7 +97,6 @@ def printBuildStatus(build):
     return failure, running
 
 
-
 for sleep in check:
     info("--------------------------------")
     time.sleep(sleep);
@@ -110,7 +109,7 @@ for sleep in check:
     print("Build https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
     failure, running = printBuildStatus(build)
 
-    print(str(failure) + " job(s) failed, " + str(running) + " job(s) running")
+    print(str(failure) + " job(s) failed, " + str(running) + " job(s) running/pending")
 
     if failure != 0:
         sys.exit(1)

--- a/travis_check.py
+++ b/travis_check.py
@@ -24,7 +24,7 @@ author = sys.argv[1]
 commit = sys.argv[2]
 
 # check interval in sec
-check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
+check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300, 600, 600, 600, 600, 600, 600]
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
@@ -53,25 +53,30 @@ def getBuildStatus(author, commit):
 def printBuildStatus(build):
     failure = 0
     running = 0
+
+    status = lambda idx, msg, jobId: '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
+
     for index, job in enumerate(build["matrix"]):
         result = job["result"]
+        jobId = job["id"]
+
         if job["started_at"] == None and result == None:
-            print("[" + str(index+1) + "] Not started")
+            print(status(index, "Not started", jobId))
             running = running + 1
         elif job["started_at"] != None and job["finished_at"] == None:
-            print("[" + str(index+1) + "] Running ...")
+            print(status(index, "Running ...", jobId))
             running = running + 1
         elif job["started_at"] != None and job["finished_at"] != None:
             if result == None:
-                print("[" + str(index+1) + "] Not completed")
+                print(status(index, "Not completed", jobId))
                 failure = failure + 1
             elif result == 0:
-                print("[" + str(index+1) + "] OK")
+                print(status(index, "OK", jobId))
             else:
-                print("[" + str(index+1) + "] Error " + str(result))
+                print(status(index, "Error " + str(result), jobId))
                 failure = failure + 1
         else:
-            print("[" + str(index+1) + "] Unknown state")
+            print(status(index, "Unknown state", jobId))
             failure = failure + 1
 
     return failure, running
@@ -87,7 +92,7 @@ for sleep in check:
         info("Can't find build for commit= " + commit)
         sys.exit(1)
 
-    print("https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
+    print("Build https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
     failure, running = printBuildStatus(build)
 
     print(str(failure) + " job(s) failed, " + str(running) + " job(s) running")


### PR DESCRIPTION
### What is this PR for?
Now travis_check.py script ran by Jenkins in each pullrequest.
In Jenkins output console, outputs are displayed after script return.
This small patch try flush output, so Jenkins output console can display output while script is running.

Also increase check polling up to 2 hours while contributors travis might be busy.

And print link to individual job for convenience.


### What type of PR is it?
Improvement

### Todos
* [x] - flush output
* [x] - increase number of check up to about 2 hours
* [x] - print url link to individual job

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2123

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
