### PR TITLE
[ZEPPELIN-2452] Can not handle message in revision mode on web.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -839,14 +839,16 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
   let getEditorSetting = function (paragraph, interpreterName) {
     let deferred = $q.defer()
-    websocketMsgSrv.getEditorSetting(paragraph.id, interpreterName)
-    $timeout(
-      $scope.$on('editorSetting', function (event, data) {
-        if (paragraph.id === data.paragraphId) {
-          deferred.resolve(data)
-        }
-      }
-      ), 1000)
+    if (!$scope.revisionView) {
+      websocketMsgSrv.getEditorSetting(paragraph.id, interpreterName)
+      $timeout(
+        $scope.$on('editorSetting', function (event, data) {
+            if (paragraph.id === data.paragraphId) {
+              deferred.resolve(data)
+            }
+          }
+        ), 1000)
+    }
     return deferred.promise
   }
 

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -843,11 +843,11 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
       websocketMsgSrv.getEditorSetting(paragraph.id, interpreterName)
       $timeout(
         $scope.$on('editorSetting', function (event, data) {
-            if (paragraph.id === data.paragraphId) {
-              deferred.resolve(data)
-            }
+          if (paragraph.id === data.paragraphId) {
+            deferred.resolve(data)
           }
-        ), 1000)
+        }
+      ), 1000)
     }
     return deferred.promise
   }


### PR DESCRIPTION
### What is this PR for?
Requests interpreter editor mode information in revision mode.
However, no information is needed in revision mode.
Produces misleading logs with misleading requests to the server.
```
ERROR [2017-04-26 18:07:48,718] ({qtp1273765644-60} NotebookServer.java[onMessage]:383) - Can't handle message
java.lang.NullPointerException
ERROR [2017-04-26 18:07:49,081] ({qtp1273765644-109} NotebookServer.java[onMessage]:383) - Can't handle message
java.lang.NullPointerException
ERROR [2017-04-26 18:07:49,083] ({qtp1273765644-14} NotebookServer.java[onMessage]:383) - Can't handle message
java.lang.NullPointerException
```

This log is requested as many as the number of paragraphs contained in the note.


### What type of PR is it?
Bug fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2452

### How should this be tested?
1. Create a git-repo based note. (Supported by default)
2. Modify the paragraph and commit.
3. Go to the committed revision.
4. Reload the page.
5. Check the server logs.

```
NotebookServer.java[onMessage]:383) - Can't handle message
java.lang.NullPointerException
```

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
