### PR TITLE
[ZEPPELIN-2451]: Add JDBC config option for calling connection.commit after paragraph execution

### DIFF
--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -75,6 +75,12 @@
         "propertyName": "zeppelin.jdbc.principal",
         "defaultValue": "",
         "description": "Kerberos principal"
+      },
+      "zeppelin.jdbc.autocommit": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.autocommit",
+        "defaultValue": "false",
+        "description": "Call connection.commit() after each paragraph execution"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
Adding config for automatically calling commit after JDBC paragraph execution

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2451

### How should this be tested?
Create property zeppelin.jdbc.autocommit with value "true" under the JDBC interpreter, run an INSERT statement against a database. The insert should be committed and should be accessible in the database.

Create property zeppelin.jdbc.autocommit with value "false" under the JDBC interpreter, run an INSERT statement against a database. The insert should not be committed and will not be in the database.

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
Yes
