### PR TITLE
[ZEPPELIN-1725] replace cleanDirectory with forceDelete

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -547,7 +547,7 @@ public class InterpreterSettingManager {
                 setting.getId());
             if (localRepoDir.exists()) {
               try {
-                FileUtils.cleanDirectory(localRepoDir);
+                FileUtils.forceDelete(localRepoDir);
               } catch (FileNotFoundException e) {
                 logger.info("A file that does not exist cannot be deleted, nothing to worry", e);
               }


### PR DESCRIPTION
### What is this PR for?
At times while updating dependency from Interpreter settings page it fails with 

```
ERROR [2017-02-24 12:56:03,503] ({Thread-87} InterpreterFactory.java[run]:550) - Error while downloading repos for interpreter group : jdbc, go to interpreter setting page click on edit and save it again to make this interpreter work properly. : Unable to delete file: /home/prabhu/zeppelin-server/local-repo/2CBX1E3VP/jcip-annotations-1.0.jar
java.io.IOException: Unable to delete file: /home/prabhu/zeppelin-server/local-repo/2CBX1E3VP/jcip-annotations-1.0.jar
        at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2279)
        at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
        at org.apache.zeppelin.interpreter.InterpreterFactory$3.run(InterpreterFactory.java:550)
```

Hence, I propose to replace cleanDirectory with forceDelete

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-1725](https://issues.apache.org/jira/browse/ZEPPELIN-1725)

### How should this be tested?
Try adding and removing dependency say "org.apache.hive:hive-jdbc::standalone:1.2.1000" in JDBC interpreter, it does not fails always, but once in a while.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
