### PR TITLE
[ZEPPELIN-2473] ZeppelinRestApiTest fails on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,9 @@ matrix:
     #
     # Several tests were excluded from this configuration due to the following issues:
     # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
-    # ZeppelinRestApiTest          - https://issues.apache.org/jira/browse/ZEPPELIN-2473
     # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
     - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java,**/ZeppelinRestApiTest.java -DfailIfNoTests=false"
+      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -167,7 +167,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
         assertEquals("paragraph col width check failed", 9.0, p.getConfig().get("colWidth"));
         assertTrue("paragraph show title check failed", ((boolean) p.getConfig().get("title")));
         Map graph = ((List<Map>)p.getConfig().get("results")).get(0);
-        String mode = graph.get("mode").toString();
+        String mode = ((Map)graph.get("graph")).get("mode").toString();
         assertEquals("paragraph graph mode check failed", "pieChart", mode);
       }
     }


### PR DESCRIPTION
### What is this PR for?
The test `testNoteCreateWithParagraphs`  fails with a `java.lang.NullPointerException`. The error occurs while getting the value of 'mode' from the Map graph. Added a fix to get the value correctly.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2473

### How should this be tested?
Tests should pass on the CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
