### PR TITLE
[ZEPPELIN-2447] Fix python interpreter as to use max result setting

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -96,7 +96,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
 
   public PythonInterpreter(Properties property) {
     super(property);
-    this.maxResult = Integer.parseInt(property.getProperty(MAX_RESULT));
+    this.maxResult = Integer.parseInt(property.getProperty(MAX_RESULT, "1000"));
     try {
       File scriptFile = File.createTempFile("zeppelin_python-", ".py", new File("/tmp"));
       scriptPath = scriptFile.getAbsolutePath();

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -96,6 +96,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
 
   public PythonInterpreter(Properties property) {
     super(property);
+    this.maxResult = Integer.parseInt(property.getProperty(MAX_RESULT));
     try {
       File scriptFile = File.createTempFile("zeppelin_python-", ".py", new File("/tmp"));
       scriptPath = scriptFile.getAbsolutePath();

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -11,7 +11,7 @@
         "description": "Python directory. It is set to python by default.(assume python is in your $PATH)"
       },
       "zeppelin.python.maxResult": {
-        "envName": null,
+        "envName": "ZEPPELIN_PYTHON_MAXRESULT",
         "propertyName": "zeppelin.python.maxResult",
         "defaultValue": "1000",
         "description": "Max number of dataframe rows to display."

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -55,7 +55,7 @@ class PyZeppelinContext(object):
     self.z = z
     self.paramOption = gateway.jvm.org.apache.zeppelin.display.Input.ParamOption
     self.javaList = gateway.jvm.java.util.ArrayList
-    self.max_result = 1000
+    self.max_result = z.getMaxResult() 
     self._displayhook = lambda *args: None
     self._setup_matplotlib()
 

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -64,10 +64,14 @@ public class PythonInterpreterTest implements InterpreterOutputListener {
 
   @Before
   public void beforeTest() throws IOException {
+    beforeTest(getPythonTestProperties());
+  }
+
+  protected void beforeTest(Properties properties) throws IOException {
     cmdHistory = "";
 
     // python interpreter
-    pythonInterpreter = new PythonInterpreter(getPythonTestProperties());
+    pythonInterpreter = new PythonInterpreter(properties);
 
     // create interpreter group
     InterpreterGroup group = new InterpreterGroup();
@@ -100,11 +104,29 @@ public class PythonInterpreterTest implements InterpreterOutputListener {
   }
 
   @Test
+  public void testInterpretPropertyMaxResultsLarger() throws InterruptedException, IOException {
+    // close existing pythonInterpreter and setup a new one with overwritten property
+    pythonInterpreter.close();
+    int maxResult = 5;
+    Properties p = getPythonTestProperties();
+    p.setProperty(MAX_RESULT, Integer.toString(maxResult));
+    beforeTest(p);
+
+    String codeParagraph = "import numpy as np\n" +
+                           "number_rows = 40\n" +
+                           "df = pd.DataFrame(np.random.randn(number_rows, 4), columns=list('ABCD'))\n" +
+                           "z.show(df)";
+    InterpreterResult result = pythonInterpreter.interpret(codeParagraph, context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertTrue(new String(out.getOutputAt(0).toByteArray()).split("<tr>").length == maxResult + 1);
+  }
+
+  @Test
   public void testInterpretInvalidSyntax() throws IOException {
     InterpreterResult result = pythonInterpreter.interpret("for x in range(0,3):  print (\"hi\")\n", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertTrue(new String(out.getOutputAt(0).toByteArray()).contains("hi\nhi\nhi"));
- }
+  }
 
   @Override
   public void onUpdateAll(InterpreterOutput out) {


### PR DESCRIPTION
### What is this PR for?
zeppelin_python.py used a hard-coded 1000 rows limit when returning results. This PR makes sure that the interpreter retrieves the max_results from PythonInterpreter.java and that the latter retrieves this configuration from the configuration via the properties object.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2447

### How should this be tested?
+ use %python interpreter
+ make a dataframe with more than a 1000 rows
+ z.show the dataframe
+ export it in csv 
+ the numbers of rows should exceed 1000 rows

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
no
* Is there breaking changes for older versions?
no
* Does this needs documentation?
no
