### PR TITLE
[ZEPPELIN-2609] Add missing shortcut descriptions

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -240,7 +240,6 @@
 
 table.table-shortcut {
   border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
 }
 
 .table-shortcut > tbody > tr > th {

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -306,6 +306,29 @@ limitations under the License.
               </div>
             </td>
           </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor to the next character</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">F</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move cursor to the previous character</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">B</kbd>
+              </div>
+            </td>
+          </tr>
+
         </table>
       </div>
     </div>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -48,28 +48,6 @@ limitations under the License.
             </td>
           </tr>
 
-          <tr>
-            <td>
-              <div class="col-md-8">Move cursor Up</div>
-            </td>
-            <td>
-              <div class="keys">
-                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">P</kbd>
-              </div>
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              <div class="col-md-8">Move cursor Down</div>
-            </td>
-            <td>
-              <div class="keys">
-                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">N</kbd>
-              </div>
-            </td>
-          </tr>
-
         <tr>
           <td>
             <div class="col-md-8">Remove paragraph</div>
@@ -283,6 +261,29 @@ limitations under the License.
               </div>
             </td>
           </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move to the previous line</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">P</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Move to next the line</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">N</kbd>
+              </div>
+            </td>
+          </tr>
+
 
           <tr>
             <td>

--- a/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
+++ b/zeppelin-web/src/components/modal-shortcut/modal-shortcut.html
@@ -29,8 +29,8 @@ limitations under the License.
           <tr>
             <td>
               <div class="col-md-8">Run paragraph</div>
-           </td>
-           <td>
+            </td>
+            <td>
               <div class="keys">
                 <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">Enter</kbd>
               </div>
@@ -48,86 +48,86 @@ limitations under the License.
             </td>
           </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Remove paragraph</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">D</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Remove paragraph</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">D</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Insert new paragraph above</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">A</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Insert new paragraph above</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">A</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Insert new paragraph below</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">B</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Insert new paragraph below</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">B</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Insert copy of paragraph below</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">C</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Insert copy of paragraph below</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">C</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Move paragraph Up</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">K</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Move paragraph Up</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">K</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Move paragraph Down</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">J</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Move paragraph Down</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">J</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Enable/Disable run paragraph</div>
-          </td>
-          <td>
-            <div class="keys">
-              <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-default">R</kbd>
-            </div>
-          </td>
-        </tr>
+          <tr>
+            <td>
+              <div class="col-md-8">Enable/Disable run paragraph</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt' }}</kbd> + <kbd class="kbd-default">R</kbd>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td>
-            <div class="col-md-8">Toggle output</div>
+          <tr>
+            <td>
+              <div class="col-md-8">Toggle output</div>
             </td>
             <td>
               <div class="keys">


### PR DESCRIPTION
### What is this PR for?

Add missing shortcut descriptions. Refer the *TODOs* section and attached screenshots for detail.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Move `CTRL-N`, `CTRL-P` to the editor shortcut section.
* [x] - Remove useless bottom border color.
* [x] - Add missing shortcut desc `CTRL-F` and `CTRL-B`

### What is the Jira issue?

[ZEPPELIN-2609](https://issues.apache.org/jira/browse/ZEPPELIN-2609)

### How should this be tested?

1. build: `mvn clean package -DskipTests; ./bin/zeppelin-daemon.sh restart`
2. open any notebook
3. click the keyboard shortcut dialog.

### Screenshots (if appropriate)

#### Before

![image](https://cloud.githubusercontent.com/assets/4968473/26706040/2dd05c96-4775-11e7-8c85-39b6a5e7d2a7.png)

#### After

![image](https://cloud.githubusercontent.com/assets/4968473/26706030/230c7bbe-4775-11e7-83f5-3f2f8e86604a.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
