### PR TITLE
[ZEPPELIN-2172] Redirect to home if notebook authentication fails in realtime

### DIFF
--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -89,7 +89,10 @@ function websocketEvents($rootScope, $websocket, $location, baseUrlSrv) {
           label: 'Cancel',
           action: function(dialog) {
             dialog.close();
-            $location.path('/');
+            // using $rootScope.apply to trigger angular digest cycle
+            $rootScope.$apply(function() {
+              $location.path('/');
+            });
           }
         }];
       }

--- a/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketEvents.factory.js
@@ -90,6 +90,7 @@ function websocketEvents($rootScope, $websocket, $location, baseUrlSrv) {
           action: function(dialog) {
             dialog.close();
             // using $rootScope.apply to trigger angular digest cycle
+            // changing $location.path inside bootstrap modal wont trigger digest
             $rootScope.$apply(function() {
               $location.path('/');
             });


### PR DESCRIPTION
### What is this PR for?
Redirect to home page, if a user declines the access failure message on a notebook

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2172](https://issues.apache.org/jira/browse/ZEPPELIN-2172)
### How should this be tested?
1. Create a notebook with qa_user user as the owner
2. Give write permissions to user test_user1, and read permissions to user test_user3
3. Now in another tab, open the notebook with test_user1 user who has write permissions
4. In the original tab, have user qa_user (owner of the notebook) remove the write permissions from test_user1 user and grant it to some other user test_user5.
5. Goto the other tab where user test_user1 was logged in. It shows an error message
6. On click of close button, UI should redirect to homepage


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
