### PR TITLE
[ZEPPELIN-2589]Let zeppelin show more than one line of error log returned by livy.

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -331,7 +331,11 @@ public abstract class BaseLivyInterpreter extends Interpreter {
   private InterpreterResult getResultFromStatementInfo(StatementInfo stmtInfo,
                                                        boolean displayAppInfo) {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
-      return new InterpreterResult(InterpreterResult.Code.ERROR, stmtInfo.output.evalue);
+      InterpreterResult result_including_traceback = new InterpreterResult(InterpreterResult.Code.ERROR);
+      result_including_traceback.add(stmtInfo.output.evalue);
+      for (int i=0;i<stmtInfo.output.traceback.length;i++)
+        result_including_traceback.add(stmtInfo.output.traceback[i]);
+      return result_including_traceback;
     } else if (stmtInfo.isCancelled()) {
       // corner case, output might be null if it is cancelled.
       return new InterpreterResult(InterpreterResult.Code.ERROR, "Job is cancelled");
@@ -632,7 +636,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       public Data data;
       public String ename;
       public String evalue;
-      public Object traceback;
+      public String[] traceback;
       public TableMagic tableMagic;
 
       public boolean isError() {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -624,6 +624,12 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     public static StatementInfo fromJson(String json) {
       LOGGER.info("json string is like the following");
       LOGGER.info(json);
+      try {
+        gson.fromJson(json, StatementInfo.class);
+      } catch (Exception e) {
+        LOGGER.info("error string is like the following");
+        LOGGER.info(json);
+      }
       return gson.fromJson(json, StatementInfo.class);
     }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -333,7 +333,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
       InterpreterResult result_including_traceback = new InterpreterResult(InterpreterResult.Code.ERROR);
       result_including_traceback.add(stmtInfo.output.evalue);
-      for (int i=0;i<stmtInfo.output.traceback.length;i++)
+      for(int i = 0; i < stmtInfo.output.traceback.length; i++)
         result_including_traceback.add(stmtInfo.output.traceback[i]);
       return result_including_traceback;
     } else if (stmtInfo.isCancelled()) {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -333,9 +333,10 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
       InterpreterResult result = new InterpreterResult(InterpreterResult.Code.ERROR);
       result.add(stmtInfo.output.evalue);
-      for (int i = 0; i < stmtInfo.output.traceback.length; i++)
-        result.add(stmtInfo.output.traceback[i]);
-      return result;
+      if (stmtInfo.output.traceback != null) {
+        for (int i = 0; i < stmtInfo.output.traceback.length; i++)
+          result.add(stmtInfo.output.traceback[i]);
+      } return result;
     } else if (stmtInfo.isCancelled()) {
       // corner case, output might be null if it is cancelled.
       return new InterpreterResult(InterpreterResult.Code.ERROR, "Job is cancelled");

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -402,7 +402,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private StatementInfo getStatementInfo(int statementId)
       throws LivyException {
-    logger.info("calling StatementInfo fromJson with id {}",String.valueOf(statementId));
+    logger.info("calling StatementInfo fromJson with id {}", String.valueOf(statementId));
     return StatementInfo.fromJson(
         callRestAPI("/sessions/" + sessionInfo.id + "/statements/" + statementId, "GET"));
   }
@@ -529,7 +529,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private void closeSession(int sessionId) {
     try {
-      logger.info("calling DELETE with session id {}",String.valueOf(sessionId));
+      logger.info("calling DELETE with session id {}", String.valueOf(sessionId));
       callRestAPI("/sessions/" + sessionId, "DELETE");
     } catch (Exception e) {
       LOGGER.error(String.format("Error closing session for user with session ID: %s",

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -402,7 +402,6 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private StatementInfo getStatementInfo(int statementId)
       throws LivyException {
-    logger.info("calling StatementInfo fromJson with id {}", String.valueOf(statementId));
     return StatementInfo.fromJson(
         callRestAPI("/sessions/" + sessionInfo.id + "/statements/" + statementId, "GET"));
   }
@@ -529,7 +528,6 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private void closeSession(int sessionId) {
     try {
-      logger.info("calling DELETE with session id {}", String.valueOf(sessionId));
       callRestAPI("/sessions/" + sessionId, "DELETE");
     } catch (Exception e) {
       LOGGER.error(String.format("Error closing session for user with session ID: %s",
@@ -622,15 +620,18 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     }
 
     public static StatementInfo fromJson(String json) {
-      LOGGER.info("json string is like the following");
-      LOGGER.info(json);
+      String right_json="";
       try {
         gson.fromJson(json, StatementInfo.class);
+        right_json = json;
       } catch (Exception e) {
-        LOGGER.info("error string is like the following");
-        LOGGER.info(json);
+        if (json.contains("\"traceback\":{}")) {
+          LOGGER.info("traceback type mismatch, replacing the mismatching part ");
+          right_json = json.replace("\"traceback\":{}", "\"traceback\":[]");
+          LOGGER.info("new json string is {}", right_json);
+        }
       }
-      return gson.fromJson(json, StatementInfo.class);
+      return gson.fromJson(right_json, StatementInfo.class);
     }
 
     public boolean isAvailable() {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -332,11 +332,13 @@ public abstract class BaseLivyInterpreter extends Interpreter {
                                                        boolean displayAppInfo) {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
       InterpreterResult result = new InterpreterResult(InterpreterResult.Code.ERROR);
-      result.add(stmtInfo.output.evalue);
       StringBuilder sb = new StringBuilder();
+      sb.append(stmtInfo.output.evalue);
+      // in case evalue doesn't have newline char
+      if (!stmtInfo.output.evalue.contains("\n"))
+        sb.append("\n");
       if (stmtInfo.output.traceback != null) {
-        for (int i = 0; i < stmtInfo.output.traceback.length; i++)
-          sb.append(stmtInfo.output.traceback[i]);
+        sb.append(StringUtils.join(stmtInfo.output.traceback));
       }
       result.add(sb.toString());
       return result;

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -402,6 +402,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private StatementInfo getStatementInfo(int statementId)
       throws LivyException {
+    logger.info("calling StatementInfo fromJson with id {}",String.valueOf(statementId));
     return StatementInfo.fromJson(
         callRestAPI("/sessions/" + sessionInfo.id + "/statements/" + statementId, "GET"));
   }
@@ -528,6 +529,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private void closeSession(int sessionId) {
     try {
+      logger.info("calling DELETE with session id {}",String.valueOf(sessionId));
       callRestAPI("/sessions/" + sessionId, "DELETE");
     } catch (Exception e) {
       LOGGER.error(String.format("Error closing session for user with session ID: %s",

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -620,7 +620,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     }
 
     public static StatementInfo fromJson(String json) {
-      String right_json="";
+      String right_json = "";
       try {
         gson.fromJson(json, StatementInfo.class);
         right_json = json;

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -334,8 +334,8 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       InterpreterResult result = new InterpreterResult(InterpreterResult.Code.ERROR);
       result.add(stmtInfo.output.evalue);
       for (int i = 0; i < stmtInfo.output.traceback.length; i++)
-        result_including_traceback.add(stmtInfo.output.traceback[i]);
-      return result_including_traceback;
+        result.add(stmtInfo.output.traceback[i]);
+      return result;
     } else if (stmtInfo.isCancelled()) {
       // corner case, output might be null if it is cancelled.
       return new InterpreterResult(InterpreterResult.Code.ERROR, "Job is cancelled");

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -331,9 +331,9 @@ public abstract class BaseLivyInterpreter extends Interpreter {
   private InterpreterResult getResultFromStatementInfo(StatementInfo stmtInfo,
                                                        boolean displayAppInfo) {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
-      InterpreterResult result_including_traceback = new InterpreterResult(InterpreterResult.Code.ERROR);
-      result_including_traceback.add(stmtInfo.output.evalue);
-      for(int i = 0; i < stmtInfo.output.traceback.length; i++)
+      InterpreterResult result = new InterpreterResult(InterpreterResult.Code.ERROR);
+      result.add(stmtInfo.output.evalue);
+      for (int i = 0; i < stmtInfo.output.traceback.length; i++)
         result_including_traceback.add(stmtInfo.output.traceback[i]);
       return result_including_traceback;
     } else if (stmtInfo.isCancelled()) {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -336,7 +336,8 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       if (stmtInfo.output.traceback != null) {
         for (int i = 0; i < stmtInfo.output.traceback.length; i++)
           result.add(stmtInfo.output.traceback[i]);
-      } return result;
+      }
+      return result;
     } else if (stmtInfo.isCancelled()) {
       // corner case, output might be null if it is cancelled.
       return new InterpreterResult(InterpreterResult.Code.ERROR, "Job is cancelled");
@@ -626,9 +627,9 @@ public abstract class BaseLivyInterpreter extends Interpreter {
         right_json = json;
       } catch (Exception e) {
         if (json.contains("\"traceback\":{}")) {
-          LOGGER.info("traceback type mismatch, replacing the mismatching part ");
+          LOGGER.debug("traceback type mismatch, replacing the mismatching part ");
           right_json = json.replace("\"traceback\":{}", "\"traceback\":[]");
-          LOGGER.info("new json string is {}", right_json);
+          LOGGER.debug("new json string is {}", right_json);
         }
       }
       return gson.fromJson(right_json, StatementInfo.class);

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -639,7 +639,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       public Data data;
       public String ename;
       public String evalue;
-      public Object traceback;
+      public String[] traceback;
       public TableMagic tableMagic;
 
       public boolean isError() {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -620,6 +620,8 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     }
 
     public static StatementInfo fromJson(String json) {
+      LOGGER.info("json string is like the following");
+      LOGGER.info(json);
       return gson.fromJson(json, StatementInfo.class);
     }
 
@@ -637,7 +639,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       public Data data;
       public String ename;
       public String evalue;
-      public String[] traceback;
+      public Object traceback;
       public TableMagic tableMagic;
 
       public boolean isError() {

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -333,10 +333,12 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     if (stmtInfo.output != null && stmtInfo.output.isError()) {
       InterpreterResult result = new InterpreterResult(InterpreterResult.Code.ERROR);
       result.add(stmtInfo.output.evalue);
+      StringBuilder sb = new StringBuilder();
       if (stmtInfo.output.traceback != null) {
         for (int i = 0; i < stmtInfo.output.traceback.length; i++)
-          result.add(stmtInfo.output.traceback[i]);
+          sb.append(stmtInfo.output.traceback[i]);
       }
+      result.add(sb.toString());
       return result;
     } else if (stmtInfo.isCancelled()) {
       // corner case, output might be null if it is cancelled.

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -779,13 +779,15 @@ public class LivyInterpreterIT {
     final InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "livy.spark",
             "title", "text", authInfo, null, null, null, null, null, output);
     sparkInterpreter.open();
-
+    final LivyPySparkInterpreter pysparkInterpreter = new LivyPySparkInterpreter(properties);
+    pysparkInterpreter.open();
     try {
       sparkInterpreter.getLivyVersion();
     } catch (APINotFoundException e) {
       // only livy 0.2 would fail this since it doesn't have /version endpoint
-      // in livy 0.2, most error msg is encapsulated in evalue field
-      InterpreterResult result = sparkInterpreter.interpret("print(a)", context);
+      // in livy 0.2, most error msg is encapsulated in evalue field, only print(a) in pyspark would return none-empty
+      // traceback
+      InterpreterResult result = pysparkInterpreter.interpret("print(a)", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().size()>1);
     }

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -539,17 +539,19 @@ public class LivyInterpreterIT {
     //test traceback msg
     try {
       pysparkInterpreter.getLivyVersion();
-      //for higher livy version , input some erroneous spark code, check the shown result is more than one line
+      //for livy version >=0.3 , input some erroneous spark code, check the shown result is more than one line
       InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
-      assertTrue(result.message().size()>1);
+      assertTrue(result.message().get(0).getData().split("\n").length>1);
+      assertTrue(result.message().get(0).getData().contains("Traceback"));
     } catch (APINotFoundException e) {
       // only livy 0.2 can throw this exception since it doesn't have /version endpoint
       // in livy 0.2, most error msg is encapsulated in evalue field, only print(a) in pyspark would return none-empty
       // traceback
       InterpreterResult result = pysparkInterpreter.interpret("print(a)", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
-      assertTrue(result.message().size()>1);
+      assertTrue(result.message().get(0).getData().split("\n").length>1);
+      assertTrue(result.message().get(0).getData().contains("Traceback"));
     }
 
     try {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -798,6 +798,7 @@ public class LivyInterpreterIT {
       assertTrue(result.message().size()>1);
     } finally {
       sparkInterpreter.close();
+      pysparkInterpreter.close();
     }
   }
 

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -768,21 +768,16 @@ public class LivyInterpreterIT {
     if (!checkPreCondition()) {
       return;
     }
-    InterpreterGroup interpreterGroup = new InterpreterGroup("group_1");
-    interpreterGroup.put("session_1", new ArrayList<Interpreter>());
-    LivySparkInterpreter sparkInterpreter = new LivySparkInterpreter(properties);
-    sparkInterpreter.setInterpreterGroup(interpreterGroup);
-    interpreterGroup.get("session_1").add(sparkInterpreter);
+    final LivyPySparkInterpreter pysparkInterpreter = new LivyPySparkInterpreter(properties);
     AuthenticationInfo authInfo = new AuthenticationInfo("user1");
     MyInterpreterOutputListener outputListener = new MyInterpreterOutputListener();
     InterpreterOutput output = new InterpreterOutput(outputListener);
-    final InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "livy.spark",
+    final InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "livy.pyspark",
             "title", "text", authInfo, null, null, null, null, null, output);
-    sparkInterpreter.open();
-    final LivyPySparkInterpreter pysparkInterpreter = new LivyPySparkInterpreter(properties);
     pysparkInterpreter.open();
+
     try {
-      sparkInterpreter.getLivyVersion();
+      pysparkInterpreter.getLivyVersion();
     } catch (APINotFoundException e) {
       // only livy 0.2 would fail this since it doesn't have /version endpoint
       // in livy 0.2, most error msg is encapsulated in evalue field, only print(a) in pyspark would return none-empty
@@ -793,11 +788,10 @@ public class LivyInterpreterIT {
     }
     try {
       //for higher livy version , input some erroneous spark code, check the shown result is more than one line
-      InterpreterResult result = sparkInterpreter.interpret("sc.parallelize(wrongSyntaxArray(1, 2)).count()", context);
+      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntaxArray(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().size()>1);
     } finally {
-      sparkInterpreter.close();
       pysparkInterpreter.close();
     }
   }

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -536,10 +536,10 @@ public class LivyInterpreterIT {
         "title", "text", authInfo, null, null, null, null, null, output);
     pysparkInterpreter.open();
 
-    //test traceback msg
+    // test traceback msg
     try {
       pysparkInterpreter.getLivyVersion();
-      //for livy version >=0.3 , input some erroneous spark code, check the shown result is more than one line
+      // for livy version >=0.3 , input some erroneous spark code, check the shown result is more than one line
       InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().get(0).getData().split("\n").length>1);

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -540,7 +540,7 @@ public class LivyInterpreterIT {
     try {
       pysparkInterpreter.getLivyVersion();
       // for livy version >=0.3 , input some erroneous spark code, check the shown result is more than one line
-      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2)).count()", context);
+      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2, 3)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().get(0).getData().split("\n").length>1);
       assertTrue(result.message().get(0).getData().contains("Traceback"));

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -540,7 +540,7 @@ public class LivyInterpreterIT {
     try {
       pysparkInterpreter.getLivyVersion();
       //for higher livy version , input some erroneous spark code, check the shown result is more than one line
-      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntaxArray(1, 2)).count()", context);
+      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().size()>1);
     } catch (APINotFoundException e) {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -540,7 +540,7 @@ public class LivyInterpreterIT {
     try {
       pysparkInterpreter.getLivyVersion();
       // for livy version >=0.3 , input some erroneous spark code, check the shown result is more than one line
-      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2, 3)).count()", context);
+      InterpreterResult result = pysparkInterpreter.interpret("sc.parallelize(wrongSyntax(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().get(0).getData().split("\n").length>1);
       assertTrue(result.message().get(0).getData().contains("Traceback"));

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -781,8 +781,17 @@ public class LivyInterpreterIT {
     sparkInterpreter.open();
 
     try {
-      // input some erroneous spark code, check the shown result is more than one line
-      InterpreterResult result = sparkInterpreter.interpret("sc.parallelize(wrongSyntaxArray(1, 2, 3, 4, 5)).count()", context);
+      sparkInterpreter.getLivyVersion();
+    } catch (APINotFoundException e) {
+      // only livy 0.2 would fail this since it doesn't have /version endpoint
+      // in livy 0.2, most error msg is encapsulated in evalue field
+      InterpreterResult result = sparkInterpreter.interpret("print(a)", context);
+      assertEquals(InterpreterResult.Code.ERROR, result.code());
+      assertTrue(result.message().size()>1);
+    }
+    try {
+      //for higher livy version , input some erroneous spark code, check the shown result is more than one line
+      InterpreterResult result = sparkInterpreter.interpret("sc.parallelize(wrongSyntaxArray(1, 2)).count()", context);
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().size()>1);
     } finally {


### PR DESCRIPTION
### What is this PR for?
Let zeppelin show more than one line of error log returned by livy.


### What type of PR is it?
Improvement


### What is the Jira issue?
[ZEPPELIN-2589
](https://issues.apache.org/jira/browse/ZEPPELIN-2589)

### How should this be tested?
1. build: mvn clean package -DskipTests; 
2. /bin/zeppelin-daemon.sh restart
3. Start a notebook 
4. Use Livy interpreter and input some erroneous spark code, check the shown result is more than one line

### Screenshots (if appropriate)

When using Livy 0.4 to run spark streaming job.
Original Zeppelin:
![image](https://user-images.githubusercontent.com/14201792/26881018-c9aaf9bc-4bc8-11e7-802a-b655656c1baf.png)

After add traceback to interpreter result:

![image](https://user-images.githubusercontent.com/14201792/26881987-a7de9d68-4bcb-11e7-8e20-e77a5e1f7033.png)



### Questions:
* Does the licenses files need update?No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
