### PR TITLE
add a configuration zeppelin.jdbc.auth.kerberos.proxy for kerberos proxy behavior

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -166,7 +166,7 @@ There are more JDBC interpreter properties you can specify like below.
   </tr>
   <tr>
       <td>zeppelin.jdbc.auth.kerberos.proxy.enable</td>
-      <td>when auth type is kerberos auth type,whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
+      <td>when auth type is kerberos,whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
   </tr>
   <tr>
     <td>default.jceks.file</td>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -166,7 +166,7 @@ There are more JDBC interpreter properties you can specify like below.
   </tr>
   <tr>
       <td>zeppelin.jdbc.auth.kerberos.proxy.enable</td>
-      <td>true or false. when auth type is kerberos, whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
+      <td>When auth type is Kerberos, enable/disable Kerberos proxy with the login user to get the connection. Default value is true.</td>
   </tr>
   <tr>
     <td>default.jceks.file</td>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -166,7 +166,7 @@ There are more JDBC interpreter properties you can specify like below.
   </tr>
   <tr>
       <td>zeppelin.jdbc.auth.kerberos.proxy.enable</td>
-      <td>when used the kerberos auth type, do the kerberos proxy behavior with login user (if not anonymous) to get the connection, default value is true</td>
+      <td>when auth type is kerberos auth type,whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
   </tr>
   <tr>
     <td>default.jceks.file</td>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -165,6 +165,10 @@ There are more JDBC interpreter properties you can specify like below.
     <td>The path to the keytab file</td>
   </tr>
   <tr>
+      <td>zeppelin.jdbc.auth.kerberos.proxy.enable</td>
+      <td>when used the kerberos auth type, do the kerberos proxy behavior with login user (if not anonymous) to get the connection, default value is true</td>
+  </tr>
+  <tr>
     <td>default.jceks.file</td>
     <td>jceks store path (e.g: jceks://file/tmp/zeppelin.jceks)</td>
   </tr>

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -166,7 +166,7 @@ There are more JDBC interpreter properties you can specify like below.
   </tr>
   <tr>
       <td>zeppelin.jdbc.auth.kerberos.proxy.enable</td>
-      <td>when auth type is kerberos,whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
+      <td>true or false. when auth type is kerberos, whether do the kerberos proxy behavior with the login user (if not anonymous) to get the connection, default value is true</td>
   </tr>
   <tr>
     <td>default.jceks.file</td>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -371,7 +371,7 @@ public class JDBCInterpreter extends Interpreter {
 
       switch (authType) {
           case KERBEROS:
-            if (user == null) {
+            if (user == null || "false".equals(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
               if (url.trim().startsWith("jdbc:hive")) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -371,7 +371,8 @@ public class JDBCInterpreter extends Interpreter {
 
       switch (authType) {
           case KERBEROS:
-            if (user == null || "false".equals(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
+            if (user == null || 
+                "false".equals(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
               if (url.trim().startsWith("jdbc:hive")) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -372,7 +372,7 @@ public class JDBCInterpreter extends Interpreter {
       switch (authType) {
           case KERBEROS:
             if (user == null || 
-                "false".equals(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
+                "false".equalsIgnoreCase(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
               if (url.trim().startsWith("jdbc:hive")) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -371,8 +371,8 @@ public class JDBCInterpreter extends Interpreter {
 
       switch (authType) {
           case KERBEROS:
-            if (user == null || 
-                "false".equalsIgnoreCase(property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
+            if (user == null || "false".equalsIgnoreCase(
+              property.getProperty("zeppelin.jdbc.auth.kerberos.proxy.enable"))) {
               connection = getConnectionFromPool(url, user, propertyKey, properties);
             } else {
               if (url.trim().startsWith("jdbc:hive")) {


### PR DESCRIPTION
…e to disable proxy behavior

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
[Improvement]
* add a configuration item  zeppelin.jdbc.auth.kerberos.proxy.enable to disable kerberos behaviour 
as we know， in current version of zeppelin， if we have kerberos auth configured，and using zeppelin with a user login，the jdbc interpreter will do a proxy behavior with the login user automatically，but in many cases， we do not want do this，and we do not want bind the zeppelin user system with kerberos auth system. I think it's make senses to add a configuration item to disable this behavior.



### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

[ZEPPELIN-2353] (https://issues.apache.org/jira/browse/ZEPPELIN-2353)

### How should this be tested?
Outline the steps to test the PR here.

when we have kerberos auth configured, and using zeppelin with a login user 
add configuration:
"zeppelin.jdbc.auth.kerberos.proxy.enable=false"
for jdbc iterpreter configuration, the jdbc iterpreter will not do the proxy behavior with the login user

### Screenshots (if appropriate)

<img width="1405" alt="2017-04-04 9 12 03" src="https://cloud.githubusercontent.com/assets/869480/24658501/7739e680-197c-11e7-90ab-c1938e31efc7.png">


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?