### PR TITLE
[ZEPPELIN-2113] Remove border and margin of Link this paragraph window

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -28,6 +28,7 @@ body {
 }
 
 .bodyAsIframe {
+  padding-top: 20px;
   background: white;
 }
 

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -82,7 +82,7 @@ limitations under the License.
        ng-controller="ParagraphCtrl"
        ng-init="init(currentParagraph, home.note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       class="paragraph-col">
+       style="margin: 0; padding: 0;">
     <div id="{{currentParagraph.id}}_paragraphColumn"
          ng-if="currentParagraph.results"
          ng-include src="'app/notebook/paragraph/paragraph.html'"

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -112,7 +112,7 @@ limitations under the License.
        ng-controller="ParagraphCtrl"
        ng-init="init(currentParagraph, note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       class="paragraph-col">
+       style="margin: 0; padding: 0;">
     <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe || revisionView">
       <h4 class="plus-sign">&#43;</h4>
     </div>


### PR DESCRIPTION
### What is this PR for?
This PR is for removing border and margin of paragraph shape in new window which is created by "Link this paragraph" operation.
It would be nice and neat to be removed such like that is suggested at [this comment](https://github.com/apache/zeppelin/pull/1983#issuecomment-279395050).


### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-2113](https://issues.apache.org/jira/browse/ZEPPELIN-2113)


### How should this be tested?
1. Click `Link this paragraph`
2. Check a paragraph shape

### Screenshots (if appropriate)
[ Before ]
![z_2113_b](https://cloud.githubusercontent.com/assets/8110458/23198655/8ab1879e-f90c-11e6-868c-3786d552ed80.png)

![image](https://cloud.githubusercontent.com/assets/8110458/23198733/f55116d2-f90c-11e6-9991-70261e1b0143.png)


[ After ]
![z_2113_a](https://cloud.githubusercontent.com/assets/8110458/23198666/9c31a102-f90c-11e6-9a37-0b3c2bfe0fe2.png)

![z_2113_a_t](https://cloud.githubusercontent.com/assets/8110458/23198668/9ff8d954-f90c-11e6-9602-a9b5cfbb034b.png)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
