### PR TITLE
[ZEPPELIN-2690] fix: should respect helium vis order in result

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -170,18 +170,24 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
   }
 
   $scope.init = function (result, config, paragraph, index) {
-    // register helium plugin vis
-    let visBundles = heliumService.getVisualizationBundles()
-    visBundles.forEach(function (vis) {
-      $scope.builtInTableDataVisualizationList.push({
-        id: vis.id,
-        name: vis.name,
-        icon: $sce.trustAsHtml(vis.icon),
-        supports: [DefaultDisplayType.TABLE, DefaultDisplayType.NETWORK]
+    // register helium plugin vis packages
+    let visPackages = heliumService.getVisualizationCachedPackages()
+    const visPackageOrder = heliumService.getVisualizationCachedPackageOrder()
+
+    // push the helium vis packages following the order
+    visPackageOrder.map(visName => {
+      visPackages.map(vis => {
+        if (vis.name !== visName) { return }
+        $scope.builtInTableDataVisualizationList.push({
+          id: vis.id,
+          name: vis.name,
+          icon: $sce.trustAsHtml(vis.icon),
+          supports: [DefaultDisplayType.TABLE, DefaultDisplayType.NETWORK]
+        })
+        builtInVisualizations[vis.id] = {
+          class: vis.class
+        }
       })
-      builtInVisualizations[vis.id] = {
-        class: vis.class
-      }
     })
 
     updateData(result, config, paragraph, index)

--- a/zeppelin-web/src/components/helium/helium.service.js
+++ b/zeppelin-web/src/components/helium/helium.service.js
@@ -28,6 +28,7 @@ export default function heliumService ($http, $sce, baseUrlSrv) {
   'ngInject'
 
   let visualizationBundles = []
+  let visualizationPackageOrder = []
   // name `heliumBundles` should be same as `HeliumBundleFactory.HELIUM_BUNDLES_VAR`
   let heliumBundles = []
   // map for `{ magic: interpreter }`
@@ -70,17 +71,23 @@ export default function heliumService ($http, $sce, baseUrlSrv) {
     })
   }
 
-  this.getVisualizationBundles = function () {
+  this.getVisualizationCachedPackages = function () {
     return visualizationBundles
   }
 
+  this.getVisualizationCachedPackageOrder = function () {
+    return visualizationPackageOrder
+  }
+
   /**
-   * @returns {Promise} which returns bundleOrder
+   * @returns {Promise} which returns bundleOrder and cache it in `visualizationPackageOrder`
    */
   this.getVisualizationPackageOrder = function () {
     return $http.get(baseUrlSrv.getRestApiBase() + '/helium/order/visualization')
       .then(function (response, status) {
-        return response.data.body
+        const order = response.data.body
+        visualizationPackageOrder = order
+        return order
       })
       .catch(function (error) {
         console.error('Can not get bundle order', error)
@@ -126,7 +133,6 @@ export default function heliumService ($http, $sce, baseUrlSrv) {
   this.getAllPackageInfo = function () {
     return $http.get(`${baseUrlSrv.getRestApiBase()}/helium/package`)
       .then(function (response, status) {
-        console.warn(Object.keys(response.data.body).length)
         return response.data.body
       })
       .catch(function (error) {
@@ -285,4 +291,11 @@ export default function heliumService ($http, $sce, baseUrlSrv) {
       }
     })
   })
+
+  this.init = function() {
+    this.getVisualizationPackageOrder()
+  }
+
+  // init
+  this.init()
 }


### PR DESCRIPTION
### What is this PR for?

Fixed to respect helium vis order in results.

This PR is written based on https://github.com/apache/zeppelin/pull/2424. Will be rebased after 2760 is handled.

### What type of PR is it?
[Bug Fix]

### Todos
DONE

### What is the Jira issue?

[ZEPPELIN-2670](https://issues.apache.org/jira/browse/ZEPPELIN-2690)

### How should this be tested?

1. Set vis order in `#helium`
2. Open a paragraph containing a table.

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/27524943-a0788edc-5a74-11e7-8fbf-8d5d8f6b3644.png)

#### After

![2690_after](https://user-images.githubusercontent.com/4968473/27525004-0b34ac1a-5a75-11e7-8c9a-6532988297b1.gif)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
