### PR TITLE
[Minor][ZEPPELIN-2328] Separate Helium related docs from 'Contribution' section

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -116,6 +116,11 @@
                 <li><a href="{{BASE_PATH}}/security/notebook_authorization.html">Notebook Authorization</a></li>
                 <li><a href="{{BASE_PATH}}/security/datasource_authorization.html">Data Source Authorization</a></li>
                 <li role="separator" class="divider"></li>
+                <li class="title"><span><b>Helium Framework</b><span></li>
+                <li><a href="{{BASE_PATH}}/development/writingzeppelinapplication.html">Writing Zeppelin Application (Experimental)</a></li>
+                <li><a href="{{BASE_PATH}}/development/writingzeppelinspell.html">Writing Zeppelin Spell (Experimental)</a></li>
+                <li><a href="{{BASE_PATH}}/development/writingzeppelinvisualization.html">Writing Zeppelin Visualization (Experimental)</a></li>
+                <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Advanced</b><span></li>
                 <li><a href="{{BASE_PATH}}/install/virtual_machine.html">Zeppelin on Vagrant VM</a></li>
                 <li><a href="{{BASE_PATH}}/install/spark_cluster_mode.html#spark-standalone-mode">Zeppelin on Spark Cluster Mode (Standalone)</a></li>
@@ -125,9 +130,6 @@
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>Contibute</b><span></li>
                 <li><a href="{{BASE_PATH}}/development/writingzeppelininterpreter.html">Writing Zeppelin Interpreter</a></li>
-                <li><a href="{{BASE_PATH}}/development/writingzeppelinspell.html">Writing Zeppelin Spell (Experimental)</a></li>
-                <li><a href="{{BASE_PATH}}/development/writingzeppelinvisualization.html">Writing Zeppelin Visualization (Experimental)</a></li>
-                <li><a href="{{BASE_PATH}}/development/writingzeppelinapplication.html">Writing Zeppelin Application (Experimental)</a></li>
                 <li><a href="{{BASE_PATH}}/development/howtocontribute.html">How to contribute (code)</a></li>
                 <li><a href="{{BASE_PATH}}/development/howtocontributewebsite.html">How to contribute (website)</a></li>
               </ul>

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,7 +153,7 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Angular (backend API)](./displaysystem/back-end-angular.html)
   * [Angular (frontend API)](./displaysystem/front-end-angular.html)
 
-####More
+#### More
 
 * Notebook Storage: a guide about saving notebooks to external storage
   * [Git Storage](./storage/storage.html#notebook-storage-in-local-git-repository)
@@ -172,6 +172,10 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Shiro Authentication](./security/shiroauthentication.html)
   * [Notebook Authorization](./security/notebook_authorization.html)
   * [Data Source Authorization](./security/datasource_authorization.html)
+* Helium Framework
+  * [Writing Zeppelin Application (Experimental)](./development/writingzeppelinapplication.html)
+  * [Writing Zeppelin Spell (Experimental)](./development/writingzeppelinspell.html)
+  * [Writing Zeppelin Visualization (Experimental)](./development/writingzeppelinvisualization.html)
 * Advanced
   * [Apache Zeppelin on Vagrant VM](./install/virtual_machine.html)
   * [Zeppelin on Spark Cluster Mode (Standalone via Docker)](./install/spark_cluster_mode.html#spark-standalone-mode)
@@ -180,9 +184,6 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Zeppelin on CDH (via Docker)](./install/cdh.html)
 * Contribute
   * [Writing Zeppelin Interpreter](./development/writingzeppelininterpreter.html)
-  * [Writing Zeppelin Application (Experimental)](./development/writingzeppelinapplication.html)
-  * [Writing Zeppelin Spell (Experimental)](./development/writingzeppelinspell.html)
-  * [Writing Zeppelin Visualization (Experimental)](./development/writingzeppelinvisualization.html)
   * [How to contribute (code)](./development/howtocontribute.html)
   * [How to contribute (documentation website)](./development/howtocontributewebsite.html)
 


### PR DESCRIPTION
### What is this PR for?
Actually writing "Visualization", "Spell" or "Application" type of Helium package is not a direct contribution to Zeppelin. So i created "Helium Framework" section and moved "Writing Zeppelin Visualization", "Writing Zeppelin Spell", and "Writing Zeppelin Application" under "Helium Framework" from "Contribution".

### What type of PR is it?
Documentation

### What is the Jira issue?
[ZEPPELIN-2328](https://issues.apache.org/jira/browse/ZEPPELIN-2328)

### Screenshots (if appropriate)
 - Before 
<img src="https://cloud.githubusercontent.com/assets/10060731/24444171/743d8c7e-14a0-11e7-8a10-ec02596d2a19.png" width="300px">

 - After 
<img src="https://cloud.githubusercontent.com/assets/10060731/24444245/aecfe274-14a0-11e7-8488-99086b1db415.png" width="300px">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
