### PR TITLE
[ZEPPELIN-2135] Don't re-license jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -271,7 +271,7 @@ The following components are provided under the BSD 3-Clause license.  See file 
 ========================================================================
 BSD 2-Clause licenses
 ========================================================================
-The following components are provided under the BSD 3-Clause license.  See file headers and project links for details.
+The following components are provided under the BSD 2-Clause license.  See file headers and project links for details.
 
   (BSD 2 Clause) portions of SQLLine (http://sqlline.sourceforge.net/) - http://sqlline.sourceforge.net/#license
    jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -1,17 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
 package org.apache.zeppelin.jdbc;
 
 /*

--- a/pom.xml
+++ b/pom.xml
@@ -898,6 +898,8 @@
               <exclude>**/interpreter-setting.json</exclude>
               <exclude>**/constants.json</exclude>
               <exclude>scripts/**</exclude>
+
+              <!-- from SQLLine 1.0.2, see ZEPPELIN-2135 -->
               <exclude>**/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java</exclude>
 
               <!-- bundled from bootstrap -->

--- a/pom.xml
+++ b/pom.xml
@@ -898,6 +898,7 @@
               <exclude>**/interpreter-setting.json</exclude>
               <exclude>**/constants.json</exclude>
               <exclude>scripts/**</exclude>
+              <exclude>**/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java</exclude>
 
               <!-- bundled from bootstrap -->
               <exclude>docs/assets/themes/zeppelin/bootstrap/**</exclude>


### PR DESCRIPTION
### What is this PR for?
jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java is taken from SQLLine 1.0.2 (BSD license) and we can't relicense it.

Remove Apache License header and exclude from RAT check plugin

### What type of PR is it?
Bug Fix

### Todos
* [x] - remove license header
* [x] - exclude from rat check plugin

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2135

### Questions:
* Does the licenses files need update? related
* Is there breaking changes for older versions? no
* Does this needs documentation? no
