### PR TITLE
[ZEPPELIN-2129] [HOTFIX] Flaky test - PySparkInterpreterTest

### DIFF
--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -35,7 +35,7 @@ fi
 
 # Install Python dependencies for Python specific tests
 if [[ -n "$PYTHON" ]] ; then
-  wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-latest-Linux-x86_64.sh -O miniconda.sh
+  wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-4.2.12-Linux-x86_64.sh -O miniconda.sh
   bash miniconda.sh -b -p $HOME/miniconda
   echo "export PATH='$HOME/miniconda/bin:$PATH'" >> ~/.environ
   source ~/.environ


### PR DESCRIPTION
### What is this PR for?
testing/install_external_dependencies.sh installs latest version of miniconda for python/pyspark testing.

It looks like miniconda just released new version and latest version of miniconda3 looks like using python 3.6.
And pyspark has problem with python 3.6 https://issues.apache.org/jira/browse/SPARK-19019.

This PR fix the miniconda version to previous one.

### What type of PR is it?
Hot Fix

### Todos
* [x] - force fix miniconda version

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2129

### How should this be tested?
CI gree

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
