### PR TITLE
[ZEPPELIN-2620] fa-area chart cannot be resized smaller

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -14,6 +14,18 @@ limitations under the License.
 
 <div>
   <div ng-include src="'app/notebook/paragraph/result/result-chart-selector.html'"></div>
+    <div ng-if="type=='TABLE'">
+        <!-- graph setting -->
+        <div class="option lightBold" style="overflow: visible;" ng-show="graphMode!='table'
+                        && config.graph.optionOpen && !asIframe && !viewOnly">
+            <div ng-repeat="viz in builtInTableDataVisualizationList track by $index" 
+            id="trsetting{{id}}_{{viz.id}}" 
+            ng-show="graphMode == viz.id"></div>
+            <div ng-repeat="viz in builtInTableDataVisualizationList track by $index" 
+            id="vizsetting{{id}}_{{viz.id}}" 
+            ng-show="graphMode == viz.id"></div>
+        </div>
+    </div>
   <div
     id="p{{id}}_resize"
     ng-if="!config.helium.activeApp"
@@ -22,18 +34,6 @@ limitations under the License.
        resizable on-resize="resize(width, height);">
 
     <div ng-if="type=='TABLE'">
-      <!-- graph setting -->
-      <div class="option lightBold" style="overflow: visible;"
-           ng-show="graphMode!='table'
-                    && config.graph.optionOpen && !asIframe && !viewOnly">
-        <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
-             id="trsetting{{id}}_{{viz.id}}"
-             ng-show="graphMode == viz.id"></div>
-        <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
-             id="vizsetting{{id}}_{{viz.id}}"
-             ng-show="graphMode == viz.id"></div>
-      </div>
-
       <!-- graph -->
       <div id="p{{id}}_graph"
            class="graphContainer"

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -25,6 +25,7 @@ limitations under the License.
             id="vizsetting{{id}}_{{viz.id}}" 
             ng-show="graphMode == viz.id"></div>
         </div>
+        
     </div>
   <div
     id="p{{id}}_resize"

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -25,7 +25,6 @@ limitations under the License.
             id="vizsetting{{id}}_{{viz.id}}" 
             ng-show="graphMode == viz.id"></div>
         </div>
-        
     </div>
   <div
     id="p{{id}}_resize"


### PR DESCRIPTION
### What is this PR for?
fix chart resizing

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Chart Resize Bug Fix

### What is the Jira issue?
[[ZEPPELIN-2620]](https://issues.apache.org/jira/browse/ZEPPELIN-2620)

### How should this be tested?
yarn run dev

Chrome
Edge

### Screenshots (if appropriate)
before
![3](https://user-images.githubusercontent.com/20390348/26860178-8226043e-4b77-11e7-823a-c319940e2e21.gif)

after
![1-capture](https://user-images.githubusercontent.com/20390348/26860193-988be702-4b77-11e7-9b81-fd68f37242e8.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no?
