### PR TITLE
[ZEPPELIN-1964] Layout info is lost after refresh

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -509,10 +509,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   $scope.changeColWidth = function(paragraph, width) {
     angular.element('.navbar-right.open').removeClass('open');
-    if (width !== paragraph.config.colWidth) {
-      paragraph.config.colWidth = width;
-      commitParagraph(paragraph);
-    }
+    paragraph.config.colWidth = width;
+    commitParagraph(paragraph);
   };
 
   $scope.toggleOutput = function(paragraph) {
@@ -1130,23 +1128,23 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
        $scope.paragraph.config = newPara.config;
      }
    };
- 
+
    $scope.updateParagraph = function(oldPara, newPara, updateCallback) {
      // 1. get status, refreshed
      const statusChanged = (newPara.status !== oldPara.status);
      const resultRefreshed = (newPara.dateFinished !== oldPara.dateFinished) ||
        isEmpty(newPara.results) !== isEmpty(oldPara.results) ||
        newPara.status === 'ERROR' || (newPara.status === 'FINISHED' && statusChanged);
- 
+
      // 2. update texts managed by $scope
      $scope.updateAllScopeTexts(oldPara, newPara);
- 
+
      // 3. execute callback to update result
      updateCallback();
- 
+
      // 4. update remaining paragraph objects
      $scope.updateParagraphObjectWhenUpdated(newPara);
- 
+
      // 5. handle scroll down by key properly if new paragraph is added
      if (statusChanged || resultRefreshed) {
        // when last paragraph runs, zeppelin automatically appends new paragraph.


### PR DESCRIPTION
### What is this PR for?
This PR fixes layout info is lost after refreshing issue.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1964


### How should this be tested?
Please do resize paragraph and then refresh browser. 

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
