### PR TITLE
[ZEPPELIN-2570] fix: indistinguishable directory icon color

### DIFF
--- a/zeppelin-web/src/app/home/notebook-template.html
+++ b/zeppelin-web/src/app/home/notebook-template.html
@@ -56,7 +56,7 @@ limitations under the License.
     <div ng-mouseenter="showFolderButton=true"
          ng-mouseleave="showFolderButton=false">
       <a style="text-decoration: none; cursor: pointer;" ng-click="toggleFolderNode(node)">
-        <i style="font-size: 10px;" ng-class="node.hidden ? 'icon-folder' : 'icon-folder-alt'"></i> {{getNoteName(node)}}
+        <i style="font-size: 10px;" ng-class="node.hidden ? 'fa fa-folder' : 'fa fa-folder-open'"></i> {{getNoteName(node)}}
       </a>
       <a ng-if="!node.isTrash" href="" data-toggle="modal" data-target="#noteNameModal" style="text-decoration: none;"
          ng-controller="NotenameCtrl as notenamectrl" ng-click="notenamectrl.getInterpreterSettings()" data-path="{{node.id}}">

--- a/zeppelin-web/src/components/expandCollapse/expandCollapse.directive.js
+++ b/zeppelin-web/src/components/expandCollapse/expandCollapse.directive.js
@@ -21,12 +21,12 @@ function expandCollapse () {
       angular.element(element).click(function (event) {
         if (angular.element(element).find('.expandable:visible').length > 1) {
           angular.element(element).find('.expandable:visible').slideUp('slow')
-          angular.element(element).find('i.icon-folder-alt').toggleClass('icon-folder icon-folder-alt')
+          angular.element(element).find('i.fa-folder-open').toggleClass('fa-folder fa-folder-open')
         } else {
           angular.element(element).find('.expandable').first().slideToggle('200', function () {
             // do not toggle trash folder
             if (angular.element(element).find('.fa-trash-o').length === 0) {
-              angular.element(element).find('i').first().toggleClass('icon-folder icon-folder-alt')
+              angular.element(element).find('i').first().toggleClass('fa-folder fa-folder-open')
             }
           })
         }

--- a/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
+++ b/zeppelin-web/src/components/navbar/navbar-noteList-elem.html
@@ -22,7 +22,7 @@ limitations under the License.
       <div ng-mouseenter="showFolderButton=true" ng-mouseleave="showFolderButton=false">
         <a class="notebook-list-item" href="javascript:void(0)">
           <div ng-if="node.id !== navbar.TRASH_FOLDER_ID">
-            <i style="font-size: 10px; margin-right: 5px;"  class="icon-folder"></i>
+            <i style="font-size: 10px; margin-right: 5px;" class="fa fa-folder"></i>
             <span>{{noteName(node)}}</span>
             <i data-toggle="modal" data-target="#noteNameModal" ng-controller="NotenameCtrl as notenamectrl"
               ng-click="notenamectrl.getInterpreterSettings()" data-path="{{node.id}}"


### PR DESCRIPTION
### What is this PR for?

Fixed indistinguishable directory icon color. See the attached screenshots.

Problem is that it's hard to

- recognize directory is opened not not
- distinguish whether it is a note is or a directory

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2570](https://issues.apache.org/jira/browse/ZEPPELIN-2570)

### How should this be tested?

- Open Directory

### Screenshots (if appropriate)

#### Before

<img width="203" alt="opened" src="https://cloud.githubusercontent.com/assets/4968473/26232541/f7881b94-3c91-11e7-8914-b01c358d781b.png">

<img width="301" alt="screen shot 2017-05-19 at 12 13 02 pm" src="https://cloud.githubusercontent.com/assets/4968473/26232542/f8e1474a-3c91-11e7-891c-84a5d2579f06.png">


#### After

<img width="317" alt="screen shot 2017-05-19 at 12 17 54 pm" src="https://cloud.githubusercontent.com/assets/4968473/26232533/ef4eea16-3c91-11e7-831a-084865b126d8.png">

<img width="553" alt="screen shot 2017-05-19 at 12 35 05 pm" src="https://cloud.githubusercontent.com/assets/4968473/26232536/f0cf7d74-3c91-11e7-8b62-2b13f3767ed6.png">


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
