### PR TITLE
[HOTFIX] Set interpreter context in zeppelin context from SparkSqlInterpreter

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -96,7 +96,8 @@ public class SparkSqlInterpreter extends Interpreter {
     }
 
     sparkInterpreter.populateSparkWebUrl(context);
-    sqlc = getSparkInterpreter().getSQLContext();
+    sparkInterpreter.getZeppelinContext().setInterpreterContext(context);
+    sqlc = sparkInterpreter.getSQLContext();
     SparkContext sc = sqlc.sparkContext();
     if (concurrentSQL()) {
       sc.setLocalProperty("spark.scheduler.pool", "fair");
@@ -126,7 +127,7 @@ public class SparkSqlInterpreter extends Interpreter {
       throw new InterpreterException(e);
     }
 
-    String msg = getSparkInterpreter().getZeppelinContext().showData(rdd);
+    String msg = sparkInterpreter.getZeppelinContext().showData(rdd);
     sc.clearJobGroup();
     return new InterpreterResult(Code.SUCCESS, msg);
   }


### PR DESCRIPTION
### What is this PR for?
When running `%sql` paragraphs sometimes a NullPointer is thrown instead of presenting the result.

This was traced back to `sparkInterpreter.getZeppelinContext().setInterpreterContext(context);` not being called as expected from SparkSqlInterpreter. Since the SparkInterpreter is used from the SparkSqlInterpreter, if a `%spark` paragraph is executed before a `%sql` paragraph it works as expected (as SparkInterpreter sets the interpreter context in the zeppelin context).

### What type of PR is it?
[Hot Fix]

### Todos

### What is the Jira issue?
Hotfix

### How should this be tested?
Start the spark context by executing
```
%sql
select 1
```
Expected result is a table with 1 in.
Before this patch a NullPointer will be thrown.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
