### PR TITLE
[ZEPPELIN-2123] [branch-0.7] backport travis_check.py to branch-0.7

### DIFF
--- a/travis_check.py
+++ b/travis_check.py
@@ -13,15 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 #
+# This script checks build status of given pullrequest identified by author, branch name and commit hash.
+#
+
 import os, sys, getopt, traceback, json, requests, time
 
 author = sys.argv[1]
 branch = sys.argv[2]
 commit = sys.argv[3]
 
-#check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
-check = [5, 10, 10]
+# check interval in sec
+check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
@@ -69,7 +73,8 @@ def printBuildStatus(build):
                 failure = failure + 1
         else:
             print("[" + str(index+1) + "] Unknown state")
-            
+            failure = failure + 1
+
     return failure, running
 
 
@@ -97,4 +102,3 @@ for sleep in check:
 
 info("Timeout")
 sys.exit(1)
-

--- a/travis_check.py
+++ b/travis_check.py
@@ -17,6 +17,18 @@
 #
 # This script checks build status of given pullrequest identified by author and commit hash.
 #
+# usage)
+#   python travis_check.py [author] [commit hash] [check interval (optional)]
+#
+# example)
+#   # full hash
+#   python travis_check.py Leemoonsoo 1f2549a38f440ebfbfe2d32a041684e3e39b496c
+#
+#   # with short hash
+#   python travis_check.py Leemoonsoo 1f2549a
+#
+#   # with custom check interval
+#   python travis_check.py Leemoonsoo 1f2549a 5,60,60
 
 import os, sys, getopt, traceback, json, requests, time
 
@@ -25,6 +37,9 @@ commit = sys.argv[2]
 
 # check interval in sec
 check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300, 600, 600, 600, 600, 600, 600]
+
+if len(sys.argv) > 3:
+    check = map(lambda x: int(x), sys.argv[3].split(","))
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)

--- a/travis_check.py
+++ b/travis_check.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 
 #
-# This script checks build status of given pullrequest identified by author, branch name and commit hash.
+# This script checks build status of given pullrequest identified by author and commit hash.
 #
 
 import os, sys, getopt, traceback, json, requests, time
 
 author = sys.argv[1]
-branch = sys.argv[2]
-commit = sys.argv[3]
+commit = sys.argv[2]
 
 # check interval in sec
 check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
@@ -31,10 +30,10 @@ def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
 
 
-info("Author: " + author + ", branch: " + branch + ", commit: " + commit)
+info("Author: " + author + ", commit: " + commit)
 
 
-def getBuildStatus(author, branch, commit):
+def getBuildStatus(author, commit):
     travisApi = "https://api.travis-ci.org/"
 
     # get latest 25 builds
@@ -43,7 +42,7 @@ def getBuildStatus(author, branch, commit):
 
     build = None
     for b in data:
-        if b["branch"] == branch and b["commit"][:len(commit)] == commit:
+        if b["commit"][:len(commit)] == commit:
             resp = requests.get(url=travisApi + "/repos/" + author + "/zeppelin/builds/" + str(b["id"]))
             build = json.loads(resp.text)
             break
@@ -83,9 +82,9 @@ for sleep in check:
     info("--------------------------------")
     time.sleep(sleep);
     info("Get build status ...")
-    build = getBuildStatus(author, branch, commit)
+    build = getBuildStatus(author, commit)
     if build == None:
-        info("Can't find build for branch=" + branch + ", commit= " + commit)
+        info("Can't find build for commit= " + commit)
         sys.exit(1)
 
     print("https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))

--- a/travis_check.py
+++ b/travis_check.py
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os, sys, getopt, traceback, json, requests, time
+
+author = sys.argv[1]
+branch = sys.argv[2]
+commit = sys.argv[3]
+
+#check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
+check = [5, 10, 10]
+
+def info(msg):
+    print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
+
+
+info("Author: " + author + ", branch: " + branch + ", commit: " + commit)
+
+
+def getBuildStatus(author, branch, commit):
+    travisApi = "https://api.travis-ci.org/"
+
+    # get latest 25 builds
+    resp = requests.get(url=travisApi + "/repos/" + author + "/zeppelin/builds")
+    data = json.loads(resp.text)
+
+    build = None
+    for b in data:
+        if b["branch"] == branch and b["commit"][:len(commit)] == commit:
+            resp = requests.get(url=travisApi + "/repos/" + author + "/zeppelin/builds/" + str(b["id"]))
+            build = json.loads(resp.text)
+            break
+
+    return build
+
+
+def printBuildStatus(build):
+    failure = 0
+    running = 0
+    for index, job in enumerate(build["matrix"]):
+        result = job["result"]
+        if job["started_at"] == None and result == None:
+            print("[" + str(index+1) + "] Not started")
+            running = running + 1
+        elif job["started_at"] != None and job["finished_at"] == None:
+            print("[" + str(index+1) + "] Running ...")
+            running = running + 1
+        elif job["started_at"] != None and job["finished_at"] != None:
+            if result == None:
+                print("[" + str(index+1) + "] Not completed")
+                failure = failure + 1
+            elif result == 0:
+                print("[" + str(index+1) + "] OK")
+            else:
+                print("[" + str(index+1) + "] Error " + str(result))
+                failure = failure + 1
+        else:
+            print("[" + str(index+1) + "] Unknown state")
+            
+    return failure, running
+
+
+
+for sleep in check:
+    info("--------------------------------")
+    time.sleep(sleep);
+    info("Get build status ...")
+    build = getBuildStatus(author, branch, commit)
+    if build == None:
+        info("Can't find build for branch=" + branch + ", commit= " + commit)
+        sys.exit(1)
+
+    print("https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
+    failure, running = printBuildStatus(build)
+
+    print(str(failure) + " job(s) failed, " + str(running) + " job(s) running")
+
+    if failure != 0:
+        sys.exit(1)
+
+    if failure == 0 and running == 0:
+        info("CI Green!")
+        sys.exit(0)
+
+info("Timeout")
+sys.exit(1)
+

--- a/travis_check.py
+++ b/travis_check.py
@@ -28,7 +28,7 @@ check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
-
+    sys.stdout.flush()
 
 info("Author: " + author + ", commit: " + commit)
 

--- a/travis_check.py
+++ b/travis_check.py
@@ -64,12 +64,12 @@ def getBuildStatus(author, commit):
 
     return build
 
+def status(index, msg, jobId):
+    return '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
 
 def printBuildStatus(build):
     failure = 0
     running = 0
-
-    status = lambda idx, msg, jobId: '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
 
     for index, job in enumerate(build["matrix"]):
         result = job["result"]
@@ -97,7 +97,6 @@ def printBuildStatus(build):
     return failure, running
 
 
-
 for sleep in check:
     info("--------------------------------")
     time.sleep(sleep);
@@ -110,7 +109,7 @@ for sleep in check:
     print("Build https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
     failure, running = printBuildStatus(build)
 
-    print(str(failure) + " job(s) failed, " + str(running) + " job(s) running")
+    print(str(failure) + " job(s) failed, " + str(running) + " job(s) running/pending")
 
     if failure != 0:
         sys.exit(1)

--- a/travis_check.py
+++ b/travis_check.py
@@ -24,7 +24,7 @@ author = sys.argv[1]
 commit = sys.argv[2]
 
 # check interval in sec
-check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300]
+check = [5, 60, 300, 300, 300, 300, 300, 300, 300, 300, 300, 300, 600, 600, 600, 600, 600, 600]
 
 def info(msg):
     print("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg)
@@ -53,25 +53,30 @@ def getBuildStatus(author, commit):
 def printBuildStatus(build):
     failure = 0
     running = 0
+
+    status = lambda idx, msg, jobId: '{:20}'.format("[" + str(index+1) + "] " + msg) + "https://travis-ci.org/" + author + "/zeppelin/jobs/" + str(jobId)
+
     for index, job in enumerate(build["matrix"]):
         result = job["result"]
+        jobId = job["id"]
+
         if job["started_at"] == None and result == None:
-            print("[" + str(index+1) + "] Not started")
+            print(status(index, "Not started", jobId))
             running = running + 1
         elif job["started_at"] != None and job["finished_at"] == None:
-            print("[" + str(index+1) + "] Running ...")
+            print(status(index, "Running ...", jobId))
             running = running + 1
         elif job["started_at"] != None and job["finished_at"] != None:
             if result == None:
-                print("[" + str(index+1) + "] Not completed")
+                print(status(index, "Not completed", jobId))
                 failure = failure + 1
             elif result == 0:
-                print("[" + str(index+1) + "] OK")
+                print(status(index, "OK", jobId))
             else:
-                print("[" + str(index+1) + "] Error " + str(result))
+                print(status(index, "Error " + str(result), jobId))
                 failure = failure + 1
         else:
-            print("[" + str(index+1) + "] Unknown state")
+            print(status(index, "Unknown state", jobId))
             failure = failure + 1
 
     return failure, running
@@ -87,7 +92,7 @@ for sleep in check:
         info("Can't find build for commit= " + commit)
         sys.exit(1)
 
-    print("https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
+    print("Build https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
     failure, running = printBuildStatus(build)
 
     print(str(failure) + " job(s) failed, " + str(running) + " job(s) running")


### PR DESCRIPTION
### What is this PR for?
ZEPPELIN-2123 introduces travis_check.py to scale out CI capacity.
However travis_check.py does not exists in branch-0.7, and PR to branch-0.7 marked as a green without regardless of the actual build result.

Since we're planning to make more releases from branch-0.7 and target branch of some PRs are branch-0.7, i think we need travis_check.py on branch-0.7, too.

### What type of PR is it?
Feature

### Todos
* [x] - bring travis_check.py to branch-0.7

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2123

### How should this be tested?
Check Jenkins successfully read build status from travis for PR targeting branch-0.7.  (this PR)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
