### PR TITLE
[ZEPPELIN-2688]. Upgrade ace to 1.2.7

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -14,7 +14,7 @@
     "angular-resource": "1.5.7",
     "angular-bootstrap": "~2.5.0",
     "angular-websocket": "~1.0.13",
-    "ace-builds": "1.2.6",
+    "ace-builds": "1.2.7",
     "angular-ui-ace": "0.1.3",
     "jquery.scrollTo": "~1.4.13",
     "nvd3": "~1.8.5",
@@ -46,13 +46,14 @@
         "src-noconflict/mode-python.js",
         "src-noconflict/mode-sql.js",
         "src-noconflict/mode-markdown.js",
+        "src-noconflict/mode-pig.js",
         "src-noconflict/mode-sh.js",
         "src-noconflict/mode-r.js",
         "src-noconflict/keybinding-emacs.js",
         "src-noconflict/ext-language_tools.js",
         "src-noconflict/theme-chrome.js"
       ],
-      "version": "1.2.6",
+      "version": "1.2.7",
       "name": "ace-builds"
     },
     "highlightjs": {
@@ -65,7 +66,7 @@
     }
   },
   "resolutions": {
-    "ace-builds": "1.2.6",
+    "ace-builds": "1.2.7",
     "angular": ">=1.5.0 <1.6"
   }
 }

--- a/zeppelin-web/karma.conf.js
+++ b/zeppelin-web/karma.conf.js
@@ -59,6 +59,7 @@ module.exports = function(config) {
       'bower_components/ace-builds/src-noconflict/mode-python.js',
       'bower_components/ace-builds/src-noconflict/mode-sql.js',
       'bower_components/ace-builds/src-noconflict/mode-markdown.js',
+      'bower_components/ace-builds/src-noconflict/mode-pig.js',
       'bower_components/ace-builds/src-noconflict/mode-sh.js',
       'bower_components/ace-builds/src-noconflict/mode-r.js',
       'bower_components/ace-builds/src-noconflict/keybinding-emacs.js',

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -140,6 +140,7 @@ limitations under the License.
     <script src="bower_components/ace-builds/src-noconflict/mode-python.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-sql.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-markdown.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/mode-pig.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-sh.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/mode-r.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/keybinding-emacs.js"></script>


### PR DESCRIPTION
### What is this PR for?
Ace 1.2.7 add syntax highlight for pig script. This ticket is to upgrade ace from 1.2.6 to 1.2.7


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2688

### How should this be tested?
Tested manually

### Screenshots (if appropriate)
Before
![before](https://user-images.githubusercontent.com/164491/27514859-802a8a24-59c8-11e7-9631-e19fcbb2f11e.png)
After
![after](https://user-images.githubusercontent.com/164491/27514861-81a22bfa-59c8-11e7-8b88-239d42a1588e.png)
### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
