### PR TITLE
ZEPPELIN-2251. Support getProgress for livy interpreter

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
@@ -28,6 +28,7 @@ public class LivyVersion {
 
   protected static final LivyVersion LIVY_0_2_0 = LivyVersion.fromVersionString("0.2.0");
   protected static final LivyVersion LIVY_0_3_0 = LivyVersion.fromVersionString("0.3.0");
+  protected static final LivyVersion LIVY_0_4_0 = LivyVersion.fromVersionString("0.4.0");
 
   private int version;
   private String versionString;
@@ -72,6 +73,10 @@ public class LivyVersion {
 
   public boolean isCancelSupported() {
     return this.newerThanEquals(LIVY_0_3_0);
+  }
+
+  public boolean isGetProgressSupported() {
+    return this.newerThanEquals(LIVY_0_4_0);
   }
 
   public boolean equals(Object versionToCompare) {


### PR DESCRIPTION
### What is this PR for?
Livy 0.4 will support getting progress from statement, this PR would integrate this feature into livy interpreter. 


### What type of PR is it?
[Improvement | Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2251

### How should this be tested?
Tested with latest livy 0.4-SNAPSHOT

### Screenshots (if appropriate)
![zeppelin_livy_progress](https://cloud.githubusercontent.com/assets/164491/23883496/4ae31dee-08a2-11e7-8ffd-86b989ad1a6a.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
