### PR TITLE
[ZEPPELIN-2339] Change 'see more' -> 'enable' next to the older ver of interpreter type pkg

### DIFF
--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -131,16 +131,9 @@ limitations under the License.
               ng-repeat="pkgSearchResult in pkgSearchResults[pkgSearchResult.pkg.name]">
             {{pkgSearchResult.pkg.artifact}} -
             <span ng-click="enable(pkgSearchResult.pkg.name, pkgSearchResult.pkg.artifact, pkgSearchResult.pkg.type, pkgSearchResult.pkg.groupId)"
-                  ng-if="pkgSearchResult.pkg.type !== 'INTERPRETER'"
                   style="margin-left:3px;cursor:pointer;text-decoration: underline;color:#3071a9">
               enable
             </span>
-            <a target="_blank"
-               ng-if="pkgSearchResult.pkg.type === 'INTERPRETER'"
-               style="margin-left:3px;cursor:pointer;text-decoration: underline;color:#3071a9"
-               href="http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22{{pkgSearchResult.pkg.artifact.split('@')[0]}}%22%20AND%20v%3A%22{{pkgSearchResult.pkg.artifact.split('@')[1]}}%22">
-              see more
-            </a>
           </li>
         </ul>
         <div class="heliumPackageDescription" ng-bind-html="getDescriptionText(pkgSearchResult)" />


### PR DESCRIPTION
### What is this PR for?
Currently "see more" is placed next to the older version of INTERPRETER type of Helium pkg. But other type of Helium pkg(e.g. SPELL or VISUALIZATION) has "enable". And if we click "enable", can see the dialog for asking if you want to enable the package or not. So I changed INTERPRETER type pkg's "see more" to "enable" for the consistency in this patch.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-2339](https://issues.apache.org/jira/browse/ZEPPELIN-2339)

### How should this be tested?

1. Run Zeppelin web under `zeppelin-web` with 
```
$ yarn run dev
```

2. Go to Helium menu and click any interpreter type of package
3. Click `versions` 
4. there should be "enable" not "see more"

### Screenshots (if appropriate)
 - Before
![before](https://cloud.githubusercontent.com/assets/10060731/24577610/e5c28c38-170b-11e7-87f9-5dd6ad22f6fa.gif)

 - After 
![after](https://cloud.githubusercontent.com/assets/10060731/24577611/e9b7c52e-170b-11e7-8164-959960e111ee.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
