### PR TITLE
[ZEPPELIN-1999] get interpreter property with replaced context parame…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ Thumbs.db
 # intelliJ IDEA project files
 .idea/
 *.iml
+*.iws
+*.ipr
 
 # maven target files
 target/

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.zeppelin.interpreter;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.remote.mock.MockInterpreterA;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class InterpreterTest {
 
@@ -58,6 +59,38 @@ public class InterpreterTest {
     assertEquals("v1", intp.getProperty("p1"));
     assertEquals("v2", intp.getProperty().get("p2"));
     assertEquals("v2", intp.getProperty("p2"));
+  }
+
+  @Test
+  public void testPropertyWithReplacedContextFields() {
+    String noteId = "testNoteId";
+    String paragraphTitle = "testParagraphTitle";
+    String user = "username";
+    InterpreterContext.set(new InterpreterContext(noteId,
+        null,
+        null,
+        paragraphTitle,
+        null,
+        new AuthenticationInfo("testUser", "testTicket"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null));
+    Properties p = new Properties();
+    p.put("p1", "paragraphTitle #{noteId}, #{paragraphTitle}, #{replName}, #{noteId}, #{user}," +
+        " #{authenticationInfo}");
+    MockInterpreterA intp = new MockInterpreterA(p);
+    intp.setUserName(user);
+    String actual = intp.getProperty("p1");
+    InterpreterContext.remove();
+
+    assertEquals(
+        String.format("paragraphTitle %s, %s, , %s, %s, #{authenticationInfo}", noteId,
+            paragraphTitle, noteId, user),
+        actual
+    );
   }
 
 }


### PR DESCRIPTION
What is this PR for?

Adds posibility to use context parameters (types: String.class, Double.class, Float.class, Short.class,
Byte.class, Character.class, Boolean.class, Integer.class, Long.class, ) into property of interpreter.
What type of PR is it?

Feature
What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1999
How should this be tested?

   Add text with markers #{contextFieldNAme} (ex. #{noteId} or #{paragraphTitle}) to interpreter property value (or add new property of interpreter)
   Get this property (getProperty(key)), markers should be replaced by context values

Questions:

   Does the licenses files need update? no
   Is there breaking changes for older versions? no
   Does this needs documentation? yes
