### PR TITLE
[ZEPPELIN-2451]: Add JDBC config option for calling connection.commit after paragraph execution

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -132,6 +132,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private final String CONCURRENT_EXECUTION_COUNT = "zeppelin.jdbc.concurrent.max_connection";
   private final String DBCP_STRING = "jdbc:apache:commons:dbcp:";
 
+  private final String JDBC_AUTOCOMMIT = "zeppelin.jdbc.autocommit";
+
   private final HashMap<String, Properties> basePropretiesMap;
   private final HashMap<String, JDBCUserConfigurations> jdbcUserConfigurationsMap;
   private final HashMap<String, SqlCompleter> sqlCompletersMap;
@@ -667,6 +669,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     ResultSet resultSet = null;
     String paragraphId = interpreterContext.getParagraphId();
     String user = interpreterContext.getAuthenticationInfo().getUser();
+    boolean commit = Boolean.valueOf(getProperty(String.format(JDBC_AUTOCOMMIT, propertyKey)));
 
     boolean splitQuery = false;
     String splitQueryProperty = getProperty(String.format("%s.%s", propertyKey, SPLIT_QURIES_KEY));
@@ -763,7 +766,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
       //In case user ran an insert/update/upsert statement
       if (connection != null) {
         try {
-          if (!connection.getAutoCommit()) {
+          if (!connection.getAutoCommit() && commit) {
             connection.commit();
           }
           connection.close();


### PR DESCRIPTION
Updated version of: https://github.com/apache/zeppelin/pull/2284

### What is this PR for?
Adding config for automatically calling commit after JDBC paragraph execution

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2451

### How should this be tested?
Create property zeppelin.jdbc.autocommit with value "true" under the JDBC interpreter, run an INSERT statement against a database. The insert should be committed and should be accessible in the database.

Create property zeppelin.jdbc.autocommit with value "false" under the JDBC interpreter, run an INSERT statement against a database. The insert should not be committed and will not be in the database.


### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
Yes
