### PR TITLE
[ZEPPELIN-2647] Set admin user as owner when user create a notebook

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -364,6 +364,12 @@
 </property>
 
 <property>
+  <name>zeppelin.notebook.owner</name>
+  <value></value>
+  <description>Set owner by default in private mode when notebook is created</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.public</name>
   <value>true</value>
   <description>Make notebook public by default when created, private otherwise</description>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -21,8 +21,11 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
@@ -41,6 +44,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   private static final String ZEPPELIN_SITE_XML = "zeppelin-site.xml";
   private static final long serialVersionUID = 4749305895693848035L;
   private static final Logger LOG = LoggerFactory.getLogger(ZeppelinConfiguration.class);
+  private static final Pattern COMMA_DELIMITER = Pattern.compile("\\s*,\\s*");
 
   private static final String HELIUM_PACKAGE_DEFAULT_URL =
       "https://s3.amazonaws.com/helium-package/helium.json";
@@ -506,6 +510,11 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE);
   }
 
+  public Set<String> getDefaultOwner() {
+    String values = getString(ConfVars.ZEPPELIN_DEFAULT_OWNER);
+    return new HashSet<>(Arrays.asList(COMMA_DELIMITER.split(values)));
+  }
+
   public String getJettyName() {
     return getString(ConfVars.ZEPPELIN_SERVER_JETTY_NAME);
   }
@@ -664,7 +673,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_CREDENTIALS_PERSIST("zeppelin.credentials.persist", true),
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),
     ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false),
-    ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null);
+    ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
+    ZEPPELIN_DEFAULT_OWNER("zeppelin.notebook.owner", "");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -340,6 +339,8 @@ public class NotebookAuthorization {
       } else {
         // add current user to owners, readers, writers - private note
         Set<String> entities = getOwners(noteId);
+        Set<String> defaultOwner = conf.getDefaultOwner();
+        entities.addAll(defaultOwner);
         entities.add(subject.getUser());
         setOwners(noteId, entities);
         entities = getReaders(noteId);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -16,18 +16,20 @@
  */
 package org.apache.zeppelin.conf;
 
-import junit.framework.Assert;
-
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
-
-import org.junit.Before;
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.junit.Before;
+import org.junit.Test;
+
+import junit.framework.Assert;
 
 
 /**
@@ -96,5 +98,16 @@ public class ZeppelinConfigurationTest {
       ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
       boolean isIt = conf.isNotebokPublic();
       assertTrue(isIt);
+    }
+
+    @Test
+    public void getDefaultOwnerTest() throws ConfigurationException {
+        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/test-zeppelin-site3.xml"));
+        Set<String> actual = conf.getDefaultOwner();
+        Set<String> expect = new HashSet<>();
+        expect.add("admin");
+        expect.add("user1");
+        expect.add("user2");
+        assertEquals(expect, actual);
     }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -17,25 +17,49 @@
 
 package org.apache.zeppelin.notebook;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
 import org.apache.zeppelin.display.AngularObjectRegistry;
-import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.interpreter.ClassloaderInterpreter;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterInfo;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.apache.zeppelin.interpreter.InterpreterProperty;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.InterpreterSettingManager;
+import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter1;
 import org.apache.zeppelin.interpreter.mock.MockInterpreter2;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
@@ -55,6 +79,9 @@ import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositoryException;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 public class NotebookTest implements JobListenerFactory{
   private static final Logger logger = LoggerFactory.getLogger(NotebookTest.class);
@@ -1194,6 +1221,22 @@ public class NotebookTest implements JobListenerFactory{
     //set back public to true
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
     ZeppelinConfiguration.create();
+  }
+
+  @Test
+  public void testNewNoteWithDefaultOwner() throws IOException, SchedulerException {
+    AuthenticationInfo subject = new AuthenticationInfo("user1");
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "false");
+    System.setProperty(ConfVars.ZEPPELIN_DEFAULT_OWNER.getVarName(), "admin");
+    ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    Set<String> expect = new HashSet<>();
+    expect.add("admin");
+    assertEquals(expect, conf.getDefaultOwner());
+    Note note = notebook.createNote(subject);
+    Set<String> owners = notebookAuthorization.getOwners(note.getId());
+    expect.add("user1");
+    assertEquals(2, owners.size());
+    assertEquals(expect, owners);
   }
   
   private void delete(File file){

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1237,6 +1237,15 @@ public class NotebookTest implements JobListenerFactory{
     expect.add("user1");
     assertEquals(2, owners.size());
     assertEquals(expect, owners);
+
+    // default owner is empty
+    System.setProperty(ConfVars.ZEPPELIN_DEFAULT_OWNER.getVarName(), "");
+    note = notebook.createNote(subject);
+    owners = notebookAuthorization.getOwners(note.getId());
+    Set<String> expect2 = new HashSet<>();
+    expect2.add("user1");
+    assertEquals(1, owners.size());
+    assertEquals(expect2, owners);
   }
   
   private void delete(File file){

--- a/zeppelin-zengine/src/test/resources/test-zeppelin-site3.xml
+++ b/zeppelin-zengine/src/test/resources/test-zeppelin-site3.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+
+  <property>
+    <name>zeppelin.server.addr</name>
+    <value>0.0.0.0</value>
+    <description>Server address</description>
+  </property>
+
+  <property>
+    <name>zeppelin.server.port</name>
+    <value>8080</value>
+    <description>Server port.</description>
+  </property>
+
+  <property>
+    <name>zeppelin.notebook.dir</name>
+    <value>notebook</value>
+    <description>path or URI for notebook persist</description>
+  </property>
+
+  <property>
+    <name>zeppelin.notebook.homescreen</name>
+    <value></value>
+    <description>id of notebook to be displayed in homescreen. ex) 2A94M5J1Z Empty value displays default home screen</description>
+  </property>
+
+  <property>
+    <name>zeppelin.notebook.homescreen.hide</name>
+    <value>false</value>
+    <description>hide homescreen notebook from list when this value set to true</description>
+  </property>
+
+
+  <!-- If used S3 to storage the notebooks, it is necessary the following folder structure bucketname/username/notebook/ -->
+  <!--
+  <property>
+    <name>zeppelin.notebook.s3.user</name>
+    <value>user</value>
+    <description>user name for s3 folder structure</description>
+  </property>
+
+  <property>
+    <name>zeppelin.notebook.s3.bucket</name>
+    <value>zeppelin</value>
+    <description>bucket name for notebook storage</description>
+  </property>
+
+  <property>
+    <name>zeppelin.notebook.storage</name>
+    <value>org.apache.zeppelin.notebook.repo.S3NotebookRepo</value>
+    <description>notebook persistence layer implementation</description>
+  </property>
+  -->
+
+  <property>
+    <name>zeppelin.notebook.storage</name>
+    <value>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</value>
+    <description>notebook persistence layer implementation</description>
+  </property>
+
+  <property>
+    <name>zeppelin.interpreter.dir</name>
+    <value>interpreter</value>
+    <description>Interpreter implementation base directory</description>
+  </property>
+
+  <property>
+    <name>zeppelin.interpreter.connect.timeout</name>
+    <value>30000</value>
+    <description>Interpreter process connect timeout in msec.</description>
+  </property>
+
+
+  <property>
+    <name>zeppelin.ssl</name>
+    <value>false</value>
+    <description>Should SSL be used by the servers?</description>
+  </property>
+
+  <property>
+    <name>zeppelin.ssl.client.auth</name>
+    <value>false</value>
+    <description>Should client authentication be used for SSL connections?</description>
+  </property>
+
+  <property>
+    <name>zeppelin.ssl.keystore.path</name>
+    <value>keystore</value>
+    <description>Path to keystore relative to Zeppelin configuration directory</description>
+  </property>
+
+  <property>
+    <name>zeppelin.ssl.keystore.type</name>
+    <value>JKS</value>
+    <description>The format of the given keystore (e.g. JKS or PKCS12)</description>
+  </property>
+
+  <property>
+    <name>zeppelin.ssl.keystore.password</name>
+    <value>change me</value>
+    <description>Keystore password. Can be obfuscated by the Jetty Password tool</description>
+  </property>
+
+  <!--
+  <property>
+    <name>zeppelin.ssl.key.manager.password</name>
+    <value>change me</value>
+    <description>Key Manager password. Defaults to keystore password. Can be obfuscated.</description>
+  </property>
+  -->
+
+  <property>
+    <name>zeppelin.ssl.truststore.path</name>
+    <value>truststore</value>
+    <description>Path to truststore relative to Zeppelin configuration directory. Defaults to the keystore path</description>
+  </property>
+
+  <property>
+    <name>zeppelin.ssl.truststore.type</name>
+    <value>JKS</value>
+    <description>The format of the given truststore (e.g. JKS or PKCS12). Defaults to the same type as the keystore type</description>
+  </property>
+
+  <property>
+    <name>zeppelin.server.allowed.origins</name>
+    <value>http://onehost:8080,http://otherhost.com,</value>
+    <description>Allowed sources for REST and WebSocket requests.</description>
+  </property>
+  <property>
+    <name>zeppelin.notebook.public</name>
+    <value>true</value>
+    <description>Make notebook public by default when created, private otherwise</description>
+  </property>
+  <property>
+    <name>zeppelin.notebook.owner</name>
+    <value>admin, user1 , user2</value>
+    <description>Set owner by default in private mode when notebook is created</description>
+  </property>
+  <!--
+  <property>
+    <name>zeppelin.ssl.truststore.password</name>
+    <value>change me</value>
+    <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password</description>
+  </property>
+  -->
+
+</configuration>
+


### PR DESCRIPTION
### What is this PR for?
When a user creates a notebook, default users (an administrator can set default users in zeppelin-site.xml) are set as owner.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2647

### How should this be tested?
1. Change Notebook workspace to private through whether ZEPPELIN_NOTEBOOK_PUBLIC = false or zeppelin.notebook.public = false.
2. Set default owners through ZEPPELIN_DEFAULT_OWNER = <comma separated username> or zeppelin.notebook.owner = <comma separated username>.
3. Create notebook.
4. Check if notebook's owner is set to both default users and the user who create the notebook.

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? Y/N
* Does this needs documentation? Y
