### PR TITLE
[ZEPPELIN-2469] HeliumBundleFactoryTest fails on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,12 @@ matrix:
     # Test core modules
     #
     # Several tests were excluded from this configuration due to the following issues:
-    # HeliumBundleFactoryTest      - https://issues.apache.org/jira/browse/ZEPPELIN-2469
     # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
     # NotebookTest                 - https://issues.apache.org/jira/browse/ZEPPELIN-2471
     # ZeppelinRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2473
     # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumBundleFactoryTest.java,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -129,6 +129,7 @@ public class HeliumBundleFactory {
       YarnInstaller yarnInstaller = frontEndPluginFactory.getYarnInstaller(getProxyConfig());
       yarnInstaller.setYarnVersion(YARN_VERSION);
       yarnInstaller.install();
+      yarnCacheDir.mkdirs();
       String yarnCacheDirPath = yarnCacheDir.getAbsolutePath();
       yarnCommand(frontEndPluginFactory, "config set cache-folder " + yarnCacheDirPath);
 


### PR DESCRIPTION
### What is this PR for?
There are 6 errors occuring with error: "yarn config set cache-folder /tmp/ZeppelinLTest_1494573109020/helium-bundle/yarn-cache --registry=http://registry.npmjs.org/' failed."
The failures seem to occur because the "yarnCacheDir" directory is not created. For this, I have added code to create the directory before the absolute path is stored in yarnCacheDirPath. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2469

### How should this be tested?
The tests should pass on the CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
