### PR TITLE
[gh-pages][ZEPPELIN-2303] Fix lately published package ordering

### DIFF
--- a/assets/themes/zeppelin/js/helium.controller.js
+++ b/assets/themes/zeppelin/js/helium.controller.js
@@ -46,14 +46,19 @@ angular.module("app", ['ui.bootstrap'])
     }
 
     $scope.latestPkgInfo = latestPkgInfo
-    $scope.numberOfAllPkgs = latestPkgInfo.length
   }
+
+  var orderPackageByPubDate = function(a, b) {
+    return new Date(a.published).getTime() - new Date(b.published).getTime();
+  };
 
   var classifyPkgByType = function(latestPkgInfo) {
     var vizTypePkgs = []
     var spellTypePkgs = []
     var interpreterTypePkgs = []
     var allTypePkgs = {}
+
+    latestPkgInfo = latestPkgInfo.sort(orderPackageByPubDate).reverse();
 
     for (var idx in latestPkgInfo) {
       switch (latestPkgInfo[idx].type) {

--- a/helium_packages.md
+++ b/helium_packages.md
@@ -60,7 +60,7 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
       </div>
       <div ng-if="pkgListByType === 'ALL'">
         <div class="row heliumPackageList"
-           ng-repeat="pkg in latestPkgInfo.slice(((currentPage-1)*itemsPerPage), ((currentPage)*itemsPerPage)) | orderBy: ['published']:true">
+             ng-repeat="pkg in latestPkgInfo.slice(((currentPage-1)*itemsPerPage), ((currentPage)*itemsPerPage))">
         <div class="col-md-12">
           <div class="heliumPackageHead">
             <div class="heliumPackageIcon"
@@ -90,14 +90,14 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
         </div>
       </div>
       <div class="text-center" style="margin-top: 24px;">
-        <ul uib-pagination boundary-links="true" total-items="numberOfAllPkgs" 
+        <ul uib-pagination boundary-links="true" total-items="latestPkgInfo.length" 
             ng-model="currentPage" class="pagination-sm"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
       </div>
     </div>
     <div ng-if="pkgListByType !== 'ALL'" ng-repeat="(types, pkgs) in allTypePkgs">
         <div class="row heliumPackageList"
-           ng-repeat="pkg in pkgs.slice(((currentPage-1)*itemsPerPage), ((currentPage)*itemsPerPage)) | orderBy: ['published']:true"
+           ng-repeat="pkg in pkgs.slice(((currentPage-1)*itemsPerPage), ((currentPage)*itemsPerPage))"
            ng-show="$parent.pkgListByType === types">
         <div class="col-md-12">
           <div class="heliumPackageHead">
@@ -129,7 +129,7 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
       </div>
       <div class="text-center" style="margin-top: 24px;">
         <ul uib-pagination boundary-links="true" total-items="pkgs.length" 
-            ng-model="currentPage" class="pagination-sm"
+            ng-model="$parent.currentPage" class="pagination-sm"
             ng-show="$parent.pkgListByType === types"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
       </div>

--- a/helium_packages.md
+++ b/helium_packages.md
@@ -34,7 +34,7 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
         <div>
           <input class="helium-radio" id="'ALL'" type="radio" 
                ng-model="pkgListByType" ng-value="'ALL'" ng-click="pkgListByType = 'ALL'">
-          <label for="'ALL'">Lately published</label>
+          <label for="'ALL'">Recently published</label>
         </div>
         <div ng-repeat="pkgTypes in allPackageTypes">
           <input class="helium-radio" id="{% raw %}{{pkgTypes}}{% endraw %}" type="radio" 


### PR DESCRIPTION
### What is this PR for?
I added pagination below Helium package list in https://zeppelin.apache.org/helium_packages.html by #2126. But after this, "Lately published" page doesn't show actual latest package first. It's because while i'm paginating the packages, I should've made ordering by `published` date first before [slicing package array](https://github.com/apache/zeppelin/compare/gh-pages...AhyoungRyu:ZEPPELIN-2303/fixLatelyPublishedOrdering?expand=1#diff-c2c3af7bcb6c1faa231eaf25c15d3732R63). This PR will fix it. 

### What type of PR is it?
Bug Fix | gh-pages

### What is the Jira issue?
[ZEPPELIN-2303](https://issues.apache.org/jira/browse/ZEPPELIN-2303)

### How should this be tested?
Run the website(`gh-pages`) locally as described in [here](https://github.com/apache/zeppelin/tree/gh-pages#run-website) and compare the ordering like below. 

```
1. "zeppelin-sigma-spell" : "2017-03-10T09:31:56.802Z"
2. "zeppelin-d3-spell" : "2017-03-08T10:08:51.022Z"
3. "zeppelin-markdown-spell" : "2017-03-07T19:17:35.975Z"
4. "zeppelin-echo-spell" : "2017-03-07T11:37:44.283Z"
5. "zeppelin-csv-spell" : "2017-02-28T04:57:05.463Z"
6. "zeppelin-json-spell" : "2017-02-28T04:49:27.897Z"
7. "zeppelin-highcharts-heatmap" : "2017-02-14T12:46:02.732Z"
...

Last. "zeppelin-bubblechart" : "2017-01-23T20:42:34.373Z"
```

tl;dr **"zeppelin-sigma-spell"** should be the first & **"zeppelin-bubblechart"** should be the last 

### Screenshots (if appropriate)
 - Before 
![before](https://cloud.githubusercontent.com/assets/10060731/24236414/fbe7b494-0fe4-11e7-9e6d-908f12fad18b.gif)

 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/24236425/fddec24c-0fe4-11e7-8c58-db05330d7bd6.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
