### PR TITLE
[ZEPPELIN-2096] Conserve class loader after running interpret method

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -92,7 +92,12 @@ public class LazyOpenInterpreter
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     open();
-    return intp.interpret(st, context);
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      return intp.interpret(st, context);
+    } finally {
+      Thread.currentThread().setContextClassLoader(classLoader);
+    }
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
This PR is a follow-up PR of ZEPPELIN-1972. It keep context class loader while running interpret method by scala. For more information, please see https://issues.apache.org/jira/browse/ZEPPELIN-1972


### What type of PR is it?
[Feature]

### Todos
* [x] - Backup and restore class loader around interpret method.

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2096

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
