### PR TITLE
[ZEPPELIN-2515] After 100 minutes R process quits silently and spark.r interpreter becomes unresponsive.

### DIFF
--- a/spark/src/main/resources/R/zeppelin_sparkr.R
+++ b/spark/src/main/resources/R/zeppelin_sparkr.R
@@ -31,7 +31,7 @@ print(paste("LibPath ", libPath))
 library(SparkR)
 
 
-SparkR:::connectBackend("localhost", port, 6000)
+SparkR:::connectBackend("localhost", port)
 
 # scStartTime is needed by R/pkg/R/sparkR.R
 assign(".scStartTime", as.integer(Sys.time()), envir = SparkR:::.sparkREnv)


### PR DESCRIPTION
### What is this PR for?
Enabling to set timeout value for R backend


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Remove timeout parameter

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2515

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
