### PR TITLE
[ZEPPELIN-2301] DON'T overwrite editor text when note is renamed, created, ...

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -108,8 +108,10 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   // Controller init
   $scope.init = function(newParagraph, note) {
-    const dirtyText = getDirtyText(note.id, newParagraph.id)
-    if (dirtyText) { newParagraph.text = dirtyText }
+    if (note && note.id && newParagraph && newParagraph.id) {
+      const dirtyText = getDirtyText(note.id, newParagraph.id)
+      if (dirtyText) { newParagraph.text = dirtyText }
+    }
 
     $scope.paragraph = newParagraph;
     $scope.parentNote = note;

--- a/zeppelin-web/src/components/editor/paragraphText.service.js
+++ b/zeppelin-web/src/components/editor/paragraphText.service.js
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+angular.module('zeppelinWebApp').service('paragraphTextService', paragraphTextService);
+
+export function paragraphTextService() {
+  'ngInject'
+
+  /** `note.paragraph.dirtyText` */
+  const dirtyTextMap = {}
+
+  this.setDirtyText = function(dirtyText, noteId, paragraphId) {
+    if (!noteId || !paragraphId) { return }
+
+    if (!dirtyTextMap[noteId]) { dirtyTextMap[noteId] = {} }
+    dirtyTextMap[noteId][paragraphId] = dirtyText
+  }
+
+  this.getDirtyText = function(noteId, paragraphId) {
+    if (!noteId || !paragraphId) { return undefined }
+
+    if (typeof dirtyTextMap[noteId] === 'undefined') { return undefined }
+    return dirtyTextMap[noteId][paragraphId]
+  }
+}

--- a/zeppelin-web/src/index.js
+++ b/zeppelin-web/src/index.js
@@ -55,6 +55,7 @@ import './components/noteName-import/notenameImport.controller.js';
 import './components/popover-html-unsafe/popover-html-unsafe.directive.js';
 import './components/popover-html-unsafe/popover-html-unsafe-popup.directive.js';
 import './components/editor/codeEditor.directive.js';
+import './components/editor/paragraphText.service';
 import './components/ngenter/ngenter.directive.js';
 import './components/dropdowninput/dropdowninput.directive.js';
 import './components/resizable/resizable.directive.js';


### PR DESCRIPTION
### What is this PR for?

DON'T overwrite local text change in editor when note is renamed, created, and so on

- `Move up paragraph` and `Move down paragraph` and other actions calling `saveNote` will reset local text change. But I will resolve it in different PRs.

#### Implementation Details

We can't access to children's `$scope` in angular. That's the reason why `paragraphText` is written as a (global) service.


### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2301](https://issues.apache.org/jira/browse/ZEPPELIN-2301)

Related with 

- https://github.com/apache/zeppelin/pull/2120 (different approach)
- https://issues.apache.org/jira/browse/ZEPPELIN-1492 (people are complaining on this issue. but different topic.)


### How should this be tested?

1. Open the same note in 2 browsers (use different sessions e.g normal chrome + secret chrome or firefox + safari)
2. Prepare a paragraph synchronized among sessions.
3. Modify text in one browser.
4. (Create, Delete) Rename other notes. The actions which triggering `NOTE` websocket messages should not overwrite local text change in editor.

### Screenshots (if appropriate)

#### After

![after_2301_new](https://cloud.githubusercontent.com/assets/4968473/24227131/5593692a-0fae-11e7-908e-161d36f04937.gif)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
