### PR TITLE
[ZEPPELIN-2641] Change encoding to UTF-8 when sending request to Livy

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -41,6 +41,7 @@ import org.apache.zeppelin.interpreter.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -520,7 +521,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     targetURL = livyURL + targetURL;
     LOGGER.debug("Call rest api in {}, method: {}, jsonData: {}", targetURL, method, jsonData);
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Content-Type", "application/json");
+    headers.add("Content-Type", MediaType.APPLICATION_JSON_UTF8_VALUE);
     headers.add("X-Requested-By", "zeppelin");
     ResponseEntity<String> response = null;
     try {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -557,8 +557,7 @@ public class LivyInterpreterIT {
 
     // test utf-8 Encoding
     try {
-      byte[] utf8Byte = new byte[] {-28,-72,-83,-27,-101,-67};
-      String utf8Str = new String(utf8Byte, StandardCharsets.UTF_8);
+      String utf8Str = "你你你你你你好";
       InterpreterResult result = pysparkInterpreter.interpret("print(\""+utf8Str+"\")", context);
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
       assertTrue(result.message().get(0).getData().contains(utf8Str));

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -552,6 +553,17 @@ public class LivyInterpreterIT {
       assertEquals(InterpreterResult.Code.ERROR, result.code());
       assertTrue(result.message().get(0).getData().split("\n").length>1);
       assertTrue(result.message().get(0).getData().contains("Traceback"));
+    }
+
+    // test utf-8 Encoding
+    try {
+      byte[] utf8Byte = new byte[] {-28,-72,-83,-27,-101,-67};
+      String utf8Str = new String(utf8Byte, StandardCharsets.UTF_8);
+      InterpreterResult result = pysparkInterpreter.interpret("print(\""+utf8Str+"\")", context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+      assertTrue(result.message().get(0).getData().contains(utf8Str));
+    }catch (Exception e) {
+      e.printStackTrace();
     }
 
     try {


### PR DESCRIPTION
### What is this PR for?
Change encoding of the request sent from Zeppelin to Livy to UTF-8. In this way, Zeppelin can support many more language than using ISO-8895-1 by default.


### What type of PR is it?
Bug Fix 


### What is the Jira issue?
[ZEPPELIN-2641](https://issues.apache.org/jira/browse/ZEPPELIN-2641)

### How should this be tested?
Build from source.
Open a Livy note book.
Run some simple print command with Chinese or Korean, see whether the return can show the character correctly

### Screenshots (if appropriate)
before 
![image](https://user-images.githubusercontent.com/14201792/27174528-11d45216-51ef-11e7-8f46-2f2e8347a3de.png)

after
![image](https://user-images.githubusercontent.com/14201792/27174517-08cdba04-51ef-11e7-989c-88e516b2d265.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
