### PR TITLE
[ZEPPELIN-2287] Add more test to ensure 'RunOnSelectionChange' works well

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -262,7 +262,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       return;
     }
     try {
-      String xpathToCheckbox = getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]";
+      String xpathToRunOnSelectionChangeCheckbox = getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]";
+      String xpathToDropdownMenu = getParagraphXPath(1) + "//select";
       String xpathToResultText = getParagraphXPath(1) + "//div[contains(@id,\"_html\")]";
 
       createNewNote();
@@ -278,7 +279,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
         driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-click, 'turnOnAutoRun(paragraph)')]")).isDisplayed(),
         CoreMatchers.equalTo(true));
 
-      Select dropDownMenu = new Select(driver.findElement(By.xpath((getParagraphXPath(1) + "//select"))));
+      Select dropDownMenu = new Select(driver.findElement(By.xpath((xpathToDropdownMenu))));
       dropDownMenu.selectByVisibleText("2");
       collector.checkThat("If 'RunOnSelectionChange' is true, the paragraph result will be updated right after click any options in the dropdown menu ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
@@ -286,17 +287,22 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       // 2. set 'RunOnSelectionChange' to false
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
-      driver.findElement(By.xpath(xpathToCheckbox)).click();
+      driver.findElement(By.xpath(xpathToRunOnSelectionChangeCheckbox)).click();
       collector.checkThat("If 'Run on selection change' checkbox is unchecked, 'paragraph.config.runOnSelectionChange' will be false ",
         driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/span[contains(@ng-if, 'paragraph.config.runOnSelectionChange == false')]")).isDisplayed(),
         CoreMatchers.equalTo(true));
 
-      Select sameDropDownMenu = new Select(driver.findElement(By.xpath((getParagraphXPath(1) + "//select"))));
+      Select sameDropDownMenu = new Select(driver.findElement(By.xpath((xpathToDropdownMenu))));
       sameDropDownMenu.selectByVisibleText("1");
       collector.checkThat("If 'RunOnSelectionChange' is false, the paragraph result won't be updated even if we select any options in the dropdown menu ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
         CoreMatchers.equalTo("My selection is 2"));
 
+      // run paragraph manually by pressing ENTER
+      driver.findElement(By.xpath(xpathToDropdownMenu)).sendKeys(Keys.ENTER);
+      collector.checkThat("Even if 'RunOnSelectionChange' is set as false, still can run the paragraph by pressing ENTER ",
+        driver.findElement(By.xpath(xpathToResultText)).getText(),
+        CoreMatchers.equalTo("My selection is 1"));
 
     } catch (Exception e) {
       handleException("Exception in ParagraphActionsIT while testRunOnSelectionChange ", e);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -257,31 +257,49 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
   }
 
   @Test
-  public void testRunOnSelectionCheckbox() throws Exception {
+  public void testRunOnSelectionChange() throws Exception {
     if (!endToEndTestEnabled()) {
       return;
     }
     try {
       String xpathToCheckbox = getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]";
+      String xpathToResultText = getParagraphXPath(1) + "//div[contains(@id,\"_html\")]";
 
       createNewNote();
 
       waitForParagraph(1, "READY");
       setTextOfParagraph(1, "%md My selection is ${my selection=1,1|2|3}");
       runParagraph(1);
+      waitForParagraph(1, "FINISHED");
 
+      // 1. 'RunOnSelectionChange' is true by default
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       collector.checkThat("'Run on selection change' checkbox will be shown under dropdown menu ",
         driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-click, 'turnOnAutoRun(paragraph)')]")).isDisplayed(),
         CoreMatchers.equalTo(true));
 
+      Select dropDownMenu = new Select(driver.findElement(By.xpath((getParagraphXPath(1) + "//select"))));
+      dropDownMenu.selectByVisibleText("2");
+      collector.checkThat("If 'RunOnSelectionChange' is true, the paragraph result will be updated right after click any options in the dropdown menu ",
+        driver.findElement(By.xpath(xpathToResultText)).getText(),
+        CoreMatchers.equalTo("My selection is 2"));
+
+      // 2. set 'RunOnSelectionChange' to false
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       driver.findElement(By.xpath(xpathToCheckbox)).click();
       collector.checkThat("If 'Run on selection change' checkbox is unchecked, 'paragraph.config.runOnSelectionChange' will be false ",
         driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/span[contains(@ng-if, 'paragraph.config.runOnSelectionChange == false')]")).isDisplayed(),
         CoreMatchers.equalTo(true));
 
+      Select sameDropDownMenu = new Select(driver.findElement(By.xpath((getParagraphXPath(1) + "//select"))));
+      sameDropDownMenu.selectByVisibleText("1");
+      collector.checkThat("If 'RunOnSelectionChange' is false, the paragraph result won't be updated even if we select any options in the dropdown menu ",
+        driver.findElement(By.xpath(xpathToResultText)).getText(),
+        CoreMatchers.equalTo("My selection is 2"));
+
+
     } catch (Exception e) {
-      handleException("Exception in ParagraphActionsIT while testRunOnSelectionButton ", e);
+      handleException("Exception in ParagraphActionsIT while testRunOnSelectionChange ", e);
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -300,6 +300,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       // run paragraph manually by pressing ENTER
       driver.findElement(By.xpath(xpathToDropdownMenu)).sendKeys(Keys.ENTER);
+      driver.navigate().refresh();
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Even if 'RunOnSelectionChange' is set as false, still can run the paragraph by pressing ENTER ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -300,7 +300,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       // run paragraph manually by pressing ENTER
       driver.findElement(By.xpath(xpathToDropdownMenu)).sendKeys(Keys.ENTER);
-      ZeppelinITUtils.sleep(1000, true);
+      waitForParagraph(1, "FINISHED");
       collector.checkThat("Even if 'RunOnSelectionChange' is set as false, still can run the paragraph by pressing ENTER ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
         CoreMatchers.equalTo("My selection is 1"));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -300,6 +300,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       // run paragraph manually by pressing ENTER
       driver.findElement(By.xpath(xpathToDropdownMenu)).sendKeys(Keys.ENTER);
+      ZeppelinITUtils.sleep(1000, true);
       collector.checkThat("Even if 'RunOnSelectionChange' is set as false, still can run the paragraph by pressing ENTER ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
         CoreMatchers.equalTo("My selection is 1"));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -281,6 +281,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       Select dropDownMenu = new Select(driver.findElement(By.xpath((xpathToDropdownMenu))));
       dropDownMenu.selectByVisibleText("2");
+      waitForParagraph(1, "FINISHED");
       collector.checkThat("If 'RunOnSelectionChange' is true, the paragraph result will be updated right after click any options in the dropdown menu ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
         CoreMatchers.equalTo("My selection is 2"));
@@ -294,13 +295,13 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
       Select sameDropDownMenu = new Select(driver.findElement(By.xpath((xpathToDropdownMenu))));
       sameDropDownMenu.selectByVisibleText("1");
+      waitForParagraph(1, "FINISHED");
       collector.checkThat("If 'RunOnSelectionChange' is false, the paragraph result won't be updated even if we select any options in the dropdown menu ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),
         CoreMatchers.equalTo("My selection is 2"));
 
       // run paragraph manually by pressing ENTER
       driver.findElement(By.xpath(xpathToDropdownMenu)).sendKeys(Keys.ENTER);
-      driver.navigate().refresh();
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Even if 'RunOnSelectionChange' is set as false, still can run the paragraph by pressing ENTER ",
         driver.findElement(By.xpath(xpathToResultText)).getText(),


### PR DESCRIPTION
### What is this PR for?
To address this feedback https://github.com/apache/zeppelin/pull/2100#issuecomment-286780437, I added more test cases to ensure `RunOnSelectionChange` works well.

The newly added test cases are like below. When we run this paragraph, one dropdown menu will be shown: 
```
%md 
My selection is ${my selection=1,1|2|3}
```
![screen shot 2017-03-20 at 4 00 20 pm](https://cloud.githubusercontent.com/assets/10060731/24090750/6a183e7c-0d86-11e7-8a66-60ed8008d2db.png)

1. When `RunOnSelectionChange` is **true** (default)
if we select "2" in the dropdown menu, the result text will be updated to "My selection is 2" right after the selection change. [See here](https://github.com/apache/zeppelin/compare/master...AhyoungRyu:ZEPPELIN-2287/addTestForRunOnSelectionChange?expand=1#diff-48409cf8ca5ddb1aea1a62ada3cd091dR282)

2. When `RunOnSelectionChange` is **false**
If we select "1" in the dropdown menu, the result text won't be updated to "My selection is 1" right after the selection change instead it'll be remained as "My selection is 2". [See here](https://github.com/apache/zeppelin/compare/master...AhyoungRyu:ZEPPELIN-2287/addTestForRunOnSelectionChange?expand=1#diff-48409cf8ca5ddb1aea1a62ada3cd091dR295)
But we can run the paragraph by pressing `Enter`. After running the paragraph manually using `Enter`, then the result text will be updated to "My selection is 1" [See here](https://github.com/apache/zeppelin/compare/master...AhyoungRyu:ZEPPELIN-2287/addTestForRunOnSelectionChange?expand=1#diff-48409cf8ca5ddb1aea1a62ada3cd091dR301)


### What type of PR is it?
Add test case 

### What is the Jira issue?
[ZEPPELIN-2287](https://issues.apache.org/jira/browse/ZEPPELIN-2287)

### How should this be tested?
After applying this patch, run 
```
TEST_SELENIUM="true" mvn package -DfailIfNoTests=false -pl 'zeppelin-interpreter,zeppelin-zengine,zeppelin-server' -Dtest=ParagraphActionsIT#testRunOnSelectionChange
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
