### PR TITLE
[ZEPPELIN-2279] excluded comments from SQL

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -506,7 +506,7 @@ public class JDBCInterpreter extends Interpreter {
   protected ArrayList<String> splitSqlQueries(String sql) {
     ArrayList<String> queries = new ArrayList<>();
     StringBuilder query = new StringBuilder();
-    Character character;
+    char character;
 
     Boolean antiSlash = false;
     Boolean multiLineComment = false;
@@ -517,8 +517,8 @@ public class JDBCInterpreter extends Interpreter {
     for (int item = 0; item < sql.length(); item++) {
       character = sql.charAt(item);
 
-      if ((singleLineComment && (character.equals('\n') || item == sql.length() - 1))
-          || (multiLineComment && character.equals('/') && sql.charAt(item - 1) == '*')) {
+      if ((singleLineComment && (character == '\n' || item == sql.length() - 1))
+          || (multiLineComment && character == '/' && sql.charAt(item - 1) == '*')) {
         singleLineComment = false;
         multiLineComment = false;
         if (item == sql.length() - 1 && query.length() > 0) {
@@ -531,11 +531,11 @@ public class JDBCInterpreter extends Interpreter {
         continue;
       }
 
-      if (character.equals('\\')) {
+      if (character == '\\') {
         antiSlash = true;
       }
 
-      if (character.equals('\'')) {
+      if (character == '\'') {
         if (antiSlash) {
           antiSlash = false;
         } else if (quoteString) {
@@ -545,7 +545,7 @@ public class JDBCInterpreter extends Interpreter {
         }
       }
 
-      if (character.equals('"')) {
+      if (character == '"') {
         if (antiSlash) {
           antiSlash = false;
         } else if (doubleQuoteString) {
@@ -557,18 +557,18 @@ public class JDBCInterpreter extends Interpreter {
 
       if (!quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment
           && sql.length() > item + 1) {
-        if (character.equals('-') && sql.charAt(item + 1) == '-') {
+        if (character == '-' && sql.charAt(item + 1) == '-') {
           singleLineComment = true;
           continue;
         }
 
-        if (character.equals('/') && sql.charAt(item + 1) == '*') {
+        if (character == '/' && sql.charAt(item + 1) == '*') {
           multiLineComment = true;
           continue;
         }
       }
 
-      if (character.equals(';') && !antiSlash && !quoteString && !doubleQuoteString) {
+      if (character == ';' && !antiSlash && !quoteString && !doubleQuoteString) {
         queries.add(StringUtils.trim(query.toString()));
         query = new StringBuilder();
       } else if (item == sql.length() - 1) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -585,12 +585,10 @@ public class JDBCInterpreter extends Interpreter {
   private void executePrecode(Connection connection, String propertyKey) throws SQLException {
     String precode = getProperty(String.format(PRECODE_KEY_TEMPLATE, propertyKey));
     if (StringUtils.isNotBlank(precode)) {
-      List<String> precodeQueries = splitSqlQueries(precode);
+      precode = StringUtils.trim(precode);
+      logger.info("Run SQL precode '{}'", precode);
       try (Statement statement = connection.createStatement()) {
-        for (String precodeQuery : precodeQueries) {
-          logger.info("Run SQL precode '{}'", precodeQuery);
-          statement.execute(precodeQuery);
-        }
+        statement.execute(precode);
         if (!connection.getAutoCommit()) {
           connection.commit();
         }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -462,6 +462,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     t.open();
 
     String sqlQuery = "/* ; */\n" +
+        "-- /* comment\n" +
         "--select * from test_table\n" +
         "select * from test_table; /* some comment ; */\n" +
         "/*\n" +

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -467,6 +467,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
         "/*\n" +
         "select * from test_table;\n" +
         "*/\n" +
+        "-- a ; b\n" +
         "select * from test_table WHERE ID = ';--';\n" +
         "select * from test_table WHERE ID = '/*' -- test";
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -448,4 +448,30 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@TESTVARIABLE\n2\n", interpreterResult.message().get(0).getData());
   }
+
+  @Test
+  public void testExcludingComments() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "/* ; */\n" +
+        "--select * from test_table\n" +
+        "select * from test_table; /* some comment ; */\n" +
+        "/*\n" +
+        "select * from test_table;\n" +
+        "*/\n" +
+        "select * from test_table WHERE ID = ';--';\n" +
+        "select * from test_table WHERE ID = '/*' -- test";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(3, interpreterResult.message().size());
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Exclusion comments (single-, multiline) from queries before execution. Comments don't need to execute  query and sometimes there are errors. 


### What type of PR is it?
Bug Fix | Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2279

### How should this be tested?
```
/* ; */
select 1;
-- text select 1
/* bla 
bla
bla*/
select 1; -- text
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no