### PR TITLE
[DOC] Update documentation: JDK 1.7 -> 1.8

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -36,7 +36,7 @@ Apache Zeppelin officially supports and is tested on the following environments:
   </tr>
   <tr>
     <td>Oracle JDK</td>
-    <td>1.7 <br /> (set <code>JAVA_HOME</code>)</td>
+    <td>1.8 <br /> (set <code>JAVA_HOME</code>)</td>
   </tr>
   <tr>
     <td>OS</td>


### PR DESCRIPTION
### What is this PR for?
Zeppelin is built with JDK 1.8 since 0.7.1 as far as I know. But it is still 1.7 on [installation documentation](https://zeppelin.apache.org/docs/0.7.1/install/install.html). Polina Marasanova pointed that out! Thanks!

This PR should be merged into master and 0.7.X in my opinion.



### What type of PR is it?
Documentation

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
