### PR TITLE
[ZEPPELIN-2575] Improve `rename note` dialog style

### DIFF
--- a/zeppelin-web/src/components/rename/rename.controller.js
+++ b/zeppelin-web/src/components/rename/rename.controller.js
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+import './rename.css'
+
 angular.module('zeppelinWebApp').controller('RenameCtrl', RenameCtrl)
 
 function RenameCtrl ($scope) {

--- a/zeppelin-web/src/components/rename/rename.css
+++ b/zeppelin-web/src/components/rename/rename.css
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .modal-header-rename {
   background-color: #3071a9;
   border: 2px solid #3071a9;

--- a/zeppelin-web/src/components/rename/rename.css
+++ b/zeppelin-web/src/components/rename/rename.css
@@ -1,0 +1,24 @@
+.modal-header-rename {
+  background-color: #3071a9;
+  border: 2px solid #3071a9;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.modal-header-rename .close {
+  color: #cfcfcf;
+  opacity: 1;
+}
+
+.modal-header-rename .modal-title {
+  color: white;
+  font-size: 20px;
+  font-weight: 300;
+}
+
+.modal-body-rename label {
+  font-size: 17px;
+  font-weight: 400;
+  margin-top: 5px;
+  margin-bottom: 15px;
+}

--- a/zeppelin-web/src/components/rename/rename.html
+++ b/zeppelin-web/src/components/rename/rename.html
@@ -11,28 +11,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div id="renameModal" class="modal fade" role="dialog"
-     tabindex="-1">
+<div id="renameModal" class="modal fade" role="dialog" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
+      <!-- modal-header -->
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
         <h4 class="modal-title">{{title}}</h4>
       </div>
+
+      <!-- modal-body -->
       <div class="modal-body">
         <label ng-if="isValid">Please enter a new name</label>
-          <label class="text-danger" ng-if="!isValid">Please enter a valid name</label>
+        <label class="text-danger" ng-if="!isValid">Please enter a valid name</label>
         <div class="form-group" ng-class="{'has-error': !isValid}">
           <input type="text" class="form-control"
-            ng-model="params.newName" ng-change="validate()"
-            ng-keyup="$event.keyCode == 13 && isValid && rename()" />
+                 ng-model="params.newName" ng-change="validate()"
+                 ng-keyup="$event.keyCode == 13 && isValid && rename()" />
         </div>
-
       </div>
       <div class="modal-footer">
         <div>
           <button type="button" class="btn btn-default btn-primary"
-            ng-click="rename()" ng-class="{'disabled': !isValid}">
+                  ng-click="rename()" ng-class="{'disabled': !isValid}">
             Rename
           </button>
         </div>

--- a/zeppelin-web/src/components/rename/rename.html
+++ b/zeppelin-web/src/components/rename/rename.html
@@ -15,15 +15,15 @@ limitations under the License.
   <div class="modal-dialog">
     <div class="modal-content">
       <!-- modal-header -->
-      <div class="modal-header">
+      <div class="modal-header modal-header-rename">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
         <h4 class="modal-title">{{title}}</h4>
       </div>
 
       <!-- modal-body -->
-      <div class="modal-body">
+      <div class="modal-body modal-body-rename">
         <label ng-if="isValid">Please enter a new name</label>
-        <label class="text-danger" ng-if="!isValid">Please enter a valid name</label>
+        <label ng-if="!isValid" class="text-danger">Please enter a valid name</label>
         <div class="form-group" ng-class="{'has-error': !isValid}">
           <input type="text" class="form-control"
                  ng-model="params.newName" ng-change="validate()"

--- a/zeppelin-web/src/components/rename/rename.html
+++ b/zeppelin-web/src/components/rename/rename.html
@@ -27,7 +27,7 @@ limitations under the License.
         <div class="form-group" ng-class="{'has-error': !isValid}">
           <input type="text" class="form-control"
                  ng-model="params.newName" ng-change="validate()"
-                 ng-keyup="$event.keyCode == 13 && isValid && rename()" />
+                 ng-enter="isValid && rename()" />
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
### What is this PR for?

Improve `rename notebook` dialog style. See the attached screenshots.


### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2575](https://issues.apache.org/jira/browse/ZEPPELIN-2575)

### How should this be tested?

1. Build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. Run Zeppelin and open browser: `localhost:8080`
3. `rename notebook` functionality should work as like before.

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26282045/8794216c-3e43-11e7-95f7-cce274c77c12.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26282047/9171c6b2-3e43-11e7-86ee-d861d5f26af9.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
