### PR TITLE
[ZEPPELIN-2085] Interpret scala code in paste mode

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -39,9 +39,6 @@
     <protobuf.version>2.5.0</protobuf.version>
     <commons.exec.version>1.1</commons.exec.version>
     <jline.version>2.12.1</jline.version>
-
-    <!--test library versions-->
-    <hamcrest.all.version>1.3</hamcrest.all.version>
   </properties>
 
   <dependencies>
@@ -66,7 +63,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>${hamcrest.all.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
 
     <!-- test library versions -->
     <junit.version>4.12</junit.version>
+    <hamcrest.all.version>1.3</hamcrest.all.version>
     <mockito.version>1.10.19</mockito.version>
     <assertj.version>1.7.0</assertj.version>
     <powermock.version>1.6.4</powermock.version>
@@ -260,6 +261,13 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${hamcrest.all.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -313,8 +313,9 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
     }
   }
 
+  @SuppressWarnings("unused") // reflection call from python
   public void appendOutput(String message) throws IOException {
-    outputStream.getInterpreterOutput().write(message);
+    outputStream.getInterpreterOutput().write(message.getBytes());
   }
 
   @Override

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -332,9 +332,10 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     }
   }
 
+  @SuppressWarnings("unused") // reflection call from python
   public void appendOutput(String message) throws IOException {
     LOGGER.debug("Output from python process: " + message);
-    outputStream.getInterpreterOutput().write(message);
+    outputStream.getInterpreterOutput().write(message.getBytes());
   }
 
   @Override

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -43,6 +43,8 @@ import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.hamcrest.CoreMatchers.is;
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SparkInterpreterTest {
 
@@ -326,5 +328,17 @@ public class SparkInterpreterTest {
     assertNotNull(jobUrl);
     assertTrue(jobUrl.startsWith(sparkUIUrl + "/jobs/job?id="));
 
+  }
+
+  @Test
+  public void define_companion_object_in_different_line() throws IOException {
+    // Companion object has access to class' private members
+    InterpreterResult result = repl.interpret(
+        "class Foo(private val privateMember: Any = null)\n" +
+            "object Foo {\n" +
+            "  def foo = new Foo().privateMember\n" +
+            "}\n",
+        context);
+    assertThat(result.code(), is(Code.SUCCESS));
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
@@ -22,8 +22,8 @@ import java.io.Serializable;
  * Interpreter result message
  */
 public class InterpreterResultMessage implements Serializable {
-  InterpreterResult.Type type;
-  String data;
+  private final InterpreterResult.Type type;
+  private final String data;
 
   public InterpreterResultMessage(InterpreterResult.Type type, String data) {
     this.type = type;
@@ -36,6 +36,24 @@ public class InterpreterResultMessage implements Serializable {
 
   public String getData() {
     return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    InterpreterResultMessage that = (InterpreterResultMessage) o;
+
+    if (type != that.type) return false;
+    return data.equals(that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type.hashCode();
+    result = 31 * result + data.hashCode();
+    return result;
   }
 
   public String toString() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/InterpreterOutputStream.java
@@ -21,6 +21,7 @@ import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Output Stream integrated with InterpreterOutput.
@@ -29,18 +30,18 @@ import java.io.IOException;
  */
 public class InterpreterOutputStream extends LogOutputStream {
   private Logger logger;
-  InterpreterOutput interpreterOutput;
-  boolean ignoreLeadingNewLinesFromScalaReporter = false;
+  private OutputStream interpreterOutput;
+  private boolean ignoreLeadingNewLinesFromScalaReporter = false;
 
   public InterpreterOutputStream(Logger logger) {
     this.logger = logger;
   }
 
-  public InterpreterOutput getInterpreterOutput() {
+  public OutputStream getInterpreterOutput() {
     return interpreterOutput;
   }
 
-  public void setInterpreterOutput(InterpreterOutput interpreterOutput) {
+  public void setInterpreterOutput(OutputStream interpreterOutput) {
     this.interpreterOutput = interpreterOutput;
   }
 

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -330,6 +330,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -16,15 +16,8 @@
  */
 package org.apache.zeppelin.rest;
 
-import static org.hamcrest.Matchers.anything;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -99,11 +92,12 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         p.setAuthenticationInfo(anonymous);
         note.run(p.getId());
         waitForFinish(p);
-        assertThat(p.getStatus(), is(Status.FINISHED));
-        assertThat(p.getResult().message(), contains(
-            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "hello\n"),
-            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "import java.util.Date\nimport java.net.URL\n")
-        ));
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals(p.getResult().message().size(), 2);
+        assertEquals(p.getResult().message().get(0),
+            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "hello\n"));
+        assertEquals(p.getResult().message().get(1),
+            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "import java.util.Date\nimport java.net.URL\n"));
         ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
     }
 
@@ -145,10 +139,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             p.setAuthenticationInfo(anonymous);
             note.run(p.getId());
             waitForFinish(p);
-            assertThat(p.getStatus(), is(Status.FINISHED));
-            assertThat(p.getResult().message(), contains(
-                hasProperty("data", containsString("Array[org.apache.spark.sql.Row] = Array([hello,20])"))
-            ));
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertTrue(p.getResult().message().get(0).getData().contains(
+                "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
 
             // test display DataFrame
             p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
@@ -159,11 +152,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             p.setAuthenticationInfo(anonymous);
             note.run(p.getId());
             waitForFinish(p);
-            assertThat(p.getStatus(), is(Status.FINISHED));
-            assertThat(p.getResult().message(), contains(
-                is(new InterpreterResultMessage(InterpreterResult.Type.TABLE, "_1\t_2\nhello\t20\n")),
-                anything()
-            ));
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals(p.getResult().message().get(0),
+                new InterpreterResultMessage(InterpreterResult.Type.TABLE, "_1\t_2\nhello\t20\n"));
 
             // test display DataSet
             if (sparkVersion >= 20) {
@@ -176,11 +167,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
                 p.setAuthenticationInfo(anonymous);
                 note.run(p.getId());
                 waitForFinish(p);
-                assertThat(p.getStatus(), is(Status.FINISHED));
-                assertThat(p.getResult().message(), contains(
-                    is(new InterpreterResultMessage(InterpreterResult.Type.TABLE, "_1\t_2\nhello\t20\n")),
-                    anything()
-                ));
+                assertEquals(Status.FINISHED, p.getStatus());
+                assertEquals(p.getResult().message().get(0),
+                    new InterpreterResultMessage(InterpreterResult.Type.TABLE, "_1\t_2\nhello\t20\n"));
             }
             ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
         }
@@ -535,17 +524,17 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
         note.run(p.getId());
         waitForFinish(p);
 
-        assertThat(p.getStatus(), is(Status.FINISHED));
+        assertEquals(Status.FINISHED, p.getStatus());
         Iterator<String> formIter = p.settings.getForms().keySet().iterator();
         assert(formIter.next().equals("my_input"));
         assert(formIter.next().equals("my_select"));
         assert(formIter.next().equals("my_checkbox"));
 
         // check dynamic forms values
-        assertThat(p.getResult().message(), contains(
-            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "default_name\n1\n2\n"),
-            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "items: Seq[Object] = Buffer(2)\n")
-        ));
+        assertEquals(p.getResult().message().get(0),
+            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "default_name\n1\n2\n"));
+        assertEquals(p.getResult().message().get(1),
+            new InterpreterResultMessage(InterpreterResult.Type.TEXT, "items: Seq[Object] = Buffer(2)\n"));
     }
 
     @Test


### PR DESCRIPTION
### What is this PR for?
Don't split scala code to lines.

Interpreter code becomes more and more complicated because some lines have to be executed
together (companion objects, etc.). And still it doesn't handle all possibilities.

I propose not to split interpreter input at all.
I checked scala repl sources: repl paste mode interpret code without splitting.

### What type of PR is it?
[Bug Fix | Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2085

### How should this be tested?
Try to run several code snippets attached to jira issue.
See also https://issues.apache.org/jira/browse/ZEPPELIN-658

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
