### PR TITLE
[ZEPPELIN-2106] providing paragraph config in create note/paragraph rest call

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -112,15 +112,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     {
       "title": "paragraph title2",
       "text": "paragraph text2",
-      "showTitle": true,
-      "colWidth": 9.0,
-      "graph": {
-        "mode": "pieChart"
-      }
-    }
-    {
-      "title": "paragraph title3",
-      "text": "paragraph text3",
       "config": {
         "title": true,
         "colWidth": 6.0,
@@ -622,31 +613,18 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
 }</pre></td>
     </tr>
     <tr>
-      <td> sample JSON input (providing graph,showTitle and colWidth information) </td>
+      <td> sample JSON input (providing paragraph config) </td>
       <td><pre>
 {
   "title": "paragraph title2",
   "text": "paragraph text2",
-  "showTitle": true,
-  "colWidth": 9.0,
-  "graph": {
-    "mode": "pieChart"
-  }
- }</pre></td>
-    </tr>
-    <tr>
-      <td> sample JSON input (providing paragraph config) </td>
-      <td><pre>
-{
-  "title": "paragraph title3",
-  "text": "paragraph text3",
   "config": {
     "title": true,
     "colWidth": 6.0,
     "results": [
       {
         "graph": {
-          "mode": "scatterChart",
+          "mode": "pieChart",
           "optionOpen": true
         }
       }

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -111,7 +111,28 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     },
     {
       "title": "paragraph title2",
-      "text": "paragraph text2"
+      "text": "paragraph text2",
+      "showTitle": true,
+      "colWidth": 9.0,
+      "graph": {
+        "mode": "pieChart"
+      }
+    }
+    {
+      "title": "paragraph title3",
+      "text": "paragraph text3",
+      "config": {
+        "title": true,
+        "colWidth": 6.0,
+        "results": [
+          {
+            "graph": {
+              "mode": "scatterChart",
+              "optionOpen": true
+            }
+          }
+        ]
+      }
     }
   ]
 }</pre></td>
@@ -598,6 +619,39 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   "title": "Paragraph insert revised",
   "text": "%spark\nprintln(\"Paragraph insert revised\")",
   "index": 0
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON input (providing graph,showTitle and colWidth information) </td>
+      <td><pre>
+{
+  "title": "paragraph title2",
+  "text": "paragraph text2",
+  "showTitle": true,
+  "colWidth": 9.0,
+  "graph": {
+    "mode": "pieChart"
+  }
+ }</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON input (providing paragraph config) </td>
+      <td><pre>
+{
+  "title": "paragraph title3",
+  "text": "paragraph text3",
+  "config": {
+    "title": true,
+    "colWidth": 6.0,
+    "results": [
+      {
+        "graph": {
+          "mode": "scatterChart",
+          "optionOpen": true
+        }
+      }
+    ]
+  }
 }</pre></td>
     </tr>
     <tr>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -955,38 +955,7 @@ public class NotebookRestApi {
     p.setTitle(request.getTitle());
     p.setText(request.getText());
     Map< String, Object > config = request.getConfig();
-    if ( config != null){
-      Vector< String > ignoredFields = new Vector<>();
-      if ( request.getGraph() != null)
-        ignoredFields.add("graph");
-      if ( request.getColWidth() != null)
-        ignoredFields.add("colWidth");
-      if ( request.getShowTitle() != null)
-        ignoredFields.add("showTitle");
-      if ( ignoredFields.size() > 0 )
-        LOG.warn("As config is provided, the following field(s) are ignored {}",
-                ignoredFields.toString());
-    }
-    else {
-      config = new HashMap<>();
-      Map graph = request.getGraph();
-      if (graph != null) {
-        List<Object> results = new ArrayList<>();
-        Map<String, Object> result = new HashMap<>();
-        result.put("graph", graph);
-        results.add(result);
-        config.put("results", results);
-      }
-      Double colWidth = request.getColWidth();
-      if (colWidth != null) {
-        config.put("colWidth", colWidth);
-      }
-      Boolean showTitle = request.getShowTitle();
-      if (showTitle != null) {
-        config.put("title", showTitle);
-      }
-    }
-    if ( !config.isEmpty()) {
+    if ( config != null && !config.isEmpty()) {
       configureParagraph(p, config, user);
     }
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
@@ -17,15 +17,24 @@
 
 package org.apache.zeppelin.rest.message;
 
+import java.util.HashMap;
+
 /**
  * NewParagraphRequest rest api request message
  *
  * index field will be ignored when it's used to provide initial paragraphs
+ * visualization (optional) one of:
+ * table,pieChart,multibarChart,stackedAreaChart,lineChart,scatterChart
+ * colWidth (optional), e.g. 12.0
  */
 public class NewParagraphRequest {
   String title;
   String text;
   Double index;
+  HashMap< String, Object > graph;
+  Boolean showTitle;
+  Double colWidth;
+  HashMap< String, Object > config;
 
   public NewParagraphRequest() {
 
@@ -42,4 +51,12 @@ public class NewParagraphRequest {
   public Double getIndex() {
     return index;
   }
+
+  public HashMap< String, Object > getGraph() { return graph; }
+
+  public Boolean getShowTitle() { return showTitle; }
+
+  public Double getColWidth() { return colWidth; }
+
+  public HashMap< String, Object > getConfig() { return config; }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewParagraphRequest.java
@@ -31,9 +31,6 @@ public class NewParagraphRequest {
   String title;
   String text;
   Double index;
-  HashMap< String, Object > graph;
-  Boolean showTitle;
-  Double colWidth;
   HashMap< String, Object > config;
 
   public NewParagraphRequest() {
@@ -51,12 +48,6 @@ public class NewParagraphRequest {
   public Double getIndex() {
     return index;
   }
-
-  public HashMap< String, Object > getGraph() { return graph; }
-
-  public Boolean getShowTitle() { return showTitle; }
-
-  public Double getColWidth() { return colWidth; }
 
   public HashMap< String, Object > getConfig() { return config; }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -134,10 +134,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String jsonRequest = "{\"name\":\"" + noteName + "\", \"paragraphs\": [" +
         "{\"title\": \"title1\", \"text\": \"text1\"}," +
         "{\"title\": \"title2\", \"text\": \"text2\"}," +
-        "{\"title\": \"titleConfig1\", \"text\": \"text3\", " +
-        "\"graph\": {\"mode\": \"pieChart\"}, " +
-        "\"colWidth\": 9.0, \"showTitle\": true}, " +
-        "{\"title\": \"titleConfig2\", \"text\": \"text4\", " +
+        "{\"title\": \"titleConfig\", \"text\": \"text3\", " +
         "\"config\": {\"colWidth\": 9.0, \"title\": true, "+
         "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}] "+
         "}}]} ";
@@ -160,7 +157,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       expectedNoteName = "Note " + newNoteId;
     }
     assertEquals("compare note name", expectedNoteName, newNoteName);
-    assertEquals("initial paragraph check failed", 5, newNote.getParagraphs().size());
+    assertEquals("initial paragraph check failed", 4, newNote.getParagraphs().size());
     for (Paragraph p : newNote.getParagraphs()) {
       if (StringUtils.isEmpty(p.getText())) {
         continue;
@@ -633,12 +630,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("title2", paragraphAtIdx0.getTitle());
     assertEquals("text2", paragraphAtIdx0.getText());
 
-    //append paragraph providing config
-    String jsonRequest3 = "{\"title\": \"title3\", \"text\": \"text3\", " +
-                          "\"graph\": {\"mode\": \"pieChart\"}, " +
-                          "\"colWidth\": 9.0, \"showTitle\": true}";
+    //append paragraph providing graph
+    String jsonRequest3 = "{\"title\": \"title3\", \"text\": \"text3\", "+
+                          "\"config\": {\"colWidth\": 9.0, \"title\": true, "+
+                          "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
     PostMethod post3 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest3);
-    LOG.info("testInsertParagraph response3\n" + post3.getResponseBodyAsString());
+    LOG.info("testInsertParagraph response4\n" + post3.getResponseBodyAsString());
     assertThat("Test insert method:", post3, isAllowed());
     post3.releaseConnection();
 
@@ -650,24 +647,6 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     assertEquals("pieChart", mode);
     assertEquals(9.0, p.getConfig().get("colWidth"));
     assertTrue(((boolean) p.getConfig().get("title")));
-
-    //append paragraph providing graph
-    String jsonRequest4 = "{\"title\": \"title4\", \"text\": \"text4\", "+
-                          "\"config\": {\"colWidth\": 9.0, \"title\": true, "+
-                          "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
-    PostMethod post4 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest4);
-    LOG.info("testInsertParagraph response4\n" + post4.getResponseBodyAsString());
-    assertThat("Test insert method:", post4, isAllowed());
-    post4.releaseConnection();
-
-    Paragraph p2 = note.getLastParagraph();
-    assertEquals("title4", p2.getTitle());
-    assertEquals("text4", p2.getText());
-    Map result2 = ((List<Map>)p.getConfig().get("results")).get(0);
-    String mode2 = ((Map)result.get("graph")).get("mode").toString();
-    assertEquals("pieChart", mode2);
-    assertEquals(9.0, p2.getConfig().get("colWidth"));
-    assertTrue(((boolean) p2.getConfig().get("title")));
 
 
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -133,8 +133,14 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     String noteName = "test";
     String jsonRequest = "{\"name\":\"" + noteName + "\", \"paragraphs\": [" +
         "{\"title\": \"title1\", \"text\": \"text1\"}," +
-        "{\"title\": \"title2\", \"text\": \"text2\"}" +
-        "]}";
+        "{\"title\": \"title2\", \"text\": \"text2\"}," +
+        "{\"title\": \"titleConfig1\", \"text\": \"text3\", " +
+        "\"graph\": {\"mode\": \"pieChart\"}, " +
+        "\"colWidth\": 9.0, \"showTitle\": true}, " +
+        "{\"title\": \"titleConfig2\", \"text\": \"text4\", " +
+        "\"config\": {\"colWidth\": 9.0, \"title\": true, "+
+        "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}] "+
+        "}}]} ";
     PostMethod post = httpPost("/notebook/", jsonRequest);
     LOG.info("testNoteCreate \n" + post.getResponseBodyAsString());
     assertThat("test note create method:", post, isAllowed());
@@ -154,13 +160,20 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       expectedNoteName = "Note " + newNoteId;
     }
     assertEquals("compare note name", expectedNoteName, newNoteName);
-    assertEquals("initial paragraph check failed", 3, newNote.getParagraphs().size());
+    assertEquals("initial paragraph check failed", 5, newNote.getParagraphs().size());
     for (Paragraph p : newNote.getParagraphs()) {
       if (StringUtils.isEmpty(p.getText())) {
         continue;
       }
       assertTrue("paragraph title check failed", p.getTitle().startsWith("title"));
       assertTrue("paragraph text check failed", p.getText().startsWith("text"));
+      if ( p.getTitle() == "titleConfig"){
+        assertEquals("paragraph col width check failed", 9.0, p.getConfig().get("colWidth"));
+        assertTrue("paragraph show title check failed", ((boolean) p.getConfig().get("title")));
+        Map graph = ((List<Map>)p.getConfig().get("results")).get(0);
+        String mode = graph.get("mode").toString();
+        assertEquals("paragraph graph mode check failed", "pieChart", mode);
+      }
     }
     // cleanup
     ZeppelinServer.notebook.removeNote(newNoteId, anonymous);
@@ -213,8 +226,8 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
 
 
   @Test
-  public void testexportNote() throws IOException {
-    LOG.info("testexportNote");
+  public void testExportNote() throws IOException {
+    LOG.info("testExportNote");
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
@@ -246,7 +259,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testImportNotebook() throws IOException {
     Map<String, Object> resp;
     String noteName = "source note for import";
-    LOG.info("testImortNote");
+    LOG.info("testImportNote");
     // create test note
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
@@ -619,6 +632,43 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Paragraph paragraphAtIdx0 = note.getParagraphs().get(0);
     assertEquals("title2", paragraphAtIdx0.getTitle());
     assertEquals("text2", paragraphAtIdx0.getText());
+
+    //append paragraph providing config
+    String jsonRequest3 = "{\"title\": \"title3\", \"text\": \"text3\", " +
+                          "\"graph\": {\"mode\": \"pieChart\"}, " +
+                          "\"colWidth\": 9.0, \"showTitle\": true}";
+    PostMethod post3 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest3);
+    LOG.info("testInsertParagraph response3\n" + post3.getResponseBodyAsString());
+    assertThat("Test insert method:", post3, isAllowed());
+    post3.releaseConnection();
+
+    Paragraph p = note.getLastParagraph();
+    assertEquals("title3", p.getTitle());
+    assertEquals("text3", p.getText());
+    Map result = ((List<Map>)p.getConfig().get("results")).get(0);
+    String mode = ((Map)result.get("graph")).get("mode").toString();
+    assertEquals("pieChart", mode);
+    assertEquals(9.0, p.getConfig().get("colWidth"));
+    assertTrue(((boolean) p.getConfig().get("title")));
+
+    //append paragraph providing graph
+    String jsonRequest4 = "{\"title\": \"title4\", \"text\": \"text4\", "+
+                          "\"config\": {\"colWidth\": 9.0, \"title\": true, "+
+                          "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
+    PostMethod post4 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest4);
+    LOG.info("testInsertParagraph response4\n" + post4.getResponseBodyAsString());
+    assertThat("Test insert method:", post4, isAllowed());
+    post4.releaseConnection();
+
+    Paragraph p2 = note.getLastParagraph();
+    assertEquals("title4", p2.getTitle());
+    assertEquals("text4", p2.getText());
+    Map result2 = ((List<Map>)p.getConfig().get("results")).get(0);
+    String mode2 = ((Map)result.get("graph")).get("mode").toString();
+    assertEquals("pieChart", mode2);
+    assertEquals(9.0, p2.getConfig().get("colWidth"));
+    assertTrue(((boolean) p2.getConfig().get("title")));
+
 
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
   }


### PR DESCRIPTION
### What is this PR for?
* Allow to provide full paragraph config directly in the Create Paragraph and Create Note endpoint.
* This saves some calls to [noteId]/paragraph/[paragraphId]/config
* Updated doc.


### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-2106](https://issues.apache.org/jira/browse/ZEPPELIN-2106)

### How should this be tested?
Outline the steps to test the PR here.

1. Clone the first paragraph of 'Zeppelin Tutorial/Basic Features (Spark)' to get the bank data loaded in a new note.
2.  curl -X POST -d @testAPI.json http://localhost:8080/api/notebook/$YOURNOTEID/paragraph
3. When running the paragraphes, the graphs will show up with the appropriate settings.

testAPI.json:
`{
        "title":"Example providing config",
        "text":"%sql\nselect age, marital, count(1) cvalue from bank group by age, marital order by age",
        "config": {
          "title":true,
          "colWidth":6.0,
          "results": [
                  {
                          "graph": {
                                  "mode": "scatterChart",
                                  "optionOpen": true
                          }
                  }
          ]
        },
        "colWidth":9.0
}
`
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
