### PR TITLE
[ZEPPELIN-2429] Improve `import notebook` dialog style

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -455,40 +455,6 @@ This part should be removed when new version of bootstrap handles this issue.
   z-index: 10003 !important;
 }
 
-#noteImportModal .modal-body {
-  min-height: 420px;
-  overflow: hidden;
-}
-
-#noteImportModal .modal-footer {
-  min-height: 65px;
-}
-
-#noteImportModal .display-inline a {
-  background: #fff;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  color: #999;
-  cursor: pointer;
-  display: block;
-  float: left;
-  font-size: 98px;
-  height: 240px;
-  margin: 0 10px 16px;
-  padding-top: 60px;
-  text-align: center;
-  text-decoration: none;
-  width: 264px;
-}
-
-#noteImportModal .display-inline a:hover {
-  background: #eee;
-}
-
-#noteImportModal .display-inline a p {
-  font-size: 14px;
-}
-
 /* ------------------------------------------- */
 /* Slide Top
 /* ------------------------------------------- */

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.css
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.css
@@ -15,3 +15,56 @@
   font-size: 20px;
   font-weight: 300;
 }
+
+.modal-body-import .note-name-input {
+  margin-left: 7px;
+  margin-right: 7px;
+}
+
+.modal-body-import label {
+  font-size: 15px;
+  font-weight: 400;
+  margin-bottom: 10px;
+}
+
+.modal-body-import {
+  min-height: 420px;
+  overflow: hidden;
+}
+
+.modal-body-import .import-btn-image-group {
+  margin-top: 4px;
+}
+
+.modal-body-import .import-btn-image a {
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 5px;
+  color: #7c828e;
+  cursor: pointer;
+  display: block;
+  float: left;
+  font-size: 98px;
+  text-align: center;
+  text-decoration: none;
+  height: 240px;
+  padding-top: 60px;
+  margin: 0 10px 0px 10px;
+  width: 264px;
+}
+
+.modal-body-import .import-btn-image a:hover {
+  background: #eee;
+}
+
+.modal-body-import .modal-body-import-desc {
+  font-size: 15px;
+  font-weight: 400;
+  margin-top: 30px;
+  color: black;
+  font-family: 'Roboto', sans-serif;
+}
+
+.modal-footer-import {
+  min-height: 65px;
+}

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.css
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.css
@@ -39,6 +39,7 @@
   font-size: 15px;
   font-weight: 400;
   margin-bottom: 10px;
+  margin-top: 15px;
 }
 
 .modal-body-import {
@@ -50,10 +51,16 @@
   margin-top: 4px;
 }
 
+.modal-body-import .import-btn-image {
+  display: inline-block;
+  margin-left: 8px;
+}
+
 .modal-body-import .import-btn-image a {
   background: #fff;
   border: 1px solid #e6e6e6;
-  border-radius: 5px;
+  /*border-radius: 20px;*/
+  border-radius: 20%;
   color: #7c828e;
   cursor: pointer;
   display: block;
@@ -64,7 +71,7 @@
   height: 240px;
   padding-top: 60px;
   margin: 0 10px 0px 10px;
-  width: 264px;
+  width: 250px;
 }
 
 .modal-body-import .import-btn-image a:hover {

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.css
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.css
@@ -1,0 +1,17 @@
+.modal-header-import {
+  background-color: #3071a9;
+  border: 2px solid #3071a9;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.modal-header-import .close {
+  color: #cfcfcf;
+  opacity: 1;
+}
+
+.modal-header-import .modal-title {
+  color: white;
+  font-size: 20px;
+  font-weight: 300;
+}

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.css
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.css
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .modal-header-import {
   background-color: #3071a9;
   border: 2px solid #3071a9;

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -25,33 +25,34 @@ limitations under the License.
       </div>
 
       <!-- modal-body -->
-      <div class="modal-body">
+      <div class="modal-body modal-body-import">
         <div class="form-group">
-          <label for="noteImportName">Import AS</label>
-          <input placeholder="Insert Note Name" type="text" class="form-control" id="noteImportName"
+          <label for="noteImportName">Import As</label>
+          <input class="form-control note-name-input" id="noteImportName"
+                 placeholder="Insert Note Name" type="text"
                  ng-model="note.noteImportName" />
-        </div>
-        <div class="form-group">
-          <label for="fileSizeLimit">JSON file size cannot exceed {{maxLimit}} MB</label>
         </div>
 
         <div class="form-group" ng-show="note.errorText">
           <div class="alert alert-danger">{{note.errorText}}</div>
         </div>
 
-        <div class="form-group slide-left" ng-show="note.step1">
-          <div class="display-inline">
+        <label>JSON file size cannot exceed {{maxLimit}} MB</label>
+
+        <div class="form-group slide-left import-btn-image-group" ng-show="note.step1">
+          <div class="import-btn-image">
             <a class="fa fa-cloud-upload import-file-upload" ng-click="uploadFile()">
-              <p>Choose a JSON here</p>
+              <p class="modal-body-import-desc">Select JSON File </p>
             </a>
           </div>
           <div style="display: none">
-            <input placeholder="Note name" type="file" class="form-control" id="noteImportFile"
+            <input class="form-control note-name-input" id="noteImportFile"
+                   placeholder="Note name" type="file"
                    ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
           </div>
-          <div class="display-inline">
+          <div class="import-btn-image">
             <a href="javascript:void(0);" ng-click="uploadURL()" class="fa fa-link">
-              <p>Add from URL</p>
+              <p class="modal-body-import-desc">Add from URL</p>
             </a>
           </div>
         </div>
@@ -64,17 +65,15 @@ limitations under the License.
         </div>
 
       </div>
-      <div class="modal-footer">
-        <div ng-show="note.step2">
-          <button type="button" id="importBackButton"
-                  class="btn btn-default"
-                  ng-click="noteimportctrl.importBack()">Back
-          </button>
-          <button type="button" id="importNoteButton"
-                  class="btn btn-default"
-                  ng-click="noteimportctrl.importNote()">Import Note
-          </button>
-        </div>
+      <div class="modal-footer modal-footer-import" ng-show="note.step2">
+        <button type="button" id="importBackButton"
+                class="btn btn-default"
+                ng-click="noteimportctrl.importBack()">Back
+        </button>
+        <button type="button" id="importNoteButton"
+                class="btn btn-default"
+                ng-click="noteimportctrl.importNote()">Import Note
+        </button>
       </div>
     </div>
   </div>

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -44,11 +44,11 @@ limitations under the License.
             <a class="fa fa-cloud-upload import-file-upload" ng-click="uploadFile()">
               <p class="modal-body-import-desc">Select JSON File </p>
             </a>
-          </div>
-          <div style="display: none">
-            <input class="form-control note-name-input" id="noteImportFile"
-                   placeholder="Note name" type="file"
-                   ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
+            <div style="display: none">
+              <input class="form-control note-name-input" id="noteImportFile"
+                     placeholder="Note name" type="file"
+                     ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
+            </div>
           </div>
           <div class="import-btn-image">
             <a href="javascript:void(0);" ng-click="uploadURL()" class="fa fa-link">

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -11,71 +11,70 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<div id="noteImportModal" class="modal fade" role="dialog"
+     tabindex="-1" data-backdrop="static" data-keyboard="false">
+  <div class="modal-dialog" >
 
-  <div id="noteImportModal" class="modal fade" role="dialog"
-       tabindex="-1" data-backdrop="static" data-keyboard="false">
-    <div class="modal-dialog" >
+    <!-- Modal content-->
+    <div class="modal-content" id="NoteImportCtrl" ng-init="NoteImportInit">
+      <div class="modal-header">
+        <!-- close button -->
+        <button type="button" class="close" data-dismiss="modal" ng-click="noteimportctrl.resetFlags()">&times;</button>
 
-      <!-- Modal content-->
-      <div class="modal-content" id="NoteImportCtrl" ng-init="NoteImportInit">
-        <div class="modal-header">
-          <!-- close button -->
-          <button type="button" class="close" data-dismiss="modal" ng-click="noteimportctrl.resetFlags()">&times;</button>
+        <h4 class="modal-title">Import new note</h4>
+      </div>
+      <div class="modal-body">
 
-          <h4 class="modal-title">Import new note</h4>
+        <div class="form-group">
+          <label for="noteImportName">Import AS</label>
+          <input placeholder="Note name" type="text" class="form-control" id="noteImportName"
+                 ng-model="note.noteImportName" />
         </div>
-        <div class="modal-body">
-
-          <div class="form-group">
-            <label for="noteImportName">Import AS</label>
-            <input placeholder="Note name" type="text" class="form-control" id="noteImportName"
-                   ng-model="note.noteImportName" />
-          </div>
-          <div class="form-group">
-            <label for="fileSizeLimit">JSON file size cannot exceed {{maxLimit}} MB</label>
-          </div>
-
-          <div class="form-group" ng-show="note.errorText">
-            <div class="alert alert-danger">{{note.errorText}}</div>
-          </div>
-
-          <div class="form-group slide-left" ng-show="note.step1">
-            <div class="display-inline">
-              <a class="fa fa-cloud-upload import-file-upload" ng-click="uploadFile()">
-                <p>Choose a JSON here</p>
-              </a>
-            </div>
-            <div style="display: none">
-              <input placeholder="Note name" type="file" class="form-control" id="noteImportFile"
-                     ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
-            </div>
-            <div class="display-inline">
-              <a href="javascript:void(0);" ng-click="uploadURL()" class="fa fa-link">
-                <p>Add from URL</p>
-              </a>
-            </div>
-          </div>
-
-          <div class="form-group slide-right" ng-show="note.step2">
-
-            <label for="noteImportUrl">URL</label>
-            <input placeholder="Note url" type="text" class="form-control" id="noteImportUrl"
-                   ng-model="note.importUrl" />
-          </div>
-
+        <div class="form-group">
+          <label for="fileSizeLimit">JSON file size cannot exceed {{maxLimit}} MB</label>
         </div>
-        <div class="modal-footer">
-          <div ng-show="note.step2">
-            <button type="button" id="importBackButton"
-                    class="btn btn-default"
-                    ng-click="noteimportctrl.importBack()">Back
-            </button>
-            <button type="button" id="importNoteButton"
-                    class="btn btn-default"
-                    ng-click="noteimportctrl.importNote()">Import Note
-            </button>
+
+        <div class="form-group" ng-show="note.errorText">
+          <div class="alert alert-danger">{{note.errorText}}</div>
+        </div>
+
+        <div class="form-group slide-left" ng-show="note.step1">
+          <div class="display-inline">
+            <a class="fa fa-cloud-upload import-file-upload" ng-click="uploadFile()">
+              <p>Choose a JSON here</p>
+            </a>
           </div>
+          <div style="display: none">
+            <input placeholder="Note name" type="file" class="form-control" id="noteImportFile"
+                   ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
+          </div>
+          <div class="display-inline">
+            <a href="javascript:void(0);" ng-click="uploadURL()" class="fa fa-link">
+              <p>Add from URL</p>
+            </a>
+          </div>
+        </div>
+
+        <div class="form-group slide-right" ng-show="note.step2">
+
+          <label for="noteImportUrl">URL</label>
+          <input placeholder="Note url" type="text" class="form-control" id="noteImportUrl"
+                 ng-model="note.importUrl" />
+        </div>
+
+      </div>
+      <div class="modal-footer">
+        <div ng-show="note.step2">
+          <button type="button" id="importBackButton"
+                  class="btn btn-default"
+                  ng-click="noteimportctrl.importBack()">Back
+          </button>
+          <button type="button" id="importNoteButton"
+                  class="btn btn-default"
+                  ng-click="noteimportctrl.importNote()">Import Note
+          </button>
         </div>
       </div>
     </div>
   </div>
+</div>

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -11,23 +11,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div id="noteImportModal" class="modal fade" role="dialog"
-     tabindex="-1" data-backdrop="static" data-keyboard="false">
-  <div class="modal-dialog" >
+<div id="noteImportModal" class="modal fade" role="dialog" tabindex="-1"
+     data-backdrop="static" data-keyboard="false">
 
-    <!-- Modal content-->
+  <div class="modal-dialog">
     <div class="modal-content" id="NoteImportCtrl" ng-init="NoteImportInit">
-      <div class="modal-header">
-        <!-- close button -->
-        <button type="button" class="close" data-dismiss="modal" ng-click="noteimportctrl.resetFlags()">&times;</button>
 
-        <h4 class="modal-title">Import new note</h4>
+      <!-- modal-header -->
+      <div class="modal-header modal-header-import">
+        <button type="button" class="close" data-dismiss="modal"
+                ng-click="noteimportctrl.resetFlags()">&times;</button>
+        <h4 class="modal-title">Import New Note</h4>
       </div>
-      <div class="modal-body">
 
+      <!-- modal-body -->
+      <div class="modal-body">
         <div class="form-group">
           <label for="noteImportName">Import AS</label>
-          <input placeholder="Note name" type="text" class="form-control" id="noteImportName"
+          <input placeholder="Insert Note Name" type="text" class="form-control" id="noteImportName"
                  ng-model="note.noteImportName" />
         </div>
         <div class="form-group">

--- a/zeppelin-web/src/components/noteName-import/note-import-dialog.html
+++ b/zeppelin-web/src/components/noteName-import/note-import-dialog.html
@@ -60,7 +60,7 @@ limitations under the License.
         <div class="form-group slide-right" ng-show="note.step2">
 
           <label for="noteImportUrl">URL</label>
-          <input placeholder="Note url" type="text" class="form-control" id="noteImportUrl"
+          <input placeholder="Note URL" type="text" class="form-control" id="noteImportUrl"
                  ng-model="note.importUrl" />
         </div>
 

--- a/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
+++ b/zeppelin-web/src/components/noteName-import/notenameImport.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import './note-import-dialog.css'
+
 angular.module('zeppelinWebApp').controller('NoteImportCtrl', NoteImportCtrl)
 
 function NoteImportCtrl ($scope, $timeout, websocketMsgSrv) {


### PR DESCRIPTION
### What is this PR for?

Improve `import notebook` dialog style. See the attached screenshots.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2429](https://issues.apache.org/jira/browse/ZEPPELIN-2429)

### How should this be tested?

1. Build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. Run Zeppelin and open browser: `localhost:8080`
3. `import notebook` functionality should work as like before.

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26281995/816eed22-3e42-11e7-8ec5-8bca9f54f919.png)


#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26281990/6f8df684-3e42-11e7-8fe5-df6f964e5921.png)

![image](https://cloud.githubusercontent.com/assets/4968473/26281992/74732f52-3e42-11e7-8d40-5083e63c7714.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
