### PR TITLE
Improve the spark sql interpreter to run paragraph with multi sql statements split by semicolon

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -142,7 +142,7 @@ public class SparkSqlInterpreter extends Interpreter {
     Stack<String> operatorStack = new Stack<String>();
     char lastCharacter = ' ';
     for (char character : script.toCharArray()) {
-      if (';' == character && lastCharacter != '\\' && operatorStack.isEmpty()) {
+      if (';' == character && operatorStack.isEmpty()) {
         if (query.length() > 0) {
           queries.add(query.toString());
           query.setLength(0);
@@ -154,7 +154,7 @@ public class SparkSqlInterpreter extends Interpreter {
             operatorStack.push("--");
           } else if (lastCharacter == '/' && '*' == character) {
             operatorStack.push("/*");
-          } else if (quoteList.contains(character) && lastCharacter != '\\') {
+          } else if (quoteList.contains(character)) {
             operatorStack.push(String.valueOf(character));
           }
         } else {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -42,189 +42,187 @@ import org.slf4j.LoggerFactory;
  * Spark SQL interpreter for Zeppelin.
  */
 public class SparkSqlInterpreter extends Interpreter {
-    private Logger logger = LoggerFactory.getLogger(SparkSqlInterpreter.class);
+  private Logger logger = LoggerFactory.getLogger(SparkSqlInterpreter.class);
 
-    public static final String MAX_RESULTS = "zeppelin.spark.maxResult";
+  public static final String MAX_RESULTS = "zeppelin.spark.maxResult";
 
-    AtomicInteger num = new AtomicInteger(0);
+  AtomicInteger num = new AtomicInteger(0);
 
-    private int maxResult;
+  private int maxResult;
 
-    public SparkSqlInterpreter(Properties property) {
-        super(property);
+  public SparkSqlInterpreter(Properties property) {
+    super(property);
+  }
+
+  @Override
+  public void open() {
+    this.maxResult = Integer.parseInt(getProperty(MAX_RESULTS));
+  }
+
+  private SparkInterpreter getSparkInterpreter() {
+    LazyOpenInterpreter lazy = null;
+    SparkInterpreter spark = null;
+    Interpreter p = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
+
+    while (p instanceof WrappedInterpreter) {
+      if (p instanceof LazyOpenInterpreter) {
+        lazy = (LazyOpenInterpreter) p;
+      }
+      p = ((WrappedInterpreter) p).getInnerInterpreter();
+    }
+    spark = (SparkInterpreter) p;
+
+    if (lazy != null) {
+      lazy.open();
+    }
+    return spark;
+  }
+
+  public boolean concurrentSQL() {
+    return Boolean.parseBoolean(getProperty("zeppelin.spark.concurrentSQL"));
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public InterpreterResult interpret(String st, InterpreterContext context) {
+    SQLContext sqlc = null;
+    SparkInterpreter sparkInterpreter = getSparkInterpreter();
+
+    if (sparkInterpreter.isUnsupportedSparkVersion()) {
+      return new InterpreterResult(Code.ERROR, "Spark "
+          + sparkInterpreter.getSparkVersion().toString() + " is not supported");
     }
 
-    @Override
-    public void open() {
-        this.maxResult = Integer.parseInt(getProperty(MAX_RESULTS));
+    sparkInterpreter.populateSparkWebUrl(context);
+    sqlc = getSparkInterpreter().getSQLContext();
+    SparkContext sc = sqlc.sparkContext();
+    if (concurrentSQL()) {
+      sc.setLocalProperty("spark.scheduler.pool", "fair");
+    } else {
+      sc.setLocalProperty("spark.scheduler.pool", null);
     }
 
-    private SparkInterpreter getSparkInterpreter() {
-        LazyOpenInterpreter lazy = null;
-        SparkInterpreter spark = null;
-        Interpreter p = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
-
-        while (p instanceof WrappedInterpreter) {
-            if (p instanceof LazyOpenInterpreter) {
-                lazy = (LazyOpenInterpreter) p;
-            }
-            p = ((WrappedInterpreter) p).getInnerInterpreter();
+    sc.setJobGroup(Utils.buildJobGroupId(context), "Zeppelin", false);
+    Object rdd = null;
+    try {
+      // method signature of sqlc.sql() is changed
+      // from  def sql(sqlText: String): SchemaRDD (1.2 and prior)
+      // to    def sql(sqlText: String): DataFrame (1.3 and later).
+      // Therefore need to use reflection to keep binary compatibility for all spark versions.
+      Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
+      for (String statement : splitSqlScript(st)) {
+        if (StringUtils.isNotBlank(statement)) {
+          rdd = sqlMethod.invoke(sqlc, statement);
         }
-        spark = (SparkInterpreter) p;
-
-        if (lazy != null) {
-            lazy.open();
-        }
-        return spark;
+      }
+    } catch (InvocationTargetException ite) {
+      if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
+        throw new InterpreterException(ite);
+      }
+      logger.error("Invocation target exception", ite);
+      String msg = ite.getTargetException().getMessage()
+              + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
+      return new InterpreterResult(Code.ERROR, msg);
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException e) {
+      throw new InterpreterException(e);
     }
 
-    public boolean concurrentSQL() {
-        return Boolean.parseBoolean(getProperty("zeppelin.spark.concurrentSQL"));
-    }
+    String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
+    sc.clearJobGroup();
+    return new InterpreterResult(Code.SUCCESS, msg);
+  }
 
-    @Override
-    public void close() {
-    }
-
-    @Override
-    public InterpreterResult interpret(String st, InterpreterContext context) {
-        SQLContext sqlc = null;
-        SparkInterpreter sparkInterpreter = getSparkInterpreter();
-
-        if (sparkInterpreter.isUnsupportedSparkVersion()) {
-            return new InterpreterResult(Code.ERROR, "Spark "
-                    + sparkInterpreter.getSparkVersion().toString() + " is not supported");
-        }
-
-        sparkInterpreter.populateSparkWebUrl(context);
-        sqlc = getSparkInterpreter().getSQLContext();
-        SparkContext sc = sqlc.sparkContext();
-        if (concurrentSQL()) {
-            sc.setLocalProperty("spark.scheduler.pool", "fair");
-        } else {
-            sc.setLocalProperty("spark.scheduler.pool", null);
-        }
-
-        sc.setJobGroup(Utils.buildJobGroupId(context), "Zeppelin", false);
-        Object rdd = null;
-        try {
-            // method signature of sqlc.sql() is changed
-            // from  def sql(sqlText: String): SchemaRDD (1.2 and prior)
-            // to    def sql(sqlText: String): DataFrame (1.3 and later).
-            // Therefore need to use reflection to keep binary compatibility for all spark versions.
-            Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
-            for (String statement : splitSqlScript(st)) {
-                if (StringUtils.isNotBlank(statement)) {
-                    rdd = sqlMethod.invoke(sqlc, statement);
-                }
-            }
-        } catch (InvocationTargetException ite) {
-            if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
-                throw new InterpreterException(ite);
-            }
-            logger.error("Invocation target exception", ite);
-            String msg = ite.getTargetException().getMessage()
-                    + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
-            return new InterpreterResult(Code.ERROR, msg);
-        } catch (NoSuchMethodException | SecurityException | IllegalAccessException
-                | IllegalArgumentException e) {
-            throw new InterpreterException(e);
-        }
-
-        String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
-        sc.clearJobGroup();
-        return new InterpreterResult(Code.SUCCESS, msg);
-    }
-
-    //split sql script to single statement list
-    public static List<String> splitSqlScript(String script) {
-        List<String> queries = new LinkedList<String>();
-        StringBuilder query = new StringBuilder();
-        List<Character> quoteList = Arrays.asList('\'', '"', '`');
-        Stack<String> operatorStack = new Stack<String>();
-        char lastCharacter = ' ';
-        for (char character : script.toCharArray()) {
-            if (';' == character && lastCharacter != '\\' && operatorStack.isEmpty()) {
-                if (query.length() > 0) {
-                    queries.add(query.toString());
-                    query.setLength(0);
-                }
-            } else {
-                query.append(character);
-                if (operatorStack.isEmpty()) {
-                    if ('-' == character && '-' == lastCharacter) {
-                        operatorStack.push("--");
-                    } else if (lastCharacter == '/' && '*' == character) {
-                        operatorStack.push("/*");
-                    } else if (quoteList.contains(character) && lastCharacter != '\\') {
-                        operatorStack.push(String.valueOf(character));
-                    }
-                } else {
-                    if ('\n' == character && "--".equals(operatorStack.peek())) {
-                        operatorStack.pop();
-                    } else if (lastCharacter == '*' && character == '/'
-                            && operatorStack.peek().equals("/*")) {
-                        operatorStack.pop();
-                    } else if (quoteList.contains(character)
-                            && operatorStack.peek().equals(String.valueOf(character))) {
-                        operatorStack.pop();
-                    }
-                }
-            }
-            lastCharacter = character;
-        }
+  //split sql script to single statement list
+  public static List<String> splitSqlScript(String script) {
+    List<String> queries = new LinkedList<String>();
+    StringBuilder query = new StringBuilder();
+    List<Character> quoteList = Arrays.asList('\'', '"', '`');
+    Stack<String> operatorStack = new Stack<String>();
+    char lastCharacter = ' ';
+    for (char character : script.toCharArray()) {
+      if (';' == character && lastCharacter != '\\' && operatorStack.isEmpty()) {
         if (query.length() > 0) {
-            queries.add(query.toString());
+          queries.add(query.toString());
+          query.setLength(0);
         }
-        return queries;
-    }
-
-    @Override
-    public void cancel(InterpreterContext context) {
-        SQLContext sqlc = getSparkInterpreter().getSQLContext();
-        SparkContext sc = sqlc.sparkContext();
-
-        sc.cancelJobGroup(Utils.buildJobGroupId(context));
-    }
-
-    @Override
-    public FormType getFormType() {
-        return FormType.SIMPLE;
-    }
-
-
-    @Override
-    public int getProgress(InterpreterContext context) {
-        SparkInterpreter sparkInterpreter = getSparkInterpreter();
-        return sparkInterpreter.getProgress(context);
-    }
-
-    @Override
-    public Scheduler getScheduler() {
-        if (concurrentSQL()) {
-            int maxConcurrency = 10;
-            return SchedulerFactory.singleton().createOrGetParallelScheduler(
-                    SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+      } else {
+        query.append(character);
+        if (operatorStack.isEmpty()) {
+          if ('-' == character && '-' == lastCharacter) {
+            operatorStack.push("--");
+          } else if (lastCharacter == '/' && '*' == character) {
+            operatorStack.push("/*");
+          } else if (quoteList.contains(character) && lastCharacter != '\\') {
+            operatorStack.push(String.valueOf(character));
+          }
         } else {
-            // getSparkInterpreter() calls open() inside.
-            // That means if SparkInterpreter is not opened, it'll wait until SparkInterpreter open.
-            // In this moment UI displays 'READY' or 'FINISHED' instead of 'PENDING' or 'RUNNING'.
-            // It's because of scheduler is not created yet, and scheduler is created by this function.
-            // Therefore, we can still use getSparkInterpreter() here, but it's better and safe
-            // to getSparkInterpreter without opening it.
-
-            Interpreter intp =
-                    getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
-            if (intp != null) {
-                return intp.getScheduler();
-            } else {
-                return null;
-            }
+          if ('\n' == character && "--".equals(operatorStack.peek())) {
+            operatorStack.pop();
+          } else if (lastCharacter == '*' && character == '/'
+                  && operatorStack.peek().equals("/*")) {
+            operatorStack.pop();
+          } else if (quoteList.contains(character)
+                  && operatorStack.peek().equals(String.valueOf(character))) {
+            operatorStack.pop();
+          }
         }
+      }
+      lastCharacter = character;
     }
+    if (query.length() > 0) {
+      queries.add(query.toString());
+    }
+    return queries;
+  }
 
-    @Override
-    public List<InterpreterCompletion> completion(String buf, int cursor) {
+  @Override
+  public void cancel(InterpreterContext context) {
+    SQLContext sqlc = getSparkInterpreter().getSQLContext();
+    SparkContext sc = sqlc.sparkContext();
+    sc.cancelJobGroup(Utils.buildJobGroupId(context));
+  }
+
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    return sparkInterpreter.getProgress(context);
+  }
+
+  @Override
+  public Scheduler getScheduler() {
+    if (concurrentSQL()) {
+      int maxConcurrency = 10;
+      return SchedulerFactory.singleton().createOrGetParallelScheduler(
+          SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+    } else {
+      // getSparkInterpreter() calls open() inside.
+      // That means if SparkInterpreter is not opened, it'll wait until SparkInterpreter open.
+      // In this moment UI displays 'READY' or 'FINISHED' instead of 'PENDING' or 'RUNNING'.
+      // It's because of scheduler is not created yet, and scheduler is created by this function.
+      // Therefore, we can still use getSparkInterpreter() here, but it's better and safe
+      // to getSparkInterpreter without opening it.
+
+      Interpreter intp =
+          getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
+      if (intp != null) {
+        return intp.getScheduler();
+      } else {
         return null;
+      }
     }
+  }
+
+  @Override
+  public List<InterpreterCompletion> completion(String buf, int cursor) {
+    return null;
+  }
 }

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -135,7 +135,6 @@ public class SparkSqlInterpreter extends Interpreter {
     return new InterpreterResult(Code.SUCCESS, msg);
   }
 
-  //split sql script to single statement list
   public static List<String> splitSqlScript(String script) {
     List<String> queries = new LinkedList<String>();
     StringBuilder query = new StringBuilder();

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -180,8 +180,10 @@ public class SparkSqlInterpreter extends Interpreter {
 
   @Override
   public void cancel(InterpreterContext context) {
-    SQLContext sqlc = getSparkInterpreter().getSQLContext();
+    SparkInterpreter sparkInterpreter = getSparkInterpreter();
+    SQLContext sqlc = sparkInterpreter.getSQLContext();
     SparkContext sc = sqlc.sparkContext();
+
     sc.cancelJobGroup(Utils.buildJobGroupId(context));
   }
 

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -42,98 +42,99 @@ import org.slf4j.LoggerFactory;
  * Spark SQL interpreter for Zeppelin.
  */
 public class SparkSqlInterpreter extends Interpreter {
-  private Logger logger = LoggerFactory.getLogger(SparkSqlInterpreter.class);
+    private Logger logger = LoggerFactory.getLogger(SparkSqlInterpreter.class);
 
-  public static final String MAX_RESULTS = "zeppelin.spark.maxResult";
+    public static final String MAX_RESULTS = "zeppelin.spark.maxResult";
 
-  AtomicInteger num = new AtomicInteger(0);
+    AtomicInteger num = new AtomicInteger(0);
 
-  private int maxResult;
+    private int maxResult;
 
-  public SparkSqlInterpreter(Properties property) {
-    super(property);
-  }
-
-  @Override
-  public void open() {
-    this.maxResult = Integer.parseInt(getProperty(MAX_RESULTS));
-  }
-
-  private SparkInterpreter getSparkInterpreter() {
-    LazyOpenInterpreter lazy = null;
-    SparkInterpreter spark = null;
-    Interpreter p = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
-
-    while (p instanceof WrappedInterpreter) {
-      if (p instanceof LazyOpenInterpreter) {
-        lazy = (LazyOpenInterpreter) p;
-      }
-      p = ((WrappedInterpreter) p).getInnerInterpreter();
-    }
-    spark = (SparkInterpreter) p;
-
-    if (lazy != null) {
-      lazy.open();
-    }
-    return spark;
-  }
-
-  public boolean concurrentSQL() {
-    return Boolean.parseBoolean(getProperty("zeppelin.spark.concurrentSQL"));
-  }
-
-  @Override
-  public void close() {}
-
-  @Override
-  public InterpreterResult interpret(String st, InterpreterContext context) {
-    SQLContext sqlc = null;
-    SparkInterpreter sparkInterpreter = getSparkInterpreter();
-
-    if (sparkInterpreter.isUnsupportedSparkVersion()) {
-      return new InterpreterResult(Code.ERROR, "Spark "
-          + sparkInterpreter.getSparkVersion().toString() + " is not supported");
+    public SparkSqlInterpreter(Properties property) {
+        super(property);
     }
 
-    sparkInterpreter.populateSparkWebUrl(context);
-    sqlc = getSparkInterpreter().getSQLContext();
-    SparkContext sc = sqlc.sparkContext();
-    if (concurrentSQL()) {
-      sc.setLocalProperty("spark.scheduler.pool", "fair");
-    } else {
-      sc.setLocalProperty("spark.scheduler.pool", null);
+    @Override
+    public void open() {
+        this.maxResult = Integer.parseInt(getProperty(MAX_RESULTS));
     }
 
-    sc.setJobGroup(Utils.buildJobGroupId(context), "Zeppelin", false);
-    Object rdd = null;
-    try {
-      // method signature of sqlc.sql() is changed
-      // from  def sql(sqlText: String): SchemaRDD (1.2 and prior)
-      // to    def sql(sqlText: String): DataFrame (1.3 and later).
-      // Therefore need to use reflection to keep binary compatibility for all spark versions.
-      Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
-      for (String statement : splitSqlScript(st)) {
-          if (StringUtils.isNotBlank(statement)) {
-              rdd = sqlMethod.invoke(sqlc, statement);
-          }
-      }
-    } catch (InvocationTargetException ite) {
-      if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
-        throw new InterpreterException(ite);
-      }
-      logger.error("Invocation target exception", ite);
-      String msg = ite.getTargetException().getMessage()
-              + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
-      return new InterpreterResult(Code.ERROR, msg);
-    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
-        | IllegalArgumentException e) {
-      throw new InterpreterException(e);
+    private SparkInterpreter getSparkInterpreter() {
+        LazyOpenInterpreter lazy = null;
+        SparkInterpreter spark = null;
+        Interpreter p = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
+
+        while (p instanceof WrappedInterpreter) {
+            if (p instanceof LazyOpenInterpreter) {
+                lazy = (LazyOpenInterpreter) p;
+            }
+            p = ((WrappedInterpreter) p).getInnerInterpreter();
+        }
+        spark = (SparkInterpreter) p;
+
+        if (lazy != null) {
+            lazy.open();
+        }
+        return spark;
     }
 
-    String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
-    sc.clearJobGroup();
-    return new InterpreterResult(Code.SUCCESS, msg);
-  }
+    public boolean concurrentSQL() {
+        return Boolean.parseBoolean(getProperty("zeppelin.spark.concurrentSQL"));
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public InterpreterResult interpret(String st, InterpreterContext context) {
+        SQLContext sqlc = null;
+        SparkInterpreter sparkInterpreter = getSparkInterpreter();
+
+        if (sparkInterpreter.isUnsupportedSparkVersion()) {
+            return new InterpreterResult(Code.ERROR, "Spark "
+                    + sparkInterpreter.getSparkVersion().toString() + " is not supported");
+        }
+
+        sparkInterpreter.populateSparkWebUrl(context);
+        sqlc = getSparkInterpreter().getSQLContext();
+        SparkContext sc = sqlc.sparkContext();
+        if (concurrentSQL()) {
+            sc.setLocalProperty("spark.scheduler.pool", "fair");
+        } else {
+            sc.setLocalProperty("spark.scheduler.pool", null);
+        }
+
+        sc.setJobGroup(Utils.buildJobGroupId(context), "Zeppelin", false);
+        Object rdd = null;
+        try {
+            // method signature of sqlc.sql() is changed
+            // from  def sql(sqlText: String): SchemaRDD (1.2 and prior)
+            // to    def sql(sqlText: String): DataFrame (1.3 and later).
+            // Therefore need to use reflection to keep binary compatibility for all spark versions.
+            Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
+            for (String statement : splitSqlScript(st)) {
+                if (StringUtils.isNotBlank(statement)) {
+                    rdd = sqlMethod.invoke(sqlc, statement);
+                }
+            }
+        } catch (InvocationTargetException ite) {
+            if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
+                throw new InterpreterException(ite);
+            }
+            logger.error("Invocation target exception", ite);
+            String msg = ite.getTargetException().getMessage()
+                    + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
+            return new InterpreterResult(Code.ERROR, msg);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+                | IllegalArgumentException e) {
+            throw new InterpreterException(e);
+        }
+
+        String msg = ZeppelinContext.showDF(sc, context, rdd, maxResult);
+        sc.clearJobGroup();
+        return new InterpreterResult(Code.SUCCESS, msg);
+    }
 
     //split sql script to single statement list
     public static List<String> splitSqlScript(String script) {
@@ -183,47 +184,47 @@ public class SparkSqlInterpreter extends Interpreter {
         SQLContext sqlc = getSparkInterpreter().getSQLContext();
         SparkContext sc = sqlc.sparkContext();
 
-    sc.cancelJobGroup(Utils.buildJobGroupId(context));
-  }
-
-  @Override
-  public FormType getFormType() {
-    return FormType.SIMPLE;
-  }
-
-
-  @Override
-  public int getProgress(InterpreterContext context) {
-    SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    return sparkInterpreter.getProgress(context);
-  }
-
-  @Override
-  public Scheduler getScheduler() {
-    if (concurrentSQL()) {
-      int maxConcurrency = 10;
-      return SchedulerFactory.singleton().createOrGetParallelScheduler(
-          SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
-    } else {
-      // getSparkInterpreter() calls open() inside.
-      // That means if SparkInterpreter is not opened, it'll wait until SparkInterpreter open.
-      // In this moment UI displays 'READY' or 'FINISHED' instead of 'PENDING' or 'RUNNING'.
-      // It's because of scheduler is not created yet, and scheduler is created by this function.
-      // Therefore, we can still use getSparkInterpreter() here, but it's better and safe
-      // to getSparkInterpreter without opening it.
-
-      Interpreter intp =
-          getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
-      if (intp != null) {
-        return intp.getScheduler();
-      } else {
-        return null;
-      }
+        sc.cancelJobGroup(Utils.buildJobGroupId(context));
     }
-  }
 
-  @Override
-  public List<InterpreterCompletion> completion(String buf, int cursor) {
-    return null;
-  }
+    @Override
+    public FormType getFormType() {
+        return FormType.SIMPLE;
+    }
+
+
+    @Override
+    public int getProgress(InterpreterContext context) {
+        SparkInterpreter sparkInterpreter = getSparkInterpreter();
+        return sparkInterpreter.getProgress(context);
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        if (concurrentSQL()) {
+            int maxConcurrency = 10;
+            return SchedulerFactory.singleton().createOrGetParallelScheduler(
+                    SparkSqlInterpreter.class.getName() + this.hashCode(), maxConcurrency);
+        } else {
+            // getSparkInterpreter() calls open() inside.
+            // That means if SparkInterpreter is not opened, it'll wait until SparkInterpreter open.
+            // In this moment UI displays 'READY' or 'FINISHED' instead of 'PENDING' or 'RUNNING'.
+            // It's because of scheduler is not created yet, and scheduler is created by this function.
+            // Therefore, we can still use getSparkInterpreter() here, but it's better and safe
+            // to getSparkInterpreter without opening it.
+
+            Interpreter intp =
+                    getInterpreterInTheSameSessionByClassName(SparkInterpreter.class.getName());
+            if (intp != null) {
+                return intp.getScheduler();
+            } else {
+                return null;
+            }
+        }
+    }
+
+    @Override
+    public List<InterpreterCompletion> completion(String buf, int cursor) {
+        return null;
+    }
 }


### PR DESCRIPTION
Improve the spark sql interpreter to run paragraph with multi sql statements split by semicolon

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

* Improve the spark sql interpreter to run paragraph with multi sql statements split by semicolon
In current version of Zeppelin, we can only run one sql statement in one paragraph, that is very inconvenient，so I think we need to improve the spark sql interpreter to fix this problem. Improve
the spark sql interpreter to run paragraph with multi sql statements split by semicolon and return the result of the last statement


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]
[ZEPPELIN-2392](https://issues.apache.org/jira/browse/ZEPPELIN-2392)
### How should this be tested?
Outline the steps to test the PR here.

### Screenshots (if appropriate)
<img width="1362" alt="2017-04-11 11 03 46" src="https://cloud.githubusercontent.com/assets/869480/24916697/72d9cf24-1f0d-11e7-8a68-50ba9973fcb8.png">

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
