### PR TITLE
[ZEPPELIN-2131] Restrict `shift + arrow` key in focused cell

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -818,20 +818,16 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
           switch (keyCode) {
             case 38:
-              keyBindingEditorFocusAction(ROW_UP)
+              if (!e.shiftKey) { keyBindingEditorFocusAction(ROW_UP) }
               break
             case 80:
-              if (e.ctrlKey && !e.altKey) {
-                keyBindingEditorFocusAction(ROW_UP)
-              }
+              if (e.ctrlKey && !e.altKey) { keyBindingEditorFocusAction(ROW_UP) }
               break
             case 40:
-              keyBindingEditorFocusAction(ROW_DOWN)
+              if (!e.shiftKey) { keyBindingEditorFocusAction(ROW_DOWN) }
               break
             case 78:
-              if (e.ctrlKey && !e.altKey) {
-                keyBindingEditorFocusAction(ROW_DOWN)
-              }
+              if (e.ctrlKey && !e.altKey) { keyBindingEditorFocusAction(ROW_DOWN) }
               break
           }
         }


### PR DESCRIPTION
### What is this PR for?

Selection of text in cell by Shift-Arrow should be restricted to focussed cell.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2131](https://issues.apache.org/jira/browse/ZEPPELIN-2131)

### How should this be tested?

1. Create multiple paragraphs.
2. Move cursors using `shift + arrow` (up, down)
3. Should keep focus on the current paragraph.

### Screenshots (if appropriate)

#### Before
![2131_before](https://cloud.githubusercontent.com/assets/4968473/26300503/438f196e-3f19-11e7-9932-21aebcd4e3c6.gif)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26300474/2322167c-3f19-11e7-8960-7abc83e9c3f4.png)



### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
