### PR TITLE
[ZEPPELIN-2428] Improve `create new note` dialog style

### DIFF
--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.css
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.css
@@ -15,3 +15,12 @@
   color: #cfcfcf;
   opacity: 1;
 }
+
+.modal-body-note-name label {
+  font-size: 17px;
+  font-weight: 400;
+}
+
+.note-name-create-input {
+  margin-top: 5px;
+}

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.css
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.css
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .modal-header-note-name {
   background-color: #3071a9;
   border: 2px solid #3071a9;

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.css
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.css
@@ -24,3 +24,8 @@
 .note-name-create-input {
   margin-top: 5px;
 }
+
+.note-name-desc-panel {
+  margin-top: 10px;
+  margin-bottom: 4px;
+}

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.css
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.css
@@ -1,0 +1,17 @@
+.modal-header-note-name {
+  background-color: #3071a9;
+  border: 2px solid #3071a9;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.modal-header-note-name > .modal-title {
+  font-weight: 300;
+  font-size: 20px;
+  color: white;
+}
+
+.modal-header-note-name > .close {
+  color: #cfcfcf;
+  opacity: 1;
+}

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.css
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.css
@@ -26,6 +26,10 @@
 }
 
 .note-name-desc-panel {
-  margin-top: 10px;
+  margin-top: 20px;
   margin-bottom: 4px;
+}
+
+.default-interpreter-select {
+  margin-top: 12px;
 }

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -11,17 +11,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div id="noteNameModal" class="modal fade" role="dialog" modalvisible previsiblecallback="notenamectrl.preVisible"
+<div id="noteNameModal" class="modal fade" role="dialog"
+     modalvisible previsiblecallback="notenamectrl.preVisible"
      targetinput="noteName" tabindex="-1">
   <div class="modal-dialog">
 
-    <!-- Modal content-->
+    <!-- modal content-->
     <div class="modal-content" id="NotenameCtrl">
-      <div class="modal-header">
+      <!-- modal header -->
+      <div class="modal-header modal-header-note-name">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title" ng-show="!notenamectrl.clone">Create new note</h4>
-        <h4 class="modal-title" ng-show="notenamectrl.clone">Clone note</h4>
+        <h4 class="modal-title" ng-show="!notenamectrl.clone">Create New Note</h4>
+        <h4 class="modal-title" ng-show="notenamectrl.clone">Clone Note</h4>
       </div>
+
+      <!-- modal body-->
       <div class="modal-body">
         <div class="form-group">
           <label for="noteName">Note Name</label> <input

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -28,9 +28,15 @@ limitations under the License.
       <!-- modal body-->
       <div class="modal-body">
         <div class="form-group">
-          <label for="noteName">Note Name</label> <input
-          placeholder="Note name" type="text" class="form-control"
-          id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/><br/>
+          <!-- note name -->
+          <div>
+            <label for="noteName">Note Name</label>
+            <input placeholder="Note name" type="text" class="form-control"
+                   id="noteName" ng-model="note.notename"
+                   ng-enter="notenamectrl.handleNameEnter()" />
+            <br/>
+          </div>
+          <!-- default interpreter -->
           <div ng-show="!notenamectrl.clone">
             <label for="defaultInterpreter">Default Interpreter </label>
             <select ng-model="note.defaultInterpreter"
@@ -40,7 +46,7 @@ limitations under the License.
                     ng-options="option.name for option in interpreterSettings">
             </select>
           </div>
-        </div>
+        </div> <!-- end: form-group -->
         Use '/' to create folders. Example: /NoteDirA/Note1
       </div>
       <div class="modal-footer">

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -26,12 +26,13 @@ limitations under the License.
       </div>
 
       <!-- modal body-->
-      <div class="modal-body">
+      <div class="modal-body modal-body-note-name">
         <div class="form-group">
           <!-- note name -->
           <div>
             <label for="noteName">Note Name</label>
-            <input placeholder="Note name" type="text" class="form-control"
+            <input placeholder="Insert Note Name" type="text"
+                   class="form-control note-name-create-input"
                    id="noteName" ng-model="note.notename"
                    ng-enter="notenamectrl.handleNameEnter()" />
             <br/>
@@ -47,7 +48,7 @@ limitations under the License.
             </select>
           </div>
         </div> <!-- end: form-group -->
-        Use '/' to create folders. Example: /NoteDirA/Note1
+        <div>Use '/' to create folders. Example: /NoteDirA/Note1</div>
       </div>
       <div class="modal-footer">
         <button type="button" id="createNoteButton"

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -45,10 +45,10 @@ limitations under the License.
       </div>
       <div class="modal-footer">
         <button type="button" id="createNoteButton"
-                class="btn btn-default"
+                class="btn btn-primary"
                 data-dismiss="modal" ng-click="notenamectrl.createNote()">
-          <span ng-show="!notenamectrl.clone">Create Note</span>
-          <span ng-show="notenamectrl.clone">Clone Note</span>
+          <span ng-show="!notenamectrl.clone">Create</span>
+          <span ng-show="notenamectrl.clone">Clone</span>
         </button>
       </div>
     </div>

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -11,42 +11,42 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-  <div id="noteNameModal" class="modal fade" role="dialog" modalvisible previsiblecallback="notenamectrl.preVisible"
-    targetinput="noteName" tabindex="-1">
-    <div class="modal-dialog">
+<div id="noteNameModal" class="modal fade" role="dialog" modalvisible previsiblecallback="notenamectrl.preVisible"
+     targetinput="noteName" tabindex="-1">
+  <div class="modal-dialog">
 
-      <!-- Modal content-->
-      <div class="modal-content" id="NotenameCtrl">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title" ng-show="!notenamectrl.clone">Create new note</h4>
-          <h4 class="modal-title" ng-show="notenamectrl.clone">Clone note</h4>
-        </div>
-        <div class="modal-body">
-          <div class="form-group">
-            <label for="noteName">Note Name</label> <input
-              placeholder="Note name" type="text" class="form-control"
-              id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/><br/>
-            <div ng-show="!notenamectrl.clone">
-              <label for="defaultInterpreter">Default Interpreter </label>
-              <select ng-model="note.defaultInterpreter"
-                      class="selectpicker"
-                      name="defaultInterpreter"
-                      id="defaultInterpreter"
-                      ng-options="option.name for option in interpreterSettings">
-              </select>
-            </div>
+    <!-- Modal content-->
+    <div class="modal-content" id="NotenameCtrl">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title" ng-show="!notenamectrl.clone">Create new note</h4>
+        <h4 class="modal-title" ng-show="notenamectrl.clone">Clone note</h4>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="noteName">Note Name</label> <input
+          placeholder="Note name" type="text" class="form-control"
+          id="noteName" ng-model="note.notename" ng-enter="notenamectrl.handleNameEnter()"/><br/>
+          <div ng-show="!notenamectrl.clone">
+            <label for="defaultInterpreter">Default Interpreter </label>
+            <select ng-model="note.defaultInterpreter"
+                    class="selectpicker"
+                    name="defaultInterpreter"
+                    id="defaultInterpreter"
+                    ng-options="option.name for option in interpreterSettings">
+            </select>
           </div>
-          Use '/' to create folders. Example: /NoteDirA/Note1
         </div>
-        <div class="modal-footer">
-          <button type="button" id="createNoteButton"
-                  class="btn btn-default"
-                  data-dismiss="modal" ng-click="notenamectrl.createNote()">
-            <span ng-show="!notenamectrl.clone">Create Note</span>
-            <span ng-show="notenamectrl.clone">Clone Note</span>
-          </button>
-        </div>
+        Use '/' to create folders. Example: /NoteDirA/Note1
+      </div>
+      <div class="modal-footer">
+        <button type="button" id="createNoteButton"
+                class="btn btn-default"
+                data-dismiss="modal" ng-click="notenamectrl.createNote()">
+          <span ng-show="!notenamectrl.clone">Create Note</span>
+          <span ng-show="notenamectrl.clone">Clone Note</span>
+        </button>
       </div>
     </div>
   </div>
+</div>

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -48,7 +48,11 @@ limitations under the License.
             </select>
           </div>
         </div> <!-- end: form-group -->
-        <div>Use '/' to create folders. Example: /NoteDirA/Note1</div>
+        <div class="panel panel-default note-name-desc-panel">
+          <div class="panel-heading">
+            Use '/' to create folders. Example: /NoteDirA/Note1
+          </div>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" id="createNoteButton"

--- a/zeppelin-web/src/components/noteName-create/note-name-dialog.html
+++ b/zeppelin-web/src/components/noteName-create/note-name-dialog.html
@@ -35,15 +35,14 @@ limitations under the License.
                    class="form-control note-name-create-input"
                    id="noteName" ng-model="note.notename"
                    ng-enter="notenamectrl.handleNameEnter()" />
-            <br/>
           </div>
           <!-- default interpreter -->
-          <div ng-show="!notenamectrl.clone">
-            <label for="defaultInterpreter">Default Interpreter </label>
-            <select ng-model="note.defaultInterpreter"
-                    class="selectpicker"
+          <div class="btn-group default-interpreter-select" ng-show="!notenamectrl.clone">
+            <label for="defaultInterpreter">Default Interpreter</label>
+            <select id="defaultInterpreter"
                     name="defaultInterpreter"
-                    id="defaultInterpreter"
+                    class="form-control"
+                    ng-model="note.defaultInterpreter"
                     ng-options="option.name for option in interpreterSettings">
             </select>
           </div>

--- a/zeppelin-web/src/components/noteName-create/notename.controller.js
+++ b/zeppelin-web/src/components/noteName-create/notename.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import './note-name-dialog.css'
+
 angular.module('zeppelinWebApp').controller('NotenameCtrl', NotenameCtrl)
 
 function NotenameCtrl ($scope, noteListDataFactory, $routeParams, websocketMsgSrv) {


### PR DESCRIPTION
### What is this PR for?

Improve `create new notebook` dialog style. See the attached screenshots.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2428](https://issues.apache.org/jira/browse/ZEPPELIN-2428)

### How should this be tested?

1. Build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. Run Zeppelin and open browser: `localhost:8080`
3. `create new notebook` functionality should work as like before.

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26282019/05c3d7a4-3e43-11e7-80d0-f1ca560449f8.png)

![image](https://cloud.githubusercontent.com/assets/4968473/26282033/3e9302c6-3e43-11e7-9b03-a64c8b0bf2fd.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26282008/cffaf8f0-3e42-11e7-8006-88f542712364.png)

![image](https://cloud.githubusercontent.com/assets/4968473/26282032/3822df24-3e43-11e7-97ac-0578a8d770eb.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
