### PR TITLE
[ZEPPELIN-2162] [ZEPPELIN-2142] Make travis_check.py work with fork under organization, and show guidance if travis is not configured

### DIFF
--- a/travis_check.py
+++ b/travis_check.py
@@ -54,8 +54,11 @@ def getBuildStatus(author, commit):
     # get latest 25 builds
     resp = requests.get(url=travisApi + "/repos/" + author + "/zeppelin/builds")
     data = json.loads(resp.text)
-
     build = None
+
+    if len(data) == 0:
+        return build;
+
     for b in data:
         if b["commit"][:len(commit)] == commit:
             resp = requests.get(url=travisApi + "/repos/" + author + "/zeppelin/builds/" + str(b["id"]))
@@ -103,8 +106,8 @@ for sleep in check:
     info("Get build status ...")
     build = getBuildStatus(author, commit)
     if build == None:
-        info("Can't find build for commit= " + commit)
-        sys.exit(1)
+        info("Can't find build for commit " + commit + " from " + author)
+        sys.exit(2)
 
     print("Build https://travis-ci.org/" + author + "/zeppelin/builds/" + str(build["id"]))
     failure, running = printBuildStatus(build)


### PR DESCRIPTION
### What is this PR for?

When contributor uses zeppelin fork under organization, Jenkins can't check it with current travis_check.py.

This PR updates travis_check.py to distinguish error 1 when it fails with build fail, error 2 when it can't find build.

When it fails with 2, jenkins configuration can retry travis_check.py with organization repo.

Even though it tried again, still get 2 in return, then print instruction how to configure travis-ci.

Jenkins configuration is updated

from
```bash
if [ -f "travis_check.py" ]; then
  git log -n 1
  STATUS=$(curl -s $BUILD_URL | grep -e "GitHub pull request.*from.*" | sed 's/.*GitHub pull request <a href=\"\(https[^"]*\).*from[^"]*.\(https[^"]*\).*/\1 \2/g')
  AUTHOR=$(echo $STATUS | sed 's/.*[/]\(.*\)$/\1/g')
  PR=$(echo $STATUS | awk '{print $1}' | sed 's/.*[/]\(.*\)$/\1/g')
  COMMIT=$(git log -n 1 | grep "^Merge:" | awk '{print $3}')
  if [ -z $COMMIT ]; then
    COMMIT=$(curl -s https://api.github.com/repos/apache/zeppelin/pulls/$PR | grep -e "\"ref\":" -e "\"sha\":" | tr '\n' ' ' | sed 's/\(.*sha[^,]*,\)\(.*ref.*\)/\1 = \2/g' | tr = '\n' | grep -v master | sed 's/.*sha.[^"]*["]\([^"]*\).*/\1/g')
  fi
  sleep 30 # sleep few moment to wait travis starts the build
  python ./travis_check.py ${AUTHOR} ${COMMIT}
else
  echo "travis_check.py does not exists"
  echo "assume it's gh-pages branch"
  echo "return okay"
fi
```

to
```bash
if [ -f "travis_check.py" ]; then
  git log -n 1
  STATUS=$(curl -s $BUILD_URL | grep -e "GitHub pull request.*from.*" | sed 's/.*GitHub pull request <a href=\"\(https[^"]*\).*from[^"]*.\(https[^"]*\).*/\1 \2/g')
  AUTHOR=$(echo $STATUS | sed 's/.*[/]\(.*\)$/\1/g')
  PR=$(echo $STATUS | awk '{print $1}' | sed 's/.*[/]\(.*\)$/\1/g')
  COMMIT=$(git log -n 1 | grep "^Merge:" | awk '{print $3}')
  if [ -z $COMMIT ]; then
    COMMIT=$(curl -s https://api.github.com/repos/apache/zeppelin/pulls/$PR | grep -e "\"ref\":" -e "\"sha\":" | tr '\n' ' ' | sed 's/\(.*sha[^,]*,\)\(.*ref.*\)/\1 = \2/g' | tr = '\n' | grep -v master | sed 's/.*sha.[^"]*["]\([^"]*\).*/\1/g')
  fi
  sleep 30 # sleep few moment to wait travis starts the build
  python ./travis_check.py ${AUTHOR} ${COMMIT}
  RET_CODE=$?
  if [ $RET_CODE -eq 2 ]; then # try with repository name when travis-ci is not available in the account
    AUTHOR=$(curl -s https://api.github.com/repos/apache/zeppelin/pulls/$PR | grep '"full_name":' | grep -v "apache/zeppelin" | sed 's/.*[:][^"]*["]\([^/]*\).*/\1/g')
 	python ./travis_check.py ${AUTHOR} ${COMMIT}
    RET_CODE=$?
  fi
  
  if [ $RET_CODE -eq 2 ]; then # fail with can't find build information in the travis
    echo "Looks like travis-ci is not configured for your fork."
    echo "Please setup by swich on 'zeppelin' repository at https://travis-ci.org/profile and travis-ci."
    echo "And then make sure 'Build pushes' option is enabled in the settings https://travis-ci.org/${AUTHOR}/zeppelin/settings."
    echo "See http://zeppelin.apache.org/contribution/contributions.html#continuous-integration."
  fi
  
  exit $RET_CODE
else
  echo "travis_check.py does not exists"
  echo "assume it's gh-pages branch"
  echo "return okay"
fi
```

### What type of PR is it?
Improvement

### Todos
* [x] - distinguish error code travis_check.py
* [x] - Update jenkins configuration

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2162
https://issues.apache.org/jira/browse/ZEPPELIN-2142

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
