### PR TITLE
[MINOR][ZEPPELIN-2308] Fix vis icon button group

### DIFF
--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -113,6 +113,10 @@
   float: left;
 }
 
+.heliumBundleOrder p {
+  margin:0 0 5px 15px
+}
+
 .sortable-row .as-sortable-item-handle {
   width: 35px;
   height: 30px;

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -40,22 +40,24 @@ limitations under the License.
     </div>
     <div ng-show="bundleOrder.length > 1"
          class="row heliumBundleOrder">
-      <div style="margin:0 0 5px 15px">Bundle package display order (drag and drop to reorder)</div>
-      <div class="col-md-12 sortable-row btn-group"
-           as-sortable="bundleOrderListeners"
-           data-ng-model="bundleOrder">
-        <div class="btn-group" data-ng-repeat="pkgName in bundleOrder"
-             as-sortable-item>
-          <div class="btn btn-default btn-sm"
-               ng-bind-html='defaultPackages[pkgName].pkg.icon'
-               as-sortable-item-handle>
+      <p>Bundle package display order (drag and drop to reorder)</p>
+      <div class="col-md-12">
+        <div class="sortable-row btn-group"
+             as-sortable="bundleOrderListeners"
+             data-ng-model="bundleOrder">
+          <div class="btn-group" data-ng-repeat="pkgName in bundleOrder"
+               as-sortable-item>
+            <div class="btn btn-default btn-sm"
+                 ng-bind-html='defaultPackages[pkgName].pkg.icon'
+                 as-sortable-item-handle>
+            </div>
           </div>
         </div>
-        <span class="saveLink"
-              ng-show="bundleOrderChanged"
-              ng-click="saveBundleOrder()">
+        <div class="saveLink"
+             ng-show="bundleOrderChanged"
+             ng-click="saveBundleOrder()">
           save
-        </span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What is this PR for?
Since "Save" button which shows up when there is change in the package bundle ordering is included in same button group with other Helium viz icon buttons, the rightmost viz icon is not regarded as last child. For this reason, its border radius is a bit wired.

<img src="https://cloud.githubusercontent.com/assets/10060731/24257346/f928756a-102d-11e7-8c06-c7d58ac2b331.png" width="200px">

So I separated "Save" button from the icon btn group. 


### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-2308](https://issues.apache.org/jira/browse/ZEPPELIN-2308)

### Screenshots (if appropriate)
 - Before
<img width="166" alt="before" src="https://cloud.githubusercontent.com/assets/10060731/24257314/e03ca210-102d-11e7-9155-82684bf9edbc.png">
 
 - After 
<img width="165" alt="after" src="https://cloud.githubusercontent.com/assets/10060731/24257317/e24d4352-102d-11e7-88f6-63be3c509cd3.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
