### PR TITLE
[ZEPPELIN-2437] Executions of notebooks are blocked after running 50 different notebooks under SparkInterpreter scoped mode

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -39,6 +39,7 @@ import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.scheduler.JobListener;
 import org.apache.zeppelin.scheduler.JobProgressPoller;
 import org.apache.zeppelin.scheduler.Scheduler;
+import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,9 +227,19 @@ public class RemoteInterpreterServer
           Interpreter inp = it.next();
           if (inp.getClassName().equals(className)) {
             inp.close();
+
+            Scheduler scheduler = inp.getScheduler();
+            if (scheduler != null) {
+              SchedulerFactory.singleton().removeScheduler(scheduler.getName());
+            }
+
             it.remove();
             break;
           }
+        }
+
+        if (interpreters.isEmpty()) {
+          interpreterGroup.remove(noteId);
         }
       }
     }


### PR DESCRIPTION
### What is this PR for?
Removes Scheduler when RemoteInterpreterServer close an interpreter.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Cherry-Picks modifications from #2175 to fix "escaped interpreters" on RemoteInterpreterServer side(Need to be done in another PR)
* [x] - Removes Scheduler when calling RemoteInterpreterServer.close()

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2437

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
