### PR TITLE
[ZEPPELIN-2202] Disable personalized mode btn when note is running (branch-0.7)

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -74,6 +74,7 @@ limitations under the License.
 
       <button type="button"
               class="btn btn-primary btn-xs"
+              ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode !== 'true'"
               ng-click="toggleNotePersonalizedMode()"
@@ -83,6 +84,7 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
+              ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -358,15 +358,14 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   $scope.isNoteRunning = function() {
-    var running = false;
     if (!$scope.note) { return false; }
     for (var i = 0; i < $scope.note.paragraphs.length; i++) {
-      if ($scope.note.paragraphs[i].status === 'PENDING' || $scope.note.paragraphs[i].status === 'RUNNING') {
-        running = true;
-        break;
+      const status = $scope.note.paragraphs[i].status;
+      if (status === 'PENDING' || status === 'RUNNING') {
+        return true;
       }
     }
-    return running;
+    return false;
   };
 
   $scope.killSaveTimer = function() {


### PR DESCRIPTION
### What is this PR for?

Disable the personalized mode button when a note is running.

- The same fix with https://github.com/apache/zeppelin/pull/2108 for branch-0.7
- CI failure might be related with https://github.com/apache/zeppelin/pull/2103

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2202](https://issues.apache.org/jira/browse/ZEPPELIN-2202)

### How should this be tested?

Refer the screenshot below.

### Screenshots (if appropriate)

![2202](https://cloud.githubusercontent.com/assets/4968473/23661339/c45dcd9e-038f-11e7-9551-6cde925aa5f4.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
