### PR TITLE
[ZEPPELIN-2271] encoding password of credentials

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -18,22 +18,30 @@
 package org.apache.zeppelin.user;
 
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static org.apache.zeppelin.user.UsernamePassword.UsernamePasswordDeserializer;
+import static org.apache.zeppelin.user.UsernamePassword.UsernamePasswordSerializer;
 
 /**
  * Class defining credentials for data source authorization
@@ -55,7 +63,9 @@ public class Credentials {
 
     if (credentialsPersist) {
       GsonBuilder builder = new GsonBuilder();
-      builder.setPrettyPrinting();
+      builder.setPrettyPrinting().disableHtmlEscaping();
+      builder.registerTypeAdapter(UsernamePassword.class, new UsernamePasswordSerializer());
+      builder.registerTypeAdapter(UsernamePassword.class, new UsernamePasswordDeserializer());
       gson = builder.create();
       loadFromFile();
     }
@@ -119,7 +129,9 @@ public class Credentials {
 
       String json = sb.toString();
       CredentialsInfoSaving info = gson.fromJson(json, CredentialsInfoSaving.class);
-      this.credentialsMap = info.credentialsMap;
+      if (info != null && info.credentialsMap != null) {
+        this.credentialsMap = info.credentialsMap;
+      }
     } catch (IOException e) {
       LOG.error("Error loading credentials file", e);
       e.printStackTrace();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/StringXORer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/StringXORer.java
@@ -1,0 +1,42 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.zeppelin.util;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * Simple encoder for string
+ */
+public class StringXORer {
+
+  public static String encode(String s, String key) {
+    return Base64.encodeBase64String(xorWithKey(s.getBytes(), key.getBytes()));
+  }
+
+  public static String decode(String s, String key) {
+    return new String(xorWithKey(Base64.decodeBase64(s.getBytes()), key.getBytes()));
+  }
+
+  private static byte[] xorWithKey(byte[] a, byte[] key) {
+    byte[] out = new byte[a.length];
+    for (int i = 0; i < a.length; i++) {
+      out[i] = (byte) (a[i] ^ key[i % key.length]);
+    }
+    return out;
+  }
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/CredentialsTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/CredentialsTest.java
@@ -17,11 +17,15 @@
 
 package org.apache.zeppelin.user;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.Test;
 
-import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CredentialsTest {
 
@@ -37,4 +41,29 @@ public class CredentialsTest {
     assertEquals(up1.getUsername(), up2.getUsername());
     assertEquals(up1.getPassword(), up2.getPassword());
   }
+
+  @Test
+  public void testPasswordEncoding() throws IOException {
+    String password = "some_password";
+    String entityName = "entity";
+    String user = "user1";
+    String encodedPassword = "BhwIF24FEhYBRhoBAQ==";
+
+    Path credentialsPath = Files.createTempFile(null, null);
+    Credentials credentials = new Credentials(true, credentialsPath.toAbsolutePath().toString());
+    UserCredentials userCredentials = new UserCredentials();
+    UsernamePassword usernamePassword = new UsernamePassword(user, password);
+    userCredentials.putUsernamePassword(entityName, usernamePassword);
+    credentials.putUserCredentials(user, userCredentials);
+    credentials.saveCredentials();
+
+    String jsonString = new String(Files.readAllBytes(credentialsPath));
+    Credentials loadedCredentials = new Credentials(true, credentialsPath.toAbsolutePath().toString());
+    credentialsPath.toFile().delete();
+
+    assertFalse(jsonString.contains(password));
+    assertTrue(jsonString.contains(encodedPassword));
+    assertEquals(password, loadedCredentials.getUserCredentials(user).getUsernamePassword(entityName).getPassword());
+  }
+
 }


### PR DESCRIPTION
### What is this PR for?
Added a simple encoding of the password in the file (the credentials.json). Application administrator (Zeppelin) which has access to the file should not see user passwords at least as plain text.

### What type of PR is it?
Improvement 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2271

### How should this be tested?
Remove credentials.json (if exist), before star Zeppelin.
Add credentials:
  Entity: test.test
  Username: user
  Password: passwd

Check content of file **credentials.conf**, password not equals "passwd"

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
