### PR TITLE
[MINOR] Hide pagination button if there is only 1 page in Helium menu

### DIFF
--- a/zeppelin-web/src/app/helium/helium.css
+++ b/zeppelin-web/src/app/helium/helium.css
@@ -225,3 +225,7 @@
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
 }
+
+.hide-last-boundaries.pagination:only-of-type {
+  display: none;
+}


### PR DESCRIPTION
### What is this PR for?
It'll be better to hide the pagination button if there is only one page. 
([`only-of-type` CSS type selector](https://www.w3schools.com/cssref/sel_only-of-type.asp) can be used for this.)
Please see the attached screenshot img. 

### What type of PR is it?
Improvement

### What is the Jira issue?
N/A

### How should this be tested?

### Screenshots (if appropriate)
 - Before 
![before](https://cloud.githubusercontent.com/assets/10060731/26078301/067ac1b8-398d-11e7-8921-be51dc01425c.png)


 - After
<img width="1372" alt="screen shot 2017-05-15 at 4 34 09 pm" src="https://cloud.githubusercontent.com/assets/10060731/26078167/a28f36fc-398c-11e7-8151-46ca79161010.png">

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
