### PR TITLE
[minor] Replace 'SIMPLE' auth with 'simple' auth everywhere in documents

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -43,7 +43,7 @@ user3 = password4, role2
 #ldapRealm.contextFactory.environment[ldap.searchBase] = dc=COMPANY,dc=COM
 #ldapRealm.contextFactory.url = ldap://ldap.test.com:389
 #ldapRealm.userDnTemplate = uid={0},ou=Users,dc=COMPANY,dc=COM
-#ldapRealm.contextFactory.authenticationMechanism = SIMPLE
+#ldapRealm.contextFactory.authenticationMechanism = simple
 
 ### A sample PAM configuration
 #pamRealm=org.apache.zeppelin.realm.PamRealm

--- a/docs/security/shiroauthentication.md
+++ b/docs/security/shiroauthentication.md
@@ -85,7 +85,7 @@ ldapRealm = org.apache.zeppelin.server.LdapGroupRealm
 ldapRealm.contextFactory.environment[ldap.searchBase] = dc=COMPANY,dc=COM
 ldapRealm.contextFactory.url = ldap://ldap.test.com:389
 ldapRealm.userDnTemplate = uid={0},ou=Users,dc=COMPANY,dc=COM
-ldapRealm.contextFactory.authenticationMechanism = SIMPLE
+ldapRealm.contextFactory.authenticationMechanism = simple
 ```
 
 also define roles/groups that you want to have in system, like below;
@@ -134,7 +134,7 @@ ldapRealm = org.apache.zeppelin.realm.LdapGroupRealm
 ldapRealm.contextFactory.environment[ldap.searchBase] = dc=COMPANY,dc=COM
 ldapRealm.contextFactory.url = ldap://ldap.test.com:389
 ldapRealm.userDnTemplate = uid={0},ou=Users,dc=COMPANY,dc=COM
-ldapRealm.contextFactory.authenticationMechanism = SIMPLE
+ldapRealm.contextFactory.authenticationMechanism = simple
 ```
 
 ### PAM


### PR DESCRIPTION
### What is this PR for?
This PR fixes a security hole in documentation when 'SIMPLE' authentication mechanism is defined in Shiro configuration (http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/security/shiroauthentication.html). With that, user can log in without entering his/her password. Zeppelin documentation should recommend the correct value which is 'simple'.

### What type of PR is it?
Documentation

### What is the Jira issue?
N/A

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? yes
