### PR TITLE
[ZEPPELIN-2603] fix: Broken Paragraph Title

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -16,10 +16,12 @@ limitations under the License.
   <h3>
     <div style="float: left; width: auto; max-width: 40%"
       ng-controller="ElasticInputCtrl as input">
-      <input type="text" pu-elastic-input class="form-control2" placeholder="New name" style="min-width: 0px; max-width: 95%;"
+      <input type="text" pu-elastic-input class="note-title-input" placeholder="New name" style="min-width: 0px; max-width: 95%;"
            ng-if="input.showEditor" ng-model="input.value" ng-escape="input.showEditor = false" focus-if="input.showEditor"
            ng-blur="updateNoteName(input.value);input.showEditor = false;" ng-enter="updateNoteName(input.value);input.showEditor = false;" />
-      <p class="form-control-static2" ng-click="input.showEditor = !revisionView; input.value = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
+      <p class="note-title"
+         ng-click="input.showEditor = !revisionView; input.value = note.name"
+         ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -14,11 +14,16 @@ limitations under the License.
 <headroom tolerance="10" offset="30" class="noteAction"
           ng-show="note.id && !paragraphUrl">
   <h3>
-    <div style="float: left; width: auto; max-width: 40%"
-      ng-controller="ElasticInputCtrl as input">
-      <input type="text" pu-elastic-input class="note-title-input" placeholder="New name" style="min-width: 0px; max-width: 95%;"
-           ng-if="input.showEditor" ng-model="input.value" ng-escape="input.showEditor = false" focus-if="input.showEditor"
-           ng-blur="updateNoteName(input.value);input.showEditor = false;" ng-enter="updateNoteName(input.value);input.showEditor = false;" />
+    <div ng-controller="ElasticInputCtrl as input"
+         style="float: left; width: auto; max-width: 40%">
+      <input type="text" pu-elastic-input
+             ng-if="input.showEditor"
+             class="note-title-input" style="min-width: 0px; max-width: 95%;"
+             placeholder="Insert New Note Name"
+             ng-model="input.value"
+             ng-escape="input.showEditor = false" focus-if="input.showEditor"
+             ng-blur="updateNoteName(input.value);input.showEditor = false;"
+             ng-enter="updateNoteName(input.value);input.showEditor = false;" />
       <p class="note-title"
          ng-click="input.showEditor = !revisionView; input.value = note.name"
          ng-show="!input.showEditor">{{noteName(note)}}</p>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -17,9 +17,9 @@ limitations under the License.
     <div ng-controller="ElasticInputCtrl as input"
          style="float: left; width: auto; max-width: 40%">
       <input type="text" pu-elastic-input
-             ng-if="input.showEditor"
              class="note-title-input" style="min-width: 0px; max-width: 95%;"
              placeholder="Insert New Note Name"
+             ng-if="input.showEditor"
              ng-model="input.value"
              ng-escape="input.showEditor = false" focus-if="input.showEditor"
              ng-blur="updateNoteName(input.value);input.showEditor = false;"

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -154,7 +154,7 @@
   color: #333333;
 }
 
-.form-control2 {
+.note-title-input {
   height: 40px;
   font-size: 29px;
   line-height: 1.2;
@@ -168,7 +168,7 @@
   margin: 2px 20px 0 14px;
 }
 
-.form-control-static2 {
+.note-title {
   padding-top: 7px;
   margin-right: 15px;
   font-size: 29px;

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -180,6 +180,7 @@
   color: #999;
   font-size: 12px;
   margin-top: 5px;
+  margin-bottom: 2px;
 }
 
 .paragraph .control li {
@@ -271,19 +272,23 @@ table.table-shortcut {
   display: inline-block;
   float: left;
   font-size: 12px;
-  margin-bottom: 7px;
-  min-height: 24px;
+  max-height: 22px;
+  width: 70%;
 }
 
 .paragraph .title div {
-  width: 80%;
   font-weight: bold;
   font-family: 'Roboto', sans-serif;
   font-size: 17px !important;
+  width: 97%;
+  display: inline-block;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .paragraph .title input {
-  width: 80%;
+  width: 97%;
   height: 24px;
   line-height: 1.42857143;
   color: #555;
@@ -295,8 +300,8 @@ table.table-shortcut {
   font-family: 'Roboto', sans-serif;
   font-size: 17px !important;
   font-weight: bold;
-  padding: 0 2px;
-  margin-left: -3px;
+  padding: 2px 2px;
+  margin-left: 3px;
 }
 
 /*
@@ -325,11 +330,16 @@ table.table-shortcut {
   Ace Text Editor CSS
 */
 
+.paragraph-editor-container {
+  margin-bottom: 3px;
+  margin-top: 10px;
+}
+
 .paragraph .editor {
   width: 100%;
   border-left: 4px solid #DDDDDD;
   background: rgba(255, 255, 255, 0.0);
-  margin: 7px 0 2px 0;
+  margin: 2px 0 2px 0;
 }
 
 .paragraph-text--dirty {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -21,9 +21,9 @@ limitations under the License.
          ng-controller="ElasticInputCtrl as input"
          class="title">
       <input type="text" pu-elastic-input
-             ng-if="input.showEditor"
-             style="min-width: 400px; max-width: 80%;"
+             style="min-width: 0px; max-width: 95%;"
              placeholder="Untitled"
+             ng-if="input.showEditor"
              ng-model="paragraph.title"
              ng-escape="input.showEditor = false; paragraph.title = oldTitle;" focus-if="input.showEditor"
              ng-blur="setTitle(paragraph); input.showEditor = false"
@@ -39,15 +39,15 @@ limitations under the License.
   </div>
 
   <div>
-    <div ng-if="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">
+    <div ng-if="!paragraph.config.editorHide && !viewOnly"
+         class="paragraph-editor-container">
       <code-editor
         paragraph-id="paragraph.id"
         paragraph-context="paragraph"
         dirty-text="dirtyText"
         original-text="originalText"
         on-load="aceLoaded"
-        revision-view="revisionView"
-      ></code-editor>
+        revision-view="revisionView"></code-editor>
     </div>
 
     <div ng-include src="'app/notebook/paragraph/paragraph-progressBar.html'"></div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -16,20 +16,18 @@ limitations under the License.
      ng-class="{'paragraph': !asIframe, 'paragraphAsIframe': asIframe}">
 
   <div>
-    <div ng-if="paragraph.config.title"
-         id="{{paragraph.id}}_title"
+    <div id="{{paragraph.id}}_title"
+         ng-if="paragraph.config.title"
          ng-controller="ElasticInputCtrl as input"
          class="title">
-      <input type="text"
-             pu-elastic-input
+      <input type="text" pu-elastic-input
+             ng-if="input.showEditor"
              style="min-width: 400px; max-width: 80%;"
              placeholder="Untitled"
              ng-model="paragraph.title"
-             ng-if="input.showEditor"
-             ng-escape="input.showEditor = false; paragraph.title = oldTitle;"
+             ng-escape="input.showEditor = false; paragraph.title = oldTitle;" focus-if="input.showEditor"
              ng-blur="setTitle(paragraph); input.showEditor = false"
-             ng-enter="setTitle(paragraph); input.showEditor = false"
-             focus-if="input.showEditor" />
+             ng-enter="setTitle(paragraph); input.showEditor = false" />
       <div ng-click="input.showEditor = !asIframe && !viewOnly && !revisionView; oldTitle = paragraph.title;"
            ng-show="!input.showEditor"
            ng-bind-html="paragraph.title || 'Untitled'">


### PR DESCRIPTION
### What is this PR for?

Paragraph titles are split into multiple lines when they are long.

- let's applying text-overflow like the note title.
- while making paragraph titles have fixed height for seamless title hiding/showing

### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [x] - text-overflow for paragraph titles
* [x] - fixed height for paragraph titles.

### What is the Jira issue?

[ZEPPELIN-2603](https://issues.apache.org/jira/browse/ZEPPELIN-2603)

### How should this be tested?

1. build
2. open any note
3. show / hide a paragraph title 
4. insert long a paragraph title.

### Screenshots (if appropriate)

#### Before: paragraph title is split into multiple lines

![image](https://cloud.githubusercontent.com/assets/4968473/26712431/cf229196-47a1-11e7-9b6e-473f1006c743.png)

#### Before: enabling paragraph title has an effect on the height of a paragraph. 

![2603_before](https://cloud.githubusercontent.com/assets/4968473/26712476/fd3b618e-47a1-11e7-8a00-3720d46c9ecc.gif)

#### After: enabling / disalbing a paragraph title seamlessly

![2603_after](https://cloud.githubusercontent.com/assets/4968473/26712410/b868b7f0-47a1-11e7-9079-41f160ab7770.gif)

#### After: text-overflow for a paragraph title

![image](https://cloud.githubusercontent.com/assets/4968473/26712357/7bd02616-47a1-11e7-9912-0463fd3a7565.png)

![image](https://cloud.githubusercontent.com/assets/4968473/26712364/82b1f342-47a1-11e7-8431-37a990050a82.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
