### PR TITLE
[ZEPPELIN-2215] Progress bar for Spell execution

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -38,7 +38,7 @@ limitations under the License.
     {{paragraph.status}}
   </span>
 
-  <span ng-if="paragraph.status=='RUNNING'">
+  <span ng-if="paragraph.status === 'RUNNING' && paragraph.executor !== 'SPELL'">
     {{getProgress()}}%
   </span>
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -17,6 +17,12 @@ import {
   ParagraphStatus, isParagraphRunning,
 } from './paragraph.status';
 
+const ParagraphExecutor = {
+  SPELL: 'SPELL',
+  INTERPRETER: 'INTERPRETER',
+  NONE: '', /** meaning `DONE` */
+};
+
 angular.module('zeppelinWebApp').controller('ParagraphCtrl', ParagraphCtrl);
 
 function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $location,
@@ -266,6 +272,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   $scope.cleanupSpellTransaction = function() {
     const status = ParagraphStatus.FINISHED;
+    $scope.paragraph.executor = ParagraphExecutor.NONE;
     $scope.paragraph.status = status;
     $scope.paragraph.results.code = status;
 
@@ -284,8 +291,10 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   $scope.runParagraphUsingSpell = function(paragraphText,
                                            magic, digestRequired, propagated) {
-    $scope.paragraph.results = {};
+    $scope.paragraph.status = 'RUNNING';
     $scope.paragraph.status = ParagraphStatus.RUNNING;
+    $scope.paragraph.executor = ParagraphExecutor.SPELL;
+    $scope.paragraph.results = {};
     $scope.paragraph.errorMessage = '';
     if (digestRequired) { $scope.$digest(); }
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -292,7 +292,6 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.runParagraphUsingSpell = function(paragraphText,
                                            magic, digestRequired, propagated) {
     $scope.paragraph.status = 'RUNNING';
-    $scope.paragraph.status = ParagraphStatus.RUNNING;
     $scope.paragraph.executor = ParagraphExecutor.SPELL;
     $scope.paragraph.results = {};
     $scope.paragraph.errorMessage = '';


### PR DESCRIPTION
### What is this PR for?

Add progress bar for spell execution.

- Used `RUNNING` state to display progress bar
- Decided not to display `{number}%` for spell, since we can't calculate in advance.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2215](https://issues.apache.org/jira/browse/ZEPPELIN-2215)

### How should this be tested?

- Install any spell what you want. However, I suggest [zeppelin-echo-spell@1.0.6](https://www.npmjs.com/package/zeppelin-echo-spell) because it allow you to [get delayed result](https://github.com/1ambda/zeppelin-echo-spell/blob/master/index.js#L23-#L25) (default delay is 1000 millisecond.)
- Execute the spell

### Screenshots (if appropriate)

![2215](https://cloud.githubusercontent.com/assets/4968473/23655669/4f514424-0379-11e7-8557-8b8d24521a7e.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
