### PR TITLE
[ZEPPELIN-2203][WIP] In case of 'spark2' default interpreter, both '%spark' and '%spark2' point to Spark2.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -368,7 +368,8 @@ public class InterpreterFactory implements InterpreterGroupFactory {
     Preconditions.checkNotNull(name, "name should be not null");
 
     String className;
-    if (null != (className = getInterpreterClassFromInterpreterSetting(setting, name))) {
+    if (setting.getName().equals(name) &&
+        null != (className = getInterpreterClassFromInterpreterSetting(setting, name))) {
       List<Interpreter> interpreterGroup = createOrGetInterpreterList(user, noteId, setting);
       for (Interpreter interpreter : interpreterGroup) {
         if (className.equals(interpreter.getClassName())) {


### PR DESCRIPTION
### What is this PR for?
In case of 'spark2' default interpreter, both '%spark' and '%spark2' point to Spark2.

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2203](https://issues.apache.org/jira/browse/ZEPPELIN-2203)


### How should this be tested?
Create two interpreters with name spark(with spark 1.6) and spark2 (with spark 2.0). Now set default interpreter as spark2 for a notebook. Now execute "%spark sc.version" notice it prints spark2 version

### Screenshots (if appropriate)

Before
![zeppelin-2203_before](https://cloud.githubusercontent.com/assets/674497/23493122/70b46446-ff2f-11e6-881d-39acc0727627.gif)


After
![zeppelin-2203_after](https://cloud.githubusercontent.com/assets/674497/23493123/70b6f1ca-ff2f-11e6-8566-1da7f943ea56.gif)



### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
