### PR TITLE
[ZEPPELIN-2124] Missing dependencies array in interpreter.json after upgrade from 0.6.2 to 0.7.0

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -70,7 +70,7 @@ public class InterpreterSetting {
   @SerializedName("interpreterGroup")
   private List<InterpreterInfo> interpreterInfos;
   private final transient Map<String, InterpreterGroup> interpreterGroupRef = new HashMap<>();
-  private List<Dependency> dependencies;
+  private List<Dependency> dependencies = new LinkedList<>();
   private InterpreterOption option;
   private transient String path;
 


### PR DESCRIPTION
### What is this PR for?
If there is no `dependencies` field specified in `interpreter.json`, front-end throws error because it tries to push new element to undefined variable. This PR fixes this issue by setting initial value of `dependencies` to empty array.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-2124](https://issues.apache.org/jira/browse/ZEPPELIN-2124)

### How should this be tested?
Remove `dependencies` field from `conf/interpreter.json` and try to add new dependencies in http://localhost:8080/#/interpreter page.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
