### PR TITLE
[ZEPPELIN-2167] User with insufficient privileges can still restore files by renaming files in/out of Trash

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -422,7 +422,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     const trimmedNewName = newName.trim();
     if (trimmedNewName.length > 0 && $scope.note.name !== trimmedNewName) {
       $scope.note.name = trimmedNewName;
-      websocketMsgSrv.updateNote($scope.note.id, $scope.note.name, $scope.note.config);
+      websocketMsgSrv.renameNote($scope.note.id, $scope.note.name);
     }
   };
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.test.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.test.js
@@ -7,7 +7,8 @@ describe('Controller: NotebookCtrl', function() {
     getNote: function() {},
     listRevisionHistory: function() {},
     getInterpreterBindings: function() {},
-    updateNote: function() {}
+    updateNote: function() {},
+    renameNote: function() {}
   };
 
   var baseUrlSrvMock = {
@@ -100,24 +101,24 @@ describe('Controller: NotebookCtrl', function() {
   });
 
   it('should NOT update note name when updateNoteName() is called with an invalid name', function() {
-    spyOn(websocketMsgSrvMock, 'updateNote');
+    spyOn(websocketMsgSrvMock, 'renameNote');
     scope.updateNoteName('');
     expect(scope.note.name).toEqual(noteMock.name);
-    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+    expect(websocketMsgSrvMock.renameNote).not.toHaveBeenCalled();
     scope.updateNoteName(' ');
     expect(scope.note.name).toEqual(noteMock.name);
-    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+    expect(websocketMsgSrvMock.renameNote).not.toHaveBeenCalled();
     scope.updateNoteName(scope.note.name);
     expect(scope.note.name).toEqual(noteMock.name);
-    expect(websocketMsgSrvMock.updateNote).not.toHaveBeenCalled();
+    expect(websocketMsgSrvMock.renameNote).not.toHaveBeenCalled();
   });
 
   it('should update note name when updateNoteName() is called with a valid name', function() {
-    spyOn(websocketMsgSrvMock, 'updateNote');
+    spyOn(websocketMsgSrvMock, 'renameNote');
     var newName = 'Your Note';
     scope.updateNoteName(newName);
     expect(scope.note.name).toEqual(newName);
-    expect(websocketMsgSrvMock.updateNote).toHaveBeenCalled();
+    expect(websocketMsgSrvMock.renameNote).toHaveBeenCalled();
   });
 
   it('should reload note info once per one "setNoteMenu" event', function() {


### PR DESCRIPTION
### What is this PR for?
User with insufficient privileges can still restore files by renaming files in/out of Trash

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2167](https://issues.apache.org/jira/browse/ZEPPELIN-2167)

### How should this be tested?
Steps to reproduce:
 - Create a notebook "test_nb" as bob.
 - Delete the notebook
 - Login as mary and try restoring "test_nb" from Trash folder. The system correctly complains of insufficient privileges.
 - Open the "test_nb" notebook from Trash folder. The notebook opens with title "~Trash/test_nb".
 - Edit the title and remove the prefix "~Trash".

If you now look at the list of notebooks there is no file "test_nb" in Trash.
Interestingly when you try and delete the recently moved file from Trash it complains that mary does not have privileges to delete it. Edit the title of that notebook to "~Trash/test_nb" and it goes back to Trash folder.


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
