### PR TITLE
[ZEPPELIN-2302] Add info level logs when installing node modules and bundling helium pkgs

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -228,7 +228,9 @@ public class HeliumBundleFactory {
               String.format("install --fetch-retries=%d --fetch-retry-factor=%d " +
                               "--fetch-retry-mintimeout=%d",
                       FETCH_RETRY_COUNT, FETCH_RETRY_FACTOR_COUNT, FETCH_RETRY_MIN_TIMEOUT);
+      logger.info("Installing required node modules");
       npmCommand(commandForNpmInstall);
+      logger.info("Installed required node modules");
     } catch (TaskRunnerException e) {
       // ignore `(empty)` warning
       String cause = new String(out.toByteArray());
@@ -239,7 +241,9 @@ public class HeliumBundleFactory {
 
     try {
       out.reset();
+      logger.info("Bundling helium packages");
       npmCommand("run bundle");
+      logger.info("Bundled helium packages");
     } catch (TaskRunnerException e) {
       throw new IOException(new String(out.toByteArray()));
     }


### PR DESCRIPTION
### What is this PR for?

Add info level logs when installing node modules and bundling helium packages.

- Because user cannot get noticed during 30secs ~ few minutes if you have multiple enabled helium packages
- User might think that Zeppelin hangs or there is another problem If there is no log message.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2302](https://issues.apache.org/jira/browse/ZEPPELIN-2302)

### How should this be tested?

1. Enable some helium packages. 
2. Then you will see log messages like

```
INFO [2017-03-23 14:57:32,709] ({qtp1587067503-18} HeliumBundleFactory.java[buildBundle]:227) - Installing required node modules
INFO [2017-03-23 14:57:36,561] ({qtp1587067503-18} HeliumBundleFactory.java[buildBundle]:233) - Installed required node modules
INFO [2017-03-23 14:57:36,562] ({qtp1587067503-18} HeliumBundleFactory.java[buildBundle]:244) - Bundling helium packages
INFO [2017-03-23 14:57:38,092] ({qtp1587067503-18} HeliumBundleFactory.java[buildBundle]:246) - Bundled helium packages
```

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
