### PR TITLE
[ZEPPELIN-2471] - NotebookTest fails on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,10 @@ matrix:
     #
     # Several tests were excluded from this configuration due to the following issues:
     # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
-    # NotebookTest                 - https://issues.apache.org/jira/browse/ZEPPELIN-2471
     # ZeppelinRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2473
     # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java,**/NotebookTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -898,6 +898,10 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public static Note fromJson(String json) {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.setPrettyPrinting();
+    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
+                          .create();
     Note note = gson.fromJson(json, Note.class);
     convertOldInput(note);
     return note;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -898,10 +898,11 @@ public class Note implements Serializable, ParagraphJobListener {
   }
 
   public static Note fromJson(String json) {
-    GsonBuilder gsonBuilder = new GsonBuilder();
+    GsonBuilder gsonBuilder = 
+            new GsonBuilder();
     gsonBuilder.setPrettyPrinting();
     Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
-                          .create();
+        .create();
     Note note = gson.fromJson(json, Note.class);
     convertOldInput(note);
     return note;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -165,10 +165,6 @@ public class VFSNotebookRepo implements NotebookRepo {
       throw new IOException(noteJson.getName().toString() + " not found");
     }
 
-    GsonBuilder gsonBuilder = new GsonBuilder();
-    gsonBuilder.setPrettyPrinting();
-    Gson gson = gsonBuilder.registerTypeAdapter(Date.class, new NotebookImportDeserializer())
-        .create();
 
     FileContent content = noteJson.getContent();
     InputStream ins = content.getInputStream();


### PR DESCRIPTION
### What is this PR for?
The stacktrace for this issue gives the error: 
```
06:31:15,263 ERROR org.apache.zeppelin.notebook.repo.VFSNotebookRepo:151 - Can't read note file:///tmp/ZeppelinLTest_1495261875233/notebook/2BQA35CJZ
com.google.gson.JsonSyntaxException: 2016-03-29T16:21:09-0700
```
This issue is related to notebooks failing to load with date ParseException and  was fixed in ZEPPELIN-1129. However, in ZEPPELIN-2395 the fix for old format is excluded and hence the issue occurs again. Added the same code to fix the old date format issue in the fromJSON method of Note.java

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2471

### How should this be tested?
Tests should pass on CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
