### PR TITLE
[ZEPPELIN-2122] Add execution time for Spell 

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -81,13 +81,17 @@ public abstract class Job {
   private transient JobListener listener;
   private long progressUpdateIntervalMs;
 
+  public static SimpleDateFormat getJobDateFormatter() {
+    return new SimpleDateFormat("yyyyMMdd-HHmmss");
+  }
+
   public Job(String jobName, JobListener listener, long progressUpdateIntervalMs) {
     this.jobName = jobName;
     this.listener = listener;
     this.progressUpdateIntervalMs = progressUpdateIntervalMs;
 
     dateCreated = new Date();
-    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
+    SimpleDateFormat dateFormat = getJobDateFormatter();
     id = dateFormat.format(dateCreated) + "_" + super.hashCode();
 
     setStatus(Status.READY);
@@ -259,8 +263,16 @@ public abstract class Job {
     return dateStarted;
   }
 
+  public synchronized void setDateStarted(Date startedAt) {
+    dateStarted = startedAt;
+  }
+
   public synchronized Date getDateFinished() {
     return dateFinished;
+  }
+
+  public synchronized void setDateFinished(Date finishedAt) {
+    dateFinished = finishedAt;
   }
 
   public abstract void setResult(Object results);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -259,8 +259,8 @@ public abstract class Job {
     return dateStarted;
   }
 
-  public synchronized void setDateStarted(Date finishedAt) {
-    dateFinished = finishedAt;
+  public synchronized void setDateStarted(Date startedAt) {
+    dateStarted = startedAt;
   }
 
   public synchronized Date getDateFinished() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -81,17 +81,13 @@ public abstract class Job {
   private transient JobListener listener;
   private long progressUpdateIntervalMs;
 
-  public static SimpleDateFormat getJobDateFormatter() {
-    return new SimpleDateFormat("yyyyMMdd-HHmmss");
-  }
-
   public Job(String jobName, JobListener listener, long progressUpdateIntervalMs) {
     this.jobName = jobName;
     this.listener = listener;
     this.progressUpdateIntervalMs = progressUpdateIntervalMs;
 
     dateCreated = new Date();
-    SimpleDateFormat dateFormat = getJobDateFormatter();
+    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss");
     id = dateFormat.format(dateCreated) + "_" + super.hashCode();
 
     setStatus(Status.READY);
@@ -263,8 +259,8 @@ public abstract class Job {
     return dateStarted;
   }
 
-  public synchronized void setDateStarted(Date startedAt) {
-    dateStarted = startedAt;
+  public synchronized void setDateStarted(Date finishedAt) {
+    dateFinished = finishedAt;
   }
 
   public synchronized Date getDateFinished() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -19,15 +19,9 @@ package org.apache.zeppelin.socket;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.regex.Matcher;
@@ -1695,6 +1689,23 @@ public class NotebookServer extends WebSocketServlet
     p.setResult(fromMessage.get("results"));
     p.setErrorMessage((String) fromMessage.get("errorMessage"));
     p.setStatusWithoutNotification(status);
+
+    // set dateStarted and dateFinished
+    String dateStarted = (String) fromMessage.get("dateStarted");
+    String dateFinished = (String) fromMessage.get("dateFinished");
+    SimpleDateFormat df = new SimpleDateFormat("MMM D, YYYY h:MM:ss aaa");
+
+    try {
+      p.setDateStarted(df.parse(dateStarted));
+    } catch (ParseException e) {
+      LOG.error("Failed parse dateStarted", e);
+    }
+
+    try {
+      p.setDateFinished(df.parse(dateFinished));
+    } catch (ParseException e) {
+      LOG.error("Failed parse dateFinished", e);
+    }
 
     addNewParagraphIfLastParagraphIsExecuted(note, p);
     if (!persistNoteWithAuthInfo(conn, note, p)) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1690,10 +1690,10 @@ public class NotebookServer extends WebSocketServlet
     p.setErrorMessage((String) fromMessage.get("errorMessage"));
     p.setStatusWithoutNotification(status);
 
-    // set dateStarted and dateFinished
+    // Spell uses ISO 8601 formatted string generated from moment
     String dateStarted = (String) fromMessage.get("dateStarted");
     String dateFinished = (String) fromMessage.get("dateFinished");
-    SimpleDateFormat df = new SimpleDateFormat("MMM D, YYYY h:MM:ss aaa");
+    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
     try {
       p.setDateStarted(df.parse(dateStarted));

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -251,12 +251,15 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   $scope.propagateSpellResult = function (paragraphId, paragraphTitle,
                                          paragraphText, paragraphResults,
                                          paragraphStatus, paragraphErrorMessage,
-                                         paragraphConfig, paragraphSettingsParam) {
+                                         paragraphConfig, paragraphSettingsParam,
+                                         paragraphDateStarted, paragraphDateFinished) {
     websocketMsgSrv.paragraphExecutedBySpell(
       paragraphId, paragraphTitle,
       paragraphText, paragraphResults,
       paragraphStatus, paragraphErrorMessage,
-      paragraphConfig, paragraphSettingsParam)
+      paragraphConfig, paragraphSettingsParam,
+      paragraphDateStarted, paragraphDateFinished
+    )
   }
 
   $scope.handleSpellError = function (paragraphText, error,
@@ -267,10 +270,15 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     console.error('Failed to execute interpret() in spell\n', error)
 
     if (!propagated) {
+      $scope.paragraph.dateFinished = $scope.getFormattedParagraphTime()
+    }
+
+    if (!propagated) {
       $scope.propagateSpellResult(
         $scope.paragraph.id, $scope.paragraph.title,
         paragraphText, [], $scope.paragraph.status, errorMessage,
-        $scope.paragraph.config, $scope.paragraph.settings.params)
+        $scope.paragraph.config, $scope.paragraph.settings.params,
+        $scope.paragraph.dateStarted, $scope.paragraph.dateFinished)
     }
   }
 
@@ -280,6 +288,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     $scope.spellTransaction.propagated = propagated
     $scope.spellTransaction.resultsMsg = resultsMsg
     $scope.spellTransaction.paragraphText = paragraphText
+
+    if (!propagated) {
+      $scope.spellTransaction.startedAt = $scope.getFormattedParagraphTime()
+    }
   }
 
   /**
@@ -306,11 +318,17 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     const paragraphText = $scope.spellTransaction.paragraphText
 
     if (!propagated) {
+      $scope.paragraph.dateStarted = $scope.spellTransaction.startedAt
+      $scope.paragraph.dateFinished = $scope.getFormattedParagraphTime()
+    }
+
+    if (!propagated) {
       const propagable = SpellResult.createPropagable(resultsMsg)
       $scope.propagateSpellResult(
         $scope.paragraph.id, $scope.paragraph.title,
         paragraphText, propagable, status, '',
-        $scope.paragraph.config, $scope.paragraph.settings.params)
+        $scope.paragraph.config, $scope.paragraph.settings.params,
+        $scope.paragraph.dateStarted, $scope.paragraph.dateFinished)
     }
   }
 
@@ -980,6 +998,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
   $scope.getProgress = function () {
     return $scope.currentProgress || 0
+  }
+
+  $scope.getFormattedParagraphTime = () => {
+    return moment().format('MMM D, YYYY h:MM:ss A')
   }
 
   $scope.getExecutionTime = function (pdata) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1000,7 +1000,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   }
 
   $scope.getFormattedParagraphTime = () => {
-    return moment()
+    return moment().toISOString()
   }
 
   $scope.getExecutionTime = function (pdata) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -288,10 +288,6 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     $scope.spellTransaction.propagated = propagated
     $scope.spellTransaction.resultsMsg = resultsMsg
     $scope.spellTransaction.paragraphText = paragraphText
-
-    if (!propagated) {
-      $scope.paragraph.dateStarted = $scope.getFormattedParagraphTime()
-    }
   }
 
   /**
@@ -344,6 +340,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
       const splited = paragraphText.split(magic)
       // remove leading spaces
       const textWithoutMagic = splited[1].replace(/^\s+/g, '')
+
+      if (!propagated) {
+        $scope.paragraph.dateStarted = $scope.getFormattedParagraphTime()
+      }
 
       // handle actual result message in promise
       heliumService.executeSpell(magic, textWithoutMagic)

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -290,7 +290,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     $scope.spellTransaction.paragraphText = paragraphText
 
     if (!propagated) {
-      $scope.spellTransaction.startedAt = $scope.getFormattedParagraphTime()
+      $scope.paragraph.dateStarted = $scope.getFormattedParagraphTime()
     }
   }
 
@@ -318,7 +318,6 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     const paragraphText = $scope.spellTransaction.paragraphText
 
     if (!propagated) {
-      $scope.paragraph.dateStarted = $scope.spellTransaction.startedAt
       $scope.paragraph.dateFinished = $scope.getFormattedParagraphTime()
     }
 
@@ -1001,7 +1000,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   }
 
   $scope.getFormattedParagraphTime = () => {
-    return moment().format('MMM D, YYYY h:MM:ss A')
+    return moment()
   }
 
   $scope.getExecutionTime = function (pdata) {

--- a/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
+++ b/zeppelin-web/src/components/websocketEvents/websocketMsg.service.js
@@ -160,9 +160,10 @@ function websocketMsgSrv ($rootScope, websocketEvents) {
     },
 
     paragraphExecutedBySpell: function (paragraphId, paragraphTitle,
-                                       paragraphText, paragraphResultsMsg,
-                                       paragraphStatus, paragraphErrorMessage,
-                                       paragraphConfig, paragraphParams) {
+                                        paragraphText, paragraphResultsMsg,
+                                        paragraphStatus, paragraphErrorMessage,
+                                        paragraphConfig, paragraphParams,
+                                        paragraphDateStarted, paragraphDateFinished) {
       websocketEvents.sendNewEvent({
         op: 'PARAGRAPH_EXECUTED_BY_SPELL',
         data: {
@@ -179,7 +180,9 @@ function websocketMsgSrv ($rootScope, websocketEvents) {
           status: paragraphStatus,
           errorMessage: paragraphErrorMessage,
           config: paragraphConfig,
-          params: paragraphParams
+          params: paragraphParams,
+          dateStarted: paragraphDateStarted,
+          dateFinished: paragraphDateFinished,
         }
       })
     },


### PR DESCRIPTION
### What is this PR for?

Add execution time for spell results. See the screenshot section.

### What type of PR is it?
[Improvement]

### Todos

NONE

### What is the Jira issue?

[ZEPPELIN-2122](https://issues.apache.org/jira/browse/ZEPPELIN-2122)

### How should this be tested?

1. Install any spell (e.g the eco spell)
2. Execute and check that the paragraph has valid execution time.

### Screenshots (if appropriate)

![spell_exec2](https://cloud.githubusercontent.com/assets/4968473/25970951/803ab842-36d5-11e7-8a18-d671466e2aba.gif)

![2122_spell_execution_time](https://cloud.githubusercontent.com/assets/4968473/25967990/e9edc96a-36ca-11e7-942e-718e37063c1b.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
