### PR TITLE
[ZEPPELIN-2130][Doc]Do not use web development port

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -44,7 +44,8 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">zeppelin.server.port</h6></td>
     <td>8080</td>
     <td>Zeppelin server port. </br>
-    <span style="font-style:italic; color: gray"> Note: please do not a use web application port (default: 9000).</span></td>
+      <span style="font-style:italic; color: gray"> Note: Please make sure you're not using the same port with 
+      <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode">Zeppelin web application port</a> (default: 9000).</span></td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_SSL_PORT</h6></td>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -45,7 +45,7 @@ If both are defined, then the **environment variables** will take priority.
     <td>8080</td>
     <td>Zeppelin server port. </br>
       <span style="font-style:italic; color: gray"> Note: Please make sure you're not using the same port with 
-      <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode">Zeppelin web application development port</a> (default: 9000).</span></td>
+      <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode" target="_blank">Zeppelin web application development port</a> (default: 9000).</span></td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_SSL_PORT</h6></td>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -45,7 +45,7 @@ If both are defined, then the **environment variables** will take priority.
     <td>8080</td>
     <td>Zeppelin server port. </br>
       <span style="font-style:italic; color: gray"> Note: Please make sure you're not using the same port with 
-      <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode">Zeppelin web application port</a> (default: 9000).</span></td>
+      <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode">Zeppelin web application development port</a> (default: 9000).</span></td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_SSL_PORT</h6></td>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -43,7 +43,7 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">ZEPPELIN_PORT</h6></td>
     <td><h6 class="properties">zeppelin.server.port</h6></td>
     <td>8080</td>
-    <td>Zeppelin server port. </br>
+    <td>Zeppelin server port </br>
       <span style="font-style:italic; color: gray"> Note: Please make sure you're not using the same port with 
       <a href="https://zeppelin.apache.org/contribution/webapplication.html#dev-mode" target="_blank">Zeppelin web application development port</a> (default: 9000).</span></td>
   </tr>

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -43,7 +43,8 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">ZEPPELIN_PORT</h6></td>
     <td><h6 class="properties">zeppelin.server.port</h6></td>
     <td>8080</td>
-    <td>Zeppelin server port</td>
+    <td>Zeppelin server port. </br>
+    <span style="font-style:italic; color: gray"> Note: please do not a use web application port (default: 9000).</span></td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_SSL_PORT</h6></td>


### PR DESCRIPTION
### What is this PR for?
If user uses web application development port such like 9000 which is default value, Zeppelin is not working because of this [line](https://github.com/apache/zeppelin/blob/master/zeppelin-web/src/components/baseUrl/baseUrl.service.js#L27). So, Zeppelin site need to guide this content until fixing this line (I'll improve to flexible web application development port later).


### What type of PR is it?
[ Documentation ]

### What is the Jira issue?
* [ZEPPELIN-2130](https://issues.apache.org/jira/browse/ZEPPELIN-2130)

### How should this be tested?
1. Run document development mode.
2. Connect `http://localhost:4000/install/configuration.html#zeppelin-properties` on browser.
3. Check the description of `ZEPPELIN_PORT`

### Screenshots (if appropriate)
![z_not_use_port](https://cloud.githubusercontent.com/assets/8110458/23350768/32cf941a-fd00-11e6-8a3c-3390ddf2d7df.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
