### PR TITLE
0.7.1 with ssl

### DIFF
--- a/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
+++ b/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
@@ -48,8 +48,8 @@ public class CassandraInterpreter extends Interpreter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CassandraInterpreter.class);
 
-  public static final String CASSANDRA_INTERPRETER_PARALLELISM = "cassandra.interpreter" +
-          ".parallelism";
+  public static final String CASSANDRA_INTERPRETER_PARALLELISM =
+          "cassandra.interpreter.parallelism";
   public static final String CASSANDRA_HOSTS = "cassandra.hosts";
   public static final String CASSANDRA_PORT = "cassandra.native.port";
   public static final String CASSANDRA_PROTOCOL_VERSION = "cassandra.protocol.version";
@@ -174,7 +174,8 @@ public class CassandraInterpreter extends Interpreter {
       hosts.append(address).append(",");
     }
 
-    LOGGER.info("Bootstrapping Cassandra Java Driver to connect to " + hosts.toString() + "on port " + port);
+    LOGGER.info("Bootstrapping Cassandra Java Driver to connect to " + hosts.toString() +
+            "on port " + port);
 
     Compression compression = driverConfig.getCompressionProtocol(this);
 
@@ -214,7 +215,9 @@ public class CassandraInterpreter extends Interpreter {
           sslContext = SSLContext.getInstance("TLS");
           sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
         }
-        clusterBuilder = clusterBuilder.withSSL(JdkSSLOptions.builder().withSSLContext(sslContext).build());
+        clusterBuilder = clusterBuilder.withSSL(JdkSSLOptions.builder()
+                .withSSLContext(sslContext)
+                .build());
       } catch (Exception e) {
         LOGGER.error(e.toString());
       }
@@ -263,11 +266,5 @@ public class CassandraInterpreter extends Interpreter {
     return SchedulerFactory.singleton()
             .createOrGetParallelScheduler(CassandraInterpreter.class.getName() + this.hashCode(),
                     parseInt(getProperty(CASSANDRA_INTERPRETER_PARALLELISM)));
-  }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-    this.close();
   }
 }

--- a/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
+++ b/cassandra/src/main/java/org/apache/zeppelin/cassandra/CassandraInterpreter.java
@@ -197,7 +197,8 @@ public class CassandraInterpreter extends Interpreter {
             .withQueryOptions(driverConfig.getQueryOptions(this))
             .withSocketOptions(driverConfig.getSocketOptions(this));
 
-    if (getProperty(CASSANDRA_WITH_SSL).equals("true")) {
+    final String runWithSSL = getProperty(CASSANDRA_WITH_SSL);
+    if (runWithSSL != null && runWithSSL.equals("true")) {
       LOGGER.debug("Cassandra Interpreter: Using SSL");
 
       try {

--- a/cassandra/src/main/resources/interpreter-setting.json
+++ b/cassandra/src/main/resources/interpreter-setting.json
@@ -189,6 +189,24 @@
         "propertyName": "cassandra.socket.tcp.no_delay",
         "defaultValue": "true",
         "description": "Cassandra socket TCP no delay. Default = true"
+      },
+      "cassandra.ssl.enabled": {
+        "envName": null,
+        "propertyName": "cassandra.ssl.enabled",
+        "defaultValue": "false",
+        "description": "Cassandra SSL"
+      },
+      "cassandra.ssl.truststore.path": {
+        "envName": null,
+        "propertyName": "cassandra.ssl.truststore.path",
+        "defaultValue": "none",
+        "description": "Cassandra truststore path. Default = none"
+      },
+      "cassandra.ssl.truststore.password": {
+        "envName": null,
+        "propertyName": "cassandra.ssl.truststore.password",
+        "defaultValue": "none",
+        "description": "Cassandra truststore password. Default = none"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
The Cassandra Interpreter does not support talking to clusters that use SSL/client to node encryption. It does not have the properties needed to configure the SSL Context. This PR adds the properties to the driver config and sets up the SSL options when they are requested.

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-1501](https://issues.apache.org/jira/browse/ZEPPELIN-1501)

### How should this be tested?
Using Cassandra/CQL interpreter connect to a Cassandra cluster that uses a client to node encryption, i.e:

```
%cassandra
describe keyspaces;
```
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes.
    The new SSL-related properties should be added to the list (cassandra.ssl.enabled, cassandra.ssl.truststore.path and cassandra.ssl.truststore.password).