### PR TITLE
[ZEPPELIN-2282] NPE on NotebookServer.java when client send null ticket.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -193,7 +193,8 @@ public class NotebookServer extends WebSocketServlet
       }
 
       String ticket = TicketContainer.instance.getTicket(messagereceived.principal);
-      if (ticket != null && !ticket.equals(messagereceived.ticket)) {
+      if (ticket != null &&
+          (messagereceived.ticket == null || !ticket.equals(messagereceived.ticket))) {
         /* not to pollute logs, log instead of exception */
         if (StringUtils.isEmpty(messagereceived.ticket)) {
           LOG.debug("{} message: invalid ticket {} != {}", messagereceived.op,


### PR DESCRIPTION
### What is this PR for?
When client (zeppelin-web) send message with null ticket, NotebookServer does not handle and throw NPE.


### What type of PR is it?
Bug Fix

### Todos
* [x] - Null check

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2282

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
