### PR TITLE
[MINOR][ZEPPELIN-2306] Improve alignment of components in Helium header

### DIFF
--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -12,6 +12,10 @@
  * limitations under the License.
  */
 
+.heliumHead {
+  padding-bottom: 34px !important;
+}
+
 .heliumPackageContainer {
   padding-bottom: 0px;
   margin-bottom: 0px;
@@ -162,6 +166,10 @@
 }
 
 .localPkgInfo {
+  margin-right: 0;
+}
+
+.localPkgInfo p {
   margin: 10px 12px 0 0;
   font-size: 11px;
   font-style: italic;

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -11,7 +11,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div class="interpreterHead">
+<div class="interpreterHead"
+     ng-class="(bundleOrder.length > 1) ? '' : 'heliumHead'">
   <div class="header">
     <div class="row">
       <div class="col-md-12">
@@ -34,7 +35,6 @@ limitations under the License.
             <i class="fa fa-cube"></i>
             {{pkgTypes}}
           </button>
-          <p class="localPkgInfo">* Local registry package's name is gray colored.</p>
         </div>
       </div>
     </div>
@@ -56,6 +56,11 @@ limitations under the License.
               ng-click="saveBundleOrder()">
           save
         </span>
+      </div>
+    </div>
+    <div class="pull-right row localPkgInfo">
+      <div class="col-md-12">
+        <p>* Local registry package's name is gray colored.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What is this PR for?
If there are 2 more enabled `VISUALIZATION` pkgs, the ordering control section will be shown like below. But the useless spaces between "Helium" and "Bundle package display order(drag and drop)". 
![helium_header](https://cloud.githubusercontent.com/assets/10060731/24256540/c98d6aec-102b-11e7-89cc-783c19db36f9.png)

So I changed some alignment to remove the extra space.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-2306](https://issues.apache.org/jira/browse/ZEPPELIN-2306)

### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
 - Before 
<img width="1278" alt="screen shot 2017-03-24 at 12 55 12 am" src="https://cloud.githubusercontent.com/assets/10060731/24256864/a3940516-102c-11e7-9fe2-71ded6115c4f.png">


 - After 
 
1. more than 2 pkgs are enabled 
<img width="1271" alt="after1" src="https://cloud.githubusercontent.com/assets/10060731/24256742/4e09d1f2-102c-11e7-9ef6-327f54d8a31a.png">

2. only 1 pkg is enabled 
<img width="1267" alt="after2" src="https://cloud.githubusercontent.com/assets/10060731/24256794/6ac384dc-102c-11e7-8861-950a8ca35427.png">



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
