### PR TITLE
[ZEPPELIN-2466] Chart resize problem

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -184,6 +184,15 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     $timeout(retry)
   }
 
+  angular.element($window).bind('resize', function() {
+    if ($scope.resizeRenderTimeout) {
+      $timeout.cancel($scope.resizeRenderTimeout)
+    }
+    $scope.resizeRenderTimeout = $timeout(function () {
+      renderResult($scope.type)
+    }, 500)
+  });
+  
   $scope.$on('updateResult', function (event, result, newConfig, paragraphRef, index) {
     if (paragraph.id !== paragraphRef.id || index !== resultIndex) {
       return

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -184,15 +184,6 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     $timeout(retry)
   }
 
-  angular.element($window).bind('resize', function() {
-    if ($scope.resizeRenderTimeout) {
-      $timeout.cancel($scope.resizeRenderTimeout)
-    }
-    $scope.resizeRenderTimeout = $timeout(function () {
-      renderResult($scope.type)
-    }, 500)
-  })
-
   $scope.$on('updateResult', function (event, result, newConfig, paragraphRef, index) {
     if (paragraph.id !== paragraphRef.id || index !== resultIndex) {
       return
@@ -549,9 +540,6 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
           builtInViz.instance.render(transformed)
           builtInViz.instance.renderSetting(visualizationSettingTargetEl)
           builtInViz.instance.activate()
-          angular.element(window).resize(() => {
-            builtInViz.instance.resize()
-          })
         } catch (err) {
           console.error('Graph drawing error %o', err)
         }

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -540,6 +540,9 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
           builtInViz.instance.render(transformed)
           builtInViz.instance.renderSetting(visualizationSettingTargetEl)
           builtInViz.instance.activate()
+          angular.element(window).resize(() => {
+            builtInViz.instance.resize()
+          })
         } catch (err) {
           console.error('Graph drawing error %o', err)
         }

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -191,8 +191,8 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     $scope.resizeRenderTimeout = $timeout(function () {
       renderResult($scope.type)
     }, 500)
-  });
-  
+  })
+
   $scope.$on('updateResult', function (event, result, newConfig, paragraphRef, index) {
     if (paragraph.id !== paragraphRef.id || index !== resultIndex) {
       return

--- a/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
@@ -58,7 +58,7 @@ export default class Nvd3ChartVisualization extends Visualization {
       .duration(animationDuration)
       .call(this.chart)
     d3.select('#' + this.targetEl[0].id + ' svg').style.height = height + 'px'
-    nv.utils.windowResize(this.chart.update);
+    nv.utils.windowResize(this.chart.update)
   }
 
   type () {

--- a/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
@@ -58,6 +58,7 @@ export default class Nvd3ChartVisualization extends Visualization {
       .duration(animationDuration)
       .call(this.chart)
     d3.select('#' + this.targetEl[0].id + ' svg').style.height = height + 'px'
+    nv.utils.windowResize(this.chart.update);
   }
 
   type () {


### PR DESCRIPTION
### What is this PR for?
If you change the size of the chart after changing the mode of the chart,
The chart size is not reflected.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2466

### How should this be tested?
1. resize for your browser.
2. chart toggle -> for example, bar chart -> table -> bar chart
3. and try resize for browser.

### Screenshots (if appropriate)
#### bug
![resize-inc](https://cloud.githubusercontent.com/assets/10525473/25518072/3f8fbb4c-2c2d-11e7-94a4-e051f1a1e382.gif)

#### fixed
![resize-c](https://cloud.githubusercontent.com/assets/10525473/25518077/4213bfd0-2c2d-11e7-8f9c-13fd5e8d2806.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
