### PR TITLE
[ZEPPELIN-2573] fix: Small font-size for navbar menus

### DIFF
--- a/zeppelin-web/src/components/navbar/navbar.css
+++ b/zeppelin-web/src/components/navbar/navbar.css
@@ -16,8 +16,13 @@
 /* Navbar
 /* ------------------------------------------- */
 
+#navbar-container .navbar-right {
+  margin-right: 5px;
+  margin-top: 1px;
+}
+
 .navbar-brand.navbar-title {
-  margin-top: -3px;
+  margin-top: -4px;
   margin-right: 20px;
 }
 
@@ -29,7 +34,7 @@
 
 .navbar-menu {
   font-weight: 300;
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .navbar-inverse .navbar-nav > li > a.navbar-menu-notebook:focus {
@@ -41,7 +46,7 @@
 }
 
 .navbar-inverse .navbar-nav > li > a {
-  padding-top: 16px;
+  padding-top: 15px;
 }
 
 .navbar-logo {

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -13,7 +13,7 @@ limitations under the License.
 <headroom tolerance="10" offset="30" class="navbar navbar-inverse navbar-fixed-top"
           style="display: none;" role="navigation"
           ng-class="{'displayNavBar': !asIframe}">
-  <div class="container">
+  <div id="navbar-container" class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">
         <span class="icon-bar"></span>
@@ -67,7 +67,7 @@ limitations under the License.
         </li>
       </ul>
 
-      <ul class="nav navbar-nav navbar-right" style="margin-right:5px;">
+      <ul class="nav navbar-nav navbar-right">
         <li class="nav-component" ng-if="ticket">
 
           <form role="search" data-ng-model="navbar.searchForm"


### PR DESCRIPTION
### What is this PR for?

Navbar style was changed by https://github.com/apache/zeppelin/pull/2355
But font-size for navbar menu is too small. 

See the screenshots.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2573](https://issues.apache.org/jira/browse/ZEPPELIN-2573)

### How should this be tested?

1. Build
2. Open `localhost:8080`

### Screenshots (if appropriate)

#### Before: Small font-size for navbar menus (16px)

![image](https://cloud.githubusercontent.com/assets/4968473/26713165/207cd930-47a6-11e7-88bd-8e4f4e5ccfdc.png)

#### After:  font-size: 18px

![image](https://cloud.githubusercontent.com/assets/4968473/26713155/1337dc8e-47a6-11e7-887b-2bde5ddce8c3.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
