### PR TITLE
add basic .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '1.0.0-dev.{build}'
+
+shallow_clone: true
+
+build: off
+
+os:
+  - Visual Studio 2015
+
+install:
+  - echo "Install"
+
+build_script:
+  - echo "Build"


### PR DESCRIPTION
### What is this PR for?
After appveyor ci is enabled for windows, PR build status shows red cross because of missing .appveyor.
This PR add skeleton appveyor.yml.


### What type of PR is it?
Feature

### Todos
* [x] - Add .appveyor.yml

### What is the Jira issue?
https://issues.apache.org/jira/browse/INFRA-14019

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
