### PR TITLE
[ZEPPELIN-2602] fix: broken navbar-title rendering in safari

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.css
+++ b/zeppelin-web/src/components/navbar/navbar.css
@@ -16,13 +16,15 @@
 /* Navbar
 /* ------------------------------------------- */
 
-.navbar-title {
+.navbar-brand.navbar-title {
+  margin-top: -3px;
+  margin-right: 20px;
+}
+
+.navbar-title > span {
   font-family: 'Patua One', cursive;
   font-size: 25px;
   color: white;
-  margin-top: 7px;
-  margin-right: 20px;
-  display: inline-block;
 }
 
 .navbar-menu {
@@ -43,6 +45,7 @@
 }
 
 .navbar-logo {
+  display: inline-block;
   padding-right: 10px;
 }
 

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -20,12 +20,11 @@ limitations under the License.
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <!-- title -->
       <a class="navbar-brand navbar-logo" href="#/">
         <img style="margin-top: -7px;" src="assets/images/zepLogoW.png" width="50" alt="Zeppelin" />
       </a>
-      <a class="" href="#/">
-        <span class="navbar-title">Zeppelin</span>
+      <a class="navbar-brand navbar-title" href="#/">
+        <span>Zeppelin</span>
       </a>
     </div>
 


### PR DESCRIPTION
### What is this PR for?

fix: broken navbar-title rendering in safari.

I attached screenshots.

### What type of PR is it?
[Bug Fix]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2602]()

### How should this be tested?

1. Clone apache/zeppelin
2. Build `mvn clean package -DskipTests;`
3. Open `localhost:8080` in **Safari**

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26576294/4dcc63fa-4563-11e7-87e0-0bc9e0d00dc1.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26576191/e9db8f4c-4562-11e7-9677-215140f0c852.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
