### PR TITLE
[MINOR] remove typo in line and area chart

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-areachart.js
@@ -23,7 +23,6 @@ export default class AreachartVisualization extends Nvd3ChartVisualization {
     super(targetEl, config);
 
     this.pivot = new PivotTransformation(config);
-    this.xLables = [];
   };
 
   type() {

--- a/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-linechart.js
@@ -23,7 +23,6 @@ export default class LinechartVisualization extends Nvd3ChartVisualization {
     super(targetEl, config);
 
     this.pivot = new PivotTransformation(config);
-    this.xLables = [];
   };
 
   type() {


### PR DESCRIPTION
### What is this PR for?
The line and area chart have the typo `xLables`, not `xLabels`.
However, this line is not necessary, because `xLabels` is defined by `render` function. That's why these chart was working well.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* None

### How should this be tested?
- Run line and area chart and check whether it works well or not.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
