### PR TITLE
[ZEPPELIN-2545] [ZEPPELIN-2546] SecurityRestApiTest, NotebookSecurityRestApiTest fails on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,9 @@ matrix:
     # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
     # NotebookTest                 - https://issues.apache.org/jira/browse/ZEPPELIN-2471
     # ZeppelinRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2473
-    # SecurityRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2545
-    # NotebookSecurityRestApiTest  - https://issues.apache.org/jira/browse/ZEPPELIN-2546
     # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumBundleFactoryTest.java,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java,**/SecurityRestApiTest.java,**/NotebookSecurityRestApiTest.java -DfailIfNoTests=false"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumBundleFactoryTest.java,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -429,13 +429,19 @@ public abstract class AbstractTestRestApi {
     LOG.info("{} - {}", postMethod.getStatusCode(), postMethod.getStatusText());
     Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]*)");
     Header[] setCookieHeaders = postMethod.getResponseHeaders("Set-Cookie");
+    String jsessionId = null;
     for (Header setCookie : setCookieHeaders) {
       java.util.regex.Matcher matcher = pattern.matcher(setCookie.toString());
       if (matcher.find()) {
-        return matcher.group(1);
+        jsessionId = matcher.group(1);
       }
     }
-    return StringUtils.EMPTY;
+
+    if (jsessionId != null) {
+      return jsessionId;
+    } else {
+      return StringUtils.EMPTY;
+    }
   }
 
   protected static boolean userAndPasswordAreNotBlank(String user, String pwd) {


### PR DESCRIPTION
### What is this PR for?
shiro returns multiple JSESSIONID on login request in integration test.

```bash
moon$ curl -v -XPOST -H "Origin: http://localhost:8080/api" -H "Host: localhost:8080" --data "userName=admin&password=password1" 'http://localhost:8080/api/login'
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
> POST /api/login HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
> Origin: http://localhost:8080/api
> Content-Length: 33
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 33 out of 33 bytes
< HTTP/1.1 200 OK
< Date: Mon, 15 May 2017 14:24:10 GMT
< Access-Control-Allow-Origin: http://localhost:8080/api
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: authorization,Content-Type
< Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, HEAD, DELETE
< Date: Monday, May 15, 2017 7:24:10 AM PDT
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Sun, 14-May-2017 14:24:10 GMT
< Set-Cookie: JSESSIONID=2c0062db-99f0-438c-a5f6-6fdffa4eb7ae; Path=/; HttpOnly
< Set-Cookie: JSESSIONID=deleteMe; Path=/; Max-Age=0; Expires=Sun, 14-May-2017 14:24:10 GMT
< Set-Cookie: JSESSIONID=6bb25285-6cb0-47ea-8bb6-e268110a6034; Path=/; HttpOnly
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Sun, 14-May-2017 14:24:10 GMT
< Content-Type: application/json
< Date: Mon, 15 May 2017 14:24:10 GMT
< Content-Length: 123
< Server: Jetty(9.2.15.v20160210)
< 
* Connection #0 to host localhost left intact
```

Later one is valid JSESSIONID. This PR changes test code to use last JSESSIONID.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2545
https://issues.apache.org/jira/browse/ZEPPELIN-2546

### How should this be tested?
After https://github.com/apache/zeppelin/pull/2342 is merged, this PR will be rebased. Then CI should be green.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
