### PR TITLE
Prevent NPE on delete local module cache

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -462,8 +462,10 @@ public class HeliumBundleFactory {
     };
 
     File[] localModuleCaches = yarnCacheDir.listFiles(filter);
-    for (File f : localModuleCaches) {
-      FileUtils.deleteQuietly(f);
+    if (localModuleCaches != null) {
+      for (File f : localModuleCaches) {
+        FileUtils.deleteQuietly(f);
+      }
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Prevent NPE on delete local module cache in HeliumBundleFactory

```
Caused by: java.lang.NullPointerException
	at org.apache.zeppelin.helium.HeliumBundleFactory.deleteYarnCache(HeliumBundleFactory.java:465)
	at org.apache.zeppelin.helium.HeliumBundleFactory.copyFrameworkModulesToInstallPath(HeliumBundleFactory.java:487)
	at org.apache.zeppelin.helium.HeliumBundleFactory.buildPackage(HeliumBundleFactory.java:403)
	at org.apache.zeppelin.helium.Helium.enable(Helium.java:314)
	at org.apache.zeppelin.rest.HeliumRestApi.enablePackage(HeliumRestApi.java:193)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:180)
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96)
	... 50 more
```

### What type of PR is it?
Bug Fix

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
