### PR TITLE
[ZEPPELIN-2315] (bug) new note.json is overwritten by old note.json (master, branch-0.7)

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -414,6 +414,10 @@ public class Notebook implements NoteEventListener {
   public void convertFromSingleResultToMultipleResultsFormat(Note note) {
     for (Paragraph p : note.paragraphs) {
       Object ret = p.getPreviousResultFormat();
+      if (ret != null && p.results != null) {
+        continue; // already converted
+      }
+
       try {
         if (ret != null && ret instanceof Map) {
           Map r = ((Map) ret);


### PR DESCRIPTION
### What is this PR for?

- `note.json` is converted every time
- as a result, changes in `note.json` is overwritten by old `note.json`

Occurs in **0.8.0-SNAPSHOT** and **branch-0.7**

### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2315](https://issues.apache.org/jira/browse/ZEPPELIN-2315)

### How should this be tested?

1. create a note in 0.6.0 which including graph
2. migrate it to 0.7.0+ (just copy dir)
3. open in Zeppelin
4. click other graph type rather than table (e.g `scatter chart`)
5. restart
7. should see the last change (graph) is persisted

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
