### PR TITLE
[gh-pages] Initialize bootstrap tooltip 

### DIFF
--- a/assets/themes/zeppelin/js/docs.js
+++ b/assets/themes/zeppelin/js/docs.js
@@ -37,4 +37,6 @@ $(function() {
   $(window).bind('hashchange', function() {
     maybeScrollToHash();
   });
+
+  $('[data-toggle="tooltip"]').tooltip();
 });


### PR DESCRIPTION
### What is this PR for?
Currently can't see a tooltip msg when I hover mouse on ![screen shot 2017-03-13 at 11 37 36 am](https://cloud.githubusercontent.com/assets/10060731/23839442/7c84c184-07e1-11e7-8df1-bf1fc4d13cae.png) which exists next to "Scalding", "Geode" and "Beam"  in https://zeppelin.apache.org/supported_interpreters.html. It needs to be initialized first as [bootstrap instruction](http://getbootstrap.com/javascript/#four-directions) says. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
N/A

### How should this be tested?
Run the website(`gh-pages`) locally as described in [here](https://github.com/apache/zeppelin/tree/gh-pages#run-website)

### Screenshots (if appropriate)
 - Before 
![before](https://cloud.githubusercontent.com/assets/10060731/23839427/62eb4b12-07e1-11e7-810e-8e990d1a5bfc.gif)

 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/23839426/614cae54-07e1-11e7-8ac2-bf3440608ffe.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
