### PR TITLE
[ZEPPELIN-465] Be able to run paragraph and the following ones

### DIFF
--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -894,6 +894,10 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> 500 </td>
     </tr>
     <tr>
+      <td> subsequent parameter (optionnal) </td>
+      <td> If set to true, all the paragraphs following the paragraph will be run as well.```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]?subsequent=true```</td>
+    </tr>
+    <tr>
       <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
       <td><pre>
 {
@@ -930,6 +934,10 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     <tr>
       <td> Fail code</td>
       <td> 500 </td>
+    </tr>
+    <tr>
+      <td> subsequent parameter (optionnal) </td>
+      <td> If set to true, all the paragraphs following the paragraph will be run as well. Warning: if one of the paragraphs fails the API will return ERROR ```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]?subsequent=true```</td>
     </tr>
     <tr>
       <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>

--- a/docs/rest-api/rest-notebook.md
+++ b/docs/rest-api/rest-notebook.md
@@ -894,11 +894,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> 500 </td>
     </tr>
     <tr>
-      <td> subsequent parameter (optionnal) </td>
-      <td> If set to true, all the paragraphs following the paragraph will be run as well.```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]?subsequent=true```</td>
-    </tr>
-    <tr>
-      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
+      <td> sample JSON input (optional, only needed to update dynamic form's value) </td>
       <td><pre>
 {
   "name": "name of new note",
@@ -913,7 +909,6 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td><pre>{"status": "OK"}</pre></td>
     </tr>
   </table>
-
 <br/>
 ### Run a paragraph synchronously
   <table class="table-configuration">
@@ -936,11 +931,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> 500 </td>
     </tr>
     <tr>
-      <td> subsequent parameter (optionnal) </td>
-      <td> If set to true, all the paragraphs following the paragraph will be run as well. Warning: if one of the paragraphs fails the API will return ERROR ```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]?subsequent=true```</td>
-    </tr>
-    <tr>
-      <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
+      <td> sample JSON input (optional, only needed to update dynamic form's value) </td>
       <td><pre>
 {
   "name": "name of new note",
@@ -967,7 +958,20 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
 }</pre></td>
     </tr>
   </table>
-
+<br/>
+### Run a paragraph and all the following ones
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>Both previous ```POST``` methods (run sync and run async) can be provided a boolean parameter <em>subsequent</em>. If set to true, all the paragraphs following the given paragraph will be run as well.The asynchronous API will always return SUCCESS while the synchronous API can return ERROR if one or many paragraphs executions fails. 
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/job/[noteId]/[paragraphId]?subsequent=true```<br/>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[noteId]/[paragraphId]?subsequent=true```</td>
+    </tr>
+  </table>
 <br/>
 ### Stop a paragraph
   <table class="table-configuration">

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -131,7 +131,9 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     post.releaseConnection();
     for (Paragraph aParagraph : paragraphs){
       assertNotEquals(aParagraph.getStatus(), Job.Status.READY); // should be running, run or about to be run
+      aParagraph.abort();
     }
+    p.abort();
     assertEquals(note1.getParagraphs().get(0).getStatus(), Job.Status.READY); // should not have changed
 
     //cleanup

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -65,9 +65,6 @@ limitations under the License.
          </li>
       </ul>
     </span>
-    <span class="icon-control-end" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph and the following ones (Ctrl+Shift+Enter)"
-          ng-click="runSubsequentParagraphs(parentNote.id,paragraph.id)"
-          ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" style="cursor:pointer" tooltip-placement="top"
           tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+e)"
           ng-click="toggleEditor(paragraph)"></span>
@@ -134,6 +131,12 @@ limitations under the License.
           <a ng-click="showLineNumbers(paragraph)"
              ng-show="!paragraph.config.lineNumbers"><span class="fa fa-list-ol shortcut-icon"></span>Show line numbers
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+m</span></a>
+        </li>
+        <li>
+          <a  ng-click="runSubsequentParagraphs(parentNote,paragraph)"
+              ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled">
+            <span class="icon-control-end shortcut-icon" tooltip="Run this paragraph and the next ones"></span>Run with next ones
+            <span class="shortcut-keys">Ctrl+Shift+Enter</span></a>
         </li>
         <li>
           <a ng-click="toggleEnableDisable(paragraph)"><span class="icon-control-play shortcut-icon"></span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -65,6 +65,9 @@ limitations under the License.
          </li>
       </ul>
     </span>
+    <span class="icon-control-end" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph and the following ones (Ctrl+Shift+Enter)"
+          ng-click="runSubsequentParagraphs(parentNote.id,paragraph.id)"
+          ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" style="cursor:pointer" tooltip-placement="top"
           tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+e)"
           ng-click="toggleEditor(paragraph)"></span>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -135,7 +135,7 @@ limitations under the License.
         <li>
           <a  ng-click="runSubsequentParagraphs(parentNote,paragraph)"
               ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled">
-            <span class="icon-control-end shortcut-icon" tooltip="Run this paragraph and the next ones"></span>Run with next ones
+            <span class="icon-control-end shortcut-icon" tooltip="Run this paragraph & the ones after."></span>Run with successors
             <span class="shortcut-keys">Ctrl+Shift+Enter</span></a>
         </li>
         <li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -319,6 +319,28 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       paragraphText, $scope.paragraph.config, $scope.paragraph.settings.params);
   };
 
+  $scope.runSubsequentParagraphs = function(noteId,paragraphId) {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Run this paragraph and the subsequent ones?',
+        callback: function(result) {
+          if (result) {
+            const paragraphs = $scope.parentNote.paragraphs.map(p => {
+              return {
+                id: p.id,
+                title: p.title,
+                paragraph: p.text,
+                config: p.config,
+                params: p.settings.params
+              };
+            });
+            websocketMsgSrv.runSubsequentParagraphs(noteId, paragraphId, paragraphs);
+          }
+        }
+      });
+    };
+
   $scope.saveParagraph = function(paragraph) {
     const dirtyText = paragraph.text;
     if (dirtyText === undefined || dirtyText === $scope.originalText) {
@@ -1256,6 +1278,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       } else if (editorHide && (keyCode === 40 || (keyCode === 78 && keyEvent.ctrlKey && !keyEvent.altKey))) { // down
         // move focus to next paragraph
         $scope.$emit('moveFocusToNextParagraph', paragraphId);
+      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13){
+        $scope.runSubsequentParagraphs(paragraphId);
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue());
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -319,14 +319,15 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       paragraphText, $scope.paragraph.config, $scope.paragraph.settings.params);
   };
 
-  $scope.runSubsequentParagraphs = function(noteId,paragraphId) {
+  $scope.runSubsequentParagraphs = function(note,paragraph) {
+    if (!(paragraph.status in ['RUNNING','PENDING']) && paragraph.config.enabled){
       BootstrapDialog.confirm({
         closable: true,
         title: '',
-        message: 'Run this paragraph and the subsequent ones?',
+        message: 'Run this paragraph and all the next ones?',
         callback: function(result) {
           if (result) {
-            const paragraphs = $scope.parentNote.paragraphs.map(p => {
+            const paragraphs = note.paragraphs.map(p => {
               return {
                 id: p.id,
                 title: p.title,
@@ -335,11 +336,12 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
                 params: p.settings.params
               };
             });
-            websocketMsgSrv.runSubsequentParagraphs(noteId, paragraphId, paragraphs);
+            websocketMsgSrv.runSubsequentParagraphs(note.id, paragraph.id, paragraphs);
           }
         }
       });
-    };
+      }
+   };
 
   $scope.saveParagraph = function(paragraph) {
     const dirtyText = paragraph.text;
@@ -1278,8 +1280,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       } else if (editorHide && (keyCode === 40 || (keyCode === 78 && keyEvent.ctrlKey && !keyEvent.altKey))) { // down
         // move focus to next paragraph
         $scope.$emit('moveFocusToNextParagraph', paragraphId);
-      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13){
-        $scope.runSubsequentParagraphs(paragraphId);
+      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13){ // Ctrl + Shift + Enter
+        $scope.runSubsequentParagraphs($scope.note,$scope.paragraph);
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue());
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -319,29 +319,38 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       paragraphText, $scope.paragraph.config, $scope.paragraph.settings.params);
   };
 
-  $scope.runSubsequentParagraphs = function(note,paragraph) {
+  var runParagraphs = function(note,paragraph){
+    const paragraphs = note.paragraphs.map(p => {
+      return {
+        id: p.id,
+        title: p.title,
+        paragraph: p.text,
+        config: p.config,
+        params: p.settings.params
+      };
+    });
+    websocketMsgSrv.runSubsequentParagraphs(note.id, paragraph.id, paragraphs);
+  }
+
+  $scope.runSubsequentParagraphs = function(note,paragraph,dialog=true) {
     if (!(paragraph.status in ['RUNNING','PENDING']) && paragraph.config.enabled){
-      BootstrapDialog.confirm({
-        closable: true,
-        title: '',
-        message: 'Run this paragraph and all the next ones?',
-        callback: function(result) {
-          if (result) {
-            const paragraphs = note.paragraphs.map(p => {
-              return {
-                id: p.id,
-                title: p.title,
-                paragraph: p.text,
-                config: p.config,
-                params: p.settings.params
-              };
-            });
-            websocketMsgSrv.runSubsequentParagraphs(note.id, paragraph.id, paragraphs);
+      if ( dialog ){
+        BootstrapDialog.confirm({
+          closable: true,
+          title: '',
+          message: 'Run this paragraph and all the next ones?',
+          callback: function(result) {
+            if (result) {
+              runParagraphs(note,paragraph);
+            }
           }
-        }
-      });
+        });
+        $scope.editor.focus();
+      } else{
+        runParagraphs(note,paragraph);
       }
-   };
+    }
+  };
 
   $scope.saveParagraph = function(paragraph) {
     const dirtyText = paragraph.text;
@@ -1281,7 +1290,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         // move focus to next paragraph
         $scope.$emit('moveFocusToNextParagraph', paragraphId);
       } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13){ // Ctrl + Shift + Enter
-        $scope.runSubsequentParagraphs($scope.note,$scope.paragraph);
+        $scope.runSubsequentParagraphs($scope.note,$scope.paragraph, false);
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue());
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -338,7 +338,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         BootstrapDialog.confirm({
           closable: true,
           title: '',
-          message: 'Run this paragraph and all the next ones?',
+          message: 'Run this paragraph and all the following ones?',
           callback: function(result) {
             if (result) {
               runParagraphs(note,paragraph);

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -207,6 +207,17 @@ function websocketMsgSrv($rootScope, websocketEvents) {
       });
     },
 
+    runSubsequentParagraphs: function(noteId, paragraphId, paragraphs){
+      websocketEvents.sendNewEvent({
+        op: 'RUN_SUBSEQUENT_PARAGRAPHS',
+        data: {
+          noteId: noteId,
+          paragraphId: paragraphId,
+          paragraphs: JSON.stringify(paragraphs)
+        }
+      });
+    },
+
     removeParagraph: function(paragraphId) {
       websocketEvents.sendNewEvent({op: 'PARAGRAPH_REMOVE', data: {id: paragraphId}});
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -560,11 +560,31 @@ public class Note implements Serializable, ParagraphJobListener {
    * Run all paragraphs sequentially.
    */
   public synchronized void runAll() {
+    runRange(0, getParagraphs().size());
+  }
+
+  /**
+   * Run a paragraph and all the ones after.
+   *
+   * @param paragraphId ID of start paragraph
+   */
+  public synchronized void runAllAfter(String paragraphId) {
+    runRange(getParagraphs().indexOf(getParagraph(paragraphId)), getParagraphs().size());
+  }
+
+  /**
+   * Run paragraphs between beg (included) to end (excluded)
+   *
+   * @param beg index of first paragraph to run
+   * @param end index of first paragraph not to run
+   */
+  public synchronized void runRange(int beg, int end){
     String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
     if (null == cronExecutingUser) {
       cronExecutingUser = "anonymous";
     }
-    for (Paragraph p : getParagraphs()) {
+    List<Paragraph> paragraphs = getParagraphs();
+    for (Paragraph p : paragraphs.subList(beg, end)) {
       if (!p.isEnabled()) {
         continue;
       }
@@ -604,7 +624,7 @@ public class Note implements Serializable, ParagraphJobListener {
       p.setStatus(Job.Status.ERROR);
       throw intpException;
     }
-    if (p.getConfig().get("enabled") == null || (Boolean) p.getConfig().get("enabled")) {
+    if (p.isEnabled()) {
       p.setAuthenticationInfo(p.getAuthenticationInfo());
       intp.getScheduler().submit(p);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -176,7 +176,8 @@ public class Message {
     RUN_ALL_PARAGRAPHS,           // [c-s] run all paragraphs
     PARAGRAPH_EXECUTED_BY_SPELL,  // [c-s] paragraph was executed by spell
     RUN_PARAGRAPH_USING_SPELL,     // [s-c] run paragraph using spell
-    PARAS_INFO                    // [s-c] paragraph runtime infos
+    PARAS_INFO,                    // [s-c] paragraph runtime infos
+    RUN_SUBSEQUENT_PARAGRAPHS      // [c-s] run paragraph and subsequent ones
   }
 
   public static final Message EMPTY = new Message(null);


### PR DESCRIPTION
### What is this PR for?
Allow to run a paragraph **and** the ones following. This is useful for instance if you are generating a dataset in a paragraph and then have others subsequent paragraphs relying on this dataset.
In a nutshell this PR contains:
* UI: added a command in paragraph dropdown menu
* REST: added an boolean option to runparagraph (sync & async)
* updated rest doc
* z-engine: added relevant function to Note
* also refacto some duplicated code here and there.

### What type of PR is it?
Feature

### Todos
* [ ] - Once committers agree on the visual impact, update relevant documentation.

### What is the Jira issue?
[ZEPPELIN-465](https://issues.apache.org/jira/browse/ZEPPELIN-465)

### How should this be tested?
* UI: click on the "run and next ones" in the dropdown menu and verify subsequent paragraphs are also run, and not precedent ones.
* REST: post request to /api/notebook/[job|run]/$noteId/$paragraphId?subsequent=true

### Screenshots (if appropriate)
![runsubsequent](https://cloud.githubusercontent.com/assets/8293897/24159054/65bc7acc-0e5e-11e7-8e41-0549cb8e3861.png)
![confirmationdialog](https://cloud.githubusercontent.com/assets/8293897/24159053/65aa31c8-0e5e-11e7-894f-2448e103b504.png)
![paragraphrunningpending](https://cloud.githubusercontent.com/assets/8293897/24159051/6598cfc8-0e5e-11e7-9f0e-c3340351ca76.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
