### PR TITLE
[ZEPPELIN-2314] Fix watcher websocket origin header

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -68,6 +68,7 @@ public class ZeppelinClient {
   private SchedulerService schedulerService;
   private Authentication authModule;
   private static final int MIN = 60;
+  private static final String ORIGIN = "Origin";
 
   private static final Set<String> actionable = new  HashSet<String>(Arrays.asList(
       // running events
@@ -188,6 +189,7 @@ public class ZeppelinClient {
   private Session openWatcherSession() {
     ClientUpgradeRequest request = new ClientUpgradeRequest();
     request.setHeader(WatcherSecurityKey.HTTP_HEADER, WatcherSecurityKey.getKey());
+    request.setHeader(ORIGIN, "*");
     WatcherWebsocket socket = WatcherWebsocket.createInstace();
     Future<Session> future = null;
     Session session = null;
@@ -241,6 +243,7 @@ public class ZeppelinClient {
   
   private Session openNoteSession(String noteId, String principal, String ticket) {
     ClientUpgradeRequest request = new ClientUpgradeRequest();
+    request.setHeader(ORIGIN, "*");
     ZeppelinWebsocket socket = new ZeppelinWebsocket(noteId);
     Future<Session> future = null;
     Session session = null;


### PR DESCRIPTION
### What is this PR for?
this is to add `Origin` header to ws client, and fix ws connection error after merging ZEPPELIN-2288, breaking ZEPPELIN-1697. more details in issue. also since breaking some changes in 0.7.0 branch, better include in `0.7.1`


### What type of PR is it?
Bug Fix

### Todos
* [x] - add header

### What is the Jira issue?
[ZEPPELIN-2314](https://issues.apache.org/jira/browse/ZEPPELIN-2314)

### How should this be tested?
same as in #2161 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
