### PR TITLE
[HOTFIX][gh-pages] Fix Maven web link for INTERPRETER type pkg

### DIFF
--- a/assets/themes/zeppelin/js/helium.controller.js
+++ b/assets/themes/zeppelin/js/helium.controller.js
@@ -2,7 +2,6 @@ angular.module("app", ['ui.bootstrap'])
   .controller("HeliumPkgCtrl", function($rootScope, $scope, $window, $sce) {
   $rootScope.keys = Object.keys
   $scope.HeliumPkgs = zeppelinHeliumPackages
-  $scope.npmWebLink = 'https://www.npmjs.com/package'
   $scope.intpDefaultIcon = $sce.trustAsHtml('<img src="assets/themes/zeppelin/img/maven_default_icon.png" style="width: 12px"/>');
   $scope.latestPkgInfo = {}
   $scope.allTypePkgs = {}

--- a/helium_packages.md
+++ b/helium_packages.md
@@ -70,7 +70,13 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
                  ng-if="pkg.type === 'INTERPRETER'"
                  ng-bind-html="intpDefaultIcon"></div>
             <div class="heliumPackageName">
-              <a ng-href="{% raw %}{{npmWebLink}}/{{pkg.name}}{% endraw %}"
+              <a ng-if="pkg.type !== 'INTERPRETER'"
+                 ng-href="https://www.npmjs.com/package/{% raw %}{{pkg.name}}{% endraw %}"
+                 target="_blank">
+                 {% raw %}{{pkg.name}}{% endraw %}
+              </a>
+              <a ng-if="pkg.type === 'INTERPRETER'"
+                 ng-href="http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22{% raw %}{{pkg.artifactId}}{% endraw %}%22%20AND%20v%3A%22{% raw %}{{pkg.version}}{% endraw %}%22"
                  target="_blank">
                  {% raw %}{{pkg.name}}{% endraw %}
               </a>
@@ -108,7 +114,13 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
                  ng-if="pkg.type === 'INTERPRETER'"
                  ng-bind-html="intpDefaultIcon"></div>
             <div class="heliumPackageName">
-              <a ng-href="{% raw %}{{npmWebLink}}/{{pkg.name}}{% endraw %}"
+              <a ng-if="pkg.type !== 'INTERPRETER'"
+                 ng-href="https://www.npmjs.com/package/{% raw %}{{pkg.name}}{% endraw %}"
+                 target="_blank">
+                 {% raw %}{{pkg.name}}{% endraw %}
+              </a>
+              <a ng-if="pkg.type === 'INTERPRETER'"
+                 ng-href="http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22{% raw %}{{pkg.artifactId}}{% endraw %}%22%20AND%20v%3A%22{% raw %}{{pkg.version}}{% endraw %}%22"
                  target="_blank">
                  {% raw %}{{pkg.name}}{% endraw %}
               </a>


### PR DESCRIPTION
### What is this PR for?
In current https://zeppelin.apache.org/helium_packages.html page, `INTERPRETER` type package web link is wrong. It should point Maven web link not npm. So I fixed it. 

### What type of PR is it?
Hot Fix

### What is the Jira issue?
N/A

### How should this be tested?
Run the website(`gh-pages`) locally as described in [here](https://github.com/apache/zeppelin/tree/gh-pages#run-website) and click any `INTERPRETER` type of package name.

### Screenshots (if appropriate)
 - Before 
![maven_link_before](https://cloud.githubusercontent.com/assets/10060731/24534152/17780970-1607-11e7-82ef-8876590477b8.gif)

 - After
![maven_link_after](https://cloud.githubusercontent.com/assets/10060731/24534153/197ab100-1607-11e7-92a9-1718f0e5b9cb.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
