### PR TITLE
[ZEPPELIN-2408] Should use $uibTooltip instead of $tooltip

### DIFF
--- a/zeppelin-web/src/components/popover-html-unsafe/popover-html-unsafe.directive.js
+++ b/zeppelin-web/src/components/popover-html-unsafe/popover-html-unsafe.directive.js
@@ -14,8 +14,8 @@
 
 angular.module('zeppelinWebApp').directive('popoverHtmlUnsafe', popoverHtmlUnsafe)
 
-function popoverHtmlUnsafe ($tooltip) {
+function popoverHtmlUnsafe ($uibTooltip) {
   'ngInject'
 
-  return $tooltip('popoverHtmlUnsafe', 'popover', 'click')
+  return $uibTooltip('popoverHtmlUnsafe', 'popover', 'click')
 }


### PR DESCRIPTION
### What is this PR for?

Since we are using angular-bootstrap 2.5+, we should use `$uibTooltip` instead of `$tooltip`
otherwise we will get an error like the screenshot below.

See also https://github.com/angular-ui/bootstrap/issues/4591


### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2048](https://issues.apache.org/jira/browse/ZEPPELIN-2408)

### How should this be tested?

1. open browser console
2. click the scatter chart.
3. shouldn't see an error

### Screenshots (if appropriate)

![](https://issues.apache.org/jira/secure/attachment/12863580/12863580_screenshot-1.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO



