### PR TITLE
[ZEPPELIN-2094] Decrease npm install retry time (for branch-0.7)

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumVisualizationFactory.java
@@ -41,6 +41,10 @@ public class HeliumVisualizationFactory {
   private final String NODE_VERSION = "v6.9.1";
   private final String NPM_VERSION = "3.10.8";
   private final String DEFAULT_NPM_REGISTRY_URL = "http://registry.npmjs.org/";
+  private final int FETCH_RETRY_COUNT = 2;
+  private final int FETCH_RETRY_FACTOR_COUNT = 1;
+  // Milliseconds
+  private final int FETCH_RETRY_MIN_TIMEOUT = 5000;
 
   private final FrontendPluginFactory frontEndPluginFactory;
   private final File workingDirectory;
@@ -214,7 +218,11 @@ public class HeliumVisualizationFactory {
 
     out.reset();
     try {
-      npmCommand("install");
+      String commandForNpmInstall =
+              String.format("install --fetch-retries=%d --fetch-retry-factor=%d " +
+                              "--fetch-retry-mintimeout=%d",
+                      FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
+      npmCommand(commandForNpmInstall);
       npmCommand("run bundle");
     } catch (TaskRunnerException e) {
       throw new IOException(new String(out.toByteArray()));
@@ -334,7 +342,11 @@ public class HeliumVisualizationFactory {
   }
 
   public synchronized void install(HeliumPackage pkg) throws TaskRunnerException {
-    npmCommand("install " + pkg.getArtifact());
+    String commandForNpmInstallArtifact =
+        String.format("install %s --fetch-retries=%d --fetch-retry-factor=%d " +
+                        "--fetch-retry-mintimeout=%d", pkg.getArtifact(),
+                FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
+    npmCommand(commandForNpmInstallArtifact);
   }
 
   private void npmCommand(String args) throws TaskRunnerException {


### PR DESCRIPTION
### What is this PR for?
**This pr is for branch-0.7**
It’s too delayed for npm install when computer do not connected any networks.
Beacause when npm install, it has too long retry timeout.
This PR is to decrease retry timeout when npm install.
[pr for mater](https://github.com/apache/zeppelin/pull/2060) https://github.com/apache/zeppelin/pull/2095

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2094

### How should this be tested?
you must enable any one helium before test

Line 221 In zeppelin-zengine org.apache.zeppelin.helium.HeliumVisualizationFactory.java

First set with 
`String commandForNpmInstall = "install —loglevel=error”;`
and You don’t connect any ethernet or wireless internet.
build & run

and set with
```
String commandForNpmInstall =
     String.format("install --fetch-retries=%d --fetch-retry-factor=%d " +
                   "--fetch-retry-mintimeout=%d",
     FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
```
also don’t connect any networks, build & run.

and also line 345. do it `npm install some artifact` again like above.

WHY
retries = 2
factor = 1
mintimeout = 5(sec)?

npm use [retry](https://github.com/tim-kos/node-retry) module to retry.
It refers [this article](http://dthain.blogspot.kr/2009/02/exponential-backoff-in-distributed.html) for retry algorithms.
It is a math which structured _Math.min(Math.round(random * minTimeout * Math.pow(factor, attempt)), maxTimeout)_.
In retry source code, between two retries. First retry doesn't care _Math.min()_, just _Math.round(random * minTimeout * Math.pow(factor, attempt))_)


Description | Before | After
------- | ------- | -------
Condition | npm's default setting<br>random = False = 1<br>retry = 2<br>minTimeout = 10 (sec)<br>maxTimeout = 60 (sec)<br>factor = 10 | custom setting<br>random = False = 1<br>retry = 2<br>minTimeout = 5 (sec)<br>maxTimeout = 60 (sec)<br>factor = 1<br>
First retry | Math.round(1 * 10 (sec) * 10^1)) | Math.round(1 * 5 (sec) * 1^1))
First retry result (Approximately) | 100 (sec) | 5 (sec)
Second retry | Math.min(Math.round(1 * 10 (sec) * 10^2), 60 (sec)) | Math.min(Math.round(1 * 5 (sec) * 1^2), 60 (sec))
Second retry result (Approximately) | 60 (sec) | 5 (sec)
Total waiting time (Approximately) | 160 (sec) | 10 (sec)


You can check like this below Screenshots.

### Screenshots
Before | After
-------|-------
<img width="1077" alt="2017-02-24 12 32 06" src="https://cloud.githubusercontent.com/assets/1144643/23267951/9deaec6e-fa2f-11e6-9171-5792f24de76d.png"> | <img width="1081" alt="2017-02-24 12 37 10" src="https://cloud.githubusercontent.com/assets/1144643/23267954/a12c0c0a-fa2f-11e6-99cd-335deef607ac.png">


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A