### PR TITLE
[HOT FIX][gh-pages] Fix 'Error: ng:areq Bad Argument' in Helium page

### DIFF
--- a/assets/themes/zeppelin/js/medium.controller.js
+++ b/assets/themes/zeppelin/js/medium.controller.js
@@ -1,4 +1,4 @@
-angular.module("app", []).controller("MediumCtrl", function($scope, $window, $sce) {
+angular.module("app").controller("MediumCtrl", function($scope, $window, $sce) {
   $scope.mediumPost = mediumPost
 
   var postInfo = $scope.mediumPost[0].items


### PR DESCRIPTION
### What is this PR for?
After #1980 merged, below error comes out in http://zeppelin.apache.org/helium_packages.html.
<img width="1045" alt="screen shot 2017-03-01 at 12 30 18 pm" src="https://cloud.githubusercontent.com/assets/10060731/23444845/dd33a006-fe7a-11e6-9324-0c737830c7b0.png">

I referred [this stackoverflow](http://stackoverflow.com/questions/25895235/angularjs-error-ngareq-argument-homecontroller-is-not-a-function-got-und) question to fix this. 


### What type of PR is it?
Bug Fix & Hot Fix


### What is the Jira issue?
N/A

### How should this be tested?
1. Run `gh-pages` locally as described in [gh-pages#run-website](https://github.com/apache/zeppelin/tree/gh-pages#run-website).
2. Go to Helium menu and check the page is properly shown or not

### Screenshots (if appropriate)

 - After 
<img width="961" alt="screen shot 2017-03-01 at 12 34 38 pm" src="https://cloud.githubusercontent.com/assets/10060731/23444943/7b911cce-fe7b-11e6-9a41-93d312437341.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
