### PR TITLE
[ZEPPELIN-2252] discreteness of line charts

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
@@ -70,7 +70,12 @@ export default class LinechartVisualization extends Nvd3ChartVisualization {
   configureChart(chart) {
     var self = this;
     chart.xAxis.tickFormat(function(d) {return self.xAxisTickFormat(d, self.xLabels);});
-    chart.yAxis.tickFormat(function(d) {return self.yAxisTickFormat(d, self.xLabels);});
+    chart.yAxis.tickFormat(function(d) {
+      if (d === undefined) {
+        return 'N/A';
+      }
+      return self.yAxisTickFormat(d, self.xLabels);
+    });
     chart.yAxis.axisLabelDistance(50);
     if (chart.useInteractiveGuideline) {   // lineWithFocusChart hasn't got useInteractiveGuideline
       chart.useInteractiveGuideline(true); // for better UX and performance issue. (https://github.com/novus/nvd3/issues/691)
@@ -110,5 +115,9 @@ export default class LinechartVisualization extends Nvd3ChartVisualization {
         }
       }
     };
+  };
+
+  defaultY() {
+    return undefined;
   };
 }

--- a/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
@@ -81,6 +81,10 @@ export default class Nvd3ChartVisualization extends Visualization {
     return s;
   };
 
+  defaultY() {
+    return 0;
+  };
+
   xAxisTickFormat(d, xLabels) {
     if (xLabels[d] && (isNaN(parseFloat(xLabels[d])) || !isFinite(xLabels[d]))) { // to handle string type xlabel
       return xLabels[d];
@@ -98,6 +102,7 @@ export default class Nvd3ChartVisualization extends Visualization {
 
   d3DataFromPivot(
     schema, rows, keys, groups, values, allowTextXAxis, fillMissingValues, multiBarChart) {
+    var self = this;
     // construct table data
     var d3g = [];
 
@@ -181,10 +186,10 @@ export default class Nvd3ChartVisualization extends Visualization {
         }
 
         var xVar = isNaN(rowValue) ? ((allowTextXAxis) ? rowValue : rowNameIndex[rowValue]) : parseFloat(rowValue);
-        var yVar = 0;
+        var yVar = self.defaultY();
         if (xVar === undefined) { xVar = colName; }
         if (value !== undefined) {
-          yVar = isNaN(value.value) ? 0 : parseFloat(value.value) / parseFloat(value.count);
+          yVar = isNaN(value.value) ? self.defaultY() : parseFloat(value.value) / parseFloat(value.count);
         }
         d3g[i].values.push({
           x: xVar,


### PR DESCRIPTION
### What is this PR for?
Added a discreteness in the line chart. Correcting the display of the chart, when the values does not exist at the point (by default Y is set to 0, at the moment). A value of 0 is unclear (it is real value from data or it is default value).

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2252

### How should this be tested?
1. Spark interpreter
```
var text = """g1,1
g1,1
g1,2
g1,3
g1,5
g1,5
g2,1
g2,1
g2,2
g2,2
g2,6
g2,6
g2,7
g2,7
g2,7"""

val array = sc.parallelize(text.split('\n'))

case class Line(group: String, value: Integer)

val line = array.map(s => s.split(",")).map(
    s => Line(s(0), 
            s(1).toInt
        )
).toDF()
line.registerTempTable("lines")
```
2.
```
%sql
select *from lines
```
Settings of chart on screenshot

### Screenshots (if appropriate)
before
![2](https://cloud.githubusercontent.com/assets/25951039/23853622/364b74a0-080f-11e7-9860-c7de95bc1507.png)
after
![1](https://cloud.githubusercontent.com/assets/25951039/23853621/364936b8-080f-11e7-9ac6-bbbdd8235be3.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
