### PR TITLE
[ZEPPELIN-2253] Piechart won't render when column selected as 'key' is changed

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
@@ -33,6 +33,8 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
   };
 
   render(pivot) {
+    // [ZEPPELIN-2253] New chart function will be created each time inside super.render()
+    this.chart = null;
     var d3Data = this.d3DataFromPivot(
       pivot.schema,
       pivot.rows,


### PR DESCRIPTION
### What is this PR for?
* Fixes issue with pie chart rendering, if user changes pie chart's domain
* When pie chart's key(domain) is changed, this error is logged:
  'Uncaught TypeError: arcs[idx] is not a function at pie.js:358'
* Even if user changes the key and values again, chart remains broken
* Fix: set this.chart to null, which makes render function to initialize new
pie chart constructor 
### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-533](https://issues.apache.org/jira/browse/ZEPPELIN-2253)

### How should this be tested?
* Create a new pie chart using built in visualization
* Remove column selected as 'key'
* Add a new column as 'key'
* Chart is rendered perfectly

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
