### PR TITLE
ZEPPELIN-2459 Zeppelin Usability Improvement for new paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -629,9 +629,18 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
       $scope.editor.getSession().setUseWrapMode(true)
       $scope.editor.setTheme('ace/theme/chrome')
       $scope.editor.setReadOnly($scope.isRunning($scope.paragraph))
+
       if ($scope.paragraphFocused) {
+        let prefix = '%' + getInterpreterName($scope.paragraph.text)
+        let paragraphText = $scope.paragraph.text ? $scope.paragraph.text.trim() : ''
+
         $scope.editor.focus()
         $scope.goToEnd($scope.editor)
+        if (prefix === paragraphText) {
+          $timeout(function () {
+            $scope.editor.gotoLine(2, 0)
+          }, 0)
+        }
       }
 
       autoAdjustEditorHeight(_editor)


### PR DESCRIPTION
### What is this PR for?
Move cursor to second line for new paragraphs

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
ZEPPELIN-2459

### How should this be tested?
For a new paragraph he initial cursor position should be on the second line.

### Screenshots (if appropriate)
**Before**
<img width="324" alt="screen shot 2017-04-26 at 10 27 48 pm" src="https://cloud.githubusercontent.com/assets/2031306/25446579/9dcdeb2a-2acf-11e7-883d-e0ccf2ef834d.png">

**After**
<img width="394" alt="screen shot 2017-04-26 at 10 27 33 pm" src="https://cloud.githubusercontent.com/assets/2031306/25446593/a66289da-2acf-11e7-8d8e-2029339f0133.png">


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
