### PR TITLE
[ZEPPELIN-2467] Restoring second travis job functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
     # Test core modules
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtest='!ZeppelinSparkClusterTest,!org.apache.zeppelin.spark.*' -DfailIfNoTests=false"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumBundleFactoryTest.java,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ matrix:
       env: SCALA_VER="2.11" SPARK_VER="2.0.2" HADOOP_VER="2.6" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
     # Test core modules
+    #
+    # Several tests were excluded from this configuration due to the following issues:
+    # HeliumBundleFactoryTest      - https://issues.apache.org/jira/browse/ZEPPELIN-2469
+    # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
+    # NotebookTest                 - https://issues.apache.org/jira/browse/ZEPPELIN-2471
+    # ZeppelinRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2473
+    # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
     - jdk: "oraclejdk7"
       env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumBundleFactoryTest.java,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,9 @@
 
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
+
+    <!-- to be able to exclude some tests using command line -->
+    <tests.to.exclude/>
   </properties>
 
   <dependencyManagement>
@@ -555,6 +558,9 @@
           <version>${plugin.surefire.version}</version>
           <configuration combine.children="append">
             <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
+            <excludes>
+              <exclude>${tests.to.exclude}</exclude>
+            </excludes>
           </configuration>
           <!-- <excludes> <exclude>**/itest/**</exclude> </excludes> <executions>
             <execution> <id>surefire-itest</id> <phase>integration-test</phase> <goals>


### PR DESCRIPTION
### What is this PR for?
Second travis job didn't work correctly. It suppose to test all core unit tests plus integration test (except for spark related test) but it was doing nothing.

It was because of the exclamation mark in **-Dtest** property:
```
-Dtest='!ZeppelinSparkClusterTest,!org.apache.zeppelin.spark.*'
```
which is not supported by maven-surefire-plugin of version 2.17 (which is used in Zeppelin). Exclamation mark is supported started from 2.19 but still does not work properly.

I've added plugin **exclude** configuratin instead of **-Dtest** property.

After travis job was restored I had found that not all core tests were working properly. I have excluded them from the travis job for now and created jira issues:
https://issues.apache.org/jira/browse/ZEPPELIN-2469
https://issues.apache.org/jira/browse/ZEPPELIN-2470
https://issues.apache.org/jira/browse/ZEPPELIN-2471
https://issues.apache.org/jira/browse/ZEPPELIN-2473

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-2467](https://issues.apache.org/jira/browse/ZEPPELIN-2467)

### Questions:
* Does the licenses files need update? **no**
* Is there breaking changes for older versions? **no**
* Does this needs documentation? **no**
