### PR TITLE
[ZEPPELIN-2463] Avoid Locking interpreterSettings during Notebook deletion

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -455,11 +455,9 @@ public class InterpreterSettingManager {
 
   private List<String> getNoteInterpreterSettingBinding(String noteId) {
     LinkedList<String> bindings = new LinkedList<>();
-    synchronized (interpreterSettings) {
-      List<String> settingIds = interpreterBindings.get(noteId);
-      if (settingIds != null) {
-        bindings.addAll(settingIds);
-      }
+    List<String> settingIds = interpreterBindings.get(noteId);
+    if (settingIds != null) {
+      bindings.addAll(settingIds);
     }
     return bindings;
   }
@@ -888,14 +886,12 @@ public class InterpreterSettingManager {
   }
 
   public void removeNoteInterpreterSettingBinding(String user, String noteId) {
-    synchronized (interpreterSettings) {
       List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
           interpreterBindings.remove(noteId) :
           Collections.<String>emptyList());
       for (String settingId : settingIds) {
         this.removeInterpretersForNote(get(settingId), user, noteId);
       }
-    }
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
Deletion of a notebook requires locking interpreterSettings. If the deletion is delayed , then lock is not released. At that point, we cannot run any notebook because everything is waiting to lock interpreterSettings.
Looking at the code, there is no reason to lock the InterpreterSettings object in InterpreterSettingManager.removeNoteInterpreterSettingBinding.
Similarly in InterpreterSettingManager.getNoteInterpreterSettingBinding only interpreterSettingBinding is accessed and its already a thread safe object. So we can remove synchronization on InterpreterSettings

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2463

### How should this be tested?
Being a concurrency issue, it is difficult to test this.

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
