### PR TITLE
[ZEPPELIN-2491] fix: Bump spell package version too

### DIFF
--- a/dev/change_zeppelin_version.sh
+++ b/dev/change_zeppelin_version.sh
@@ -57,6 +57,7 @@ mvn versions:set -DnewVersion="${TO_VERSION}" -DgenerateBackupPoms=false > /dev/
 sed -i '' 's/-'"${FROM_VERSION}"'.jar",/-'"${TO_VERSION}"'.jar",/g' zeppelin-examples/zeppelin-example-clock/zeppelin-example-clock.json
 sed -i '' 's/"version": "'"${FROM_VERSION}"'",/"version": "'"${TO_VERSION}"'",/g' zeppelin-web/src/app/tabledata/package.json
 sed -i '' 's/"version": "'"${FROM_VERSION}"'",/"version": "'"${TO_VERSION}"'",/g' zeppelin-web/src/app/visualization/package.json
+sed -i '' 's/"version": "'"${FROM_VERSION}"'",/"version": "'"${TO_VERSION}"'",/g' zeppelin-web/src/app/spell/package.json
 
 # When preparing new dev version from release tag, doesn't need to change docs version
 if is_dev_version "${FROM_VERSION}" || ! is_dev_version "${TO_VERSION}"; then


### PR DESCRIPTION
### What is this PR for?

[ZEPPELIN-2491] fix: Bump spell package version too

### What type of PR is it?
[Bug Fix]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2491](https://issues.apache.org/jira/browse/ZEPPELIN-2491)

### How should this be tested?

1. ` ./dev/change_zeppelin_version.sh 0.8.0-SNAPSHOT 0.8.0`
2. Check `/zeppelin-web/src/app/spell/package.json`

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
