### PR TITLE
[MINOR] Add paragraph to note

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -341,11 +341,11 @@ public class NotebookRestApi {
     List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
     if (initialParagraphs != null) {
       for (NewParagraphRequest paragraphRequest : initialParagraphs) {
-        Paragraph p = note.addParagraph(subject);
+        Paragraph p = note.addNewParagraph(subject);
         initParagraph(p, paragraphRequest, user);
       }
     }
-    note.addParagraph(subject); // add one paragraph to the last
+    note.addNewParagraph(subject); // add one paragraph to the last
     String noteName = request.getName();
     if (noteName.isEmpty()) {
       noteName = "Note " + note.getId();
@@ -433,9 +433,9 @@ public class NotebookRestApi {
     Paragraph p;
     Double indexDouble = request.getIndex();
     if (indexDouble == null) {
-      p = note.addParagraph(subject);
+      p = note.addNewParagraph(subject);
     } else {
-      p = note.insertParagraph(indexDouble.intValue(), subject);
+      p = note.insertNewParagraph(indexDouble.intValue(), subject);
     }
     initParagraph(p, request, user);
     note.persist(subject);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -37,7 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
-import com.google.gson.*;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -1004,7 +1003,7 @@ public class NotebookServer extends WebSocketServlet
         note = notebook.createNote(subject);
       }
 
-      note.addParagraph(subject); // it's an empty note. so add one paragraph
+      note.addNewParagraph(subject); // it's an empty note. so add one paragraph
       if (message != null) {
         String noteName = (String) message.get("name");
         if (StringUtils.isEmpty(noteName)) {
@@ -1568,7 +1567,7 @@ public class NotebookServer extends WebSocketServlet
       return null;
     }
 
-    Paragraph newPara = note.insertParagraph(index, subject);
+    Paragraph newPara = note.insertNewParagraph(index, subject);
     note.persist(subject);
     broadcastNewParagraph(note, newPara);
 
@@ -1713,7 +1712,7 @@ public class NotebookServer extends WebSocketServlet
     if (!(p.getText().trim().equals(p.getMagic()) ||
         Strings.isNullOrEmpty(p.getText())) &&
         isTheLastParagraph) {
-      Paragraph newPara = note.addParagraph(p.getAuthenticationInfo());
+      Paragraph newPara = note.addNewParagraph(p.getAuthenticationInfo());
       broadcastNewParagraph(note, newPara);
     }
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -242,7 +242,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   public void testInterpreterRestart() throws IOException, InterruptedException {
     // when: create new note
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();
     config.put("enabled", true);
@@ -269,7 +269,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
     }
 
     // when: run markdown paragraph, again
-    p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setConfig(config);
     p.setText("%md markdown restarted");
     p.setAuthenticationInfo(anonymous);
@@ -287,7 +287,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   public void testRestartInterpreterPerNote() throws IOException, InterruptedException {
     // when: create new note
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Paragraph p = note.getLastParagraph();
     Map config = p.getConfig();
     config.put("enabled", true);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.rest;
 
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -72,7 +71,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   @Test
   public void testGetNoteParagraphJobStatus() throws IOException {
     Note note1 = ZeppelinServer.notebook.createNote(anonymous);
-    note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     String paragraphId = note1.getLastParagraph().getId();
 
@@ -94,9 +93,9 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   @Test
   public void testRunParagraphJob() throws IOException {
     Note note1 = ZeppelinServer.notebook.createNote(anonymous);
-    note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Paragraph p = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // run blank paragraph
     PostMethod post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
@@ -150,7 +149,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   public void testUpdateParagraphConfig() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     String noteId = note.getId();
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     assertNull(p.getConfig().get("colWidth"));
     String paragraphId = p.getId();
     String jsonRequest = "{\"colWidth\": 6.0}";
@@ -176,11 +175,11 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   public void testClearAllParagraphOutput() throws IOException {
     // Create note and set result explicitly
     Note note = ZeppelinServer.notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
     p1.setResult(result);
 
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setReturn(result, new Throwable());
 
     // clear paragraph result

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -88,7 +87,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -228,7 +227,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("source note for export");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -261,7 +260,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName(noteName);
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -323,7 +322,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("source note for clone");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = paragraph.getConfig();
     config.put("enabled", true);
     paragraph.setConfig(config);
@@ -374,7 +373,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -429,7 +428,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -483,7 +482,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
     assertNotNull("can't create new note", note);
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     Map config = paragraph.getConfig();
     config.put("enabled", true);
@@ -527,7 +526,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("%md This is test paragraph.");
     
     Map config = paragraph.getConfig();
@@ -576,7 +575,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
     note.setName("note for run test");
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
 
     note.persist(anonymous);
@@ -656,7 +655,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testGetParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("hello");
     p.setText("world");
     note.persist(anonymous);
@@ -685,11 +684,11 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testMoveParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("title1");
     p.setText("text1");
 
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setTitle("title2");
     p2.setText("text2");
 
@@ -717,7 +716,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   public void testDeleteParagraph() throws IOException {
     Note note = ZeppelinServer.notebook.createNote(anonymous);
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setTitle("title1");
     p.setText("text1");
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -80,7 +80,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     public void scalaOutputTest() throws IOException {
         // create new note
         Note note = ZeppelinServer.notebook.createNote(anonymous);
-        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config = p.getConfig();
         config.put("enabled", true);
         p.setConfig(config);
@@ -106,7 +106,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         Note note = ZeppelinServer.notebook.createNote(anonymous);
 
         // run markdown paragraph, again
-        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config = p.getConfig();
         config.put("enabled", true);
         p.setConfig(config);
@@ -127,7 +127,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         // DataFrame API is available from spark 1.3
         if (sparkVersion >= 13) {
             // test basic dataframe api
-            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -141,7 +141,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                     "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
 
             // test display DataFrame
-            p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -156,7 +156,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
             // test display DataSet
             if (sparkVersion >= 20) {
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -195,7 +195,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         if (sparkVersion >= 20) {
           sqlContextName = "spark";
         }
-        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config = p.getConfig();
         config.put("enabled", true);
         p.setConfig(config);
@@ -222,7 +222,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
         if (isPyspark() && sparkVersion >= 12) {   // pyspark supported from 1.2.1
             // run markdown paragraph, again
-            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -234,7 +234,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             assertEquals("55\n", p.getResult().message().get(0).getData());
             if (sparkVersion >= 13) {
                 // run sqlContext test
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -248,7 +248,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("[Row(age=20, id=1)]\n", p.getResult().message().get(0).getData());
 
                 // test display Dataframe
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -264,7 +264,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("age\tid\n20\t1\n", p.getResult().message().get(0).getData());
 
                 // test udf
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -278,7 +278,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             }
             if (sparkVersion >= 20) {
                 // run SparkSession test
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -292,7 +292,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 assertEquals("[Row(age=20, id=1)]\n", p.getResult().message().get(0).getData());
 
                 // test udf
-                p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+                p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
                 config = p.getConfig();
                 config.put("enabled", true);
                 p.setConfig(config);
@@ -319,7 +319,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
         if (isPyspark() && sparkVersionNumber >= 14) {   // auto_convert enabled from spark 1.4
             // run markdown paragraph, again
-            Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p.getConfig();
             config.put("enabled", true);
             p.setConfig(config);
@@ -344,19 +344,19 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     public void zRunTest() throws IOException {
         // create new note
         Note note = ZeppelinServer.notebook.createNote(anonymous);
-        Paragraph p0 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config0 = p0.getConfig();
         config0.put("enabled", true);
         p0.setConfig(config0);
         p0.setText("%spark z.run(1)");
         p0.setAuthenticationInfo(anonymous);
-        Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config1 = p1.getConfig();
         config1.put("enabled", true);
         p1.setConfig(config1);
         p1.setText("%spark val a=10");
         p1.setAuthenticationInfo(anonymous);
-        Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config2 = p2.getConfig();
         config2.put("enabled", true);
         p2.setConfig(config2);
@@ -374,7 +374,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         assertEquals(Status.FINISHED, p2.getStatus());
         assertEquals("10", p2.getResult().message().get(0).getData());
 
-        Paragraph p3 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p3 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         Map config3 = p3.getConfig();
         config3.put("enabled", true);
         p3.setConfig(config3);
@@ -424,7 +424,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             }
 
             // load dep
-            Paragraph p0 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             Map config = p0.getConfig();
             config.put("enabled", true);
             p0.setConfig(config);
@@ -439,7 +439,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             FileUtils.write(tmpFile, "a,b\n1,2");
 
             // load data using libraries from dep loader
-            Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+            Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
             p1.setConfig(config);
 
             String sqlContextName = "sqlContext";
@@ -465,7 +465,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
      * eg. 1.1.x => 11, 1.2.x => 12, 1.3.x => 13 ...
      */
     private int getSparkVersionNumber(Note note) {
-        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         note.setName("note");
         Map config = p.getConfig();
         config.put("enabled", true);
@@ -485,7 +485,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     @Test
     public void testZeppelinContextDynamicForms() throws IOException {
         Note note = ZeppelinServer.notebook.createNote(anonymous);
-        Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
         note.setName("note");
         Map config = p.getConfig();
         config.put("enabled", true);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -110,7 +110,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     }
 
     // start interpreter process
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%md start remote interpreter process");
     p1.setAuthenticationInfo(anonymous);
     note1.run(p1.getId());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -341,17 +341,30 @@ public class Note implements Serializable, ParagraphJobListener {
    * @param index index of paragraphs
    */
   public Paragraph insertNewParagraph(int index, AuthenticationInfo authenticationInfo) {
+    Paragraph paragraph = createParagraph(index, authenticationInfo);
+    insertParagraph(paragraph, index);
+    return paragraph;
+  }
+
+  private Paragraph createParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory, interpreterSettingManager);
     p.setAuthenticationInfo(authenticationInfo);
-    setParagraphMagic(p, index);
-    synchronized (paragraphs) {
-      paragraphs.add(index, p);
-    }
     p.addUser(p, p.getUser());
-    if (noteEventListener != null) {
-      noteEventListener.onParagraphCreate(p);
-    }
+    setParagraphMagic(p, index);
     return p;
+  }
+
+  public void addParagraph(Paragraph paragraph) {
+    insertParagraph(paragraph, paragraphs.size());
+  }
+
+  public void insertParagraph(Paragraph paragraph, int index) {
+    synchronized (paragraphs) {
+      paragraphs.add(index, paragraph);
+    }
+    if (noteEventListener != null) {
+      noteEventListener.onParagraphCreate(paragraph);
+    }
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -292,16 +292,7 @@ public class Note implements Serializable, ParagraphJobListener {
    * Create a new paragraph and add it to the end of the note.
    */
   public Paragraph addNewParagraph(AuthenticationInfo authenticationInfo) {
-    Paragraph p = new Paragraph(this, this, factory, interpreterSettingManager);
-    p.setAuthenticationInfo(authenticationInfo);
-    setParagraphMagic(p, paragraphs.size());
-    synchronized (paragraphs) {
-      paragraphs.add(p);
-    }
-    if (noteEventListener != null) {
-      noteEventListener.onParagraphCreate(p);
-    }
-    return p;
+    return insertNewParagraph(paragraphs.size(), authenticationInfo);
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -289,9 +289,9 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   /**
-   * Add paragraph last.
+   * Create a new paragraph and add it to the end of the note.
    */
-  public Paragraph addParagraph(AuthenticationInfo authenticationInfo) {
+  public Paragraph addNewParagraph(AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory, interpreterSettingManager);
     p.setAuthenticationInfo(authenticationInfo);
     setParagraphMagic(p, paragraphs.size());
@@ -345,11 +345,11 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   /**
-   * Insert paragraph in given index.
+   * Create a new paragraph and insert it to the note in given index.
    *
    * @param index index of paragraphs
    */
-  public Paragraph insertParagraph(int index, AuthenticationInfo authenticationInfo) {
+  public Paragraph insertNewParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory, interpreterSettingManager);
     p.setAuthenticationInfo(authenticationInfo);
     setParagraphMagic(p, index);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -153,7 +153,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note1.getId(),interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -199,7 +199,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note1.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -239,7 +239,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
     notebook.bindInterpretersToNote("user", note1.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");
@@ -270,7 +270,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
     Note note1 = notebook.createNote(anonymous);
 
     // add paragraph with invalid magic
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%fake ");
 
     // make sure that p1's repl is null
@@ -307,7 +307,7 @@ public class HeliumApplicationFactoryTest implements JobListenerFactory {
       }
     }
 
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
     p1.setText("%mock1 job");

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -74,7 +74,7 @@ public class NoteTest {
     String pText = "%spark sc.version";
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(pText);
     p.setAuthenticationInfo(anonymous);
     note.run(p.getId());
@@ -90,7 +90,7 @@ public class NoteTest {
   public void addParagraphWithEmptyReplNameTest() {
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     assertNull(p.getText());
   }
 
@@ -99,9 +99,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%spark ");
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     assertEquals("%spark\n", p2.getText());
   }
@@ -111,9 +111,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("spark"))).thenReturn(interpreter);
 
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%spark ");
-    Paragraph p2 = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.insertNewParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
 
     assertEquals("%spark\n", p2.getText());
   }
@@ -123,9 +123,9 @@ public class NoteTest {
     when(interpreterFactory.getInterpreter(anyString(), anyString(), eq("invalid"))).thenReturn(null);
 
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("%invalid ");
-    Paragraph p2 = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.insertNewParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
 
     assertNull(p2.getText());
   }
@@ -133,7 +133,7 @@ public class NoteTest {
   @Test
   public void insertParagraphwithUser() {
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p = note.insertParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.insertNewParagraph(note.getParagraphs().size(), AuthenticationInfo.ANONYMOUS);
     assertEquals("anonymous", p.getUser());
   }
 
@@ -143,11 +143,11 @@ public class NoteTest {
     when(interpreter.getScheduler()).thenReturn(scheduler);
 
     Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS, InterpreterResult.Type.TEXT, "result");
     p1.setResult(result);
 
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setReturn(result, new Throwable());
 
     note.clearAllParagraphOutput();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -128,7 +128,7 @@ public class NotebookTest implements JobListenerFactory{
     interpreterSettingManager.setInterpreters(anonymous.getUser(), note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
     // run with default repl
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -139,7 +139,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals("repl1: hello world", p1.getResult().message().get(0).getData());
 
     // run with specific repl
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setConfig(config);
     p2.setText("%mock2 hello world");
     p2.setAuthenticationInfo(anonymous);
@@ -219,7 +219,7 @@ public class NotebookTest implements JobListenerFactory{
     try {
       assertEquals(0, notebook.getAllNotes().size());
       note = notebook.createNote(anonymous);
-      Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
       Map config = p1.getConfig();
       config.put("enabled", true);
       p1.setConfig(config);
@@ -242,7 +242,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
 
     // run with default repl
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -274,7 +274,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException{
     Note note = notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -294,7 +294,7 @@ public class NotebookTest implements JobListenerFactory{
   @Test
   public void testRunBlankParagraph() throws IOException, SchedulerException, InterruptedException {
     Note note = notebook.createNote(anonymous);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("");
     p1.setAuthenticationInfo(anonymous);
     note.run(p1.getId());
@@ -311,21 +311,21 @@ public class NotebookTest implements JobListenerFactory{
     interpreterSettingManager.setInterpreters("user", note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
     // p1
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config1 = p1.getConfig();
     config1.put("enabled", true);
     p1.setConfig(config1);
     p1.setText("p1");
 
     // p2
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config2 = p2.getConfig();
     config2.put("enabled", false);
     p2.setConfig(config2);
     p2.setText("p2");
 
     // p3
-    Paragraph p3 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p3 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p3.setText("p3");
 
     // when
@@ -349,7 +349,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = new HashMap<>();
     p.setConfig(config);
     p.setText("p1");
@@ -400,7 +400,7 @@ public class NotebookTest implements JobListenerFactory{
   }
 
   private void executeNewParagraphByCron(Note note, String cron) {
-    Paragraph paragraph = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     paragraph.setText("p");
     Map<String, Object> config = note.getConfig();
     config.put("enabled", true);
@@ -422,12 +422,12 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters(anonymous.getUser(), note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
     
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = new HashMap<>();
     p.setConfig(config);
     p.setText("sleep 1000");
 
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setConfig(config);
     p2.setText("%mock2 sleep 500");
 
@@ -475,7 +475,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     String simpleText = "hello world";
     p.setText(simpleText);
 
@@ -514,7 +514,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
     note.runAll();
     while(p.isTerminated()==false || p.getResult()==null) Thread.yield();
@@ -560,7 +560,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters(anonymous.getUser(), note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    final Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
     note.runAll();
     while (p.isTerminated() == false || p.getResult() == null) {
@@ -587,9 +587,9 @@ public class NotebookTest implements JobListenerFactory{
     for (InterpreterGroup intpGroup : InterpreterGroup.getAll()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
     }
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("hello");
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p2.setText("%mock2 world");
 
     note.runAll();
@@ -618,7 +618,7 @@ public class NotebookTest implements JobListenerFactory{
         .getInterpreterSettings(note.getId()).get(0).getInterpreterGroup(anonymous.getUser(), "sharedProcess")
         .getAngularObjectRegistry();
 
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // add paragraph scope object
     registry.add("o1", "object1", note.getId(), p1.getId());
@@ -651,7 +651,7 @@ public class NotebookTest implements JobListenerFactory{
         .getInterpreterSettings(note.getId()).get(0).getInterpreterGroup(anonymous.getUser(), "sharedProcess")
         .getAngularObjectRegistry();
 
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // add paragraph scope object
     registry.add("o1", "object1", note.getId(), p1.getId());
@@ -797,11 +797,11 @@ public class NotebookTest implements JobListenerFactory{
     interpreterSettingManager.setInterpreters(anonymous.getUser(), note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
     // create three paragraphs
-    Paragraph p1 = note.addParagraph(anonymous);
+    Paragraph p1 = note.addNewParagraph(anonymous);
     p1.setText("sleep 1000");
-    Paragraph p2 = note.addParagraph(anonymous);
+    Paragraph p2 = note.addNewParagraph(anonymous);
     p2.setText("sleep 1000");
-    Paragraph p3 = note.addParagraph(anonymous);
+    Paragraph p3 = note.addNewParagraph(anonymous);
     p3.setText("sleep 1000");
 
 
@@ -829,7 +829,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException {
     // create a notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
 
@@ -846,7 +846,7 @@ public class NotebookTest implements JobListenerFactory{
     // remove note and recreate
     notebook.removeNote(note1.getId(), anonymous);
     note1 = notebook.createNote(anonymous);
-    p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
 
@@ -861,10 +861,10 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreter() throws IOException {
     // create two notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     Note note2  = notebook.createNote(anonymous);
-    Paragraph p2 = note2.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
@@ -905,10 +905,10 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerNoteSessionInterpreter() throws IOException {
     // create two notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     Note note2  = notebook.createNote(anonymous);
-    Paragraph p2 = note2.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     p1.setText("getId");
     p1.setAuthenticationInfo(anonymous);
@@ -964,7 +964,7 @@ public class NotebookTest implements JobListenerFactory{
   public void testPerSessionInterpreterCloseOnUnbindInterpreterSetting() throws IOException {
     // create a notes
     Note note1  = notebook.createNote(anonymous);
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setAuthenticationInfo(anonymous);
     p1.setText("getId");
 
@@ -1034,7 +1034,7 @@ public class NotebookTest implements JobListenerFactory{
     Note note1 = notebook.createNote(anonymous);
     assertEquals(1, onNoteCreate.get());
 
-    Paragraph p1 = note1.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     assertEquals(1, onParagraphCreate.get());
 
     note1.addCloneParagraph(p1);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -28,8 +28,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
-import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
-import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -143,7 +141,7 @@ public class GitNotebookRepoTest {
 
     //modify, save and checkpoint first note
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -158,7 +156,7 @@ public class GitNotebookRepoTest {
 
     //modify, save and checkpoint second note
     note = notebookRepo.get(TEST_NOTE_ID2, null);
-    p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     config = p.getConfig();
     config.put("enabled", false);
     p.setConfig(config);
@@ -184,7 +182,7 @@ public class GitNotebookRepoTest {
     
     // add changes to note
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -223,7 +221,7 @@ public class GitNotebookRepoTest {
 
     // add paragraph and save
     Note note = notebookRepo.get(TEST_NOTE_ID, null);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -245,7 +243,7 @@ public class GitNotebookRepoTest {
     assertThat(note.getParagraphs().size()).isEqualTo(paragraphCount_2);
 
     // add one more paragraph and save
-    Paragraph p2 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     config.put("enabled", false);
     p2.setConfig(config);
     p2.setText("get revision when modified note test text");
@@ -281,7 +279,7 @@ public class GitNotebookRepoTest {
     assertThat(note.getParagraphs().size()).isEqualTo(paragraphCount_1);
 
     // add one more paragraph and save
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -323,7 +321,7 @@ public class GitNotebookRepoTest {
     assertThat(notebookRepo.revisionHistory(TEST_NOTE_ID, null).size()).isEqualTo(1);
     
     // add one more paragraph and save
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -162,7 +162,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     
     /* create note */
     Note note = notebookSync.createNote(anonymous);
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);
@@ -299,7 +299,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     int vCount = gitRepo.revisionHistory(noteId, anonymous).size();
     assertThat(vCount).isEqualTo(1);
     
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p.getConfig();
     config.put("enabled", true);
     p.setConfig(config);
@@ -333,7 +333,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(0, authInfo.getWriters(note.getId()).size());
     
     /* update note and save on secondary storage */
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p1.setText("hello world");
     assertEquals(1, note.getParagraphs().size());
     notebookRepoSync.save(1, note, null);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -133,7 +133,7 @@ public class VFSNotebookRepoTest implements JobListenerFactory {
     Note note = notebook.createNote(anonymous);
     interpreterSettingManager.setInterpreters("user", note.getId(), interpreterSettingManager.getDefaultInterpreterSettingList());
 
-    Paragraph p1 = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     Map<String, Object> config = p1.getConfig();
     config.put("enabled", true);
     p1.setConfig(config);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -278,13 +278,13 @@ public class LuceneSearchTest {
   }
 
   private Paragraph addParagraphWithText(Note note, String text) {
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(text);
     return p;
   }
 
   private Paragraph addParagraphWithTextAndTitle(Note note, String text, String title) {
-    Paragraph p = note.addParagraph(AuthenticationInfo.ANONYMOUS);
+    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(text);
     p.setTitle(title);
     return p;


### PR DESCRIPTION
### What is this PR for?
We need to add an ability of adding custom _Paragraph_ to a _Note_. This will make it easier to write _Note_ and _Paragraph_ tests. At the moment all paragraphs are created inside _Note_ class.

This refactoring will allow to write a test for [ZEPPELIN-1856](https://issues.apache.org/jira/browse/ZEPPELIN-1856) issue.


### What type of PR is it?
[Refactoring]

### Todos
* [x] - Rename `addParagraph()` -> `addNewParagraph()` and `insertParagraph()` -> `insertNewParagraph()`. These names will describe what mathods do: create new paragraph and add it to the note.
* [x] - Remove duplicated code from `addNewParagraph()` and `insertNewParagraph()` methods.
* [x] - Add methods `addParagraph()` and `insertParagraph()`, which receive a _Paragraph_ instance in parameters and add it to the _Note_.

### Questions:
* Does the licenses files need update? **no**
* Is there breaking changes for older versions? **no**
* Does this needs documentation? **no**
