### PR TITLE
[ZEPPELIN-2527] Use thin (normal) cursor.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -671,8 +671,8 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
       })
 
       if (navigator.appVersion.indexOf('Mac') !== -1) {
-        $scope.editor.setKeyboardHandler('ace/keyboard/emacs')
         $rootScope.isMac = true
+        $scope.editor.commands.bindKey('ctrl-p', 'golineup')
       } else if (navigator.appVersion.indexOf('Win') !== -1 ||
         navigator.appVersion.indexOf('X11') !== -1 ||
         navigator.appVersion.indexOf('Linux') !== -1) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -376,14 +376,8 @@ table.table-shortcut {
   opacity: 0;
 }
 
-/** set cursor color */
-#main .emacs-mode .ace_cursor {
-  background: #C0C0C0!important;
-  border: none !important;
-}
-
 .ace_text-input, .ace_gutter, .ace_layer,
-.emacs-mode, .ace_text-layer, .ace_cursor-layer,
+.ace_text-layer, .ace_cursor-layer,
 .ace_cursor, .ace_scrollbar {
   z-index: auto !important;
 }


### PR DESCRIPTION
### What is this PR for?

Previously, it's hard to recognize where (**before or after**) the cursor is since it's too thick.
Also, it's better for fonts which is not monospaced. (e.g Chinese, Korean, ...)

See the attached GIFs for comparison.

These key bindings are still supported in the default mode. 

- `CTRL + P`, `CTRL+N`: go to next / previous line
- `CTRL + F`, `CTRL+B`: go to next / previous letter
- `CTRL + A`, `CTRL+E`: go to the beginning / end of the line

### What type of PR is it?
[Improvement]

### Todos
* [x] - Use default mode instead of emacs
* [x] - Bind `CTRL + P` for OSX.

### What is the Jira issue?

[ZEPPELIN-2527](https://issues.apache.org/jira/browse/ZEPPELIN-2527)

### How should this be tested?

1. Build: `mvn clean package -DskipTests;`
2. Open a paragraph.
2. Check the cursor 

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26563771/777d026e-4512-11e7-9f77-7c64fad776da.png)

![2527_before](https://cloud.githubusercontent.com/assets/4968473/26563687/b7133c88-4510-11e7-9acc-0baea08f29fc.gif)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26563763/487c4542-4512-11e7-992f-7aee56135455.png)


![2527_after](https://cloud.githubusercontent.com/assets/4968473/26563690/c1bcd982-4510-11e7-9032-eb5c4a28e976.gif)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

