### PR TITLE
[ZEPPELIN-2484] Fix NullPointerException in check for empty last paragraph

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1742,10 +1742,10 @@ public class NotebookServer extends WebSocketServlet
   }
 
   private void addNewParagraphIfLastParagraphIsExecuted(Note note, Paragraph p) {
-    // if it's the last paragraph and empty, let's add a new one
+    // if it's the last paragraph and not empty, let's add a new one
     boolean isTheLastParagraph = note.isLastParagraph(p.getId());
-    if (!(p.getText().trim().equals(p.getMagic()) ||
-        Strings.isNullOrEmpty(p.getText())) &&
+    if (!(Strings.isNullOrEmpty(p.getText()) ||
+        p.getText().trim().equals(p.getMagic())) &&
         isTheLastParagraph) {
       Paragraph newPara = note.addNewParagraph(p.getAuthenticationInfo());
       broadcastNewParagraph(note, newPara);


### PR DESCRIPTION
### What is this PR for?
Prevent NullPointerException during check to determine whether a new paragraph needs to added.
The fix is to switch order of null check and trim operation so that null check is performed before trim()


### What type of PR is it?
Bug Fix 


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2484

### How should this be tested?
This can be tested with a hive interpreter 
Create a note and add a paragraph with some query in it. 
Run all paragraphs.
A new paragraph is automatically added.
Run all paragraphs again. A NullPointerException is logged in the logs.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No 
* Is there breaking changes for older versions? No
* Does this needs documentation? No
