### PR TITLE
[ZEPPELIN-2060] Show tooltip msg after dynamic form value is changed

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -44,7 +44,9 @@ limitations under the License.
 
   <!-- Run / Cancel button -->
   <span ng-if="!revisionView">
-    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
+    <span class="icon-control-play" style="cursor:pointer;color:#3071A9"
+          tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
+          tooltip-is-open="tooltipIsOpen"
           ng-click="runParagraphFromButton(getEditorValue())"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -22,6 +22,7 @@ limitations under the License.
 
       <input class="form-control input-sm"
              ng-if="!paragraph.settings.forms[formulaire.name].options"
+             ng-change="showTooltip()"
              ng-enter="runParagraphFromButton(getEditorValue())"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
@@ -30,6 +31,7 @@ limitations under the License.
       <select class="form-control input-sm"
              ng-if="paragraph.settings.forms[formulaire.name].options && paragraph.settings.forms[formulaire.name].type != 'checkbox'"
              ng-enter="runParagraphFromButton(getEditorValue())"
+             ng-change="showTooltip()"
              ng-model="paragraph.settings.params[formulaire.name]"
              ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
              name="{{formulaire.name}}"
@@ -42,7 +44,7 @@ limitations under the License.
           <input type="checkbox"
                  ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }"
                  ng-checked="paragraph.settings.params[formulaire.name].indexOf(option.value) > -1"
-                 ng-click="toggleCheckbox(formulaire, option, false)"/>{{option.displayName||option.value}}
+                 ng-click="toggleCheckbox(formulaire, option, false); showTooltip()"/>{{option.displayName||option.value}}
         </label>
       </div>
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -31,6 +31,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.paragraph.results.msg = [];
   $scope.originalText = '';
   $scope.editor = null;
+  $scope.tooltipIsOpen = false;
 
   var editorSetting = {};
   // flag that is used to set editor setting on paste percent sign
@@ -449,6 +450,10 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     console.log('open the output');
     paragraph.config.tableHide = false;
     commitParagraph(paragraph);
+  };
+  
+  $scope.showTooltip = function () {
+    $scope.tooltipIsOpen = !$scope.tooltipIsOpen;
   };
 
   var openEditorAndCloseTable = function(paragraph) {


### PR DESCRIPTION
### What is this PR for? 
As described in [ZEPPELIN-2060](https://issues.apache.org/jira/browse/ZEPPELIN-2060), the dynamic form's behaviour has been changed back and forth.
In current status(nothing happened when user change the dynamic form value), I made this tooltip msg automatically shows up. This will be helpful to let users know they need to click run button or `Shift+Enter`. 

![screen shot 2017-02-27 at 2 58 16 pm](https://cloud.githubusercontent.com/assets/10060731/23350345/41c2cf44-fcfd-11e6-883f-21b13aa84076.png)

If there can be better way for this, please let me know :)
### What type of PR is it?
Improvement

### Todos
* [ ] - set timeout 

### What is the Jira issue?
[ZEPPELIN-2060](https://issues.apache.org/jira/browse/ZEPPELIN-2060)

### How should this be tested?
1. Apply this patch and run Zeppelin web as dev mode
```bash
#under zeppelin-web
$yarn run dev
```

2. Go to Spark tutorial note and try to change value in dynamic forms as below screenshot imgs 


### Screenshots (if appropriate)
After this change
![record](https://cloud.githubusercontent.com/assets/10060731/23350176/1350c75c-fcfc-11e6-8544-6556ec06abea.gif)
![record2](https://cloud.githubusercontent.com/assets/10060731/23350180/19ddd8b2-fcfc-11e6-864b-794a9dc583aa.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? yes?
* Does this needs documentation? no
