### PR TITLE
[ZEPPELIN-2521] fix: Confusing axis description in advanced-transformation

### DIFF
--- a/zeppelin-web/src/app/tabledata/advanced-transformation-setting.html
+++ b/zeppelin-web/src/app/tabledata/advanced-transformation-setting.html
@@ -86,14 +86,10 @@ limitations under the License.
         <div class="columns lightBold">
           <!-- axis name -->
           <span class="label label-default"
-                uib-tooltip="{{axisSpec.description ? axisSpec.description : ''}}"
+                ng-style="getAxisAnnotationColor(axisSpec)"
+                uib-tooltip="{{axisSpec.description ? axisSpec.description + ' ' + getAxisTypeAnnotation(axisSpec) : ''}}"
                 style="font-weight: 300; font-size: 13px; margin-left: 1px;">
             {{getAxisAnnotation(axisSpec)}}
-          </span>
-          <span class="label label-default"
-                ng-style="getAxisTypeAnnotationColor(axisSpec)"
-                style="font-weight: 300; font-size: 13px; margin-left: 3px;">
-            {{getAxisTypeAnnotation(axisSpec)}}
           </span>
 
           <!-- axis box: in case of single dimension -->

--- a/zeppelin-web/src/app/tabledata/advanced-transformation.js
+++ b/zeppelin-web/src/app/tabledata/advanced-transformation.js
@@ -100,7 +100,7 @@ export default class AdvancedTransformation extends Transformation {
         },
 
         getAxisTypeAnnotation: (axisSpec) => {
-          let anno = `${axisSpec.axisType}`
+          let anno = ''
 
           let minAxisCount = axisSpec.minAxisCount
           let maxAxisCount = axisSpec.maxAxisCount
@@ -121,7 +121,7 @@ export default class AdvancedTransformation extends Transformation {
           return anno
         },
 
-        getAxisTypeAnnotationColor: (axisSpec) => {
+        getAxisAnnotationColor: (axisSpec) => {
           if (isAggregatorAxis(axisSpec)) {
             return { 'background-color': '#5782bd' }
           } else if (isGroupAxis(axisSpec)) {


### PR DESCRIPTION
### What is this PR for?

Fixed confusing axis descriptions in advanced-transformation.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2521](https://issues.apache.org/jira/browse/ZEPPELIN-2521)

### How should this be tested?

1. Install any helium visualization package written with advanced-transformation. For example ultimate-heatmap-chart.
2. Open the `setting` menu.

### Screenshots (if appropriate)

#### Before

<img width="797" alt="2521_before" src="https://cloud.githubusercontent.com/assets/4968473/25875376/0c327874-3552-11e7-883e-3667e198e180.png">

#### After

<img width="793" alt="2521_after" src="https://cloud.githubusercontent.com/assets/4968473/25875379/0f603de2-3552-11e7-8c50-2ac0b783b704.png">

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
