### PR TITLE
Remove ticket after logout

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -126,6 +126,8 @@ public class LoginRestApi {
   public Response logout() {
     JsonResponse response;
     Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
+    TicketContainer.instance.removeTicket(SecurityUtils.getPrincipal());
+    currentUser.getSession().stop();
     currentUser.logout();
     response = new JsonResponse(Response.Status.UNAUTHORIZED, "", "");
     LOG.warn(response.toString());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/ticket/TicketContainer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/ticket/TicketContainer.java
@@ -21,6 +21,8 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Very simple ticket container
@@ -30,6 +32,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 
 public class TicketContainer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TicketContainer.class);
+
   private static class Entry {
     public final String ticket;
     // lastAccessTime still unused
@@ -78,5 +83,19 @@ public class TicketContainer {
     entry = new Entry(ticket);
     sessions.put(principal, entry);
     return ticket;
+  }
+
+  /**
+   * Remove ticket from session cache.
+   * @param principal
+   */
+  public synchronized void removeTicket(String principal) {
+    try {
+      if (sessions.get(principal) != null) {
+        sessions.remove(principal);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error removing ticket", e);
+    }
   }
 }


### PR DESCRIPTION
### What is this PR for?
IMO on logout of user Z-sever should also remove ticket.

### What type of PR is it?
[Improvement]

### How should this be tested?
On logout and login, Z-sever should return a new ticket for the same user.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
