### PR TITLE
[ZEPPELIN-2191] Helium package should be able to import css

### DIFF
--- a/zeppelin-zengine/src/main/resources/helium/package.json
+++ b/zeppelin-zengine/src/main/resources/helium/package.json
@@ -12,6 +12,10 @@
     "babel-core": "^6.23.1",
     "babel-loader": "^6.3.2",
     "babel-preset-es2015": "^6.22.0",
-    "babel-preset-stage-0": "^6.22.0"
+    "babel-preset-stage-0": "^6.22.0",
+    "css-loader": "^0.26.2",
+    "style-loader": "^0.13.2",
+    "url-loader": "^0.5.8",
+    "file-loader": "^0.10.1"
   }
 }

--- a/zeppelin-zengine/src/main/resources/helium/webpack.config.js
+++ b/zeppelin-zengine/src/main/resources/helium/webpack.config.js
@@ -19,11 +19,36 @@ module.exports = {
     entry: './load.js',
     output: { path: './', filename: 'helium.bundle.js', },
     module: {
-        loaders: [{
+        loaders: [
+          {
             test: /\.js$/,
             // DON'T exclude. since zeppelin will bundle all necessary packages: `exclude: /node_modules/,`
             loader: 'babel-loader',
             query: { presets: ['es2015', 'stage-0'] },
-        }]
+          },
+          {
+            test: /(\.css)$/,
+            loaders: ['style', 'css?sourceMap&importLoaders=1'],
+          },
+          {
+            test: /\.woff(\?\S*)?$/,
+            loader: 'url-loader?limit=10000&minetype=application/font-woff',
+          },
+          {
+            test: /\.woff2(\?\S*)?$/,
+            loader: 'url-loader?limit=10000&minetype=application/font-woff',
+          },
+          {
+            test: /\.eot(\?\S*)?$/,
+            loader: 'url-loader',
+          }, {
+            test: /\.ttf(\?\S*)?$/,
+            loader: 'url-loader',
+          },
+          {
+            test: /\.svg(\?\S*)?$/,
+            loader: 'url-loader',
+          },
+        ],
     }
 }


### PR DESCRIPTION
### What is this PR for?

Helium package should be able to import css. For example,

- Someone want to create spell using jsoneditor (https://github.com/josdejong/jsoneditor/blob/master/docs/usage.md). In this case, he/she should import css

```js
import 'jsoneditor/dist/jsoneditor.min.css' /** here */
import JSONEditor from 'jsoneditor/dist/jsoneditor.min.js'
```

<br>

**This PR is written based on #2071, so the duplicated commit will be dropped. Please review the commit 505c7db only.**

### What type of PR is it?
[Improvement]

### Todos
* [x] - denote required packages in `package.json`
* [x] - setup `webpack.config.js`

### What is the Jira issue?

[ZEPPELIN-2191](https://issues.apache.org/jira/browse/ZEPPELIN-2191)

### How should this be tested?

Should be able to bundle [zeppelin-json-spell](https://github.com/1ambda/zeppelin-json-spell)

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
