### PR TITLE
[ZEPPELIN-2396] eliminate the 'ctrl/command+L' keyboard shortcut

### DIFF
--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -60,4 +60,4 @@ So, copying `notebook` and `conf` directory should be enough.
 ### Upgrading from Zeppelin 0.7 to 0.8
 
  - From 0.8, we recommend to use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` instead of `zeppelin.pyspark.python` as `zeppelin.pyspark.python` only effects driver. You can use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` as using them in spark.
- - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` is not supported. This function is provided by [Ace](https://ace.c9.io/) editor. 
+ - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` which go to the line somewhere user wants is not supported. 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -60,4 +60,4 @@ So, copying `notebook` and `conf` directory should be enough.
 ### Upgrading from Zeppelin 0.7 to 0.8
 
  - From 0.8, we recommend to use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` instead of `zeppelin.pyspark.python` as `zeppelin.pyspark.python` only effects driver. You can use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` as using them in spark.
- 
+ - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` is not supported. 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -60,4 +60,4 @@ So, copying `notebook` and `conf` directory should be enough.
 ### Upgrading from Zeppelin 0.7 to 0.8
 
  - From 0.8, we recommend to use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` instead of `zeppelin.pyspark.python` as `zeppelin.pyspark.python` only effects driver. You can use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` as using them in spark.
- - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` is not supported. 
+ - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` is not supported. This function is provided by [Ace](https://ace.c9.io/) editor. 

--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -60,4 +60,4 @@ So, copying `notebook` and `conf` directory should be enough.
 ### Upgrading from Zeppelin 0.7 to 0.8
 
  - From 0.8, we recommend to use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` instead of `zeppelin.pyspark.python` as `zeppelin.pyspark.python` only effects driver. You can use `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` as using them in spark.
- - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` which go to the line somewhere user wants is not supported. 
+ - From 0.8, depending on your device, the keyboard shortcut `Ctrl-L` or `Command-L` which goes to the line somewhere user wants is not supported. 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -709,20 +709,27 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
        */
 
       // remove binding
-      $scope.editor.commands.bindKey('ctrl-alt-n.', null);
       $scope.editor.commands.removeCommand('showSettingsMenu');
 
-      $scope.editor.commands.bindKey('ctrl-alt-l', null);
-      $scope.editor.commands.bindKey('ctrl-alt-w', null);
-      $scope.editor.commands.bindKey('ctrl-alt-a', null);
-      $scope.editor.commands.bindKey('ctrl-alt-k', null);
-      $scope.editor.commands.bindKey('ctrl-alt-e', null);
-      $scope.editor.commands.bindKey('ctrl-alt-t', null);
+      var isOption = $rootScope.isMac? 'option' : 'alt';
+
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-n.', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-l', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-w', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-a', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-k', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-e', null);
+      $scope.editor.commands.bindKey('ctrl-'+isOption+'-t', null);
+      $scope.editor.commands.bindKey('ctrl-space', null);
+
+      if ($rootScope.isMac) {
+        $scope.editor.commands.bindKey('command-l', null);
+      } else {
+        $scope.editor.commands.bindKey('ctrl-l', null);
+      }
 
       // autocomplete on 'ctrl+.'
       $scope.editor.commands.bindKey('ctrl-.', 'startAutocomplete');
-      $scope.editor.commands.bindKey('ctrl-space', null);
-      $scope.editor.commands.bindKey('ctrl-l', null);
 
       var keyBindingEditorFocusAction = function(scrollValue) {
         var numRows = $scope.editor.getSession().getLength();

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -722,6 +722,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       // autocomplete on 'ctrl+.'
       $scope.editor.commands.bindKey('ctrl-.', 'startAutocomplete');
       $scope.editor.commands.bindKey('ctrl-space', null);
+      $scope.editor.commands.bindKey('ctrl-l', null);
 
       var keyBindingEditorFocusAction = function(scrollValue) {
         var numRows = $scope.editor.getSession().getLength();

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -713,13 +713,13 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
       var isOption = $rootScope.isMac? 'option' : 'alt';
 
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-n.', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-l', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-w', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-a', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-k', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-e', null);
-      $scope.editor.commands.bindKey('ctrl-'+isOption+'-t', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-n.', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-l', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-w', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-a', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-k', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-e', null);
+      $scope.editor.commands.bindKey('ctrl-' + isOption + '-t', null);
       $scope.editor.commands.bindKey('ctrl-space', null);
 
       if ($rootScope.isMac) {


### PR DESCRIPTION
### What is this PR for?
This PR is for that eliminate the `Ctrl/Command+L` shortcut keyboard. This function is what the ace editor defined.

### What type of PR is it?
[Improvement | Document]

### What is the Jira issue?
* [ZEPPELIN-2396](https://issues.apache.org/jira/browse/ZEPPELIN-2396)

### How should this be tested?
* **Improvement** - Press `Ctrl + L` key and check if showing the dialog or not
* **Document** - Run document development mode and check [this document](http://localhost:4000/install/upgrade.html#upgrading-from-zeppelin-07-to-08)

### Screenshots (if appropriate)
[Before]
![image](https://cloud.githubusercontent.com/assets/8110458/24990819/8529312a-2051-11e7-8849-e00803310752.png)

[After]
![z_zeppelin-2396](https://cloud.githubusercontent.com/assets/8110458/24990966/9764e108-2052-11e7-9387-560f9d587782.gif)



[Document]
![image](https://cloud.githubusercontent.com/assets/8110458/25040847/e772e024-2146-11e7-9ded-322c589b424b.png)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, I did. Please review [this document](http://localhost:4000/install/upgrade.html#upgrading-from-zeppelin-07-to-08) if you run document development mode (localhost:4000)
