### PR TITLE
[ZEPPELIN-2691] fix: should display setting for table

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -94,7 +94,7 @@ limitations under the License.
 </div>
 
 <span
-   ng-if="(type == 'TABLE' || type == 'NETWORK') && !config.helium.activeApp && graphMode!='table' && !asIframe && !viewOnly"
+   ng-if="(type == 'TABLE' || type == 'NETWORK') && !config.helium.activeApp && !asIframe && !viewOnly"
    style="margin-left:10px; cursor:pointer; display: inline-block; vertical-align:top; position: relative; line-height:30px;">
   <a class="btnText" ng-click="toggleGraphSetting()">
     settings <span ng-class="config.graph.optionOpen ? 'fa fa-caret-up' : 'fa fa-caret-down'"></span>


### PR DESCRIPTION
### What is this PR for?

The table has few settings, but currently, the menu is not displayed. 

I attached screenshots for comparison.

### What type of PR is it?
[Bug Fix]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2691](https://issues.apache.org/jira/browse/ZEPPELIN-2691)

### How should this be tested?

Create a table result and check whether `setting` menu is displayed or not.

```scala
print("%table a\tb\n1\t2")
```

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/27583766-74e42c70-5b70-11e7-9cb7-537f40f1b699.png)

#### After

![image](https://user-images.githubusercontent.com/4968473/27583753-6accc828-5b70-11e7-85f2-c71e53bbda80.png)


### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
