### PR TITLE
[ZEPPELIN-2166] HeliumBundleFactoty can't transfile imported es6+

### DIFF
--- a/zeppelin-zengine/src/main/resources/helium/package.json
+++ b/zeppelin-zengine/src/main/resources/helium/package.json
@@ -9,7 +9,9 @@
   },
   "devDependencies": {
     "webpack": "^1.12.2",
-    "babel": "^5.8.23",
-    "babel-loader": "^5.3.2"
+    "babel-core": "^6.23.1",
+    "babel-loader": "^6.3.2",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-stage-0": "^6.22.0"
   }
 }

--- a/zeppelin-zengine/src/main/resources/helium/webpack.config.js
+++ b/zeppelin-zengine/src/main/resources/helium/webpack.config.js
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 module.exports = {
-    entry: ['./'],
-    output: {
-        path: './',
-        filename: 'helium.bundle.js',
-    },
-    resolve: {
-        root: __dirname + "/node_modules"
-    },
+    entry: './load.js',
+    output: { path: './', filename: 'helium.bundle.js', },
     module: {
         loaders: [{
             test: /\.js$/,
-            //exclude: /node_modules/,
-            loader: 'babel-loader'
+            // DON'T exclude. since zeppelin will bundle all necessary packages: `exclude: /node_modules/,`
+            loader: 'babel-loader',
+            query: { presets: ['es2015', 'stage-0'] },
         }]
     }
 }


### PR DESCRIPTION
### What is this PR for?

Currently, we don't use any preset. This cause error messages like
when a helium package imports another packages which include es6+ syntax.

```
SyntaxError: Unexpected token import
    at helium.service.js:36
    at angular.js:10973
    at processQueue (angular.js:15552)
    at angular.js:15568
    at Scope.$eval (angular.js:16820)
    at Scope.$digest (angular.js:16636)
    at Scope.$apply (angular.js:16928)
    at done (angular.js:11266)
    at completeRequest (angular.js:11464)
    at XMLHttpRequest.requestLoaded (angular.js:11405)
```

- https://github.com/1ambda/zeppelin-advanced-transformation/blob/master/examples/example-highcharts-columnrange/index.js#L3
- https://github.com/1ambda/zeppelin-advanced-transformation/blob/master/index.js#L11

### What type of PR is it?
[Improvement]

### Todos
* [x] - Install required NPM packages
* [x] - fix babel configuration

### What is the Jira issue?

[ZEPPELIN-2166](https://issues.apache.org/jira/browse/ZEPPELIN-2166)

### How should this be tested?

- Should be able to bundle existing helium vis
- Should be able to bundle https://github.com/1ambda/zeppelin-advanced-transformation/tree/master/examples/example-highcharts-columnrange

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NONE
* Is there breaking changes for older versions? - NONE
* Does this needs documentation? - NONE
