### PR TITLE
ZEPPELIN-2377. Hive Support can not be enabled in spark master

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -246,7 +246,7 @@ public class SparkInterpreter extends Interpreter {
    */
   private boolean hiveClassesArePresent() {
     try {
-      this.getClass().forName("org.apache.spark.sql.hive.HiveSessionState");
+      this.getClass().forName("org.apache.spark.sql.hive.execution.InsertIntoHiveTable");
       this.getClass().forName("org.apache.hadoop.hive.conf.HiveConf");
       return true;
     } catch (ClassNotFoundException | NoClassDefFoundError e) {


### PR DESCRIPTION
### What is this PR for?
The root cause is that `org.apache.spark.sql.hive.HiveSessionState` is removed in spark master. I change it to `org.apache.spark.sql.hive.execution.InsertIntoHiveTable` which is existed early in spark 1.0. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2377

### How should this be tested?
Verify it manually in spark master, spark 2.1.0 and spark 1.6.2 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
