### PR TITLE
[ZEPPELIN-2229] revert ndv3 version from 1.8.5 to 1.7.1

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -17,7 +17,7 @@
     "ace-builds": "1.2.6",
     "angular-ui-ace": "0.1.3",
     "jquery.scrollTo": "~1.4.13",
-    "nvd3": "~1.8.5",
+    "nvd3": "~1.7.1",
     "angular-dragdrop": "~1.0.8",
     "perfect-scrollbar": "~0.5.4",
     "ng-sortable": "~1.3.3",

--- a/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-piechart.js
@@ -76,8 +76,9 @@ export default class PiechartVisualization extends Nvd3ChartVisualization {
 
   configureChart(chart) {
     chart.x(function(d) { return d.label;})
-	 .y(function(d) { return d.value;})
-	 .showLabels(false)
-	 .showTooltipPercent(true);
+	 .y(function(d) { return d.value;});
+	 // if upgrade ndv3 to 1.8.5 or over, the following code is available
+	 /*.showLabels(false)
+	 .showTooltipPercent(true);*/
   };
 }

--- a/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-scatterchart.js
@@ -69,6 +69,16 @@ export default class ScatterchartVisualization extends Nvd3ChartVisualization {
     chart.xAxis.tickFormat(function(d) {return self.xAxisTickFormat(d, self.xLabels);});
     chart.yAxis.tickFormat(function(d) {return self.yAxisTickFormat(d, self.yLabels);});
 
+    // configure how the tooltip looks.
+    chart.tooltipContent(function(key, x, y, graph, data) {
+      var tooltipContent = '<h3>' + key + '</h3>';
+      if (self.config.size &&
+        self.isValidSizeOption(self.config, self.tableData.rows)) {
+        tooltipContent += '<p>' + data.point.size + '</p>';
+      }
+      return tooltipContent;
+    });
+
     chart.showDistX(true).showDistY(true);
     //handle the problem of tooltip not showing when muliple points have same value.
   };


### PR DESCRIPTION
### What is this PR for?
After [[ZEPPELIN-1588]: bumping nvd3 to 1.8.5](#2042) merged, Zeppelin was occurring front-end side error such as `Uncaught TypeError: Cannot read property 'x' of null` because of upgrading for `1.7.1` to `1.8.5`. 
AFAIK, this is a bug in `ndv3`, and ndv3 is still fixing the problem discussing [here](https://github.com/novus/nvd3/issues/330).
Also The latest release(1.8.5 version) scatter file and the master scatter file have a lot of changes, so we should wait for the next release.
Thus, I think we need to revert version from 1.8.5 to 1.7.1 for stable Zeppelin and our next 0.7.1 release.

_Plus, when I check on current master of nvd3, scatter chart works well like this._
![z_2229_master_check](https://cloud.githubusercontent.com/assets/8110458/24280800/f1cd4caa-1096-11e7-8d68-bc831d9e228b.gif)

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2229](https://issues.apache.org/jira/browse/ZEPPELIN-2229)

### How should this be tested?
* Switch some of chart such like screenshots.

### Screenshots (if appropriate)
[Before]
![x_of_null_error](https://cloud.githubusercontent.com/assets/8110458/24280810/1ffe2432-1097-11e7-8d25-51237144d4ff.gif)

[After]
![z_2229_revert_chart2](https://cloud.githubusercontent.com/assets/8110458/24280802/f7447640-1096-11e7-864f-733d9fd17031.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
