### PR TITLE
[ZEPPELIN-2434] Credential feature does work in JDBC interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -149,7 +149,7 @@ public class JDBCInterpreter extends Interpreter {
       logger.debug("propertyKey: {}", propertyKey);
       String[] keyValue = propertyKey.split("\\.", 2);
       if (2 == keyValue.length) {
-        logger.info("key: {}, value: {}", keyValue[0], keyValue[1]);
+        logger.debug("key: {}, value: {}", keyValue[0], keyValue[1]);
 
         Properties prefixProperties;
         if (basePropretiesMap.containsKey(keyValue[0])) {
@@ -249,6 +249,7 @@ public class JDBCInterpreter extends Interpreter {
 
   private boolean existAccountInBaseProperty(String propertyKey) {
     return basePropretiesMap.get(propertyKey).containsKey(USER_KEY) &&
+        !isEmpty((String) basePropretiesMap.get(propertyKey).get(USER_KEY)) &&
         basePropretiesMap.get(propertyKey).containsKey(PASSWORD_KEY);
   }
 
@@ -295,7 +296,6 @@ public class JDBCInterpreter extends Interpreter {
       }
     }
     jdbcUserConfigurations.setPropertyMap(propertyKey, basePropretiesMap.get(propertyKey));
-
     if (existAccountInBaseProperty(propertyKey)) {
       return;
     }
@@ -576,7 +576,7 @@ public class JDBCInterpreter extends Interpreter {
     String precode = getProperty(String.format(PRECODE_KEY_TEMPLATE, propertyKey));
     if (StringUtils.isNotBlank(precode)) {
       precode = StringUtils.trim(precode);
-      logger.info("Run SQL precode '{}'", precode);
+      logger.debug("Run SQL precode '{}'", precode);
       try (Statement statement = connection.createStatement()) {
         statement.execute(precode);
         if (!connection.getAutoCommit()) {
@@ -720,7 +720,7 @@ public class JDBCInterpreter extends Interpreter {
 
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
-    logger.info("Run SQL command '{}'", cmd);
+    logger.debug("Run SQL command '{}'", cmd);
     String propertyKey = getPropertyKey(cmd);
 
     if (null != propertyKey && !propertyKey.equals(DEFAULT_KEY)) {
@@ -728,8 +728,7 @@ public class JDBCInterpreter extends Interpreter {
     }
 
     cmd = cmd.trim();
-
-    logger.info("PropertyKey: {}, SQL command: '{}'", propertyKey, cmd);
+    logger.debug("PropertyKey: {}, SQL command: '{}'", propertyKey, cmd);
     return executeSql(propertyKey, cmd, contextInterpreter);
   }
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -339,18 +339,18 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
      * 'jdbc1' interpreter has user('dbuser')/password('dbpassword') property
      * 'jdbc2' interpreter doesn't have user/password property
      * 'user1' doesn't have Credential information.
-     * 'user2' has 'jdbc2' Credential information that is same with database account.
+     * 'user2' has 'jdbc2' Credential information that is 'user2Id' / 'user2Pw' as id and password
      */
 
     JDBCInterpreter jdbc1 = new JDBCInterpreter(getDBProperty("dbuser", "dbpassword"));
-    JDBCInterpreter jdbc2 = new JDBCInterpreter(getDBProperty(null, null));
+    JDBCInterpreter jdbc2 = new JDBCInterpreter(getDBProperty("", ""));
 
     AuthenticationInfo user1Credential = getUserAuth("user1", null, null, null);
-    AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.jdbc2", "dbuser", "dbpassword");
+    AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.jdbc2", "user2Id","user2Pw");
 
     // user1 runs jdbc1
     jdbc1.open();
-    InterpreterContext ctx1 = new InterpreterContext("", "1", "jdbc.jdbc1", "", "", user1Credential,
+    InterpreterContext ctx1 = new InterpreterContext("", "1", "jdbc1", "", "", user1Credential,
       null, null, null, null, null, null);
     jdbc1.interpret("", ctx1);
 
@@ -361,7 +361,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     // user1 runs jdbc2
     jdbc2.open();
-    InterpreterContext ctx2 = new InterpreterContext("", "1", "jdbc.jdbc2", "", "", user1Credential,
+    InterpreterContext ctx2 = new InterpreterContext("", "1", "jdbc2", "", "", user1Credential,
       null, null, null, null, null, null);
     jdbc2.interpret("", ctx2);
 
@@ -372,7 +372,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     // user2 runs jdbc1
     jdbc1.open();
-    InterpreterContext ctx3 = new InterpreterContext("", "1", "jdbc.jdbc1", "", "", user2Credential,
+    InterpreterContext ctx3 = new InterpreterContext("", "1", "jdbc1", "", "", user2Credential,
       null, null, null, null, null, null);
     jdbc1.interpret("", ctx3);
 
@@ -383,13 +383,13 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     // user2 runs jdbc2
     jdbc2.open();
-    InterpreterContext ctx4 = new InterpreterContext("", "1", "jdbc.jdbc2", "", "", user2Credential,
+    InterpreterContext ctx4 = new InterpreterContext("", "1", "jdbc2", "", "", user2Credential,
       null, null, null, null, null, null);
     jdbc2.interpret("", ctx4);
 
     JDBCUserConfigurations user2JDBC2Conf = jdbc2.getJDBCConfiguration("user2");
-    assertNull(user2JDBC2Conf.getPropertyMap("default").get("user"));
-    assertNull(user2JDBC2Conf.getPropertyMap("default").get("password"));
+    assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("default").get("user"));
+    assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("default").get("password"));
     jdbc2.close();
   }
 


### PR DESCRIPTION
### What is this PR for?
Credential feature does not work in JDBC interpreter.

This PR fixes unittest that does not detect this bug and fix jdbc interpreter to correctly read credential.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix unittest
* [x] - Fix condition when use credential, when use property.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2434

### How should this be tested?
Set empty `default.user` property and set id/pw in 'credential' menu. And try use jdbc interpreter.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
