### PR TITLE
[ZEPPELIN-2094] Decrease npm install retry time

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -45,6 +45,10 @@ public class HeliumBundleFactory {
   public static final String HELIUM_BUNDLE_CACHE = "helium.bundle.cache.js";
   public static final String HELIUM_BUNDLE = "helium.bundle.js";
   public static final String HELIUM_BUNDLES_VAR = "heliumBundles";
+  private final int FETCH_RETRY_COUNT = 2;
+  private final int FETCH_RETRY_FACTOR_COUNT = 1;
+  // Milliseconds
+  private final int FETCH_RETRY_MIN_TIMEOUT = 5000;
 
   private final FrontendPluginFactory frontEndPluginFactory;
   private final File workingDirectory;
@@ -194,7 +198,11 @@ public class HeliumBundleFactory {
 
     try {
       out.reset();
-      npmCommand("install --loglevel=error");
+      String commandForNpmInstall =
+              String.format("install --fetch-retries=%d --fetch-retry-factor=%d " +
+                              "--fetch-retry-mintimeout=%d",
+                      FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
+      npmCommand(commandForNpmInstall);
     } catch (TaskRunnerException e) {
       // ignore `(empty)` warning
       String cause = new String(out.toByteArray());
@@ -373,7 +381,11 @@ public class HeliumBundleFactory {
   }
 
   public synchronized void install(HeliumPackage pkg) throws TaskRunnerException {
-    npmCommand("install " + pkg.getArtifact() + " npm install --loglevel=error");
+    String commandForNpmInstallArtifact =
+        String.format("install %s --fetch-retries=%d --fetch-retry-factor=%d " +
+                        "--fetch-retry-mintimeout=%d", pkg.getArtifact(),
+                FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
+    npmCommand(commandForNpmInstallArtifact);
   }
 
   private void npmCommand(String args) throws TaskRunnerException {


### PR DESCRIPTION
### What is this PR for?
It’s too delayed for npm install when computer do not connected any networks.
Beacause when npm install, it has too long retry timeout.
This PR is to decrease retry timeout when npm install.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2094

### How should this be tested?
you must enable any one helium before test

Line 197 In zeppelin-zengine org.apache.zeppelin.helium.HeliumBundleFactory.java

First set with 
`String npmCommand = "install —loglevel=error”;`
and You don’t connect any ethernet or wireless internet.
build & run

and set with
`String npmCommand = "install —fetch-retries=2 —fetch-retry-factor=1 —fetch-retry-mintimeout=5000 —loglevel=error”;`
also don’t connect any networks, build & run.

WHY
retries = 2
factor = 1
mintimeout = 5(sec)?

npm use [retry](https://github.com/tim-kos/node-retry) module to retry.
It refers [this article](http://dthain.blogspot.kr/2009/02/exponential-backoff-in-distributed.html) for retry algorithms.
It is a math which structured _Math.min(Math.round(random * minTimeout * Math.pow(factor, attempt)), maxTimeout)_.
In retry source code, between two retries. First retry doesn't care _Math.min()_, just _Math.round(random * minTimeout * Math.pow(factor, attempt))_)


Description | Before | After
------- | ------- | -------
Condition | npm's default setting<br>random = False = 1<br>retry = 2<br>minTimeout = 10 (sec)<br>maxTimeout = 60 (sec)<br>factor = 10 | custom setting<br>random = False = 1<br>retry = 2<br>minTimeout = 5 (sec)<br>maxTimeout = 60 (sec)<br>factor = 1<br>
First retry | Math.round(1 * 10 (sec) * 10^1)) | Math.round(1 * 5 (sec) * 1^1))
First retry result (Approximately) | 100 (sec) | 5 (sec)
Second retry | Math.min(Math.round(1 * 10 (sec) * 10^2), 60 (sec)) | Math.min(Math.round(1 * 5 (sec) * 1^2), 60 (sec))
Second retry result (Approximately) | 60 (sec) | 5 (sec)
Total waiting time (Approximately) | 160 (sec) | 10 (sec)


You can check like this below Screenshots.

### Screenshots
Before | After
-------|-------
<img width="1077" alt="2017-02-24 12 32 06" src="https://cloud.githubusercontent.com/assets/1144643/23267951/9deaec6e-fa2f-11e6-9171-5792f24de76d.png"> | <img width="1081" alt="2017-02-24 12 37 10" src="https://cloud.githubusercontent.com/assets/1144643/23267954/a12c0c0a-fa2f-11e6-99cd-335deef607ac.png">


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A