### PR TITLE
[ZEPPELIN-2612] Remove duplicates from ZeppelinConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
 
     <!-- test library versions -->
     <junit.version>4.12</junit.version>
+    <hamcrest-all.version>1.3</hamcrest-all.version>
     <mockito.version>1.10.19</mockito.version>
     <assertj.version>1.7.0</assertj.version>
     <powermock.version>1.6.4</powermock.version>
@@ -260,6 +261,13 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${hamcrest-all.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -57,6 +57,7 @@ import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.util.Util;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -171,7 +172,6 @@ public class ZeppelinServer extends Application {
   public static void main(String[] args) throws InterruptedException {
 
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-    conf.setProperty("args", args);
 
     jettyWebServer = setupJettyServer(conf);
 
@@ -238,6 +238,9 @@ public class ZeppelinServer extends Application {
     final Server server = new Server();
     ServerConnector connector;
 
+    LOG.info("Server Host: " + conf.getServerAddress());
+    LOG.info("Context Path: " + conf.getServerContextPath());
+    LOG.info("Zeppelin Version: " + Util.getVersion());
     if (conf.useSsl()) {
       LOG.debug("Enabling SSL for Zeppelin Server on port " + conf.getServerSslPort());
       HttpConfiguration httpConfig = new HttpConfiguration();
@@ -260,6 +263,7 @@ public class ZeppelinServer extends Application {
               new SslConnectionFactory(getSslContextFactory(conf), HttpVersion.HTTP_1_1.asString()),
               new HttpConnectionFactory(httpsConfig));
     } else {
+      LOG.info("Server Port: " + conf.getServerPort());
       connector = new ServerConnector(server);
     }
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -251,6 +251,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/HadoopLikeConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/HadoopLikeConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.conf;
+
+import org.apache.commons.configuration.AbstractFileConfiguration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.QName;
+import org.dom4j.io.SAXReader;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Configuration in hadoop like format:
+ * <p><pre>
+ * <configuration>
+ *   <property>
+ *     <name>zeppelin.server.addr</name>
+ *     <value>0.0.0.0</value>
+ *     <description>Server address</description>
+ *   </property>
+ *   <property>
+ *     <name>zeppelin.server.port</name>
+ *     <value>8080</value>
+ *     <description>Server port.</description>
+ *   </property>
+ *   ...
+ * </pre></p>
+ */
+public class HadoopLikeConfiguration extends AbstractFileConfiguration {
+
+  @Override
+  public void load(Reader in) throws ConfigurationException {
+    try {
+      SAXReader reader = new SAXReader();
+      Document document = reader.read(in);
+      Element root = document.getRootElement();
+      checkArgument(root.getQName().equals(QName.get("configuration")));
+
+      for (Element property : (List<Element>) root.elements(QName.get("property"))) {
+        String name = property.element(QName.get("name")).getText();
+        String value = property.element(QName.get("value")).getText();
+        addProperty(name, value);
+      }
+    } catch (DocumentException e) {
+      throw new ConfigurationException(e);
+    }
+  }
+
+  @Override
+  public void save(Writer out) throws ConfigurationException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -25,11 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.XMLConfiguration;
-import org.apache.commons.configuration.tree.ConfigurationNode;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.notebook.repo.GitNotebookRepo;
-import org.apache.zeppelin.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,9 +34,9 @@ import org.slf4j.LoggerFactory;
  * Zeppelin configuration.
  *
  */
-public class ZeppelinConfiguration extends XMLConfiguration {
+public class ZeppelinConfiguration extends HadoopLikeConfiguration {
+
   private static final String ZEPPELIN_SITE_XML = "zeppelin-site.xml";
-  private static final long serialVersionUID = 4749305895693848035L;
   private static final Logger LOG = LoggerFactory.getLogger(ZeppelinConfiguration.class);
 
   private static final String HELIUM_PACKAGE_DEFAULT_URL =
@@ -109,87 +106,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
       }
     }
 
-    LOG.info("Server Host: " + conf.getServerAddress());
-    if (conf.useSsl() == false) {
-      LOG.info("Server Port: " + conf.getServerPort());
-    } else {
-      LOG.info("Server SSL Port: " + conf.getServerSslPort());
-    }
-    LOG.info("Context Path: " + conf.getServerContextPath());
-    LOG.info("Zeppelin Version: " + Util.getVersion());
-
     return conf;
-  }
-
-
-  private String getStringValue(String name, String d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return (String) p.getChildren("value").get(0).getValue();
-      }
-    }
-    return d;
-  }
-
-  private int getIntValue(String name, int d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Integer.parseInt((String) p.getChildren("value").get(0).getValue());
-      }
-    }
-    return d;
-  }
-
-  private long getLongValue(String name, long d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Long.parseLong((String) p.getChildren("value").get(0).getValue());
-      }
-    }
-    return d;
-  }
-
-  private float getFloatValue(String name, float d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Float.parseFloat((String) p.getChildren("value").get(0).getValue());
-      }
-    }
-    return d;
-  }
-
-  private boolean getBooleanValue(String name, boolean d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Boolean.parseBoolean((String) p.getChildren("value").get(0).getValue());
-      }
-    }
-    return d;
   }
 
   public String getString(ConfVars c) {
@@ -204,7 +121,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
       return System.getProperty(propertyName);
     }
 
-    return getStringValue(propertyName, defaultValue);
+    return super.getString(propertyName, defaultValue);
   }
 
   public int getInt(ConfVars c) {
@@ -219,7 +136,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     if (System.getProperty(propertyName) != null) {
       return Integer.parseInt(System.getProperty(propertyName));
     }
-    return getIntValue(propertyName, defaultValue);
+    return super.getInt(propertyName, defaultValue);
   }
 
   public long getLong(ConfVars c) {
@@ -234,7 +151,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     if (System.getProperty(propertyName) != null) {
       return Long.parseLong(System.getProperty(propertyName));
     }
-    return getLongValue(propertyName, defaultValue);
+    return super.getLong(propertyName, defaultValue);
   }
 
   public float getFloat(ConfVars c) {
@@ -248,7 +165,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     if (System.getProperty(propertyName) != null) {
       return Float.parseFloat(System.getProperty(propertyName));
     }
-    return getFloatValue(propertyName, defaultValue);
+    return super.getFloat(propertyName, defaultValue);
   }
 
   public boolean getBoolean(ConfVars c) {
@@ -263,7 +180,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     if (System.getProperty(propertyName) != null) {
       return Boolean.parseBoolean(System.getProperty(propertyName));
     }
-    return getBooleanValue(propertyName, defaultValue);
+    return super.getBoolean(propertyName, defaultValue);
   }
 
   public boolean useSsl() {
@@ -469,7 +386,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     }
   }
 
-  public boolean isWindowsPath(String path){
+  public boolean isWindowsPath(String path) {
     return path.matches("^[A-Za-z]:\\\\.*");
   }
 
@@ -485,8 +402,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_CONF_DIR);
   }
 
-  public List<String> getAllowedOrigins()
-  {
+  public List<String> getAllowedOrigins() {
     if (getString(ConfVars.ZEPPELIN_ALLOWED_ORIGINS).isEmpty()) {
       return Arrays.asList(new String[0]);
     }
@@ -753,50 +669,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     }
 
     enum VarType {
-      STRING {
-        @Override
-        void checkType(String value) throws Exception {}
-      },
-      INT {
-        @Override
-        void checkType(String value) throws Exception {
-          Integer.valueOf(value);
-        }
-      },
-      LONG {
-        @Override
-        void checkType(String value) throws Exception {
-          Long.valueOf(value);
-        }
-      },
-      FLOAT {
-        @Override
-        void checkType(String value) throws Exception {
-          Float.valueOf(value);
-        }
-      },
-      BOOLEAN {
-        @Override
-        void checkType(String value) throws Exception {
-          Boolean.valueOf(value);
-        }
-      };
-
-      boolean isType(String value) {
-        try {
-          checkType(value);
-        } catch (Exception e) {
-          LOG.error("Exception in ZeppelinConfiguration while isType", e);
-          return false;
-        }
-        return true;
-      }
-
-      String typeString() {
-        return name().toUpperCase();
-      }
-
-      abstract void checkType(String value) throws Exception;
+      STRING, INT, LONG, FLOAT, BOOLEAN
     }
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/HadoopLikeConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/HadoopLikeConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.conf;
+
+import org.apache.commons.configuration.ConfigurationConverter;
+import org.apache.commons.configuration.ConfigurationException;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+
+public class HadoopLikeConfigurationTest {
+
+  @Test
+  public void testParsing() throws ConfigurationException {
+    HadoopLikeConfiguration configuration = new HadoopLikeConfiguration();
+    configuration.load(new StringReader(
+        "<configuration>" +
+            " <property>" +
+            "   <name>key1</name>" +
+            "   <value>val1</value>" +
+            " </property>" +
+            " <property>" +
+            "   <name>key2</name>" +
+            "   <value>val2</value>" +
+            " </property>" +
+            "</configuration>"
+    ));
+    Map<Object, Object> map = ConfigurationConverter.getMap(configuration);
+    assertThat(map, Matchers.allOf(
+        hasEntry((Object) "key1", (Object) "val1"),
+        hasEntry((Object) "key2", (Object) "val2")
+    ));
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -16,11 +16,10 @@
  */
 package org.apache.zeppelin.conf;
 
-import junit.framework.Assert;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
### What is this PR for?
Remove duplicated code from `ZeppelinConfiguration` and make proper use of commons-configuraion

And I propose using interpolation instead of `getRelativeDir` (Not in this PR).
For example,
```
ZEPPELIN_INTERPRETER_DIR("zeppelin.interpreter.dir", "${zeppelin.home}/interpreter")
```

### What type of PR is it?
[Refactoring]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2612

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
