### PR TITLE
[gh-pages] set max size for pagination btn & hide arrows when current page is first/last 

### DIFF
--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -670,6 +670,29 @@ a.anchorjs-link:hover { text-decoration: none; }
   background: #c9e2f9; 
 }
 
+/* hide arrows when current page is on first & last */
+.hide-first-boundaries.pagination > .disabled > a,
+.hide-first-boundaries.pagination > li:first-child > a,
+.hide-first-boundaries.pagination > li:first-child > span {
+  display: none;
+}
+
+.hide-first-boundaries.pagination > .active > a {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
+.hide-last-boundaries.pagination > .disabled > a,
+.hide-last-boundaries.pagination > li:last-child > a,
+.hide-last-boundaries.pagination > li:last-child > span {
+  display: none;
+}
+
+.hide-last-boundaries.pagination > .active > a {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
 /* For what's new section */
 .new {
   background: rgba(226, 233, 239, 0.4);

--- a/helium_packages.md
+++ b/helium_packages.md
@@ -98,6 +98,8 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
       <div class="text-center" style="margin-top: 24px;">
         <ul uib-pagination boundary-links="true" total-items="latestPkgInfo.length" 
             ng-model="currentPage" class="pagination-sm"
+            max-size="maxSize"
+            items-per-page="itemsPerPage"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
       </div>
     </div>
@@ -143,6 +145,8 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
         <ul uib-pagination boundary-links="true" total-items="pkgs.length" 
             ng-model="$parent.currentPage" class="pagination-sm"
             ng-show="$parent.pkgListByType === types"
+            max-size="maxSize"
+            items-per-page="itemsPerPage"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
       </div>
     </div>

--- a/helium_packages.md
+++ b/helium_packages.md
@@ -98,6 +98,7 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
       <div class="text-center" style="margin-top: 24px;">
         <ul uib-pagination boundary-links="true" total-items="latestPkgInfo.length" 
             ng-model="currentPage" class="pagination-sm"
+            ng-class="{'hide-first-boundaries': currentPage == 1, 'hide-last-boundaries': currentPage &gt;= latestPkgInfo.length/itemsPerPage}"
             max-size="maxSize"
             items-per-page="itemsPerPage"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
@@ -145,6 +146,7 @@ and [What is Apache Zeppelin Spell](https://zeppelin.apache.org/docs/snapshot/de
         <ul uib-pagination boundary-links="true" total-items="pkgs.length" 
             ng-model="$parent.currentPage" class="pagination-sm"
             ng-show="$parent.pkgListByType === types"
+            ng-class="{'hide-first-boundaries': $parent.currentPage == 1, 'hide-last-boundaries': $parent.currentPage &gt;= pkgs.length/itemsPerPage}"
             max-size="maxSize"
             items-per-page="itemsPerPage"
             previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>


### PR DESCRIPTION
### What is this PR for?
As the number of Helium packages is increasing, more pagination buttons will be generated accordingly. If we don't set `maxSize`, pagination layout will be broken when screen size is small. So I set the `maxSize` to 5 to prevent it.
And also hided unnecessary arrows when current page is on first & last. (related feedback is https://github.com/apache/zeppelin/pull/2174#issuecomment-289776096 suggested by @1ambda)

### What type of PR is it?
Improvement | gh-pages

### What is the Jira issue?
N/A

### How should this be tested?
Run the website(`gh-pages`) locally as described in [here](https://github.com/apache/zeppelin/tree/gh-pages#run-website) and click pagination button

### Screenshots (if appropriate)
 - before
![before](https://cloud.githubusercontent.com/assets/10060731/24579183/3fa531fa-172b-11e7-90b4-4a4a9b946ef5.gif)

 - after
![after](https://cloud.githubusercontent.com/assets/10060731/24579184/40e77ed8-172b-11e7-8162-3f66406a8493.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
