### PR TITLE
[ZEPPELIN-2357] fix: tooltip doesn't work in btn-group

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -229,7 +229,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) Json3 v3.3.1 (http://bestiejs.github.io/json3) - https://github.com/bestiejs/json3/blob/v3.3.1/LICENSE
     (The MIT License) es5-shim v3.1.0 (https://github.com/es-shims/es5-shim) - https://github.com/es-shims/es5-shim/blob/v3.1.0/LICENSE
     (The MIT License) bootstrap v3.2.0 (http://getbootstrap.com/) - https://github.com/twbs/bootstrap/blob/v3.2.0/LICENSE
-    (The MIT License) UI Bootstrap v0.13.0 (http://angular-ui.github.io/bootstrap/) - https://github.com/angular-ui/bootstrap/blob/0.13.0/LICENSE
+    (The MIT License) UI Bootstrap v2.5.0 (http://angular-ui.github.io/bootstrap/) - https://github.com/angular-ui/bootstrap/blob/2.5.0/LICENSE
     (The MIT License) bootstrap3-dialog v1.34.7 (https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7) - https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7
     (The MIT License) Angular Websocket v1.0.13 (http://angularclass.github.io/angular-websocket/) - https://github.com/AngularClass/angular-websocket/blob/v1.0.13/LICENSE
     (The MIT License) UI.Ace v0.1.1 (http://angularclass.github.io/angular-websocket/) - https://github.com/angular-ui/ui-ace/blob/master/LICENSE

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -125,7 +125,7 @@ public class WebDriverManager {
         (new WebDriverWait(driver, 30)).until(new ExpectedCondition<Boolean>() {
           @Override
           public Boolean apply(WebDriver d) {
-            return d.findElement(By.xpath("//i[@tooltip='WebSocket Connected']"))
+            return d.findElement(By.xpath("//i[@uib-tooltip='WebSocket Connected']"))
                 .isDisplayed();
           }
         });

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -187,7 +187,7 @@ public class AuthenticationIT extends AbstractZeppelinIT {
 
       String noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
 
-      pollingWait(By.xpath("//span[@tooltip='Note permissions']"),
+      pollingWait(By.xpath("//span[@uib-tooltip='Note permissions']"),
           MAX_BROWSER_TIMEOUT_SEC).click();
       pollingWait(By.xpath(".//*[@id='selectOwners']/following::span//input"),
           MAX_BROWSER_TIMEOUT_SEC).sendKeys("finance ");

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -198,8 +198,8 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
     }
     try {
       // restart spark interpreter before running %dep
-      clickAndWait(By.xpath("//span[@tooltip='Interpreter binding']"));
-      clickAndWait(By.xpath("//div[font[contains(text(), 'spark')]]/preceding-sibling::a[@tooltip='Restart']"));
+      clickAndWait(By.xpath("//span[@uib-tooltip='Interpreter binding']"));
+      clickAndWait(By.xpath("//div[font[contains(text(), 'spark')]]/preceding-sibling::a[@uib-tooltip='Restart']"));
       clickAndWait(By.xpath("//button[contains(.,'OK')]"));
 
       setTextOfParagraph(1,"%dep z.load(\"org.apache.commons:commons-csv:1.1\")");

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -12,7 +12,7 @@
     "angular-touch": "1.5.0",
     "angular-route": "1.5.0",
     "angular-resource": "1.5.0",
-    "angular-bootstrap": "~0.13.0",
+    "angular-bootstrap": "~2.5.0",
     "angular-websocket": "~1.0.13",
     "ace-builds": "1.2.6",
     "angular-ui-ace": "0.1.3",

--- a/zeppelin-web/src/app/credential/credential.html
+++ b/zeppelin-web/src/app/credential/credential.html
@@ -22,7 +22,7 @@ limitations under the License.
           <a style="cursor:pointer;margin-right:10px;text-decoration:none;"
              target="_blank"
              ng-href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/security/datasource_authorization.html"
-             tooltip-placement="bottom" tooltip="Learn more">
+             tooltip-placement="bottom" uib-tooltip="Learn more">
             <i class="icon-question" ng-style="{color: showRepositoryInfo ? '#3071A9' : 'black' }"></i>
           </a>
           <button class="btn btn-default btn-sm"

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -185,13 +185,13 @@ limitations under the License.
       </div>
     </div>
     <div class="text-center" style="margin-top: 20px;" ng-if="getPackageSize(defaultPackages, pkgListByType) !== 0">
-      <pagination boundary-links="true" total-items="defaultPackages.length"
+      <ul uib-pagination boundary-links="true" total-items="defaultPackages.length"
                   ng-model="$parent.currentPage" class="pagination-sm"
                   ng-show="$parent.pkgListByType === types"
                   max-size="maxSize"
                   items-per-page="itemsPerPage"
                   ng-class="{'hide-first-boundaries': $parent.currentPage == 1, 'hide-last-boundaries': $parent.currentPage >= defaultPackages.length/itemsPerPage}"
-                  previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></pagination>
+                  previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"></ul>
     </div>
   </div>
 </div>

--- a/zeppelin-web/src/app/helium/helium.html
+++ b/zeppelin-web/src/app/helium/helium.html
@@ -23,8 +23,7 @@ limitations under the License.
           <a target="_blank"
              class="helium-repo-btn"
              ng-href="https://zeppelin.apache.org/helium_packages.html"
-             tooltip-placement="bottom"
-             tooltip="Learn more">
+             tooltip-placement="bottom" uib-tooltip="Learn more">
             <i class="icon-question" ng-style="{color: 'black'}"></i>
           </a>
           <button tabindex="0" role="button"

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -29,7 +29,7 @@ limitations under the License.
             <i ng-class="isReloadingNotes ? 'fa fa-refresh fa-spin' : 'fa fa-refresh'"
               ng-style="!isReloadingNotes && {'cursor': 'pointer'}" style="font-size: 13px;"
               ng-click="reloadNoteList();"
-              tooltip-placement="bottom" tooltip="Reload notes from storage">
+              tooltip-placement="bottom" uib-tooltip="Reload notes from storage">
             </i>
           </h4>
 

--- a/zeppelin-web/src/app/home/notebook-template.html
+++ b/zeppelin-web/src/app/home/notebook-template.html
@@ -25,28 +25,28 @@ limitations under the License.
       <i style="margin-left: 10px;"
          class="fa fa-pencil notebook-list-btn" ng-show="showNoteButton"
          ng-click="node.path ? renameNote(node.id, node.path) : renameNote(node.id, node.name)"
-         tooltip-placement="bottom" tooltip="Rename note">
+         tooltip-placement="bottom" uib-tooltip="Rename note">
       </i>
     </a>
     <a ng-if="!node.isTrash" style="text-decoration: none;">
       <i class="fa fa-eraser notebook-list-btn" ng-show="showNoteButton" ng-click="clearAllParagraphOutput(node.id)"
-         tooltip-placement="bottom" tooltip="Clear output">
+         tooltip-placement="bottom" uib-tooltip="Clear output">
       </i>
     </a>
     <a ng-if="!node.isTrash" style="text-decoration: none;">
       <i class="fa fa-trash-o notebook-list-btn" ng-show="showNoteButton" ng-click="moveNoteToTrash(node.id)"
-         tooltip-placement="bottom" tooltip="Move note to Trash">
+         tooltip-placement="bottom" uib-tooltip="Move note to Trash">
       </i>
     </a>
     <!-- if note is in trash -->
     <a ng-if="node.isTrash">
       <i class="fa fa-undo notebook-list-btn" ng-show="showNoteButton" ng-click="restoreNote(node.id)"
-         tooltip-placement="bottom" tooltip="Restore note">
+         tooltip-placement="bottom" uib-tooltip="Restore note">
       </i>
     </a>
     <a ng-if="node.isTrash" style="font-size: 16px;">
       <i class="fa fa-times notebook-list-btn" ng-show="showNoteButton" ng-click="removeNote(node.id)"
-         tooltip-placement="bottom" tooltip="Remove note permanently">
+         tooltip-placement="bottom" uib-tooltip="Remove note permanently">
       </i>
     </a>
   </div>
@@ -61,24 +61,24 @@ limitations under the License.
       <a ng-if="!node.isTrash" style="text-decoration: none;">
         <i style="margin-left: 10px;"
            class="fa fa-pencil notebook-list-btn" ng-show="showFolderButton" ng-click="renameFolder(node)"
-           tooltip-placement="bottom" tooltip="Rename folder">
+           tooltip-placement="bottom" uib-tooltip="Rename folder">
         </i>
       </a>
       <!-- if folder is not in trash -->
       <a ng-if="!node.isTrash">
         <i class="fa fa-trash-o notebook-list-btn" ng-show="showFolderButton" ng-click="moveFolderToTrash(node.id)"
-           tooltip-placement="bottom" tooltip="Move folder to Trash">
+           tooltip-placement="bottom" uib-tooltip="Move folder to Trash">
         </i>
       </a>
       <!-- if folder is in trash -->
       <a ng-if="node.isTrash">
         <i class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreFolder(node.id)"
-           tooltip-placement="bottom" tooltip="Restore folder">
+           tooltip-placement="bottom" uib-tooltip="Restore folder">
         </i>
       </a>
       <a ng-if="node.isTrash" style="font-size: 16px">
         <i class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="removeFolder(node.id)"
-           tooltip-placement="bottom" tooltip="Remove folder permanently">
+           tooltip-placement="bottom" uib-tooltip="Remove folder permanently">
         </i>
       </a>
     </div>
@@ -98,11 +98,11 @@ limitations under the License.
       <a style="text-decoration: none;">
         <i style="margin-left: 10px"
            class="fa fa-undo notebook-list-btn" ng-show="showFolderButton" ng-click="restoreAll()"
-           tooltip-placement="bottom" tooltip="Restore all">
+           tooltip-placement="bottom" uib-tooltip="Restore all">
         </i>
         <i style="font-size: 16px;"
            class="fa fa-times notebook-list-btn" ng-show="showFolderButton" ng-click="emptyTrash()"
-           tooltip-placement="bottom" tooltip="Empty trash">
+           tooltip-placement="bottom" uib-tooltip="Empty trash">
         </i>
       </a>
     </div>

--- a/zeppelin-web/src/app/home/notebook.html
+++ b/zeppelin-web/src/app/home/notebook.html
@@ -18,7 +18,7 @@ limitations under the License.
         <i ng-class="isReloadingNotes ? 'fa fa-refresh fa-spin' : 'fa fa-refresh'"
            ng-style="!isReloadingNotes && {'cursor': 'pointer'}" style="font-size: 13px;"
            ng-click="reloadNoteList();"
-           tooltip-placement="bottom" tooltip="Reload notes from storage">
+           tooltip-placement="bottom" uib-tooltip="Reload notes from storage">
          </i>
       </h4>
         <h5><a href="" data-toggle="modal" data-target="#noteImportModal" style="text-decoration: none;">

--- a/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create/interpreter-create.html
@@ -84,7 +84,7 @@ limitations under the License.
                 <li
                   ng-if="getInterpreterRunningOption(setting.id) === 'Globally'">
                   <a style="cursor:pointer"
-                     tooltip="Single interpreter instance are shared across notes"
+                     uib-tooltip="Single interpreter instance are shared across notes"
                      ng-click="setPerNoteOption(setting.id, 'shared')">
                     shared per note
                   </a>
@@ -93,7 +93,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
-                     tooltip="Separate Interpreter instance for each note"
+                     uib-tooltip="Separate Interpreter instance for each note"
                      ng-click="setPerNoteOption(setting.id, 'scoped')">
                     scoped per note
                   </a>
@@ -101,7 +101,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
-                     tooltip="Separate Interpreter instance for each note"
+                     uib-tooltip="Separate Interpreter instance for each note"
                      ng-click="setPerUserOption(setting.id, 'scoped')">
                     scoped per user
                   </a>
@@ -110,7 +110,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
-                     tooltip="Separate Interpreter process for each note"
+                     uib-tooltip="Separate Interpreter process for each note"
                      ng-click="setPerNoteOption(setting.id, 'isolated')">
                     isolated per note
                   </a>
@@ -118,7 +118,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
-                     tooltip="Separate Interpreter process for each note"
+                     uib-tooltip="Separate Interpreter process for each note"
                      ng-click="setPerUserOption(setting.id, 'isolated')">
                     isolated per user
                   </a>
@@ -171,14 +171,14 @@ limitations under the License.
                   <ul class="dropdown-menu" role="menu">
                     <li>
                       <a style="cursor:pointer"
-                         tooltip="Separate Interpreter instance for each note"
+                         uib-tooltip="Separate Interpreter instance for each note"
                          ng-click="setPerNoteOption(setting.id, 'scoped')">
                         scoped per note
                       </a>
                     </li>
                     <li>
                       <a style="cursor:pointer"
-                         tooltip="Separate Interpreter process for each note"
+                         uib-tooltip="Separate Interpreter process for each note"
                          ng-click="setPerNoteOption(setting.id, 'isolated')">
                         isolated per note
                       </a>

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -109,18 +109,18 @@ limitations under the License.
           <small ng-switch="setting.status">
             <small ng-switch-when="READY">
               <i style="color: green; margin-right: 3px;" class="fa fa-circle"
-                 tooltip="Ready">
+                 uib-tooltip="Ready">
               </i>
             </small>
             <small ng-switch-when="ERROR">
               <i style="color: red; cursor: pointer" class="fa fa-circle"
                  ng-click="showErrorMessage(setting)"
-                 tooltip="Error downloading dependencies">
+                 uib-tooltip="Error downloading dependencies">
               </i>
             </small>
             <small ng-switch-default>
               <i style="color: blue" class="fa fa-spinner spinAnimation"
-                 tooltip="Dependencies are downloading">
+                 uib-tooltip="Dependencies are downloading">
               </i>
             </small>
           </small>
@@ -196,7 +196,7 @@ limitations under the License.
                 <li
                   ng-if="getInterpreterRunningOption(setting.id) === 'Globally'">
                   <a style="cursor:pointer"
-                     tooltip="Single interpreter instance are shared across notes"
+                     uib-tooltip="Single interpreter instance are shared across notes"
                      ng-click="setPerNoteOption(setting.id, 'shared')">
                     shared per note
                   </a>
@@ -205,7 +205,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
-                     tooltip="Separate Interpreter instance for each note"
+                     uib-tooltip="Separate Interpreter instance for each note"
                      ng-click="setPerNoteOption(setting.id, 'scoped')">
                     scoped per note
                   </a>
@@ -213,7 +213,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
-                     tooltip="Separate Interpreter instance for each note"
+                     uib-tooltip="Separate Interpreter instance for each note"
                      ng-click="setPerUserOption(setting.id, 'scoped')">
                     scoped per user
                   </a>
@@ -222,7 +222,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per Note'"
-                     tooltip="Separate Interpreter process for each note"
+                     uib-tooltip="Separate Interpreter process for each note"
                      ng-click="setPerNoteOption(setting.id, 'isolated')">
                     isolated per note
                   </a>
@@ -230,7 +230,7 @@ limitations under the License.
                 <li>
                   <a style="cursor:pointer"
                      ng-if="getInterpreterRunningOption(setting.id) === 'Per User'"
-                     tooltip="Separate Interpreter process for each note"
+                     uib-tooltip="Separate Interpreter process for each note"
                      ng-click="setPerUserOption(setting.id, 'isolated')">
                     isolated per user
                   </a>
@@ -285,14 +285,14 @@ limitations under the License.
                 <ul class="dropdown-menu" role="menu">
                   <li>
                     <a style="cursor:pointer"
-                       tooltip="Separate Interpreter instance for each note"
+                       uib-tooltip="Separate Interpreter instance for each note"
                        ng-click="setPerNoteOption(setting.id, 'scoped')">
                       scoped per note
                     </a>
                   </li>
                   <li>
                     <a style="cursor:pointer"
-                       tooltip="Separate Interpreter process for each note"
+                       uib-tooltip="Separate Interpreter process for each note"
                        ng-click="setPerNoteOption(setting.id, 'isolated')">
                       isolated per note
                     </a>

--- a/zeppelin-web/src/app/jobmanager/jobmanager.html
+++ b/zeppelin-web/src/app/jobmanager/jobmanager.html
@@ -39,7 +39,7 @@ limitations under the License.
                   class="btn btn-default"
                   style="width: 25px; height: 25px; margin-right: 0px; padding: 1px 0px 3px 3px"
                   ng-click="onChangeSortAsc()"
-                  tooltip-placement="right" tooltip="{{sortTooltipMsg}}">
+                  tooltip-placement="right" uib-tooltip="{{sortTooltipMsg}}">
             <i class="fa" ng-class="{true: 'fa-sort-amount-asc', false : 'fa-sort-amount-desc'}[filterConfig.isSortByAsc]"></i>
           </button>
         </span>

--- a/zeppelin-web/src/app/jobmanager/jobs/job-control.html
+++ b/zeppelin-web/src/app/jobmanager/jobs/job-control.html
@@ -31,12 +31,12 @@ limitations under the License.
   <!-- Run / Cancel button -->
   <span
     ng-if="!notebookJob.isRunningJob"
-    class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="left" tooltip="START ALL Job"
+    class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="left" uib-tooltip="START ALL Job"
     ng-click="runNotebookJob(notebookJob.noteId)">
   </span>
   <span
     ng-if="notebookJob.isRunningJob"
-    class="icon-control-pause" style="cursor:pointer;color:#3071A9" tooltip-placement="left" tooltip="STOP ALL Job"
+    class="icon-control-pause" style="cursor:pointer;color:#3071A9" tooltip-placement="left" uib-tooltip="STOP ALL Job"
     ng-click="stopNotebookJob(notebookJob.noteId)">
   </span>
 </div>

--- a/zeppelin-web/src/app/jobmanager/jobs/job.html
+++ b/zeppelin-web/src/app/jobmanager/jobs/job.html
@@ -51,7 +51,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: green" class="fa fa-circle-o"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is READY">
+           uib-tooltip="{{paragraphJob.name}} is READY">
         </i>
       </a>
       <a ng-switch-when="FINISHED"
@@ -59,7 +59,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: green" class="fa fa-circle"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is FINISHED">
+           uib-tooltip="{{paragraphJob.name}} is FINISHED">
         </i>
       </a>
       <a ng-switch-when="ABORT"
@@ -67,7 +67,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: orange" class="fa fa-circle"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is ABORT">
+           uib-tooltip="{{paragraphJob.name}} is ABORT">
         </i>
       </a>
       <a ng-switch-when="ERROR"
@@ -75,7 +75,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: red" class="fa fa-circle"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is ERROR">
+           uib-tooltip="{{paragraphJob.name}} is ERROR">
         </i>
       </a>
       <a ng-switch-when="PENDING"
@@ -83,7 +83,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: gray" class="fa fa-circle"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is PENDING">
+           uib-tooltip="{{paragraphJob.name}} is PENDING">
         </i>
       </a>
       <a ng-switch-when="RUNNING"
@@ -91,7 +91,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i style="color: blue" class="fa fa-spinner spinAnimation"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is RUNNING">
+           uib-tooltip="{{paragraphJob.name}} is RUNNING">
         </i>
       </a>
       <a ng-switch-default class="icon-question"
@@ -99,7 +99,7 @@ limitations under the License.
          ng-href="#/notebook/{{notebookJob.noteId}}?paragraph={{paragraphJob.id}}">
         <i class="icon-question"
            tooltip-placement="top-left"
-           tooltip="{{paragraphJob.name}} is {{paragraphJob.status}}">
+           uib-tooltip="{{paragraphJob.name}} is {{paragraphJob.status}}">
         </i>
       </a>
     </span>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -26,7 +26,7 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-click="runAllParagraphs(note.id)"
               ng-class="{'disabled':isNoteRunning()}"
-              tooltip-placement="bottom" tooltip="Run all paragraphs"
+              tooltip-placement="bottom" uib-tooltip="Run all paragraphs"
               ng-disabled="revisionView">
         <i class="icon-control-play"></i>
       </button>
@@ -34,14 +34,14 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-click="toggleAllEditor()"
               ng-hide="viewOnly"
-              tooltip-placement="bottom" tooltip="Show/hide the code"
+              tooltip-placement="bottom" uib-tooltip="Show/hide the code"
               ng-disabled="revisionView">
         <i ng-class="editorToggled ?  'fa icon-size-fullscreen' :'fa icon-size-actual'"></i></button>
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="toggleAllTable()"
               ng-hide="viewOnly"
-              tooltip-placement="bottom" tooltip="Show/hide the output"
+              tooltip-placement="bottom" uib-tooltip="Show/hide the output"
               ng-disabled="revisionView">
         <i ng-class="tableToggled ? 'fa icon-notebook' : 'fa icon-book-open'"></i>
       </button>
@@ -50,7 +50,7 @@ limitations under the License.
               ng-click="clearAllParagraphOutput(note.id)"
               ng-hide="viewOnly"
               ng-class="{'disabled':isNoteRunning()}"
-              tooltip-placement="bottom" tooltip="Clear output"
+              tooltip-placement="bottom" uib-tooltip="Clear output"
               ng-disabled="revisionView">
         <i class="fa fa-eraser"></i>
       </button>
@@ -58,7 +58,7 @@ limitations under the License.
       <button type="button"
               class="btn btn-default btn-xs"
               ng-hide="viewOnly"
-              tooltip-placement="bottom" tooltip="Clone this note" data-source-note-name="{{note.name}}"
+              tooltip-placement="bottom" uib-tooltip="Clone this note" data-source-note-name="{{note.name}}"
               data-toggle="modal" data-target="#noteNameModal" data-clone="true"
               ng-disabled="revisionView">
         <i class="fa fa-copy"></i>
@@ -67,7 +67,7 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-hide="viewOnly"
               ng-click="exportNote()"
-              tooltip-placement="bottom" tooltip="Export this note"
+              tooltip-placement="bottom" uib-tooltip="Export this note"
               ng-disabled="revisionView">
         <i class="fa fa-download"></i>
       </button>
@@ -78,7 +78,7 @@ limitations under the License.
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode !== 'true'"
               ng-click="toggleNotePersonalizedMode()"
-              tooltip-placement="bottom" tooltip="Switch to collaboration mode {{isOwner ? '' : '(owner can change)'}}"
+              tooltip-placement="bottom" uib-tooltip="Switch to collaboration mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
         <i class="fa fa-user"></i>
       </button>
@@ -88,7 +88,7 @@ limitations under the License.
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"
-              tooltip-placement="bottom" tooltip="Switch to personal mode {{isOwner ? '' : '(owner can change)'}}"
+              tooltip-placement="bottom" uib-tooltip="Switch to personal mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
         <i class="fa fa-users"></i>
       </button>
@@ -101,7 +101,7 @@ limitations under the License.
                 id="versionControlDropdown"
                 ng-hide="viewOnly"
                 data-toggle="dropdown"
-                tooltip-placement="bottom" tooltip="Version control"
+                tooltip-placement="bottom" uib-tooltip="Version control"
                 ng-disabled="revisionView">
           <i class="fa fa-file-code-o"></i>
         </button>
@@ -111,7 +111,7 @@ limitations under the License.
                 ng-hide="viewOnly"
                 ng-click="setNoteRevision()"
                 ng-disabled="!revisionView"
-                tooltip-placement="bottom" tooltip="Set revision">
+                tooltip-placement="bottom" uib-tooltip="Set revision">
           <i class="fa fa-arrow-circle-o-right"></i>
         </button>
         <ul class="dropdown-menu" style="width:250px"
@@ -130,7 +130,7 @@ limitations under the License.
                         ng-hide="viewOnly"
                         ng-click="checkpointNote(note.checkpoint.message)"
                         style="margin-left: 4px;"
-                        tooltip-placement="bottom" tooltip="Commit this note">Commit
+                        tooltip-placement="bottom" uib-tooltip="Commit this note">Commit
                 </button>
               </div>
             </div>
@@ -169,7 +169,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
                 ng-hide="viewOnly"
-                tooltip-placement="bottom" tooltip="Remove this note permanently"
+                tooltip-placement="bottom" uib-tooltip="Remove this note permanently"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>
         </button>
@@ -179,7 +179,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"
                 ng-hide="viewOnly"
-                tooltip-placement="bottom" tooltip="Move this note to trash"
+                tooltip-placement="bottom" uib-tooltip="Move this note to trash"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>
         </button>
@@ -191,7 +191,7 @@ limitations under the License.
              type="button"
              data-toggle="dropdown"
              ng-class="{ 'btn-info' : note.config.cron, 'btn-danger' : note.info.cron, 'btn-default' : !note.config.cron}"
-             tooltip-placement="bottom" tooltip="Run scheduler"
+             tooltip-placement="bottom" uib-tooltip="Run scheduler"
              ng-disabled="revisionView">
           <span class="fa fa-clock-o"></span> {{getCronOptionNameFromValue(note.config.cron)}}
         </div>
@@ -244,19 +244,19 @@ limitations under the License.
               type="button"
               data-toggle="modal"
               data-target="#shortcutModal"
-              tooltip-placement="bottom" tooltip="List of shortcut">
+              tooltip-placement="bottom" uib-tooltip="List of shortcut">
           <i class="fa fa-keyboard-o"></i>
         </span>
         <span class="setting-btn"
               type="button"
               ng-click="toggleSetting()"
-              tooltip-placement="bottom" tooltip="Interpreter binding">
+              tooltip-placement="bottom" uib-tooltip="Interpreter binding">
           <i class="fa fa-cog" ng-style="{color: showSetting ? '#3071A9' : 'black' }"></i>
         </span>
         <span class="setting-btn"
               type="button"
               ng-click="togglePermissions()"
-              tooltip-placement="bottom" tooltip="Note permissions">
+              tooltip-placement="bottom" uib-tooltip="Note permissions">
           <i class="fa fa-lock" ng-style="{color: showPermissions ? '#3071A9' : 'black' }"></i>
         </span>
       </span>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -35,7 +35,7 @@ limitations under the License.
           <div>
             <a ng-click="restartInterpreter(item)"
                ng-class="{'inactivelink': !item.selected}"
-               tooltip="Restart">
+               uib-tooltip="Restart">
               <span class="glyphicon glyphicon-refresh btn-md"></span>
             </a>&nbsp
             <div as-sortable-item-handle

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -16,13 +16,13 @@ limitations under the License.
   <span>
     <span ng-show="paragraph.runtimeInfos.jobUrl.values.length == 1">
       <a href="{{paragraph.runtimeInfos.jobUrl.values[0]}}" target="_blank" style="text-decoration: none;"
-         tooltip-placement="top" tooltip="{{paragraph.runtimeInfos.jobUrl.tooltip}}" >
+         tooltip-placement="top" uib-tooltip="{{paragraph.runtimeInfos.jobUrl.tooltip}}" >
         <span class="fa fa-tasks"></span>
         {{paragraph.runtimeInfos.jobUrl.label}}
       </a>
     </span>
     <span class="dropdown" ng-show="paragraph.runtimeInfos.jobUrl.values.length > 1">
-      <span style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="{{paragraph.runtimeInfos.jobUrl.tooltip}}"
+      <span style="cursor:pointer;color:#3071A9" tooltip-placement="top" uib-tooltip="{{paragraph.runtimeInfos.jobUrl.tooltip}}"
             data-toggle="dropdown" type="button">
         <span class="fa fa-tasks"></span>
         {{paragraph.runtimeInfos.jobUrl.label}}S
@@ -44,18 +44,18 @@ limitations under the License.
 
   <!-- Run / Cancel button -->
   <span ng-if="!revisionView">
-    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
+    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" uib-tooltip="Run this paragraph (Shift+Enter)"
           ng-click="runParagraphFromButton(getEditorValue())"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top"
-          tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
+          uib-tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
           ng-click="cancelParagraph(paragraph)"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
     <span ng-show="paragraph.runtimeInfos.jobUrl.length == 1">
       <a href="{{paragraph.runtimeInfos.jobUrl[0]}}" target="_blank"><span class="fa fa-tasks"></span> Spark job </a>
     </span>
     <span class="dropdown" ng-show="paragraph.runtimeInfos.jobUrl.length > 1">
-      <span class="fa fa-tasks" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
+      <span class="fa fa-tasks" style="cursor:pointer;color:#3071A9" tooltip-placement="top" uib-tooltip="Run this paragraph (Shift+Enter)"
           data-toggle="dropdown"
           type="button">  Spark Jobs
       </span>
@@ -66,10 +66,10 @@ limitations under the License.
       </ul>
     </span>
     <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" style="cursor:pointer" tooltip-placement="top"
-          tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+E)"
+          uib-tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+E)"
           ng-click="toggleEditor(paragraph)"></span>
     <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" style="cursor:pointer" tooltip-placement="top"
-          tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide')}} output (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+O)"
+          uib-tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide')}} output (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+O)"
           ng-click="toggleOutput(paragraph)"></span>
     <span class="dropdown navbar-right">
       <span class="icon-settings" style="cursor:pointer"
@@ -84,7 +84,7 @@ limitations under the License.
               ngclipboard-error="clipError($event)"
               data-clipboard-text="{{paragraph.id}}"
               tooltip-placement="top"
-              tooltip="{{tooltip}}">
+              uib-tooltip="{{tooltip}}">
             <span>{{paragraph.id}}</span>
           </a>
         </li>
@@ -96,7 +96,7 @@ limitations under the License.
           <form style="display:inline; float:right">
             <input type="checkbox"
                    style="width:16px; margin-right:20px"
-                   tooltip-placement="top" tooltip="Even if you uncheck this, still can run the paragraph by pressing Enter"
+                   tooltip-placement="top" uib-tooltip="Even if you uncheck this, still can run the paragraph by pressing Enter"
                    ng-checked="{{paragraph.config.runOnSelectionChange}}"
                    ng-click="turnOnAutoRun(paragraph)"/>
           </form>

--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -21,6 +21,7 @@ limitations under the License.
             ng-repeat="viz in builtInTableDataVisualizationList track by $index"
             ng-class="{'active' : viz.id == graphMode && !config.helium.activeApp}"
             ng-click="switchViz(viz.id)"
+            tooltip-placement="bottom" uib-tooltip="{{viz.name ? viz.name : ''}}"
             ng-bind-html="viz.icon">
     </button>
   </div>

--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -77,7 +77,7 @@ limitations under the License.
   <button type="button" class="btn btn-default btn-sm"
           style="margin-left:10px"
           ng-click="exportToDSV(',')"
-          tooltip="Download Data as CSV" tooltip-placement="bottom">
+          uib-tooltip="Download Data as CSV" tooltip-placement="bottom">
     <i class="fa fa-download"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm dropdown-toggle caretBtn"

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -56,14 +56,14 @@ limitations under the License.
       <div class="fa fa-level-down scroll-paragraph-down"
            ng-show="showScrollDownIcon()"
            ng-click="scrollParagraphDown()"
-           tooltip="Follow Output"></div>
+           uib-tooltip="Follow Output"></div>
       <div id="p{{id}}_text"
            style="max-height: {{config.graph.height}}px; overflow: auto"
            class="text plainTextContent"></div>
       <div class="fa fa-chevron-up scroll-paragraph-up"
            ng-show="showScrollUpIcon()"
            ng-click="scrollParagraphUp()"
-           tooltip="Scroll Top"></div>
+           uib-tooltip="Scroll Top"></div>
     </div>
 
     <div id="p{{id}}_custom" class="resultContained"

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -80,9 +80,9 @@ limitations under the License.
         <li style="margin-left: 10px;">
           <div class="dropdown">
             <i ng-if="navbar.connected" class="fa fa-circle server-connected"
-               tooltip="WebSocket Connected" tooltip-placement="bottom" style="margin-top: 7px; margin-right: 0px; vertical-align: top"></i>
+               uib-tooltip="WebSocket Connected" tooltip-placement="bottom" style="margin-top: 7px; margin-right: 0px; vertical-align: top"></i>
             <i ng-if="!navbar.connected" class="fa fa-circle server-disconnected"
-               tooltip="WebSocket Disconnected" tooltip-placement="bottom" style="margin-top: 7px; vertical-align: top"></i>
+               uib-tooltip="WebSocket Disconnected" tooltip-placement="bottom" style="margin-top: 7px; vertical-align: top"></i>
             <button ng-if="ticket" class="nav-btn dropdown-toggle" type="button" data-toggle="dropdown" style="margin:11px 5px 0 0; padding-left: 0px;">
               <span class="username">{{ticket.principal}}</span>
               <span class="caret" style="margin-bottom: 8px"></span>


### PR DESCRIPTION
### What is this PR for?

tooltip provided by [angular-ui: bootstrap](https://github.com/angular-ui/bootstrap) doesn't work with `btn-group` class. 

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - fixed tooltip issue by bumping version of angular-bootstrap
* [x] - added tooltip to charts as like before 

### What is the Jira issue?

[ZEPPELIN-2357](https://issues.apache.org/jira/browse/ZEPPELIN-2357)

### How should this be tested?

1. Open spark tutorial
2. Test tooltips in notebook controller and in paragraphs.

### Screenshots (if appropriate)

#### Before

![tooltip_before](https://cloud.githubusercontent.com/assets/4968473/24699102/dc76be40-1a2d-11e7-9ae3-b550a1739ca8.gif)


#### After

![tooltip_after1](https://cloud.githubusercontent.com/assets/4968473/24699105/dfaa5716-1a2d-11e7-8d8a-0576fb307200.gif)

![tooltip_after2](https://cloud.githubusercontent.com/assets/4968473/24699111/e429454a-1a2d-11e7-97cc-09bd77dcc4ca.gif)

### Questions:
* Does the licenses files need update? - YES, updated
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
