### PR TITLE
[HOTFIX][ZEPPELIN-2149] correct variable name used in interpreter.sh

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -23,7 +23,7 @@ function usage() {
     echo "usage) $0 -p <port> -d <interpreter dir to load> -l <local interpreter repo dir to load> -g <interpreter group name>"
 }
 
-while getopts "hp:d:l:v:u:n:" o; do
+while getopts "hp:d:l:v:u:g:" o; do
     case ${o} in
         h)
             usage

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -112,7 +112,7 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
     }
     cmdLine.addArgument("-l", false);
     cmdLine.addArgument(localRepoDir, false);
-    cmdLine.addArgument("-n", false);
+    cmdLine.addArgument("-g", false);
     cmdLine.addArgument(interpreterGroupName, false);
 
     executor = new DefaultExecutor();


### PR DESCRIPTION
### What is this PR for?
This fixes the typo is https://github.com/apache/zeppelin/pull/2107.


### What type of PR is it?
[Bug Fix]


### How should this be tested?
Create multiple interpreters (say shell interpreter) with different names (say sh1, sh2, etc.).
Now on running these different interpreters should log to different files.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
