### PR TITLE
[ZEPPELIN-2319] new methods for ZeppelinContext

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/ZeppelinContext.java
@@ -413,6 +413,15 @@ public class ZeppelinContext {
     String noteId = interpreterContext.getNoteId();
     run(noteId, idx, interpreterContext);
   }
+  
+  @ZeppelinApi
+  public void run(int... paragraphIndexes) {
+    ArrayList<Object> listIDs = new ArrayList<Object>();
+    for (int i = 0; i < paragraphIndexes.length; i++) {
+      listIDs.add(paragraphIndexes[i]);
+    }
+    run(listIDs);
+  }
 
   /**
    * Run paragraph at index
@@ -457,7 +466,16 @@ public class ZeppelinContext {
       }
     }
   }
-
+  
+  @ZeppelinApi
+  public void run(String... paragraphIDs) {
+    ArrayList<Object> listIDs = new ArrayList<Object>();
+    for (int i = 0; i < paragraphIDs.length; i++) {
+      listIDs.add(paragraphIDs[i]);
+    }
+    run(listIDs);
+  }
+  
   @ZeppelinApi
   public void runAll() {
     runAll(interpreterContext);
@@ -469,6 +487,88 @@ public class ZeppelinContext {
   @ZeppelinApi
   public void runAll(InterpreterContext context) {
     runNote(context.getNoteId());
+  }
+
+  @ZeppelinApi
+  public void runAllAfter() {
+    runAllAfter(interpreterContext);
+  }
+
+  /**
+   * Run all following paragraphs after the current one (excluded)
+   */
+  @ZeppelinApi
+  public void runAllAfter(InterpreterContext context) {
+    List<Object> paragraphs = listParagraphsIDAsObjects();
+    for (Iterator<Object> iterator = paragraphs.iterator(); iterator.hasNext();) {
+      if (((String) iterator.next()).equals(context.getParagraphId())) {
+        iterator.remove();
+        break;
+      }
+      iterator.remove();
+    }
+    run(paragraphs, context);
+  }
+  
+  @ZeppelinApi
+  public void runNext(int N) {
+    runNext(interpreterContext, N);
+  }
+
+  /**
+   * Run following N paragraphs after the current one (excluded)
+   */
+  @ZeppelinApi
+  public void runNext(InterpreterContext context, int N){
+    List<Object> paragraphs = listParagraphsIDAsObjects();
+    boolean found = false;
+    int counter = N;
+    for (Iterator<Object> iterator = paragraphs.iterator(); iterator.hasNext();) {
+      if (((String) iterator.next()).equals(context.getParagraphId())) {
+        iterator.remove();
+        found = true;
+      } else {
+        if (!found || !(--counter >= 0)) {
+          iterator.remove(); 
+        }
+      }
+    }
+    run(paragraphs, context);
+  }
+  
+  /**
+   * Run all paragraphs preceding the current one (excluded)
+   */
+  @ZeppelinApi
+  public void runAllBefore() {
+    runAllBefore(interpreterContext);
+  }
+  
+  @ZeppelinApi
+  public void runAllBefore(InterpreterContext context) {
+    List<Object> paragraphs = listParagraphsIDAsObjects();
+    boolean isCurrentFound = false;
+    for (Iterator<Object> iterator = paragraphs.iterator(); iterator.hasNext();) {
+      if (isCurrentFound) {
+        iterator.next();
+        iterator.remove();
+      } else if (((String) iterator.next()).equals(context.getParagraphId())) {
+        isCurrentFound = true;
+        iterator.remove();
+      }
+    }
+    run(paragraphs, context);
+  }
+
+  /**
+   * Return paragraphs String IDs as list of Objects
+   */
+  private List<Object> listParagraphsIDAsObjects() {
+    List<Object> paragraphs = new LinkedList<Object>();
+    for (InterpreterContextRunner r : interpreterContext.getRunners()) {
+      paragraphs.add(r.getParagraphId());
+    }
+    return paragraphs;
   }
 
   @ZeppelinApi

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -514,7 +514,8 @@ public class InterpreterSettingManager {
         }
       }
     } catch (NullPointerException e) {
-      logger.warn("Couldn't get interpreter editor setting");
+      // Use `debug` level because this log occurs frequently
+      logger.debug("Couldn't get interpreter editor setting");
     }
     return editor;
   }


### PR DESCRIPTION
### What is this PR for?
Adds new methods to ZeppelinContext to run paragraphs in a more user-friendly mode.

```java
z.runAllBefore()
z.runAllAfter()
z.run(int... ids)
z.run(String... ids)
z.runNext(int i)
```
more details in the Jira tickets.

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-2319](https://issues.apache.org/jira/browse/ZEPPELIN-2319)

### How should this be tested?
They all wrap the ``run(List<Object> ids)`` method, hence can be tested in the same test suite.

### Screenshots (if appropriate)
Coming soon

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
