### PR TITLE
[HOTFIX] Invalid method signature in GroovyInterpreter

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -121,7 +121,8 @@ public class GroovyInterpreter extends Interpreter {
   }
 
   @Override
-  public List<InterpreterCompletion> completion(String buf, int cursor) {
+  public List<InterpreterCompletion> completion(String buf, int cursor,
+                                                InterpreterContext interpreterContext) {
     return null;
   }
 


### PR DESCRIPTION
### What is this PR for?

- https://github.com/apache/zeppelin/pull/2203 was merged
- but https://github.com/apache/zeppelin/pull/2203 was not rebased recently
- as a result, `GroovyInterperter` has invalid method signature.

```
[ERROR] COMPILATION ERROR : 
[ERROR] /home/travis/build/1ambda/zeppelin/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java:[123,3] method does not override or implement a method from a supertype
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project zeppelin-groovy: Compilation failure
[ERROR] /home/travis/build/1ambda/zeppelin/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java:[123,3] method does not override or implement a method from a supertype
```

You can see CI failures in

- https://travis-ci.org/1ambda/zeppelin/jobs/222709988
- https://travis-ci.org/1ambda/zeppelin/jobs/222709989

### What type of PR is it?
[Hot Fix]

### Todos

NONE

### What is the Jira issue?

Hotfix

### How should this be tested?

- CI should be green.
- Build this PR locally, `mvn clean package -DskipTests;`

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
