### PR TITLE
[ZEPPELIN-2520] DON'T set bottom margin for markdown table

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -254,7 +254,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) bcprov-jdk15on v1.51 (org.bouncycastle:bcprov-jdk15on:jar:1.51 - http://www.bouncycastle.org/java.html) - http://www.bouncycastle.org/licence.html
     (The MIT License) AnchorJS (https://github.com/bryanbraun/anchorjs) - https://github.com/bryanbraun/anchorjs/blob/master/README.md#license
     (The MIT License) moment-duration-format v1.3.0 (https://github.com/jsmreese/moment-duration-format) - https://github.com/jsmreese/moment-duration-format/blob/master/LICENSE
-    (The MIT License) github-markdown-css 2.4.0 (https://github.com/sindresorhus/github-markdown-css) - https://github.com/sindresorhus/github-markdown-css/blob/gh-pages/license
+    (The MIT License) github-markdown-css 2.6.0 (https://github.com/sindresorhus/github-markdown-css) - https://github.com/sindresorhus/github-markdown-css/blob/v2.6.0/license
     (The MIT License) scopt (com.github.scopt:scopt_2.10:3.2.0 - https://github.com/scopt/scopt)
     (The MIT License) Objenesis (org.objenesis:objenesis:2.1 - https://github.com/easymock/objenesis) - Copyright (c) 2006-2015 the original author and authors
     (The MIT License) JCL 1.1.1 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.16 - http://www.slf4j.org)

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -33,7 +33,6 @@
     "handsontable": "~0.24.2",
     "moment-duration-format": "^1.3.0",
     "select2": "^4.0.3",
-    "github-markdown-css": "^2.4.0",
     "MathJax": "2.7.0",
     "ngclipboard": "^1.1.1"
   },

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -22,6 +22,7 @@
     "test": "karma start karma.conf.js"
   },
   "dependencies": {
+    "github-markdown-css": "2.6.0",
     "grunt-angular-templates": "^0.5.7",
     "grunt-dom-munger": "^3.4.0",
     "headroom.js": "^0.9.3"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -44,7 +44,7 @@
   word-wrap: break-word !important;
 }
 
-.paragraph table {
+.paragraph table:not(.markdown-body table) {
   margin-bottom: 0;
 }
 

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -46,7 +46,6 @@ limitations under the License.
     <link rel="stylesheet" href="bower_components/bootstrap3-dialog/dist/css/bootstrap-dialog.min.css" />
     <link rel="stylesheet" href="bower_components/pikaday/css/pikaday.css" />
     <link rel="stylesheet" href="bower_components/handsontable/dist/handsontable.css" />
-    <link rel="stylesheet" href="bower_components/github-markdown-css/github-markdown.css" />
     <!-- endbower -->
     <link rel="stylesheet" href="bower_components/jquery-ui/themes/base/jquery-ui.css" />
     <link rel="stylesheet" href="bower_components/select2/dist/css/select2.css" />

--- a/zeppelin-web/src/index.js
+++ b/zeppelin-web/src/index.js
@@ -12,6 +12,9 @@
  * limitations under the License.
  */
 
+// import globally uses css here
+import 'github-markdown-css/github-markdown.css'
+
 import './app/app.js'
 import './app/app.controller.js'
 import './app/home/home.controller.js'

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -165,7 +165,7 @@ module.exports = function makeWebpackConfig () {
       //
       // Reference: https://github.com/webpack/style-loader
       // Use style-loader in development.
-      loader: isTest ? 'null' : ExtractTextPlugin.extract('style-loader', 'css-loader?sourceMap!postcss-loader')
+      loader: ExtractTextPlugin.extract('style-loader', 'css-loader?sourceMap!postcss-loader')
     }, {
       // ASSET LOADER
       // Reference: https://github.com/webpack/file-loader
@@ -215,6 +215,10 @@ module.exports = function makeWebpackConfig () {
    * List: http://webpack.github.io/docs/list-of-plugins.html
    */
   config.plugins = [
+      // Reference: https://github.com/webpack/extract-text-webpack-plugin
+      // Extract css files
+      // Disabled when in test mode or not in build mode
+      new ExtractTextPlugin('[name].[hash].css', {disable: !isProd}),
   ];
 
   // Skip rendering index.html in test mode
@@ -226,11 +230,6 @@ module.exports = function makeWebpackConfig () {
         template: './src/index.html',
         inject: 'body'
       }),
-
-      // Reference: https://github.com/webpack/extract-text-webpack-plugin
-      // Extract css files
-      // Disabled when in test mode or not in build mode
-      new ExtractTextPlugin('[name].[hash].css', {disable: !isProd}),
 
       // Reference: https://webpack.github.io/docs/list-of-plugins.html#defineplugin
       new webpack.DefinePlugin({


### PR DESCRIPTION
### What is this PR for?

DON'T set bottom margin for the markdown table.

#### Implementation Details

that's because `.paragraph table` overwrites `.markdown-body table`

![image](https://cloud.githubusercontent.com/assets/4968473/25874159/542adc12-354c-11e7-93fd-7bdb65766b63.png)

### What type of PR is it?
[Bug Fix]

### Todos

* [x] - Bump version up from 2.4.0 to 2.6.0
* [x] - Update `bin_license/LICENSE`
* [x] - Import it using commonjs
* [x] - Fix paragraph.css 

### What is the Jira issue?

[ZEPPELIN-2520](https://issues.apache.org/jira/browse/ZEPPELIN-2520)

### How should this be tested?

1. Build: `mvn clean package -DskipTests;`
2. Execute a paragraph using this text.

```md
Colons can be used to align columns.

| Tables        | Are           | Cool  |
| ------------- |:-------------:| -----:|
| col 3 is      | right-aligned | $1600 |
| col 2 is      | centered      |   $12 |
| zebra stripes | are neat      |    $1 |

There must be at least 3 dashes separating each header cell.
The outer pipes (|) are optional, and you don't need to make the 
raw Markdown line up prettily. You can also use inline Markdown.

Markdown | Less | Pretty
--- | --- | ---
*Still* | `renders` | **nicely**
1 | 2 | 3
```

### Screenshots (if appropriate)

#### Before


![image](https://cloud.githubusercontent.com/assets/4968473/25874112/14d03a08-354c-11e7-8abb-8a270cd0b35b.png)

#### After


![image](https://cloud.githubusercontent.com/assets/4968473/25874100/025c030c-354c-11e7-9c66-c0c3874304a9.png)



### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
