### PR TITLE
[ZEPPELIN-2463] Avoid Locking interpreterSettings during Notebook deletion

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -455,11 +455,9 @@ public class InterpreterSettingManager {
 
   private List<String> getNoteInterpreterSettingBinding(String noteId) {
     LinkedList<String> bindings = new LinkedList<>();
-    synchronized (interpreterSettings) {
-      List<String> settingIds = interpreterBindings.get(noteId);
-      if (settingIds != null) {
-        bindings.addAll(settingIds);
-      }
+    List<String> settingIds = interpreterBindings.get(noteId);
+    if (settingIds != null) {
+      bindings.addAll(settingIds);
     }
     return bindings;
   }
@@ -888,7 +886,6 @@ public class InterpreterSettingManager {
   }
 
   public void removeNoteInterpreterSettingBinding(String user, String noteId) throws IOException {
-    synchronized (interpreterSettings) {
       List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
           interpreterBindings.remove(noteId) :
           Collections.<String>emptyList());
@@ -899,7 +896,6 @@ public class InterpreterSettingManager {
         }
       }
       saveToFile();
-    }
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -886,16 +886,16 @@ public class InterpreterSettingManager {
   }
 
   public void removeNoteInterpreterSettingBinding(String user, String noteId) throws IOException {
-      List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
-          interpreterBindings.remove(noteId) :
+    List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
+        interpreterBindings.remove(noteId) :
           Collections.<String>emptyList());
-      for (String settingId : settingIds) {
-        InterpreterSetting setting = get(settingId);
-        if (setting != null) {
-          this.removeInterpretersForNote(setting, user, noteId);
-        }
+    for (String settingId : settingIds) {
+      InterpreterSetting setting = get(settingId);
+      if (setting != null) {
+        this.removeInterpretersForNote(setting, user, noteId);
       }
-      saveToFile();
+    }
+    saveToFile();
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -886,13 +886,13 @@ public class InterpreterSettingManager {
   }
 
   public void removeNoteInterpreterSettingBinding(String user, String noteId) throws IOException {
-    List<String> settingIds = (interpreterBindings.containsKey(noteId) ?
-        interpreterBindings.remove(noteId) :
-          Collections.<String>emptyList());
-    for (String settingId : settingIds) {
-      InterpreterSetting setting = get(settingId);
-      if (setting != null) {
-        this.removeInterpretersForNote(setting, user, noteId);
+    List<String> settingIds = interpreterBindings.remove(noteId);
+    if (settingIds != null) {
+      for (String settingId : settingIds) {
+        InterpreterSetting setting = get(settingId);
+        if (setting != null) {
+          this.removeInterpretersForNote(setting, user, noteId);
+        }
       }
     }
     saveToFile();


### PR DESCRIPTION
### What is this PR for?
Deletion of a notebook requires locking interpreterSettings. If the deletion is delayed , then lock is not released. At that point, we cannot run any notebook because everything is waiting to lock interpreterSettings.
Looking at the code, there is no reason to lock the InterpreterSettings object in InterpreterSettingManager.removeNoteInterpreterSettingBinding.
Similarly in InterpreterSettingManager.getNoteInterpreterSettingBinding only interpreterSettingBinding is accessed and its already a thread safe object. So we can remove synchronization on InterpreterSettings


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2463

### How should this be tested?
Being a concurrency issue, it is difficult to test. 
Please see the comments in the jira to see the issue experienced on a production zeppelin server.

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
