### PR TITLE
ZEPPELIN-2148: On creation of Bar graph zeppelin UI shows it as mini graph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -267,7 +267,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
 
   $scope.renderDefaultDisplay = function(targetElemId, type, data, refresh) {
     if (type === DefaultDisplayType.TABLE) {
-      setTimeout(function() {
+      $timeout(function() {
         $scope.renderGraph(targetElemId, $scope.graphMode, refresh);
       }, 10);
     } else if (type === DefaultDisplayType.HTML) {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -267,7 +267,9 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
 
   $scope.renderDefaultDisplay = function(targetElemId, type, data, refresh) {
     if (type === DefaultDisplayType.TABLE) {
-      $scope.renderGraph(targetElemId, $scope.graphMode, refresh);
+      setTimeout(function() {
+        $scope.renderGraph(targetElemId, $scope.graphMode, refresh);
+      }, 10);
     } else if (type === DefaultDisplayType.HTML) {
       renderHtml(targetElemId, data);
     } else if (type === DefaultDisplayType.ANGULAR) {


### PR DESCRIPTION
### What is this PR for?
On creation of Bar graph zeppelin UI shows it as mini graph, and is easily reproducible on safari.

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2148](https://issues.apache.org/jira/browse/ZEPPELIN-2148)

### How should this be tested?
Check screen shot.

### Screenshots (if appropriate)
Before:
![zeppelin-2148-before](https://cloud.githubusercontent.com/assets/674497/23291765/b1469780-fa80-11e6-9a13-3ecb6ca275ba.gif)


After:
![zeppelin-2148-after](https://cloud.githubusercontent.com/assets/674497/23291751/9aa39122-fa80-11e6-962e-482e12c4bca5.gif)



### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
