### PR TITLE
Show dialog if owners field set to be empty on shiro

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -208,9 +208,6 @@ public class NotebookRestApi {
     HashSet<String> writers = permMap.get("writers");
     // Set readers, if writers and owners is empty -> set to user requesting the change
     if (readers != null && !readers.isEmpty()) {
-      if (writers.isEmpty()) {
-        writers = Sets.newHashSet(SecurityUtils.getPrincipal());
-      }
       if (owners.isEmpty()) {
         owners = Sets.newHashSet(SecurityUtils.getPrincipal());
       }


### PR DESCRIPTION
### What is this PR for?
This PR is for a showing dialog when note's permission set `Readers/Writers` but `Owners` is empty. 
Currently, after merged #849, if user set `Owners` is empty, it's automatically set as the current user.
So, It would be better to show a dialog before `Owners` is fill with the current user because user might think it is not intended. 

Plus, if a user only set `Readers` role, all field(`Writers` and `Owners`) role is filled as the current user like below. It's not necessary to fill because the `Owner` role can read and write note.
![not_need_wirters](https://cloud.githubusercontent.com/assets/8110458/24869746/2a77d2da-1e4f-11e7-86a5-794e1aac02d0.gif)


### What type of PR is it?
[ Improvement ]


### What is the Jira issue?
* [ZEPPELIN-2206; Be added a writer account when adding a reader account on Shiro](https://issues.apache.org/jira/browse/ZEPPELIN-2206)
* [ZEPPELIN-2418; show dialog if user set to the empty owner permission](https://issues.apache.org/jira/browse/ZEPPELIN-2418)

### How should this be tested?
1. Turn on shiro.
2. Set permission `Writers` and `Readers` except `Owner` role.
3. Check the dialog appears

### Screenshots (if appropriate)
[Before]
* Set `Readers` and `Writers` except `Owners`
![zeppelin-2206_auto_shiro_b_1](https://cloud.githubusercontent.com/assets/8110458/24869964/cf382676-1e4f-11e7-8e95-30c149a4aba5.gif)

* Set only 'Writers`
![zeppelin-2206_auto_shiro_b_2](https://cloud.githubusercontent.com/assets/8110458/24870112/3821f518-1e50-11e7-9310-fcafd4e26376.gif)

* set only `Readers`; this screen is attached above.

[After]
* Set `Readers` and `Writers` except `Owners` ( Set only `Writers`; this result is same)
![zeppelin-2206_auto_shiro_a_1](https://cloud.githubusercontent.com/assets/8110458/24870781/61d8f1c0-1e52-11e7-8faa-38ff4fd64f6f.gif)

* Set only 'Readers`
![zeppelin-2206_auto_shiro_a_2](https://cloud.githubusercontent.com/assets/8110458/24870811/76f547ca-1e52-11e7-98b2-f6a5541284ab.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
