### PR TITLE
[ZEPPELIN-2288] Fix Cross-Site WebSocket check

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookWebSocketCreator.java
@@ -19,18 +19,31 @@ package org.apache.zeppelin.socket;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_ALLOWED_ORIGINS;
 
 /**
  * Responsible to create the WebSockets for the NotebookServer.
  */
 public class NotebookWebSocketCreator implements WebSocketCreator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookWebSocketCreator.class);
   private NotebookServer notebookServer;
 
   public NotebookWebSocketCreator(NotebookServer notebookServer) {
     this.notebookServer = notebookServer;
   }
   public Object createWebSocket(ServletUpgradeRequest request, ServletUpgradeResponse response) {
-    return new NotebookSocket(request.getHttpServletRequest(), "", notebookServer);
+    String origin = request.getHeader("Origin");
+    if (notebookServer.checkOrigin(request.getHttpServletRequest(), origin)) {
+      return new NotebookSocket(request.getHttpServletRequest(), "", notebookServer);
+    } else {
+      LOG.error("Websocket request is not allowed by {} settings. Origin: {}",
+          ZEPPELIN_ALLOWED_ORIGINS, origin);
+      return null;
+    }
   }
 
 }


### PR DESCRIPTION
Change-Id: Iad87ebe0b5dd6bd67a12e47fe83fbd0e1e71bda9

### What is this PR for?

ZEPPELIN-173 implemented an optional check for the Origin header during the websocket connection creation. This check is no longer active since jetty is upgraded to 9 as the checkOrigin method is no longer called automatically.

This fix, just calls the existing check from the WebsocketCreator manually.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-2288

### How should this be tested?

1. Set `zeppelin.server.allowed.origins` in zeppelin-site.xml other than the default `*`. Eg. `xxxx`
2. Start zeppelin
3. Try to open the zeppelin ws conection with different origin:

```
curl 'http://localhost:8080/ws' -H 'Host: localhost:8080' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:47.0) Gecko/20100101 Firefox/47.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Sec-WebSocket-Version: 13' -H 'origin: http://other:8080' -H 'Sec-WebSocket-Extensions: permessage-deflate' -H 'Sec-WebSocket-Key: BpiqAMwZaQUJQ//NtEaQPw==' -H 'Connection: keep-alive, Upgrade' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache' -H 'Upgrade: websocket'
```

4. The websocket creation should be failed if the origin is not localhost or not the string configurated at 2. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
