### PR TITLE
[ZEPPELIN-2410]: Using UUID from filename in registry cache dir inste…

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * This registry reads helium package json data
@@ -55,7 +56,10 @@ public class HeliumOnlineRegistry extends HeliumRegistry {
   public HeliumOnlineRegistry(String name, String uri, File registryCacheDir) {
     super(name, uri);
     registryCacheDir.mkdirs();
-    this.registryCacheFile = new File(registryCacheDir, name);
+
+    UUID registryCacheFileUuid = UUID.nameUUIDFromBytes(uri.getBytes());
+    this.registryCacheFile = new File(registryCacheDir, registryCacheFileUuid.toString());
+
     gson = new Gson();
   }
 


### PR DESCRIPTION
…ad of uri.


### What is this PR for?

Fixing issue ZEPPELIN-2410:

The previous version of this file used the full uri as file name in the
cache. This included special characters like the : in http: which
caused problems.

Since this is just a cache file, a better approach is to use an UUID.

The UUID is constructed from the URI to avoid the cache dir to grow
over time (in case there is no clean up of the cache dir).

Output of `ls -la` on macOS before the fix:
```
drwxr-xr-x  4 fries  staff  136 17 Apr 22:28 .
drwxr-xr-x  8 fries  staff  272 21 Apr 12:43 ..
drwxr-xr-x  3 fries  staff  102 17 Apr 10:39 https:
```

Output of `ls -la` on macOS after the fix:
```
drwxr-xr-x  4 fries  staff    136 21 Apr 17:32 .
drwxr-xr-x  8 fries  staff    272 21 Apr 17:32 ..
-rw-r--r--  1 fries  staff  89666 21 Apr 17:32 a6618b3e-540a-340e-b624-07bf7f2b5e7d
```

Note: Windows 7 just fails to create the cache before the fix.

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-2410?filter=-2

### How should this be tested?

Non-Regression Test.
Run on Windows, check cache dir.

### Screenshots (if appropriate)

N/A

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No