### PR TITLE
[Hot Fix] Remove 'bower_component' from caching list in travis cfg file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ cache:
     - ${HOME}/R
     -  zeppelin-web/node
     -  zeppelin-web/node_modules
-    -  zeppelin-web/bower_components
 
 addons:
   apt:


### PR DESCRIPTION
### What is this PR for?
After #2042 merged, cached `bower_components/` causes CI failure like 
```
"message": "Unable to find suitable version for d3" (bower installation failure)
```
```
[ERROR] [{
[ERROR]   "code": "ECONFLICT",
[ERROR]   "name": "d3",
[ERROR]   "picks": [
[ERROR]     {
[ERROR]       "endpoint": {
[ERROR]         "name": "d3",
[ERROR]         "source": "d3",
[ERROR]         "target": "~3.3.13"
[ERROR]       },
[ERROR]       "canonicalDir": "/home/travis/build/apache/zeppelin/zeppelin-web/bower_components/d3",
[ERROR]       "pkgMeta": {
[ERROR]         "name": "d3",
[ERROR]         "version": "3.3.13",
[ERROR]         "main": "d3.js",
[ERROR]         "scripts": [
[ERROR]           "d3.js"
[ERROR]         ],
...
```

It can be resolved in each contributors' travis account by deleting all cache in their repository like [this](https://github.com/apache/zeppelin/pull/2042#issuecomment-284324008), but current Zeppelin master is under Apache travis account. So we need to clear the cache by removing `zeppelin-web/bower_components` in caching list in `.travis.yml`. 

Let's see the master branch's CI turns to green light :)


### What type of PR is it?
Hot Fix

### What is the Jira issue?
No Jira issue for this 

### How should this be tested?
No need to test 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
