### PR TITLE
[ZEPPELIN-2663] Helium vizualisations do not appear in the list of builtInt visualizations in paragraph

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -176,7 +176,8 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
       $scope.builtInTableDataVisualizationList.push({
         id: vis.id,
         name: vis.name,
-        icon: $sce.trustAsHtml(vis.icon)
+        icon: $sce.trustAsHtml(vis.icon),
+        supports: [DefaultDisplayType.TABLE, DefaultDisplayType.NETWORK]
       })
       builtInVisualizations[vis.id] = {
         class: vis.class

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -227,7 +227,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
      * should be made. Also, it was observed that between PENDING
      * and RUNNING states, append-events can be called and we can't
      * miss those, else during the length of paragraph run, few
-     * initial output line/s will be missing. 
+     * initial output line/s will be missing.
      */
     if (paragraph.id === data.paragraphId &&
       resultIndex === data.index &&

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -227,7 +227,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
      * should be made. Also, it was observed that between PENDING
      * and RUNNING states, append-events can be called and we can't
      * miss those, else during the length of paragraph run, few
-     * initial output line/s will be missing.
+     * initial output line/s will be missing. 
      */
     if (paragraph.id === data.paragraphId &&
       resultIndex === data.index &&


### PR DESCRIPTION
### What is this PR for?
Within the helium only default build in visualizations are in the list of possible visualizations


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Correct the bug

### What is the Jira issue?
[ZEPPELIN-2663](https://issues.apache.org/jira/browse/ZEPPELIN-2663)

### How should this be tested?
* git clone zeppelin
* mvn clean package
* run, open browser
* go to helium
* enable few additional visualizations
* create new note and add paragraph: print("%table text\tme\n")

### Screenshots (if appropriate)
No

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No