### PR TITLE
[ZEPPELIN-2336] Fix note reload on another note create/rename/remove

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -128,11 +128,6 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
 
   initNotebook();
 
-  // force notebook reload on user change
-  $scope.$on('setNoteMenu', function(event, note) {
-    initNotebook();
-  });
-
   $scope.focusParagraphOnClick = function(clickEvent) {
     if (!$scope.note) {
       return;

--- a/zeppelin-web/src/app/notebook/notebook.controller.test.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.test.js
@@ -126,14 +126,14 @@ describe('Controller: NotebookCtrl', function() {
     spyOn(websocketMsgSrvMock, 'listRevisionHistory');
 
     scope.$broadcast('setNoteMenu');
-    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(1);
-    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(1);
+    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(0);
+    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(0);
 
     websocketMsgSrvMock.getNote.calls.reset();
     websocketMsgSrvMock.listRevisionHistory.calls.reset();
 
     scope.$broadcast('setNoteMenu');
-    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(1);
-    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(1);
+    expect(websocketMsgSrvMock.getNote.calls.count()).toEqual(0);
+    expect(websocketMsgSrvMock.listRevisionHistory.calls.count()).toEqual(0);
   });
 });


### PR DESCRIPTION
### What is this PR for?
This is to fix the issue with repeated note reload when some other note is created/renamed/removed


### What type of PR is it?
Bug Fix

### Todos
* [x] - don't initialise controller on note list update

### What is the Jira issue?
[ZEPPELIN-2336](https://issues.apache.org/jira/browse/ZEPPELIN-2336)

### How should this be tested?
Described in [ZEPPELIN-2336](https://issues.apache.org/jira/browse/ZEPPELIN-2336),
also additional test from [ZEPPELIN-1145](https://issues.apache.org/jira/browse/ZEPPELIN-1145) would be nice

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
