### PR TITLE
ZEPPELIN-2486. AngularElem's onChange is only invoked once

### DIFF
--- a/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularElem.scala
+++ b/zeppelin-display/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularElem.scala
@@ -131,10 +131,10 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
     // create AngularFunction in current paragraph
     val functionName = eventName.replaceAll("-", "_") + "_" + uniqueId
     val elem = this % Attribute(None, eventName,
-      Text(s"${functionName}=$$event.timeStamp"),
+      Text(s"${functionName}=${functionName} + 1"),
       Null)
 
-    val angularObject = addAngularObject(functionName, "")
+    val angularObject = addAngularObject(functionName, 0)
 
     angularObject.addWatcher(new AngularObjectWatcher(interpreterContext) {
       override def watch(oldObject: scala.Any, newObject: scala.Any, context: InterpreterContext)


### PR DESCRIPTION
### What is this PR for?
`ng-change` can not capture event, so that means `$event.timeStamp` is undefined. https://github.com/angular/angular.js/issues/6370
This cause AngularElem's onChange is only invoked once. This PR use another approach to update the angularObject. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2486

### How should this be tested?
Tested manually

### Screenshots (if appropriate)

Before
![zeppelin_before](https://cloud.githubusercontent.com/assets/164491/25662178/227ec2ec-3046-11e7-9852-9e041d008698.gif)
After
![zeppelin_after](https://cloud.githubusercontent.com/assets/164491/25662177/2108e898-3046-11e7-816f-7685480df83e.gif)
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
