### PR TITLE
ZEPPELIN-2687: Show code in description section of Spark UI

### DIFF
--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -277,12 +277,16 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     public String statements;
     public String jobGroup;
     public String jobDescription;
+    public String jobShortText;
+    public String jobLongText;
 
     public PythonInterpretRequest(String statements, String jobGroup,
-        String jobDescription) {
+        String jobDescription, String shortText, String longText) {
       this.statements = statements;
       this.jobGroup = jobGroup;
       this.jobDescription = jobDescription;
+      this.jobShortText = shortText;
+      this.jobLongText = longText;
     }
 
     public String statements() {
@@ -295,6 +299,14 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
 
     public String jobDescription() {
       return jobDescription;
+    }
+
+    public String jobShortText() {
+      return jobShortText;
+    }
+
+    public String jobLongText() {
+      return jobLongText;
     }
   }
 
@@ -406,7 +418,9 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     SparkZeppelinContext __zeppelin__ = sparkInterpreter.getZeppelinContext();
     __zeppelin__.setInterpreterContext(context);
     __zeppelin__.setGui(context.getGui());
-    pythonInterpretRequest = new PythonInterpretRequest(st, jobGroup, jobDesc);
+    pythonInterpretRequest = new PythonInterpretRequest(st, jobGroup, jobDesc,
+        Utils.getJobShortText(context.getParagraphText()), Utils.getJobLongText(context
+            .getParagraphText()));
     statementOutput = null;
 
     synchronized (statementSetNotifier) {
@@ -484,7 +498,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       return new LinkedList<>();
     }
 
-    pythonInterpretRequest = new PythonInterpretRequest(completionCommand, "", "");
+    pythonInterpretRequest = new PythonInterpretRequest(completionCommand, "", "", "", "");
     statementOutput = null;
 
     synchronized (statementSetNotifier) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -46,6 +46,7 @@ import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.ui.SparkUI;
 import org.apache.spark.ui.jobs.JobProgressListener;
+import org.apache.spark.util.CallSite;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.util.InterpreterOutputStream;
@@ -1183,6 +1184,9 @@ public class SparkInterpreter extends Interpreter {
   public InterpreterResult interpret(String[] lines, InterpreterContext context) {
     synchronized (this) {
       z.setGui(context.getGui());
+      String paraText = context.getParagraphText();
+      sc.setCallSite(new CallSite(Utils.getJobShortText(paraText),
+          Utils.getJobLongText(paraText)));
       String jobDesc = "Started by: " + Utils.getUserName(context.getAuthenticationInfo());
       sc.setJobGroup(Utils.buildJobGroupId(context), jobDesc, false);
       InterpreterResult r = interpretInput(lines, context);

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.util.CallSite;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
@@ -104,7 +105,9 @@ public class SparkSqlInterpreter extends Interpreter {
     } else {
       sc.setLocalProperty("spark.scheduler.pool", null);
     }
-
+    String paraText = context.getParagraphText();
+    sc.setCallSite(new CallSite(Utils.getJobShortText(paraText),
+        Utils.getJobLongText(paraText)));
     String jobDesc = "Started by: " + Utils.getUserName(context.getAuthenticationInfo());
     sc.setJobGroup(Utils.buildJobGroupId(context), jobDesc, false);
     Object rdd = null;

--- a/spark/src/main/java/org/apache/zeppelin/spark/Utils.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/Utils.java
@@ -135,4 +135,33 @@ class Utils {
     }
     return uName;
   }
+
+  public static String getJobShortText(String paraText) {
+    paraText = sanitizeText(paraText);
+    String text = paraText;
+    if (paraText != null && !paraText.isEmpty()) {
+      String[] splits = paraText.split(System.lineSeparator(), 2);
+      if (splits.length > 0) {
+        text = splits[0];
+      }
+    }
+    return text;
+  }
+
+  public static String getJobLongText(String paraText) {
+    String text = sanitizeText(paraText);
+    return text;
+  }
+
+  private static String sanitizeText(String paraText) {
+    String text = paraText;
+    if (paraText != null && !paraText.isEmpty() && paraText.startsWith("%")) {
+      String[] splits = paraText.split(System.lineSeparator() + "|\\s", 2);
+      if (splits.length == 2) {
+        text = splits[1];
+        text = text.trim();
+      }
+    }
+    return text;
+  }
 }

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -299,6 +299,8 @@ while True :
     stmts = req.statements().split("\n")
     jobGroup = req.jobGroup()
     jobDesc = req.jobDescription()
+    jobShortText = req.jobShortText()
+    jobLongText = req.jobLongText()
     
     # Get post-execute hooks
     try:
@@ -319,6 +321,8 @@ while True :
     if stmts:
       # use exec mode to compile the statements except the last statement,
       # so that the last statement's evaluation will be printed to stdout
+      sc.setLocalProperty("callSite.short", jobShortText)
+      sc.setLocalProperty("callSite.long", jobLongText)
       sc.setJobGroup(jobGroup, jobDesc)
       code = compile('\n'.join(stmts), '<stdin>', 'exec', ast.PyCF_ONLY_AST, 1)
       to_run_hooks = []

--- a/spark/src/test/java/org/apache/zeppelin/spark/UtilsTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/UtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.spark;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UtilsTest {
+
+  static Logger LOGGER = LoggerFactory.getLogger(UtilsTest.class);
+
+  @Test
+  public void testLongJobDescription() {
+    String paracode = "paraText";
+
+    // interpretertype and code on same line
+    String paraText = "%spark " + paracode;
+    String jobLongText = Utils.getJobLongText(paraText);
+    assertEquals(paracode, jobLongText);
+    LOGGER.info("Test passed with interpretertype and code on same line ");
+
+    // Interpreter type and code in different lines
+    paraText = "%spark\n" + paracode;
+    jobLongText = Utils.getJobLongText(paraText);
+    assertEquals(paracode, jobLongText);
+    LOGGER.info("Test passed with interpretertype and code on same line ");
+
+    // Only code(uses default interpreter type from bindings)
+    paraText = paracode;
+    jobLongText = Utils.getJobLongText(paraText);
+    assertEquals(paracode, jobLongText);
+    LOGGER.info("Test passed with no explicit interpreter type");
+  }
+
+  @Test
+  public void testShortJobDescription() {
+    String paracodeFirstLine = "paraText1";
+    String paracode = paracodeFirstLine + "\nparatext2";
+
+    // interpretertype and code on same line
+    String paraText = "%spark " + paracode;
+    String jobShortText = Utils.getJobShortText(paraText);
+    assertEquals(paracodeFirstLine, jobShortText);
+    LOGGER.info("Test passed with interpretertype and code on same line ");
+
+    // Interpreter type and code in different lines
+    paraText = "%spark\n" + paracode;
+    jobShortText = Utils.getJobShortText(paraText);
+    assertEquals(paracodeFirstLine, jobShortText);
+    LOGGER.info("Test passed with Interpreter type and code in different lines");
+
+    // Only code(uses first interpreter type from bindings)
+    paraText = paracode;
+    jobShortText = Utils.getJobShortText(paraText);
+    assertEquals(paracodeFirstLine, jobShortText);
+    LOGGER.info("Test passed with no explicit interpreter type");
+  }
+}


### PR DESCRIPTION
### What is this PR for?
Show code in description section of Spark UI


### What type of PR is it?
 Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
ZEPPELIN-2687

### How should this be tested?
Run scala, pyspark and sql snippet(should result in a spark job), and check Spark Web UI


### Screenshots (if appropriate)
Before:
<img width="1014" alt="screen shot 2017-06-24 at 12 26 02" src="https://user-images.githubusercontent.com/5082742/27506617-5b6955e8-58d9-11e7-901c-f61dc0fc5f13.png">

After:
Collapsed(short desc):
<img width="543" alt="screen shot 2017-06-24 at 12 12 38" src="https://user-images.githubusercontent.com/5082742/27506620-72242312-58d9-11e7-8fdc-1fdfa1973b75.png">

Expanded(Long desc):
<img width="1200" alt="screen shot 2017-06-24 at 12 12 43" src="https://user-images.githubusercontent.com/5082742/27506623-7a48ccbe-58d9-11e7-99bb-b103f464443c.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
