### PR TITLE
[ZEPPELIN-2164] Typo in Insufficient Privileges popup of Zeppelin

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -717,7 +717,7 @@ public class NotebookServer extends WebSocketServlet
     LOG.info("Cannot {}. Connection readers {}. Allowed readers {}", op, userAndRoles, allowed);
 
     conn.send(serializeMessage(new Message(OP.AUTH_INFO).put("info",
-        "Insufficient privileges to " + op + "note.\n\n" + "Allowed users or roles: " + allowed
+        "Insufficient privileges to " + op + " note.\n\n" + "Allowed users or roles: " + allowed
             .toString() + "\n\n" + "But the user " + userName + " belongs to: " + userAndRoles
             .toString())));
   }


### PR DESCRIPTION
### What is this PR for?
When trying to delete a note of another user Zeppelin correctly throws a popup for insufficient privileges but has a small typo "removenote" (no space between remove note). Similar issue exist for renaming notebook "renamenote".

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2164](https://issues.apache.org/jira/browse/ZEPPELIN-2164)

### How should this be tested?
Refer before/after screen shot

### Screenshots (if appropriate)
Before:
<img width="628" alt="screen shot 2017-02-24 at 11 49 59 am 1" src="https://cloud.githubusercontent.com/assets/674497/23292690/66b808fa-fa87-11e6-9bde-4f9fbbb1cb67.png">


After:
<img width="645" alt="screen shot 2017-02-24 at 11 48 35 am" src="https://cloud.githubusercontent.com/assets/674497/23292691/66c0e9c0-fa87-11e6-9abc-16dc7b52ce3c.png">



### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
