### PR TITLE
[ZEPPELIN-2581] Shell ansi codes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -256,6 +256,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (Apache 2.0) Software under ./bigquery/*  was developed at Google (http://www.google.com/). Licensed under the Apache v2.0 License.
     (Apache 2.0) Roboto Font (https://github.com/google/roboto/)
     (Apache 2.0) Gson extra (https://github.com/DanySK/gson-extras)
+    (Apache 2.0) Jansi (http://fusesource.github.io/jansi/)
 
 ========================================================================
 BSD 3-Clause licenses

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -69,6 +69,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <version>1.15</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Properties;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.junit.After;
@@ -41,7 +42,8 @@ public class ShellInterpreterTest {
     p.setProperty("shell.command.timeout.millisecs", "2000");
     shell = new ShellInterpreter(p);
 
-    context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null, null);
+    context = new InterpreterContext("", "1", null, "", "", null, null, null, null, null, null,
+        new InterpreterOutput(null));
     shell.open();
   }
 


### PR DESCRIPTION
### What is this PR for?
Support ANSI escape codes for colors in shell interpreter output

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2581

### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/2759002/26547220/90c162f2-4476-11e7-9fa4-4b023c1a415f.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
