### PR TITLE
[ZEPPELIN-2267] Improve Helium Enable / Disable Dialogs

### DIFF
--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -149,37 +149,55 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
     return license;
   }
 
-  $scope.enable = function(name, artifact, type, groupId) {
+  const getHeliumTypeText = function(type) {
+    if (type === HeliumType.VISUALIZATION) {
+      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinvisualization.html">${type}</a>`;
+    } else if (type === HeliumType.SPELL) {
+      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinspell.html">${type}</a>`;
+    } else {
+      return type;
+    }
+  }
+
+  $scope.enable = function(name, artifact, type, groupId, description) {
     var license = getLicense(name, artifact);
     var mavenArtifactInfoToHTML = groupId +':'+ artifact.split('@')[0] + ':' + artifact.split('@')[1];
     var zeppelinVersion = $rootScope.zeppelinVersion;
     var url = 'https://zeppelin.apache.org/docs/' + zeppelinVersion + '/manual/interpreterinstallation.html';
-    
+
     var confirm = ''
-    if (type === 'INTERPRETER') {
-    confirm = BootstrapDialog.show({
-      title: '',
-      message: '<p>Below command will download maven artifact ' +
-      '<code style="font-size: 11.5px; background-color: #f5f5f5; color: #0a0a0a">' +
+    if (type === HeliumType.INTERPRETER) {
+      confirm = BootstrapDialog.show({
+        title: '',
+        message: '<p>Below command will download maven artifact ' +
+        '<code style="font-size: 11.5px; background-color: #f5f5f5; color: #0a0a0a">' +
         mavenArtifactInfoToHTML + '</code>' +
-      ' and all of its transitive dependencies into interpreter/interpreter-name directory.<p>' +
-      '<div class="highlight"><pre><code class="text language-text" data-lang="text" style="font-size: 11.5px">' +
-      './bin/install-interpreter.sh --name "interpreter-name" --artifact ' +
+        ' and all of its transitive dependencies into interpreter/interpreter-name directory.<p>' +
+        '<div class="highlight"><pre><code class="text language-text" data-lang="text" style="font-size: 11.5px">' +
+        './bin/install-interpreter.sh --name "interpreter-name" --artifact ' +
         mavenArtifactInfoToHTML +' </code></pre>' +
-      '<p>After restart Zeppelin, create interpreter setting and bind it with your note. ' +
-      'For more detailed information, see <a target="_blank" href=' +
+        '<p>After restart Zeppelin, create interpreter setting and bind it with your note. ' +
+        'For more detailed information, see <a target="_blank" href=' +
         url + '>Interpreter Installation.</a></p>'
-    });
+      });
     } else {
       confirm = BootstrapDialog.confirm({
         closable: false,
         closeByBackdrop: false,
         closeByKeyboard: false,
-        title: '',
-        message: 'Do you want to enable ' + name + '?' +
-        '<div style="color:gray">' + artifact + '</div>' +
-        '<div style="border-top: 1px solid #efefef; margin-top: 10px; padding-top: 5px;">License</div>' +
-        '<div style="color:gray">' + license + '</div>',
+        title: `<div style="font-weight: 300;">Do you want to enable new Helium Package?</div>`,
+        message:
+          `<div style="font-size: 14px; margin-top: 5px;">Artifact</div>` +
+          `<div style="color:gray">${artifact}</div>` +
+          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
+          `<div style="font-size: 14px; margin-bottom: 2px;">Type</div>` +
+          `<div style="color:gray">${getHeliumTypeText(type)}</div>` +
+          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
+          `<div style="font-size: 14px;">Description</div>` +
+          `<div style="color:gray">${description}</div>` +
+          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
+          `<div style="font-size: 14px;">License</div>` +
+          `<div style="color:gray">${license}</div>`,
         callback: function (result) {
           if (result) {
             confirm.$modalFooter.find('button').addClass('disabled');

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -151,9 +151,9 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
   const getHeliumTypeText = function(type) {
     if (type === HeliumType.VISUALIZATION) {
-      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinvisualization.html">${type}</a>`;
+      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinvisualization.html">${type}</a>`; // eslint-disable-line max-len
     } else if (type === HeliumType.SPELL) {
-      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinspell.html">${type}</a>`;
+      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinspell.html">${type}</a>`; // eslint-disable-line max-len
     } else {
       return type;
     }
@@ -185,18 +185,18 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
         closable: false,
         closeByBackdrop: false,
         closeByKeyboard: false,
-        title: `<div style="font-weight: 300;">Do you want to enable new Helium Package?</div>`,
+        title: '<div style="font-weight: 300;">Do you want to enable Helium Package?</div>',
         message:
-          `<div style="font-size: 14px; margin-top: 5px;">Artifact</div>` +
+          '<div style="font-size: 14px; margin-top: 5px;">Artifact</div>' +
           `<div style="color:gray">${artifact}</div>` +
-          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
-          `<div style="font-size: 14px; margin-bottom: 2px;">Type</div>` +
+          '<hr style="margin-top: 10px; margin-bottom: 10px;" />' +
+          '<div style="font-size: 14px; margin-bottom: 2px;">Type</div>' +
           `<div style="color:gray">${getHeliumTypeText(type)}</div>` +
-          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
-          `<div style="font-size: 14px;">Description</div>` +
+          '<hr style="margin-top: 10px; margin-bottom: 10px;" />' +
+          '<div style="font-size: 14px;">Description</div>' +
           `<div style="color:gray">${description}</div>` +
-          `<hr style="margin-top: 10px; margin-bottom: 10px;" />` +
-          `<div style="font-size: 14px;">License</div>` +
+          '<hr style="margin-top: 10px; margin-bottom: 10px;" />' +
+          '<div style="font-size: 14px;">License</div>' +
           `<div style="color:gray">${license}</div>`,
         callback: function (result) {
           if (result) {
@@ -226,7 +226,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
       closable: false,
       closeByBackdrop: false,
       closeByKeyboard: false,
-      title: `<div style="font-weight: 300;">Do you want to disable Helium Package?</div>`,
+      title: '<div style="font-weight: 300;">Do you want to disable Helium Package?</div>',
       message: artifact,
       callback: function(result) {
         if (result) {

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -221,13 +221,13 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
     }
   };
 
-  $scope.disable = function(name) {
+  $scope.disable = function(name, artifact) {
     var confirm = BootstrapDialog.confirm({
       closable: false,
       closeByBackdrop: false,
       closeByKeyboard: false,
-      title: '',
-      message: 'Do you want to disable ' + name + '?',
+      title: `<div style="font-weight: 300;">Do you want to disable Helium Package?</div>`,
+      message: artifact,
       callback: function(result) {
         if (result) {
           confirm.$modalFooter.find('button').addClass('disabled');

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -151,9 +151,9 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
   const getHeliumTypeText = function(type) {
     if (type === HeliumType.VISUALIZATION) {
-      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinvisualization.html">${type}</a>`; // eslint-disable-line max-len
+      return `<a target="_blank" href="https://zeppelin.apache.org/docs/${$rootScope.zeppelinVersion}/development/writingzeppelinvisualization.html">${type}</a>`; // eslint-disable-line max-len
     } else if (type === HeliumType.SPELL) {
-      return `<a href="https://zeppelin.apache.org/docs/latest/development/writingzeppelinspell.html">${type}</a>`; // eslint-disable-line max-len
+      return `<a target="_blank" href="https://zeppelin.apache.org/docs/${$rootScope.zeppelinVersion}/development/writingzeppelinspell.html">${type}</a>`; // eslint-disable-line max-len
     } else {
       return type;
     }

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -100,7 +100,7 @@ limitations under the License.
              class="btn btn-success btn-xs"
              style="float:right">Enable</div>
         <div ng-show="pkgSearchResult.enabled"
-             ng-click="disable(pkgSearchResult.pkg.name)"
+             ng-click="disable(pkgSearchResult.pkg.name, pkgSearchResult.pkg.artifact)"
              ng-if="pkgSearchResult.pkg.type !== 'INTERPRETER'"
              class="btn btn-info btn-xs"
              style="float:right">Disable</div>

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -96,7 +96,7 @@ limitations under the License.
           <span class="heliumType">{{pkgSearchResult.pkg.type}}</span>
         </div>
         <div ng-show="!pkgSearchResult.enabled"
-             ng-click="enable(pkgSearchResult.pkg.name, pkgSearchResult.pkg.artifact, pkgSearchResult.pkg.type, pkgSearchResult.pkg.groupId)"
+             ng-click="enable(pkgSearchResult.pkg.name, pkgSearchResult.pkg.artifact, pkgSearchResult.pkg.type, pkgSearchResult.pkg.groupId, pkgSearchResult.pkg.description)"
              class="btn btn-success btn-xs"
              style="float:right">Enable</div>
         <div ng-show="pkgSearchResult.enabled"


### PR DESCRIPTION
### What is this PR for?

Improved Helium Enable / Disable Dialogs to

- include more detailed info for enable dialog
- include more concise info for disable dialog
- use dialog title as well just instead of message
- link to doc if `type === SPELL || type === VISUALIZATION`
- parse `description` and `license` as HTML

I attached screenshots for comparison.

### What type of PR is it?
[Improvement]

### Todos

 NONE

### What is the Jira issue?

[ZEPPELIN-2267](https://issues.apache.org/jira/browse/ZEPPELIN-2267)

### How should this be tested?

1. Test with local, online helium packages.
2. In case of local package modify description and license text to test HTML parsing like

```
  "description": "The Ultimate Line Chart for Apache Zeppelin using <a href src=\"https://www.amcharts.com\">amcharts</a>",

  "license": "<a href=\"https://www.amcharts.com/licenses/javascript-charts-free-license\">Amcharts License</a>"
```

### Screenshots (if appropriate)

#### Before: enable dialog

<img width="631" alt="enable_local" src="https://cloud.githubusercontent.com/assets/4968473/23984205/a45babf6-0a5b-11e7-934d-83d6ed31c5eb.png">

#### After: enable dialog

<img width="631" alt="after_enable_local" src="https://cloud.githubusercontent.com/assets/4968473/23984234/c98335ca-0a5b-11e7-9b72-810fda629635.png">

#### Before: disable dialog

<img width="632" alt="disable_local" src="https://cloud.githubusercontent.com/assets/4968473/23984232/c65ed642-0a5b-11e7-8f67-a4ce2c5378f8.png">

#### After: disable dialog

<img width="647" alt="after_disable" src="https://cloud.githubusercontent.com/assets/4968473/23984226/bb0fcfd0-0a5b-11e7-9afb-2326c2f6b778.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
