### PR TITLE
ZEPPELIN-2543: Add ability to change the log level at runtime

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -105,6 +105,7 @@
                 <li><a href="{{BASE_PATH}}/storage/storage.html#notebook-storage-in-mongodb">MongoDB Storage</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span><b>REST API</b><span></li>
+                <li><a href="{{BASE_PATH}}/rest-api/rest-zeppelin-server.html">Zeppelin Server API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-interpreter.html">Interpreter API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-notebook.html">Notebook API</a></li>
                 <li><a href="{{BASE_PATH}}/rest-api/rest-notebookRepo.html">Notebook Repository API</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,7 @@ Join to our [Mailing list](https://zeppelin.apache.org/community.html) and repor
   * [Azure Storage](./storage/storage.html#notebook-storage-in-azure)
   * [ZeppelinHub Storage](./storage/storage.html#storage-in-zeppelinhub)
 * REST API: available REST API list in Apache Zeppelin
+  * [Zeppelin server API](./rest-api/rest-zeppelin-server.html)
   * [Interpreter API](./rest-api/rest-interpreter.html)
   * [Notebook API](./rest-api/rest-notebook.html)
   * [Notebook Repository API](./rest-api/rest-notebookRepo.html)

--- a/docs/rest-api/rest-configuration.md
+++ b/docs/rest-api/rest-configuration.md
@@ -29,7 +29,6 @@ All REST APIs are available starting with the following endpoint `http://[zeppel
 Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
 
 If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
-nd a need for an additional REST API, please [file an issue or send us mail](../../community.html).
 
 
 ## Configuration REST API list

--- a/docs/rest-api/rest-zeppelin-server.md
+++ b/docs/rest-api/rest-zeppelin-server.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: "Apache Zeppelin Server REST API"
+description: "This page contains Apache Zeppelin Server REST API information."
+group: rest-api
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Apache Zeppelin Server REST API
+
+<div id="toc"></div>
+
+## Overview
+Apache Zeppelin provides several REST APIs for interaction and remote activation of zeppelin functionality.
+All REST APIs are available starting with the following endpoint `http://[zeppelin-server]:[zeppelin-port]/api`. 
+Note that Apache Zeppelin REST APIs receive or return JSON objects, it is recommended for you to install some JSON viewers such as [JSONView](https://chrome.google.com/webstore/detail/jsonview/chklaanhfefbnpoihckbnefhakgolnmc).
+
+If you work with Apache Zeppelin and find a need for an additional REST API, please [file an issue or send us an email](http://zeppelin.apache.org/community.html).
+
+
+## Zeppelin Server REST API list
+
+### Change the log level of Zeppelin Server 
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method is used to update the root logger's log level of the server.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/log/level/<LOG_LEVEL>```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 406 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{
+  "status": "OK"
+}     
+        </pre>
+      </td>
+    </tr>
+    <tr>
+      <td> sample error JSON response
+      </td>
+      <td>
+        <pre>
+{
+  "status":"NOT_ACCEPTABLE",
+  "message":"Please check LOG level specified. Valid values: DEBUG, ERROR, FATAL, INFO, TRACE, WARN"
+}     
+        </pre>
+      </td>
+    </tr>
+  </table>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
@@ -75,7 +75,8 @@ public class ZeppelinRestApi {
       return new JsonResponse<>(Response.Status.OK).build();
     } else {
       return new JsonResponse<>(Response.Status.NOT_ACCEPTABLE,
-          "Not a valid LOG level").build();
+          "Please check LOG level specified. Valid values: DEBUG, ERROR, FATAL, "
+              + "INFO, TRACE, WARN").build();
     }
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
@@ -17,12 +17,18 @@
 
 package org.apache.zeppelin.rest;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.util.Util;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
@@ -51,5 +57,25 @@ public class ZeppelinRestApi {
   @ZeppelinApi
   public Response getVersion() {
     return new JsonResponse<>(Response.Status.OK, "Zeppelin version", Util.getVersion()).build();
+  }
+
+  /**
+   * Set the log level for root logger
+   * @param request
+   * @param logLevel new log level for Rootlogger
+   * @return
+   */
+  @PUT
+  @Path("log/level/{logLevel}")
+  public Response changeRootLogLevel(@Context HttpServletRequest request,
+      @PathParam("logLevel") String logLevel) {
+    Level level = Level.toLevel(logLevel);
+    if (logLevel.toLowerCase().equalsIgnoreCase(level.toString().toLowerCase())) {
+      Logger.getRootLogger().setLevel(level);
+      return new JsonResponse<>(Response.Status.OK).build();
+    } else {
+      return new JsonResponse<>(Response.Status.NOT_ACCEPTABLE,
+          "Not a valid LOG level").build();
+    }
   }
 }


### PR DESCRIPTION
### What is this PR for?
Add ability to change the log level at runtime


### What type of PR is it?
Improvement

### Todos
* [x] - Update/Add the interpreter rest API documentation(edited: added a new Zeppelin server API doc page)

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2543

### How should this be tested?

>➜  ~ curl -X PUT http://localhost:8080/api/log/level/debug  
{"status":"OK"}  
>➜  ~ curl -X PUT http://localhost:8080/api/log/level/adx   
{"status":"NOT_ACCEPTABLE","message":"Not a valid LOG level"}  


### Screenshots (if appropriate) NA

### Questions:
* Does the licenses files need update?  NA
* Is there breaking changes for older versions? No
* Does this needs documentation?  Yes(Will need to the interpreter Rest api doc, if the approach looks fine)
