### PR TITLE
[ZEPPELIN-2683] fix: should provide horizontal scrollbar for table

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -51,7 +51,8 @@ const requiredModules = [
   'ui.grid.cellNav', 'ui.grid.pinning',
   'ui.grid.grouping',
   'ui.grid.emptyBaseLayer',
-  'ui.grid.resizeColumns', 'ui.grid.moveColumns',
+  'ui.grid.resizeColumns',
+  'ui.grid.moveColumns',
   'ui.grid.pagination',
   'ui.grid.saveState',
 ]

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -290,6 +290,7 @@ export default class TableVisualization extends Visualization {
         gridApi.grouping.on.groupingChanged(scope, () => { self.persistConfigWithGridState(self.config) })
         gridApi.treeBase.on.rowCollapsed(scope, () => { self.persistConfigWithGridState(self.config) })
         gridApi.treeBase.on.rowExpanded(scope, () => { self.persistConfigWithGridState(self.config) })
+        gridApi.colResizable.on.columnSizeChanged(scope, () => { self.persistConfigWithGridState(self.config) });
 
         // pagination doesn't follow usual life-cycle in ui-grid v4.0.4
         // gridApi.pagination.on.paginationChanged(scope, () => { self.persistConfigWithGridState(self.config) })

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -63,6 +63,16 @@ export default class TableVisualization extends Visualization {
     initializeTableConfig(config, TABLE_OPTION_SPECS)
   }
 
+  getColumnMinWidth(colName) {
+    let width = 150 // default
+    const calculatedWidth = colName.length * 10
+
+    // use the broad one
+    if (calculatedWidth > width) { width = calculatedWidth }
+
+    return width
+  }
+
   createGridOptions(tableData, onRegisterApiCallback, config) {
     const rows = tableData.rows
     const columnNames = tableData.columns.map(c => c.name)
@@ -99,6 +109,8 @@ export default class TableVisualization extends Visualization {
                  class="ui-grid-cell-contents">
             </div>
           `,
+          minWidth: this.getColumnMinWidth(colName),
+          width: '*',
         }
       }),
       rowEditWaitInterval: -1, /** disable saveRow event */
@@ -245,7 +257,8 @@ export default class TableVisualization extends Visualization {
               ui-grid-selection
               ui-grid-cellNav ui-grid-pinning
               ui-grid-empty-base-layer
-              ui-grid-resize-columns ui-grid-move-columns
+              ui-grid-resize-columns 
+              ui-grid-move-columns
               ui-grid-grouping
               ui-grid-save-state
               ui-grid-exporter></div>`)

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -290,7 +290,7 @@ export default class TableVisualization extends Visualization {
         gridApi.grouping.on.groupingChanged(scope, () => { self.persistConfigWithGridState(self.config) })
         gridApi.treeBase.on.rowCollapsed(scope, () => { self.persistConfigWithGridState(self.config) })
         gridApi.treeBase.on.rowExpanded(scope, () => { self.persistConfigWithGridState(self.config) })
-        gridApi.colResizable.on.columnSizeChanged(scope, () => { self.persistConfigWithGridState(self.config) });
+        gridApi.colResizable.on.columnSizeChanged(scope, () => { self.persistConfigWithGridState(self.config) })
 
         // pagination doesn't follow usual life-cycle in ui-grid v4.0.4
         // gridApi.pagination.on.paginationChanged(scope, () => { self.persistConfigWithGridState(self.config) })


### PR DESCRIPTION
### What is this PR for?

fixed to use a more broad column width (150+)

- the default width is 150
- if column.length * 10 > 150, use it

additionally, I tried [ui-grid-auto-fit-columns](https://www.npmjs.com/package/ui-grid-auto-fit-columns) but doesn't work.

### What type of PR is it?
[Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2583](https://issues.apache.org/jira/browse/ZEPPELIN-2683)

### How should this be tested?

Execute these paragraphs sequentially

```scala
%spark

import org.apache.commons.io.IOUtils
import java.net.URL
import java.nio.charset.Charset

// Zeppelin creates and injects sc (SparkContext) and sqlContext (HiveContext or SqlContext)
// So you don't need create them manually

// load bank data
val bankText = sc.parallelize(
    IOUtils.toString(
        new URL("https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv"),
        Charset.forName("utf8")).split("\n"))

case class Bank(
    age: Integer, 
    job: String, 
    marital: String, 
    education: String, 
    balance: Integer,
    housing: String,
    loan: String,
    contact: String,
    day: Int,
    month: String,
    duration: Int,
    campaign: String,
    pdays: Int,
    previous: Int,
    poutcome: String,
    y: String
)

val bank = bankText.map(s => s.split(";")).filter(s => s(0) != "\"age\"").map(
    s => Bank(s(0).toInt, 
        s(1).replaceAll("\"", ""),
        s(2).replaceAll("\"", ""),
        s(3).replaceAll("\"", ""),
        s(5).replaceAll("\"", "").toInt,
        s(6).replaceAll("\"", ""),
        s(7).replaceAll("\"", ""),
        s(8).replaceAll("\"", ""),
        s(9).replaceAll("\"", "").toInt,
        s(10).replaceAll("\"", ""),
        s(11).replaceAll("\"", "").toInt,
        s(12).replaceAll("\"", ""),
        s(13).replaceAll("\"", "").toInt,            
        s(14).replaceAll("\"", "").toInt,            
        s(15).replaceAll("\"", ""),
        s(16).replaceAll("\"", "")
    )
).toDF()

bank.registerTempTable("bank")
```

```sql
%sql

select 
    age as age,
    job as job,
    marital as marital_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    education as education_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    balance as balance_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    housing as housing_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    loan as loan_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    contact as contact_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    day as days_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    month as month_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    duration as duration_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    campaign as compaign_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    pdays as pdays_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    previous as previous_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    poutcome as poutcome_ABCDEFGHIJKLMNOPQRSTUVWXYZ,
    y as y_ABCDEFGHIJKLMNOPQRSTUVWXYZ
    
from bank
```

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/27570401-cde9ad78-5b38-11e7-9165-c6148c5b2137.png)

#### After

![2683_after](https://user-images.githubusercontent.com/4968473/27570484-8b9401de-5b39-11e7-9414-75af9a73bc2f.gif)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
