### PR TITLE
[ZEPPELIN-2304] Fix vis Icon sizes in helium page

### DIFF
--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -140,6 +140,12 @@
   display: inline-block;
 }
 
+.heliumVisIconButton > img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
 .heliumLocalPackage {
   color: #636363;
 }

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -47,10 +47,10 @@ limitations under the License.
              data-ng-model="bundleOrder">
           <div class="btn-group" data-ng-repeat="pkgName in bundleOrder"
                as-sortable-item>
-            <div class="btn btn-default btn-sm"
+            <button class="btn btn-default btn-sm heliumVisIconButton"
                  ng-bind-html='defaultPackages[pkgName].pkg.icon'
                  as-sortable-item-handle>
-            </div>
+            </button>
           </div>
         </div>
         <div class="saveLink"


### PR DESCRIPTION
### What is this PR for?

Icon size of helium vis packages doesn't fit into the container button. I attached a image.




### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2304](https://issues.apache.org/jira/browse/ZEPPELIN-2304)

### How should this be tested?

1. Install 2+ vis packages.
2. Open the `#helium` page

### Screenshots (if appropriate)

#### Before

<img width="378" alt="2304_before" src="https://cloud.githubusercontent.com/assets/4968473/24238569/17b7dbaa-0fee-11e7-9994-39fd7700c70c.png">

#### After

<img width="389" alt="2304_after" src="https://cloud.githubusercontent.com/assets/4968473/24238572/1aac7b72-0fee-11e7-934d-da4c2d864b54.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
