### PR TITLE
[HOTFIX] Remove unintended characters from r tutorial

### DIFF
--- a/notebook/2BWJFTXKJ/note.json
+++ b/notebook/2BWJFTXKJ/note.json
@@ -675,7 +675,7 @@
     },
     {
       "title": "Create a R Dataframe",
-      "text": "%r \n\nlocalNames \u003c- data.frame(name\u003dc(\"John\", \"Smith\", \"Sarah\"), budget\u003dc(19, 53, 18))kjkjkj\nnames \u003c- createDataFrame(sqlContext, localNames)\nprintSchema(names)\nregisterTempTable(names, \"names\")\n\n# SparkR::head(names)",
+      "text": "%r \n\nlocalNames \u003c- data.frame(name\u003dc(\"John\", \"Smith\", \"Sarah\"), budget\u003dc(19, 53, 18))\nnames \u003c- createDataFrame(sqlContext, localNames)\nprintSchema(names)\nregisterTempTable(names, \"names\")\n\n# SparkR::head(names)",
       "user": "anonymous",
       "dateUpdated": "Jan 29, 2017 3:19:59 AM",
       "config": {


### PR DESCRIPTION
### What is this PR for?
If user runs **Create a R Dataframe** paragraph in **Zeppelin Tutorial/R (SparkR)** note, he/she will get error because of some unintended characters inserted.

### What type of PR is it?
Documentation | Hot Fix

### Screenshots (if appropriate)
**Before**
![screen shot 2017-03-29 at 11 07 09 am](https://cloud.githubusercontent.com/assets/8503346/24435405/177f5c22-1470-11e7-868c-919fec07a2b3.png)


**After**
![screen shot 2017-03-29 at 11 06 52 am](https://cloud.githubusercontent.com/assets/8503346/24435417/1d7e2568-1470-11e7-9b1f-964d3157bf0d.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
