### PR TITLE
[ZEPPELIN-2622] Add Zeppelin Git info REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ tramp
 
 # tmp files
 /tmp/
+
+# Git properties
+**/git.properties

--- a/docs/rest-api/rest-zeppelin-server.md
+++ b/docs/rest-api/rest-zeppelin-server.md
@@ -49,12 +49,11 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       <td>200</td>
     </tr>
     <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
+      <td>Fail code</td>
+      <td>500</td>
     </tr>
     <tr>
-      <td> sample JSON response
-      </td>
+      <td>sample JSON response</td>
       <td>
         <pre>
 {
@@ -62,12 +61,12 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
   "message": "Zeppelin version",
   "body": [
     {
-      "version": "0.8.0-SNAPSHOT",
-      "commitId": "abc0123",
-      "timestamp": "2017-01-02 03:04:05"
+      "version": "0.8.0",
+      "git-commit-id": "abc0123",
+      "git-timestamp": "2017-01-02 03:04:05"
     }
   ]
-}     
+}
         </pre>
       </td>
     </tr>
@@ -89,29 +88,27 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       <td>200</td>
     </tr>
     <tr>
-      <td> Fail code</td>
-      <td> 406 </td>
+      <td>Fail code</td>
+      <td>406</td>
     </tr>
     <tr>
-      <td> sample JSON response
-      </td>
+      <td>sample JSON response</td>
       <td>
         <pre>
 {
   "status": "OK"
-}     
+}
         </pre>
       </td>
     </tr>
     <tr>
-      <td> sample error JSON response
-      </td>
+      <td>sample error JSON response</td>
       <td>
         <pre>
 {
   "status":"NOT_ACCEPTABLE",
   "message":"Please check LOG level specified. Valid values: DEBUG, ERROR, FATAL, INFO, TRACE, WARN"
-}     
+}
         </pre>
       </td>
     </tr>

--- a/docs/rest-api/rest-zeppelin-server.md
+++ b/docs/rest-api/rest-zeppelin-server.md
@@ -60,42 +60,9 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
 {
   "status": "OK",
   "message": "Zeppelin version",
-  "body": "0.8.0-SNAPSHOT"
-}     
-        </pre>
-      </td>
-    </tr>
-  </table>
-
-### Get Zeppelin git info
-  <table class="table-configuration">
-    <col width="200">
-    <tr>
-      <td>Description</td>
-      <td>This ```GET``` method returns Zeppelin Git info</td>
-    </tr>
-    <tr>
-      <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/git```</td>
-    </tr>
-    <tr>
-      <td>Success code</td>
-      <td>200</td>
-    </tr>
-    <tr>
-      <td> Fail code</td>
-      <td> 500 </td>
-    </tr>
-    <tr>
-      <td> sample JSON response
-      </td>
-      <td>
-        <pre>
-{
-  "status": "OK",
-  "message": "Zeppelin Git Info",
   "body": [
     {
+      "version": "0.8.0-SNAPSHOT",
       "commitId": "abc0123",
       "timestamp": "2017-01-02 03:04:05"
     }

--- a/docs/rest-api/rest-zeppelin-server.md
+++ b/docs/rest-api/rest-zeppelin-server.md
@@ -33,6 +33,79 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
 
 ## Zeppelin Server REST API list
 
+### Get Zeppelin version
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns Zeppelin version</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/version```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "Zeppelin version",
+  "body": "0.8.0-SNAPSHOT"
+}     
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+### Get Zeppelin git info
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns Zeppelin Git info</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/git```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response
+      </td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "Zeppelin Git Info",
+  "body": [
+    {
+      "commitId": "abc0123",
+      "timestamp": "2017-01-02 03:04:05"
+    }
+  ]
+}     
+        </pre>
+      </td>
+    </tr>
+  </table>
+
 ### Change the log level of Zeppelin Server 
   <table class="table-configuration">
     <col width="200">

--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,27 @@
         <version>${plugin.deploy.version}</version>
       </plugin>
 
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skipPoms>false</skipPoms>
+          <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <dateFormat>yyyy-MM-dd HH:mm:ss</dateFormat>
+        </configuration>
+      </plugin>
+
     <!--TODO(alex): make part of the build and reconcile conflicts
     <plugin>
       <groupId>com.ning.maven.plugins</groupId>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
@@ -61,8 +61,8 @@ public class ZeppelinRestApi {
   public Response getVersion() {
     Map<String, String> versionInfo = new HashMap<>();
     versionInfo.put("version", Util.getVersion());
-    versionInfo.put("commitId", Util.getGitCommitId());
-    versionInfo.put("timestamp", Util.getGitTimestamp());
+    versionInfo.put("git-commit-id", Util.getGitCommitId());
+    versionInfo.put("git-timestamp", Util.getGitTimestamp());
 
     return new JsonResponse<>(Response.Status.OK, "Zeppelin version", versionInfo).build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
@@ -23,6 +23,9 @@ import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.util.Util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -57,6 +60,17 @@ public class ZeppelinRestApi {
   @ZeppelinApi
   public Response getVersion() {
     return new JsonResponse<>(Response.Status.OK, "Zeppelin version", Util.getVersion()).build();
+  }
+
+  @GET
+  @Path("git")
+  @ZeppelinApi
+  public Response getGitInfo() {
+    Map<String, String> gitInfo = new HashMap<>();
+    gitInfo.put("commitId", Util.getGitCommitId());
+    gitInfo.put("timestamp", Util.getGitTimestamp());
+
+    return new JsonResponse<>(Response.Status.OK, "Zeppelin Git info", gitInfo).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ZeppelinRestApi.java
@@ -59,18 +59,12 @@ public class ZeppelinRestApi {
   @Path("version")
   @ZeppelinApi
   public Response getVersion() {
-    return new JsonResponse<>(Response.Status.OK, "Zeppelin version", Util.getVersion()).build();
-  }
+    Map<String, String> versionInfo = new HashMap<>();
+    versionInfo.put("version", Util.getVersion());
+    versionInfo.put("commitId", Util.getGitCommitId());
+    versionInfo.put("timestamp", Util.getGitTimestamp());
 
-  @GET
-  @Path("git")
-  @ZeppelinApi
-  public Response getGitInfo() {
-    Map<String, String> gitInfo = new HashMap<>();
-    gitInfo.put("commitId", Util.getGitCommitId());
-    gitInfo.put("timestamp", Util.getGitTimestamp());
-
-    return new JsonResponse<>(Response.Status.OK, "Zeppelin Git info", gitInfo).build();
+    return new JsonResponse<>(Response.Status.OK, "Zeppelin version", versionInfo).build();
   }
 
   /**

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -38,7 +38,7 @@ function NavCtrl ($scope, $rootScope, $http, $routeParams, $location,
   function getZeppelinVersion () {
     $http.get(baseUrlSrv.getRestApiBase() + '/version').success(
       function (data, status, headers, config) {
-        $rootScope.zeppelinVersion = data.body
+        $rootScope.zeppelinVersion = data.body.version
       }).error(
       function (data, status, headers, config) {
         console.log('Error %o %o', status, data.message)

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/Util.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/util/Util.java
@@ -27,13 +27,18 @@ import java.util.Properties;
  */
 public class Util {
   private static final String PROJECT_PROPERTIES_VERSION_KEY = "version";
+  private static final String GIT_PROPERTIES_COMMIT_ID_KEY = "git.commit.id.abbrev";
+  private static final String GIT_PROPERTIES_COMMIT_TS_KEY = "git.commit.time";
 
   private static Properties projectProperties;
+  private static Properties gitProperties;
 
   static {
     projectProperties = new Properties();
+    gitProperties = new Properties();
     try {
       projectProperties.load(Util.class.getResourceAsStream("/project.properties"));
+      gitProperties.load(Util.class.getResourceAsStream("/git.properties"));
     } catch (IOException e) {
       //Fail to read project.properties
     }
@@ -46,6 +51,26 @@ public class Util {
    */
   public static String getVersion() {
     return StringUtils.defaultIfEmpty(projectProperties.getProperty(PROJECT_PROPERTIES_VERSION_KEY),
+            StringUtils.EMPTY);
+  }
+
+  /**
+   * Get Zeppelin Git latest commit id
+   *
+   * @return Latest Zeppelin commit id
+   */
+  public static String getGitCommitId() {
+    return StringUtils.defaultIfEmpty(gitProperties.getProperty(GIT_PROPERTIES_COMMIT_ID_KEY),
+            StringUtils.EMPTY);
+  }
+
+  /**
+   * Get Zeppelin Git latest commit timestamp
+   *
+   * @return Latest Zeppelin commit timestamp
+   */
+  public static String getGitTimestamp() {
+    return StringUtils.defaultIfEmpty(gitProperties.getProperty(GIT_PROPERTIES_COMMIT_TS_KEY),
             StringUtils.EMPTY);
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/util/UtilTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/util/UtilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.util;
 
 import org.junit.Test;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/util/UtilTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/util/UtilTest.java
@@ -1,0 +1,18 @@
+package org.apache.zeppelin.util;
+
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+
+public class UtilTest {
+
+    @Test
+    public void getVersionTest() {
+        assertNotNull(Util.getVersion());
+    }
+
+    @Test
+    public void getGitInfoTest() {
+        assertNotNull(Util.getGitCommitId());
+        assertNotNull(Util.getGitTimestamp());
+    }
+}


### PR DESCRIPTION
### What is this PR for?
Added a new REST API that provides more detailed info. on the exact source code Git commit Id that created the build. Useful to track down bugs and replicate issues.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Add more Git properties

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2622

### How should this be tested?
Build Zeppelin. Open http://localhost:8080/api/git

### Screenshots (if appropriate)
Expected output: {"status":"OK","message":"Zeppelin Git info","body":{"commitId":"4c2d295","timestamp":"2017-06-06 19:00:01"}}

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? Y (Done)
