### PR TITLE
ZEPPELIN-2356. Improvement for z.angularBind and z.angularWatch

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
@@ -17,9 +17,7 @@
 
 package org.apache.zeppelin.display;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.zeppelin.scheduler.ExecutorFactory;
@@ -38,7 +36,7 @@ public class AngularObject<T> {
   private T object;
   
   private transient AngularObjectListener listener;
-  private transient List<AngularObjectWatcher> watchers = new LinkedList<>();
+  private transient Map<String, AngularObjectWatcher> watchers = new LinkedHashMap<>();
   
   private String noteId;   // noteId belonging to. null for global scope 
   private String paragraphId; // paragraphId belongs to. null for notebook scope
@@ -176,7 +174,7 @@ public class AngularObject<T> {
     final Logger logger = LoggerFactory.getLogger(AngularObject.class);
     List<AngularObjectWatcher> ws = new LinkedList<>();
     synchronized (watchers) {
-      ws.addAll(watchers);
+      ws.addAll(watchers.values());
     }
 
     ExecutorService executor = ExecutorFactory.singleton().createOrGet("angularObjectWatcher", 50);
@@ -218,7 +216,7 @@ public class AngularObject<T> {
    */
   public void addWatcher(AngularObjectWatcher watcher) {
     synchronized (watchers) {
-      watchers.add(watcher);
+      watchers.put(watcher.getWatcherId(), watcher);
     }
   }
 
@@ -228,7 +226,13 @@ public class AngularObject<T> {
    */
   public void removeWatcher(AngularObjectWatcher watcher) {
     synchronized (watchers) {
-      watchers.remove(watcher);
+      watchers.remove(watcher.getWatcherId());
+    }
+  }
+
+  public void removeWatcher(String watcherId) {
+    synchronized (watchers) {
+      watchers.remove(watcherId);
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectWatcher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectWatcher.java
@@ -25,8 +25,29 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 public abstract class AngularObjectWatcher {
   private InterpreterContext context;
 
+  private String watcherId;
+
+  public AngularObjectWatcher(InterpreterContext context, String watcherId) {
+    this.context = context;
+    this.watcherId = watcherId;
+  }
+
+  /**
+   * @deprecated  use AngularObjectWatcher(context, watcherId) instead.
+   *              watcherId should be specified.
+   * @param context
+   */
+  @Deprecated
   public AngularObjectWatcher(InterpreterContext context) {
     this.context = context;
+  }
+
+  public String getWatcherId() {
+    return watcherId;
+  }
+
+  public void setWatcherId(String watcherId) {
+    this.watcherId = watcherId;
   }
 
   void watch(Object oldObject, Object newObject) {


### PR DESCRIPTION
### What is this PR for?
There're 2 issues in the current angular object usage in `ZeppelinContext` when user run the paragraph with code `z.angularBind` and `z.angularWatch` multiple times （It is not idempotent for the paragraph)
* `z.angularBind` would set a new value if the angular object is existed (the second run of paragraph), so the registered watcher will be called which might not be what user expect
* `z.angularWatch` would register the same watcher multiple times if the angular object is existed (the second run), this also might not be what user expect.

I made 2 changes for this issue.
* Remove the existing angular object and create a new one in `angularBind`, and create new method `angularSet` for setting new value for angular object.
* Add watcherId in `AngularObjectWatcher` so that we can uniquely identify watcher, and won't add duplicated watcher.

### What type of PR is it?
[Bug Fix | Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2356

### How should this be tested?
Test is added.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
