### PR TITLE
ZEPPELIN-2555: Run all paragraphs API does not run all paragraph as front-end user.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -588,17 +588,17 @@ public class NotebookRestApi {
       throws IOException, IllegalArgumentException {
     LOG.info("run note jobs {} ", noteId);
     Note note = notebook.getNote(noteId);
+    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     checkIfNoteIsNotNull(note);
     checkIfUserCanWrite(noteId, "Insufficient privileges you cannot run job for this note");
 
     try {
-      note.runAll();
+      note.runAll(subject);
     } catch (Exception ex) {
       LOG.error("Exception from run", ex);
       return new JsonResponse<>(Status.PRECONDITION_FAILED,
           ex.getMessage() + "- Not selected or Invalid Interpreter bind").build();
     }
-
     return new JsonResponse<>(Status.OK).build();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -588,12 +588,16 @@ public class Note implements Serializable, ParagraphJobListener {
     if (null == cronExecutingUser) {
       cronExecutingUser = "anonymous";
     }
+    AuthenticationInfo authenticationInfo = new AuthenticationInfo();
+    authenticationInfo.setUser(cronExecutingUser);
+    runAll(authenticationInfo);
+  }
+
+  public void runAll(AuthenticationInfo authenticationInfo) {
     for (Paragraph p : getParagraphs()) {
       if (!p.isEnabled()) {
         continue;
       }
-      AuthenticationInfo authenticationInfo = new AuthenticationInfo();
-      authenticationInfo.setUser(cronExecutingUser);
       p.setAuthenticationInfo(authenticationInfo);
       run(p.getId());
     }


### PR DESCRIPTION
### What is this PR for?
Run all paragraphs API (http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/rest-api/rest-notebook.html#run-all-paragraphs) does not run all paragraph as front-end user.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-2555](https://issues.apache.org/jira/browse/ZEPPELIN-2555)

### How should this be tested?
Testing steps in screenshot

### Screenshots (if appropriate)
Before:
![zeppelin-2555-before](https://cloud.githubusercontent.com/assets/674497/26120584/d9990846-3a8e-11e7-897b-754e2075ddc6.gif)


After:
![zeppelin-2555-after](https://cloud.githubusercontent.com/assets/674497/26120391/38ba4b2e-3a8e-11e7-9a0c-c214dbc416e4.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
