### PR TITLE
[ZEPPELIN-2112] Disable keyboard shortcut in "Link this paragraph" URL on 0.7.0 version

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -29,7 +29,6 @@ body {
 
 .bodyAsIframe {
   padding-top: 20px;
-  padding-left: 10px;
   background: white;
 }
 

--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -28,6 +28,8 @@ body {
 }
 
 .bodyAsIframe {
+  padding-top: 20px;
+  padding-left: 10px;
   background: white;
 }
 

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -82,7 +82,7 @@ limitations under the License.
        ng-controller="ParagraphCtrl"
        ng-init="init(currentParagraph, home.note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       class="paragraph-col">
+       style="margin: 0; padding: 0;">
     <div id="{{currentParagraph.id}}_paragraphColumn"
          ng-if="currentParagraph.results"
          ng-include src="'app/notebook/paragraph/paragraph.html'"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -993,14 +993,16 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
       $location.path('/');
     }
 
+    $scope.note = note;
+
     $scope.paragraphUrl = $routeParams.paragraphId;
     $scope.asIframe = $routeParams.asIframe;
     if ($scope.paragraphUrl) {
-      note = cleanParagraphExcept($scope.paragraphUrl, note);
+      $scope.note = cleanParagraphExcept($scope.paragraphUrl, note);
+      $scope.$broadcast('$unBindKeyEvent', $scope.$unBindKeyEvent);
       $rootScope.$broadcast('setIframe', $scope.asIframe);
     }
 
-    $scope.note = note;
     initializeLookAndFeel();
     //open interpreter binding setting when there're none selected
     getInterpreterBindings();
@@ -1015,6 +1017,11 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     $scope.killSaveTimer();
     $scope.saveNote();
 
+    document.removeEventListener('click', $scope.focusParagraphOnClick);
+    document.removeEventListener('keydown', $scope.keyboardShortcut);
+  });
+
+  $scope.$on('$unBindKeyEvent', function() {
     document.removeEventListener('click', $scope.focusParagraphOnClick);
     document.removeEventListener('keydown', $scope.keyboardShortcut);
   });

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -58,12 +58,12 @@
   padding-left: 3px !important;
 }
 
-/*
+
 .paragraph-col {
   margin: 0;
   padding: 0;
 }
-*/
+
 .paragraph {
   padding: 2px 8px 4px 8px;
   min-height: 32px;

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -58,7 +58,6 @@
   padding-left: 3px !important;
 }
 
-
 .paragraph-col {
   margin: 0;
   padding: 0;

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -58,11 +58,12 @@
   padding-left: 3px !important;
 }
 
+/*
 .paragraph-col {
   margin: 0;
   padding: 0;
 }
-
+*/
 .paragraph {
   padding: 2px 8px 4px 8px;
   min-height: 32px;

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -112,7 +112,7 @@ limitations under the License.
        ng-controller="ParagraphCtrl"
        ng-init="init(currentParagraph, note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       class="paragraph-col">
+       style="margin: 0; padding: 0;">
     <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe || revisionView">
       <h4 class="plus-sign">&#43;</h4>
     </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -114,7 +114,7 @@ table.dataTable.table-condensed .sorting_desc:after {
 .paragraphAsIframe {
   padding: 0;
   margin-top: -79px;
-  margin-left: -10px;
+  margin-left: 0px;
   margin-right: -10px;
 }
 
@@ -146,12 +146,21 @@ table.dataTable.table-condensed .sorting_desc:after {
   display: block;
   unicode-bidi: embed;
   display: block !important;
-  margin: 0 0 10px!important;
+  margin-top: 0;
+  margin-left: 10px;
   font-size: 12px!important;
   line-height: 1.42857143!important;
   word-break: break-all!important;
   word-wrap: break-word!important;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+}
+
+.paragraphAsIframe .title {
+  width: 80%;
+  font-weight: bold;
+  font-family: 'Roboto', sans-serif;
+  font-size: 17px !important;
+  margin: 0 10px !important;
 }
 
 /*


### PR DESCRIPTION
### What is this PR for?
If using a `Link this paragraph`, new window works the keyboard shortcut on the 0.7.0 version.
So that this is the keyboard shortcut should not work in `Link this paragraph` URL on branch-0.7.

Also, I remove border and margin of paragraph in new window of "Link this paragraph". this would be more useful.

This issue is related to [ZEPPELIN-1808](https://issues.apache.org/jira/browse/ZEPPELIN-1808) and this [comment](https://github.com/apache/zeppelin/pull/1983#issuecomment-279395050) suggestion by @Leemoonsoo. 


### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [x] - Disable keyboard shortcut in new window of "Link this paragraph" on 0.7.0 version
* [x] - Fix layout about border and margin in paragraph website

### What is the Jira issue?
* [ZEPPELIN-2112](https://issues.apache.org/jira/browse/ZEPPELIN-2112)

### How should this be tested?
1. Build `branch-0.7` branch and run Zeppelin
2. Click `Link this paragraph` or Use Ctrl+Alt(command)+w in a paragraph.
3. Use some keyboard shortcut in new window which is created by `Link this paragraph`.
4. Check text and title shape of the paragraph such like text, title, graph.. etc.

### Screenshots (if appropriate)
[ Before ]
![z_2112_b](https://cloud.githubusercontent.com/assets/8110458/23150314/0dc640e8-f836-11e6-9158-aa5bba3d98ca.gif)

[ After ]
![image](https://cloud.githubusercontent.com/assets/8110458/23150810/d85a08d2-f839-11e6-8a11-519c8822ca27.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
