### PR TITLE
[ZEPPELIN-2388] Improve the keyboard shortcuts dialog

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -244,14 +244,20 @@ table.dataTable.table-condensed .sorting_desc:after {
   padding: 15px;
   border-bottom: 1px solid #9cb4c5;
   background-color: #3071a9;
+  border: 2px solid #3071a9;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .shortcut-modal-header .close {
-  margin-top: -2px;
+  color: #cfcfcf;
+ opacity: 1;
 }
 
 .shortcut-modal-title {
   color: white;
+  margin-top: 2px;
+  margin-bottom: 2px;
 }
 
 table.table-shortcut {
@@ -262,12 +268,12 @@ table.table-shortcut {
 .table-shortcut > tbody > tr > th {
   background-color: #d6dde7;
   border-color: 1px solid #9cb4c5;
-  color: #337ab7;
+  color: #383a3c;
   font-size: 14px !important;
+  font-weight: 500;
 }
 
-.kbd-white {
-  color: #777777;
+.kbd-default {
   border: 1;
 }
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -251,7 +251,7 @@ table.dataTable.table-condensed .sorting_desc:after {
 
 .shortcut-modal-header .close {
   color: #cfcfcf;
- opacity: 1;
+  opacity: 1;
 }
 
 .shortcut-modal-title {
@@ -269,12 +269,20 @@ table.table-shortcut {
   background-color: #d6dde7;
   border-color: 1px solid #9cb4c5;
   color: #383a3c;
-  font-size: 14px !important;
+  font-size: 15px !important;
   font-weight: 500;
+}
+
+.table-shortcut > tbody > tr > td {
+  border-top: 0px;
+  padding: 5px;
+  vertical-align: middle;
+  font-size: 14px !important;
 }
 
 .kbd-default {
   border: 1;
+  font-size: 10px !important;
 }
 
 /*

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -222,14 +222,53 @@ table.dataTable.table-condensed .sorting_desc:after {
   cursor: pointer;
 }
 
-.dropdown-menu .shortcut-icon{
+.dropdown-menu .shortcut-icon {
   padding-right: 7px;
   float: left;
 }
 
-.dropdown-menu .shortcut-keys{
+.dropdown-menu .shortcut-keys {
   float: right;
   color: #999;
+}
+
+.modal-dialog .table-scroll {
+  max-height: 70vh;
+  min-width: 160px;
+  overflow: auto;
+  overflow-y: scroll;
+}
+
+.shortcut-modal-header {
+  min-height: 16.428571429px;
+  padding: 15px;
+  border-bottom: 1px solid #9cb4c5;
+  background-color: #3071a9;
+}
+
+.shortcut-modal-header .close {
+  margin-top: -2px;
+}
+
+.shortcut-modal-title {
+  color: white;
+}
+
+table.table-shortcut {
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+}
+
+.table-shortcut > tbody > tr > th {
+  background-color: #d6dde7;
+  border-color: 1px solid #9cb4c5;
+  color: #337ab7;
+  font-size: 14px !important;
+}
+
+.kbd-white {
+  color: #777777;
+  border: 1;
 }
 
 /*

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -15,292 +15,297 @@ limitations under the License.
 <div class="modal fade" id="shortcutModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <div class="modal-header">
+      <div class="shortcut-modal-header">
         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-        <h4 class="modal-title" id="myModalLabel">Keyboard shortcuts</h4>
+        <h4 class="shortcut-modal-title" id="myModalLabel">Keyboard shortcuts</h4>
       </div>
-      <div class="modal-body">
+      <div class="table-scroll">
+        <table class="table table-shortcut">
+          <tr>
+            <th style="width:70%">Note Keyboard Shortcuts</th>
+            <th></th>
+          </tr>
 
-        <h4>Note Shortcuts</h4>
+          <tr>
+            <td>
+              <div class="col-md-8">Run paragraph</div>
+           </td>
+           <td>
+              <div class="keys">
+                <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">Enter</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+          <tr>
+            <td>
+              <div class="col-md-8">Cancel</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">C</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor Up</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">P</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor Down</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">N</kbd>
+              </div>
+            </td>
+          </tr>
+
+        <tr>
+          <td>
+            <div class="col-md-8">Remove paragraph</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">Enter</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">D</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Run paragraph
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Insert new paragraph above</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">C</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">A</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Cancel
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Insert new paragraph below</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">P</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">B</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Move cursor Up
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Insert copy of paragraph below</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">N</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">C</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Move cursor Down
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Move paragraph Up</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">D</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">K</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Remove paragraph
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Move paragraph Down</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">A</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">J</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Insert new paragraph above
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
+        <tr>
+          <td>
+            <div class="col-md-8">Enable/Disable run paragraph</div>
+          </td>
+          <td>
             <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">B</kbd>
+              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-white">R</kbd>
             </div>
-          </div>
-          <div class="col-md-8">
-            Insert new paragraph below
-          </div>
-        </div>
+          </td>
+        </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">C</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Insert copy of paragraph below
-          </div>
-        </div>
+        <tr>
+          <td>
+            <div class="col-md-8">Toggle output</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">O</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">K</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Move paragraph Up
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Toggle editor</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">E</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">J</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Move paragraph Down
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Toggle line number</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">M</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-dark">R</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Enable/Disable run paragraph
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Toggle title</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">T</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">O</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Toggle output
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Clear output</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">L</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">E</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Toggle editor
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Link this paragraph</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">W</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">M</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Toggle line number
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Reduce paragraph width</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">-</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">T</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Toggle title
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Increase paragraph width</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">+</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">L</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Clear output
-          </div>
-        </div>
+          <tr class="sub-title">
+            <th style="width:70%">Editor Keyboard Shortcuts</th>
+            <th></th>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-dark">W</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Link this paragraph
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Auto-completion</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">.</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">-</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Reduce paragraph width
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Cut the line</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">K</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Shift</kbd> + <kbd class="kbd-dark">+</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Increase paragraph width
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Paste the line</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Y</kbd>
+              </div>
+            </td>
+          </tr>
 
+          <tr>
+            <td>
+              <div class="col-md-8">Search inside the code</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">S</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <h4>Editor Shortcuts</h4>
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor to the beginning</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">A</kbd>
+              </div>
+            </td>
+          </tr>
 
-      <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">.</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Auto-completion
-          </div>
-        </div>
-
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">K</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Cut the line
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">Y</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Paste the line
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">S</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Search inside the code
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">A</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Move cursor to the beginning
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-4">
-            <div class="keys">
-              <kbd class="kbd-dark">Ctrl</kbd> + <kbd class="kbd-dark">E</kbd>
-            </div>
-          </div>
-          <div class="col-md-8">
-            Move cursor at the end
-          </div>
-        </div>
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor at the end</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">E</kbd>
+              </div>
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
   </div>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -32,7 +32,7 @@ limitations under the License.
            </td>
            <td>
               <div class="keys">
-                <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">Enter</kbd>
+                <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">Enter</kbd>
               </div>
             </td>
           </tr>
@@ -43,7 +43,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">C</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">C</kbd>
               </div>
             </td>
           </tr>
@@ -54,7 +54,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">P</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">P</kbd>
               </div>
             </td>
           </tr>
@@ -65,7 +65,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">N</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">N</kbd>
               </div>
             </td>
           </tr>
@@ -76,7 +76,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">D</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">D</kbd>
             </div>
           </td>
         </tr>
@@ -87,7 +87,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">A</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">A</kbd>
             </div>
           </td>
         </tr>
@@ -98,7 +98,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">B</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">B</kbd>
             </div>
           </td>
         </tr>
@@ -109,7 +109,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">C</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">C</kbd>
             </div>
           </td>
         </tr>
@@ -120,7 +120,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">K</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">K</kbd>
             </div>
           </td>
         </tr>
@@ -131,7 +131,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">J</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">J</kbd>
             </div>
           </td>
         </tr>
@@ -142,7 +142,7 @@ limitations under the License.
           </td>
           <td>
             <div class="keys">
-              <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-white">R</kbd>
+              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-default">R</kbd>
             </div>
           </td>
         </tr>
@@ -153,7 +153,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">O</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">O</kbd>
               </div>
             </td>
           </tr>
@@ -164,7 +164,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">E</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">E</kbd>
               </div>
             </td>
           </tr>
@@ -175,7 +175,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">M</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">M</kbd>
               </div>
             </td>
           </tr>
@@ -186,7 +186,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">T</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">T</kbd>
               </div>
             </td>
           </tr>
@@ -197,7 +197,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">L</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">L</kbd>
               </div>
             </td>
           </tr>
@@ -208,7 +208,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-white">W</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">W</kbd>
               </div>
             </td>
           </tr>
@@ -219,7 +219,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">-</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">-</kbd>
               </div>
             </td>
           </tr>
@@ -230,7 +230,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Shift</kbd> + <kbd class="kbd-white">+</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">+</kbd>
               </div>
             </td>
           </tr>
@@ -246,7 +246,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">.</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">.</kbd>
               </div>
             </td>
           </tr>
@@ -257,7 +257,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">K</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">K</kbd>
               </div>
             </td>
           </tr>
@@ -268,7 +268,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">Y</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Y</kbd>
               </div>
             </td>
           </tr>
@@ -279,7 +279,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">S</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">S</kbd>
               </div>
             </td>
           </tr>
@@ -290,7 +290,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">A</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">A</kbd>
               </div>
             </td>
           </tr>
@@ -301,7 +301,7 @@ limitations under the License.
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-white">Ctrl</kbd> + <kbd class="kbd-white">E</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">E</kbd>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
## What is this PR for?
This PR is for Improving the keyboard shortcuts dialog form and here is what i improve.
- change to table shape
- add scrollbar
- fixed that text is misaligned when resizing windows

## What type of PR is it?
[Bug fix | Improvement]

## What is the Jira issue?
* [ZEPPELIN-2388; Prettify Keyboard Shortcut Dialog](https://issues.apache.org/jira/browse/ZEPPELIN-2388)

## How should this be tested?
1. Click `Keyboard Shortcuts' icon in a paragraph.
2. Check `Keyboard Shortcuts` shape.
3. Check resizing windows.

## Screenshots (if appropriate)
### [Before - 1. default]
![old_keyboard_shortcut](https://cloud.githubusercontent.com/assets/8110458/25274009/412a3f68-26c9-11e7-82ac-07835a04de83.png)

### [Before  - 2. text is misaligned when resizing windows]
![broken_shortcuts](https://cloud.githubusercontent.com/assets/8110458/25274381/c27c75d0-26ca-11e7-9262-4955bc4fcd42.png)

### [Before - 3. not scrollbar]
![need_scrollbar](https://cloud.githubusercontent.com/assets/8110458/25274313/76b4097e-26ca-11e7-8f11-599629c6c2b3.gif)


### [After - 1. default]
![new_keboard_shortcuts](https://cloud.githubusercontent.com/assets/8110458/25274041/5919f2bc-26c9-11e7-82a9-bd25526b118b.gif)

### [After - 2. resizing windows (my image is a little broken.)]
![resizing_shortcut](https://cloud.githubusercontent.com/assets/8110458/25274044/5c4e7494-26c9-11e7-9f23-2dbf2c9cf40f.gif)

### Last improvement dialog shape
![image](https://cloud.githubusercontent.com/assets/8110458/25366441/9a70432c-29aa-11e7-9b07-8a6b7cf9cc8a.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
