### PR TITLE
[ZEPPELIN-2448] Fix paragraph navigation issue

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1331,7 +1331,8 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         $scope.$emit('moveFocusToPreviousParagraph', paragraphId)
       } else if (editorHide && (keyCode === 40 || (keyCode === 78 && keyEvent.ctrlKey && !keyEvent.altKey))) { // down
         // move focus to next paragraph
-        $scope.$emit('moveFocusToNextParagraph', paragraphId)
+        // $timeout stops chaining effect of focus propogation
+        $timeout(() => $scope.$emit('moveFocusToNextParagraph', paragraphId))
       } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue())
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c


### PR DESCRIPTION
### What is this PR for?
* Keyboard events are broadcasted to components in lower tree
* Focus was getting transferred to the lower paragraphs, causing a chaining effect
* Making emit synchronous fixes the problem

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2448

### How should this be tested?
* Open a notebook with three or more paragraphs (A, B, C, D) one below the other
* Hide editor in B and C
* Try to navigate A to D
* The focus is passed through all four paragraphs

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
