### PR TITLE
[ZEPPELIN-2684] Flaky Test: ParagraphActionsIT.testSingleDynamicFormTextInput

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -42,7 +42,7 @@ abstract public class AbstractZeppelinIT {
   protected final static Logger LOG = LoggerFactory.getLogger(AbstractZeppelinIT.class);
   protected static final long MAX_IMPLICIT_WAIT = 30;
   protected static final long MAX_BROWSER_TIMEOUT_SEC = 30;
-  protected static final long MAX_PARAGRAPH_TIMEOUT_SEC = 60;
+  protected static final long MAX_PARAGRAPH_TIMEOUT_SEC = 120;
 
   protected void setTextOfParagraph(int paragraphNo, String text) {
     String editorId = driver.findElement(By.xpath(getParagraphXPath(paragraphNo) + "//div[contains(@class, 'editor')]")).getAttribute("id");


### PR DESCRIPTION
### What is this PR for?
Raw Log - https://s3.amazonaws.com/archive.travis-ci.org/jobs/246113686/log.txt?X-Amz-Expires=30&X-Amz-Date=20170624T042931Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20170624/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=6ad442e67857da5228e08363229dc2a6748506c14fd3f17c2fcb8cf826ce9c64

Travis seems to be failing at times with the paragraph state as Running and expecting Finished. I believe we can increase this MAX_PARAGRAPH_TIMEOUT_SEC to say 2min should solve this problem.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2684](https://issues.apache.org/jira/browse/ZEPPELIN-2684)

### How should this be tested?
CI should be green for 3rd (Selenium) matrix.

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
