### PR TITLE
[ZEPPELIN-2260] Skip node,npm install and bundle when no helium package is selected

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumBundleFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumBundleFactoryTest.java
@@ -59,6 +59,13 @@ public class HeliumBundleFactoryTest {
 
   @Test
   public void testInstallNpm() throws InstallationException {
+    assertFalse(new File(tmpDir,
+        HeliumBundleFactory.HELIUM_LOCAL_REPO + "/node/npm").isFile());
+    assertFalse(new File(tmpDir,
+        HeliumBundleFactory.HELIUM_LOCAL_REPO + "/node/node").isFile());
+
+    hbf.installNodeAndNpm();
+
     assertTrue(new File(tmpDir,
         HeliumBundleFactory.HELIUM_LOCAL_REPO + "/node/npm").isFile());
     assertTrue(new File(tmpDir,


### PR DESCRIPTION
### What is this PR for?
Zeppelin 0.7.0 installs node and npm when it first starts for Helium package.
To be installed, or to failed to be installed due to network timeout, it takes some times.
We can just create empty file when no Helium package is enabled, instead of install npm and build bundle.
See discussion https://github.com/apache/zeppelin/pull/2095#issuecomment-285447619

### What type of PR is it?
Improvement

### Todos
* [x] - skip node,npm install and bundle package when no package is selected

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2260

### How should this be tested?
When no package is selected (e.g. right after clean install Zeppelin), npm and node is no longer installed on startup.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
