### PR TITLE
[gh-pages] Hide pagination btn if there is only 1 page

### DIFF
--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -693,6 +693,10 @@ a.anchorjs-link:hover { text-decoration: none; }
   border-bottom-right-radius: 3px;
 }
 
+.hide-last-boundaries.pagination:only-of-type {
+  display: none;
+}
+
 /* For what's new section */
 .new {
   background: rgba(226, 233, 239, 0.4);


### PR DESCRIPTION
### What is this PR for?
Same work with #2345 but for `gh-pages`


### What type of PR is it?
 Improvement

### What is the Jira issue?
N/A

### Screenshots (if appropriate)
 - Before
<img width="1084" alt="screen shot 2017-05-15 at 4 45 45 pm" src="https://cloud.githubusercontent.com/assets/10060731/26078695/55cba402-398e-11e7-9f12-f9748480db38.png">

 - After
<img width="1109" alt="screen shot 2017-05-15 at 4 45 53 pm" src="https://cloud.githubusercontent.com/assets/10060731/26078697/58981a6c-398e-11e7-9921-22b9219f0f79.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
