### PR TITLE
[ZEPPELIN-2640] Roles are not getting honored from shiro_ini for setting permissions in Zeppelin notebook

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -297,6 +297,16 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     return userNameList;
   }
 
+  public Map<String, String> getListRoles() {
+    Map<String, String> roles = new HashMap<>();
+    Iterator it = this.groupRolesMap.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry pair = (Map.Entry) it.next();
+      roles.put((String) pair.getValue(), "*");
+    }
+    return roles;
+  }
+
   private Set<String> getRoleNamesForUser(String username, LdapContext ldapContext)
       throws NamingException {
     Set<String> roleNames = new LinkedHashSet<>();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -34,6 +34,7 @@ import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.realm.ActiveDirectoryGroupRealm;
 import org.apache.zeppelin.realm.LdapRealm;
 import org.mortbay.log.Log;
 import org.slf4j.Logger;
@@ -132,6 +133,9 @@ public class SecurityUtils {
           break;
         } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
           allRoles = ((LdapRealm) realm).getListRoles();
+          break;
+        } else if (name.equals("org.apache.zeppelin.realm.ActiveDirectoryGroupRealm")) {
+          allRoles = ((ActiveDirectoryGroupRealm) realm).getListRoles();
           break;
         }
       }


### PR DESCRIPTION
### What is this PR for?
Roles are not getting honored from shiro_ini for setting permissions in Zeppelin notebook when securityManager.realm is set to $activeDirectoryRealm

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Create JIRA 

### What is the Jira issue?
* [ZEPPELIN-2640](https://issues.apache.org/jira/browse/ZEPPELIN-2640)

### How should this be tested?
Use the below-attached shiro.ini, the thing which is different is `securityManager.realm = $activeDirectoryRealm`. When this is used, Zeppelin does not set the roles that were assigned to that particular user.  

```
[main]
activeDirectoryRealm = org.apache.zeppelin.realm.ActiveDirectoryGroupRealm
activeDirectoryRealm.systemUsername = CN=Administrator,CN=Users,DC=COMPANY,DC=COM
activeDirectoryRealm.systemPassword = Password1!
activeDirectoryRealm.searchBase = CN=Users,DC=COMPANY,DC=COM
activeDirectoryRealm.url = ldap://ad-nano.mydomain.com:389
activeDirectoryRealm.groupRolesMap = "CN=zeppelin,OU=groups,DC=COMPANY,DC=COM":"admin","CN=finance,OU=groups,DC=COMPANY,DC=COM":"finance"
activeDirectoryRealm.authorizationCachingEnabled = true

securityManager.realm = $activeDirectoryRealm

sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
cacheManager = org.apache.shiro.cache.MemoryConstrainedCacheManager
securityManager.cacheManager = $cacheManager
securityManager.sessionManager = $sessionManager
securityManager.sessionManager.globalSessionTimeout = 86400000
shiro.loginUrl = /api/login

[urls]
/api/version = anon
/** = authc
```

So, before this PR if you `tail -f zeppelin-<username>-<machine-name>.local.log` in the log you will see this line 
` WARN [2017-06-12 12:42:06,620] ({qtp226744878-19} LoginRestApi.java[postLogin]:119) - {"status":"OK","message":"","body":{"principal":"zeppelin","ticket":"4b1e513f-7736-4474-b2d6-259ff3d39f91","roles":"[]"}}` 

And after applying this PR you will be able to see the role that got assigned to this user i.e.
` WARN [2017-06-12 12:42:06,620] ({qtp226744878-19} LoginRestApi.java[postLogin]:119) - {"status":"OK","message":"","body":{"principal":"zeppelin","ticket":"4b1e513f-7736-4474-b2d6-259ff3d39f91","roles":"[admin]"}}`

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
