### PR TITLE
[ZEPPELIN-2344] Fix problem with running zeppelin-web in visualization dev mode

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -15,7 +15,7 @@
     "dev:helium": "HELIUM_BUNDLE_DEV=true webpack-dev-server --hot",
     "dev:watch": "grunt watch-webpack-dev",
     "dev": "npm-run-all --parallel dev:server dev:watch",
-    "visdev": "npm-run-all --parallel visdev:server dev:watch",
+    "visdev": "npm-run-all --parallel dev:server dev:watch",
     "pretest": "npm install karma-phantomjs-launcher",
     "test": "karma start karma.conf.js"
   },


### PR DESCRIPTION
### What is this PR for?
Solving problems with executing yarn run visdev


### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
[ZEPPELIN-2344](https://issues.apache.org/jira/browse/ZEPPELIN-2344)

### How should this be tested?
From the zeppelin-web folder execute `yarn run visdev` without getting the following error:
```
yarn run v0.21.3
$ npm-run-all --parallel visdev:server dev:watch 
ERROR: Task not found: "visdev:server"
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
