### PR TITLE
[ZEPPELIN-2234][BUG] Can't display the same chart again (branch-0.7)

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -263,7 +263,12 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       renderApp(app);
     } else {
       if (type === 'TABLE') {
-        $scope.renderGraph($scope.graphMode, refresh);
+        var retryRenderer = function() {
+          var elem = angular.element('#p' + $scope.id + '_graph');
+          if (elem.length) { $scope.renderGraph($scope.graphMode, refresh); }
+          else { $timeout(retryRenderer, 10); }
+        };
+        $timeout(retryRenderer);
       } else if (type === 'HTML') {
         renderHtml();
       } else if (type === 'ANGULAR') {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -28,10 +28,10 @@ limitations under the License.
                     && config.graph.optionOpen && !asIframe && !viewOnly">
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="trsetting{{id}}_{{viz.id}}"
-             ng-if="graphMode == viz.id"></div>
+             ng-show="graphMode == viz.id"></div>
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="vizsetting{{id}}_{{viz.id}}"
-             ng-if="graphMode == viz.id"></div>
+             ng-show="graphMode == viz.id"></div>
       </div>
 
       <!-- graph -->
@@ -41,7 +41,7 @@ limitations under the License.
            >
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="p{{id}}_{{viz.id}}"
-             ng-if="graphMode == viz.id">
+             ng-show="graphMode == viz.id">
         </div>
       </div>
 


### PR DESCRIPTION
### What is this PR for?

Can't display the same chart again. I attached a screenshot.

- this is the same fix with https://github.com/apache/zeppelin/pull/2110
- except refactoring PR
- based on branch-0.7

and 

- CI failure might be related with https://github.com/apache/zeppelin/pull/2103

#### Implementation Details

After https://github.com/apache/zeppelin/pull/2092, 

- result.html will draw chart every time since we use `ng-if` instead of `ng-show`
- that means DOM is deleted, and created too
- so we have to create visualization instance every time which requires a newly created DOM.

```js
builtInViz.instance = new Visualization(loadedElem, config); // `loadedElem` is the newly created DOM.
```

### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?

I attached a screenshot

### Screenshots (if appropriate)

##### Before: buggy

![2234](https://cloud.githubusercontent.com/assets/4968473/23694278/4451594e-041c-11e7-9971-f0bb5945a1be.gif)

##### After: fixed

![2234-2](https://cloud.githubusercontent.com/assets/4968473/23694270/34866ba8-041c-11e7-83a8-693a93646fa4.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
