### PR TITLE
[ZEPPELIN-2431] Corrected deletion of notes by incorrect interpreter.json

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -887,14 +887,18 @@ public class InterpreterSettingManager {
     saveToFile();
   }
 
-  public void removeNoteInterpreterSettingBinding(String user, String noteId) {
+  public void removeNoteInterpreterSettingBinding(String user, String noteId) throws IOException {
     synchronized (interpreterSettings) {
       List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
           interpreterBindings.remove(noteId) :
           Collections.<String>emptyList());
       for (String settingId : settingIds) {
-        this.removeInterpretersForNote(get(settingId), user, noteId);
+        InterpreterSetting setting = get(settingId);
+        if (setting != null) {
+          this.removeInterpretersForNote(setting, user, noteId);
+        }
       }
+      saveToFile();
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -338,7 +338,11 @@ public class Notebook implements NoteEventListener {
       note = notes.remove(id);
       folders.removeNote(note);
     }
-    interpreterSettingManager.removeNoteInterpreterSettingBinding(subject.getUser(), id);
+    try {
+      interpreterSettingManager.removeNoteInterpreterSettingBinding(subject.getUser(), id);
+    } catch (IOException e) {
+      logger.error(e.toString(), e);
+    }
     noteSearchService.deleteIndexDocs(note);
     notebookAuthorization.removeNote(id);
 


### PR DESCRIPTION
## What is this PR for?

We sometimes can not delete a note, or we will be accompanied by an NPE for deleting a note.

This problem occurs when:
When interpreter.json 's note binding is wrong, or there is a problem.
If you are configuring an interpreter that is not through zeppelin's user interface.
As a result, it happens when synchronization of notes deletion and setting retention is not normal.
Therefore, we should add handling for note deletion and exception handling for nonexistent interpreter bindings.
It reduces the synchronization problem of interpreter.json.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2431

### How should this be tested?
1. zeppelin stop
2. edit con/interpreter.json and `interpreterBindings`
  fix any notes or incorrect information.
  for example 
  ```
    },  
  "interpreterBindings": {
    "2CFS9YSM5": [
      "2CFRR1D3TINVALIDINVALIDINVALID", <-- edit
      "2CFZ1JKUR",
      "2CEAJK1VW",
      "2CGSESWBH",
      "2CERNPGW5",
   }
  ```
3. zeppelin start
4. You can try remove invalid interpreter bind note on web. (on example = `2CFS9YSM5`)

result : 
If the modifications to this PR are not reflected,
It will not be deleted or an error will appear on the server.
Also, the interpreterBindings information in interpreter.json does not respond to delete events.

### Screenshots (if appropriate)
problem animation
![cantremove](https://cloud.githubusercontent.com/assets/10525473/25327785/7031f960-2910-11e7-88c7-d322da21290c.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
