### PR TITLE
[MINOR][ZEPPELIN-2154] Enable work in the web dev mode if changing default server port

### DIFF
--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -31,7 +31,7 @@ $ yarn run build
 # you need to run zeppelin backend instance also
 $ yarn run dev
 
-# If you are using a custom port, you must use 'SERVER_PORT' variables to run the web application development mode.
+# If you are using a custom port, you must use the 'SERVER_PORT' variable to run the web application development mode
 $ SERVER_PORT=8080 yarn run dev
 
 # execute tests

--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -31,6 +31,9 @@ $ yarn run build
 # you need to run zeppelin backend instance also
 $ yarn run dev
 
+# If you are using a custom port, you must use `SERVER_PORT` variables to run the web application development mode.
+$ SERVER_PORT=8080 yarn run dev
+
 # execute tests
 $ yarn run test
 ```

--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -31,7 +31,7 @@ $ yarn run build
 # you need to run zeppelin backend instance also
 $ yarn run dev
 
-# If you are using a custom port, you must use `SERVER_PORT` variables to run the web application development mode.
+# If you are using a custom port, you must use 'SERVER_PORT' variables to run the web application development mode.
 $ SERVER_PORT=8080 yarn run dev
 
 # execute tests

--- a/zeppelin-web/src/components/baseUrl/baseUrl.service.js
+++ b/zeppelin-web/src/components/baseUrl/baseUrl.service.js
@@ -24,8 +24,8 @@ function baseUrlSrv() {
       }
     }
     //Exception for when running locally via grunt
-    if (port === 3333 || port === 9000) {
-      port = 8080;
+    if (port === 9000) {
+      port = process.env.SERVER_PORT;
     }
     return port;
   };

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -87,6 +87,12 @@ module.exports = function makeWebpackConfig () {
     app: './src/index.js'
   };
 
+  var serverPort = 8080;
+
+  if(process.env.SERVER_PORT) {
+     serverPort = process.env.SERVER_PORT;
+  }
+
   /**
    * Output
    * Reference: http://webpack.github.io/docs/configuration.html#output
@@ -211,7 +217,8 @@ module.exports = function makeWebpackConfig () {
       // Reference: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
       new webpack.DefinePlugin({
         'process.env': {
-          HELIUM_BUNDLE_DEV: process.env.HELIUM_BUNDLE_DEV
+          HELIUM_BUNDLE_DEV: process.env.HELIUM_BUNDLE_DEV,
+          SERVER_PORT: serverPort
         }
       })
     )


### PR DESCRIPTION
### What is this PR for?
If user change `zeppelin.server.port` variable in zeppelin-site.xml, zeppelin doesn't work in web development. 
In order for user to run zeppelin correctly, so that user can add `SERVER_PORT` as an environment variable when running web application development mode.

### What type of PR is it?
[Bug Fix | Improvement | Documentation]

### What is the Jira issue?
* [ZEPPELIN-2154](https://issues.apache.org/jira/browse/ZEPPELIN-2154)

### How should this be tested?
1. Change `zeppelin.server.port` from 8080 to 8888 (or another port) in `zeppelin-site.xml`
2. Run zeppelin (`bin/zeppelin-daemon.sh start`)
3. Run web development mode under `zeppelin-web` folder such like `SERVER_PORT=8888 yarn run dev` 
4. Connect `localhost:9000`

### Screenshots (if appropriate)
[Before]
![z_2130_before](https://cloud.githubusercontent.com/assets/8110458/23586226/37f38252-01d4-11e7-8261-37e4e17c7eaf.gif)

[After]
![z_2130_after](https://cloud.githubusercontent.com/assets/8110458/23586227/3aa4422a-01d4-11e7-8cd0-c0644e315131.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, added in README.md
