### PR TITLE
[ZEPPELIN-2291] Notebook commit dropdown cut-off

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -298,8 +298,19 @@ a.navbar-brand:hover {
 }
 
 @media (min-width: 768px) {
-  .dropdown-menu.navbar-dropdown-maxHeight {
+  .navbar-fixed-top .dropdown-menu {
     max-height: calc(100vh - 60px);
+    overflow: auto;
+  }
+  #actionbar .dropdown-menu {
+    max-height: calc(100vh - 110px);
+    overflow: auto;
+  }
+}
+
+@media (max-width: 767px) {
+  #actionbar .dropdown-menu {
+    max-height: calc(100vh - 160px);
     overflow: auto;
   }
 }

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -27,7 +27,7 @@ limitations under the License.
       <ul class="nav navbar-nav" ng-if="ticket">
         <li class="dropdown notebook-list-dropdown" dropdown>
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" dropdown-toggle>Notebook <span class="caret"></span></a>
-          <ul class="dropdown-menu navbar-dropdown-maxHeight" role="menu">
+          <ul class="dropdown-menu" role="menu">
             <li ng-controller="NotenameCtrl as notenamectrl"><a href="" data-toggle="modal" data-target="#noteNameModal" ng-click="notenamectrl.getInterpreterSettings()"><i class="fa fa-plus"></i> Create new note</a></li>
             <li class="divider"></li>
             <div id="notebook-list" class="scrollbar-container" ng-if="isDrawNavbarNoteList">


### PR DESCRIPTION
### What is this PR for?
When you have a notebook under GIT version control, the dropdown with your commits will be cut-off with no possibility to scroll to older commits (see attached screenshot).

This fixes it by applying a relative max-height and appropriate overflow (similar styles as for the notebooks dropdown in the navigation bar). If the dropdown is longer than max-height, a scrollbar will be shown :)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2291

### How should this be tested?
Create a notebook under version control and make a couple of changes & commits, until the dropdown gets too long to fit on one screen. If everything works as intended, you should now be able to scroll to older commits inside the dropdown.

### Screenshots (if appropriate)
![apache_zeppelin_commit_dropdown_cut_off](https://cloud.githubusercontent.com/assets/1144202/24155455/3041dcfc-0e54-11e7-8120-3617d579f29f.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
