### PR TITLE
ZEPPELIN-2530: Zeppelin user impersonation with domain name suffix is failing

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -202,6 +202,9 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
   }
 
   protected AuthenticationInfo buildAuthenticationInfo(String username, char[] password) {
+    if (this.principalSuffix != null && username.indexOf('@') > 1) {
+      username = username.split("@")[0];
+    }
     return new SimpleAuthenticationInfo(username, password, getName());
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -186,7 +186,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     LdapContext ctx = null;
     try {
       String userPrincipalName = upToken.getUsername();
-      if (userPrincipalName == null) {
+      if (!isValidPrincipalName(userPrincipalName)) {
         return null;
       }
       if (this.principalSuffix != null && userPrincipalName.indexOf('@') < 0) {
@@ -199,6 +199,20 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     }
 
     return buildAuthenticationInfo(upToken.getUsername(), upToken.getPassword());
+  }
+
+  private Boolean isValidPrincipalName(String userPrincipalName) {
+    if (userPrincipalName != null) {
+      if (StringUtils.isNotEmpty(userPrincipalName) && userPrincipalName.contains("@")) {
+        String userPrincipalWithoutDomain = userPrincipalName.split("@")[0].trim();
+        if (StringUtils.isNotEmpty(userPrincipalWithoutDomain)) {
+          return true;
+        }
+      } else if (StringUtils.isNotEmpty(userPrincipalName)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   protected AuthenticationInfo buildAuthenticationInfo(String username, char[] password) {


### PR DESCRIPTION
### What is this PR for?
Basically what happens is, if a user login using full name with suffix then the user impersonation fails, as the HDFS expects username without the suffix.
This is because the username is passed to underlying components with suffix and got rejected in security layer with IllegalArgumentException

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2530](https://issues.apache.org/jira/browse/ZEPPELIN-2530)

### How should this be tested?
 - Enable AD authentication 
 - set `activeDirectoryRealm.principalSuffix` in shiro.ini
 - now try to login with the full user name (in my example its zepplin@testdomain.com)

### Screenshots (if appropriate)

Before:
<img width="1439" alt="screen shot 2017-05-11 at 7 01 24 pm" src="https://cloud.githubusercontent.com/assets/674497/25951758/44d8adda-367c-11e7-82c1-ecbe2737e13a.png">

After:
<img width="1440" alt="screen shot 2017-05-11 at 7 00 47 pm" src="https://cloud.githubusercontent.com/assets/674497/25951766/47fbc470-367c-11e7-8d14-31465a4db8bf.png">


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
