### PR TITLE
ZEPPELIN-2256. poll job progress is called twice

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -2138,7 +2138,7 @@ public class NotebookServer extends WebSocketServlet
     @Override
     public void onProgressUpdate(Job job, int progress) {
       notebookServer.broadcast(note.getId(),
-          new Message(OP.PROGRESS).put("id", job.getId()).put("progress", job.progress()));
+          new Message(OP.PROGRESS).put("id", job.getId()).put("progress", progress));
     }
 
     @Override


### PR DESCRIPTION
### What is this PR for?
Minor change to only call getProgress one time. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2256

### How should this be tested?
Before
```
DEBUG [2017-03-14 10:03:44,376] ({pool-2-thread-6} BaseLivyInterprereter.java[callRestAPI]:441) - Get response, StatusCode: 200, responseBody: {"id":1,"state":"running","output":null,"progress":0.6}
 INFO [2017-03-14 10:03:44,777] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:60
 INFO [2017-03-14 10:03:44,778] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:60
 INFO [2017-03-14 10:03:45,284] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:60
 INFO [2017-03-14 10:03:45,284] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:60
DEBUG [2017-03-14 10:03:45,378] ({pool-2-thread-6} BaseLivyInterprereter.java[callRestAPI]:407) - Call rest api in http://localhost:8999/sessions/11/statements/1, method: GET, jsonData:
DEBUG [2017-03-14 10:03:45,387] ({pool-2-thread-6} BaseLivyInterprereter.java[callRestAPI]:441) - Get response, StatusCode: 200, responseBody: {"id":1,"state":"running","output":null,"progress":0.8}
 INFO [2017-03-14 10:03:45,786] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:80
 INFO [2017-03-14 10:03:45,786] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:80
 INFO [2017-03-14 10:03:46,291] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:80
 INFO [2017-03-14 10:03:46,292] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:80
DEBUG [2017-03-14 10:03:46,392] ({pool-2-thread-6} BaseLivyInterprereter.java[callRestAPI]:407) - Call rest api in http://localhost:8999/sessions/11/statements/1, method: GET, jsonData:
DEBUG [2017-03-14 10:03:46,422] ({pool-2-thread-6} BaseLivyInterprereter.java[callRestAPI]:441) - Get response, StatusCode: 200, responseBody: {"id":1,"state":"running","output":null,"progress":0.9}
 INFO [2017-03-14 10:03:46,795] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:90
 INFO [2017-03-14 10:03:46,796] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:90
 INFO [2017-03-14 10:03:47,297] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:90
 INFO [2017-03-14 10:03:47,297] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:181) - progress:90
```

After
```
DEBUG [2017-03-14 11:15:57,176] ({pool-2-thread-2} BaseLivyInterprereter.java[callRestAPI]:432) - Get response, StatusCode: 200, responseBody: {"id":0,"state":"running","output":null,"progress":0.6}
 INFO [2017-03-14 11:15:57,439] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
 INFO [2017-03-14 11:15:57,942] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
DEBUG [2017-03-14 11:15:58,177] ({pool-2-thread-2} BaseLivyInterprereter.java[callRestAPI]:398) - Call rest api in http://localhost:8999/sessions/4/statements/0, method: GET, jsonData:
DEBUG [2017-03-14 11:15:58,193] ({pool-2-thread-2} BaseLivyInterprereter.java[callRestAPI]:432) - Get response, StatusCode: 200, responseBody: {"id":0,"state":"running","output":null,"progress":0.8}
 INFO [2017-03-14 11:15:58,443] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
 INFO [2017-03-14 11:15:58,947] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
DEBUG [2017-03-14 11:15:59,195] ({pool-2-thread-2} BaseLivyInterprereter.java[callRestAPI]:398) - Call rest api in http://localhost:8999/sessions/4/statements/0, method: GET, jsonData:
DEBUG [2017-03-14 11:15:59,213] ({pool-2-thread-2} BaseLivyInterprereter.java[callRestAPI]:432) - Get response, StatusCode: 200, responseBody: {"id":0,"state":"running","output":null,"progress":0.9}
 INFO [2017-03-14 11:15:59,451] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
 INFO [2017-03-14 11:15:59,957] ({pool-1-thread-3} BaseLivyInterprereter.java[getProgress]:176) - getProcess:**********
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
