### PR TITLE
[DOCS][ZEPPELIN-2140] Add docs for notebookRepo REST API

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -106,6 +106,7 @@
                 <li class="title"><span><b>REST API</b><span></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-interpreter.html">Interpreter API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-notebook.html">Notebook API</a></li>
+                <li><a href="{{BASE_PATH}}/rest-api/rest-notebookRepo.html">Notebook Repository API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-configuration.html">Configuration API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-credential.html">Credential API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-helium.html">Helium API</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,8 +163,10 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
 * REST API: available REST API list in Apache Zeppelin
   * [Interpreter API](./rest-api/rest-interpreter.html)
   * [Notebook API](./rest-api/rest-notebook.html)
+  * [Notebook Repository API](./rest-api/rest-notebookRepo.html)
   * [Configuration API](./rest-api/rest-configuration.html)
   * [Credential API](./rest-api/rest-credential.html)
+  * [Helium API](./rest-api/rest-helium.html)
 * Security: available security support in Apache Zeppelin
   * [Authentication for NGINX](./security/authentication.html)
   * [Shiro Authentication](./security/shiroauthentication.html)
@@ -179,6 +181,8 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
 * Contribute
   * [Writing Zeppelin Interpreter](./development/writingzeppelininterpreter.html)
   * [Writing Zeppelin Application (Experimental)](./development/writingzeppelinapplication.html)
+  * [Writing Zeppelin Spell (Experimental)](./development/writingzeppelinspell.html)
+  * [Writing Zeppelin Visualization (Experimental)](./development/writingzeppelinvisualization.html)
   * [How to contribute (code)](./development/howtocontribute.html)
   * [How to contribute (documentation website)](./development/howtocontributewebsite.html)
 

--- a/docs/rest-api/rest-helium.md
+++ b/docs/rest-api/rest-helium.md
@@ -103,7 +103,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
         "enabled": false
       }
     ],
-    "zeppelin_horizontalbar": [
+    "zeppelin\_horizontalbar": [
       {
         "registry": "local",
         "pkg": {

--- a/docs/rest-api/rest-notebookRepo.md
+++ b/docs/rest-api/rest-notebookRepo.md
@@ -1,0 +1,179 @@
+---
+layout: page
+title: "Apache Zeppelin notebook repository REST API"
+description: "This page contains Apache Zeppelin notebook repository REST API information."
+group: rest-api
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Apache Zeppelin Notebook Repository API
+
+<div id="toc"></div>
+
+## Overview
+Apache Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
+All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. 
+Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
+
+If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
+
+## Notebook Repository REST API List
+
+### List all available notebook repositories
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns all the available notebook repositories.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook-repositories```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>500</td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": [
+    {
+      "name": "GitNotebookRepo",
+      "className": "org.apache.zeppelin.notebook.repo.GitNotebookRepo",
+      "settings": [
+        {
+          "type": "INPUT",
+          "value": [],
+          "selected": "ZEPPELIN_HOME/zeppelin/notebook/",
+          "name": "Notebook Path"
+        }
+      ]
+    }
+  ]
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+<br/>
+
+### Reload a notebook repository
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method triggers reloading and broadcasting of the note list.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook-repositories/reload```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>500</td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": ""
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+<br/>
+
+### Update a specific notebook repository
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method updates a specific notebook repository.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook-repositories```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>
+        404 when the specified notebook repository doesn't existed <br/> 
+        406 for invalid payload <br/>
+        500 for any other errors
+      </td>
+    </tr>
+    <tr>
+      <td>Sample JSON input</td>
+      <td>
+        <pre>
+{
+  "name":"org.apache.zeppelin.notebook.repo.GitNotebookRepo",
+  "settings":{
+    "Notebook Path":"/tmp/notebook/"
+  }
+}
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+    "name": "GitNotebookRepo",
+    "className": "org.apache.zeppelin.notebook.repo.GitNotebookRepo",
+    "settings": [
+      {
+        "type": "INPUT",
+        "value": [],
+        "selected": "/tmp/notebook/",
+        "name": "Notebook Path"
+      }
+    ]
+  }
+}
+        </pre>
+      </td>
+    </tr>
+  </table>

--- a/docs/rest-api/rest-notebookRepo.md
+++ b/docs/rest-api/rest-notebookRepo.md
@@ -135,7 +135,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Fail code</td>
       <td>
-        404 when the specified notebook repository doesn't existed <br/> 
+        404 when the specified notebook repository doesn't exist <br/> 
         406 for invalid payload <br/>
         500 for any other errors
       </td>


### PR DESCRIPTION
### What is this PR for?
Added a docs page for notebookRepo REST API based on [NotebookRepoRestApi.java](https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java). And this PR will cover "notebook repository reload endpoint" : #2043 as well. 

### What type of PR is it?
Documentation

### What is the Jira issue?
[ZEPPELIN-2140](https://issues.apache.org/jira/browse/ZEPPELIN-2140)

### How should this be tested?
Just checking screenshots will be faster! 

### Screenshots (if appropriate)
 - In navbar 
<img width="300" alt="screen shot 2017-02-25 at 11 02 02 pm" src="https://cloud.githubusercontent.com/assets/10060731/23331707/76551c8a-fbae-11e6-99b8-cc686e208c39.png">

 - API description list 
<img width="751" alt="screen shot 2017-02-25 at 10 54 21 pm" src="https://cloud.githubusercontent.com/assets/10060731/23331704/57dd7d4c-fbae-11e6-8cc2-189fc9e68ece.png">
<img width="715" alt="screen shot 2017-02-25 at 10 54 29 pm" src="https://cloud.githubusercontent.com/assets/10060731/23331708/85f722a0-fbae-11e6-9b40-7f4c98761dd6.png">
<img width="730" alt="screen shot 2017-02-25 at 10 54 38 pm" src="https://cloud.githubusercontent.com/assets/10060731/23331709/8882b93a-fbae-11e6-9fe2-95bc2620e2c9.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
