### PR TITLE
[ZEPPELIN-2231] Helium bundle should be able to import JSON

### DIFF
--- a/zeppelin-zengine/src/main/resources/helium/package.json
+++ b/zeppelin-zengine/src/main/resources/helium/package.json
@@ -16,6 +16,7 @@
     "css-loader": "^0.26.2",
     "style-loader": "^0.13.2",
     "url-loader": "^0.5.8",
-    "file-loader": "^0.10.1"
+    "file-loader": "^0.10.1",
+    "json-loader": "^0.5.4"
   }
 }

--- a/zeppelin-zengine/src/main/resources/helium/webpack.config.js
+++ b/zeppelin-zengine/src/main/resources/helium/webpack.config.js
@@ -49,6 +49,10 @@ module.exports = {
             test: /\.svg(\?\S*)?$/,
             loader: 'url-loader',
           },
+          {
+            test: /\.json$/,
+            loader: 'json-loader'
+          },
         ],
     }
 }


### PR DESCRIPTION
### What is this PR for?

Helium bundle should be able to import JSON to use some libraries which require JSON. For example, [markdown-it](https://github.com/markdown-it/markdown-it)

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2231](https://issues.apache.org/jira/browse/ZEPPELIN-2231)

### How should this be tested?

1. Clone https://github.com/1ambda/zeppelin-markdown-spell
2. Copy `zeppelin-markdown-spell.json` into `$ZEPPELIN_HOME/helium`
3. Modify artifact (= file path) in `zeppelin-markdown-spell.json` properly
4. Install it in `localhost:9000/#helium`
5. Test `%markdown` spell with 

```
%markdown

# h1 Heading 8-)

## Horizontal Rules

___

## Tables

Right aligned columns

| Option | Description |
| ------:| -----------:|
| data   | path to data files to supply the data that will be passed into templates. |
| engine | engine to be used for processing templates. Handlebars is the default. |
| ext    | extension to be used for dest files. |
```

### Screenshots (if appropriate)

<img width="829" alt="usage1" src="https://cloud.githubusercontent.com/assets/4968473/23673868/30cf6ef2-03b7-11e7-923a-bf4ea05df186.png">

<img width="831" alt="usage2" src="https://cloud.githubusercontent.com/assets/4968473/23673869/3296d04a-03b7-11e7-9a8b-64ba3fcae5b4.png">


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
