### PR TITLE
[ZEPPELIN-2242] Toggle helium type buttons

### DIFF
--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -155,6 +155,12 @@
   outline: 0;
 }
 
+.heliumRepoBtnToggled {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color:#adadad;
+}
+
 .localPkgInfo {
   margin: 10px 12px 0 0;
   font-size: 11px;

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -26,9 +26,10 @@ limitations under the License.
              tooltip="Learn more">
             <i class="icon-question" ng-style="{color: 'black'}"></i>
           </a>
-          <button tabindex="0" class="btn btn-default btn-sm heliumRepoBtn helium-popover"
-                  role="button"
+          <button tabindex="0" role="button"
                   ng-repeat="pkgTypes in allPackageTypes"
+                  class="btn btn-default btn-sm heliumRepoBtn helium-popover"
+                  ng-class="($parent.pkgListByType === pkgTypes) ? 'heliumRepoBtnToggled' : ''"
                   ng-click="$parent.pkgListByType = pkgTypes">
             <i class="fa fa-cube"></i>
             {{pkgTypes}}


### PR DESCRIPTION
### What is this PR for?

Toggle helium type buttons so that user can distinguish which button is clicked easily. Previously,

- it's hard to get noticed that `VISUALIZATION` button is clicked by default.
- and buttons lose their focus when user clicks other things.

I attached screenshots.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2242](https://issues.apache.org/jira/browse/ZEPPELIN-2242)

### How should this be tested?

1. Open `/#helium` page
2. Click buttons. (refer the screenshots below)

### Screenshots (if appropriate)

#### Before

![before_2242](https://cloud.githubusercontent.com/assets/4968473/23785456/1887d4ba-05ab-11e7-93fa-1a67fb45ae74.gif)

#### After

![2242_after](https://cloud.githubusercontent.com/assets/4968473/23785459/1bd0d0cc-05ab-11e7-9e12-b144822ccf2c.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
