### PR TITLE
WebHDFS Support

### DIFF
--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -33,6 +33,7 @@ There are few notebook storage systems available for a use out of the box:
   * storage using Amazon S3 service - `S3NotebookRepo`
   * storage using Azure service - `AzureNotebookRepo`
   * storage using MongoDB - `MongoNotebookRepo`
+  * storage using HDFS - `HdfsNotebookRepo`
 
 Multiple storage systems can be used at the same time by providing a comma-separated list of the class-names in the configuration.
 By default, only first two of them will be automatically kept in sync by Zeppelin.
@@ -246,6 +247,31 @@ Optionally, you can specify Azure folder structure name in the file **zeppelin-s
 ```
 
 </br>
+
+## Notebook Storage in Hdfs <a name="HDFS"></a>
+ 
+ To enable your notebooks to be stored on HDFS - uncomment the next property in `zeppelin-site.xml` in order to use HdfsNotebookRepo class:
+ 
+ ```
+ <property>
+   <name>zeppelin.notebook.storage</name>
+   <value>org.apache.zeppelin.notebook.repo.HdfsNotebookRepo</value>
+   <description>notebook persistence layer implementation</description>
+ </property>
+ ```
+ 
+ and replace the notebook directory property below by an absolute HDFS location as follows :
+ ```
+  <property>
+   <name>zeppelin.notebook.dir</name>
+   <value>hdfs://localhost:9000/tmp/notebook</value>
+   <description>path or URI for notebook persist</description>
+ </property>
+```
+ 
+ </br>
+  
+ 
 ## Storage in ZeppelinHub  <a name="ZeppelinHub"></a>
 
 ZeppelinHub storage layer allows out of the box connection of Zeppelin instance with your ZeppelinHub account. First of all, you need to either comment out the following  property in **zeppelin-site.xml**:

--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -33,9 +33,9 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  *
  */
 public class HDFSFileInterpreter extends FileInterpreter {
-  static final String HDFS_URL = "hdfs.url";
-  static final String HDFS_USER = "hdfs.user";
-  static final String HDFS_MAXLENGTH = "hdfs.maxlength";
+  public static final String HDFS_URL = "hdfs.url";
+  public static final String HDFS_USER = "hdfs.user";
+  public static final String HDFS_MAXLENGTH = "hdfs.maxlength";
 
   Exception exceptionOnConnect = null;
   HDFSCommand cmd = null;
@@ -214,8 +214,8 @@ public class HDFSFileInterpreter extends FileInterpreter {
           AllFileStatus allFiles = gson.fromJson(sfs, AllFileStatus.class);
 
           if (allFiles != null &&
-                  allFiles.FileStatuses != null &&
-                  allFiles.FileStatuses.FileStatus != null)
+              allFiles.FileStatuses != null &&
+              allFiles.FileStatuses.FileStatus != null)
           {
             for (OneFileStatus fs : allFiles.FileStatuses.FileStatus)
               all = all + listOne(path, fs) + '\n';
@@ -250,7 +250,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
 
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor,
-      InterpreterContext interpreterContext) {
+                                                InterpreterContext interpreterContext) {
     logger.info("Completion request at position\t" + cursor + " in string " + buf);
     final List<InterpreterCompletion> suggestions = new ArrayList<>();
     if (StringUtils.isEmpty(buf)) {
@@ -294,8 +294,8 @@ public class HDFSFileInterpreter extends FileInterpreter {
           AllFileStatus allFiles = gson.fromJson(fileStatusString, AllFileStatus.class);
 
           if (allFiles != null &&
-                  allFiles.FileStatuses != null &&
-                  allFiles.FileStatuses.FileStatus != null)
+              allFiles.FileStatuses != null &&
+              allFiles.FileStatuses.FileStatus != null)
           {
             for (OneFileStatus fs : allFiles.FileStatuses.FileStatus) {
               if (fs.pathSuffix.contains(unfinished)) {

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -60,6 +60,18 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-file</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/HdfsNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/HdfsNotebookRepo.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.repo;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.notebook.NotebookImportDeserializer;
+import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.util.HdfsSite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+
+public class HdfsNotebookRepo implements NotebookRepo {
+  private static Logger logger = LoggerFactory.getLogger(HdfsNotebookRepo.class);
+  private HdfsSite hdfsSite;
+  private ZeppelinConfiguration conf;
+  private String rootDir;
+
+
+  public HdfsNotebookRepo(ZeppelinConfiguration conf) throws IOException {
+    this.conf = conf;
+    try {
+      rootDir = removeProtocol(conf.getNotebookDir());
+      hdfsSite = new HdfsSite(conf);
+      hdfsSite.mkdirs(rootDir);
+    } catch (URISyntaxException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public String removeProtocol(String hdfsUrl) {
+    String newUrl = hdfsUrl.replaceAll("/$", "");
+    if (newUrl.startsWith("hdfs://")) {
+      return "/" + newUrl.replaceAll("^hdfs://", "").split("/", 2)[1];
+    } else {
+      return newUrl;
+    }
+  }
+
+
+  @Override
+  public List<NoteInfo> list(AuthenticationInfo subject) throws IOException {
+    String[] children = hdfsSite.listFiles(rootDir);
+    List<NoteInfo> infos = new LinkedList<>();
+    for (String child : children) {
+      String fileName = child;
+      if (fileName.startsWith(".")
+          || fileName.startsWith("#")
+          || fileName.startsWith("~")) {
+        // skip hidden, temporary files
+        continue;
+      }
+
+      if (!hdfsSite.isDirectory(rootDir + "/" + child)) {
+        // currently single note is saved like, [NOTE_ID]/note.json.
+        // so it must be a directory
+        continue;
+      }
+
+      NoteInfo info = null;
+
+      try {
+        info = getNoteInfo(rootDir + "/" + child);
+        if (info != null) {
+          infos.add(info);
+        }
+      } catch (Exception e) {
+        logger.error("Can't read note " + fileName, e);
+      }
+    }
+
+    return infos;
+  }
+
+  private Note getNote(String noteDir) throws IOException {
+    if (!hdfsSite.isDirectory(noteDir)) {
+      throw new IOException(noteDir + " is not a directory");
+    }
+
+    String noteJson = noteDir + "/" + "note.json";
+    if (!hdfsSite.exists(noteJson)) {
+      throw new IOException(noteJson + " not found");
+    }
+
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
+        .create();
+
+    byte[] content = hdfsSite.readFile(noteJson);
+    String json = new String(content, conf.getString(ConfVars.ZEPPELIN_ENCODING));
+
+    Note note = gson.fromJson(json, Note.class);
+
+    for (Paragraph p : note.getParagraphs()) {
+      if (p.getStatus() == Status.PENDING || p.getStatus() == Status.RUNNING) {
+        p.setStatus(Status.ABORT);
+      }
+    }
+    return note;
+  }
+
+  private NoteInfo getNoteInfo(String noteDir) throws IOException {
+    Note note = getNote(noteDir);
+    return new NoteInfo(note);
+  }
+
+  @Override
+  public Note get(String noteId, AuthenticationInfo subject) throws IOException {
+    String path = rootDir + "/" + noteId;
+    return getNote(path);
+  }
+
+  protected String getRootDir() throws IOException {
+    if (!hdfsSite.exists(rootDir)) {
+      throw new IOException("Root path does not exists");
+    }
+
+    if (!hdfsSite.isDirectory(rootDir)) {
+      throw new IOException("Root path is not a directory");
+    }
+    return rootDir;
+  }
+
+  @Override
+  public synchronized void save(Note note, AuthenticationInfo subject) throws IOException {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.create();
+    String json = gson.toJson(note);
+
+    String noteDir = rootDir + "/" + note.getId();
+
+    if (!hdfsSite.exists(noteDir)) {
+      hdfsSite.mkdirs(noteDir);
+    }
+    if (!hdfsSite.isDirectory(noteDir)) {
+      throw new IOException(noteDir + " is not a directory");
+    }
+
+    String noteJson = noteDir + "/" + "note.json";
+    hdfsSite.writeFile(json.getBytes(conf.getString(ConfVars.ZEPPELIN_ENCODING)), noteJson);
+  }
+
+  @Override
+  public void remove(String noteId, AuthenticationInfo subject) throws IOException {
+    String noteDir = rootDir + "/" + noteId;
+
+    if (!hdfsSite.exists(noteDir)) {
+      throw new IOException("Can not remove " + noteDir);
+    }
+    hdfsSite.delete(noteDir);
+  }
+
+  @Override
+  public void close() {
+    
+  }
+
+  @Override
+  public Revision checkpoint(String noteId, String checkpointMsg, AuthenticationInfo subject)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public Note get(String noteId, String revId, AuthenticationInfo subject) throws IOException {
+    return null;
+  }
+
+  @Override
+  public List<Revision> revisionHistory(String noteId, AuthenticationInfo subject) {
+    return null;
+  }
+
+  @Override
+  public Note setNoteRevision(String noteId, String revId, AuthenticationInfo subject)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
+    return null;
+  }
+
+  @Override
+  public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
+
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/HdfsSite.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/HdfsSite.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.util;
+
+import com.google.gson.Gson;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.file.HDFSCommand;
+import org.apache.zeppelin.file.HDFSFileInterpreter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.zeppelin.file.HDFSFileInterpreter.HDFS_MAXLENGTH;
+import static org.apache.zeppelin.file.HDFSFileInterpreter.HDFS_URL;
+
+/**
+ * Class to create / move / delete / write to / read from HDFS filessytem
+ */
+public class HdfsSite {
+  private static Logger logger = LoggerFactory.getLogger(HdfsSite.class);
+  public static final String HDFS_NOTEBOOK_DIR = "hdfs.notebook.dir";
+  static final String NOTE_JSON = "note.json";
+  static final String NOTE_JSON_TEMP = "_note.json";
+
+  ZeppelinConfiguration conf;
+  boolean enableWebHDFS = true;
+  String hdfsUrl = null;
+  String hdfsUser = null;
+  int hdfsMaxLength = 0;
+  HDFSCommand hdfsCmd = null;
+
+
+  public HdfsSite(ZeppelinConfiguration conf) throws URISyntaxException {
+    this.conf = conf;
+    this.hdfsUrl = conf.getString(HDFS_URL, HDFS_URL, "http://localhost:50070/webhdfs/v1/");
+    this.hdfsMaxLength = conf.getInt(HDFS_URL, HDFS_MAXLENGTH, 100000);
+    this.hdfsUser = System.getenv("HADOOP_USER_NAME");
+    if (this.hdfsUser == null) {
+      this.hdfsUser = System.getenv("LOGNAME");
+    }
+    if (this.hdfsUser == null) {
+
+      this.enableWebHDFS = false;
+    } else {
+      this.hdfsCmd = new HDFSCommand(hdfsUrl, hdfsUser, logger, this.hdfsMaxLength);
+      this.enableWebHDFS = exists("/");
+    }
+  }
+
+  public boolean exists(String path) {
+    boolean ret = false;
+    HDFSFileInterpreter.SingleFileStatus fileStatus;
+    Gson gson = new Gson();
+    try {
+      String notebookStatus = this.hdfsCmd.runCommand(this.hdfsCmd.getFileStatus, path, null);
+      fileStatus = gson.fromJson(notebookStatus, HDFSFileInterpreter.SingleFileStatus.class);
+      ret = fileStatus.FileStatus.modificationTime > 0;
+    } catch (Exception e) {
+      logger.info("disabled webHDFS. Please check webhdfs configurations");
+      ret = false;
+    } finally {
+      return ret;
+    }
+  }
+
+
+  public String[] listFiles(String directory) throws IOException {
+    List<String> hdfsNotebook = new ArrayList<String>();
+    Gson gson = new Gson();
+    String hdfsDirStatus;
+
+    try {
+      hdfsDirStatus = this.hdfsCmd.runCommand(this.hdfsCmd.listStatus, directory, null);
+      if (hdfsDirStatus != null) {
+        HDFSFileInterpreter.AllFileStatus allFiles = gson.fromJson(hdfsDirStatus,
+            HDFSFileInterpreter.AllFileStatus.class);
+        if (allFiles != null && allFiles.FileStatuses != null
+            && allFiles.FileStatuses.FileStatus != null) {
+          for (HDFSFileInterpreter.OneFileStatus fs : allFiles.FileStatuses.FileStatus) {
+            if ("DIRECTORY".equals(fs.type) && fs.pathSuffix.startsWith("_") == false) {
+              hdfsNotebook.add(fs.pathSuffix);
+              logger.info("read a notebook from HDFS: " + fs.pathSuffix);
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      logger.error("exception occurred during getting notebook from hdfs : ", e);
+    }
+    return hdfsNotebook.toArray(new String[0]);
+  }
+
+  public void delete(String path) throws IOException {
+    logger.debug("remove : " + path);
+
+    HDFSCommand.Arg recursive = this.hdfsCmd.new Arg("recursive", "true");
+    HDFSCommand.Arg[] args = {recursive};
+
+    try {
+      this.hdfsCmd.runCommand(this.hdfsCmd.deleteFile, path, args);
+    } catch (Exception e) {
+      logger.error("Exception: ", e);
+      throw new IOException(e.getCause());
+    }
+  }
+
+  public void mkdirs(String path) throws IOException {
+
+    try {
+      this.hdfsCmd.runCommand(this.hdfsCmd.makeDirectory, path, null);
+    } catch (Exception e) {
+      logger.error("Exception: ", e);
+      throw new IOException(e.getCause());
+    }
+  }
+
+
+  public void writeFile(byte[] content, String path) throws IOException {
+    try {
+      HDFSCommand.Arg dest = this.hdfsCmd.new Arg("overwrite", "true");
+      HDFSCommand.Arg[] createArgs = {dest};
+      this.hdfsCmd.runCommand(this.hdfsCmd.createWriteFile, path, content, createArgs);
+    } catch (Exception e) {
+      logger.error("Exception: ", e);
+      throw new IOException(e.getCause());
+    }
+  }
+
+  public void rename(String oldPath, String newPath) throws IOException {
+    try {
+      HDFSCommand.Arg dest = this.hdfsCmd.new Arg("destination", newPath);
+      HDFSCommand.Arg[] renameArgs = {dest};
+      this.hdfsCmd.runCommand(this.hdfsCmd.renameFile, oldPath, renameArgs);
+    } catch (Exception e) {
+      logger.error("Exception: ", e);
+      throw new IOException(e.getCause());
+    } finally {
+    }
+  }
+
+  public boolean isDirectory(String path) throws IOException {
+    boolean ret = false;
+    HDFSFileInterpreter.SingleFileStatus fileStatus;
+    Gson gson = new Gson();
+    try {
+      String notebookStatus = this.hdfsCmd.runCommand(this.hdfsCmd.getFileStatus, path, null);
+      fileStatus = gson.fromJson(notebookStatus, HDFSFileInterpreter.SingleFileStatus.class);
+      ret = fileStatus.FileStatus.type.equals("DIRECTORY");
+    } catch (Exception e) {
+      logger.info("disabled webHDFS. Please check webhdfs configurations");
+      ret = false;
+    } finally {
+      return ret;
+    }
+  }
+
+  public byte[] readFile(String path) throws IOException {
+    byte[] res = new byte[0];
+    try {
+      res = this.hdfsCmd.runCommand(this.hdfsCmd.openFile, path, null, null).getBytes();
+    } catch (Exception e) {
+      logger.error("Exception: ", e);
+      throw new IOException(e.getCause());
+    } finally {
+      return res;
+    }
+  }
+}


### PR DESCRIPTION
What is this PR for?
This PR replaces the PR-1403 by removing any hadoop dependency using WEBHDFS as a communication protocol (code borrowed from PR1600)
Zeppelin currently supports many backends for storing notes through Apache Commons VFS.
Apache Commons VFS supports HDFS in readonly mode.
This PR makes HDFS a first class citizen by allowing users to load notes from / save notes to HDFS.

What type of PR is it?

Improvement

Todos

 - Task
What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-1515

How should this be tested?

Update zeppelin.notebook.dir property to a value like hdfs://localhost:9000/tmp/notebook and the property zeppelin.notebook.storage to the value org.apache.zeppelin.notebook.repo.HdfsNotebookRepo

check that your notes are loaded from and stored to HDFS by listing notes using the command :
hdfs dfs -ls /tmp/notebook

Screenshots (if appropriate)

Questions:

Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? Yes