### PR TITLE
[ZEPPELIN-1588]: bumping nvd3 to 1.8.5

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -17,7 +17,7 @@
     "ace-builds": "1.2.6",
     "angular-ui-ace": "0.1.3",
     "jquery.scrollTo": "~1.4.13",
-    "nvd3": "~1.7.1",
+    "nvd3": "~1.8.5",
     "angular-dragdrop": "~1.0.8",
     "perfect-scrollbar": "~0.5.4",
     "ng-sortable": "~1.3.3",

--- a/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
@@ -60,7 +60,7 @@ export default class AreachartVisualization extends Nvd3ChartVisualization {
   configureChart(chart) {
     var self = this;
     chart.xAxis.tickFormat(function(d) {return self.xAxisTickFormat(d, self.xLabels);});
-    chart.yAxisTickFormat(function(d) {return self.yAxisTickFormat(d);});
+    chart.yAxis.tickFormat(function(d) {return self.yAxisTickFormat(d);});
     chart.yAxis.axisLabelDistance(50);
     chart.useInteractiveGuideline(true); // for better UX and performance issue. (https://github.com/novus/nvd3/issues/691)
 

--- a/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
@@ -21,7 +21,6 @@ import PivotTransformation from '../../tabledata/pivot';
 export default class PiechartVisualization extends Nvd3ChartVisualization {
   constructor(targetEl, config) {
     super(targetEl, config);
-
     this.pivot = new PivotTransformation(config);
   };
 
@@ -43,7 +42,6 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
       true,
       false,
       false);
-
     var d = d3Data.d3g;
     var d3g = [];
     if (d.length > 0) {
@@ -67,6 +65,9 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
   };
 
   configureChart(chart) {
-    chart.x(function(d) { return d.label;}).y(function(d) { return d.value;});
+    chart.x(function(d) { return d.label;})
+	 .y(function(d) { return d.value;})
+	 .showLabels(false)
+	 .showTooltipPercent(true);
   };
 }

--- a/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
@@ -70,16 +70,15 @@ export default class ScatterchartVisualization extends Nvd3ChartVisualization {
     chart.yAxis.tickFormat(function(d) {return self.yAxisTickFormat(d, self.yLabels);});
 
     // configure how the tooltip looks.
-    chart.tooltipContent(function(key, x, y, graph, data) {
-      var tooltipContent = '<h3>' + key + '</h3>';
-      if (self.config.size &&
-        self.isValidSizeOption(self.config, self.tableData.rows)) {
-        tooltipContent += '<p>' + data.point.size + '</p>';
-      }
-
+  /*  chart.tooltip.contentGenerator(function(d) {
+      var tooltipContent = '<h3>' + d.value + '</h3>';
+      d.series.forEach(function(elem){
+        tooltipContent += '<p>'+elem.key+':<b>'
+                       +elem.value+'</b></p>';
+      })
       return tooltipContent;
     });
-
+  */
     chart.showDistX(true).showDistY(true);
     //handle the problem of tooltip not showing when muliple points have same value.
   };


### PR DESCRIPTION
### What is this PR for?
* bump nvd3 to 1.8.5 (and remove depecrated functions)
* display percentage in pie chart [solve ZEPPELIN-1891]

NB: visualization-scatterchart.js's tooltip content generator has been updated to stop using depecrated tooltip property and use tooltip.contentGenerator instead. However I have commented the code as I think nvd3 scatterchart's default tooltip is far more elegant, open to discussion.

### What type of PR is it?
Improvement

### Todos
* [ ] - 

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-1588>
* <https://issues.apache.org/jira/browse/ZEPPELIN-1891>

### How should this be tested?
Visual testing of the builtin visualization.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
