### PR TITLE
[ZEPPELIN-1492] fixing the issue where updating a paragraph was not propagated correctly

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1120,7 +1120,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   function isUpdateRequired(oldPara, newPara) {
     return (newPara.id === oldPara.id &&
       (newPara.dateCreated !== oldPara.dateCreated ||
-      newPara.paragraph.text !== oldPara.paragraph.text ||
+      newPara.text !== oldPara.text ||
       newPara.dateFinished !== oldPara.dateFinished ||
       newPara.dateStarted !== oldPara.dateStarted ||
       newPara.dateUpdated !== oldPara.dateUpdated ||

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -681,6 +681,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
       $scope.editor.on('blur', function() {
         handleFocus(false);
+        $scope.saveParagraph($scope.paragraph);
       });
 
       $scope.editor.on('paste', function(e) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1120,6 +1120,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   function isUpdateRequired(oldPara, newPara) {
     return (newPara.id === oldPara.id &&
       (newPara.dateCreated !== oldPara.dateCreated ||
+      newPara.paragraph.text !== oldPara.paragraph.text ||
       newPara.dateFinished !== oldPara.dateFinished ||
       newPara.dateStarted !== oldPara.dateStarted ||
       newPara.dateUpdated !== oldPara.dateUpdated ||


### PR DESCRIPTION
### What is this PR for?

This pull request fixes two issues regarding paragraphs not being updated and therefore overwritten unintentionally. The first issue yields to local changes being overwritten when remote changes are made. The second issue yields to changes being overwritten when, e.g., the notebook is renamed.

The first change happens in the `updateParagraph` broadcast event handler function. This function has the purpose to update the local state of the paragraph in the paragraph controller scope when there is an update from the web socket.

However, it did not update the state if the only thing that has changed was the text. Now it will, which fixes the original issue in the issue description. This was one of the issues identified by https://issues.apache.org/jira/browse/ZEPPELIN-1492?focusedCommentId=15744928&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15744928

The second issue is fixed by saving the paragraph when the editor loses focus.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

- https://issues.apache.org/jira/browse/ZEPPELIN-1492

### How should this be tested?

The first issue can be reproduced with the following two browser-windows and a single notebook.

Browser A:

```
%pyspark
print "Original Zeppelin Notebook"
```

In Browser B, edit the notebook and the above command to:

```
%pyspark
print "Notebook is updated...."
```

If I run the notebook via browser A followed by Browser B, everything is updated nicely. Now also if I you add the following line to the Notebook though Browser B:

```
print "....once again"
```

and run the notebook through Browser B again, the content in Browser A will be updated.

The second issue can be reproduced by editing a cell without executing it and renaming the notebook right afterwards. The rename will reset your cell to the previous state. With the fix, your state is saved.
