### PR TITLE
[ZEPPELIN-2393] fix 403 error on http client ZeppelinHubRealm authentication

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ZeppelinHubRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ZeppelinHubRealm.java
@@ -131,6 +131,8 @@ public class ZeppelinHubRealm extends AuthorizingRealm {
     String responseBody = StringUtils.EMPTY;
     String userSession = StringUtils.EMPTY;
     try {
+      put.addRequestHeader("User-Agent",
+          "Mozilla/5.0 (X11; Linux x86_64; rv:39.0) Gecko/20100101 Firefox/39.0");
       put.setRequestEntity(new StringRequestEntity(requestBody, JSON_CONTENT_TYPE, UTF_8_ENCODING));
       int statusCode = httpClient.executeMethod(put);
       if (statusCode != HttpStatus.SC_OK) {


### PR DESCRIPTION
### What is this PR for?
as described in issue, some of services may wrongly reject the http requests with default configuration of httpcomponents client. this is to add `User-Agent` header which is normally checked for security reasons


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-2393](https://issues.apache.org/jira/browse/ZEPPELIN-2393)

### How should this be tested?
apply shiro config in [here](https://zeppelin.apache.org/docs/0.7.0/security/shiroauthentication.html#zeppelinhub)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
