### PR TITLE
[ZEPPELIN-2652] Can't open spark tutorial note in 0.8.0-SNAPSHOT

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -37,6 +37,7 @@ public class Input<T> implements Serializable {
   // in future.
   public static final RuntimeTypeAdapterFactory TypeAdapterFactory =
       RuntimeTypeAdapterFactory.of(Input.class, "type")
+        .registerSubtype(Input.class, "Input")
         .registerSubtype(TextBox.class, "TextBox")
         .registerSubtype(Select.class, "Select")
         .registerSubtype(CheckBox.class, "CheckBox")


### PR DESCRIPTION
### What is this PR for?
Fix the bug which cannot open a note containing a dynamic form.

It is not a problem of backward version compatibility.
I checked that it still cannot open the note created on v0.8.0.

With the line I added, now it works well.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2652

### How should this be tested?
* Create a note with dynamic form
* Reload notes
* Try to open the note

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
