### PR TITLE
ZEPPELIN-2485. AngularModel can not be serialized correctly.

### DIFF
--- a/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularModel.scala
+++ b/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularModel.scala
@@ -23,9 +23,9 @@ import org.apache.zeppelin.interpreter.InterpreterContext
 /**
   * Represents ng-model with angular object
   */
-abstract class AbstractAngularModel(name: String) {
-  val context = InterpreterContext.get
-  val registry = context.getAngularObjectRegistry
+abstract class AbstractAngularModel(val name: String) {
+  @transient val context = InterpreterContext.get
+  @transient val registry = context.getAngularObjectRegistry
 
 
   /**

--- a/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModel.scala
+++ b/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModel.scala
@@ -23,7 +23,7 @@ import org.apache.zeppelin.interpreter.InterpreterContext
 /**
   * Represents ng-model in notebook scope
   */
-class AngularModel(name: String)
+class AngularModel(override val name: String)
   extends org.apache.zeppelin.display.angular.AbstractAngularModel(name) {
 
   def this(name: String, newValue: Any) = {

--- a/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModel.scala
+++ b/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModel.scala
@@ -22,7 +22,7 @@ import org.apache.zeppelin.display.angular.AbstractAngularModel
 /**
   * Represents ng-model in paragraph scope
   */
-class AngularModel(name: String)
+class AngularModel(override val name: String)
   extends org.apache.zeppelin.display.angular.AbstractAngularModel(name) {
 
   def this(name: String, newValue: Any) = {

--- a/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularModelTest.scala
+++ b/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularModelTest.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.display.angular
 
+import com.google.gson.Gson
 import org.apache.zeppelin.display.{AngularObjectRegistry, GUI}
 import org.apache.zeppelin.interpreter._
 import org.apache.zeppelin.user.AuthenticationInfo
@@ -42,6 +43,7 @@ with BeforeAndAfter with BeforeAndAfterEach with Eventually with Matchers {
 
   def angularModel(name: String): AbstractAngularModel
   def angularModel(name: String, value: Any): AbstractAngularModel
+  def angularModelClass: Class[_]
 
   "AngularModel" should "able to create AngularObject" in {
     val registry = InterpreterContext.get().getAngularObjectRegistry
@@ -80,6 +82,13 @@ with BeforeAndAfter with BeforeAndAfterEach with Eventually with Matchers {
     registrySize should be(0)
   }
 
+  "AngularModel" should "" in {
+    val gson = new Gson()
+    val m1 = angularModel("name")
+    val json = gson.toJson(m1)
+    val m2 = gson.fromJson(json, angularModelClass)
+    m1.name should be(m2.asInstanceOf[AbstractAngularModel].name)
+  }
 
   def registry() = {
     InterpreterContext.get().getAngularObjectRegistry

--- a/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModelTest.scala
+++ b/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModelTest.scala
@@ -29,4 +29,6 @@ class AngularModelTest extends AbstractAngularModelTest {
   override def angularModel(name: String, value: Any): AbstractAngularModel = {
     AngularModel(name, value)
   }
+
+  override def angularModelClass = classOf[AngularModel]
 }

--- a/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModelTest.scala
+++ b/zeppelin-display/src/test/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModelTest.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.display.angular.paragraphscope
 
+import org.apache.zeppelin.display.angular.notebookscope.AngularModel
 import org.apache.zeppelin.display.angular.{AbstractAngularModel, AbstractAngularModelTest}
 
 /**
@@ -29,4 +30,6 @@ class AngularModelTest extends AbstractAngularModelTest {
   override def angularModel(name: String, value: Any): AbstractAngularModel = {
     AngularModel(name, value)
   }
+
+  override def angularModelClass = classOf[AngularModel]
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
@@ -175,7 +175,6 @@ public class AngularObject<T> {
       emit();
     }
     LOGGER.debug("Update angular object: " + name + " with value: " + o);
-    final Logger logger = LoggerFactory.getLogger(AngularObject.class);
     List<AngularObjectWatcher> ws = new LinkedList<>();
     synchronized (watchers) {
       ws.addAll(watchers);
@@ -187,9 +186,10 @@ public class AngularObject<T> {
         @Override
         public void run() {
           try {
+            LOGGER.debug("Watcher of angular object {} is invoked.", name);
             w.watch(before, after);
           } catch (Exception e) {
-            logger.error("Exception on watch", e);
+            LOGGER.error("Exception on watch", e);
           }
         }
       });


### PR DESCRIPTION
### What is this PR for?
AngularModel would be serialized as part of AngularObject, but it would fail to serialized to json sometimes. 

```
ERROR [2017-05-03 14:25:31,563] ({pool-21-thread-1} AngularObject.java[run]:193) - Exception on watch
java.lang.IllegalArgumentException: class org.apache.zeppelin.display.angular.notebookscope.AngularModel declares multiple JSON fields named name
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:122)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:72)
    at com.google.gson.Gson.getAdapter(Gson.java:349)
    at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:55)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:89)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:195)
    at com.google.gson.Gson.toJson(Gson.java:582)
    at com.google.gson.Gson.toJson(Gson.java:561)
    at com.google.gson.Gson.toJson(Gson.java:516)
    at com.google.gson.Gson.toJson(Gson.java:496)
    at org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient.angularObjectUpdate(RemoteInterpreterEventClient.java:96)
```


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2485

### How should this be tested?
Unit test is added


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
