### PR TITLE
[ZEPPELIN-2175] Jdbc interpreter sometime doesn't show detailed error message

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -633,7 +633,7 @@ public class JDBCInterpreter extends Interpreter {
         } catch (SQLException e) { /*ignored*/ }
       }
       getJDBCConfiguration(user).removeStatement(paragraphId);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       if (e.getCause() instanceof TTransportException &&
           Throwables.getStackTraceAsString(e).contains("GSS") &&
           getJDBCConfiguration(user).isConnectionInDBDriverPoolSuccessful(propertyKey)) {


### PR DESCRIPTION
### What is this PR for?
Zeppelin's JDBC interpreter sometimes doesn't show detailed error message on the notebook ui. It shows only plain "ERROR" text near run button in case of failure. User has to check JDBC interpreter log file in order to see a detailed error message.

This is mostly in case of incompatible JAR and I see errors mentioned below;
```
java.lang.NoSuchMethodError: org.apache.curator.utils.ZKPaths.fixForNamespace(Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
	at org.apache.curator.framework.imps.NamespaceImpl.fixForNamespace(NamespaceImpl.java:82)
```

```
java.lang.NoSuchMethodError: org.apache.hive.service.auth.HiveAuthFactory.getSocketTransport(Ljava/lang/String;II)Lorg/apache/hive/org/apache/thrift/transport/TTransport;
	at org.apache.hive.jdbc.HiveConnection.createBinaryTransport(HiveConnection.java:447)
```

Hence, IMO instead of catch -> Exception; we should use catch ->Throwable.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-2175](https://issues.apache.org/jira/browse/ZEPPELIN-2175)

### How should this be tested?
Use any incompatible in interpreter dependency, which would throw Error instead of Exception.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
