### PR TITLE
[ZEPPELIN-2666] docs: Add docker usage to download page

### DIFF
--- a/download.md
+++ b/download.md
@@ -59,6 +59,8 @@ To persist `logs` and `notebook` directories, use the [volume](https://docs.dock
 docker run -p 8080:8080 --rm -v $PWD/logs:/logs -v $PWD/notebook:/notebook -e ZEPPELIN_LOG_DIR='/logs' -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.7.2
 ```
 
+If you have trouble accessing `localhost:8080` in the browser, Please clear browser cache.
+
 ## Verify the integrity of the files
 
 It is essential that you [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files using the PGP or MD5 signatures. This signature should be matched against the [KEYS](https://www.apache.org/dist/zeppelin/KEYS) file.

--- a/download.md
+++ b/download.md
@@ -53,7 +53,7 @@ Use this command to launch Apache Zeppelin in a container.
 docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.7.2
 ```
 
-To persist `logs` and `notebook` directories in local machine, Use the [volumn](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
+To persist `logs` and `notebook` directories in local machine, use the [volumn](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
 
 ```bash
 docker run -p 8080:8080 --rm -v $PWD/logs:/logs -v $PWD/notebook:/notebook -e ZEPPELIN_LOG_DIR='/logs' -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.7.2

--- a/download.md
+++ b/download.md
@@ -53,7 +53,7 @@ Use this command to launch Apache Zeppelin in a container.
 docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.7.2
 ```
 
-To persist `logs` and `notebook` directories in local machine, use the [volumn](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
+To persist `logs` and `notebook` directories, use the [volume](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
 
 ```bash
 docker run -p 8080:8080 --rm -v $PWD/logs:/logs -v $PWD/notebook:/notebook -e ZEPPELIN_LOG_DIR='/logs' -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.7.2

--- a/download.md
+++ b/download.md
@@ -43,6 +43,21 @@ The latest release of Apache Zeppelin is **0.7.2**.
     [md5](https://www.apache.org/dist/zeppelin/zeppelin-0.7.2/zeppelin-0.7.2.tgz.md5),
     [sha](https://www.apache.org/dist/zeppelin/zeppelin-0.7.2/zeppelin-0.7.2.tgz.sha512))
 
+# Using the official docker image 
+
+Make sure that [docker](https://www.docker.com/community-edition) is installed in your local machine.  
+
+Use this command to launch Apache Zeppelin in a container. 
+
+```bash
+docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin:0.7.2
+```
+
+To persist `logs` and `notebook` directories in local machine, Use the [volumn](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v-read-only) option for docker container.
+
+```bash
+docker run -p 8080:8080 --rm -v $PWD/logs:/logs -v $PWD/notebook:/notebook -e ZEPPELIN_LOG_DIR='/logs' -e ZEPPELIN_NOTEBOOK_DIR='/notebook' --name zeppelin apache/zeppelin:0.7.2
+```
 
 ## Verify the integrity of the files
 


### PR DESCRIPTION
### What is this PR for?

Recently, Zeppelin community released the official docker image for Zeppelin 0.7.2. 
If we add some usage in http://zeppelin.apache.org/download.html, it would be helpful.

### What type of PR is it?
[Documentation]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2666](https://issues.apache.org/jira/browse/ZEPPELIN-2666)

### How should this be tested?

1. checkout
2. `bundle exec jekyll serve --watch` (make sure that you have ruby and required gems are installed already)

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4968473/27274556-c648bc92-550e-11e7-8d06-0f04ad35b1f7.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
