### PR TITLE
[HOTFIX] Keep interpreter group when save and restart

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -151,7 +151,10 @@ public class InterpreterSettingManager {
     init();
   }
 
-  private void loadFromFile() {
+  /**
+   * Remember this method doesn't keep current connections after being called
+   */
+  private void  loadFromFile() {
     if (!Files.exists(interpreterBindingPath)) {
       // nothing to read
       return;
@@ -913,9 +916,8 @@ public class InterpreterSettingManager {
 
           saveToFile();
         } catch (Exception e) {
-          throw e;
-        } finally {
           loadFromFile();
+          throw e;
         }
       } else {
         throw new InterpreterException("Interpreter setting id " + id + " not found");


### PR DESCRIPTION
### What is this PR for?
Not removing interpreter group reference while editing and saving interpreter setting.

### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Move `loadFromFile` into proper location

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2037
* #1976 

### How should this be tested?
1. Enable shiro for login
1. Execute sample code by %python and %pyspark
1. Switch spark interpreter from global mode to Per user mode and save it.
1. Switch python interpreter from Per user mode to global mode save it.
1. Shutdown zeppelin
1. Verify if there's no zombie processes

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
