### PR TITLE
[ZEPPELIN-2330] Helium.html doesn't render spell information only in production build

### DIFF
--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -143,7 +143,7 @@ limitations under the License.
             </a>
           </li>
         </ul>
-        <div class="heliumPackageDescription" ng-bind-html="getDescriptionText(pkgSearchResult)" />
+        <div class="heliumPackageDescription" ng-bind-html="getDescriptionText(pkgSearchResult)"></div>
         <div ng-if="pkgSearchResult.pkg.type === 'SPELL' && pkgSearchResult.pkg.spell"
              class="spellInfo">
           <div>


### PR DESCRIPTION
### What is this PR for?

Helium.html doesn't render spell information only in production build.

That's because self-closed div doesn't work with `ng-bind-html` when it's minified. 


### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2330](https://issues.apache.org/jira/browse/ZEPPELIN-2330)

### How should this be tested?

1. Build `mvn clean package -DskipTests;`
2. Open `localhost:8080/#/helium.html`
3. Click the `Spell` tab

### Screenshots (if appropriate)

#### Before

![2330](https://cloud.githubusercontent.com/assets/4968473/24493212/04338b30-1569-11e7-9b20-63eab389c9a5.gif)

#### After

<img width="830" alt="screen shot 2017-03-30 at 4 45 25 pm" src="https://cloud.githubusercontent.com/assets/4968473/24493204/fca731d2-1568-11e7-9550-b1e975dbdd55.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
