### PR TITLE
[ZEPPELIN-2414] Memory leak under scoped mode of SparkInterpreter caused by inapproprately setting Thread.contextClassLoader

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -163,7 +163,8 @@ public class RemoteInterpreterServer
           interpreterGroup.put(noteId, interpreters);
         }
 
-        interpreters.add(new LazyOpenInterpreter(repl));
+        interpreters.add(new LazyOpenInterpreter(
+            new ClassloaderInterpreter(repl, Thread.currentThread().getContextClassLoader())));
       }
 
       logger.info("Instantiate interpreter {}", className);


### PR DESCRIPTION
### What is this PR for?
Fix memory leak under scoped mode of SparkInterpreter which is caused by inapproprately setting Thread.contextClassLoader.

### What type of PR is it?
Bug Fix

### Todos
Rest Thread.contextClassLoader in Methods:
* [x] - Wraps interpreters with ClassLoader with ClassLoaderInterpreter in RemoteInterpreterServer.createInterpreter

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2414

### How should this be tested?

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
