### PR TITLE
[ZEPPELIN-2673] - Helium skip node install

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -119,7 +119,8 @@ public class HeliumBundleFactory {
 
   void installNodeAndNpm() throws TaskRunnerException {
     File nodeTargetDir = new File(nodeInstallationDirectory, "node");
-    if (nodeTargetDir.exists() && nodeTargetDir.isDirectory()) {
+    File successFile = new File(nodeTargetDir, "_SUCCESS");
+    if (successFile.exists()) {
       logger.info("Skipping Node and NPM install");
       return;
     }
@@ -146,8 +147,13 @@ public class HeliumBundleFactory {
       yarnCommand(frontEndPluginFactory, "config set cache-folder " + yarnCacheDirPath);
 
       configureLogger();
+
+      successFile.createNewFile();
     } catch (InstallationException e) {
       logger.error(e.getMessage(), e);
+    } catch (IOException e) {
+      logger.error(e.getMessage(), e);
+      e.printStackTrace();
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -80,7 +80,6 @@ public class HeliumBundleFactory {
   private String defaultNpmInstallerUrl;
   private String defaultYarnInstallerUrl;
   private Gson gson;
-  private boolean nodeAndNpmInstalled = false;
 
   ByteArrayOutputStream out  = new ByteArrayOutputStream();
 
@@ -119,7 +118,9 @@ public class HeliumBundleFactory {
   }
 
   void installNodeAndNpm() throws TaskRunnerException {
-    if (nodeAndNpmInstalled) {
+    File nodeTargetDir = new File(nodeInstallationDirectory, "node");
+    if (nodeTargetDir.exists() && nodeTargetDir.isDirectory()) {
+      logger.info("Skipping Node and NPM install");
       return;
     }
     try {
@@ -145,7 +146,6 @@ public class HeliumBundleFactory {
       yarnCommand(frontEndPluginFactory, "config set cache-folder " + yarnCacheDirPath);
 
       configureLogger();
-      nodeAndNpmInstalled = true;
     } catch (InstallationException e) {
       logger.error(e.getMessage(), e);
     }


### PR DESCRIPTION
### What is this PR for?
Skip altogether the install of NPM. Node and YarnPkg when the packages have been successfully downloaded into the node installer dir (default ../local-repo/helium-bundles/node/)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2673

### How should this be tested?
Open Zeppelin > Helium > Enable Plugin > Check NPM/Node install > Stop Zeppelin > Start Zeppelin > Enable Plugin > Check skip of NPM/Node install

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
