### PR TITLE
[HOLD][ZEPPELIN-2248] Fix javax.ws.rs and cxf version mismatch

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -34,11 +34,11 @@
 
   <properties>
     <!--library versions-->
-    <cxf.version>2.7.8</cxf.version>
+    <cxf.version>3.1.6</cxf.version>
     <hadoop-common.version>2.6.0</hadoop-common.version>
     <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
-    <jersey.servlet.version>1.13</jersey.servlet.version>
-    <javax.ws.rsapi.version>2.0-m10</javax.ws.rsapi.version>
+    <jersey.servlet.version>2.25.1</jersey.servlet.version>
+    <javax.ws.rsapi.version>2.0.1</javax.ws.rsapi.version>
     <libpam4j.version>1.8</libpam4j.version>
     <jna.version>4.1.0</jna.version>
 
@@ -170,18 +170,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-api</artifactId>
-      <version>${cxf.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
       <version>${jetty.version}</version>
@@ -292,9 +280,14 @@
       <version>${quartz.scheduler.version}</version>
     </dependency>
 
-    <dependency>
+    <!--<dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-servlet</artifactId>
+      <version>${jersey.servlet.version}</version>
+    </dependency>-->
+    <dependency>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
       <version>${jersey.servlet.version}</version>
     </dependency>
 

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -280,11 +280,6 @@
       <version>${quartz.scheduler.version}</version>
     </dependency>
 
-    <!--<dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-servlet</artifactId>
-      <version>${jersey.servlet.version}</version>
-    </dependency>-->
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -16,6 +16,9 @@
  */
 package org.apache.zeppelin.rest;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response.Status;
 import org.apache.shiro.authc.*;
 import org.apache.shiro.subject.Subject;
 import org.apache.zeppelin.annotation.ZeppelinApi;
@@ -51,6 +54,18 @@ public class LoginRestApi {
     super();
   }
 
+  @GET
+  @ZeppelinApi
+  public Response getLogin() {
+    if (SecurityUtils.isAuthenticated()) {
+      return new JsonResponse<>(Status.METHOD_NOT_ALLOWED, "", "").build();
+    }
+    Map<String, String> data = new HashMap<>();
+    data.put("principal", SecurityUtils.ANONYMOUS);
+    data.put("roles", "");
+    data.put("ticket", "anonymous");
+    return new JsonResponse<>(Response.Status.OK, "", data).build();
+  }
 
   /**
    * Post Login

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -46,7 +46,7 @@ import com.google.common.collect.Sets;
  */
 public class SecurityUtils {
 
-  private static final String ANONYMOUS = "anonymous";
+  public static final String ANONYMOUS = "anonymous";
   private static final HashSet<String> EMPTY_HASHSET = Sets.newHashSet();
   private static boolean isEnabled = false;
   private static final Logger log = LoggerFactory.getLogger(SecurityUtils.class);

--- a/zeppelin-web/src/WEB-INF/web.xml
+++ b/zeppelin-web/src/WEB-INF/web.xml
@@ -23,9 +23,9 @@
  <display-name>zeppelin-web</display-name>
 	<servlet>
 		<servlet-name>default</servlet-name>
-		<servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+		<servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
 		<init-param>
-			<param-name>com.sun.jersey.config.property.packages</param-name>
+			<param-name>jersey.config.server.provider.packages</param-name>
 			<param-value>org.apache.zeppelin.rest</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>


### PR DESCRIPTION
### What is this PR for?
Fixing version mismatch among jetty, cxf, jersey


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Match all versions of javax.ws related libraries

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2248

### How should this be tested?
No error while starting and accessing the web at the first time

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
