### PR TITLE
[ZEPPELIN-2179] "clear output" paragraph doesn't work in personalized mode (branch-0.7)

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -621,14 +621,13 @@ public class NotebookServer extends WebSocketServlet
 
   public void broadcastParagraph(Note note, Paragraph p) {
     if (note.isPersonalizedMode()) {
-      broadcastParagraphs(p.getUserParagraphMap(), p);
+      broadcastParagraphs(p.getUserParagraphMap());
     } else {
       broadcast(note.getId(), new Message(OP.PARAGRAPH).put("paragraph", p));
     }
   }
 
-  public void broadcastParagraphs(Map<String, Paragraph> userParagraphMap,
-                                  Paragraph defaultParagraph) {
+  public void broadcastParagraphs(Map<String, Paragraph> userParagraphMap) {
     if (null != userParagraphMap) {
       for (String user : userParagraphMap.keySet()) {
         multicastToUser(user,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -628,7 +628,7 @@ public class NotebookServer extends WebSocketServlet
   }
 
   public void broadcastParagraphs(Map<String, Paragraph> userParagraphMap,
-      Paragraph defaultParagraph) {
+                                  Paragraph defaultParagraph) {
     if (null != userParagraphMap) {
       for (String user : userParagraphMap.keySet()) {
         multicastToUser(user,
@@ -1239,9 +1239,11 @@ public class NotebookServer extends WebSocketServlet
           notebookAuthorization.getWriters(noteId));
       return;
     }
-    note.clearParagraphOutput(paragraphId);
-    Paragraph paragraph = note.getParagraph(paragraphId);
-    broadcastParagraph(note, paragraph);
+
+    String user = (note.isPersonalizedMode()) ?
+            new AuthenticationInfo(fromMessage.principal).getUser() : null;
+    Paragraph p = note.clearParagraphOutput(paragraphId, user);
+    broadcastParagraph(note, p);
   }
 
   private void completion(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1806,7 +1808,7 @@ public class NotebookServer extends WebSocketServlet
   public void onOutputClear(String noteId, String paragraphId) {
     Notebook notebook = notebook();
     final Note note = notebook.getNote(noteId);
-    note.clearParagraphOutput(paragraphId);
+    note.clearParagraphOutput(paragraphId, null);
     Paragraph paragraph = note.getParagraph(paragraphId);
     broadcastParagraph(note, paragraph);
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1142,7 +1142,7 @@ public class NotebookServer extends WebSocketServlet
     if (note.isPersonalizedMode()) {
       Map<String, Paragraph> userParagraphMap =
           note.getParagraph(paragraphId).getUserParagraphMap();
-      broadcastParagraphs(userParagraphMap, p);
+      broadcastParagraphs(userParagraphMap);
     } else {
       broadcastParagraph(note, p);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -395,15 +395,25 @@ public class Note implements Serializable, ParagraphJobListener {
    * Clear paragraph output by id.
    *
    * @param paragraphId ID of paragraph
+   * @param user not null if personalized mode is enabled
    * @return Paragraph
    */
-  public Paragraph clearParagraphOutput(String paragraphId) {
+  public Paragraph clearParagraphOutput(String paragraphId, String user) {
     synchronized (paragraphs) {
       for (Paragraph p : paragraphs) {
-        if (p.getId().equals(paragraphId)) {
-          p.setReturn(null, null);
-          return p;
+        if (!p.getId().equals(paragraphId)) {
+          continue;
         }
+
+        /** `broadcastParagraph` requires original paragraph */
+        Paragraph originParagraph = p;
+
+        if (user != null) {
+          p = p.getUserParagraphMap().get(user);
+        }
+
+        p.setReturn(null, null);
+        return originParagraph;
       }
     }
     return null;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -284,7 +284,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals("repl1: hello world", p1.getResult().message().get(0).getData());
 
     // clear paragraph output/result
-    note.clearParagraphOutput(p1.getId());
+    note.clearParagraphOutput(p1.getId(), null);
     assertNull(p1.getResult());
     notebook.removeNote(note.getId(), anonymous);
   }


### PR DESCRIPTION
### What is this PR for?

`clear output` (`cmd` + `opt` + `L`) doesn't work in the personalized mode.

- CI failure might be related with https://github.com/apache/zeppelin/pull/2103

### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2179](https://issues.apache.org/jira/browse/ZEPPELIN-2179)

### How should this be tested?

1. Execute a paragraph
2. Click `clear output` button (`CMD` + `OPT` + `L)

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
