### PR TITLE
[ZEPPELIN-2300] SHOULD NOT update paragraph text when local change exists

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -129,15 +129,12 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   var initializeDefault = function(config) {
     var forms = $scope.paragraph.settings.forms;
-    
     if (!config.colWidth) {
       config.colWidth = 12;
     }
-  
     if (config.enabled === undefined) {
       config.enabled = true;
     }
-  
     for (var idx in forms) {
       if (forms[idx]) {
         if (forms[idx].options) {
@@ -1135,14 +1132,16 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   $scope.updateAllScopeTexts = function(oldPara, newPara) {
     if (oldPara.text !== newPara.text) {
-      if ($scope.dirtyText) {         // check if editor has local update
-        if ($scope.dirtyText === newPara.text) {  // when local update is the same from remote, clear local update
+      // check if editor has local update
+      if ($scope.dirtyText) {
+        // when local update is the same from remote, clear local update
+        if ($scope.dirtyText === newPara.text) {
           $scope.paragraph.text = newPara.text;
           $scope.dirtyText = undefined;
           $scope.originalText = angular.copy(newPara.text);
 
-        } else { // if there're local update, keep it.
-          $scope.paragraph.text = newPara.text;
+        } else {
+          // if there're local update, keep it.
         }
       } else {
         $scope.paragraph.text = newPara.text;


### PR DESCRIPTION
### What is this PR for?

**SHOULD NOT** update paragraph text when local change exists

### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2300](https://issues.apache.org/jira/browse/ZEPPELIN-2300)

Related with 

- https://github.com/apache/zeppelin/pull/2120 (different approach)
- https://issues.apache.org/jira/browse/ZEPPELIN-1492 (people are complaining on this issue. but different topic.)

### How should this be tested?

1. Open the same note in 2 browsers (use different sessions e.g normal chrome + secret chrome or firefox + safari)
2. Prepare a paragraph synchronized among sessions.
3. Modify text in one browser. 
4. Run the paragraph in different session.

### Screenshots (if appropriate)

#### After
![after_2300_new](https://cloud.githubusercontent.com/assets/4968473/24227028/990d2da4-0fad-11e7-9b36-5a149dc460a0.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
