### PR TITLE
[ZEPPELIN-2049 : z0.7.1] Note name is gone when switch to personal mode

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -715,6 +715,7 @@ public class Note implements Serializable, ParagraphJobListener {
    */
   public Note getUserNote(String user) {
     Note newNote = new Note();
+    newNote.name = getName();
     newNote.id = getId();
     newNote.config = getConfig();
     newNote.angularObjects = getAngularObjects();


### PR DESCRIPTION
### What is this PR for?
Note name is gone when switch to personal mode
There was a part of the note name that was missing processing.
So, I fixed it.


### What type of PR is it?
Bug Fix - 0.7.1 related

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2049

### How should this be tested?
You can personalized mode.
and then plase refresh note view.
and check to note name.

### Screenshots (if appropriate)
#### before(problem)
![screenshot](https://issues.apache.org/jira/secure/attachment/12850799/record.gif)

#### after (resolved)
![personal](https://cloud.githubusercontent.com/assets/10525473/23093214/31f0b0a6-f620-11e6-89ce-fabafa7c0000.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
