### PR TITLE
[HOTFIX] Disabled to close interpreters when option is shared globally

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -799,7 +799,12 @@ public class InterpreterSettingManager {
 
   public void removeInterpretersForNote(InterpreterSetting interpreterSetting, String user,
       String noteId) {
-    interpreterSetting.closeAndRemoveInterpreterGroup(noteId, "");
+    //TODO(jl): This is only for hotfix. You should fix it as a beautiful way
+    InterpreterOption interpreterOption = interpreterSetting.getOption();
+    if (!(InterpreterOption.SHARED.equals(interpreterOption.perNote)
+        && InterpreterOption.SHARED.equals(interpreterOption.perUser))) {
+      interpreterSetting.closeAndRemoveInterpreterGroup(noteId, "");
+    }
   }
 
   public String getInterpreterSessionKey(String user, String noteId, InterpreterSetting setting) {


### PR DESCRIPTION
### What is this PR for?
Avoid closing interpreter in shared mode


### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Disable that feature no to work in shared mode

### What is the Jira issue?
N/A

### How should this be tested?
N/A

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
