### PR TITLE
[ZEPPELIN-2348] Line chart setting is not rendered (branch-0.7)

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -456,7 +456,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
         var retryRenderer = function() {
           var targetEl = angular.element('#p' + $scope.id + '_' + type);
           var transformationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + type);
-          var visualizationSettingTargetEl = angular.element('#trsetting' + $scope.id + '_' + type);
+          var visualizationSettingTargetEl = angular.element('#vizsetting' + $scope.id + '_' + type);
           if (targetEl.length) {
             var config = getVizConfig(type);
             targetEl.height(height);


### PR DESCRIPTION
### What is this PR for?

Line chart setting is not rendered.

### What type of PR is it?
[Bug Fix]

### Todos

None.

### What is the Jira issue?

[ZEPPELIN-2348](https://issues.apache.org/jira/browse/ZEPPELIN-2348)

### How should this be tested?

1. Open the default line chart's setting
2. Check checkboxes for options.

### Screenshots (if appropriate)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/24643544/ad22b336-1949-11e7-95c4-5a5ba17f1d1b.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
