### PR TITLE
[ZEPPELIN-1889] [FIX] Multiple groups in chart doesn't work

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-barchart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-barchart.js
@@ -41,7 +41,7 @@ export default class BarchartVisualization extends Nvd3ChartVisualization {
       pivot.groups,
       pivot.values,
       true,
-      false,
+      true,
       true);
 
     super.render(d3Data);


### PR DESCRIPTION
### What is this PR for?
Fix for multiple group in multi-bar chart

If any value is missing under any domain key in stacked multi-bar chart,
it won't get rendered. Fix this bug by adding `fillMissingValues` flag in
`d3DataFromPivot()`


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-1889](https://issues.apache.org/jira/browse/ZEPPELIN-1889)

### How should this be tested?
* Create a paragraph with tabular output
* Add multiple groups to input
* Render the stacked multi bar chart
* Chart should be rendered properly

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
