### PR TITLE
[ZEPPELIN-1470] limiting results from jdbc

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -681,7 +681,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
       for (int i = 0; i < sqlArray.size(); i++) {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
+
+        // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());
+        statement.setMaxRows(getMaxResult() + 1);
 
         if (statement == null) {
           return new InterpreterResult(Code.ERROR, "Prefix not found.");

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -681,6 +681,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
       for (int i = 0; i < sqlArray.size(); i++) {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
+        statement.setFetchSize(getMaxResult());
+
         if (statement == null) {
           return new InterpreterResult(Code.ERROR, "Prefix not found.");
         }


### PR DESCRIPTION
### What is this PR for?

One thing we tracked down is that if you issue a large query on a very large table, it will simply try to load all results (and then cap them on Zeppelin's side), which seems suboptimal (and will freeze the server). Setting this on the JDBC level seems to solve the problem.

### What type of PR is it?
Bug Fix

### Todos
* [x] Tests

### How should this be tested?

- Create or use a table with a very large number of rows. In our tests, I simply created a:

```
createdb zeppelin_test

psql zeppelin_test

create table too_many_rows(n int)
```

And added 5m rows to it.

Making a paragraph like this will hang without setting a limit:
```
%zeppelin_test

select * from too_many_rows
```

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
