### PR TITLE
[ZEPPELIN-2460] Highlight active line in editor

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -253,7 +253,6 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
     } catch (Exception e) {
       handleException("Exception in ParagraphActionsIT while testDisableParagraphRunButton ", e);
     }
-
   }
 
   @Test
@@ -263,7 +262,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
     }
     try {
       String xpathToRunOnSelectionChangeCheckbox = getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]";
-      String xpathToDropdownMenu = getParagraphXPath(1) + "//select";
+      String xpathToDropdownMenu = "(" + (getParagraphXPath(1) + "//select)[2]");
       String xpathToResultText = getParagraphXPath(1) + "//div[contains(@id,\"_html\")]";
 
       createNewNote();
@@ -593,7 +592,8 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
               CoreMatchers.equalTo("Howdy "));
 
-      Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[1]"))));
+      Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[2]"))));
+
       dropDownMenu.selectByVisibleText("Alice");
       collector.checkThat("After selection in drop down menu, output should display the newly selected option",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -602,7 +602,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       clickAndWait(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]"));
 
-      Select sameDropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[1]"))));
+      Select sameDropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[2]"))));
       sameDropDownMenu.selectByVisibleText("Bob");
       collector.checkThat("After 'Run on selection change' checkbox is unchecked, the paragraph should not run if selecting a different option",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -632,7 +632,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
               CoreMatchers.containsString("Greetings han and leia and luke"));
 
-      WebElement firstCheckbox = driver.findElement(By.xpath("(" + getParagraphXPath(1) + "//input[@type='checkbox'])[1]"));
+      WebElement firstCheckbox = driver.findElement(By.xpath("(" + getParagraphXPath(1) + "//input[@type='checkbox'])[2]"));
       firstCheckbox.click();
       collector.checkThat("After unchecking one of the boxes, we can see the newly updated output without the option we unchecked",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -641,7 +641,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       clickAndWait(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]"));
 
-      WebElement secondCheckbox = driver.findElement(By.xpath("(" + getParagraphXPath(1) + "//input[@type='checkbox'])[2]"));
+      WebElement secondCheckbox = driver.findElement(By.xpath("(" + getParagraphXPath(1) + "//input[@type='checkbox'])[3]"));
       secondCheckbox.click();
       collector.checkThat("After 'Run on selection change' checkbox is unchecked, the paragraph should not run if check box state is modified",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -676,7 +676,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
               CoreMatchers.equalTo("Howdy \nHowdy "));
 
-      Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[1]"))));
+      Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[2]"))));
       dropDownMenu.selectByVisibleText("Apple");
       collector.checkThat("After selection in drop down menu, output should display the new option we selected",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -685,7 +685,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       clickAndWait(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]"));
 
-      Select sameDropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[2]"))));
+      Select sameDropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[3]"))));
       sameDropDownMenu.selectByVisibleText("Earth");
       waitForParagraph(1, "FINISHED");
       collector.checkThat("After 'Run on selection change' checkbox is unchecked, the paragraph should not run if selecting a different option",

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -469,10 +469,12 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
 
   let addPara = function (paragraph, index) {
     $scope.note.paragraphs.splice(index, 0, paragraph)
-    _.each($scope.note.paragraphs, function (para) {
+    $scope.note.paragraphs.map(para => {
       if (para.id === paragraph.id) {
         para.focus = true
-        $scope.$broadcast('focusParagraph', para.id, 0, false)
+
+        // we need `$timeout` since angular DOM might not be initialized
+        $timeout(() => { $scope.$broadcast('focusParagraph', para.id, 0, false) })
       }
     })
   }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -44,11 +44,12 @@ limitations under the License.
 
   <!-- Run / Cancel button -->
   <span ng-if="!revisionView">
-    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" uib-tooltip="Run this paragraph (Shift+Enter)"
+    <span class="icon-control-play" style="cursor:pointer;color:#3071A9"
+          tooltip-placement="top" uib-tooltip="Run this paragraph (Shift+Enter)"
           ng-click="runParagraphFromButton(getEditorValue())"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
-    <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top"
-          uib-tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
+    <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C"
+          tooltip-placement="top" uib-tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
           ng-click="cancelParagraph(paragraph)"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
     <span ng-show="paragraph.runtimeInfos.jobUrl.length == 1">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -840,8 +840,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     }
   }
 
-  const handleFocus = function (value, isDigestPass) {
-    $scope.paragraphFocused = value
+  const handleFocus = function (focused, isDigestPass) {
+    $scope.paragraphFocused = focused
+    $scope.editor.setHighlightActiveLine(focused) // highlight active line
+
     if (isDigestPass === false || isDigestPass === undefined) {
       // Protect against error in case digest is already running
       $timeout(function () {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -630,10 +630,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
       $scope.editor.renderer.setShowGutter($scope.paragraph.config.lineNumbers)
       $scope.editor.setShowFoldWidgets(false)
       $scope.editor.setHighlightActiveLine(false)
-      $scope.editor.setHighlightGutterLine(false)
       $scope.editor.getSession().setUseWrapMode(true)
       $scope.editor.setTheme('ace/theme/chrome')
       $scope.editor.setReadOnly($scope.isRunning($scope.paragraph))
+      $scope.editor.setHighlightActiveLine($scope.paragraphFocused)
 
       if ($scope.paragraphFocused) {
         let prefix = '%' + getInterpreterName($scope.paragraph.text)
@@ -842,7 +842,8 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
   const handleFocus = function (focused, isDigestPass) {
     $scope.paragraphFocused = focused
-    $scope.editor.setHighlightActiveLine(focused) // highlight active line
+
+    if ($scope.editor) { $scope.editor.setHighlightActiveLine(focused) }
 
     if (isDigestPass === false || isDigestPass === undefined) {
       // Protect against error in case digest is already running

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -113,7 +113,6 @@
   display: none;
   float: right;
   color: #999;
-  margin-top: -9px;
   margin-right: 0;
   position: absolute;
   clear: both;
@@ -178,15 +177,8 @@
   background: rgba(255,255,255,0.85);
   float: right;
   color: #999;
-  margin-top: 1px;
-  margin-right: 5px;
-  position: absolute;
-  clear: both;
-  right: 15px;
-  top: 16px;
-  text-align: right;
   font-size: 12px;
-  padding: 4px;
+  margin-bottom: 3px;
 }
 
 .paragraph .control li {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -362,8 +362,20 @@ table.table-shortcut {
   direction: ltr;
 }
 
+/** set highlight line color */
+#main .ace-chrome .ace_marker-layer .ace_active-line {
+  background: rgba(230, 224, 21, 0.08);
+}
+
+/** hide not focused cursors */
 .ace_hidden-cursors {
   opacity: 0;
+}
+
+/** set cursor color */
+#main .emacs-mode .ace_cursor {
+  background: #C0C0C0!important;
+  border: none !important;
 }
 
 .ace_text-input, .ace_gutter, .ace_layer,
@@ -374,11 +386,6 @@ table.table-shortcut {
 
 .ace_text-input.ace_composition {
  opacity: 0 !important;
-}
-
-#main .emacs-mode .ace_cursor {
-  background: #C0C0C0!important;
-  border: none !important;
 }
 
 /*

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -174,11 +174,12 @@
 }
 
 .paragraph .control {
-  background: rgba(255,255,255,0.85);
+  display: inline-block;
   float: right;
+  background: rgba(255,255,255,0.85);
   color: #999;
   font-size: 12px;
-  margin-bottom: 3px;
+  margin-top: 5px;
 }
 
 .paragraph .control li {
@@ -267,8 +268,11 @@ table.table-shortcut {
 */
 
 .paragraph .title {
-  margin: 0;
+  display: inline-block;
+  float: left;
   font-size: 12px;
+  margin-bottom: 7px;
+  min-height: 24px;
 }
 
 .paragraph .title div {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -364,7 +364,7 @@ table.table-shortcut {
 
 /** set highlight line color */
 #main .ace-chrome .ace_marker-layer .ace_active-line {
-  background: rgba(230, 224, 21, 0.08);
+  background: rgba(114, 127, 222, 0.08);
 }
 
 /** hide not focused cursors */

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -35,6 +35,8 @@ limitations under the License.
     </div>
   </div>
 
+  <div ng-include src="'app/notebook/paragraph/paragraph-control.html'"></div>
+
   <div>
     <div ng-if="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">
       <code-editor
@@ -62,8 +64,6 @@ limitations under the License.
          ng-bind="paragraph.errorMessage">
     </div>
   </div>
-
-  <div ng-include src="'app/notebook/paragraph/paragraph-control.html'"></div>
 
   <div ng-if="!asIframe" class="paragraphFooter">
     <div ng-show="!paragraph.config.tableHide && !viewOnly"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -16,7 +16,7 @@ limitations under the License.
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
   <div>
-    <div ng-show="paragraph.config.title"
+    <div ng-if="paragraph.config.title"
          id="{{paragraph.id}}_title"
          ng-controller="ElasticInputCtrl as input"
          class="title">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -15,27 +15,30 @@ limitations under the License.
 <div id="{{paragraph.id}}_container"
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
-  <div ng-if="paragraph.config.title"
-       id="{{paragraph.id}}_title"
-       ng-controller="ElasticInputCtrl as input"
-       class="title">
-    <input type="text"
-           pu-elastic-input
-           style="min-width: 400px; max-width: 80%;"
-           placeholder="Untitled"
-           ng-model="paragraph.title"
-           ng-if="input.showEditor"
-           ng-escape="input.showEditor = false; paragraph.title = oldTitle;"
-           ng-blur="setTitle(paragraph); input.showEditor = false"
-           ng-enter="setTitle(paragraph); input.showEditor = false"
-           focus-if="input.showEditor" />
-    <div ng-click="input.showEditor = !asIframe && !viewOnly && !revisionView; oldTitle = paragraph.title;"
-         ng-show="!input.showEditor"
-         ng-bind-html="paragraph.title || 'Untitled'">
+  <div>
+    <div ng-show="paragraph.config.title"
+         id="{{paragraph.id}}_title"
+         ng-controller="ElasticInputCtrl as input"
+         class="title">
+      <input type="text"
+             pu-elastic-input
+             style="min-width: 400px; max-width: 80%;"
+             placeholder="Untitled"
+             ng-model="paragraph.title"
+             ng-if="input.showEditor"
+             ng-escape="input.showEditor = false; paragraph.title = oldTitle;"
+             ng-blur="setTitle(paragraph); input.showEditor = false"
+             ng-enter="setTitle(paragraph); input.showEditor = false"
+             focus-if="input.showEditor" />
+      <div ng-click="input.showEditor = !asIframe && !viewOnly && !revisionView; oldTitle = paragraph.title;"
+           ng-show="!input.showEditor"
+           ng-bind-html="paragraph.title || 'Untitled'">
+      </div>
     </div>
-  </div>
 
-  <div ng-include src="'app/notebook/paragraph/paragraph-control.html'"></div>
+    <div ng-include src="'app/notebook/paragraph/paragraph-control.html'"></div>
+    <div style="display: inline-block; clear: both;"></div>
+  </div>
 
   <div>
     <div ng-if="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">

--- a/zeppelin-web/src/components/editor/ace.editor.directive.html
+++ b/zeppelin-web/src/components/editor/ace.editor.directive.html
@@ -13,13 +13,7 @@ limitations under the License.
 -->
 
 <div class="editor"
-     ui-ace="{ advanced: {
-                 highlightActiveLine: true,
-                 highlightGutterLine: false,
-               },
-               onLoad : onLoad,
-               require : ['ace/ext/language_tools']
-             }"
+     ui-ace="{ onLoad : onLoad, require : ['ace/ext/language_tools'] }"
      ng-model="paragraph.text"
      ng-class="{'paragraph-disable': paragraph.status == 'RUNNING' || paragraph.status == 'PENDING' || revisionView === true,
            'paragraph-text--dirty' : dirtyText !== originalText && dirtyText !== undefined}">

--- a/zeppelin-web/src/components/editor/ace.editor.directive.html
+++ b/zeppelin-web/src/components/editor/ace.editor.directive.html
@@ -13,7 +13,10 @@ limitations under the License.
 -->
 
 <div class="editor"
-     ui-ace="{
+     ui-ace="{ advanced: {
+                 highlightActiveLine: true,
+                 highlightGutterLine: false,
+               },
                onLoad : onLoad,
                require : ['ace/ext/language_tools']
              }"


### PR DESCRIPTION
### What is this PR for?

Highlight active line.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Added ui-ace option
* [x] - Fix css for paragraph control not to be overrided by active line 

### What is the Jira issue?

[ZEPPELIN-2460](https://issues.apache.org/jira/browse/ZEPPELIN-2460)

### How should this be tested?

1. Build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. Open a note and write some text.

### Screenshots (if appropriate)

![2460_active_line](https://cloud.githubusercontent.com/assets/4968473/26279598/de38b114-3df2-11e7-9d3a-f0d4f59b8cd1.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
