### PR TITLE
[ZEPPELIN-2574] Improve `about` dialog style

### DIFF
--- a/zeppelin-web/src/app/home/home.css
+++ b/zeppelin-web/src/app/home/home.css
@@ -824,28 +824,3 @@ This part should be removed when new version of bootstrap handles this issue.
 .bootstrap-dialog.type-primary .modal-header {
   background: #3071a9;
 }
-
-/* About Zeppelin */
-.about {
-  height: 200px;
-  padding: 25px;
-}
-
-.about .logo {
-  padding-top: 30px;
-}
-
-.about .logo img {
-  width: 95%;
-}
-
-.about .content {
-  text-align: center;
-}
-
-.about .content h3 {
-  font-family: 'Patua One';
-  color: #3071A9;
-  font-size: 30px;
-  margin: 0 auto;
-}

--- a/zeppelin-web/src/components/navbar/navbar.css
+++ b/zeppelin-web/src/components/navbar/navbar.css
@@ -41,3 +41,29 @@
 }
 .navbar-fixed-top.headroom--unpinned { top: -100px; }
 .navbar-fixed-top.headroom--pinned { top: 0; /** `navbar` top */ }
+
+
+/* About Dialog */
+.about {
+  height: 200px;
+  padding: 25px;
+}
+
+.about .logo {
+  padding-top: 30px;
+}
+
+.about .logo img {
+  width: 95%;
+}
+
+.about .content {
+  text-align: center;
+}
+
+.about .content h3 {
+  font-family: 'Patua One';
+  color: #3071A9;
+  font-size: 30px;
+  margin: 0 auto;
+}

--- a/zeppelin-web/src/components/navbar/navbar.css
+++ b/zeppelin-web/src/components/navbar/navbar.css
@@ -42,26 +42,48 @@
 .navbar-fixed-top.headroom--unpinned { top: -100px; }
 .navbar-fixed-top.headroom--pinned { top: 0; /** `navbar` top */ }
 
-
 /* About Dialog */
-.about {
-  height: 200px;
-  padding: 25px;
+
+.modal-header-about {
+  background-color: #3071a9;
+  border: 2px solid #3071a9;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
-.about .logo {
+.modal-header-about > .close {
+  color: #cfcfcf;
+  opacity: 1;
+}
+
+.modal-header-about > .modal-title {
+  font-weight: 300;
+  font-size: 20px;
+  color: #e8e8e8;
+}
+
+.modal-body-about-version {
+  font-weight: 500;
+}
+
+.modal-body-about {
+  height: 250px;
+  padding: 50px;
+}
+
+.modal-body-about .logo {
   padding-top: 30px;
 }
 
-.about .logo img {
+.modal-body-about .logo img {
   width: 95%;
 }
 
-.about .content {
+.modal-body-about .content {
   text-align: center;
 }
 
-.about .content h3 {
+.modal-body-about .content h3 {
   font-family: 'Patua One';
   color: #3071A9;
   font-size: 30px;

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -112,19 +112,19 @@ limitations under the License.
     </div>
   </div>
 </headroom>
-<div id="aboutModal" class="modal fade" role="dialog"
-     tabindex="-1">
-  <div class="modal-dialog">
 
-    <!-- Modal content-->
-    <div class="modal-content" id="NoteImportCtrl" ng-init="NoteImportInit">
-      <div class="modal-header">
+<!-- about dialog -->
+<div id="aboutModal" class="modal fade" role="dialog" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <!-- about dialog header -->
+      <div class="modal-header modal-header-about">
         <button type="button" class="close" data-dismiss="modal">&times;</button>
         <h4 class="modal-title">About Zeppelin</h4>
       </div>
-      <div class="modal-body">
 
-        <div class="row about">
+      <!-- about dialog body -->
+      <div class="modal-body modal-body-about">
           <div class="hidden-xs col-sm-4 logo">
             <img src="assets/images/zepLogo.png" alt="Apache Zeppelin" title="Apache Zeppelin" />
           </div>
@@ -132,13 +132,12 @@ limitations under the License.
             <h3>Apache Zeppelin</h3>
             <br/>
             <span id="i18n-14">Version</span>
-            {{zeppelinVersion}}
+            <span class="modal-body-about-version"> {{zeppelinVersion}} </span>
             <br/>
             <br/>
             <a href="http://zeppelin.apache.org/" target="_blank"><span id="i18n-15">Get involved!</span></a>
             <br/>
             <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank"><span id="i18n-16">Licensed under the Apache License, Version 2.0</span></a>
-          </div>
         </div>
 
       </div>


### PR DESCRIPTION
### What is this PR for?

Improve `about` dialog style. See the attached screenshots.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2574](https://issues.apache.org/jira/browse/ZEPPELIN-2574)

### How should this be tested?

1. Build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. Run Zeppelin and open browser: `localhost:8080`
3. Click the `About Zeppelin` button

![image](https://cloud.githubusercontent.com/assets/4968473/26282057/f4ccec14-3e43-11e7-8f30-aa58f1dbebc0.png)


### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26282052/cc7c879c-3e43-11e7-94e8-887794aba27c.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26282051/c779a284-3e43-11e7-9ee4-3aee2c8d8e17.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
