### PR TITLE
[ZEPPELIN-2680] allow opening notebook as a reader

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -249,9 +249,16 @@ public class AuthenticationIT extends AbstractZeppelinIT {
               "//div[contains(.,'Insufficient privileges')]"));
       collector.checkThat("Check is user has permission to view this note", 0,
           CoreMatchers.equalTo(privilegesModal.size()));
-      deleteTestNotebook(driver);
-      authenticationIT.logoutUser("finance2");
 
+      // delete option not available for non-writer/owner
+      collector.checkThat(
+        driver.findElement(
+          By.xpath(".//*[@id='main']//button[@ng-click='moveNoteToTrash(note.id)']")
+        ).isDisplayed(),
+        CoreMatchers.is(false)
+      );
+
+      authenticationIT.logoutUser("finance2");
 
     } catch (Exception e) {
       handleException("Exception in ParagraphActionsIT while testGroupPermission ", e);

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -75,6 +75,7 @@ function HomeCtrl ($scope, noteListDataFactory, websocketMsgSrv, $rootScope, arr
 
       // make it read only
       vm.viewOnly = true
+      vm.reportMode = false
 
       vm.notebookHome = true
       vm.staticHome = false

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -87,7 +87,7 @@ limitations under the License.
          ng-if="currentParagraph.results"
          ng-include src="'app/notebook/paragraph/paragraph.html'"
          ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused}"
-         ng-hide="currentParagraph.config.tableHide && home.viewOnly">
+         ng-hide="currentParagraph.config.tableHide && home.reportMode">
     </div>
   </div>
 

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -34,14 +34,14 @@ limitations under the License.
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="toggleAllEditor()"
-              ng-hide="viewOnly"
+              ng-hide="reportMode"
               tooltip-placement="bottom" uib-tooltip="Show/hide the code"
               ng-disabled="revisionView">
         <i ng-class="editorToggled ?  'fa icon-size-fullscreen' :'fa icon-size-actual'"></i></button>
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="toggleAllTable()"
-              ng-hide="viewOnly"
+              ng-hide="reportMode"
               tooltip-placement="bottom" uib-tooltip="Show/hide the output"
               ng-disabled="revisionView">
         <i ng-class="tableToggled ? 'fa icon-notebook' : 'fa icon-book-open'"></i>
@@ -49,7 +49,7 @@ limitations under the License.
       <button type="button"
               class="btn btn-default btn-xs"
               ng-click="clearAllParagraphOutput(note.id)"
-              ng-hide="viewOnly"
+              ng-hide="viewOnly || reportMode"
               ng-class="{'disabled':isNoteRunning()}"
               tooltip-placement="bottom" uib-tooltip="Clear output"
               ng-disabled="revisionView">
@@ -58,7 +58,7 @@ limitations under the License.
 
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-hide="viewOnly"
+              ng-hide="viewOnly || reportMode"
               tooltip-placement="bottom" uib-tooltip="Clone this note" data-source-note-name="{{note.name}}"
               data-toggle="modal" data-target="#noteNameModal" data-clone="true"
               ng-disabled="revisionView">
@@ -66,7 +66,7 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-hide="viewOnly"
+              ng-hide="reportMode"
               ng-click="exportNote()"
               tooltip-placement="bottom" uib-tooltip="Export this note"
               ng-disabled="revisionView">
@@ -77,7 +77,7 @@ limitations under the License.
               class="btn btn-primary btn-xs"
               ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
-              ng-hide="viewOnly || note.config.personalizedMode !== 'true'"
+              ng-hide="viewOnly || reportMode || note.config.personalizedMode !== 'true'"
               ng-click="toggleNotePersonalizedMode()"
               tooltip-placement="bottom" uib-tooltip="Switch to collaboration mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
@@ -87,7 +87,7 @@ limitations under the License.
               class="btn btn-default btn-xs"
               ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
-              ng-hide="viewOnly || note.config.personalizedMode === 'true'"
+              ng-hide="viewOnly || reportMode || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"
               tooltip-placement="bottom" uib-tooltip="Switch to personal mode {{isOwner ? '' : '(owner can change)'}}"
               ng-disabled="revisionView">
@@ -100,7 +100,7 @@ limitations under the License.
         <button type="button"
                 class="btn btn-default btn-xs dropdown-toggle"
                 id="versionControlDropdown"
-                ng-hide="viewOnly"
+                ng-hide="reportMode"
                 data-toggle="dropdown"
                 tooltip-placement="bottom" uib-tooltip="Version control"
                 ng-disabled="revisionView">
@@ -109,7 +109,7 @@ limitations under the License.
         <button type="button"
                 class="btn btn-default btn-xs"
                 id="setRevision"
-                ng-hide="viewOnly"
+                ng-hide="reportMode"
                 ng-click="setNoteRevision()"
                 ng-disabled="!revisionView"
                 tooltip-placement="bottom" uib-tooltip="Set revision">
@@ -128,7 +128,7 @@ limitations under the License.
                        ng-model="note.checkpoint.message"/>
                 <button type="button"
                         class="btn btn-default btn-xs"
-                        ng-hide="viewOnly"
+                        ng-hide="viewOnly || reportMode"
                         ng-click="checkpointNote(note.checkpoint.message)"
                         style="margin-left: 4px;"
                         tooltip-append-to-body="true"
@@ -171,7 +171,7 @@ limitations under the License.
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
-                ng-hide="viewOnly"
+                ng-hide="viewOnly || reportMode"
                 tooltip-placement="bottom" uib-tooltip="Remove this note permanently"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>
@@ -181,14 +181,14 @@ limitations under the License.
                 type="button"
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"
-                ng-hide="viewOnly"
+                ng-hide="viewOnly || reportMode"
                 tooltip-placement="bottom" uib-tooltip="Move this note to trash"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>
         </button>
       </span>
 
-      <span ng-hide="viewOnly">
+      <span ng-hide="viewOnly || reportMode">
       <div class="labelBtn btn-group">
         <div class="btn btn-default btn-xs dropdown-toggle"
              type="button"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -433,11 +433,15 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
     }
   }
 
+  const isViewOnly = function () {
+    return ($scope.note.config.looknfeel === 'report') || (!$scope.isOwner && !$scope.isWriter)
+  }
+
   const initializeLookAndFeel = function () {
     if (!$scope.note.config.looknfeel) {
       $scope.note.config.looknfeel = 'default'
     } else {
-      $scope.viewOnly = $scope.note.config.looknfeel === 'report' ? true : false
+      $scope.viewOnly = isViewOnly()
     }
 
     if ($scope.note.paragraphs && $scope.note.paragraphs[0]) {
@@ -678,7 +682,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
         minimumInputLength: 3
       }
 
-      $scope.setIamOwner()
+      $scope.setRelationships()
       angular.element('#selectOwners').select2(selectJson)
       angular.element('#selectReaders').select2(selectJson)
       angular.element('#selectWriters').select2(selectJson)
@@ -857,14 +861,14 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
     }
   }
 
-  $scope.setIamOwner = function () {
-    if ($scope.permissions.owners.length > 0 &&
-      _.indexOf($scope.permissions.owners, $rootScope.ticket.principal) < 0) {
-      $scope.isOwner = false
-      return false
-    }
-    $scope.isOwner = true
-    return true
+  $scope.setRelationships = function () {
+    $scope.isOwner = !($scope.permissions.owners.length > 0 &&
+      _.indexOf($scope.permissions.owners, $rootScope.ticket.principal) < 0)
+
+    $scope.isWriter = !($scope.permissions.writers.length > 0 &&
+      _.indexOf($scope.permissions.writers, $rootScope.ticket.principal) < 0)
+
+    $scope.viewOnly = isViewOnly()
   }
 
   $scope.toggleNotePersonalizedMode = function () {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -30,6 +30,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   $scope.editorToggled = false
   $scope.tableToggled = false
   $scope.viewOnly = false
+  $scope.reportMode = false
   $scope.showSetting = false
   $scope.looknfeelOption = ['default', 'simple', 'report']
   $scope.cronOption = [
@@ -151,7 +152,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
 
   $scope.keyboardShortcut = function (keyEvent) {
     // handle keyevent
-    if (!$scope.viewOnly && !$scope.revisionView) {
+    if (!$scope.viewOnly && !$scope.revisionView && !$scope.reportMode) {
       $scope.$broadcast('keyEvent', keyEvent)
     }
   }
@@ -434,14 +435,18 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   }
 
   const isViewOnly = function () {
-    return ($scope.note.config.looknfeel === 'report') || (!$scope.isOwner && !$scope.isWriter)
+    return (!$scope.isOwner && !$scope.isWriter)
+  }
+
+  const isReportMode = function () {
+    return ($scope.note.config.looknfeel === 'report')
   }
 
   const initializeLookAndFeel = function () {
     if (!$scope.note.config.looknfeel) {
       $scope.note.config.looknfeel = 'default'
     } else {
-      $scope.viewOnly = isViewOnly()
+      $scope.reportMode = isReportMode()
     }
 
     if ($scope.note.paragraphs && $scope.note.paragraphs[0]) {

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -114,17 +114,17 @@ limitations under the License.
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
        style="margin: 0; padding: 0;"
        viewport-watch>
-    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe || revisionView">
+    <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="reportMode || viewOnly || asIframe || revisionView">
       <h4 class="plus-sign">&#43;</h4>
     </div>
     <div id="{{currentParagraph.id}}_paragraphColumn"
          ng-include src="'app/notebook/paragraph/paragraph.html'"
          ng-class="{'paragraph-space box paragraph-margin': !asIframe, 'focused': paragraphFocused,
                     'lastEmptyParagraph': !paragraph.text && !paragraph.result}"
-         ng-hide="currentParagraph.config.tableHide && viewOnly"
+         ng-hide="currentParagraph.config.tableHide && reportMode"
          ng-dblclick="paragraphOnDoubleClick(currentParagraph.id);">
     </div>
-    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || asIframe || revisionView">
+    <div class="new-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || reportMode || asIframe || revisionView">
       <h4 class="plus-sign">&#43;</h4>
     </div>
   </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -29,14 +29,14 @@ limitations under the License.
            ng-blur="setTitle(paragraph); input.showEditor = false"
            ng-enter="setTitle(paragraph); input.showEditor = false"
            focus-if="input.showEditor" />
-    <div ng-click="input.showEditor = !asIframe && !viewOnly && !revisionView; oldTitle = paragraph.title;"
+    <div ng-click="input.showEditor = !asIframe && !reportMode && !viewOnly && !revisionView; oldTitle = paragraph.title;"
          ng-show="!input.showEditor"
          ng-bind-html="paragraph.title || 'Untitled'">
     </div>
   </div>
 
   <div>
-    <div ng-if="!paragraph.config.editorHide && !viewOnly" style="margin-bottom:3px;">
+    <div ng-if="!paragraph.config.editorHide && !reportMode" style="margin-bottom:3px;">
       <code-editor
         paragraph-id="paragraph.id"
         paragraph-context="paragraph"
@@ -66,7 +66,7 @@ limitations under the License.
   <div ng-include src="'app/notebook/paragraph/paragraph-control.html'"></div>
 
   <div ng-if="!asIframe" class="paragraphFooter">
-    <div ng-show="!paragraph.config.tableHide && !viewOnly"
+    <div ng-show="!paragraph.config.tableHide && !reportMode"
          id="{{paragraph.id}}_executionTime"
          class="executionTime" ng-bind-html="getExecutionTime(paragraph)">
     </div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.html
@@ -29,7 +29,7 @@ limitations under the License.
            ng-blur="setTitle(paragraph); input.showEditor = false"
            ng-enter="setTitle(paragraph); input.showEditor = false"
            focus-if="input.showEditor" />
-    <div ng-click="input.showEditor = !asIframe && !reportMode && !viewOnly && !revisionView; oldTitle = paragraph.title;"
+    <div ng-click="input.showEditor = !asIframe && !reportMode && !revisionView; oldTitle = paragraph.title;"
          ng-show="!input.showEditor"
          ng-bind-html="paragraph.title || 'Untitled'">
     </div>

--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -46,7 +46,7 @@ limitations under the License.
 </div>
 
 <div id="{{paragraph.id}}_helium"
-     ng-if="(suggestion.available && suggestion.available.length > 0) && !asIframe && !viewOnly"
+     ng-if="(suggestion.available && suggestion.available.length > 0) && !asIframe && !reportMode"
      class="btn-group"
      style="margin-bottom: 10px;">
   <button type="button"
@@ -74,7 +74,7 @@ limitations under the License.
 </div>
 
 <div class="btn-group"
-     ng-if="(type == 'TABLE' || type == 'NETWORK') && !asIframe && !viewOnly"
+     ng-if="(type == 'TABLE' || type == 'NETWORK') && !asIframe && !reportMode"
      style="margin-bottom: 10px;">
   <button type="button" class="btn btn-default btn-sm"
           style="margin-left:10px"
@@ -94,7 +94,7 @@ limitations under the License.
 </div>
 
 <span
-   ng-if="(type == 'TABLE' || type == 'NETWORK') && !config.helium.activeApp && !asIframe && !viewOnly"
+   ng-if="(type == 'TABLE' || type == 'NETWORK') && !config.helium.activeApp && !asIframe && !reportMode"
    style="margin-left:10px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">
   <a class="btnText" ng-click="toggleGraphSetting()">
     settings <span ng-class="config.graph.optionOpen ? 'fa fa-caret-up' : 'fa fa-caret-down'"></span>

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -637,7 +637,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     let newParagraphConfig = angular.copy(paragraph.config)
     newParagraphConfig.results = newParagraphConfig.results || []
     newParagraphConfig.results[resultIndex] = config
-    if ($scope.revisionView === true || $scope.viewOnly) {
+    if ($scope.revisionView || $scope.viewOnly || $scope.reportMode) {
       // local update without commit
       updateData({
         type: $scope.type,

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -637,7 +637,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     let newParagraphConfig = angular.copy(paragraph.config)
     newParagraphConfig.results = newParagraphConfig.results || []
     newParagraphConfig.results[resultIndex] = config
-    if ($scope.revisionView === true) {
+    if ($scope.revisionView === true || $scope.viewOnly) {
       // local update without commit
       updateData({
         type: $scope.type,

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -20,14 +20,14 @@ limitations under the License.
     id="p{{id}}_resize"
     ng-if="!config.helium.activeApp"
     style="padding-bottom: 5px;"
-    resize='{"allowresize": "{{!asIframe && !viewOnly}}", "graphType": "{{type}}"}'
+    resize='{"allowresize": "{{!asIframe && !reportMode}}", "graphType": "{{type}}"}'
     resizable on-resize="resize(width, height);">
 
     <div ng-if="type=='TABLE' || type == 'NETWORK'"
          ng-style="getPointerEvent()">
       <!-- setting -->
       <div class="option lightBold" style="overflow: visible;"
-           ng-show="config.graph.optionOpen && !asIframe && !viewOnly">
+           ng-show="config.graph.optionOpen && !asIframe && !reportMode">
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="trsetting{{id}}_{{viz.id}}"
              ng-show="graphMode == viz.id"></div>


### PR DESCRIPTION
### What is this PR for?

We have a few notebooks that have a list of writers & owners, but no restricted readers list.
When you try to open these notebooks as a reader AND they have a chart the app sends a COMMIT_PARAGRAPH for each, which causes a write permission popup to show ("Insufficient privileges to write note").
I tracked down the issue to the result.controller.js (commitParagraphResult) - propagating the "viewOnly" state fixes that behavior.

### What type of PR is it?
Bug Fix

### How should this be tested?

- Create a notebook. Add a paragraph with a graph. Set the "owner" of the notebook to something other than yourself. You won't be able to load the notebook without the security popup anymore (unless logging in as the owner)

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
