### PR TITLE
[ZEPPELIN-1965] Livy SQL Interpreter: Should use df.show(1000, false)…

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -61,6 +61,11 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
     <td>Max number of Spark SQL result to display.</td>
   </tr>
   <tr>
+    <td>zeppelin.livy.spark.sql.truncate</td>
+    <td>true</td>
+    <td>Whether to truncate strings or not</td>
+  </tr>
+  <tr>
     <td>zeppelin.livy.session.create_timeout</td>
     <td>120</td>
     <td>Timeout in seconds for session creation</td>

--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -56,14 +56,14 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
     <td>URL where livy server is running</td>
   </tr>
   <tr>
-    <td>zeppelin.livy.spark.maxResult</td>
+    <td>zeppelin.livy.spark.sql.maxResult</td>
     <td>1000</td>
     <td>Max number of Spark SQL result to display.</td>
   </tr>
   <tr>
-    <td>zeppelin.livy.spark.sql.truncate</td>
+    <td>zeppelin.livy.spark.sql.field.truncate</td>
     <td>true</td>
-    <td>Whether to truncate strings or not</td>
+    <td>Whether to truncate field values longer than 20 characters or not</td>
   </tr>
   <tr>
     <td>zeppelin.livy.session.create_timeout</td>

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -272,7 +272,9 @@ public abstract class BaseLivyInterprereter extends Interpreter {
           throw new LivyException(e);
         }
         stmtInfo = getStatementInfo(stmtInfo.id);
-        paragraphId2StmtProgressMap.put(paragraphId, (int) (stmtInfo.progress * 100));
+        if (paragraphId != null) {
+          paragraphId2StmtProgressMap.put(paragraphId, (int) (stmtInfo.progress * 100));
+        }
       }
       if (appendSessionExpired) {
         return appendSessionExpire(getResultFromStatementInfo(stmtInfo, displayAppInfo),

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -36,10 +36,12 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
 
   private boolean isSpark2 = false;
   private int maxResult = 1000;
+  private boolean truncate = true;
 
   public LivySparkSQLInterpreter(Properties property) {
     super(property);
     this.maxResult = Integer.parseInt(property.getProperty("zeppelin.livy.spark.sql.maxResult"));
+    this.truncate = Boolean.parseBoolean(property.getProperty("zeppelin.livy.spark.sql.truncate"));
   }
 
   @Override
@@ -111,9 +113,11 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
       // use triple quote so that we don't need to do string escape.
       String sqlQuery = null;
       if (isSpark2) {
-        sqlQuery = "spark.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ")";
+        sqlQuery = "spark.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ", " +
+            truncate + ")";
       } else {
-        sqlQuery = "sqlContext.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ")";
+        sqlQuery = "sqlContext.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ", " +
+            truncate + ")";
       }
       InterpreterResult result = sparkInterpreter.interpret(sqlQuery, context.getParagraphId(),
           this.displayAppInfo, true);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -32,6 +32,12 @@ import java.util.Properties;
  */
 public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
 
+  public static final String ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE =
+      "zeppelin.livy.spark.sql.field.truncate";
+
+  public static final String ZEPPELIN_LIVY_SPARK_SQL_MAX_RESULT =
+      "zeppelin.livy.spark.sql.maxResult";
+
   private LivySparkInterpreter sparkInterpreter;
 
   private boolean isSpark2 = false;
@@ -40,10 +46,10 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
 
   public LivySparkSQLInterpreter(Properties property) {
     super(property);
-    this.maxResult = Integer.parseInt(property.getProperty("zeppelin.livy.spark.sql.maxResult"));
-    if (property.getProperty("zeppelin.livy.spark.sql.truncate") != null) {
+    this.maxResult = Integer.parseInt(property.getProperty(ZEPPELIN_LIVY_SPARK_SQL_MAX_RESULT));
+    if (property.getProperty(ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE) != null) {
       this.truncate =
-          Boolean.parseBoolean(property.getProperty("zeppelin.livy.spark.sql.truncate"));
+          Boolean.parseBoolean(property.getProperty(ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE));
     }
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -41,7 +41,10 @@ public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
   public LivySparkSQLInterpreter(Properties property) {
     super(property);
     this.maxResult = Integer.parseInt(property.getProperty("zeppelin.livy.spark.sql.maxResult"));
-    this.truncate = Boolean.parseBoolean(property.getProperty("zeppelin.livy.spark.sql.truncate"));
+    if (property.getProperty("zeppelin.livy.spark.sql.truncate") != null) {
+      this.truncate =
+          Boolean.parseBoolean(property.getProperty("zeppelin.livy.spark.sql.truncate"));
+    }
   }
 
   @Override

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -118,6 +118,11 @@
         "defaultValue": "1000",
         "description": "Max number of Spark SQL result to display."
       },
+      "zeppelin.livy.spark.sql.truncate": {
+        "propertyName": "zeppelin.livy.spark.sql.truncate",
+        "defaultValue": "true",
+        "description": "If true, truncate strings greater than 20 characters."
+      },
       "zeppelin.livy.concurrentSQL": {
         "propertyName": "zeppelin.livy.concurrentSQL",
         "defaultValue": "false",

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -118,10 +118,10 @@
         "defaultValue": "1000",
         "description": "Max number of Spark SQL result to display."
       },
-      "zeppelin.livy.spark.sql.truncate": {
-        "propertyName": "zeppelin.livy.spark.sql.truncate",
+      "zeppelin.livy.spark.sql.field.truncate": {
+        "propertyName": "zeppelin.livy.spark.sql.field.truncate",
         "defaultValue": "true",
-        "description": "If true, truncate strings greater than 20 characters."
+        "description": "If true, truncate field values longer than 20 characters."
       },
       "zeppelin.livy.concurrentSQL": {
         "propertyName": "zeppelin.livy.concurrentSQL",

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -377,7 +377,7 @@ public class LivyInterpreterIT {
     for (Object name: properties.keySet()) {
       newProps.put(name, properties.get(name));
     }
-    newProps.put("zeppelin.livy.spark.sql.truncate", "false");
+    newProps.put(LivySparkSQLInterpreter.ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE, "false");
     LivySparkInterpreter sparkInterpreter = new LivySparkInterpreter(newProps);
     sparkInterpreter.setInterpreterGroup(interpreterGroup);
     interpreterGroup.get("session_1").add(sparkInterpreter);


### PR DESCRIPTION
… to display results

### What is this PR for?
Livy SQL interpreter truncate result strings of size greater than 20. In some cases, we like to see the full string. We are adding a interpreter property **zeppelin.livy.spark.sql.field.truncate** to control whether to truncate strings or not. By default, **zeppelin.livy.spark.sql.field.truncate** is set to **true**.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1965

### How should this be tested?
Set zeppelin.livy.spark.sql.field.truncate to true or false 
Run a SQL query which produces string values of length greater than 20.
Depending on the value of zeppelin.livy.spark.sql.field.truncate, the strings will either get truncated or not.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
