### PR TITLE
[ZEPPELIN-2452] block update paragraph event on revision mode

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -483,20 +483,23 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   }
 
   $scope.$on('addParagraph', function (event, paragraph, index) {
-    if ($scope.paragraphUrl) {
+    if ($scope.paragraphUrl || $scope.revisionView === true) {
       return
     }
     addPara(paragraph, index)
   })
 
   $scope.$on('removeParagraph', function (event, paragraphId) {
-    if ($scope.paragraphUrl) {
+    if ($scope.paragraphUrl || $scope.revisionView === true) {
       return
     }
     removePara(paragraphId)
   })
 
   $scope.$on('moveParagraph', function (event, paragraphId, newIdx) {
+    if ($scope.revisionView === true) {
+      return
+    }
     let removedPara = removePara(paragraphId)
     if (removedPara && removedPara.length === 1) {
       addPara(removedPara[0], newIdx)
@@ -958,6 +961,9 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   })
 
   $scope.$on('insertParagraph', function (event, paragraphId, position) {
+    if ($scope.revisionView === true) {
+      return
+    }
     let newIndex = -1
     for (let i = 0; i < $scope.note.paragraphs.length; i++) {
       if ($scope.note.paragraphs[i].id === paragraphId) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -610,7 +610,9 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     let session = editor.getSession()
     let dirtyText = session.getValue()
     $scope.dirtyText = dirtyText
-    $scope.startSaveTimer()
+    if ($scope.dirtyText != $scope.originalText) {
+      $scope.startSaveTimer();
+    }
     setParagraphMode(session, dirtyText, editor.getCursorPosition())
   }
 
@@ -1241,23 +1243,28 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   }
 
   $scope.updateParagraph = function (oldPara, newPara, updateCallback) {
-     // 1. get status, refreshed
+     // 1. can't update on revision view
+    if (!!$scope.revisionView) {
+      return;
+    }
+
+     // 2. get status, refreshed
     const statusChanged = (newPara.status !== oldPara.status)
     const resultRefreshed = (newPara.dateFinished !== oldPara.dateFinished) ||
        isEmpty(newPara.results) !== isEmpty(oldPara.results) ||
        newPara.status === ParagraphStatus.ERROR ||
        (newPara.status === ParagraphStatus.FINISHED && statusChanged)
 
-     // 2. update texts managed by $scope
+     // 3. update texts managed by $scope
     $scope.updateAllScopeTexts(oldPara, newPara)
 
-     // 3. execute callback to update result
+     // 4. execute callback to update result
     updateCallback()
 
-     // 4. update remaining paragraph objects
+     // 5. update remaining paragraph objects
     $scope.updateParagraphObjectWhenUpdated(newPara)
 
-     // 5. handle scroll down by key properly if new paragraph is added
+     // 6. handle scroll down by key properly if new paragraph is added
     if (statusChanged || resultRefreshed) {
        // when last paragraph runs, zeppelin automatically appends new paragraph.
        // this broadcast will focus to the newly inserted paragraph

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -610,8 +610,8 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     let session = editor.getSession()
     let dirtyText = session.getValue()
     $scope.dirtyText = dirtyText
-    if ($scope.dirtyText != $scope.originalText) {
-      $scope.startSaveTimer();
+    if ($scope.dirtyText !== $scope.originalText) {
+      $scope.startSaveTimer()
     }
     setParagraphMode(session, dirtyText, editor.getCursorPosition())
   }
@@ -1244,8 +1244,8 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
   $scope.updateParagraph = function (oldPara, newPara, updateCallback) {
      // 1. can't update on revision view
-    if (!!$scope.revisionView) {
-      return;
+    if ($scope.revisionView === true) {
+      return
     }
 
      // 2. get status, refreshed


### PR DESCRIPTION
### What is this PR for?
In revision mode using git-repository, by default all paragraphs must remain unmodifiable.
However, we are currently performing an incorrect update.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2452

### How should this be tested?
1. create note and modify to paragraph and version control commit on web
2. modify to paragraph and execute
3. open your 2 browser - one browser is HEAD, and other browser move to before commit
4. insert paragarph or modify and execute.
check update

### Screenshots (if appropriate)

#### problem
![incorrectrevisionupdate](https://cloud.githubusercontent.com/assets/10525473/25425492/1a0ebcce-2aa7-11e7-9a06-cfc84a1c1fe3.gif)

#### fixed (this pr)
![correctrevisionupdate](https://cloud.githubusercontent.com/assets/10525473/25425498/1dce1bfc-2aa7-11e7-816c-c25a64963475.gif)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
