### PR TITLE
ZEPPELIN-2241: JDBC interpreter throws npe on connecting to any db that has a schema with "null" name

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -111,6 +111,7 @@ public class SqlCompleter extends StringsCompleter {
       try {
         while (schemas.next()) {
           String schemaName = schemas.getString("TABLE_SCHEM");
+          //Some databases will have schemas with no name
           if (schemaName == null)
             schemaName = "";
           if (schemaFilter.equals("") || schemaFilter == null || schemaName.matches(

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -111,6 +111,8 @@ public class SqlCompleter extends StringsCompleter {
       try {
         while (schemas.next()) {
           String schemaName = schemas.getString("TABLE_SCHEM");
+          if (schemaName == null)
+            schemaName = "";
           if (schemaFilter.equals("") || schemaFilter == null || schemaName.matches(
                   schemaFilter.replace("_", ".").replace("%", ".*?"))) {
             res.add(schemaName);

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -111,7 +111,6 @@ public class SqlCompleter extends StringsCompleter {
       try {
         while (schemas.next()) {
           String schemaName = schemas.getString("TABLE_SCHEM");
-          //Some databases will have schemas with no name
           if (schemaName == null)
             schemaName = "";
           if (schemaFilter.equals("") || schemaFilter == null || schemaName.matches(


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

Prevents JDBC interpreter from throwing a stacktrace when the database has a schema with no name (null).

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

https://issues.apache.org/jira/browse/ZEPPELIN-2241

### How should this be tested?
Outline the steps to test the PR here.

Use JDBC interpreter to connect to any database that has a schema without a name. Apache Phoenix in particular has such a schema by default.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?

No

* Is there breaking changes for older versions?

No

* Does this needs documentation?

No
