### PR TITLE
[ZEPPELIN-2670] fix: DON'T reset all helium config when saving display order

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -305,7 +305,7 @@ public class HeliumRestApi {
   @GET
   @Path("order/visualization")
   public Response getVisualizationPackageOrder() {
-    List<String> order = helium.setVisualizationPackageOrder();
+    List<String> order = helium.getVisualizationPackageOrder();
     return new JsonResponse(Response.Status.OK, order).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -211,13 +211,6 @@ public class HeliumRestApi {
   }
 
   @GET
-  @Path("order/visualization")
-  public Response getVisualizationPackageOrder() {
-    List<String> order = helium.setVisualizationPackageOrder();
-    return new JsonResponse(Response.Status.OK, order).build();
-  }
-
-  @GET
   @Path("spell/config/{packageName}")
   public Response getSpellConfigUsingMagic(@PathParam("packageName") String packageName) {
     if (StringUtils.isEmpty(packageName)) {
@@ -307,6 +300,13 @@ public class HeliumRestApi {
     }
 
     return new JsonResponse(Response.Status.OK, packageConfig).build();
+  }
+
+  @GET
+  @Path("order/visualization")
+  public Response getVisualizationPackageOrder() {
+    List<String> order = helium.setVisualizationPackageOrder();
+    return new JsonResponse(Response.Status.OK, order).build();
   }
 
   @POST

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -311,7 +311,7 @@ public class HeliumRestApi {
 
   @POST
   @Path("order/visualization")
-  public Response getVisualizationPackageOrder(String orderedPackageNameList) {
+  public Response setVisualizationPackageOrder(String orderedPackageNameList) {
     List<String> orderedList = gson.fromJson(
         orderedPackageNameList, new TypeToken<List<String>>(){}.getType());
 

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -50,10 +50,8 @@ export default function HeliumCtrl ($scope, $rootScope, $sce,
       })
       .then(defaultPackageConfigs => {
         $scope.defaultPackageConfigs = defaultPackageConfigs
+        return heliumService.getVisualizationPackageOrder()
       })
-
-    // 2. get vis package order
-    heliumService.getVisualizationPackageOrder()
       .then(visPackageOrder => {
         $scope.bundleOrder = visPackageOrder
         $scope.bundleOrderChanged = false

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -133,18 +133,18 @@ export default function HeliumCtrl ($scope, $rootScope, $sce,
           confirm.$modalFooter.find('button:contains("OK")')
             .html('<i class="fa fa-circle-o-notch fa-spin"></i> Enabling')
           heliumService.setVisualizationPackageOrder($scope.bundleOrder)
-          .success(function (data, status) {
-            init()
-            confirm.close()
-          })
-          .error(function (data, status) {
-            confirm.close()
-            console.log('Failed to save order')
-            BootstrapDialog.show({
-              title: 'Error on saving order ',
-              message: data.message
+            .success(function (data, status) {
+              init()
+              confirm.close()
             })
-          })
+            .error(function (data, status) {
+              confirm.close()
+              console.log('Failed to save order')
+              BootstrapDialog.show({
+                title: 'Error on saving order ',
+                message: data.message
+              })
+            })
           return false
         }
       }

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -53,9 +53,13 @@ export default function HeliumCtrl ($scope, $rootScope, $sce,
         return heliumService.getVisualizationPackageOrder()
       })
       .then(visPackageOrder => {
-        $scope.bundleOrder = visPackageOrder
-        $scope.bundleOrderChanged = false
+        setVisPackageOrder(visPackageOrder)
       })
+  }
+
+  const setVisPackageOrder = function(visPackageOrder) {
+    $scope.bundleOrder = visPackageOrder
+    $scope.bundleOrderChanged = false
   }
 
   let orderPackageByPubDate = function (a, b) {
@@ -132,7 +136,7 @@ export default function HeliumCtrl ($scope, $rootScope, $sce,
             .html('<i class="fa fa-circle-o-notch fa-spin"></i> Enabling')
           heliumService.setVisualizationPackageOrder($scope.bundleOrder)
             .success(function (data, status) {
-              init()
+              setVisPackageOrder($scope.bundleOrder)
               confirm.close()
             })
             .error(function (data, status) {

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -126,6 +126,7 @@ export default function heliumService ($http, $sce, baseUrlSrv) {
   this.getAllPackageInfo = function () {
     return $http.get(`${baseUrlSrv.getRestApiBase()}/helium/package`)
       .then(function (response, status) {
+        console.warn(Object.keys(response.data.body).length)
         return response.data.body
       })
       .catch(function (error) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -453,10 +453,6 @@ public class Helium {
   public void setVisualizationPackageOrder(List<String> orderedPackageList)
       throws IOException {
     heliumConf.setBundleDisplayOrder(orderedPackageList);
-
-    // if package is visualization, rebuild buildBundle
-    bundleFactory.buildAllPackages(getBundlePackagesToBundle());
-
     save();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -309,13 +309,21 @@ public class Helium {
       return;
     }
 
-    // if package is visualization, rebuild bundle
+    // if package is bundle, rebuild bundle
     if (HeliumPackage.isBundleType(pkgInfo.getPkg().getType())) {
       bundleFactory.buildPackage(pkgInfo.getPkg(), true, true);
     }
 
-    // update conf and save
+    // set `enable` field
     heliumConf.enablePackage(name, artifact);
+    // set display order
+    if (pkgInfo.getPkg().getType() == HeliumType.VISUALIZATION) {
+      List<String> currentDisplayOrder = heliumConf.getBundleDisplayOrder();
+      if (!currentDisplayOrder.contains(name)) {
+        currentDisplayOrder.add(name);
+      }
+    }
+
     save();
   }
 
@@ -326,8 +334,16 @@ public class Helium {
       return;
     }
 
-    // update conf and save
+    HeliumPackageSearchResult pkgInfo = getPackageInfo(name, artifact);
+
+    // set `enable` field
     heliumConf.disablePackage(name);
+    if (pkgInfo.getPkg().getType() == HeliumType.VISUALIZATION) {
+      List<String> currentDisplayOrder = heliumConf.getBundleDisplayOrder();
+      if (currentDisplayOrder.contains(name)) {
+        currentDisplayOrder.remove(name);
+      }
+    }
     save();
   }
 
@@ -437,17 +453,8 @@ public class Helium {
    * Get enabled package list in order
    * @return
    */
-  public List<String> setVisualizationPackageOrder() {
-    List orderedPackageList = new LinkedList<>();
-    List<HeliumPackage> packages = getBundlePackagesToBundle();
-
-    for (HeliumPackage pkg : packages) {
-      if (HeliumType.VISUALIZATION == pkg.getType()) {
-        orderedPackageList.add(pkg.getName());
-      }
-    }
-
-    return orderedPackageList;
+  public List<String> getVisualizationPackageOrder() {
+    return heliumConf.getBundleDisplayOrder();
   }
 
   public void setVisualizationPackageOrder(List<String> orderedPackageList)

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumConf.java
@@ -31,7 +31,8 @@ public class HeliumConf {
           new HashMap<String, Map<String, Object>>());
 
   // enabled visualization package display order
-  private List<String> bundleDisplayOrder = new LinkedList<>();
+  private List<String> bundleDisplayOrder =
+          Collections.synchronizedList(new LinkedList<String>());
 
   public Map<String, String> getEnabledPackages() {
     return new HashMap<>(enabled);
@@ -88,6 +89,6 @@ public class HeliumConf {
   }
 
   public void setBundleDisplayOrder(List<String> orderedPackageList) {
-    bundleDisplayOrder = orderedPackageList;
+    bundleDisplayOrder = Collections.synchronizedList(orderedPackageList);
   }
 }


### PR DESCRIPTION
### What is this PR for?

Reordering vis package using the `save` button resets all helium configuration.

Originally, reported in [ZEPPELIN-2656](https://issues.apache.org/jira/browse/ZEPPELIN-2656) but created a new issue track that problem only.

### What type of PR is it?
[Bug Fix]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2670](https://issues.apache.org/jira/browse/ZEPPELIN-2670)

### How should this be tested?

1. Enable 2 vis packages
2. Change display order
3. Refresh (**necessary**) the page
4. Change display order again

### Screenshots (if appropriate)

#### before

![2670_before](https://user-images.githubusercontent.com/4968473/27380768-702d2dd0-56bb-11e7-8565-00b08550b343.gif)


#### after


![2670_after](https://user-images.githubusercontent.com/4968473/27380773-74704058-56bb-11e7-95b7-035eb9cd8116.gif)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
