### PR TITLE
[ZEPPELIN-2479] Fix incorrect tooltip view inside of version control menu

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -131,6 +131,8 @@ limitations under the License.
                         ng-hide="viewOnly"
                         ng-click="checkpointNote(note.checkpoint.message)"
                         style="margin-left: 4px;"
+                        tooltip-append-to-body="true"
+                        tooltip-class="revisionTooltip"
                         tooltip-placement="bottom" uib-tooltip="Commit this note">Commit
                 </button>
               </div>

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -51,6 +51,10 @@
   border-color: #ccc;
 }
 
+.revisionTooltip {
+  z-index: 10003;
+}
+
 .caretSeparator {
   height: 22px;
   line-height: 9px;
@@ -313,7 +317,6 @@
   max-width: 50%;
 }
 
-
 .inactivelink {
   color: darkgrey;
   cursor: default;
@@ -330,4 +333,3 @@
 }
 .noteAction.headroom--unpinned { top: -100px; }
 .noteAction.headroom--pinned { top: 50px; /** `noteAction` top */ }
-


### PR DESCRIPTION
### What is this PR for?
This is to fix incorrect appearance of tooltip inside version control menu

### What type of PR is it?
Improvement

### Todos
* [x] - fix/remove tooltip

### What is the Jira issue?
[ZEPPELIN-2479](https://issues.apache.org/jira/browse/ZEPPELIN-2479)

### How should this be tested?
go to `version control` menu in notebook action bar of note

### Screenshots (if appropriate)
before: 
<img width="689" alt="screen shot 2017-05-02 at 3 32 23 pm" src="https://cloud.githubusercontent.com/assets/1642088/25606467/62f0901c-2f4c-11e7-95ef-c22f1df410be.png">


after:
![screen shot 2017-05-02 at 6 55 24 pm](https://cloud.githubusercontent.com/assets/1642088/25613839/aac216a4-2f6a-11e7-8cab-a77ddb48382b.png)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
