### PR TITLE
[ZEPPELIN-2243] Use uppercase for shortcut description

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -372,7 +372,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(xpathToShowTitle)).getText(),
           CoreMatchers.allOf(CoreMatchers.startsWith("Show title"), CoreMatchers.containsString("Ctrl+"),
               CoreMatchers.anyOf(CoreMatchers.containsString("Option"), CoreMatchers.containsString("Alt")),
-              CoreMatchers.containsString("+t")));
+              CoreMatchers.containsString("+T")));
 
       clickAndWait(By.xpath(xpathToShowTitle));
       collector.checkThat("After Show Title : The title field contains",
@@ -384,7 +384,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(xpathToHideTitle)).getText(),
           CoreMatchers.allOf(CoreMatchers.startsWith("Hide title"), CoreMatchers.containsString("Ctrl+"),
               CoreMatchers.anyOf(CoreMatchers.containsString("Option"), CoreMatchers.containsString("Alt")),
-              CoreMatchers.containsString("+t")));
+              CoreMatchers.containsString("+T")));
 
       clickAndWait(By.xpath(xpathToHideTitle));
       ZeppelinITUtils.turnOffImplicitWaits(driver);
@@ -438,7 +438,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(xpathToShowLineNumberButton)).getText(),
           CoreMatchers.allOf(CoreMatchers.startsWith("Show line numbers"), CoreMatchers.containsString("Ctrl+"),
               CoreMatchers.anyOf(CoreMatchers.containsString("Option"), CoreMatchers.containsString("Alt")),
-              CoreMatchers.containsString("+m")));
+              CoreMatchers.containsString("+M")));
 
 
       clickAndWait(By.xpath(xpathToShowLineNumberButton));
@@ -451,7 +451,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(xpathToHideLineNumberButton)).getText(),
           CoreMatchers.allOf(CoreMatchers.startsWith("Hide line numbers"), CoreMatchers.containsString("Ctrl+"),
               CoreMatchers.anyOf(CoreMatchers.containsString("Option"), CoreMatchers.containsString("Alt")),
-              CoreMatchers.containsString("+m")));
+              CoreMatchers.containsString("+M")));
 
       clickAndWait(By.xpath(xpathToHideLineNumberButton));
       collector.checkThat("After \"Hide line number\" the Line Number is Enabled",

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -48,7 +48,7 @@ limitations under the License.
           ng-click="runParagraphFromButton(getEditorValue())"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top"
-          tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+c)"
+          tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
           ng-click="cancelParagraph(paragraph)"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
     <span ng-show="paragraph.runtimeInfos.jobUrl.length == 1">
@@ -66,10 +66,10 @@ limitations under the License.
       </ul>
     </span>
     <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" style="cursor:pointer" tooltip-placement="top"
-          tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+e)"
+          tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+E)"
           ng-click="toggleEditor(paragraph)"></span>
     <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" style="cursor:pointer" tooltip-placement="top"
-          tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide')}} output (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+o)"
+          tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide')}} output (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+O)"
           ng-click="toggleOutput(paragraph)"></span>
     <span class="dropdown navbar-right">
       <span class="icon-settings" style="cursor:pointer"
@@ -113,54 +113,54 @@ limitations under the License.
         </li>
         <li>
           <a ng-click="moveUp(paragraph)" ng-hide="$first"><span class="icon-arrow-up shortcut-icon"></span>Move up
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+k</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+K</span></a>
         </li>
         <li>
           <a ng-click="moveDown(paragraph)" ng-hide="$last"><span class="icon-arrow-down shortcut-icon"></span>Move down
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+j</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+J</span></a>
         </li>
         <li>
           <a ng-click="insertNew('below')"><span class="icon-plus shortcut-icon"></span>Insert new
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+b</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+B</span></a>
         </li>
         <li>
           <a ng-click="copyParagraph(getEditorValue())"><span class="fa fa-copy shortcut-icon"></span>Clone paragraph
-            <span class="shortcut-keys">Ctrl+Shift+c</span></a>
+            <span class="shortcut-keys">Ctrl+Shift+C</span></a>
         </li>
         <li>
           <!-- paragraph handler -->
           <a ng-click="hideTitle(paragraph)"
              ng-show="paragraph.config.title"><span class="fa fa-font shortcut-icon"></span>Hide title
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+t</span></a>
+            <span class="shortcut-keys">Ctrl+ {{ isMac ? 'Option' : 'Alt'}} +T</span></a>
           <a ng-click="showTitle(paragraph)"
              ng-show="!paragraph.config.title"><span class="fa fa-font shortcut-icon"></span>Show title
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+t</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+T</span></a>
         </li>
         <li>
           <a ng-click="hideLineNumbers(paragraph)"
              ng-show="paragraph.config.lineNumbers"><span class="fa fa-list-ol shortcut-icon"></span>Hide line numbers
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+m</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+M</span></a>
           <a ng-click="showLineNumbers(paragraph)"
              ng-show="!paragraph.config.lineNumbers"><span class="fa fa-list-ol shortcut-icon"></span>Show line numbers
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+m</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+M</span></a>
         </li>
         <li>
           <a ng-click="toggleEnableDisable(paragraph)"><span class="icon-control-play shortcut-icon"></span>
             {{paragraph.config.enabled ? "Disable" : "Enable"}} run
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+r</span></a>
+            <span class="shortcut-keys">Ctrl+ {{ isMac ? 'Option' : 'Alt'}}+R</span></a>
         </li>
         <li>
           <a ng-click="goToSingleParagraph()"><span class="icon-share-alt shortcut-icon"></span>Link this paragraph
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+w</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+W</span></a>
         </li>
         <li>
           <a ng-click="clearParagraphOutput(paragraph)"><span class="fa fa-eraser shortcut-icon"></span>Clear output
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+l</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+L</span></a>
         </li>
         <li>
           <!-- remove paragraph -->
           <a ng-click="removeParagraph(paragraph)" ng-hide="$last"><span class="fa fa-times shortcut-icon"></span>Remove
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+d</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+D</span></a>
         </li>
       </ul>
     </span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -131,7 +131,7 @@ limitations under the License.
           <!-- paragraph handler -->
           <a ng-click="hideTitle(paragraph)"
              ng-show="paragraph.config.title"><span class="fa fa-font shortcut-icon"></span>Hide title
-            <span class="shortcut-keys">Ctrl+ {{ isMac ? 'Option' : 'Alt'}} +T</span></a>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+T</span></a>
           <a ng-click="showTitle(paragraph)"
              ng-show="!paragraph.config.title"><span class="fa fa-font shortcut-icon"></span>Show title
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+T</span></a>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -37,7 +37,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">c</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">C</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -48,7 +48,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">p</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">P</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -59,7 +59,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">n</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">N</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -70,7 +70,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">d</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">D</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -81,7 +81,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">a</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">A</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -92,7 +92,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">b</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">B</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -103,7 +103,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">c</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">C</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -114,7 +114,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">k</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">K</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -125,7 +125,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">j</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">J</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -136,7 +136,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-dark">r</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-dark">R</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -147,7 +147,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">o</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">O</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -158,7 +158,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">e</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">E</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -169,7 +169,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">m</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">M</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -180,7 +180,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">t</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">T</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -191,7 +191,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">l</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">L</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -202,7 +202,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">w</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">W</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -250,7 +250,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">k</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">K</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -261,7 +261,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">y</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Y</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -272,7 +272,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">s</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">S</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -283,7 +283,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">a</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">A</kbd>
             </div>
           </div>
           <div class="col-md-8">
@@ -294,7 +294,7 @@ limitations under the License.
         <div class="row">
           <div class="col-md-4">
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">e</kbd>
+              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">E</kbd>
             </div>
           </div>
           <div class="col-md-8">


### PR DESCRIPTION
### What is this PR for?

Use uppercase for keyboard shortcut description so that user can recognize shortcuts easily.
it's hard to understand for some shortcuts since we used lowercases. For example, `Ctrl+Option+l` (actually this `L`, not `I`)

I attached screenshots.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2243](https://issues.apache.org/jira/browse/ZEPPELIN-2243)

### How should this be tested?

1. Open the paragraph shortcut panel.
2. Open the note shortcut dialog.

### Screenshots (if appropriate)

#### Before

<img width="261" alt="before_2243" src="https://cloud.githubusercontent.com/assets/4968473/23786191/fb3dafe8-05ae-11e7-8e1e-36b5f151070f.png">

#### After

<img width="263" alt="after_2243" src="https://cloud.githubusercontent.com/assets/4968473/23786194/fe59b1e0-05ae-11e7-9741-371f8e3f77de.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
