### PR TITLE
ZEPPELIN-2421. AngularObject miss AngularObjectListener when it is pushed from frontend

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectRegistry.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectRegistry.java
@@ -252,5 +252,10 @@ public class AngularObjectRegistry {
 
   public void setRegistry(Map<String, Map<String, AngularObject>> registry) {
     this.registry = registry;
+    for (Map<String, AngularObject> map : registry.values()) {
+      for (AngularObject ao : map.values()) {
+        ao.setListener(angularObjectListener);
+      }
+    }
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
@@ -46,7 +46,7 @@ import java.util.Map;
  * RemoteInterpreterEventPoller is counter part in ZeppelinServer
  */
 public class RemoteInterpreterEventClient implements ResourcePoolConnector {
-  private final Logger logger = LoggerFactory.getLogger(RemoteInterpreterEvent.class);
+  private final Logger logger = LoggerFactory.getLogger(RemoteInterpreterEventClient.class);
   private final List<RemoteInterpreterEvent> eventQueue = new LinkedList<>();
   private final List<ResourceSet> getAllResourceResponse = new LinkedList<>();
   private final Map<ResourceId, Object> getResourceResponse = new HashMap<>();
@@ -415,6 +415,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector {
   }
 
   private void sendEvent(RemoteInterpreterEvent event) {
+    logger.debug("Send Event: " + event);
     synchronized (eventQueue) {
       eventQueue.add(event);
       eventQueue.notifyAll();
@@ -446,7 +447,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector {
     appendOutput.put("appId", appId);
     appendOutput.put("type", type);
     appendOutput.put("data", output);
-    logger.info("onAppoutputUpdate = {}", output);
+    logger.debug("onAppoutputUpdate = {}", output);
     sendEvent(new RemoteInterpreterEvent(
         RemoteInterpreterEventType.OUTPUT_UPDATE,
         gson.toJson(appendOutput)));

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -124,6 +124,9 @@ public class RemoteInterpreterEventPoller extends Thread {
       AngularObjectRegistry angularObjectRegistry = interpreterGroup.getAngularObjectRegistry();
 
       try {
+        if (event.getType() != RemoteInterpreterEventType.NO_OP) {
+          logger.debug("Receive message from RemoteInterpreter Process: " + event.toString());
+        }
         if (event.getType() == RemoteInterpreterEventType.NO_OP) {
           continue;
         } else if (event.getType() == RemoteInterpreterEventType.ANGULAR_OBJECT_ADD) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -492,7 +492,7 @@ public class NotebookServer extends WebSocketServlet
       if (socketLists == null || socketLists.size() == 0) {
         return;
       }
-      LOG.debug("SEND >> " + m.op);
+      LOG.debug("SEND >> " + m);
       for (NotebookSocket conn : socketLists) {
         try {
           conn.send(serializeMessage(m));
@@ -510,7 +510,7 @@ public class NotebookServer extends WebSocketServlet
       if (socketLists == null || socketLists.size() == 0) {
         return;
       }
-      LOG.debug("SEND >> " + m.op);
+      LOG.debug("SEND >> " + m);
       for (NotebookSocket conn : socketLists) {
         if (exclude.equals(conn)) {
           continue;


### PR DESCRIPTION

### What is this PR for?
This bug happens when you save your note, and restart zeppelin and run it again. The root cause is that the angular object miss  AngularObjectListener which means you can not sync up the changes on angular object to frontend. This PR would restore the listener correctly when we restore the angular objects saved before.  Also make some changes for logging in this PR. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2421

### How should this be tested?
Tested manually

### Screenshots (if appropriate)

Before
![zeppelin_before](https://cloud.githubusercontent.com/assets/164491/25173268/0824dc72-2526-11e7-955c-ea5e20dae746.gif)


After
![zeppelin_after](https://cloud.githubusercontent.com/assets/164491/25173272/09e11bfc-2526-11e7-9096-5adb6f1992ef.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
