### PR TITLE
[ZEPPELIN-2113] Paragraph border is not highlighted when focused

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -537,7 +537,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     if ($scope.asIframe) {
       return 'col-md-12';
     } else {
-      return 'col-md-' + n;
+      return 'paragraph-col col-md-' + n;
     }
   };
 


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/zeppelin/pull/2054 [removes `paragraph-col` css class](https://github.com/apache/zeppelin/pull/2054/files#diff-fe483b8eb5467153a772f202838dfb18L115). As a result paragraph is not highlighted when focused. 

This PR apply `paragraph-col` css class when it is not iframe mode.

### What type of PR is it?
Bug Fix

### Todos
* [x] - apply `paragraph-col` css class

### What is the Jira issue?
http://issues.apache.org/jira/browse/ZEPPELIN-2113


### How should this be tested?
Click any paragraph and see if paragraph border is highlighted

### Screenshots (if appropriate)

before
![zeppelin_focus_no](https://cloud.githubusercontent.com/assets/1540981/23927184/78061500-08d5-11e7-8136-aaa53d8a4f35.gif)

after
![zeppelin_focus_on](https://cloud.githubusercontent.com/assets/1540981/23927192/804d93a0-08d5-11e7-9136-35dc17aca902.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
