### PR TITLE
ZEPPELIN-2189. The order of dynamic forms should be the order that you create them

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
@@ -19,11 +19,7 @@ package org.apache.zeppelin.display;
 
 import java.io.Serializable;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import org.apache.zeppelin.display.Input.ParamOption;
 
@@ -33,7 +29,7 @@ import org.apache.zeppelin.display.Input.ParamOption;
 public class GUI implements Serializable {
 
   Map<String, Object> params = new HashMap<>(); // form parameters from client
-  Map<String, Input> forms = new TreeMap<>(); // form configuration
+  LinkedHashMap<String, Input> forms = new LinkedHashMap<>(); // form configuration
 
   public GUI() {
 
@@ -47,11 +43,11 @@ public class GUI implements Serializable {
     return params;
   }
 
-  public Map<String, Input> getForms() {
+  public LinkedHashMap<String, Input> getForms() {
     return forms;
   }
 
-  public void setForms(Map<String, Input> forms) {
+  public void setForms(LinkedHashMap<String, Input> forms) {
     this.forms = forms;
   }
 
@@ -105,6 +101,6 @@ public class GUI implements Serializable {
   }
 
   public void clear() {
-    this.forms = new TreeMap<>();
+    this.forms = new LinkedHashMap<>();
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -20,13 +20,7 @@ package org.apache.zeppelin.display;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -291,21 +285,21 @@ public class Input implements Serializable {
     return new Input(varName, displayName, type, arg, defaultValue, paramOptions, hidden);
   }
 
-  public static Map<String, Input> extractSimpleQueryParam(String script) {
-    Map<String, Input> params = new HashMap<>();
+  public static LinkedHashMap<String, Input> extractSimpleQueryForm(String script) {
+    LinkedHashMap<String, Input> forms = new LinkedHashMap<>();
     if (script == null) {
-      return params;
+      return forms;
     }
     String replaced = script;
 
     Matcher match = VAR_PTN.matcher(replaced);
     while (match.find()) {
-      Input param = getInputForm(match);
-      params.put(param.name, param);
+      Input form = getInputForm(match);
+      forms.put(form.name, form);
     }
 
-    params.remove("pql");
-    return params;
+    forms.remove("pql");
+    return forms;
   }
 
   private static final String DEFAULT_DELIMITER = ",";

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
@@ -44,7 +44,7 @@ public class InputTest {
 	public void testFormExtraction() {
 		// input form
 		String script = "${input_form=}";
-		Map<String, Input> forms = Input.extractSimpleQueryParam(script);
+		Map<String, Input> forms = Input.extractSimpleQueryForm(script);
 		assertEquals(1, forms.size());
 		Input form = forms.get("input_form");
 		assertEquals("input_form", form.name);
@@ -54,13 +54,13 @@ public class InputTest {
 
 		// input form with display name & default value
 		script = "${input_form(Input Form)=xxx}";
-		forms = Input.extractSimpleQueryParam(script);
+		forms = Input.extractSimpleQueryForm(script);
 		form = forms.get("input_form");
 		assertEquals("xxx", form.defaultValue);
 
 		// selection form
 		script = "${select_form(Selection Form)=op1,op1|op2(Option 2)|op3}";
-		form = Input.extractSimpleQueryParam(script).get("select_form");
+		form = Input.extractSimpleQueryForm(script).get("select_form");
 		assertEquals("select_form", form.name);
 		assertEquals("op1", form.defaultValue);
 		assertArrayEquals(new ParamOption[]{new ParamOption("op1", null),
@@ -68,7 +68,7 @@ public class InputTest {
 
 		// checkbox form
 		script = "${checkbox:checkbox_form=op1,op1|op2|op3}";
-		form = Input.extractSimpleQueryParam(script).get("checkbox_form");
+		form = Input.extractSimpleQueryForm(script).get("checkbox_form");
 		assertEquals("checkbox_form", form.name);
 		assertEquals("checkbox", form.type);
 		assertArrayEquals(new Object[]{"op1"}, (Object[]) form.defaultValue);
@@ -77,7 +77,7 @@ public class InputTest {
 
 		// checkbox form with multiple default checks
 		script = "${checkbox:checkbox_form(Checkbox Form)=op1|op3,op1(Option 1)|op2|op3}";
-		form = Input.extractSimpleQueryParam(script).get("checkbox_form");
+		form = Input.extractSimpleQueryForm(script).get("checkbox_form");
 		assertEquals("checkbox_form", form.name);
 		assertEquals("Checkbox Form", form.displayName);
 		assertEquals("checkbox", form.type);
@@ -87,7 +87,7 @@ public class InputTest {
 
 		// checkbox form with no default check
 		script = "${checkbox:checkbox_form(Checkbox Form)=,op1(Option 1)|op2(Option 2)|op3(Option 3)}";
-		form = Input.extractSimpleQueryParam(script).get("checkbox_form");
+		form = Input.extractSimpleQueryForm(script).get("checkbox_form");
 		assertEquals("checkbox_form", form.name);
 		assertEquals("Checkbox Form", form.displayName);
 		assertEquals("checkbox", form.type);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -479,5 +480,30 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         String[] split = sparkVersion.split("\\.");
         int version = Integer.parseInt(split[0]) * 10 + Integer.parseInt(split[1]);
         return version;
+    }
+
+    @Test
+    public void testZeppelinContextDynamicForms() throws IOException {
+        Note note = ZeppelinServer.notebook.createNote(anonymous);
+        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        note.setName("note");
+        Map config = p.getConfig();
+        config.put("enabled", true);
+        p.setConfig(config);
+        String code = "%spark.spark z.input(\"my_input\", \"default_name\")\n" +
+            "z.select(\"my_select\", \"select_2\"," +
+            "Seq((\"1\", \"select_1\"), (\"2\", \"select_2\")))\n" +
+            "z.checkbox(\"my_checkbox\", Seq(\"check_1\"), " +
+            "Seq((\"1\", \"check_1\"), (\"2\", \"check_2\")))";
+        p.setText(code);
+        p.setAuthenticationInfo(anonymous);
+        note.run(p.getId());
+        waitForFinish(p);
+
+        assertEquals(Status.FINISHED, p.getStatus());
+        Iterator<String> formIter = p.settings.getForms().keySet().iterator();
+        assert(formIter.next().equals("my_input"));
+        assert(formIter.next().equals("my_select"));
+        assert(formIter.next().equals("my_checkbox"));
     }
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-parameterizedQueryForm.html
@@ -15,7 +15,7 @@ limitations under the License.
       ng-show="!paragraph.config.tableHide"
       class=" paragraphForm form-horizontal row">
   <div class="form-group col-sm-6 col-md-6 col-lg-4"
-       ng-repeat="formulaire in paragraph.settings.forms | toArray | orderBy:'name.toString()'"
+       ng-repeat="formulaire in paragraph.settings.forms | toArray"
        ng-init="loadForm(formulaire, paragraph.settings.params)">
     <label class="control-label input-sm" ng-class="{'disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' }">{{formulaire.name}}</label>
     <div>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -21,11 +21,7 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -320,8 +316,8 @@ public class Note implements Serializable, ParagraphJobListener {
         interpreterSettingManager);
 
     Map<String, Object> config = new HashMap<>(srcParagraph.getConfig());
-    Map<String, Object> param = new HashMap<>(srcParagraph.settings.getParams());
-    Map<String, Input> form = new HashMap<>(srcParagraph.settings.getForms());
+    Map<String, Object> param = srcParagraph.settings.getParams();
+    LinkedHashMap<String, Input> form = srcParagraph.settings.getForms();
 
     newParagraph.setConfig(config);
     newParagraph.settings.setParams(param);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -389,8 +389,8 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       settings.clear();
     } else if (repl.getFormType() == FormType.SIMPLE) {
       String scriptBody = getScriptBody();
-      LinkedHashMap<String, Input> inputs = Input.extractSimpleQueryForm(scriptBody); // inputs will be built
-      // from script body
+      // inputs will be built from script body
+      LinkedHashMap<String, Input> inputs = Input.extractSimpleQueryForm(scriptBody);
 
       final AngularObjectRegistry angularRegistry =
           repl.getInterpreterGroup().getAngularObjectRegistry();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -139,7 +139,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
   public Paragraph cloneParagraphForUser(String user) {
     Paragraph p = new Paragraph();
     p.settings.setParams(Maps.newHashMap(settings.getParams()));
-    p.settings.setForms(Maps.newHashMap(settings.getForms()));
+    p.settings.setForms(Maps.newLinkedHashMap(settings.getForms()));
     p.setConfig(Maps.newHashMap(config));
     p.setTitle(getTitle());
     p.setText(getText());
@@ -389,7 +389,7 @@ public class Paragraph extends Job implements Serializable, Cloneable {
       settings.clear();
     } else if (repl.getFormType() == FormType.SIMPLE) {
       String scriptBody = getScriptBody();
-      Map<String, Input> inputs = Input.extractSimpleQueryParam(scriptBody); // inputs will be built
+      LinkedHashMap<String, Input> inputs = Input.extractSimpleQueryForm(scriptBody); // inputs will be built
       // from script body
 
       final AngularObjectRegistry angularRegistry =


### PR DESCRIPTION
### What is this PR for?
The order of dynamic forms should be the order that you create them. So I made the following 2 changes for this:
* change the type of forms in GUI from TreeMap to LinkedHashMap
*  remove orderBy in paragraph-parameterizedQueryForm.html

Besides, I also did some code refactoring. 


### What type of PR is it?
[Bug Fix | Improvement | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2189

### How should this be tested?
Tested manually.

### Screenshots (if appropriate)
Before
![2017-02-27_1310](https://cloud.githubusercontent.com/assets/164491/24486826/9ac3c1e4-153e-11e7-8280-8cf4f6ef7560.png)

After 
![2017-03-30_1109](https://cloud.githubusercontent.com/assets/164491/24486828/9b733ee4-153e-11e7-9a13-44ed71aa29d8.png)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
