### PR TITLE
Improved comment, removed admin user definition per default

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -18,7 +18,8 @@
 [users]
 # List of users with their password allowed to access Zeppelin.
 # To use a different strategy (LDAP / Database / ...) check the shiro doc at http://shiro.apache.org/configuration.html#Configuration-INISections
-admin = password1, admin
+# To enable admin user, uncomment the following line and set an appropriate password.
+#admin = password1, admin
 user1 = password2, role1, role2
 user2 = password3, role3
 user3 = password4, role2
@@ -73,14 +74,22 @@ role3 = *
 admin = *
 
 [urls]
-# This section is used for url-based security.
-# You can secure interpreter, configuration and credential information by urls. Comment or uncomment the below urls that you want to hide.
+# This section is used for url-based security. For details see the shiro.ini documentation.
+#
+# You can secure interpreter, configuration and credential information by urls.
+# Comment or uncomment the below urls that you want to hide:
 # anon means the access is anonymous.
-# authc means Form based Auth Security
-# To enfore security, comment the line below and uncomment the next one
+# authc means form based auth Security.
+#
+# IMPORTANT: Order matters: URL path expressions are evaluated against an incoming request
+# in the order they are defined and the FIRST MATCH WINS.
+#
+# To allow anonymous access to all but the stated urls,
+# uncomment the line second last line (/** = anon) and comment the last line (/** = authc)
+#
 /api/version = anon
-#/api/interpreter/** = authc, roles[admin]
-#/api/configurations/** = authc, roles[admin]
-#/api/credential/** = authc, roles[admin]
+/api/interpreter/** = authc, roles[admin]
+/api/configurations/** = authc, roles[admin]
+/api/credential/** = authc, roles[admin]
 #/** = anon
 /** = authc


### PR DESCRIPTION
### What is this PR for?
Improved shiro.ini.template.

Since the file is just a template, it should be such that if the user copies it from shiro.ini.template to shiro.ini the auth settings are comparable conservative.
Hence: The admin user has been commented out to avoid enabling admin by
default with a default password.

In addition, the comment in the url section was misleading. It has been clarified. The comment "To enfore security, comment the line below and uncomment the next one“ was
misleading, since the setting was already on "authc" and it was not the "line below". This has been fixed.

### What type of PR is it?
[ Improvement]

### Todos
* N/A

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2588

### How should this be tested?
Non regression test / unit testing.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? *NO*
* Is there breaking changes for older versions? *NO*
* Does this needs documentation? *NO*

