### PR TITLE
[ZEPPELIN-2577] No graphs visible on IE11

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -200,14 +200,15 @@ angular.element(document).ready(function () {
 // See ZEPPELIN-2577. No graphs visible on IE 11
 // Polyfill. https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
 if (!String.prototype.endsWith) {
+  // eslint-disable-next-line no-extend-native
   String.prototype.endsWith = function(searchString, position) {
-    var subjectString = this.toString();
+    let subjectString = this.toString()
     if (typeof position !== 'number' || !isFinite(position) ||
         Math.floor(position) !== position || position > subjectString.length) {
-      position = subjectString.length;
+      position = subjectString.length
     }
-    position -= searchString.length;
-    var lastIndex = subjectString.indexOf(searchString, position);
-    return lastIndex !== -1 && lastIndex === position;
-  };
+    position -= searchString.length
+    let lastIndex = subjectString.indexOf(searchString, position)
+    return lastIndex !== -1 && lastIndex === position
+  }
 }

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -196,3 +196,18 @@ function bootstrapApplication () {
 angular.element(document).ready(function () {
   auth().then(bootstrapApplication)
 })
+
+// See ZEPPELIN-2577. No graphs visible on IE 11
+// Polyfill. https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+    var subjectString = this.toString();
+    if (typeof position !== 'number' || !isFinite(position) ||
+        Math.floor(position) !== position || position > subjectString.length) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.indexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+}


### PR DESCRIPTION
### What is this PR for?
This PR fixes issue described in https://issues.apache.org/jira/browse/ZEPPELIN-2577 by adding .endsWith method.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2577

### How should this be tested?
Build this PR and make sure built-in visualization is displayed in ie11

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
