### PR TITLE
[ZEPPELIN-2650] fix: DON'T set uppercase automatically for column names in table

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -193,7 +193,7 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
       }
 
       collector.checkThat("Paragraph from SparkParagraphIT of testSqlSpark result: ",
-          headerNames, CoreMatchers.equalTo("Age|Job|Marital|Education|Balance|"));
+          headerNames, CoreMatchers.equalTo("age|job|marital|education|balance|"));
     } catch (Exception e) {
       handleException("Exception in SparkParagraphIT while testSqlSpark", e);
     }

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -86,6 +86,7 @@ export default class TableVisualization extends Visualization {
 
       columnDefs: columnNames.map(colName => {
         return {
+          displayName: colName,
           name: colName,
           type: DefaultTableColumnType,
           cellTemplate: `


### PR DESCRIPTION
### What is this PR for?

fix: DON'T set uppercase automatically for column names in a table

### What type of PR is it?
[Bug Fix]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2650](https://issues.apache.org/jira/browse/ZEPPELIN-2650)

### How should this be tested?

1. Create a table result
2. Check the column names

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/27167154-51c6fdf2-51da-11e7-990c-ee8c3b8db10b.png)

#### After

![image](https://user-images.githubusercontent.com/4968473/27167147-44962cd4-51da-11e7-8339-8c14eee305ef.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
