### PR TITLE
ZEPPELIN-2407. Livy Interpreter always return plain text result

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterprereter.java
@@ -371,7 +371,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
 
       if (displayAppInfo) {
         InterpreterResult interpreterResult = new InterpreterResult(InterpreterResult.Code.SUCCESS);
-        interpreterResult.add(InterpreterResult.Type.TEXT, result);
+        interpreterResult.add(result);
         String appInfoHtml = "<hr/>Spark Application Id: " + sessionInfo.appId + "<br/>"
             + "Spark WebUI: <a href=\"" + sessionInfo.webUIAddress + "\">"
             + sessionInfo.webUIAddress + "</a>";

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -145,6 +145,13 @@ public class LivyInterpreterIT {
         assertTrue(result.message().get(0).getData().contains("defined object Person"));
       }
 
+      // html output
+      String htmlCode = "println(\"%html <h1> hello </h1>\")";
+      result = sparkInterpreter.interpret(htmlCode, context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+      assertEquals(1, result.message().size());
+      assertEquals(InterpreterResult.Type.HTML, result.message().get(0).getType());
+
       // error
       result = sparkInterpreter.interpret("println(a)", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
@@ -544,8 +551,15 @@ public class LivyInterpreterIT {
       InterpreterResult result = sparkInterpreter.interpret("sc.version", context);
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
       assertEquals(2, result.message().size());
-
       assertTrue(result.message().get(1).getData().contains("Spark Application Id"));
+
+      // html output
+      String htmlCode = "println(\"%html <h1> hello </h1>\")";
+      result = sparkInterpreter.interpret(htmlCode, context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+      assertEquals(2, result.message().size());
+      assertEquals(InterpreterResult.Type.HTML, result.message().get(0).getType());
+
     } finally {
       sparkInterpreter.close();
     }


### PR DESCRIPTION
### What is this PR for?
It happens when zeppelin.livy.displayAppInfo is true. Straightforward fix. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2407

### How should this be tested?
Test is added

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
