### PR TITLE
[HOTFIX] Remove adduser while creating note

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -353,7 +353,6 @@ public class Note implements Serializable, ParagraphJobListener {
   private Paragraph createParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph p = new Paragraph(this, this, factory, interpreterSettingManager);
     p.setAuthenticationInfo(authenticationInfo);
-    p.addUser(p, p.getUser());
     setParagraphMagic(p, index);
     return p;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -217,4 +217,20 @@ public class NoteTest {
 
     assertEquals("getName should return same as getId when name is empty", note.getId(), note.getName());
   }
+
+  @Test
+  public void personalizedModeReturnDifferentParagraphInstancePerUser() {
+    Note note = new Note(repo, interpreterFactory, interpreterSettingManager, jobListenerFactory, index, credentials, noteEventListener);
+
+    String user1 = "user1";
+    String user2 = "user2";
+    note.setPersonalizedMode(true);
+    note.addNewParagraph(new AuthenticationInfo(user1));
+    Paragraph baseParagraph = note.getParagraphs().get(0);
+    Paragraph user1Paragraph = baseParagraph.getUserParagraph(user1);
+    Paragraph user2Paragraph = baseParagraph.getUserParagraph(user2);
+    assertNotEquals(System.identityHashCode(baseParagraph), System.identityHashCode(user1Paragraph));
+    assertNotEquals(System.identityHashCode(baseParagraph), System.identityHashCode(user2Paragraph));
+    assertNotEquals(System.identityHashCode(user1Paragraph), System.identityHashCode(user2Paragraph));
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Adding user paragraph while creating paragraph makes default paragraph and user paragraph have same reference. It breaks personalized mode works well. 

### What type of PR is it?
[Bug Fix | Hot Fix]

### Todos
* [x] - Remove `addUser` from `createParagraph`
* [x] - Add test case for it

### What is the Jira issue?
N/A

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
