### PR TITLE
[ZEPPELIN-2564] - LivySparkSQLInterpreter throws NullPointerException when getProgress is called

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -241,7 +241,11 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
 
   @Override
   public int getProgress(InterpreterContext context) {
-    return this.sparkInterpreter.getProgress(context);
+    if (this.sparkInterpreter != null) {
+      return this.sparkInterpreter.getProgress(context);
+    } else {
+      return 0;
+    }
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -61,7 +61,6 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
   @Override
   public void open() {
     this.sparkInterpreter = getSparkInterpreter();
-    this.livyVersion = this.sparkInterpreter.livyVersion;
     // As we don't know whether livyserver use spark2 or spark1, so we will detect SparkSession
     // to judge whether it is using spark2.
     try {
@@ -238,6 +237,11 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
   @Override
   public void close() {
     this.sparkInterpreter.close();
+  }
+
+  @Override
+  public int getProgress(InterpreterContext context) {
+    return this.sparkInterpreter.getProgress(context);
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -61,6 +61,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
   @Override
   public void open() {
     this.sparkInterpreter = getSparkInterpreter();
+    this.livyVersion = this.sparkInterpreter.livyVersion;
     // As we don't know whether livyserver use spark2 or spark1, so we will detect SparkSession
     // to judge whether it is using spark2.
     try {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -313,6 +313,28 @@ public class LivyInterpreterIT {
     }
   }
 
+  @Test
+  public void testSparkSQLLivyVersion() throws LivyException {
+    InterpreterGroup interpreterGroup = new InterpreterGroup("group_1");
+    interpreterGroup.put("session_1", new ArrayList<Interpreter>());
+    LivySparkInterpreter sparkInterpreter = new LivySparkInterpreter(properties);
+    sparkInterpreter.setInterpreterGroup(interpreterGroup);
+    interpreterGroup.get("session_1").add(sparkInterpreter);
+    AuthenticationInfo authInfo = new AuthenticationInfo("user1");
+    MyInterpreterOutputListener outputListener = new MyInterpreterOutputListener();
+    InterpreterOutput output = new InterpreterOutput(outputListener);
+    final InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "livy.spark",
+            "title", "text", authInfo, null, null, null, null, null, output);
+    sparkInterpreter.open();
+
+    final LivySparkSQLInterpreter sqlInterpreter = new LivySparkSQLInterpreter(properties);
+    interpreterGroup.get("session_1").add(sqlInterpreter);
+    sqlInterpreter.setInterpreterGroup(interpreterGroup);
+    sqlInterpreter.open();
+
+    LivyVersion livyVersion = sqlInterpreter.livyVersion;
+    assertTrue(livyVersion!=null);
+  }
 
   @Test
   public void testSparkSQLCancellation() {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -332,8 +332,8 @@ public class LivyInterpreterIT {
     sqlInterpreter.setInterpreterGroup(interpreterGroup);
     sqlInterpreter.open();
 
-    LivyVersion livyVersion = sqlInterpreter.livyVersion;
-    assertTrue(livyVersion!=null);
+    int r = sqlInterpreter.getProgress(context);
+    assertTrue(r == 0);
   }
 
   @Test

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -308,33 +308,13 @@ public class LivyInterpreterIT {
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
       assertEquals(InterpreterResult.Type.TABLE, result.message().get(0).getType());
       assertTrue(result.message().get(0).getData().contains("tableName"));
+      int r = sqlInterpreter.getProgress(context);
+      assertTrue(r == 0);
     } finally {
       sqlInterpreter.close();
     }
   }
 
-  @Test
-  public void testSparkSQLLivyVersion() throws LivyException {
-    InterpreterGroup interpreterGroup = new InterpreterGroup("group_1");
-    interpreterGroup.put("session_1", new ArrayList<Interpreter>());
-    LivySparkInterpreter sparkInterpreter = new LivySparkInterpreter(properties);
-    sparkInterpreter.setInterpreterGroup(interpreterGroup);
-    interpreterGroup.get("session_1").add(sparkInterpreter);
-    AuthenticationInfo authInfo = new AuthenticationInfo("user1");
-    MyInterpreterOutputListener outputListener = new MyInterpreterOutputListener();
-    InterpreterOutput output = new InterpreterOutput(outputListener);
-    final InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "livy.spark",
-            "title", "text", authInfo, null, null, null, null, null, output);
-    sparkInterpreter.open();
-
-    final LivySparkSQLInterpreter sqlInterpreter = new LivySparkSQLInterpreter(properties);
-    interpreterGroup.get("session_1").add(sqlInterpreter);
-    sqlInterpreter.setInterpreterGroup(interpreterGroup);
-    sqlInterpreter.open();
-
-    int r = sqlInterpreter.getProgress(context);
-    assertTrue(r == 0);
-  }
 
   @Test
   public void testSparkSQLCancellation() {


### PR DESCRIPTION
### What is this PR for?
When using %livy.sql interpreter following error is logged into interpreter log:

`ERROR [2017-05-17 15:01:32,897] (
{pool-1-thread-1}
TThreadPoolServer.java[run]:296) - Error occurred during processing of message.
java.lang.NullPointerException
at org.apache.zeppelin.livy.BaseLivyInterpreter.getProgress(BaseLivyInterpreter.java:178)
at org.apache.zeppelin.interpreter.LazyOpenInterpreter.getProgress(LazyOpenInterpreter.java:121)
at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer.getProgress(RemoteInterpreterServer.java:558)
at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Processor$getProgress.getResult(RemoteInterpreterService.java:1899)
at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Processor$getProgress.getResult(RemoteInterpreterService.java:1884)
at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:285)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:748)`

and zeppelin server log:
`ERROR [2017-05-17 15:01:44,004] (
{JobProgressPoller, jobId=20170511-200435_1144682471}
JobProgressPoller.java[run]:58) - Can not get or update progress
org.apache.zeppelin.interpreter.InterpreterException: org.apache.thrift.transport.TTransportException
at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getProgress(RemoteInterpreter.java:468)
at org.apache.zeppelin.interpreter.LazyOpenInterpreter.getProgress(LazyOpenInterpreter.java:121)
at org.apache.zeppelin.notebook.Paragraph.progress(Paragraph.java:334)
at org.apache.zeppelin.scheduler.JobProgressPoller.run(JobProgressPoller.java:55)
Caused by: org.apache.thrift.transport.TTransportException
at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:132)
at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.recv_getProgress(RemoteInterpreterService.java:321)
at org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService$Client.getProgress(RemoteInterpreterService.java:306)
at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getProgress(RemoteInterpreter.java:465)
... 3 more`

This happens because this.livyVersion is never assigned in LivySparkSQLInterpreter: https://github.com/apache/zeppelin/blob/master/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java#L63



### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2564

### How should this be tested?
New test added to verify that livyVersion is not null

### Screenshots (if appropriate)
![errors](https://cloud.githubusercontent.com/assets/14924427/26164543/9aaa33a6-3b35-11e7-809d-e976277dac44.gif)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?