### PR TITLE
[ZEPPELIN-2409] DON'T block body scrolling in results scrollbar

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -138,6 +138,15 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
   // queue for append output
   const textResultQueueForAppend = []
 
+  // prevent body area scrollbar from blocking due to scroll in paragraph results
+  $scope.mouseOver = false
+  $scope.onMouseOver = function() { $scope.mouseOver = true }
+  $scope.onMouseOut = function() { $scope.mouseOver = false }
+  $scope.getPointerEvent = function() {
+    return ($scope.mouseOver) ? {'pointer-events': 'auto' }
+      : {'pointer-events': 'none' }
+  }
+
   $scope.init = function (result, config, paragraph, index) {
     // register helium plugin vis
     let visBundles = heliumService.getVisualizationBundles()

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -21,13 +21,13 @@ limitations under the License.
     ng-if="!config.helium.activeApp"
     style="padding-bottom: 5px;"
     resize='{"allowresize": "{{!asIframe && !viewOnly}}", "graphType": "{{type}}"}'
-       resizable on-resize="resize(width, height);">
+    resizable on-resize="resize(width, height);">
 
-    <div ng-if="type=='TABLE'">
+    <div ng-if="type=='TABLE'"
+         ng-style="getPointerEvent()">
       <!-- graph setting -->
       <div class="option lightBold" style="overflow: visible;"
-           ng-show="graphMode!='table'
-                    && config.graph.optionOpen && !asIframe && !viewOnly">
+           ng-show="graphMode!='table' && config.graph.optionOpen && !asIframe && !viewOnly">
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="trsetting{{id}}_{{viz.id}}"
              ng-show="graphMode == viz.id"></div>
@@ -55,8 +55,7 @@ limitations under the License.
 
     <div ng-if="type == 'TEXT'"
          class="plainTextContainer"
-         ng-style="getPointerEvent()"
-    >
+         ng-style="getPointerEvent()">
       <div class="fa fa-level-down scroll-paragraph-down"
            ng-show="showScrollDownIcon()"
            ng-click="scrollParagraphDown()"
@@ -70,30 +69,40 @@ limitations under the License.
            uib-tooltip="Scroll Top"></div>
     </div>
 
-    <div id="p{{id}}_custom" class="resultContained"
-      ng-if="!isDefaultDisplay()">
+    <div id="p{{id}}_custom"
+         class="resultContained"
+         ng-if="!isDefaultDisplay()"
+         ng-style="getPointerEvent()">
     </div>
 
-    <div id="p{{id}}_elem" class="resultContained"
-         ng-if="type == 'ELEMENT'">
+    <div id="p{{id}}_elem"
+         class="resultContained"
+         ng-if="type == 'ELEMENT'"
+         ng-style="getPointerEvent()">
     </div>
 
-    <div id="p{{id}}_html" class="resultContained"
-         ng-if="type == 'HTML'">
+    <div id="p{{id}}_html"
+         class="resultContained"
+         ng-if="type == 'HTML'"
+         ng-style="getPointerEvent()">
     </div>
 
-    <div id="p{{id}}_angular" class="resultContained"
-         ng-if="type == 'ANGULAR'">
+    <div id="p{{id}}_angular"
+         class="resultContained"
+         ng-if="type == 'ANGULAR'"
+         ng-style="getPointerEvent()">
     </div>
 
     <img id="{{id}}_img"
          ng-if="type == 'IMG'"
-         ng-src="{{getBase64ImageSrc(result.data)}}" />
+         ng-src="{{getBase64ImageSrc(result.data)}}"
+         ng-style="getPointerEvent()" />
   </div>
 
   <div ng-repeat="app in apps">
     <div id="p{{app.id}}"
-         ng-show="config.helium.activeApp == app.id">
+         ng-show="config.helium.activeApp == app.id"
+         ng-style="getPointerEvent()">
     </div>
   </div>
 </div>

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -15,6 +15,8 @@ limitations under the License.
 <div>
   <div ng-include src="'app/notebook/paragraph/result/result-chart-selector.html'"></div>
   <div
+    ng-mouseout="onMouseOut()"
+    ng-mouseover="onMouseOver()"
     id="p{{id}}_resize"
     ng-if="!config.helium.activeApp"
     style="padding-bottom: 5px;"
@@ -52,7 +54,9 @@ limitations under the License.
     </div>
 
     <div ng-if="type == 'TEXT'"
-         class="plainTextContainer">
+         class="plainTextContainer"
+         ng-style="getPointerEvent()"
+    >
       <div class="fa fa-level-down scroll-paragraph-down"
            ng-show="showScrollDownIcon()"
            ng-click="scrollParagraphDown()"


### PR DESCRIPTION
### What is this PR for?

DON'T block body scrolling in results scrollbar. 
See the GIFs below.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2409](https://issues.apache.org/jira/browse/ZEPPELIN-2409)

### How should this be tested?

1. Create multiple paragraphs including scrollbar in result. For example,

```
bank.printSchema
bank.show()
```

```
select * from bank limit 1000
```

2. Scrolling down, up

### Screenshots (if appropriate)

#### Before

![2407_before](https://cloud.githubusercontent.com/assets/4968473/25261209/f25c2956-268b-11e7-877d-28c6281f7567.gif)

#### After

![2407_2](https://cloud.githubusercontent.com/assets/4968473/25309978/258c2da0-2815-11e7-8e65-fd8b0dd3f760.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
