### PR TITLE
SSL Support for Groovy Interpreter HTTP requests [ZEPPELIN-2443]

### DIFF
--- a/docs/interpreter/groovy.md
+++ b/docs/interpreter/groovy.md
@@ -39,7 +39,8 @@ def r = HTTP.get(
   headers: [
     'Accept':'application/json',
     //'Authorization:' : g.getProperty('search_auth'),
-  ] 
+  ],
+  ssl : g.getProperty('search_ssl') // assume groovy interpreter property search_ssl = HTTP.getNaiveSSLContext()
 )
 //check response code
 if( r.response.code==200 ) {
@@ -76,41 +77,62 @@ g.table(
 
 * `g.angular(String name)`
 
-Returns angular object by name. Look up notebook scope first and then global scope.
+   Returns angular object by name. Look up notebook scope first and then global scope.
 
 
 * `g.angularBind(String name, Object value)`
-
-Assign a new `value` into angular object `name`
+ 
+   Assign a new `value` into angular object `name`
 
 
 * `java.util.Properties g.getProperties()`
 
-returns all properties defined for this interpreter
+   returns all properties defined for this interpreter
 
 
 * `String g.getProperty('PROPERTY_NAME')` 
-```groovy 
-g.PROPERTY_NAME
-g.'PROPERTY_NAME'
-g['PROPERTY_NAME']
-g.getProperties().getProperty('PROPERTY_NAME')
-```
+   ```groovy 
+   g.PROPERTY_NAME
+   g.'PROPERTY_NAME'
+   g['PROPERTY_NAME']
+   g.getProperties().getProperty('PROPERTY_NAME')
+   ```
 
-All above the accessor to named property defined in groovy interpreter.
-In this case with name `PROPERTY_NAME`
+   All above the accessor to named property defined in groovy interpreter.
+   In this case with name `PROPERTY_NAME`
 
 
 * `groovy.xml.MarkupBuilder g.html()`
 
-Starts or continues rendering of `%angular` to output and returns [groovy.xml.MarkupBuilder](http://groovy-lang.org/processing-xml.html#_markupbuilder)
-MarkupBuilder is usefull to generate html (xml)
+   Starts or continues rendering of `%angular` to output and returns [groovy.xml.MarkupBuilder](http://groovy-lang.org/processing-xml.html#_markupbuilder)
+   MarkupBuilder is usefull to generate html (xml)
 
 * `void g.table(obj)`
 
-starts or continues rendering table rows.
+   starts or continues rendering table rows.
 
-obj:  List(rows) of List(columns) where first line is a header 
+   obj:  List(rows) of List(columns) where first line is a header 
 
 
+* `g.input(name, value )`
 
+   Creates `text` input with value specified. The parameter `value` is optional.
+   
+* `g.select(name, default, Map<Object, String> options)`
+
+   Creates `select` input with defined options. The parameter `default` is optional.
+
+   ```g.select('sex', 'm', ['m':'man', 'w':'woman'])```
+   
+* `g.checkbox(name, Collection checked, Map<Object, String> options)`
+
+   Creates `checkbox` input.
+   
+* `g.get(name, default)`
+
+   Returns interpreter-based variable. Visibility depends on interpreter scope. The parameter `default` is optional.
+
+* `g.put(name, value)`
+
+   Stores new value into interpreter-based variable. Visibility depends on interpreter scope.
+   


### PR DESCRIPTION
### What is this PR for?

Target: Create ability to call http services with custom keystores in a groovy way.
The following should work:
```groovy
//connect to host xxx.yyy with special keystore
HTTP.get(
  url: "https://xxx.yyy/zzz",
  ssl: " HTTP.getKeystoreSSLContext('./xxx_yyy_keystore.jks', 'testpass') "
)
//take context initialization code from groovy interpreter properties
HTTP.get(
  url: "https://xxx.yyy/zzz",
  ssl: g.SSL_CONTEXT_FROM_GROOVY_INTERPRET_PROPERTIES
)
//connect to host xxx.yyy with trust all (do not check trust certificates - dev mode only) 
HTTP.get(
  url: "https://xxx.yyy/zzz",
  ssl: " HTTP.getNaiveSSLContext() "
)
//
HTTP.get(
  url: "https://xxx.yyy/zzz",
  ssl: " MyCustomSSLBuilder.build() "
)
```


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-2443]

### How should this be tested?
follow the samples above or in documentation

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? YES
