### PR TITLE
[ZEPPELIN-2211] Too many WARN logs: "Couldn't get interpreter editor setting"

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -514,7 +514,8 @@ public class InterpreterSettingManager {
         }
       }
     } catch (NullPointerException e) {
-      logger.warn("Couldn't get interpreter editor setting");
+      // Use `debug` level because this log occurs frequently
+      logger.debug("Couldn't get interpreter editor setting");
     }
     return editor;
   }


### PR DESCRIPTION
### What is this PR for?

every time we insert invalid backend magic (e.g `sparc`), `InterpreterSettingManager` throws WARN log. 

I changed the log level to debug because

- WARN level should not be used for this kind of situation. 
- This log doesn't provide any useful information for user.  So info level is not proper as well.

I attached a screenshot.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2211](https://issues.apache.org/jira/browse/ZEPPELIN-2211)

### How should this be tested?

- Insert invalid magic in your paragraph. For example `sparc` or `marcdown`

### Screenshots (if appropriate)

![interpreter_setting_manager](https://cloud.githubusercontent.com/assets/4968473/24235266/cbecbbf4-0fdf-11e7-9fcc-f1a95a5e82ab.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
