### PR TITLE
[ZEPPELIN-2152] Fix for npe in Helium loading when no proxies are set

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -164,9 +164,10 @@ public class HeliumBundleFactory {
             System.getenv("HTTPS_PROXY") : System.getenv("https_proxy");
 
     try {
-      if (isSecure)
+      if (isSecure && StringUtils.isNotBlank(httpsProxy))
         proxies.add(generateProxy("secure", new URI(httpsProxy)));
-      else proxies.add(generateProxy("insecure", new URI(httpProxy)));
+      else if (!isSecure && StringUtils.isNotBlank(httpProxy))
+        proxies.add(generateProxy("insecure", new URI(httpProxy)));
     } catch (Exception ex) {
       logger.error(ex.getMessage(), ex);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -119,17 +118,18 @@ public class HeliumOnlineRegistry extends HeliumRegistry {
 
     try {
       String scheme = new URI(uri).getScheme();
-      if (scheme.toLowerCase().startsWith("https")) {
+      if (scheme.toLowerCase().startsWith("https") && StringUtils.isNotBlank(httpsProxy)) {
         URI httpsProxyUri = new URI(httpsProxy);
         return new HttpHost(httpsProxyUri.getHost(),
                 httpsProxyUri.getPort(), httpsProxyUri.getScheme());
       }
-      else {
+      else if (scheme.toLowerCase().startsWith("http") && StringUtils.isNotBlank(httpProxy)){
         URI httpProxyUri = new URI(httpProxy);
         return new HttpHost(httpProxyUri.getHost(),
                 httpProxyUri.getPort(), httpProxyUri.getScheme());
       }
-    } catch (URISyntaxException ex) {
+      else return null;
+    } catch (Exception ex) {
       logger.error(ex.getMessage(), ex);
       return null;
     }


### PR DESCRIPTION
### What is this PR for?
Emergency fix for npe when calling Helium and with no proxies env variables set.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2152

### How should this be tested?
* clone new zeppelin repository
* unset http_proxy/https_proxy env variables (if set)
* build ` mvn clean package -DskipTests;`
* start zeppelin instance

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
