### PR TITLE
[MINOR] fix: Remove newlines in spark tutorial output

### DIFF
--- a/notebook/2A94M5J1Z/note.json
+++ b/notebook/2A94M5J1Z/note.json
@@ -83,7 +83,7 @@
         "msg": [
           {
             "type": "TEXT",
-            "data": "\nimport org.apache.commons.io.IOUtils\n\nimport java.net.URL\n\nimport java.nio.charset.Charset\n\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[0] at parallelize at \u003cconsole\u003e:32\n\ndefined class Bank\n\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string ... 3 more fields]\n\nwarning: there were 1 deprecation warning(s); re-run with -deprecation for details\n"
+            "data": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[36] at parallelize at \u003cconsole\u003e:43\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string ... 3 more fields]\nwarning: there were 1 deprecation warning(s); re-run with -deprecation for details\n"
           }
         ]
       },


### PR DESCRIPTION
### What is this PR for?

fix: Remove newlines in spark tutorial output. I attached screenshots.

### What type of PR is it?
[Bug Fix]

### Todos

DONE

### What is the Jira issue?

MINOR

### How should this be tested?

1. Check out this PR. 
2. Build
3. Open the `Zeppelin Tutorial / Basic Features(Spark)` notebook
4. Check the output.

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26576428/ddd50236-4563-11e7-9cb4-ecfd2c888421.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26576451/ea0601c2-4563-11e7-9efa-f4f0d581000b.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
