### PR TITLE
[ZEPPELIN-2348] Line chart setting is not rendered (master)

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -468,6 +468,14 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
     }
   }
 
+  const getTrSettingElem = function(scopeId, graphMode) {
+    return angular.element('#trsetting' + scopeId + '_' + graphMode)
+  }
+
+  const getVizSettingElem = function(scopeId, graphMode) {
+    return angular.element('#vizsetting' + scopeId + '_' + graphMode)
+  }
+
   const renderGraph = function(graphElemId, graphMode, refresh) {
     // set graph height
     const height = $scope.config.graph.height;
@@ -495,8 +503,8 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       // render when targetEl is available
       afterLoaded = function(loadedElem) {
         try {
-          const transformationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + graphMode);
-          const visualizationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + graphMode);
+          const transformationSettingTargetEl = getTrSettingElem($scope.id, graphMode)
+          const visualizationSettingTargetEl = getVizSettingElem($scope.id, graphMode)
           // set height
           loadedElem.height(height);
 
@@ -537,8 +545,8 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       console.log('Refresh data %o', tableData);
 
       afterLoaded = function(loadedElem) {
-        const transformationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + graphMode);
-        const visualizationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + graphMode);
+        const transformationSettingTargetEl = getTrSettingElem($scope.id, graphMode)
+        const visualizationSettingTargetEl = getVizSettingElem($scope.id, graphMode)
         const config = getVizConfig(graphMode);
         loadedElem.height(height);
         const transformation = builtInViz.instance.getTransformation();


### PR DESCRIPTION
### What is this PR for?

Line chart setting is not rendered.

### What type of PR is it?
[Bug Fix]

### Todos

None.

### What is the Jira issue?

[ZEPPELIN-2348](https://issues.apache.org/jira/browse/ZEPPELIN-2348)

### How should this be tested?

1. Open the default line chart's setting
2. Check checkboxes for options.

### Screenshots (if appropriate)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/24643544/ad22b336-1949-11e7-95c4-5a5ba17f1d1b.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
