### PR TITLE
[ZEPPELIN-1828] Flaky Test: RemoteInterpreterTest hanged in zeppelin-interpreter

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -263,9 +263,18 @@ public class RemoteInterpreterEventPoller extends Thread {
         logger.error("Can't handle event " + event, e);
       }
     }
+    try {
+      clearUnreadEvents(interpreterProcess.getClient());
+    } catch (Exception e1) {
+      logger.error("Can't get RemoteInterpreterEvent", e1);
+    }
     if (appendFuture != null) {
       appendFuture.cancel(true);
     }
+  }
+
+  private void clearUnreadEvents(Client client) throws TException {
+    while (client.getEvent().getType() != RemoteInterpreterEventType.NO_OP) {}
   }
 
   private void progressRemoteZeppelinControlEvent(

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPollerTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPollerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.remote;
+
+import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterEvent;
+import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService;
+import org.junit.Test;
+
+import static org.apache.zeppelin.interpreter.thrift.RemoteInterpreterEventType.NO_OP;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RemoteInterpreterEventPollerTest {
+
+	@Test
+	public void shouldClearUnreadEventsOnShutdown() throws Exception {
+		RemoteInterpreterProcess interpreterProc = getMockEventsInterpreterProcess();
+		RemoteInterpreterEventPoller eventPoller = new RemoteInterpreterEventPoller(null, null);
+
+		eventPoller.setInterpreterProcess(interpreterProc);
+		eventPoller.shutdown();
+		eventPoller.start();
+		eventPoller.join();
+
+		assertEquals(NO_OP, interpreterProc.getClient().getEvent().getType());
+	}
+
+	private RemoteInterpreterProcess getMockEventsInterpreterProcess() throws Exception {
+		RemoteInterpreterEvent fakeEvent = new RemoteInterpreterEvent();
+		RemoteInterpreterEvent noMoreEvents = new RemoteInterpreterEvent(NO_OP, "");
+		RemoteInterpreterService.Client client = mock(RemoteInterpreterService.Client.class);
+		RemoteInterpreterProcess intProc = mock(RemoteInterpreterProcess.class);
+
+		when(client.getEvent()).thenReturn(fakeEvent, fakeEvent, noMoreEvents);
+		when(intProc.getClient()).thenReturn(client);
+
+		return intProc;
+	}
+}


### PR DESCRIPTION
### What is this PR for?
When `interpreter.close()` occurs in code it shuts down _RemoteInterpreterEventPoller_ and then tries to close thrift connection. While closing thrift client will wait until events queue is empty. If _RemoteInterpreterEventPoller_ has not processed all thrift events before the shutdown signal comes, thrift client will wait forever. As a result Travis will terminate the build after code is not responding for 10 minutes.

### What type of PR is it?
[Bug Fix]

### Todos
We need to:
* [x] - write a test that checks that event queue is empty after _RemoteInterpreterEventPoller_ is done,
* [x] - clear unread events on _RemoteInterpreterEventPoller_ shutdown signal.

### What is the Jira issue?
[ZEPPELIN-1828](https://issues.apache.org/jira/browse/ZEPPELIN-1828)

### How should this be tested?
This issue can be reprodused if you put `Thread.sleep(3000L);` to  _RemoteInterpreterEventPoller.java_ 
```
...
} else if (event.getType() == RemoteInterpreterEventType.OUTPUT_UPDATE_ALL) {
    Thread.sleep(3000L);
    ...
}
```
and run _RemoteInterpreterTest.java_.

### Questions:
* Does the licenses files need update? **no**
* Is there breaking changes for older versions? **no**
* Does this needs documentation? **no**
