### PR TITLE
[ZEPPELIN-2512] Prevent slow note, interpreter search. (master, branch-0.7)

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -41,7 +41,10 @@ limitations under the License.
     <div class="row">
       <div class="col-md-4">
         <div class="input-group" style="margin-top: 10px">
-          <input type="text" ng-model="searchInterpreter" class="form-control ng-pristine ng-untouched ng-valid ng-empty" placeholder="Search interpreters"/>
+          <input type="text" ng-model="searchInterpreter"
+                 class="form-control ng-pristine ng-untouched ng-valid ng-empty"
+                 ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
+                 placeholder="Search interpreters"/>
           <span class="input-group-btn">
             <button type="submit" class="btn btn-default" ng-disabled="!navbar.connected">
               <i class="glyphicon glyphicon-search"></i>

--- a/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
+++ b/zeppelin-web/src/components/filterNoteNames/filter-note-names.html
@@ -11,5 +11,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<input type="text" class="note-name-query form-control" ng-click="$event.stopPropagation()"
-       placeholder="&#xf002 Filter" ng-model="$parent.query.q" />
+<input type="text"
+       class="note-name-query form-control"
+       ng-click="$event.stopPropagation()"
+       placeholder="&#xf002 Filter"
+       ng-model="$parent.query.q"
+       ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }" />


### PR DESCRIPTION
### What is this PR for?

Use debounce in search input to avoid the slow search.

See more:

![image](https://cloud.githubusercontent.com/assets/4968473/25814653/3be8890e-3459-11e7-9be2-6a440ab41861.png)

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2512](https://issues.apache.org/jira/browse/ZEPPELIN-2512)

### How should this be tested?

1. Create many notes with different names. (50+)
2. Search using note name filter in home and navbar.
3. Do the same thing for interpreters in the interpreter page

### Screenshots (if appropriate)

NONE

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
