### PR TITLE
[ZEPPELIN-2048] Can't run first paragraph when personalize mode on.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -348,6 +348,7 @@ public class Note implements Serializable, ParagraphJobListener {
     synchronized (paragraphs) {
       paragraphs.add(index, p);
     }
+    p.addUser(p, p.getUser());
     if (noteEventListener != null) {
       noteEventListener.onParagraphCreate(p);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -142,10 +142,12 @@ public class Paragraph extends Job implements Serializable, Cloneable {
     p.setResult(getReturn());
     p.setStatus(getStatus());
     p.setId(getId());
-
-    userParagraphMap.put(user, p);
-
+    addUser(p, user);
     return p;
+  }
+
+  public void addUser(Paragraph p, String user) {
+    userParagraphMap.put(user, p);
   }
 
   public String getUser() {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -131,6 +131,13 @@ public class NoteTest {
   }
 
   @Test
+  public void insertParagraphwithUser() {
+    Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
+    Paragraph p = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
+    assertEquals("anonymous", p.getUser());
+  }
+
+  @Test
   public void clearAllParagraphOutputTest() {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("md"))).thenReturn(interpreter);
     when(interpreter.getScheduler()).thenReturn(scheduler);


### PR DESCRIPTION
### What is this PR for?
Problem of ZEPPELIN-2048 was because not set the user id when inserting new paragraph.


### What type of PR is it?
Bug Fix 


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2048


### How should this be tested?
please refer to the screenshot of jira.


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
