### PR TITLE
[Zeppelin-802] Support for Zeppelin Context redefinition on Python and Pyspark 

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -222,7 +222,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
     // Add matplotlib display hook
     InterpreterGroup intpGroup = getInterpreterGroup();
     if (intpGroup != null && intpGroup.getInterpreterHookRegistry() != null) {
-      registerHook(HookType.POST_EXEC_DEV, "z._displayhook()");
+      registerHook(HookType.POST_EXEC_DEV, "_zc._displayhook()");
     }
     // Add matplotlib display hook
     try {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -222,7 +222,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
     // Add matplotlib display hook
     InterpreterGroup intpGroup = getInterpreterGroup();
     if (intpGroup != null && intpGroup.getInterpreterHookRegistry() != null) {
-      registerHook(HookType.POST_EXEC_DEV, "_zc._displayhook()");
+      registerHook(HookType.POST_EXEC_DEV, "__zeppelin__._displayhook()");
     }
     // Add matplotlib display hook
     try {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreterPandasSql.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreterPandasSql.java
@@ -87,7 +87,8 @@ public class PythonInterpreterPandasSql extends Interpreter {
     LOG.info("Running SQL query: '{}' over Pandas DataFrame", st);
     Interpreter python = getPythonInterpreter();
 
-    return python.interpret("_zc.show(pysqldf('" + st + "'))\n_zc._displayhook()", context);
+    return python.interpret(
+            "__zeppelin__.show(pysqldf('" + st + "'))\n__zeppelin__._displayhook()", context);
   }
 
   @Override

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreterPandasSql.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreterPandasSql.java
@@ -87,7 +87,7 @@ public class PythonInterpreterPandasSql extends Interpreter {
     LOG.info("Running SQL query: '{}' over Pandas DataFrame", st);
     Interpreter python = getPythonInterpreter();
 
-    return python.interpret("z.show(pysqldf('" + st + "'))\nz._displayhook()", context);
+    return python.interpret("_zc.show(pysqldf('" + st + "'))\n_zc._displayhook()", context);
   }
 
   @Override

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -195,6 +195,7 @@ host = "127.0.0.1"
 if len(sys.argv) >= 3:
   host = sys.argv[2]
 
+_zcUserQueryNameSpace = {}
 client = GatewayClient(address=host, port=int(sys.argv[1]))
 
 #gateway = JavaGateway(client, auto_convert = True)
@@ -204,8 +205,11 @@ intp = gateway.entry_point
 intp.onPythonScriptInitialized(os.getpid())
 
 java_import(gateway.jvm, "org.apache.zeppelin.display.Input")
-z = _zc = __PyZeppelinContext__(intp)
-_zc._setup_matplotlib()
+z = __zeppelin__ = __PyZeppelinContext__(intp)
+__zeppelin__._setup_matplotlib()
+
+_zcUserQueryNameSpace["__zeppelin__"] = __zeppelin__
+_zcUserQueryNameSpace["z"] = z
 
 __zcStdOutput__ = __ZeppelinLogger__()
 sys.stdout = __zcStdOutput__
@@ -227,7 +231,7 @@ while True :
       global_hook = None
 
     try:
-      user_hook = _zc.getHook('post_exec')
+      user_hook = __zeppelin__.getHook('post_exec')
     except:
       user_hook = None
       
@@ -263,17 +267,17 @@ while True :
         for node in to_run_exec:
           mod = ast.Module([node])
           code = compile(mod, '<stdin>', 'exec')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
 
         for node in to_run_single:
           mod = ast.Interactive([node])
           code = compile(mod, '<stdin>', 'single')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
 
         for node in to_run_hooks:
           mod = ast.Module([node])
           code = compile(mod, '<stdin>', 'exec')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
       except:
         raise Exception(traceback.format_exc())
 

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -47,7 +47,7 @@ class __ZeppelinLogger__(object):
     pass
 
 
-class PyZeppelinContext(object):
+class __PyZeppelinContext__(object):
   """ A context impl that uses Py4j to communicate to JVM
   """
 
@@ -204,11 +204,11 @@ intp = gateway.entry_point
 intp.onPythonScriptInitialized(os.getpid())
 
 java_import(gateway.jvm, "org.apache.zeppelin.display.Input")
-z = _zc = PyZeppelinContext(intp)
+z = _zc = __PyZeppelinContext__(intp)
 _zc._setup_matplotlib()
 
-output = __ZeppelinLogger__()
-sys.stdout = output
+__zcStdOutput__ = __ZeppelinLogger__()
+sys.stdout = __zcStdOutput__
 #sys.stderr = output
 
 while True :
@@ -290,4 +290,4 @@ while True :
   except:
     intp.setStatementsFinished(traceback.format_exc(), True)
 
-  output.reset()
+  __zcStdOutput__.reset()

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -33,7 +33,7 @@ except ImportError:
 
 # for back compatibility
 
-class __ZeppelinLogger__(object):
+class Logger(object):
   def __init__(self):
     pass
 
@@ -47,7 +47,7 @@ class __ZeppelinLogger__(object):
     pass
 
 
-class __PyZeppelinContext__(object):
+class PyZeppelinContext(object):
   """ A context impl that uses Py4j to communicate to JVM
   """
 
@@ -205,14 +205,14 @@ intp = gateway.entry_point
 intp.onPythonScriptInitialized(os.getpid())
 
 java_import(gateway.jvm, "org.apache.zeppelin.display.Input")
-z = __zeppelin__ = __PyZeppelinContext__(intp)
+z = __zeppelin__ = PyZeppelinContext(intp)
 __zeppelin__._setup_matplotlib()
 
 _zcUserQueryNameSpace["__zeppelin__"] = __zeppelin__
 _zcUserQueryNameSpace["z"] = z
 
-__zcStdOutput__ = __ZeppelinLogger__()
-sys.stdout = __zcStdOutput__
+output = Logger()
+sys.stdout = output
 #sys.stderr = output
 
 while True :
@@ -294,4 +294,4 @@ while True :
   except:
     intp.setStatementsFinished(traceback.format_exc(), True)
 
-  __zcStdOutput__.reset()
+  output.reset()

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -204,8 +204,8 @@ intp = gateway.entry_point
 intp.onPythonScriptInitialized(os.getpid())
 
 java_import(gateway.jvm, "org.apache.zeppelin.display.Input")
-z = PyZeppelinContext(intp)
-z._setup_matplotlib()
+z = _zc = PyZeppelinContext(intp)
+_zc._setup_matplotlib()
 
 output = Logger()
 sys.stdout = output
@@ -227,7 +227,7 @@ while True :
       global_hook = None
 
     try:
-      user_hook = z.getHook('post_exec')
+      user_hook = _zc.getHook('post_exec')
     except:
       user_hook = None
       

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -33,7 +33,7 @@ except ImportError:
 
 # for back compatibility
 
-class Logger(object):
+class __ZeppelinLogger__(object):
   def __init__(self):
     pass
 
@@ -207,7 +207,7 @@ java_import(gateway.jvm, "org.apache.zeppelin.display.Input")
 z = _zc = PyZeppelinContext(intp)
 _zc._setup_matplotlib()
 
-output = Logger()
+output = __ZeppelinLogger__()
 sys.stdout = output
 #sys.stderr = output
 

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -109,7 +109,7 @@ public class PythonInterpreterTest implements InterpreterOutputListener {
   @Test
   public void testRedefinitionZeppelinContext() {
     String pyRedefinitionCode = "z = 1\n";
-    String pyRestoreCode = "z = _zc\n";
+    String pyRestoreCode = "z = __zeppelin__\n";
     String pyValidCode = "z.input(\"test\")\n";
 
     assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyValidCode, context).code());

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -106,6 +106,19 @@ public class PythonInterpreterTest implements InterpreterOutputListener {
     assertTrue(new String(out.getOutputAt(0).toByteArray()).contains("hi\nhi\nhi"));
  }
 
+  @Test
+  public void testRedefinitionZeppelinContext() {
+    String pyRedefinitionCode = "z = 1\n";
+    String pyRestoreCode = "z = _zc\n";
+    String pyValidCode = "z.input(\"test\")\n";
+
+    assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyValidCode, context).code());
+    assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyRedefinitionCode, context).code());
+    assertEquals(InterpreterResult.Code.ERROR, pythonInterpreter.interpret(pyValidCode, context).code());
+    assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyRestoreCode, context).code());
+    assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyValidCode, context).code());
+  }
+
   @Override
   public void onUpdateAll(InterpreterOutput out) {
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -113,7 +113,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     // Add matplotlib display hook
     InterpreterGroup intpGroup = getInterpreterGroup();
     if (intpGroup != null && intpGroup.getInterpreterHookRegistry() != null) {
-      registerHook(HookType.POST_EXEC_DEV, "z._displayhook()");
+      registerHook(HookType.POST_EXEC_DEV, "_zc._displayhook()");
     }
     DepInterpreter depInterpreter = getDepInterpreter();
 
@@ -390,9 +390,9 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       return new InterpreterResult(Code.ERROR, errorMessage);
     }
     String jobGroup = Utils.buildJobGroupId(context);
-    ZeppelinContext z = sparkInterpreter.getZeppelinContext();
-    z.setInterpreterContext(context);
-    z.setGui(context.getGui());
+    ZeppelinContext _zc = sparkInterpreter.getZeppelinContext();
+    _zc.setInterpreterContext(context);
+    _zc.setGui(context.getGui());
     pythonInterpretRequest = new PythonInterpretRequest(st, jobGroup);
     statementOutput = null;
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -113,7 +113,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     // Add matplotlib display hook
     InterpreterGroup intpGroup = getInterpreterGroup();
     if (intpGroup != null && intpGroup.getInterpreterHookRegistry() != null) {
-      registerHook(HookType.POST_EXEC_DEV, "_zc._displayhook()");
+      registerHook(HookType.POST_EXEC_DEV, "__zeppelin__._displayhook()");
     }
     DepInterpreter depInterpreter = getDepInterpreter();
 
@@ -390,9 +390,9 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       return new InterpreterResult(Code.ERROR, errorMessage);
     }
     String jobGroup = Utils.buildJobGroupId(context);
-    ZeppelinContext _zc = sparkInterpreter.getZeppelinContext();
-    _zc.setInterpreterContext(context);
-    _zc.setGui(context.getGui());
+    ZeppelinContext __zeppelin__ = sparkInterpreter.getZeppelinContext();
+    __zeppelin__.setInterpreterContext(context);
+    __zeppelin__.setGui(context.getGui());
     pythonInterpretRequest = new PythonInterpretRequest(st, jobGroup);
     statementOutput = null;
 

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -271,19 +271,34 @@ else:
 
 java_import(gateway.jvm, "scala.Tuple2")
 
+_zcUserQueryNameSpace = {}
+
 jconf = intp.getSparkConf()
 conf = SparkConf(_jvm = gateway.jvm, _jconf = jconf)
-sc = SparkContext(jsc=jsc, gateway=gateway, conf=conf)
+sc = _zsc_ = SparkContext(jsc=jsc, gateway=gateway, conf=conf)
+_zcUserQueryNameSpace["_zsc_"] = _zsc_
+_zcUserQueryNameSpace["sc"] = sc
+
 if sparkVersion.isSpark2():
-  spark = SparkSession(sc, intp.getSparkSession())
-  sqlc = spark._wrapped
+  spark = __zSpark__ = SparkSession(sc, intp.getSparkSession())
+  sqlc = __zSqlc__ = __zSpark__._wrapped
+  _zcUserQueryNameSpace["sqlc"] = sqlc
+  _zcUserQueryNameSpace["__zSqlc__"] = __zSqlc__
+  _zcUserQueryNameSpace["spark"] = spark
+  _zcUserQueryNameSpace["__zSpark__"] = __zSpark__
 else:
-  sqlc = SQLContext(sparkContext=sc, sqlContext=intp.getSQLContext())
-sqlContext = sqlc
+  sqlc = __zSqlc__ = SQLContext(sparkContext=sc, sqlContext=intp.getSQLContext())
+  _zcUserQueryNameSpace["sqlc"] = sqlc
+  _zcUserQueryNameSpace["__zSqlc__"] = sqlc
+
+sqlContext = __zSqlc__
+_zcUserQueryNameSpace["sqlContext"] = sqlContext
 
 completion = PySparkCompletion(intp)
-z = _zc = __PyZeppelinContext__(intp.getZeppelinContext())
-_zc._setup_matplotlib()
+z = __zeppelin__ = __PyZeppelinContext__(intp.getZeppelinContext())
+__zeppelin__._setup_matplotlib()
+_zcUserQueryNameSpace["z"] = z
+_zcUserQueryNameSpace["__zeppelin__"] = __zeppelin__
 
 while True :
   req = intp.getStatements()
@@ -299,7 +314,7 @@ while True :
       global_hook = None
       
     try:
-      user_hook = _zc.getHook('post_exec')
+      user_hook = __zeppelin__.getHook('post_exec')
     except:
       user_hook = None
       
@@ -334,17 +349,17 @@ while True :
         for node in to_run_exec:
           mod = ast.Module([node])
           code = compile(mod, '<stdin>', 'exec')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
 
         for node in to_run_single:
           mod = ast.Interactive([node])
           code = compile(mod, '<stdin>', 'single')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
           
         for node in to_run_hooks:
           mod = ast.Module([node])
           code = compile(mod, '<stdin>', 'exec')
-          exec(code)
+          exec(code, _zcUserQueryNameSpace)
       except:
         raise Exception(traceback.format_exc())
 

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -294,7 +294,10 @@ else:
 sqlContext = __zSqlc__
 _zcUserQueryNameSpace["sqlContext"] = sqlContext
 
-completion = PySparkCompletion(intp)
+completion = __zeppelin_completion__ = PySparkCompletion(intp)
+_zcUserQueryNameSpace["completion"] = completion
+_zcUserQueryNameSpace["__zeppelin_completion__"] = __zeppelin_completion__
+
 z = __zeppelin__ = PyZeppelinContext(intp.getZeppelinContext())
 __zeppelin__._setup_matplotlib()
 _zcUserQueryNameSpace["z"] = z

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -35,7 +35,7 @@ import warnings
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, Row
 
-class __ZeppelinLogger__(object):
+class Logger(object):
   def __init__(self):
     pass
 
@@ -49,7 +49,7 @@ class __ZeppelinLogger__(object):
     pass
 
 
-class __PyZeppelinContext__(dict):
+class PyZeppelinContext(dict):
   def __init__(self, zc):
     self.z = zc
     self._displayhook = lambda *args: None
@@ -230,9 +230,9 @@ class PySparkCompletion:
       self.interpreterObject.setStatementsFinished(result, False)
 
 
-__zcStdOutput__ = __ZeppelinLogger__()
-sys.stdout = __zcStdOutput__
-sys.stderr = __zcStdOutput__
+output = Logger()
+sys.stdout = output
+sys.stderr = output
 
 client = GatewayClient(port=int(sys.argv[1]))
 sparkVersion = SparkVersion(int(sys.argv[2]))
@@ -295,7 +295,7 @@ sqlContext = __zSqlc__
 _zcUserQueryNameSpace["sqlContext"] = sqlContext
 
 completion = PySparkCompletion(intp)
-z = __zeppelin__ = __PyZeppelinContext__(intp.getZeppelinContext())
+z = __zeppelin__ = PyZeppelinContext(intp.getZeppelinContext())
 __zeppelin__._setup_matplotlib()
 _zcUserQueryNameSpace["z"] = z
 _zcUserQueryNameSpace["__zeppelin__"] = __zeppelin__
@@ -373,4 +373,4 @@ while True :
   except:
     intp.setStatementsFinished(traceback.format_exc(), True)
 
-  __zcStdOutput__.reset()
+  output.reset()

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -282,8 +282,8 @@ else:
 sqlContext = sqlc
 
 completion = PySparkCompletion(intp)
-z = PyZeppelinContext(intp.getZeppelinContext())
-z._setup_matplotlib()
+z = _zc = PyZeppelinContext(intp.getZeppelinContext())
+_zc._setup_matplotlib()
 
 while True :
   req = intp.getStatements()
@@ -299,7 +299,7 @@ while True :
       global_hook = None
       
     try:
-      user_hook = z.getHook('post_exec')
+      user_hook = _zc.getHook('post_exec')
     except:
       user_hook = None
       

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -49,7 +49,7 @@ class __ZeppelinLogger__(object):
     pass
 
 
-class PyZeppelinContext(dict):
+class __PyZeppelinContext__(dict):
   def __init__(self, zc):
     self.z = zc
     self._displayhook = lambda *args: None
@@ -230,9 +230,9 @@ class PySparkCompletion:
       self.interpreterObject.setStatementsFinished(result, False)
 
 
-output = __ZeppelinLogger__()
-sys.stdout = output
-sys.stderr = output
+__zcStdOutput__ = __ZeppelinLogger__()
+sys.stdout = __zcStdOutput__
+sys.stderr = __zcStdOutput__
 
 client = GatewayClient(port=int(sys.argv[1]))
 sparkVersion = SparkVersion(int(sys.argv[2]))
@@ -282,7 +282,7 @@ else:
 sqlContext = sqlc
 
 completion = PySparkCompletion(intp)
-z = _zc = PyZeppelinContext(intp.getZeppelinContext())
+z = _zc = __PyZeppelinContext__(intp.getZeppelinContext())
 _zc._setup_matplotlib()
 
 while True :
@@ -358,4 +358,4 @@ while True :
   except:
     intp.setStatementsFinished(traceback.format_exc(), True)
 
-  output.reset()
+  __zcStdOutput__.reset()

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -35,7 +35,7 @@ import warnings
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, Row
 
-class Logger(object):
+class __ZeppelinLogger__(object):
   def __init__(self):
     pass
 
@@ -230,7 +230,7 @@ class PySparkCompletion:
       self.interpreterObject.setStatementsFinished(result, False)
 
 
-output = Logger()
+output = __ZeppelinLogger__()
 sys.stdout = output
 sys.stderr = output
 

--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
@@ -128,10 +128,11 @@ public class PySparkInterpreterTest {
     if (getSparkVersionNumber() > 11) {
       String redefinitionCode = "z = 1\n";
       String restoreCode = "z = _zc\n";
-      String validCode = "print(z)\n";
+      String validCode = "z.input(\"test\")\n";
 
       assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(validCode, context).code());
-      assertEquals(InterpreterResult.Code.ERROR, pySparkInterpreter.interpret(redefinitionCode, context).code());
+      assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(redefinitionCode, context).code());
+      assertEquals(InterpreterResult.Code.ERROR, pySparkInterpreter.interpret(validCode, context).code());
       assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(restoreCode, context).code());
       assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(validCode, context).code());
     }

--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
@@ -127,7 +127,7 @@ public class PySparkInterpreterTest {
   public void testRedefinitionZeppelinContext() {
     if (getSparkVersionNumber() > 11) {
       String redefinitionCode = "z = 1\n";
-      String restoreCode = "z = _zc\n";
+      String restoreCode = "z = __zeppelin__\n";
       String validCode = "z.input(\"test\")\n";
 
       assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(validCode, context).code());

--- a/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterTest.java
@@ -123,6 +123,20 @@ public class PySparkInterpreterTest {
     }
   }
 
+  @Test
+  public void testRedefinitionZeppelinContext() {
+    if (getSparkVersionNumber() > 11) {
+      String redefinitionCode = "z = 1\n";
+      String restoreCode = "z = _zc\n";
+      String validCode = "print(z)\n";
+
+      assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(validCode, context).code());
+      assertEquals(InterpreterResult.Code.ERROR, pySparkInterpreter.interpret(redefinitionCode, context).code());
+      assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(restoreCode, context).code());
+      assertEquals(InterpreterResult.Code.SUCCESS, pySparkInterpreter.interpret(validCode, context).code());
+    }
+  }
+
   private class infinityPythonJob implements Runnable {
     @Override
     public void run() {


### PR DESCRIPTION
### What is this PR for?
If you override the reserved word ZeppelinContext such as `z` in the python language, the whole paragraph output problem occurred.
I have taken care to avoid this issue.

`z` == `_zc` == `zeppelin context`


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-802

### How should this be tested?
The error should not occur in the following situations:
```
%python
z = 1
print("Hello Zeppelin")
```

```
%pyspark
z = 1
print("Hello Zeppelin")
```


### Screenshots (if appropriate)

#### before
![replace zeppelin context-err](https://cloud.githubusercontent.com/assets/10525473/24521772/319946be-15c8-11e7-96cf-7fdf41c70a66.png)

#### after
![replace zeppelin context](https://cloud.githubusercontent.com/assets/10525473/24521775/349fa7cc-15c8-11e7-8fe4-4f3f5597deff.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
