### PR TITLE
[ZEPPELIN-2154] Support zeppelin.server.port in dev mode (branch-0.7)

### DIFF
--- a/zeppelin-web/README.md
+++ b/zeppelin-web/README.md
@@ -31,6 +31,9 @@ $ yarn run build
 # you need to run zeppelin backend instance also
 $ yarn run dev
 
+# If you are using a custom port, you must use the 'SERVER_PORT' variable to run the web application development mode
+$ SERVER_PORT=8080 yarn run dev
+
 # execute tests
 $ yarn run test
 ```

--- a/zeppelin-web/src/components/baseUrl/baseUrl.service.js
+++ b/zeppelin-web/src/components/baseUrl/baseUrl.service.js
@@ -24,8 +24,8 @@ function baseUrlSrv() {
       }
     }
     //Exception for when running locally via grunt
-    if (port === 3333 || port === 9000) {
-      port = 8080;
+    if (port === 9000) {
+      port = process.env.SERVER_PORT;
     }
     return port;
   };

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -86,6 +86,12 @@ module.exports = function makeWebpackConfig () {
     app: './src/index.js'
   };
 
+  var serverPort = 8080;
+
+  if(process.env.SERVER_PORT) {
+    serverPort = process.env.SERVER_PORT;
+  }
+
   /**
    * Output
    * Reference: http://webpack.github.io/docs/configuration.html#output
@@ -210,7 +216,8 @@ module.exports = function makeWebpackConfig () {
       // Reference: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
       new webpack.DefinePlugin({
         'process.env': {
-          HELIUM_VIS_DEV: process.env.HELIUM_VIS_DEV
+          HELIUM_VIS_DEV: process.env.HELIUM_VIS_DEV,
+          SERVER_PORT: serverPort
         }
       })
     )


### PR DESCRIPTION
### What is this PR for?
If user change `zeppelin.server.port` variable in zeppelin-site.xml, zeppelin doesn't work in web development on `branch-0.7`
#2097 PR which is same issue on master branch was already merged to master branch. 

### What type of PR is it?
[Bug Fix | Improvement | Documentation (README.md)]

### What is the Jira issue?
* [ZEPPELIN-2154](https://issues.apache.org/jira/browse/ZEPPELIN-2154)

### How should this be tested?
1. Change `zeppelin.server.port` from 8080 to 8888 (or another port) in `zeppelin-site.xml`
2. Run zeppelin (`bin/zeppelin-daemon.sh start`)
3. Run web development mode under zeppelin-web folder such like `SERVER_PORT=8888 yarn run dev`
4. Connect localhost:9000


### Screenshots (if appropriate)
**[Before]**
![image](https://cloud.githubusercontent.com/assets/8110458/23829990/b3b7f436-0742-11e7-8bbe-c14245c42003.png)


**[After]**
![z_0 7_server_port_cmd](https://cloud.githubusercontent.com/assets/8110458/23829958/f9b9be84-0741-11e7-9db8-af4e2952b989.png)
![z_0 7_server_port_after](https://cloud.githubusercontent.com/assets/8110458/23829960/fc3fe4a8-0741-11e7-8d63-2bccf07055a1.png)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does thi`sneeds documentation? Yes, `README.md`
