### PR TITLE
[ZEPPELIN-791] Build infra: move all RAT to root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -900,8 +900,8 @@
               <exclude>scripts/**</exclude>
               <exclude>**/**/*.log</exclude>
               <exclude>**/**/logs/**</exclude>
-              
-              <!-- bundled from zeppelin-web module -->
+                           
+              <!-- bundled from zeppelin-web -->
               <exclude>**/test/karma.conf.js</exclude>
               <exclude>**/test/spec/**</exclude>     
               <exclude>**/.babelrc</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
               <exclude>**/**/*.log</exclude>
               <exclude>**/**/logs/**</exclude>
               
-              <!-- bundled from zeppelin-web -->
+              <!-- bundled from zeppelin-web module -->
               <exclude>**/test/karma.conf.js</exclude>
               <exclude>**/test/spec/**</exclude>     
               <exclude>**/.babelrc</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -898,6 +898,38 @@
               <exclude>**/interpreter-setting.json</exclude>
               <exclude>**/constants.json</exclude>
               <exclude>scripts/**</exclude>
+              <exclude>**/**/*.log</exclude>
+              <exclude>**/**/logs/**</exclude>
+              
+              <!-- bundled from zeppelin-web -->
+              <exclude>**/test/karma.conf.js</exclude>
+              <exclude>**/test/spec/**</exclude>     
+              <exclude>**/.babelrc</exclude>
+              <exclude>**/.bowerrc</exclude>
+              <exclude>.editorconfig</exclude>
+              <exclude>.eslintrc</exclude>
+              <exclude>**/.tmp/**</exclude>
+              <exclude>**/target/**</exclude>
+              <exclude>**/node/**</exclude>
+              <exclude>**/node_modules/**</exclude>
+              <exclude>**/bower_components/**</exclude>
+              <exclude>**/dist/**</exclude>
+              <exclude>**/.buildignore</exclude>
+              <exclude>**/.npmignore</exclude>
+              <exclude>**/.jshintrc</exclude>
+              <exclude>**/yarn.lock</exclude>
+              <exclude>**/bower.json</exclude>
+              <exclude>**/src/fonts/Patua-One*</exclude>
+              <exclude>**/src/fonts/patua-one*</exclude>
+              <exclude>**/src/fonts/Roboto*</exclude>
+              <exclude>**/src/fonts/roboto*</exclude>
+              <exclude>**/src/fonts/fontawesome*</exclude>
+              <exclude>**/src/fonts/font-awesome*</exclude>
+              <exclude>**/src/styles/font-awesome*</exclude>
+              <exclude>**/src/fonts/Simple-Line*</exclude>
+              <exclude>**/src/fonts/simple-line*</exclude>
+              <exclude>**/src/fonts/Source-Code-Pro*</exclude>
+              <exclude>**/src/fonts/source-code-pro*</exclude>
 
               <!-- from SQLLine 1.0.2, see ZEPPELIN-2135 -->
               <exclude>**/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java</exclude>
@@ -947,22 +979,22 @@
               <exclude>**/package.json</exclude>
 
               <!-- compiled R packages (binaries) -->
-              <exclude>R/lib/**</exclude>
+              <exclude>**/R/lib/**</exclude>
               <exclude>r/lib/**</exclude>
 
               <!--R-related files with alternative licenses-->
-              <exclude>r/R/rzeppelin/R/globals.R</exclude>
-              <exclude>r/R/rzeppelin/R/common.R</exclude>
-              <exclude>r/R/rzeppelin/R/protocol.R</exclude>
-              <exclude>r/R/rzeppelin/R/rServer.R</exclude>
-              <exclude>r/R/rzeppelin/R/scalaInterpreter.R</exclude>
-              <exclude>r/R/rzeppelin/R/zzz.R</exclude>
-              <exclude>r/src/main/scala/scala/Console.scala</exclude>
-              <exclude>r/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/Package.scala</exclude>
-              <exclude>r/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/RClient.scala</exclude>
+              <exclude>**/R/rzeppelin/R/globals.R</exclude>
+              <exclude>**/R/rzeppelin/R/common.R</exclude>
+              <exclude>**/R/rzeppelin/R/protocol.R</exclude>
+              <exclude>**/R/rzeppelin/R/rServer.R</exclude>
+              <exclude>**/R/rzeppelin/R/scalaInterpreter.R</exclude>
+              <exclude>**/R/rzeppelin/R/zzz.R</exclude>
+              <exclude>**/src/main/scala/scala/Console.scala</exclude>
+              <exclude>**/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/Package.scala</exclude>
+              <exclude>**/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/RClient.scala</exclude>
               <!--The following files are mechanical-->
-              <exclude>r/R/rzeppelin/DESCRIPTION</exclude>
-              <exclude>r/R/rzeppelin/NAMESPACE</exclude>
+              <exclude>**/R/rzeppelin/DESCRIPTION</exclude>
+              <exclude>**/R/rzeppelin/NAMESPACE</exclude>
             </excludes>
           </configuration>
 

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -190,43 +190,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>lib/**</exclude>
-            <exclude>**/r/lib/**</exclude>
-            <!--The following files are subject to the BSD-license or variants,
-            as shown in the file headers-->
-            <exclude>**/R/rzeppelin/R/globals.R</exclude>
-            <exclude>**/R/rzeppelin/R/common.R</exclude>
-            <exclude>**/R/rzeppelin/R/protocol.R</exclude>
-            <exclude>**/R/rzeppelin/R/rServer.R</exclude>
-            <exclude>**/R/rzeppelin/R/scalaInterpreter.R</exclude>
-            <exclude>**/R/rzeppelin/R/zzz.R</exclude>
-            <exclude>**/scala/Console.scala</exclude>
-            <exclude>**/zeppelin/rinterpreter/rscala/Package.scala</exclude>
-            <exclude>**/zeppelin/rinterpreter/rscala/RClient.scala</exclude>
-            <!--End of files subject to BSD-license.-->
-            <exclude>**/.idea/</exclude>
-            <!--The following files are mechanical-->
-            <exclude>**/R/rzeppelin/DESCRIPTION</exclude>
-            <exclude>**/R/rzeppelin/NAMESPACE</exclude>
-            <!--End of mechanical R files-->
-            <exclude>**/*.iml</exclude>
-            <exclude>.gitignore</exclude>
-            <exclude>**/.settings/*</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/.project</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>**/derby.log</exclude>
-            <exclude>**/metastore_db/</exclude>
-            <exclude>**/README.md</exclude>
-            <exclude>**/dependency-reduced-pom.xml</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -59,51 +59,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/.idea/</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>.git/</exclude>
-            <exclude>.gitignore</exclude>
-            <exclude>.babelrc</exclude>
-            <exclude>.bowerrc</exclude>
-            <exclude>.editorconfig</exclude>
-            <exclude>.jscsrc</exclude>
-            <exclude>.eslintrc</exclude>
-            <exclude>.tmp/**</exclude>
-            <exclude>**/.settings/*</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/.project</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>node/**</exclude>
-            <exclude>node_modules/**</exclude>
-            <exclude>bower_components/**</exclude>
-            <exclude>test/**</exclude>
-            <exclude>dist/**</exclude>
-            <exclude>src/.buildignore</exclude>
-            <exclude>src/fonts/fontawesome*</exclude>
-            <exclude>src/fonts/font-awesome*</exclude>
-            <exclude>src/styles/font-awesome*</exclude>
-            <exclude>src/fonts/Simple-Line*</exclude>
-            <exclude>src/fonts/simple-line*</exclude>
-            <exclude>src/fonts/Patua-One*</exclude>
-            <exclude>src/fonts/patua-one*</exclude>
-            <exclude>src/fonts/Roboto*</exclude>
-            <exclude>src/fonts/roboto*</exclude>
-            <exclude>src/fonts/Source-Code-Pro*</exclude>
-            <exclude>src/fonts/source-code-pro*</exclude>
-            <exclude>bower.json</exclude>
-            <exclude>**/package.json</exclude>
-            <exclude>**/.npmignore</exclude>
-            <exclude>yarn.lock</exclude>
-            <exclude>*.md</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${plugin.frontned.version}</version>


### PR DESCRIPTION
What is this PR for?

It is better have a single place where we manage project-wise RAT exclusions for a contributions under licenses different from Apache, then let maven sub-modules have them as we do now (makes things harder to track)
What type of PR is it?

[Improvement]
Todos

N/A
What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-791
How should this be tested?

mvn verify -DskipTests
Screenshots (if appropriate)
Questions:

    Does the licenses files need update? - No
    Is there breaking changes for older versions? - No
    Does this needs documentation? - No