### PR TITLE
[WIP] [Discuss] Make use of all grouped data to draw pie chart

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
@@ -33,7 +33,7 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
   };
 
   render(pivot) {
-    var d3Data = this.d3DataFromPivot(
+    const d3Data = this.d3DataFromPivot(
       pivot.schema,
       pivot.rows,
       pivot.keys,
@@ -42,17 +42,25 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
       true,
       false,
       false);
-    var d = d3Data.d3g;
-    var d3g = [];
-    if (d.length > 0) {
-      for (var i = 0; i < d[0].values.length ; i++) {
-        var e = d[0].values[i];
-        d3g.push({
-          label: e.x,
-          value: e.y
-        });
-      }
+    const d = d3Data.d3g;
+
+    let generateLabel;
+    // data is grouped
+    if (pivot.groups && pivot.groups.length > 0) {
+      generateLabel = (suffix, prefix) => `${prefix}.${suffix}`;
+    } else { // data isn't grouped
+      generateLabel = suffix => suffix;
     }
+
+    let d3g = d.map(group => {
+      return group.values.map(row => ({
+        label: generateLabel(row.x, group.key),
+        value: row.y
+      }));
+    });
+    // the map function returns d3g as a nested array
+    // [].concat flattens it, http://stackoverflow.com/a/10865042/5154397
+    d3g = [].concat.apply([], d3g);
     super.render({d3g: d3g});
   };
 


### PR DESCRIPTION
### What is this PR for?
Now, grouped pie charts only uses the data from the first group
With this fix- 
* Add data from all groups to variable d3g, so all groups could be rendered
* Rewrite for loop with map and concat
* Refactor some variables to const and let

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
*  [ZEPPELIN-2237](https://issues.apache.org/jira/browse/ZEPPELIN-2237)

### How should this be tested?
* Create a built in pie chart visualization
* Select a column to group the data
* Should display the visualization based on all the available grouped data

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
