### PR TITLE
ZEPPELIN-2324. Add property zeppelin.spark.enableSupportedVersionCheck for trying new spark version

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -140,6 +140,11 @@ You can also set other Spark properties which are not listed in the table. For a
     <td>true</td>
     <td>Import implicits, UDF collection, and sql if set true.</td>
   </tr>
+  <tr>
+    <td>zeppelin.spark.unSupportedVersionCheck</td>
+    <td>true</td>
+    <td>Don't change it, It is only for zeppelin developer use, not safe or use in production</td>
+  </tr>
 </table>
 
 Without any configuration, Spark interpreter works out of box in local mode. But if you want to connect to your Spark cluster, you'll need to follow below two simple steps.

--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -141,9 +141,9 @@ You can also set other Spark properties which are not listed in the table. For a
     <td>Import implicits, UDF collection, and sql if set true.</td>
   </tr>
   <tr>
-    <td>zeppelin.spark.unSupportedVersionCheck</td>
+    <td>zeppelin.spark.enableSupportedVersionCheck</td>
     <td>true</td>
-    <td>Don't change it, It is only for zeppelin developer use, not safe or use in production</td>
+    <td>Do not change - developer only setting, not for production use</td>
   </tr>
 </table>
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -337,8 +337,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
   public InterpreterResult interpret(String st, InterpreterContext context) {
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
     sparkInterpreter.populateSparkWebUrl(context);
-    if (sparkInterpreter.isUnsupportedVersionCheck
-      && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+    if (sparkInterpreter.isUnsupportedSparkVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }
@@ -467,9 +466,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
 
     //start code for completion
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    if (sparkInterpreter.isUnsupportedVersionCheck
-        && sparkInterpreter.getSparkVersion().isUnsupportedVersion() == false
-            && pythonscriptRunning == false) {
+    if (sparkInterpreter.isUnsupportedSparkVersion() || pythonscriptRunning == false) {
       return new LinkedList<>();
     }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -337,7 +337,8 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
   public InterpreterResult interpret(String st, InterpreterContext context) {
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
     sparkInterpreter.populateSparkWebUrl(context);
-    if (sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+    if (sparkInterpreter.isUnsupportedVersionCheck
+      && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }
@@ -466,7 +467,8 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
 
     //start code for completion
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    if (sparkInterpreter.getSparkVersion().isUnsupportedVersion() == false
+    if (sparkInterpreter.isUnsupportedVersionCheck
+        && sparkInterpreter.getSparkVersion().isUnsupportedVersion() == false
             && pythonscriptRunning == false) {
       return new LinkedList<>();
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -128,7 +128,7 @@ public class SparkInterpreter extends Interpreter {
   private static File outputDir;          // class outputdir for scala 2.11
   private Object classServer;      // classserver for scala 2.11
   private JavaSparkContext jsc;
-
+  boolean isUnsupportedVersionCheck;
 
   public SparkInterpreter(Properties property) {
     super(property);
@@ -609,6 +609,9 @@ public class SparkInterpreter extends Interpreter {
 
   @Override
   public void open() {
+    this.isUnsupportedVersionCheck = java.lang.Boolean.parseBoolean(
+            property.getProperty("zeppelin.spark.unSupportedVersionCheck", "true"));
+
     // set properties and do login before creating any spark stuff for secured cluster
     if (isYarnMode()) {
       System.setProperty("SPARK_YARN_MODE", "true");
@@ -1158,7 +1161,7 @@ public class SparkInterpreter extends Interpreter {
    */
   @Override
   public InterpreterResult interpret(String line, InterpreterContext context) {
-    if (sparkVersion.isUnsupportedVersion()) {
+    if (isUnsupportedVersionCheck && sparkVersion.isUnsupportedVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark " + sparkVersion.toString()
           + " is not supported");
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -43,7 +43,6 @@ import org.apache.spark.repl.SparkILoop;
 import org.apache.spark.scheduler.ActiveJob;
 import org.apache.spark.scheduler.DAGScheduler;
 import org.apache.spark.scheduler.Pool;
-import org.apache.spark.scheduler.SparkListenerApplicationEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.ui.SparkUI;
@@ -128,7 +127,7 @@ public class SparkInterpreter extends Interpreter {
   private static File outputDir;          // class outputdir for scala 2.11
   private Object classServer;      // classserver for scala 2.11
   private JavaSparkContext jsc;
-  boolean isUnsupportedVersionCheck;
+  private boolean enableSupportedVersionCheck;
 
   public SparkInterpreter(Properties property) {
     super(property);
@@ -609,8 +608,8 @@ public class SparkInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    this.isUnsupportedVersionCheck = java.lang.Boolean.parseBoolean(
-            property.getProperty("zeppelin.spark.unSupportedVersionCheck", "true"));
+    this.enableSupportedVersionCheck = java.lang.Boolean.parseBoolean(
+            property.getProperty("zeppelin.spark.enableSupportedVersionCheck", "true"));
 
     // set properties and do login before creating any spark stuff for secured cluster
     if (isYarnMode()) {
@@ -1156,12 +1155,16 @@ public class SparkInterpreter extends Interpreter {
     return obj;
   }
 
+  boolean isUnsupportedSparkVersion() {
+    return enableSupportedVersionCheck  && sparkVersion.isUnsupportedVersion();
+  }
+
   /**
    * Interpret a single line.
    */
   @Override
   public InterpreterResult interpret(String line, InterpreterContext context) {
-    if (isUnsupportedVersionCheck && sparkVersion.isUnsupportedVersion()) {
+    if (isUnsupportedSparkVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark " + sparkVersion.toString()
           + " is not supported");
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -108,8 +108,7 @@ public class SparkRInterpreter extends Interpreter {
 
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
     sparkInterpreter.populateSparkWebUrl(interpreterContext);
-    if (sparkInterpreter.isUnsupportedVersionCheck
-      && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+    if (sparkInterpreter.isUnsupportedSparkVersion()) {
       return new InterpreterResult(InterpreterResult.Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -108,6 +108,11 @@ public class SparkRInterpreter extends Interpreter {
 
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
     sparkInterpreter.populateSparkWebUrl(interpreterContext);
+    if (sparkInterpreter.isUnsupportedVersionCheck
+      && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+      return new InterpreterResult(InterpreterResult.Code.ERROR, "Spark "
+          + sparkInterpreter.getSparkVersion().toString() + " is not supported");
+    }
 
     String jobGroup = Utils.buildJobGroupId(interpreterContext);
     sparkInterpreter.getSparkContext().setJobGroup(jobGroup, "Zeppelin", false);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -87,8 +87,7 @@ public class SparkSqlInterpreter extends Interpreter {
     SQLContext sqlc = null;
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
 
-    if (sparkInterpreter.isUnsupportedVersionCheck
-        && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+    if (sparkInterpreter.isUnsupportedSparkVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -87,7 +87,8 @@ public class SparkSqlInterpreter extends Interpreter {
     SQLContext sqlc = null;
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
 
-    if (sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
+    if (sparkInterpreter.isUnsupportedVersionCheck
+        && sparkInterpreter.getSparkVersion().isUnsupportedVersion()) {
       return new InterpreterResult(Code.ERROR, "Spark "
           + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -56,9 +56,9 @@
       },
       "zeppelin.spark.unSupportedVersionCheck": {
         "envName": null,
-        "propertyName": "zeppelin.spark.unSupportedVersionCheck",
+        "propertyName": "zeppelin.spark.enableSupportedVersionCheck",
         "defaultValue": "true",
-        "description": "Don't change it, It is only for zeppelin developer use, not safe to use in production"
+        "description": "Do not change - developer only setting, not for production use"
       }
     },
     "editor": {

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -53,6 +53,12 @@
         "propertyName": "spark.master",
         "defaultValue": "local[*]",
         "description": "Spark master uri. ex) spark://masterhost:7077"
+      },
+      "zeppelin.spark.unSupportedVersionCheck": {
+        "envName": null,
+        "propertyName": "zeppelin.spark.unSupportedVersionCheck",
+        "defaultValue": "true",
+        "description": "Don't change it, It is only for zeppelin developer use, not safe to use in production"
       }
     },
     "editor": {

--- a/spark/src/main/sparkr-resources/interpreter-setting.json
+++ b/spark/src/main/sparkr-resources/interpreter-setting.json
@@ -56,9 +56,9 @@
       },
       "zeppelin.spark.unSupportedVersionCheck": {
         "envName": null,
-        "propertyName": "zeppelin.spark.unSupportedVersionCheck",
+        "propertyName": "zeppelin.spark.enableSupportedVersionCheck",
         "defaultValue": "true",
-        "description": "Don't change it, It is only for zeppelin developer use, not safe to use in production"
+        "description": "Do not change - developer only setting, not for production use"
       }
     },
     "editor": {

--- a/spark/src/main/sparkr-resources/interpreter-setting.json
+++ b/spark/src/main/sparkr-resources/interpreter-setting.json
@@ -53,6 +53,12 @@
         "propertyName": "spark.master",
         "defaultValue": "local[*]",
         "description": "Spark master uri. ex) spark://masterhost:7077"
+      },
+      "zeppelin.spark.unSupportedVersionCheck": {
+        "envName": null,
+        "propertyName": "zeppelin.spark.unSupportedVersionCheck",
+        "defaultValue": "true",
+        "description": "Don't change it, It is only for zeppelin developer use, not safe to use in production"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
For now, every time when I want to try new spark version, I have to change file `SparkVersion.java` and rebuild it. It is not so convenient, so I'd like to add property `zeppelin.spark. enableSupportedVersionCheck` for spark interpreter. So that I can try new spark version by setting this property as false, of course it is only for zeppelin developer.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2324

### How should this be tested?
Verify it in spark master

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
