### PR TITLE
[ZEPPELIN-2465] Minor code fixes for the livy package

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -57,9 +56,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Base class for livy interpreters.
  */
-public abstract class BaseLivyInterprereter extends Interpreter {
+public abstract class BaseLivyInterpreter extends Interpreter {
 
-  protected static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterprereter.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterpreter.class);
   private static Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
   private static String SESSION_NOT_FOUND_PATTERN = "\"Session '\\d+' not found.\"";
 
@@ -68,7 +67,6 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   private int sessionCreationTimeout;
   private int pullStatusInterval;
   protected boolean displayAppInfo;
-  private AtomicBoolean sessionExpired = new AtomicBoolean(false);
   protected LivyVersion livyVersion;
   private RestTemplate restTemplate;
 
@@ -77,7 +75,7 @@ public abstract class BaseLivyInterprereter extends Interpreter {
   private ConcurrentHashMap<String, Integer> paragraphId2StmtProgressMap =
       new ConcurrentHashMap<>();
 
-  public BaseLivyInterprereter(Properties property) {
+  public BaseLivyInterpreter(Properties property) {
     super(property);
     this.livyURL = property.getProperty("zeppelin.livy.url");
     this.displayAppInfo = Boolean.parseBoolean(

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySpark3Interpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySpark3Interpreter.java
@@ -17,16 +17,6 @@
 
 package org.apache.zeppelin.livy;
 
-import org.apache.zeppelin.interpreter.*;
-import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.scheduler.Scheduler;
-import org.apache.zeppelin.scheduler.SchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkBaseInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkBaseInterpreter.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 /**
  * Base class for PySpark Interpreter
  */
-public abstract class LivyPySparkBaseInterpreter extends BaseLivyInterprereter {
+public abstract class LivyPySparkBaseInterpreter extends BaseLivyInterpreter {
 
   public LivyPySparkBaseInterpreter(Properties property) {
     super(property);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkInterpreter.java
@@ -17,16 +17,6 @@
 
 package org.apache.zeppelin.livy;
 
-import org.apache.zeppelin.interpreter.*;
-import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.scheduler.Scheduler;
-import org.apache.zeppelin.scheduler.SchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -17,23 +17,12 @@
 
 package org.apache.zeppelin.livy;
 
-import org.apache.zeppelin.interpreter.*;
-import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.scheduler.Scheduler;
-import org.apache.zeppelin.scheduler.SchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Livy Spark interpreter for Zeppelin.
  */
-public class LivySparkInterpreter extends BaseLivyInterprereter {
+public class LivySparkInterpreter extends BaseLivyInterpreter {
 
   public LivySparkInterpreter(Properties property) {
     super(property);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkRInterpreter.java
@@ -17,23 +17,13 @@
 
 package org.apache.zeppelin.livy;
 
-import org.apache.zeppelin.interpreter.*;
-import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
-import org.apache.zeppelin.scheduler.Scheduler;
-import org.apache.zeppelin.scheduler.SchedulerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 
 /**
  * Livy PySpark interpreter for Zeppelin.
  */
-public class LivySparkRInterpreter extends BaseLivyInterprereter {
+public class LivySparkRInterpreter extends BaseLivyInterpreter {
 
   public LivySparkRInterpreter(Properties property) {
     super(property);

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -30,7 +30,7 @@ import java.util.Properties;
 /**
  * Livy SparkSQL Interpreter for Zeppelin.
  */
-public class LivySparkSQLInterpreter extends BaseLivyInterprereter {
+public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
 
   public static final String ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE =
       "zeppelin.livy.spark.sql.field.truncate";

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -761,7 +761,7 @@ public class LivyInterpreterIT {
     }
   }
 
-  private boolean isSpark2(BaseLivyInterprereter interpreter, InterpreterContext context) {
+  private boolean isSpark2(BaseLivyInterpreter interpreter, InterpreterContext context) {
     InterpreterResult result = null;
     if (interpreter instanceof LivySparkRInterpreter) {
       result = interpreter.interpret("sparkR.session()", context);


### PR DESCRIPTION
### What is this PR for?
Minor code fixes for the livy package.
The code fixes include :
Fixing a typo in a classname - BaseLivyInterprereter to BaseLivyInterpreter
Removing an unused variable in BaseLivyInterpreter
Removing unused imports in a few classes


### What type of PR is it?
Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2465

### How should this be tested?
No need to test as there is no change in funcionality


### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
