### PR TITLE
User does not land on Zeppelin UI Login page after clicking logout button when Zeppelin is running behind proxy server.

### DIFF
--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -34,7 +34,7 @@ function ConfigurationCtrl ($scope, $rootScope, $http, baseUrlSrv, ngToast) {
           timeout: '3000'
         })
         setTimeout(function () {
-          window.location.replace('/')
+          window.location = baseUrlSrv.getBase()
         }, 3000)
       }
       console.log('Error %o %o', status, data.message)

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -40,7 +40,7 @@ function CredentialCtrl ($scope, $rootScope, $http, baseUrlSrv, ngToast) {
           timeout: '3000'
         })
         setTimeout(function () {
-          window.location.replace('/')
+          window.location = baseUrlSrv.getBase()
         }, 3000)
       }
       console.log('Error %o %o', status, data.message)

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -101,7 +101,7 @@ function InterpreterCtrl ($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeo
             timeout: '3000'
           })
           setTimeout(function () {
-            window.location.replace('/')
+            window.location = baseUrlSrv.getBase()
           }, 3000)
         }
         console.log('Error %o %o', status, data.message)

--- a/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
+++ b/zeppelin-web/src/app/notebookRepos/notebookRepos.controller.js
@@ -74,7 +74,7 @@ function NotebookReposCtrl ($http, baseUrlSrv, ngToast) {
             timeout: '3000'
           })
           setTimeout(function () {
-            window.location.replace('/')
+            window.location = baseUrlSrv.getBase()
           }, 3000)
         }
         console.log('Error %o %o', status, data.message)

--- a/zeppelin-web/src/components/baseUrl/baseUrl.service.js
+++ b/zeppelin-web/src/components/baseUrl/baseUrl.service.js
@@ -37,9 +37,7 @@ function baseUrlSrv () {
   }
 
   this.getBase = function() {
-    let aa = location.protocol + '//' + location.hostname + ':' +
-    this.getPort() + location.pathname
-    return aa
+    return location.protocol + '//' + location.hostname + ':' + this.getPort() + location.pathname
   }
 
   this.getRestApiBase = function () {

--- a/zeppelin-web/src/components/baseUrl/baseUrl.service.js
+++ b/zeppelin-web/src/components/baseUrl/baseUrl.service.js
@@ -36,10 +36,14 @@ function baseUrlSrv () {
       skipTrailingSlash(location.pathname) + '/ws'
   }
 
+  this.getBase = function() {
+    let aa = location.protocol + '//' + location.hostname + ':' +
+    this.getPort() + location.pathname
+    return aa
+  }
+
   this.getRestApiBase = function () {
-    return location.protocol + '//' + location.hostname + ':' +
-      this.getPort() + skipTrailingSlash(location.pathname) +
-      '/api'
+    return skipTrailingSlash(this.getBase()) + '/api'
   }
 
   const skipTrailingSlash = function (path) {

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -101,7 +101,7 @@ function NavCtrl ($scope, $rootScope, $http, $routeParams, $location,
           message: 'Logout Success'
         })
         setTimeout(function () {
-          window.location.replace('/')
+          window.location = baseUrlSrv.getBase()
         }, 1000)
       })
     })


### PR DESCRIPTION
### What is this PR for?
The user is no more on Zeppelin UI Login page after clicking logout button or links where user doesn't have access to when Zeppelin is running behind a proxy server like Nginx.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2601](https://issues.apache.org/jira/browse/ZEPPELIN-2601)

### How should this be tested?
Set up any reverse proxy server like Nginx, exmaple config below;

```
location /abc/def/zeppelin/ {
        proxy_pass http://localhost:8080/;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
}
```

And now from browser navigate to this URL, and click on any like for which user doesn't have access to. In my example `user1` did not have access to any of `/api/interpreter/**` `/api/configurations/**` and `/api/credential/**`

### Screenshots (if appropriate)

Before:
![before](https://cloud.githubusercontent.com/assets/674497/26574347/a204b064-453e-11e7-8799-2c5d38bca5ad.gif)

After:
![after](https://cloud.githubusercontent.com/assets/674497/26574348/a20f3412-453e-11e7-97bb-4ffb54c6e985.gif)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
