### PR TITLE
ZEPPELIN-2224. Throw more meaningful exception when kerberos is enabled in livy interpreter

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -25,6 +25,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.zeppelin.interpreter.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -484,6 +485,8 @@ public abstract class BaseLivyInterprereter extends Interpreter {
         if (cause.getResponseBodyAsString().matches(SESSION_NOT_FOUND_PATTERN)) {
           throw new SessionNotFoundException(cause.getResponseBodyAsString());
         }
+        throw new LivyException(cause.getResponseBodyAsString() + "\n"
+            + ExceptionUtils.getFullStackTrace(ExceptionUtils.getRootCause(e)));
       }
       throw new LivyException(e);
     }

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -368,13 +368,11 @@ public abstract class BaseLivyInterprereter extends Interpreter {
       }
 
       if (displayAppInfo) {
-        //TODO(zjffdu), use multiple InterpreterResult to display appInfo
         InterpreterResult interpreterResult = new InterpreterResult(InterpreterResult.Code.SUCCESS);
         interpreterResult.add(InterpreterResult.Type.TEXT, result);
         String appInfoHtml = "<hr/>Spark Application Id: " + sessionInfo.appId + "<br/>"
             + "Spark WebUI: <a href=\"" + sessionInfo.webUIAddress + "\">"
             + sessionInfo.webUIAddress + "</a>";
-        LOGGER.info("appInfoHtml:" + appInfoHtml);
         interpreterResult.add(InterpreterResult.Type.HTML, appInfoHtml);
         return interpreterResult;
       } else {


### PR DESCRIPTION
### What is this PR for?
In kerberos enviroment, user would get the following exception is impersonation configuration is not correctly. This is not so useful for users. This PR would print more meaning exception for users. 

```
org.springframework.web.client.HttpClientErrorException: 403 Forbidden at 
org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:91) at 
org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:667) at 
org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:620) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.doExecuteSubject(KerberosRestTemplate.java:202) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.access$100(KerberosRestTemplate.java:67) at 
org.springframework.security.kerberos.client.KerberosRestTemplate$1.run(KerberosRestTemplate.java:191) at java.security.AccessController.doPrivileged(Native Method) at 
javax.security.auth.Subject.doAs(Subject.java:360) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.doExecute(KerberosRestTemplate.java:187) at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:580) at 
org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:498) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.callRestAPI(BaseLivyInterprereter.java:406) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.createSession(BaseLivyInterprereter.java:192) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.initLivySession(BaseLivyInterprereter.java:98) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.open(BaseLivyInterprereter.java:80) at 
org.apache.zeppelin.interpreter.LazyOpenInterpreter.open(LazyOpenInterpreter.java:69)
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2224

### How should this be tested?
Tested manually in secured cluster.

### Screenshots (if appropriate)

Before this PR


```
org.springframework.web.client.HttpClientErrorException: 403 Forbidden at 
org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:91) at 
org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:667) at 
org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:620) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.doExecuteSubject(KerberosRestTemplate.java:202) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.access$100(KerberosRestTemplate.java:67) at org.springframework.security.kerberos.client.KerberosRestTemplate$1.run(KerberosRestTemplate.java:191) at java.security.AccessController.doPrivileged(Native Method) at 
javax.security.auth.Subject.doAs(Subject.java:360) at 
org.springframework.security.kerberos.client.KerberosRestTemplate.doExecute(KerberosRestTemplate.java:187) at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:580) at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:498) at org.apache.zeppelin.livy.BaseLivyInterprereter.callRestAPI(BaseLivyInterprereter.java:406) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.createSession(BaseLivyInterprereter.java:192) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.initLivySession(BaseLivyInterprereter.java:98) at 
org.apache.zeppelin.livy.BaseLivyInterprereter.open(BaseLivyInterprereter.java:80) at 
org.apache.zeppelin.interpreter.LazyOpenInterpreter.open(LazyOpenInterpreter.java:69)
```

After this PR
```
org.apache.zeppelin.livy.LivyException: {"msg":"User 'zeppelin-sandbox' not allowed to impersonate 'Some(user1)'."}
org.springframework.web.client.HttpClientErrorException: 403 Forbidden
	at org.springframework.web.client.DefaultResponseErrorHandler.handleError(DefaultResponseErrorHandler.java:91)
	at org.springframework.web.client.RestTemplate.handleResponse(RestTemplate.java:667)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:620)
	at org.springframework.security.kerberos.client.KerberosRestTemplate.doExecuteSubject(KerberosRestTemplate.java:202)
	at org.springframework.security.kerberos.client.KerberosRestTemplate.access$100(KerberosRestTemplate.java:67)
	at org.springframework.security.kerberos.client.KerberosRestTemplate$1.run(KerberosRestTemplate.java:191)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at org.springframework.security.kerberos.client.KerberosRestTemplate.doExecute(KerberosRestTemplate.java:187)
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:580)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:498)
	at org.apache.zeppelin.livy.BaseLivyInterprereter.callRestAPI(BaseLivyInterprereter.java:407)
	at org.apache.zeppelin.livy.BaseLivyInterprereter.createSession(BaseLivyInterprereter.java:193)
	at org.apache.zeppelin.livy.BaseLivyInterprereter.initLivySession(BaseLivyInterprereter.java:99)
```
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
