### PR TITLE
[ZEPPELIN-1968] Added property to disable hive user impersonation

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -423,7 +423,12 @@ Here are some examples you can refer to. Including the below connectors, you can
     <td>default.password</td>
     <td>hive_password</td>
   </tr>
+  <tr>
+    <td>hive.proxy.user</td>
+    <td>true or false</td>
 </table>
+
+Connection to Hive JDBC with a proxy user can be disabled with `hive.proxy.user` property (set to true by default)
 
 [Apache Hive 1 JDBC Driver Docs](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC)
 [Apache Hive 2 JDBC Driver Docs](https://cwiki.apache.org/confluence/display/Hive/HiveServer2+Clients#HiveServer2Clients-JDBC)

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -374,7 +374,8 @@ public class JDBCInterpreter extends Interpreter {
                 if (lastIndexOfUrl == -1) {
                   lastIndexOfUrl = connectionUrl.length();
                 }
-                if (!property.getProperty("hive.proxy.user").equals("false")){
+                boolean hasProxyUser = property.containsKey("hive.proxy.user");
+                if (!hasProxyUser || !property.getProperty("hive.proxy.user").equals("false")){
                   logger.debug("Using hive proxy user");
                   connectionUrl.insert(lastIndexOfUrl, ";hive.server2.proxy.user=" + user + ";");
                 }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -383,14 +383,11 @@ public class JDBCInterpreter extends Interpreter {
                         user, propertyKey, properties);
               } else {
                 UserGroupInformation ugi = null;
-
                 try {
-                  ugi = property.getProperty("hive.proxy.user").equals("false") ?
-                          UserGroupInformation.getCurrentUser() :
-                          UserGroupInformation.createProxyUser(
-                                  user, UserGroupInformation.getCurrentUser());
+                  ugi = UserGroupInformation.createProxyUser(
+                          user, UserGroupInformation.getCurrentUser());
                 } catch (Exception e) {
-                  logger.error("Error in getCurrentUser or createProxyUser", e);
+                  logger.error("Error in getCurrentUser", e);
                   StringBuilder stringBuilder = new StringBuilder();
                   stringBuilder.append(e.getMessage()).append("\n");
                   stringBuilder.append(e.getCause());

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -374,16 +374,22 @@ public class JDBCInterpreter extends Interpreter {
                 if (lastIndexOfUrl == -1) {
                   lastIndexOfUrl = connectionUrl.length();
                 }
-                connectionUrl.insert(lastIndexOfUrl, ";hive.server2.proxy.user=" + user + ";");
+                if (!property.getProperty("hive.proxy.user").equals("false")){
+                  logger.debug("Using hive proxy user");
+                  connectionUrl.insert(lastIndexOfUrl, ";hive.server2.proxy.user=" + user + ";");
+                }
                 connection = getConnectionFromPool(connectionUrl.toString(),
-                    user, propertyKey, properties);
+                        user, propertyKey, properties);
               } else {
                 UserGroupInformation ugi = null;
+
                 try {
-                  ugi = UserGroupInformation.createProxyUser(user,
-                    UserGroupInformation.getCurrentUser());
+                  ugi = property.getProperty("hive.proxy.user").equals("false") ?
+                          UserGroupInformation.getCurrentUser() :
+                          UserGroupInformation.createProxyUser(
+                                  user, UserGroupInformation.getCurrentUser());
                 } catch (Exception e) {
-                  logger.error("Error in createProxyUser", e);
+                  logger.error("Error in getCurrentUser or createProxyUser", e);
                   StringBuilder stringBuilder = new StringBuilder();
                   stringBuilder.append(e.getMessage()).append("\n");
                   stringBuilder.append(e.getCause());


### PR DESCRIPTION
### What is this PR for?

Added new property "hive.proxy.user"  to disable hive impersonation (on some clusters, this option is disabled) in order to make Hive Interpreter even without this

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1968

### How should this be tested?
Set "hive.proxy.user" to true in the jdbc interpreter setttings, and you should see "Using hive proxy user" in the jdbc logs.

If "hive.proxy.user" has another value, this is not mentionned in the logs

You can also test with the appropriate hive configuration, but this could take longer :) 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
