### PR TITLE
[hotfix][gh-pages] Put blog post's description back

### DIFF
--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -845,14 +845,24 @@ a.anchorjs-link:hover { text-decoration: none; }
   margin-bottom: 14px;
   letter-spacing: -.02em;
   font-weight: 200;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 1.3;
-  color: rgba(0,0,0,.5);
+  color: #000;
 }
 
-.blogList .blogPublished {
+.blogList .blogAuthor {
   font-weight: 200;
   color: #00ab6b;
+  float: left;
+}
+
+.blogList .blogPublishDate::before {
+  content: '\00B7';
+}
+
+.blogList .blogPublishDate {
+  font-weight: 200;
+  color: rgba(0,0,0,.44);
 }
 
 /* Demo img thumbnail */ 

--- a/assets/themes/zeppelin/js/medium.controller.js
+++ b/assets/themes/zeppelin/js/medium.controller.js
@@ -4,30 +4,44 @@ angular.module("app").controller("MediumCtrl", function($scope, $window, $sce) {
   var postInfo = $scope.mediumPost[0].items
   var postInfoArray = []
 
-  function unicodeToChar(text) {
-   return text.replace(/\&#x[\dA-F]{4}/gi, 
-    function (match) {
-      return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
-    })
+  var init = function () {
+    createPostInfoArray()
+  }
+
+  var unicodeToChar = function (text) {
+    return text.replace(/\&#x[\dA-F]{4}/gi,
+      function (match) {
+        return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
+      })
+  }
+
+  var truncateString = function (string) {
+    return string.length > 150 ? string.substring(0, 150) + '...' : string
   }
   
-  for (var idx in postInfo) {
-    var eachPosts = postInfo[idx]
+  var createPostInfoArray = function () {
+    for (var idx in postInfo) {
+      var post = postInfo[idx]
 
-    // 1. remove HTML tag from description value
-    var regExString = /(<([^>]+)>)/ig
-    postInfo[idx].description = postInfo[idx].description.replace(regExString, '')
-    // 2. remove 'Continue reading on Apache Zeppelin Stories »'
-    postInfo[idx].description = postInfo[idx].description.replace(/Continue reading on Apache Zeppelin Stories »/g, '')
-    // 3. replace unicode char -> string
-    postInfo[idx].description = unicodeToChar(postInfo[idx].description)
+      // 1. remove HTML tag from description value
+      var regExString = /(<([^>]+)>)/ig
+      post.description = post.description.replace(regExString, '')
+      // 2. remove 'Continue reading on Apache Zeppelin Stories »'
+      post.description = post.description.replace(/Continue reading on Apache Zeppelin Stories »/g, '')
+      // 3. replace unicode char -> string
+      post.description = unicodeToChar(post.description)
+      // 4. truncate description string & attach '...'
+      post.description = truncateString(post.description)
 
-    // parse strigified date to 'MMMM Do, YYYY' format (e.g October 4th, 2016)
-    postInfo[idx].created = new Date(postInfo[idx].created)
-    postInfo[idx].created = moment(postInfo[idx].created).format("MMMM Do, YYYY")
-    
-    postInfoArray.push(postInfo[idx])
+      // parse strigified date to 'MMMM Do, YYYY' format (e.g October 4th, 2016)
+      post.created = new Date(post.created)
+      post.created = moment(post.created).format("MMMM Do, YYYY")
+
+      postInfoArray.push(post)
+    }
+
+    $scope.postInfoArray = postInfoArray
   }
 
-  $scope.postInfoArray = postInfoArray
-});
+  init()
+})

--- a/medium.md
+++ b/medium.md
@@ -33,9 +33,11 @@ limitations under the License.
             <div class="blogDescription">
               {% raw %}{{post.description}}{% endraw %}
             </div>
-            <div class="blogPublished">
-              <i class="fa fa-calendar" aria-hidden="true"></i> &nbsp;
-              {% raw %}{{post.created}}{% endraw %}
+            <div class="blogAuthor">
+              {% raw %}{{post.author}} {% endraw %}
+            </div>
+            <div class="blogPublishDate">
+              Published on {% raw %}{{post.created}}{% endraw %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### What is this PR for?
Currently can't see each `description` of blog posts in http://zeppelin.apache.org/#apache-zeppelin-stories. This PR is fixing for it. 
And added `author` name like medium does https://medium.com/apache-zeppelin-stories

### What type of PR is it?
hotfix 

### What is the Jira issue?
N/A

### How should this be tested?

### Screenshots (if appropriate)
 - Before
<img width="917" alt="screen shot 2017-03-21 at 5 19 55 pm" src="https://cloud.githubusercontent.com/assets/10060731/24138191/a461dad2-0e5a-11e7-8a5d-c01250962948.png">

 - After 
<img width="927" alt="screen shot 2017-03-21 at 5 11 05 pm" src="https://cloud.githubusercontent.com/assets/10060731/24138167/86638148-0e5a-11e7-8f79-eeada02b37fc.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
