### PR TITLE
[ZEPPELIN-2202] Disable personalized mode btn when note is running (master)

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import { ParagraphStatus, } from '../notebook/paragraph/paragraph.status';
+
 angular.module('zeppelinWebApp').controller('InterpreterCtrl', InterpreterCtrl);
 
 function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeout, $route) {
@@ -114,7 +116,7 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
         isDownloading = true;
       }
 
-      if (setting.status === 'ERROR' || setting.errorReason) {
+      if (setting.status === ParagraphStatus.ERROR || setting.errorReason) {
         ngToast.danger({content: 'Error setting properties for interpreter \'' +
         setting.group + '.' + setting.name + '\': ' + setting.errorReason,
           verticalPosition: 'top', dismissOnTimeout: false});

--- a/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
+++ b/zeppelin-web/src/app/jobmanager/jobs/job.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import { ParagraphStatus, } from '../../notebook/paragraph/paragraph.status';
+
 angular.module('zeppelinWebApp').controller('JobCtrl', JobCtrl);
 
 function JobCtrl($scope, $http, baseUrlSrv) {
@@ -24,7 +26,7 @@ function JobCtrl($scope, $http, baseUrlSrv) {
   $scope.getProgress = function() {
     var statusList = _.pluck($scope.notebookJob.paragraphs, 'status');
     var runningJob = _.countBy(statusList, function(status) {
-      if (status === 'FINISHED' || status === 'RUNNING') {
+      if (status === ParagraphStatus.RUNNING || status === ParagraphStatus.FINISHED) {
         return 'matchCount';
       } else {
         return 'none';

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -74,6 +74,7 @@ limitations under the License.
 
       <button type="button"
               class="btn btn-primary btn-xs"
+              ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode !== 'true'"
               ng-click="toggleNotePersonalizedMode()"
@@ -83,6 +84,7 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
+              ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-// import { ParagraphStatus } from './paragraph/paragraph.status';
+import { isParagraphRunning, } from './paragraph/paragraph.status';
 
 angular.module('zeppelinWebApp').controller('NotebookCtrl', NotebookCtrl);
 
@@ -351,8 +351,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     if (!$scope.note) { return false; }
 
     for (let i = 0; i < $scope.note.paragraphs.length; i++) {
-      const status = $scope.note.paragraphs[i].status;
-      if (status === 'PENDING' || status === 'RUNNING') {
+      if (isParagraphRunning($scope.note.paragraphs[i])) {
         return true;
       }
     }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+// import { ParagraphStatus } from './paragraph/paragraph.status';
+
 angular.module('zeppelinWebApp').controller('NotebookCtrl', NotebookCtrl);
 
 function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
@@ -342,16 +344,20 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     $scope.$broadcast('closeTable');
   };
 
+  /**
+   * @returns {boolean} true if one more paragraphs are running. otherwise return false.
+   */
   $scope.isNoteRunning = function() {
-    var running = false;
     if (!$scope.note) { return false; }
-    for (var i = 0; i < $scope.note.paragraphs.length; i++) {
-      if ($scope.note.paragraphs[i].status === 'PENDING' || $scope.note.paragraphs[i].status === 'RUNNING') {
-        running = true;
-        break;
+
+    for (let i = 0; i < $scope.note.paragraphs.length; i++) {
+      const status = $scope.note.paragraphs[i].status;
+      if (status === 'PENDING' || status === 'RUNNING') {
+        return true;
       }
     }
-    return running;
+
+    return false;
   };
 
   $scope.killSaveTimer = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -12,9 +12,10 @@
  * limitations under the License.
  */
 
+import { SpellResult, } from '../../spell';
 import {
-  SpellResult,
-} from '../../spell';
+  ParagraphStatus, isParagraphRunning,
+} from './paragraph.status';
 
 angular.module('zeppelinWebApp').controller('ParagraphCtrl', ParagraphCtrl);
 
@@ -208,7 +209,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.isRunning = function(paragraph) {
-    return paragraph.status === 'RUNNING' || paragraph.status === 'PENDING';
+    return isParagraphRunning(paragraph);
   };
 
   $scope.cancelParagraph = function(paragraph) {
@@ -230,7 +231,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.handleSpellError = function(paragraphText, error,
                                      digestRequired, propagated) {
     const errorMessage = error.stack;
-    $scope.paragraph.status = 'ERROR';
+    $scope.paragraph.status = ParagraphStatus.ERROR;
     $scope.paragraph.errorMessage = errorMessage;
     console.error('Failed to execute interpret() in spell\n', error);
 
@@ -264,7 +265,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.cleanupSpellTransaction = function() {
-    const status = 'FINISHED';
+    const status = ParagraphStatus.FINISHED;
     $scope.paragraph.status = status;
     $scope.paragraph.results.code = status;
 
@@ -284,7 +285,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.runParagraphUsingSpell = function(paragraphText,
                                            magic, digestRequired, propagated) {
     $scope.paragraph.results = {};
-    $scope.paragraph.status = 'PENDING';
+    $scope.paragraph.status = ParagraphStatus.RUNNING;
     $scope.paragraph.errorMessage = '';
     if (digestRequired) { $scope.$digest(); }
 
@@ -1143,7 +1144,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     $scope.paragraph.title = newPara.title;
     $scope.paragraph.lineNumbers = newPara.lineNumbers;
     $scope.paragraph.status = newPara.status;
-    if (newPara.status !== 'RUNNING') {
+    if (newPara.status !== ParagraphStatus.RUNNING) {
       $scope.paragraph.results = newPara.results;
     }
     $scope.paragraph.settings = newPara.settings;
@@ -1167,7 +1168,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
      const statusChanged = (newPara.status !== oldPara.status);
      const resultRefreshed = (newPara.dateFinished !== oldPara.dateFinished) ||
        isEmpty(newPara.results) !== isEmpty(oldPara.results) ||
-       newPara.status === 'ERROR' || (newPara.status === 'FINISHED' && statusChanged);
+       newPara.status === ParagraphStatus.ERROR ||
+       (newPara.status === ParagraphStatus.FINISHED && statusChanged);
 
      // 2. update texts managed by $scope
      $scope.updateAllScopeTexts(oldPara, newPara);

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.status.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.status.js
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ParagraphStatus = {
+  READY: 'READY',
+  PENDING: 'PENDING',
+  RUNNING: 'RUNNING',
+  FINISHED: 'FINISHED',
+  ABORT: 'ABORT',
+  ERROR: 'ERROR',
+};
+
+export function isParagraphRunning(paragraph) {
+  if (!paragraph) { return false; }
+  const status = paragraph.status;
+  if (!status) { return false; }
+
+  return status === ParagraphStatus.PENDING || status === ParagraphStatus.RUNNING;
+}

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -23,6 +23,7 @@ import {
   DefaultDisplayType,
   SpellResult,
 } from '../../../spell'
+import { ParagraphStatus, } from '../paragraph.status';
 
 angular.module('zeppelinWebApp').controller('ResultCtrl', ResultCtrl);
 
@@ -198,7 +199,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
      */
     if (paragraph.id === data.paragraphId &&
       resultIndex === data.index &&
-      (paragraph.status === 'RUNNING' || paragraph.status === 'PENDING')) {
+      (paragraph.status === ParagraphStatus.PENDING || paragraph.status === ParagraphStatus.RUNNING)) {
 
       if (DefaultDisplayType.TEXT !== $scope.type) {
         $scope.type = DefaultDisplayType.TEXT;


### PR DESCRIPTION
### What is this PR for?

Disable the personalized mode button when a note is running.

- This improvement is done in https://github.com/1ambda/zeppelin/commit/0afacbf45e9d4e96121b662da87d4b7e3c655838.
- The second commit https://github.com/1ambda/zeppelin/commit/305ad05790c09920539f3e5b4e4763d04ccabfab is about refactoring.
- So please review https://github.com/1ambda/zeppelin/commit/0afacbf45e9d4e96121b662da87d4b7e3c655838 first.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2202](https://issues.apache.org/jira/browse/ZEPPELIN-2202)

### How should this be tested?

Refer the screenshot below.

### Screenshots (if appropriate)

![2202](https://cloud.githubusercontent.com/assets/4968473/23661339/c45dcd9e-038f-11e7-9551-6cde925aa5f4.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
