### PR TITLE
[ZEPPELIN-2468] Enable websocket without Origin if allowed.origins is *

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -60,11 +60,13 @@ public class SecurityUtils {
 
   public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)
       throws UnknownHostException, URISyntaxException {
-    if (sourceHost == null || sourceHost.isEmpty()) {
-      return false;
+
+    String sourceUriHost = "";
+
+    if (sourceHost != null && !sourceHost.isEmpty()) {
+      sourceUriHost = new URI(sourceHost).getHost();
+      sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase();
     }
-    String sourceUriHost = new URI(sourceHost).getHost();
-    sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase();
 
     sourceUriHost = sourceUriHost.toLowerCase();
     String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
@@ -71,6 +71,12 @@ public class SecurityUtilsTest {
   }
 
   @Test
+  public void nullOriginWithStar() throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(SecurityUtils.isValidOrigin(null,
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
+  }
+
+  @Test
   public void emptyOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
     assertFalse(SecurityUtils.isValidOrigin("",
           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));


### PR DESCRIPTION
Change-Id: Iaad10a69983036e84b766a22fbc32113b926b60d

### What is this PR for?
With ZEPPELIN-2288 we restored the check of the Origin field for websocket requests.

Unfortunately the current implementation will deny the request if the Origin HTTP header is empty, even if the zeppelin.server.allowed.origins is *

This patch enables websocket requests without Origin in the HTTP header if the zeppelin.server.allowed.origins=*. This fixes the work behind a restrictive reverse proxy (or behind Apache Knox)


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2468

### How should this be tested?

It could be tested with curl as described in ZEPPELIN-2288, but I added additional unit test, so the change has been covered on unit test level.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
