### PR TITLE
[ZEPPELIN-1586][MINOR] add new line char before "[urls]"

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -84,7 +84,7 @@ public abstract class AbstractTestRestApi {
       "role1 = *\n" +
       "role2 = *\n" +
       "role3 = *\n" +
-      "admin = *" +
+      "admin = *\n" +
       "[urls]\n" +
       "/api/version = anon\n" +
       "/** = authc";


### PR DESCRIPTION
### What is this PR for?
This is a minor bug fix in ZEPPELIN-1586; add new line char before "[urls]"

### What type of PR is it?
[Minor Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-1586](https://issues.apache.org/jira/browse/ZEPPELIN-1586)

### How should this be tested?
CI should be green.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
