### PR TITLE
[branch-0.7] Minor styling for Helium menu

### DIFF
--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -47,6 +47,7 @@
         }
       }
       $scope.defaultVersions = defaultVersions;
+      console.log(_.size(defaultVersions));
     };
 
     var getAllPackageInfo = function() {
@@ -214,6 +215,10 @@
       } else {
         $scope.showVersions[pkgName] = true;
       }
+    };
+  
+    $scope.getPackageSize = function(pkgSearchResult) {
+      return _.size(pkgSearchResult)
     };
   }
 })();

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -47,7 +47,6 @@
         }
       }
       $scope.defaultVersions = defaultVersions;
-      console.log(_.size(defaultVersions));
     };
 
     var getAllPackageInfo = function() {

--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -17,6 +17,16 @@
   margin-bottom: 0px;
 }
 
+.heliumLearnMore {
+  margin-top:10px;
+}
+
+.heliumLearnMore a {
+  cursor:pointer;
+  margin-right:20px;
+  text-decoration:none;
+}
+
 .heliumPackageList {
   min-height: 25px;
   margin-bottom: 15px;
@@ -104,4 +114,8 @@
   text-decoration:
   underline;color:#3071a9;
   display: inline-block;
+}
+
+.heliumVisualizationOrder p {
+  margin:0 0 5px 15px;
 }

--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -127,3 +127,7 @@
 .gray40-message a:hover {
   text-decoration: none;
 }
+
+.gray40-message a:focus {
+  text-decoration: none;
+}

--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -119,3 +119,11 @@
 .heliumVisualizationOrder p {
   margin:0 0 5px 15px;
 }
+
+.gray40-message a:before {
+  content: "\00a0";
+}
+
+.gray40-message a:hover {
+  text-decoration: none;
+}

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -18,32 +18,50 @@ limitations under the License.
         <h3 class="new_h3">
           Helium
         </h3>
+        <div class="pull-right heliumLearnMore">
+          <a target="_blank"
+             class="helium-repo-btn"
+             ng-href="https://zeppelin.apache.org/helium_packages.html"
+             tooltip-placement="bottom"
+             tooltip="Learn more">
+            <i class="icon-question" ng-style="{color: 'black'}"></i>
+          </a>
+        </div>
       </div>
     </div>
     <div ng-show="visualizationOrder.length > 1"
          class="row heliumVisualizationOrder">
-      <div style="margin:0 0 5px 15px">Visualization package display order (drag and drop to reorder)</div>
-      <div class="col-md-12 sortable-row btn-group"
-           as-sortable="visualizationOrderListeners"
-           data-ng-model="visualizationOrder">
-        <div class="btn-group" data-ng-repeat="pkgName in visualizationOrder"
-             as-sortable-item>
-          <div class="btn btn-default btn-sm"
-               ng-bind-html='defaultVersions[pkgName].pkg.icon'
-               as-sortable-item-handle>
+      <p>Visualization package display order (drag and drop to reorder)</p>
+      <div class="col-md-12">
+        <div class="sortable-row btn-group"
+             as-sortable="visualizationOrderListeners"
+             data-ng-model="visualizationOrder">
+          <div class="btn-group" data-ng-repeat="pkgName in visualizationOrder"
+               as-sortable-item>
+            <div class="btn btn-default btn-sm"
+                 ng-bind-html='defaultVersions[pkgName].pkg.icon'
+                 as-sortable-item-handle>
+            </div>
           </div>
         </div>
-        <span class="saveLink"
-           ng-show="visualizationOrderChanged"
-           ng-click="saveVisualizationOrder()">
-          save
-        </span>
+        <div class="saveLink"
+              ng-show="visualizationOrderChanged"
+              ng-click="saveVisualizationOrder()">
+            save
+        </div>
       </div>
     </div>
   </div>
 </div>
 
 <div class="box width-full heliumPackageContainer">
+  <div class="row"
+       style="padding-bottom: 15px"
+       ng-if="getPackageSize(defaultVersions) === 0">
+    <div class="col-md-12 gray40-message">
+      <em>Currently there is no available package to be listed</em>
+    </div>
+  </div>
   <div class="row heliumPackageList"
        ng-repeat="(pkgName, pkgInfo) in defaultVersions">
     <div class="col-md-12">

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -23,7 +23,7 @@ limitations under the License.
              class="helium-repo-btn"
              ng-href="https://zeppelin.apache.org/helium_packages.html"
              tooltip-placement="bottom"
-             tooltip="Learn more">
+             tooltip="What is Helium?">
             <i class="icon-question" ng-style="{color: 'black'}"></i>
           </a>
         </div>
@@ -59,7 +59,14 @@ limitations under the License.
        style="padding-bottom: 15px"
        ng-if="getPackageSize(defaultVersions) === 0">
     <div class="col-md-12 gray40-message">
-      <em>Currently there is no available package to be listed</em>
+      <em>No package installed</em>
+      <a target="_blank"
+         class="helium-repo-btn"
+         ng-href="https://zeppelin.apache.org/docs/{{zeppelinVersion}}/development/writingzeppelinvisualization.html#how-it-works"
+         tooltip-placement="top"
+         tooltip="How to use?">
+        <i class="icon-question" ng-style="{color: 'black'}"></i>
+      </a>
     </div>
   </div>
   <div class="row heliumPackageList"


### PR DESCRIPTION
### What is this PR for?
Since Helium online registry is available in develop version(0.8.0-SNAPSHOT) for now, people only can use their local registry(e.g. `ZEPPELIN_HOME/helium`) in 0.7.X. So they will see below empty screen when open Helium menu at the first time. 

<img width="930" alt="screen shot 2017-03-25 at 11 03 20 pm" src="https://cloud.githubusercontent.com/assets/10060731/24322858/4f9c21c6-11af-11e7-93fc-8975dbfcaddf.png">

It's hard to recognize what Helium is and not that attractive actually.

So I added 
 - initial sentence "Currently there is no available package to be listed" when there is no package under local registry
 - question icon to header -> link to https://zeppelin.apache.org/helium_packages.html to give some hint(?) about Helium :)

And also fixed `VISUALIZATION` button group as I did in #2185.
Please see below screenshot images for the details. 

### What type of PR is it?
Improvement

### What is the Jira issue?
N/A

### How should this be tested?
1. Run 
```
$ yarn run dev
```
under `zeppelin-web/`

2. Go to Helium menu

### Screenshots (if appropriate)
  - when the package size is 0 & question mark icon (link to 
![record](https://cloud.githubusercontent.com/assets/10060731/24322921/4f094e40-11b0-11e7-9e8f-0321e0586e57.gif)

 - fixed viz type icon ordering button group 
    - before
<img width="126" alt="screen shot 2017-03-25 at 6 46 13 pm" src="https://cloud.githubusercontent.com/assets/10060731/24322931/6dd2e728-11b0-11e7-9b7b-111b751c1dfb.png">
 
    - after (round border in rightmost icon)
<img width="134" alt="screen shot 2017-03-25 at 6 42 24 pm" src="https://cloud.githubusercontent.com/assets/10060731/24322932/6f8c3538-11b0-11e7-8198-a221376f9f44.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
