### PR TITLE
[ZEPPELIN-2707][DOCS][HOTFIX] fix: broken image URLs in 0.8.0-SNAPSHOT doc

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -9,7 +9,7 @@
           </button>
           <div class="navbar-brand">
             <a class="navbar-brand-main" href="{{site.production_url}}">
-              <img src="/assets/themes/zeppelin/img/zeppelin_logo.png" width="50"
+              <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/zeppelin_logo.png" width="50"
                    style="margin-top: -2px;" alt="I'm zeppelin">
               <span style="margin-left: 5px; font-size: 27px;">Zeppelin</span>
               <a class="navbar-brand-version" href="{{BASE_PATH}}"

--- a/docs/development/helium/writing_spell.md
+++ b/docs/development/helium/writing_spell.md
@@ -47,14 +47,14 @@ Helium Spell works like [Helium Visualization](./writing_visualization_basic.htm
 
 Find a spell what you want to use in `/helium` package and click `Enable` button.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_spell_registered.png" />
+<img class="img-responsive" style="width:70%" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/writing_spell_registered.png" />
 
 ### 2. Using
 
 Spell works like an interpreter. Use the `MAGIC` value to execute spell in a note. (you might need to refresh after enabling)
 For example, Use `%echo` for the Echo Spell.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_spell_using.gif" />
+<img class="img-responsive" style="width:70%" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/writing_spell_using.gif" />
 
 
 ## Write a new Spell

--- a/docs/development/helium/writing_visualization_basic.md
+++ b/docs/development/helium/writing_visualization_basic.md
@@ -41,7 +41,7 @@ Once Zeppelin loads _Helium package files_ from registries, available packages a
 
 Click 'enable' button.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_visualization_helium_menu.png" />
+<img class="img-responsive" style="width:70%" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/writing_visualization_helium_menu.png" />
 
 
 #### 3. Create and load visualization bundle on the fly
@@ -53,7 +53,7 @@ Once a Visualization package is enabled, [HeliumBundleFactory](https://github.co
 Zeppelin shows additional button for loaded Visualizations.
 User can use just like any other built-in visualizations.
 
-<img class="img-responsive" style="width:70%" src="/assets/themes/zeppelin/img/docs-img/writing_visualization_example.png" />
+<img class="img-responsive" style="width:70%" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/writing_visualization_example.png" />
 
 
 

--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -29,7 +29,7 @@ Apache Zeppelin Interpreter is a language backend. For example to use scala code
 Every Interpreters belongs to an **InterpreterGroup**.
 Interpreters in the same InterpreterGroup can reference each other. For example, SparkSqlInterpreter can reference SparkInterpreter to get SparkContext from it while they're in the same group.
 
-<img class="img-responsive" style="width:50%; border: 1px solid #ecf0f1;" height="auto" src="/assets/themes/zeppelin/img/interpreter.png" />
+<img class="img-responsive" style="width:50%; border: 1px solid #ecf0f1;" height="auto" src="{{BASE_PATH}}/assets/themes/zeppelin/img/interpreter.png" />
 
 [InterpreterSetting](https://github.com/apache/zeppelin/blob/master/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java) is configuration of a given [InterpreterGroup](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterGroup.java) and a unit of start/stop interpreter.
 All Interpreters in the same InterpreterSetting are launched in a single, separate JVM process. The Interpreter communicates with Zeppelin engine via **[Thrift](https://github.com/apache/zeppelin/blob/master/zeppelin-interpreter/src/main/thrift/RemoteInterpreterService.thrift)**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ limitations under the License.
   </div>
   <div class="col-sm-6 col-md-6" style="padding:0;">
     <div class="hidden-xs" style="margin-top: 60px;"></div>
-    <img class="img-responsive" style="border: 1px solid #ecf0f1;" src="/assets/themes/zeppelin/img/notebook.png" />
+    <img class="img-responsive" style="border: 1px solid #ecf0f1;" src="{{BASE_PATH}}/assets/themes/zeppelin/img/notebook.png" />
   </div>
 </div>
 

--- a/docs/interpreter/alluxio.md
+++ b/docs/interpreter/alluxio.md
@@ -246,5 +246,5 @@ Following steps are performed:
 *  using sh interpreter it's checked the existence of the new file copied from Alluxio and its content is showed
 
 <center>
-  ![Alluxio Interpreter Example](/assets/themes/zeppelin/img/docs-img/alluxio-example.png)
+  ![Alluxio Interpreter Example]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/alluxio-example.png)
 </center>

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -41,9 +41,9 @@ limitations under the License.
 In a notebook, to enable the **Cassandra** interpreter, click on the **Gear** icon and select **Cassandra**
 
  <center>
- ![Interpreter Binding](/assets/themes/zeppelin/img/docs-img/cassandra-InterpreterBinding.png)
+ ![Interpreter Binding]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cassandra-InterpreterBinding.png)
 
- ![Interpreter Selection](/assets/themes/zeppelin/img/docs-img/cassandra-InterpreterSelection.png)
+ ![Interpreter Selection]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cassandra-InterpreterSelection.png)
  </center>
 
 ## Using the Cassandra Interpreter
@@ -53,7 +53,7 @@ In a paragraph, use **_%cassandra_** to select the **Cassandra** interpreter and
 To access the interactive help, type **HELP;**
 
  <center>
-   ![Interactive Help](/assets/themes/zeppelin/img/docs-img/cassandra-InteractiveHelp.png)
+   ![Interactive Help]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cassandra-InteractiveHelp.png)
  </center>
 
 ## Interpreter Commands
@@ -312,7 +312,7 @@ The schema objects (cluster, keyspace, table, type, function and aggregate) are 
 There is a drop-down menu on the top left corner to expand objects details. On the top right menu is shown the Icon legend.
 
 <center>
-  ![Describe Schema](/assets/themes/zeppelin/img/docs-img/cassandra-DescribeSchema.png)
+  ![Describe Schema]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cassandra-DescribeSchema.png)
 </center>
 
 ## Runtime Parameters

--- a/docs/interpreter/elasticsearch.md
+++ b/docs/interpreter/elasticsearch.md
@@ -73,7 +73,7 @@ It is generally used as the underlying engine/technology that powers application
 </table>
 
 <center>
-  ![Interpreter configuration](/assets/themes/zeppelin/img/docs-img/elasticsearch-config.png)
+  ![Interpreter configuration]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-config.png)
 </center>
 
 > **Note #1 :** You can add more properties to configure the Elasticsearch client.
@@ -121,7 +121,7 @@ get /index/type/id
 ```
 
 Example:
-![Elasticsearch - Get](/assets/themes/zeppelin/img/docs-img/elasticsearch-get.png)
+![Elasticsearch - Get]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-get.png)
 
 ### Search
 With the `search` command, you can send a search query to Elasticsearch. There are two formats of query:
@@ -206,25 +206,25 @@ content_length | date | request.headers[0] | request.headers[1] | request.method
 Examples:
 
 * With a table containing the results:
-![Elasticsearch - Search - table](/assets/themes/zeppelin/img/docs-img/elasticsearch-search-table.png)
+![Elasticsearch - Search - table]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-search-table.png)
 
 * You can also use a predefined diagram:
-![Elasticsearch - Search - diagram](/assets/themes/zeppelin/img/docs-img/elasticsearch-search-pie.png)
+![Elasticsearch - Search - diagram]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-search-pie.png)
 
 * With a JSON query:
-![Elasticsearch - Search with query](/assets/themes/zeppelin/img/docs-img/elasticsearch-search-json-query-table.png)
+![Elasticsearch - Search with query]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-search-json-query-table.png)
 
 * With a JSON query containing a `fields` parameter (for filtering the fields in the response): in this case, all the fields values in the response are arrays, so, after flattening the result, the format of all the field names is `field_name[x]`
-![Elasticsearch - Search with query and a fields param](/assets/themes/zeppelin/img/docs-img/elasticsearch-query-with-fields-param.png)
+![Elasticsearch - Search with query and a fields param]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-query-with-fields-param.png)
 
 * With a query string:
-![Elasticsearch - Search with query string](/assets/themes/zeppelin/img/docs-img/elasticsearch-query-string.png)
+![Elasticsearch - Search with query string]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-query-string.png)
 
 * With a query containing a multi-value metric aggregation:
-![Elasticsearch - Search with aggregation (multi-value metric)](/assets/themes/zeppelin/img/docs-img/elasticsearch-agg-multi-value-metric.png)
+![Elasticsearch - Search with aggregation (multi-value metric)]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-agg-multi-value-metric.png)
 
 * With a query containing a multi-bucket aggregation:
-![Elasticsearch - Search with aggregation (multi-bucket)](/assets/themes/zeppelin/img/docs-img/elasticsearch-agg-multi-bucket-pie.png)
+![Elasticsearch - Search with aggregation (multi-bucket)]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-agg-multi-bucket-pie.png)
 
 ### Count
 With the `count` command, you can count documents available in some indices and types. You can also provide a query.
@@ -237,10 +237,10 @@ count /index1,index2,.../type1,type2,... <JSON document containing the query OR 
 Examples:
 
 * Without query:
-![Elasticsearch - Count](/assets/themes/zeppelin/img/docs-img/elasticsearch-count.png)
+![Elasticsearch - Count]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-count.png)
 
 * With a query:
-![Elasticsearch - Count with query](/assets/themes/zeppelin/img/docs-img/elasticsearch-count-with-query.png)
+![Elasticsearch - Count with query]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/elasticsearch-count-with-query.png)
 
 ### Index
 With the `index` command, you can insert/update a document in Elasticsearch.

--- a/docs/interpreter/ignite.md
+++ b/docs/interpreter/ignite.md
@@ -26,7 +26,7 @@ limitations under the License.
 ## Overview
 [Apache Ignite](https://ignite.apache.org/) In-Memory Data Fabric is a high-performance, integrated and distributed in-memory platform for computing and transacting on large-scale data sets in real-time, orders of magnitude faster than possible with traditional disk-based or flash technologies.
 
-![Apache Ignite](/assets/themes/zeppelin/img/docs-img/ignite-logo.png)
+![Apache Ignite]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-logo.png)
 
 You can use Zeppelin to retrieve distributed data from cache using Ignite SQL interpreter. Moreover, Ignite interpreter allows you to execute any Scala code in cases when SQL doesn't fit to your requirements. For example, you can populate data into your caches or execute distributed computations.
 
@@ -82,12 +82,12 @@ At the "Interpreters" menu, you may edit Ignite interpreter or create new one. Z
   </tr>
 </table>
 
-![Configuration of Ignite Interpreter](/assets/themes/zeppelin/img/docs-img/ignite-interpreter-setting.png)
+![Configuration of Ignite Interpreter]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-interpreter-setting.png)
 
 ## How to use
 After configuring Ignite interpreter, create your own notebook. Then you can bind interpreters like below image.
 
-![Binding Interpreters](/assets/themes/zeppelin/img/docs-img/ignite-interpreter-binding.png)
+![Binding Interpreters]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-interpreter-binding.png)
 
 For more interpreter binding information see [here](../usage/interpreter/overview.html#what-is-interpreter-setting).
 
@@ -101,7 +101,7 @@ For example, you can select top 10 words in the words cache using the following 
 select _val, count(_val) as cnt from String group by _val order by cnt desc limit 10
 ```
 
-![IgniteSql on Zeppelin](/assets/themes/zeppelin/img/docs-img/ignite-sql-example.png)
+![IgniteSql on Zeppelin]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-sql-example.png)
 
 As long as your Ignite version and Zeppelin Ignite version is same, you can also use scala code. Please check the Zeppelin Ignite version before you download your own Ignite.
 
@@ -123,6 +123,6 @@ val res = cache.query(qry).getAll()
 collectionAsScalaIterable(res).foreach(println _)
 ```
 
-![Using Scala Code](/assets/themes/zeppelin/img/docs-img/ignite-scala-example.png)
+![Using Scala Code]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-scala-example.png)
 
 Apache Ignite also provides a guide docs for Zeppelin ["Ignite with Apache Zeppelin"](https://apacheignite.readme.io/docs/data-analysis-with-apache-zeppelin)

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -33,7 +33,7 @@ By now, it has been tested with:
 
 <div class="row" style="margin: 30px auto;">
   <div class="col-md-6">
-    <img src="/assets/themes/zeppelin/img/docs-img/tested_databases.png" width="300px"/>
+    <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/tested_databases.png" width="300px"/>
   </div>
   <div class="col-md-6">
     <li style="padding-bottom: 5px; list-style: circle">
@@ -76,13 +76,13 @@ If you are using other databases not in the above list, please feel free to shar
 
 First, click `+ Create` button at the top-right corner in the interpreter setting page.
 
-<img src="/assets/themes/zeppelin/img/docs-img/click_create_button.png" width="600px"/>
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/click_create_button.png" width="600px"/>
 
 Fill `Interpreter name` field with whatever you want to use as the alias(e.g. mysql, mysql2, hive, redshift, and etc..). 
 Please note that this alias will be used as `%interpreter_name` to call the interpreter in the paragraph. 
 Then select `jdbc` as an `Interpreter group`. 
 
-<img src="/assets/themes/zeppelin/img/docs-img/select_name_and_group.png" width="200px"/>
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/select_name_and_group.png" width="200px"/>
 
 The default driver of JDBC interpreter is set as `PostgreSQL`. It means Zeppelin includes `PostgreSQL` driver jar in itself.
 So you don't need to add any dependencies(e.g. the artifact name or path for `PostgreSQL` driver jar) for `PostgreSQL` connection.
@@ -148,11 +148,11 @@ the JDBC interpreter will get the account information from [Credential](../setup
 
 The below example is for `Mysql` connection.
 
-<img src="/assets/themes/zeppelin/img/docs-img/edit_properties.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/edit_properties.png" width="600px" />
 
 The last step is **Dependency Setting**. Since Zeppelin only includes `PostgreSQL` driver jar by default, you need to add each driver's maven coordinates or JDBC driver's jar file path for the other databases.
 
-<img src="/assets/themes/zeppelin/img/docs-img/edit_dependencies.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/edit_dependencies.png" width="600px" />
 
 That's it. You can find more JDBC connection setting examples([Mysql](#mysql), [MariaDB](#mariadb), [Redshift](#redshift), [Apache Hive](#apache-hive), [Apache Phoenix](#apache-phoenix), and [Apache Tajo](#apache-tajo)) in [this section](#examples).
 
@@ -211,13 +211,13 @@ For example, if a connection needs a schema parameter, it would have to add the 
 ## Binding JDBC interpter to notebook
 To bind the interpreters created in the interpreter setting page, click the gear icon at the top-right corner.
 
-<img src="/assets/themes/zeppelin/img/docs-img/click_interpreter_binding_button.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/click_interpreter_binding_button.png" width="600px" />
 
 Select(blue) or deselect(white) the interpreter buttons depending on your use cases.
 If you need to use more than one interpreter in the notebook, activate several buttons.
 Don't forget to click `Save` button, or you will face `Interpreter *** is not found` error.
 
-<img src="/assets/themes/zeppelin/img/docs-img/jdbc_interpreter_binding.png" width="550px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/jdbc_interpreter_binding.png" width="550px" />
 
 ## How to use
 ### Run the paragraph with JDBC interpreter
@@ -230,7 +230,7 @@ show databases
 If the paragraph is `FINISHED` without any errors, a new paragraph will be automatically added after the previous one with `%jdbc_interpreter_name`.
 So you don't need to type this prefix in every paragraphs' header.
 
-<img src="/assets/themes/zeppelin/img/docs-img/run_paragraph_with_jdbc.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/run_paragraph_with_jdbc.png" width="600px" />
 
 ### Apply Zeppelin Dynamic Forms
 
@@ -317,7 +317,7 @@ Here are some examples you can refer to. Including the below connectors, you can
 
 ### Postgres
 
-<img src="/assets/themes/zeppelin/img/docs-img/postgres_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/postgres_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -361,7 +361,7 @@ Here are some examples you can refer to. Including the below connectors, you can
 
 ### Mysql
 
-<img src="/assets/themes/zeppelin/img/docs-img/mysql_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/mysql_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -405,7 +405,7 @@ Here are some examples you can refer to. Including the below connectors, you can
 
 ### MariaDB
 
-<img src="/assets/themes/zeppelin/img/docs-img/mariadb_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/mariadb_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -449,7 +449,7 @@ Here are some examples you can refer to. Including the below connectors, you can
 
 ### Redshift
 
-<img src="/assets/themes/zeppelin/img/docs-img/redshift_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/redshift_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -493,7 +493,7 @@ Here are some examples you can refer to. Including the below connectors, you can
 
 ### Apache Hive
 
-<img src="/assets/themes/zeppelin/img/docs-img/hive_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/hive_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -596,7 +596,7 @@ Use the appropriate `default.driver`, `default.url`, and the dependency artifact
 
 #### Thick client connection
 
-<img src="/assets/themes/zeppelin/img/docs-img/phoenix_thick_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/phoenix_thick_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -638,7 +638,7 @@ Use the appropriate `default.driver`, `default.url`, and the dependency artifact
 
 #### Thin client connection
 
-<img src="/assets/themes/zeppelin/img/docs-img/phoenix_thin_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/phoenix_thin_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">
@@ -690,7 +690,7 @@ Before Adding one of the below dependencies, check the Phoenix version first.
 
 ### Apache Tajo
 
-<img src="/assets/themes/zeppelin/img/docs-img/tajo_setting.png" width="600px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/tajo_setting.png" width="600px" />
 
 ##### Properties
 <table class="table-configuration">

--- a/docs/interpreter/lens.md
+++ b/docs/interpreter/lens.md
@@ -26,7 +26,7 @@ limitations under the License.
 ## Overview
 [Apache Lens](https://lens.apache.org/) provides an Unified Analytics interface. Lens aims to cut the Data Analytics silos by providing a single view of data across multiple tiered data stores and optimal execution environment for the analytical query. It seamlessly integrates Hadoop with traditional data warehouses to appear like one.
 
-![Apache Lens](/assets/themes/zeppelin/img/docs-img/lens-logo.png)
+![Apache Lens]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/lens-logo.png)
 
 ## Installing and Running Lens
 In order to use Lens interpreters, you may install Apache Lens in some simple steps:
@@ -90,12 +90,12 @@ At the "Interpreters" menu, you can edit Lens interpreter or create new one. Zep
   </tr>
 </table>
 
-![Apache Lens Interpreter Setting](/assets/themes/zeppelin/img/docs-img/lens-interpreter-setting.png)
+![Apache Lens Interpreter Setting]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/lens-interpreter-setting.png)
 
 ### Interpreter Binding for Zeppelin Notebook
 After configuring Lens interpreter, create your own notebook, then you can bind interpreters like below image.
 
-![Zeppelin Notebook Interpreter Binding](/assets/themes/zeppelin/img/docs-img/lens-interpreter-binding.png)
+![Zeppelin Notebook Interpreter Binding]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/lens-interpreter-binding.png)
 
 For more interpreter binding information see [here](../usage/interpreter/overview.html#interpreter-binding-mode).
 
@@ -174,11 +174,11 @@ fact add partitions --fact_name sales_raw_fact --storage_name local --path your/
 query execute cube select customer_city_name, product_details.description, product_details.category, product_details.color, store_sales from sales where time_range_in(delivery_time, '2015-04-11-00', '2015-04-13-00')
 ```
 
-![Lens Query Result](/assets/themes/zeppelin/img/docs-img/lens-result.png)
+![Lens Query Result]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/lens-result.png)
 
 These are just examples that provided in advance by Lens. If you want to explore whole tutorials of Lens, see the [tutorial video](https://cwiki.apache.org/confluence/display/LENS/2015/07/13/20+Minute+video+demo+of+Apache+Lens+through+examples).
 
 ## Lens UI Service
 Lens also provides web UI service. Once the server starts up, you can open the service on http://serverhost:19999/index.html and browse. You may also check the structure that you made and use query easily here.
 
-![Lens UI Service](/assets/themes/zeppelin/img/docs-img/lens-ui-service.png)
+![Lens UI Service]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/lens-ui-service.png)

--- a/docs/interpreter/markdown.md
+++ b/docs/interpreter/markdown.md
@@ -31,13 +31,13 @@ In Zeppelin notebook, you can use ` %md ` in the beginning of a paragraph to inv
 
 In Zeppelin, Markdown interpreter is enabled by default and uses the [pegdown](https://github.com/sirthias/pegdown) parser.
 
-<img src="/assets/themes/zeppelin/img/docs-img/markdown-interpreter-setting.png" width="60%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-interpreter-setting.png" width="60%" />
 
 ## Example
 
 The following example demonstrates the basic usage of Markdown in a Zeppelin notebook.
 
-<img src="/assets/themes/zeppelin/img/docs-img/markdown-example.png" width="70%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-example.png" width="70%" />
 
 ## Mathematical expression
 
@@ -63,11 +63,11 @@ For more information, please see [Mathematical Expression](../usage/display_syst
 
 `pegdown` parser provides github flavored markdown.
 
-<img src="/assets/themes/zeppelin/img/docs-img/markdown-example-pegdown-parser.png" width="70%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-example-pegdown-parser.png" width="70%" />
 
 `pegdown` parser provides [YUML](http://yuml.me/) and [Websequence](https://www.websequencediagrams.com/) plugins also. 
 
-<img src="/assets/themes/zeppelin/img/docs-img/markdown-example-pegdown-parser-plugins.png" width="70%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/markdown-example-pegdown-parser-plugins.png" width="70%" />
 
 ### Markdown4j Parser
 

--- a/docs/interpreter/pig.md
+++ b/docs/interpreter/pig.md
@@ -145,7 +145,7 @@ foreach b generate group, COUNT($1) as count;
 
 The above examples are in the Pig tutorial note in Zeppelin, you can check that for details. Here's the screenshot.
 
-<img class="img-responsive" width="1024px" style="margin:0 auto; padding: 26px;" src="/assets/themes/zeppelin/img/pig_zeppelin_tutorial.png" />
+<img class="img-responsive" width="1024px" style="margin:0 auto; padding: 26px;" src="{{BASE_PATH}}/assets/themes/zeppelin/img/pig_zeppelin_tutorial.png" />
 
 
 Data is shared between `%pig` and `%pig.query`, so that you can do some common work in `%pig`, 

--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -186,7 +186,7 @@ The `z.show()` function can take optional parameters to adapt graph dimensions (
 z.show(plt, width='50px')
 z.show(plt, height='150px', fmt='svg')
 ```
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/pythonMatplotlib.png" />
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/pythonMatplotlib.png" />
 
 
 ## Pandas integration

--- a/docs/interpreter/r.md
+++ b/docs/interpreter/r.md
@@ -69,23 +69,23 @@ By default, the R Interpreter appears as two Zeppelin Interpreters, `%r` and `%k
 
 `%r` will behave like an ordinary REPL.  You can execute commands as in the CLI.   
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/repl2plus2.png" width="700px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/repl2plus2.png" width="700px"/>
 
 R base plotting is fully supported
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/replhist.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/replhist.png" width="550px"/>
 
 If you return a data.frame, Zeppelin will attempt to display it using Zeppelin's built-in visualizations.
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/replhead.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/replhead.png" width="550px"/>
 
 `%knitr` interfaces directly against `knitr`, with chunk options on the first line:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/knitgeo.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/knitgeo.png" width="550px"/>
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/knitstock.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/knitstock.png" width="550px"/>
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/knitmotion.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/knitmotion.png" width="550px"/>
 
 The two interpreters share the same environment.  If you define a variable from `%r`, it will be within-scope if you then make a call using `knitr`.
 
@@ -93,23 +93,23 @@ The two interpreters share the same environment.  If you define a variable from 
 
 If `SPARK_HOME` is set, the `SparkR` package will be loaded automatically:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/sparkrfaithful.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/sparkrfaithful.png" width="550px"/>
 
 The Spark Context and SQL Context are created and injected into the local environment automatically as `sc` and `sql`.
 
 The same context are shared with the `%spark`, `%sql` and `%pyspark` interpreters:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/backtoscala.png" width="700px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/backtoscala.png" width="700px"/>
 
 You can also make an ordinary R variable accessible in scala and Python:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/varr1.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/varr1.png" width="550px"/>
 
 And vice versa:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/varscala.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/varscala.png" width="550px"/>
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/varr2.png" width="550px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/varr2.png" width="550px"/>
 
 ## Caveats & Troubleshooting
 

--- a/docs/interpreter/scalding.md
+++ b/docs/interpreter/scalding.md
@@ -37,9 +37,9 @@ In a notebook, to enable the **Scalding** interpreter, click on the **Gear** ico
 
 <center>
 
-![Interpreter Binding](/assets/themes/zeppelin/img/docs-img/scalding-InterpreterBinding.png)
+![Interpreter Binding]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/scalding-InterpreterBinding.png)
 
-![Interpreter Selection](/assets/themes/zeppelin/img/docs-img/scalding-InterpreterSelection.png)
+![Interpreter Selection]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/scalding-InterpreterSelection.png)
 
 </center>
 
@@ -124,7 +124,7 @@ print("%table " + table)
 ```
 
 If you click on the icon for the pie chart, you should be able to see a chart like this:
-![Scalding - Pie - Chart](/assets/themes/zeppelin/img/docs-img/scalding-pie.png)
+![Scalding - Pie - Chart]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/scalding-pie.png)
 
 
 ### HDFS mode

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -63,7 +63,7 @@ At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property v
 ## Example
 The following example demonstrates the basic usage of Shell in a Zeppelin notebook.
 
-<img src="/assets/themes/zeppelin/img/docs-img/shell-example.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-example.png" />
 
 If you need further information about **Zeppelin Interpreter Setting** for using Shell interpreter, 
 please read [What is interpreter setting?](../usage/interpreter/overview.html#what-is-interpreter-setting) section first.

--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -398,7 +398,7 @@ a popular plotting library for python. More details can be found in the [python 
 since matplotlib support is identical. More advanced interactive plotting can be done with pyspark through 
 utilizing Zeppelin's built-in [Angular Display System](../usage/display_system/angular_backend.html), as shown below:
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/matplotlibAngularExample.gif" />
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/matplotlibAngularExample.gif" />
 
 ## Interpreter setting option
 
@@ -410,7 +410,7 @@ It creates separated SparkContext per each notebook in `isolated` mode.
 ## Setting up Zeppelin with Kerberos
 Logical setup with Zeppelin, Kerberos Key Distribution Center (KDC), and Spark on YARN:
 
-<img src="/assets/themes/zeppelin/img/docs-img/kdc_zeppelin.png">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/kdc_zeppelin.png">
 
 ### Configuration Setup
 

--- a/docs/quickstart/explore_ui.md
+++ b/docs/quickstart/explore_ui.md
@@ -27,19 +27,19 @@ limitations under the License.
 
 The first time you connect to Zeppelin ([default installations start on http://localhost:8080](http://localhost:8080/)), you'll land at the main page similar to the below screen capture.
 
-<img src="/assets/themes/zeppelin/img/ui-img/homepage.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/homepage.png" />
 
 On the left of the page are listed all existing notes. Those notes are stored by default in the `$ZEPPELIN_HOME/notebook` folder.
 
 You can filter them by name using the input text form. You can also create a new note, refresh the list of existing notes
 (in case you manually copy them into the `$ZEPPELIN_HOME/notebook` folder) and import a note.
 
-<img src="/assets/themes/zeppelin/img/ui-img/notes_management.png" width="230px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/notes_management.png" width="230px" />
 
 When clicking on `Import Note` link, a new dialog open. From there you can import your note from local disk or from a remote location
 if you provide the URL.
 
-<img src="/assets/themes/zeppelin/img/ui-img/note_import_dialog.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/note_import_dialog.png" />
 
 By default, the name of the imported note is the same as the original note but you can override it by providing a new name.
 
@@ -54,18 +54,18 @@ The `Notebook` menu proposes almost the same features as the note management sec
 2. Filter node by name
 3. Create a new note
 
-<img src="/assets/themes/zeppelin/img/ui-img/notebook_menu.png" width="170px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/notebook_menu.png" width="170px" />
 
 ### Settings
 This menu gives you access to settings and displays information about Zeppelin. User name is set to `anonymous` if you use default shiro configuration. If you want to set up authentification, see [Shiro Authentication](../setup/security/shiro_authentication.html).
 
-<img src="/assets/themes/zeppelin/img/ui-img/settings_menu.png" width="170px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/settings_menu.png" width="170px" />
 
 #### About Zeppelin
 
 You can check Zeppelin version in this menu.
 
-<img src="/assets/themes/zeppelin/img/ui-img/about_menu.png" width="450px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/about_menu.png" width="450px" />
 
 #### Interpreter
 
@@ -74,19 +74,19 @@ In this menu you can:
 1. Configure existing **interpreter instance**
 2. Add/remove **interpreter instances**
 
-<img src="/assets/themes/zeppelin/img/ui-img/interpreter_menu.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/interpreter_menu.png" />
 
 #### Credential
 
 This menu allows you to save credentials for data sources which are passed to interpreters.
 
-<img src="/assets/themes/zeppelin/img/ui-img/credential_menu.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/credential_menu.png" />
 
 #### Configuration
 
 This menu displays all the Zeppelin configuration that are set in the config file `$ZEPPELIN_HOME/conf/zeppelin-site.xml`
 
-<img src="/assets/themes/zeppelin/img/ui-img/configuration_menu.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/configuration_menu.png" />
 
 
 <br />
@@ -94,13 +94,13 @@ This menu displays all the Zeppelin configuration that are set in the config fil
 
 Each Zeppelin note is composed of 1 .. N paragraphs. The note can be viewed as a paragraph container.
 
-<img src="/assets/themes/zeppelin/img/ui-img/note_paragraph_layout.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/note_paragraph_layout.png" />
 
 ### Paragraph
 
 Each paragraph consists of 2 sections: `code section` where you put your source code and `result section` where you can see the result of the code execution.
 
-<img src="/assets/themes/zeppelin/img/ui-img/paragraph_layout.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/paragraph_layout.png" />
 
 On the top-right corner of each paragraph there are some commands to:
 
@@ -111,7 +111,7 @@ On the top-right corner of each paragraph there are some commands to:
 
 To configure the paragraph, just click on the gear icon:
 
-<img src="/assets/themes/zeppelin/img/ui-img/paragraph_configuration_dialog.png" width="180px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/paragraph_configuration_dialog.png" width="180px" />
 
 From this dialog, you can (in descending order):
 
@@ -131,7 +131,7 @@ From this dialog, you can (in descending order):
 
 At the top of the note, you can find a toolbar which exposes command buttons as well as configuration, security and display options.
 
-<img src="/assets/themes/zeppelin/img/ui-img/note_toolbar.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/note_toolbar.png" />
 
 On the far right is displayed the note name, just click on it to reveal the input form and update it.
 
@@ -147,7 +147,7 @@ In the middle of the toolbar you can find the command buttons:
 * delete the note
 * schedule the execution of **all paragraph** using a CRON syntax
 
-<img src="/assets/themes/zeppelin/img/ui-img/note_commands.png" width="300px"/>
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/note_commands.png" width="300px"/>
 
 On the right of the note tool bar you can find configuration icons:
 
@@ -156,4 +156,4 @@ On the right of the note tool bar you can find configuration icons:
 * configure the note permissions
 * switch the node display mode between `default`, `simple` and `report`
 
-<img src="/assets/themes/zeppelin/img/ui-img/note_configuration.png" width="180px"/>
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/note_configuration.png" width="180px"/>

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -20,22 +20,22 @@ limitations under the License.
 
 <div class="row">
      <div class="col-md-3">
-          <a href="assets/themes/zeppelin/img/screenshots/sparksql.png"><img class="thumbnail" src="assets/themes/zeppelin/img/screenshots/sparksql.png" /></a>
+          <a href="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/sparksql.png"><img class="thumbnail" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/sparksql.png" /></a>
           <center>Spark SQL with inline visualization</center>
      </div>
      <div class="col-md-3">
-          <a href="assets/themes/zeppelin/img/screenshots/spark.png"><img class="thumbnail" src="assets/themes/zeppelin/img/screenshots/spark.png" /></a>
+          <a href="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/spark.png"><img class="thumbnail" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/spark.png" /></a>
           <center>Scala code runs with Spark</center>
      </div>
      <div class="col-md-3">
-          <a href="assets/themes/zeppelin/img/screenshots/markdown.png"><img class="thumbnail" src="assets/themes/zeppelin/img/screenshots/markdown.png" /></a>
+          <a href="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/markdown.png"><img class="thumbnail" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/markdown.png" /></a>
           <center>Markdown supported</center>
      </div>
 </div>
 <br />
 <div class="row">
      <div class="col-md-3">
-          <a href="assets/themes/zeppelin/img/screenshots/notebook.png"><img class="thumbnail" src="assets/themes/zeppelin/img/screenshots/notebook.png" /></a>
+          <a href="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/notebook.png"><img class="thumbnail" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/notebook.png" /></a>
           <center>Notebook</center>
      </div>
      <div class="col-md-3">

--- a/docs/setup/deployment/cdh.md
+++ b/docs/setup/deployment/cdh.md
@@ -85,16 +85,16 @@ export SPARK_HOME=[your_spark_home_path]
 
 Don't forget to set Spark `master` as `yarn-client` in Zeppelin **Interpreters** setting page like below.
 
-<img src="/assets/themes/zeppelin/img/docs-img/zeppelin_yarn_conf.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin_yarn_conf.png" />
 
 ### 5. Run Zeppelin with Spark interpreter
 After running a single paragraph with Spark interpreter in Zeppelin,
 
-<img src="/assets/themes/zeppelin/img/docs-img/zeppelin_with_cdh.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin_with_cdh.png" />
 
 <br/>
 
 browse `http://<hostname>:8088/cluster/apps` to check Zeppelin application is running well or not.
 
-<img src="/assets/themes/zeppelin/img/docs-img/cdh_yarn_applications.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/cdh_yarn_applications.png" />
 

--- a/docs/setup/deployment/flink_and_spark_cluster.md
+++ b/docs/setup/deployment/flink_and_spark_cluster.md
@@ -291,7 +291,7 @@ build-target/bin/start-cluster.sh
 
 In a browser, navigate to http://`yourip`:8082 to see the Flink Web-UI.  Click on 'Task Managers' in the left navigation bar. Ensure there is at least one Task Manager present.
 
-<center>![alt text](/assets/themes/zeppelin/img/screenshots/flink-webui.png "The Flink Web-UI")</center>
+<center>![alt text]({{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/flink-webui.png "The Flink Web-UI")</center>
 
 
 If no task managers are present, restart the Flink cluster with the following commands:
@@ -369,7 +369,7 @@ spark/sbin/start-master.sh --webui-port 8082
 
 Open a browser and navigate to http://`yourip`:8082 to ensure the Spark master is running.
 
-<center>![alt text](/assets/themes/zeppelin/img/screenshots/spark-master-webui1.png "It should look like this...")</center>
+<center>![alt text]({{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/spark-master-webui1.png "It should look like this...")</center>
 
 Toward the top of the page there will be a *URL*: spark://`yourhost`:7077.  Note this URL, the Spark Master URI, it will be needed in subsequent steps.
 

--- a/docs/setup/deployment/spark_cluster_mode.md
+++ b/docs/setup/deployment/spark_cluster_mode.md
@@ -61,12 +61,12 @@ Note that `sparkmaster` hostname used here to run docker container should be def
 ### 3. Configure Spark interpreter in Zeppelin
 Set Spark master as `spark://<hostname>:7077` in Zeppelin **Interpreters** setting page.
 
-<img src="/assets/themes/zeppelin/img/docs-img/standalone_conf.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/standalone_conf.png" />
 
 ### 4. Run Zeppelin with Spark interpreter
 After running single paragraph with Spark interpreter in Zeppelin, browse `https://<hostname>:8080` and check whether Spark cluster is running well or not.
 
-<img src="/assets/themes/zeppelin/img/docs-img/spark_ui.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/spark_ui.png" />
 
 You can also simply verify that Spark is running well in Docker with below command.
 
@@ -139,12 +139,12 @@ export SPARK_HOME=[your_spark_home_path]
 
 Don't forget to set Spark `master` as `yarn-client` in Zeppelin **Interpreters** setting page like below.
 
-<img src="/assets/themes/zeppelin/img/docs-img/zeppelin_yarn_conf.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin_yarn_conf.png" />
 
 ### 5. Run Zeppelin with Spark interpreter
 After running a single paragraph with Spark interpreter in Zeppelin, browse `http://<hostname>:8088/cluster/apps` and check Zeppelin application is running well or not.
 
-<img src="/assets/themes/zeppelin/img/docs-img/yarn_applications.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/yarn_applications.png" />
 
 
 
@@ -201,13 +201,13 @@ export SPARK_HOME=[PATH OF SPARK HOME]
 
 Don't forget to set Spark `master` as `mesos://127.0.1.1:5050` in Zeppelin **Interpreters** setting page like below.
 
-<img src="/assets/themes/zeppelin/img/docs-img/zeppelin_mesos_conf.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin_mesos_conf.png" />
 
 
 ### 5. Run Zeppelin with Spark interpreter
 After running a single paragraph with Spark interpreter in Zeppelin, browse `http://<hostname>:5050/#/frameworks` and check Zeppelin application is running well or not.
 
-<img src="/assets/themes/zeppelin/img/docs-img/mesos_frameworks.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/mesos_frameworks.png" />
 
 ### Troubleshooting for Spark on Mesos
 

--- a/docs/setup/security/datasource_authorization.md
+++ b/docs/setup/security/datasource_authorization.md
@@ -35,14 +35,14 @@ In this case, you can add your credential information to Apache Zeppelin and use
 ## How to save the credential information?
 You can add new credentials in the dropdown menu for your data source which can be passed to interpreters. 
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/credential_tab.png" width="180px"/>
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/credential_tab.png" width="180px"/>
 
 **Entity** can be the key that distinguishes each credential sets.(We suggest that the convention of the **Entity** is `[Interpreter Group].[Interpreter Name]`.)
 Please see [what is interpreter group](../../usage/interpreter/overview.html#what-is-interpreter-group) for the detailed information.
 
 Type **Username & Password** for your own credentials. ex) Mysql user & password of the JDBC Interpreter.
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/add_credential.png" />
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/add_credential.png" />
 
 The credentials saved as per users defined in `conf/shiro.ini`.
 If you didn't activate [shiro authentication in Apache Zeppelin](./shiro_authentication.html), your credential information will be saved as `anonymous`.

--- a/docs/setup/security/notebook_authorization.md
+++ b/docs/setup/security/notebook_authorization.md
@@ -37,14 +37,14 @@ As you can see, each Zeppelin notebooks has 3 entities :
 * Readers ( users or groups )
 * Writers ( users or groups )
 
-<center><img src="/assets/themes/zeppelin/img/docs-img/permission_setting.png"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/permission_setting.png"></center>
 
 Fill out the each forms with comma seperated **users** and **groups** configured in `conf/shiro.ini` file.
 If the form is empty (*), it means that any users can perform that operation.
 
 If someone who doesn't have **read** permission is trying to access the notebook or someone who doesn't have **write** permission is trying to edit the notebook, Zeppelin will ask to login or block the user.
 
-<center><img src="/assets/themes/zeppelin/img/docs-img/insufficient_privileges.png"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/insufficient_privileges.png"></center>
 
 ## Separate notebook workspaces (public vs. private)
 By default, the authorization rights allow other users to see the newly created note, meaning the workspace is `public`. This behavior is controllable and can be set through either `ZEPPELIN_NOTEBOOK_PUBLIC` variable in `conf/zeppelin-env.sh`, or through `zeppelin.notebook.public` property in `conf/zeppelin-site.xml`. Thus, in order to make newly created note appear only in your `private` workspace by default, you can set either `ZEPPELIN_NOTEBOOK_PUBLIC` to `false` in your `conf/zeppelin-env.sh` as follows:

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -55,7 +55,7 @@ Then you can browse Zeppelin at [http://localhost:8080](http://localhost:8080).
 ### 4. Login
 Finally, you can login using one of the below **username/password** combinations.
 
-<center><img src="/assets/themes/zeppelin/img/docs-img/zeppelin-login.png"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin-login.png"></center>
 
 ```
 [users]

--- a/docs/usage/display_system/angular_backend.md
+++ b/docs/usage/display_system/angular_backend.md
@@ -33,7 +33,7 @@ Therefore, you can not only update scope variables from your interpreter but als
 ### Print AngularJS view
 
 To use angular display system, you should start with `%angular`.
-<img src="/assets/themes/zeppelin/img/screenshots/display_angular.png" width="60%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_angular.png" width="60%" />
 
 Since `name` is not defined, `Hello {{name}}` will display `Hello`.
 > **Please Note:** Display system is backend independent.
@@ -60,7 +60,7 @@ z.angularUnbindGlobal(String name)
 
 Using the above example, let's bind `world` variable to `name`. Then you can see **AngularJs view** is immediately updated.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_angular1.png" width="60%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_angular1.png" width="60%" />
 
 
 <br />
@@ -86,12 +86,12 @@ z.angularUnwatchGlobal(String name)
 
 Let's make a button. When it is clicked, the value of `run` will be increased 1 by 1.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_angular2.png" width="60%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_angular2.png" width="60%" />
 
 `z.angularBind("run", 0)` will initialize `run` to zero. And then, it will be also applied to `run` in `z.angularWatch()`.
 When the button is clicked, you'll see both `run` and `numWatched` are incremented by 1.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_angular3.png" width="60%" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_angular3.png" width="60%" />
 
 ## Let's make it Simpler and more Intuitive
 In this section, we will introduce a simpler and more intuitive way of using **Angular Display System** in Zeppelin.
@@ -188,7 +188,7 @@ AngularModel("myModel")()
 AngularModel("myModel", "New value")
 ```
 
-<img src="/assets/themes/zeppelin/img/docs-img/basic-usage-angular.png" width="70%">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/basic-usage-angular.png" width="70%">
 
 ### Example: String Converter
 Using below example, you can convert the lowercase string to uppercase.
@@ -211,4 +211,4 @@ val button = <div class="btn btn-success btn-sm">Convert</div>.onClick{() =>
 ```
 {% endraw %}
 
-<img src="/assets/themes/zeppelin/img/docs-img/string-converter-angular.gif" width="70%">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/string-converter-angular.gif" width="70%">

--- a/docs/usage/display_system/angular_frontend.md
+++ b/docs/usage/display_system/angular_frontend.md
@@ -47,7 +47,7 @@ Bind a value to an angular object and a **mandatory** target paragraph:
 
 ```
 
-<img src="/assets/themes/zeppelin/img/screenshots/z_angularBind.gif" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/z_angularBind.gif" />
 
 <hr/>
 
@@ -63,7 +63,7 @@ Unbind/remove a value from angular object and a **mandatory** target paragraph:
 
 ```
 
-<img src="/assets/themes/zeppelin/img/screenshots/z_angularUnbind.gif" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/z_angularUnbind.gif" />
 
 The signature for the **`z.angularBind() / z.angularUnbind()`** functions are:
 
@@ -98,7 +98,7 @@ You can also trigger paragraph execution by calling **`z.runParagraph()`** funct
 
 ```
 
-<img src="/assets/themes/zeppelin/img/screenshots/z_runParagraph.gif" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/z_runParagraph.gif" />
 
 <br />
 ## Overriding dynamic form with Angular Object
@@ -110,7 +110,7 @@ The idea is to create a custom form using plain HTML/AngularJS code and bind act
 Consequently if you use the **Dynamic Form** syntax in a paragraph and there is a bound Angular object having the same name as the `${formName}`, the Angular object will have higher priority and the **Dynamic Form** will not be displayed. Example: 
  
 
-<img src="/assets/themes/zeppelin/img/screenshots/z_angularJs_overriding_dynamic_form.gif" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/z_angularJs_overriding_dynamic_form.gif" />
 
 
 <br />

--- a/docs/usage/display_system/basic.md
+++ b/docs/usage/display_system/basic.md
@@ -27,38 +27,38 @@ limitations under the License.
 
 By default, Apache Zeppelin prints interpreter response as a plain text using `text` display system.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_text.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_text.png" />
 
 You can explicitly say you're using `text` display system.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_text1.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_text1.png" />
 
 ## Html
 
 With `%html` directive, Zeppelin treats your output as HTML
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_html.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_html.png" />
 
 ### Mathematical expressions
 HTML display system automatically formats mathematical expression using [MathJax](https://www.mathjax.org/). You can use
 `\\( INLINE EXPRESSION \\)` and `$$ EXPRESSION $$` to format. For example
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_formula.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_formula.png" />
 
 
 ## Table
 
 If you have data that row separated by `\n` (newline) and column separated by `\t` (tab) with first row as header row, for example
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_table.png" />
 
 You can simply use `%table` display system to leverage Zeppelin's built in visualization.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table1.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_table1.png" />
 
 If table contents start with `%html`, it is interpreted as an HTML.
 
-<img src="/assets/themes/zeppelin/img/screenshots/display_table_html.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_table_html.png" />
 
 > **Note :** Display system is backend independent.
 
@@ -109,11 +109,11 @@ The new NETWORK visualization is based on json with the following params:
 
 If you click on a node or edge on the bottom of the paragraph you find a list of entity properties
 
-<img src="../assets/themes/zeppelin/img/screenshots/display_network.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_network.png" />
 
 This kind of graph can be easily *flatten* in order to support other visualization formats provided by Zeppelin.
 
-<img src="../assets/themes/zeppelin/img/screenshots/display_network_flatten.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_network_flatten.png" />
 
 ### How to use it?
 
@@ -142,7 +142,7 @@ print(s"""
 
 that will look like:
 
-<img src="../assets/themes/zeppelin/img/screenshots/display_simple_network.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_simple_network.png" />
 
 A little more complex graph:
 
@@ -161,4 +161,4 @@ print(s"""
 
 that will look like:
 
-<img src="../assets/themes/zeppelin/img/screenshots/display_complex_network.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/display_complex_network.png" />

--- a/docs/usage/dynamic_form/intro.md
+++ b/docs/usage/dynamic_form/intro.md
@@ -36,12 +36,12 @@ To create text input form, use `${formName}` templates.
 
 for example
 
-<img class="img-responsive" src="/assets/themes/zeppelin/img/screenshots/form_input.png" width="450px" />
+<img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_input.png" width="450px" />
 
 
 Also you can provide default value, using `${formName=defaultValue}`.
 
-<img src="/assets/themes/zeppelin/img/screenshots/form_input_default.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_input_default.png" />
 
 ### Select form
 
@@ -49,11 +49,11 @@ To create select form, use `${formName=defaultValue,option1|option2...}`
 
 for example
 
-<img src="/assets/themes/zeppelin/img/screenshots/form_select.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_select.png" />
 
 Also you can separate option's display name and value, using `${formName=defaultValue,option1(DisplayName)|option2(DisplayName)...}`
 
-<img src="/assets/themes/zeppelin/img/screenshots/form_select_displayname.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_select_displayname.png" />
 
 The paragraph will be automatically run after you change your selection by default.
 But in case you have multiple types dynamic form in one paragraph, you might want to run the paragraph after changing all the selections.
@@ -61,17 +61,17 @@ You can control this by unchecking the below **Run on selection change** option 
 
 Even if you uncheck this option, still you can run it by pressing `Enter`.
 
-<img src="/assets/themes/zeppelin/img/screenshots/selectForm-checkbox.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/selectForm-checkbox.png" />
 
 ### Checkbox form
 
 For multi-selection, you can create a checkbox form using `${checkbox:formName=defaultValue1|defaultValue2...,option1|option2...}`. The variable will be substituted by a comma-separated string based on the selected items. For example:
 
-<img src="/assets/themes/zeppelin/img/screenshots/form_checkbox.png">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_checkbox.png">
 
 You can specify the delimiter using `${checkbox(delimiter):formName=...}`:
 
-<img src="/assets/themes/zeppelin/img/screenshots/form_checkbox_delimiter.png">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_checkbox_delimiter.png">
 
 Like [select form](#select-form), the paragraph will be automatically run after you change your selection by default.
 But in case you have multiple types dynamic form in one paragraph, you might want to run the paragraph after changing all the selections.
@@ -79,7 +79,7 @@ You can control this by unchecking the below **Run on selection change** option 
 
 Even if you uncheck this option, still you can run it by pressing `Enter`.
 
-<img src="/assets/themes/zeppelin/img/screenshots/selectForm-checkbox.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/selectForm-checkbox.png" />
 
 ## Creates Programmatically
 
@@ -106,7 +106,7 @@ print("Hello "+z.input("name"))
 
     </div>
 </div>
-<img src="/assets/themes/zeppelin/img/screenshots/form_input_prog.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_input_prog.png" />
 
 ### Text input form with default value
 <div class="codetabs">
@@ -127,7 +127,7 @@ print("Hello "+z.input("name", "sun"))
 
     </div>
 </div>
-<img src="/assets/themes/zeppelin/img/screenshots/form_input_default_prog.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_input_default_prog.png" />
 
 ### Select form
 <div class="codetabs">
@@ -160,7 +160,7 @@ print("Hello "+z.select("day", [("1","mon"),
 
     </div>
 </div>
-<img src="/assets/themes/zeppelin/img/screenshots/form_select_prog.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_select_prog.png" />
 
 #### Checkbox form
 <div class="codetabs">
@@ -183,4 +183,4 @@ print("Hello "+ " and ".join(z.checkbox("fruit", options, ["apple"])))
 
     </div>
 </div>
-<img src="/assets/themes/zeppelin/img/screenshots/form_checkbox_prog.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/form_checkbox_prog.png" />

--- a/docs/usage/interpreter/dependency_management.md
+++ b/docs/usage/interpreter/dependency_management.md
@@ -34,8 +34,8 @@ When your code requires external library, instead of doing download/copy/restart
 <hr>
 <div class="row">
   <div class="col-md-6">
-    <a data-lightbox="compiler" href="/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png">
-      <img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png" />
+    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png">
+      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-dependency-loading.png" />
     </a>
   </div>
   <div class="col-md-6" style="padding-top:30px">
@@ -53,11 +53,11 @@ When your code requires external library, instead of doing download/copy/restart
 <hr>
 <div class="row">
   <div class="col-md-6">
-    <a data-lightbox="compiler" href="/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png">
-      <img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png" />
+    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png">
+      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo1.png" />
     </a>
-    <a data-lightbox="compiler" href="/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png">
-      <img class="img-responsive" src="/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png" />
+    <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png">
+      <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter-add-repo2.png" />
     </a>
   </div>
   <div class="col-md-6" style="padding-top:30px">

--- a/docs/usage/interpreter/dynamic_loading.md
+++ b/docs/usage/interpreter/dynamic_loading.md
@@ -29,7 +29,7 @@ Before we start, if you are not familiar with the concept of **Zeppelin interpre
 ## Overview 
 In the past, Zeppelin was loading interpreter binaries from `/interpreter/[interpreter_name]` directory. They were configured by `zeppelin.interpreters` property in `conf/zeppelin-site.xml` or `ZEPPELIN_INTERPRETERS` env variables in `conf/zeppelin-env.sh`. They were loaded on Zeppelin server startup and stayed alive until the server was stopped.
 In order to simplify using 3rd party interpreters, we changed this way to **dynamically** load interpreters from **Maven Repository** using **REST API**. Hopefully, the picture below will help you to understand the process. 
-<center><img src="/assets/themes/zeppelin/img/docs-img/zeppelin_user.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/zeppelin_user.png" height="85%" width="85%"></center>
 
 ## Load & Unload Interpreters Using REST API
 
@@ -106,19 +106,19 @@ After loading an interpreter, you can use it by creating and configuring it in Z
 Oh, you don't need to restart your Zeppelin server. Because it is **Dynamic Loading**, you can configure and load it **at runtime** !
 
 1. After Zeppelin server up, browse Zeppelin home and click **Interpreter tab**.
-<center><img src="/assets/themes/zeppelin/img/docs-img/interpreter_setting_1.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter_setting_1.png" height="85%" width="85%"></center>
 
 2. At the **Interpreter** section, click **+Create** button. 
-<center><img src="/assets/themes/zeppelin/img/docs-img/interpreter_setting_2.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter_setting_2.png" height="85%" width="85%"></center>
  
 3. Then, you can verify the interpreter list that you loaded.
-<center><img src="/assets/themes/zeppelin/img/docs-img/interpreter_setting_3.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter_setting_3.png" height="85%" width="85%"></center>
 
 4. After choosing an interpreter, you can configure and use it. Don't forget to save it.
 
 5. Create a new notebook in the **Notebook** section, then you can bind the interpreters from your interpreter list. Just drag and drop !
-<center><img src="/assets/themes/zeppelin/img/docs-img/interpreter_binding_1.png" height="85%" width="85%"></center>
-<center><img src="/assets/themes/zeppelin/img/docs-img/interpreter_binding_2.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter_binding_1.png" height="85%" width="85%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/interpreter_binding_2.png" height="85%" width="85%"></center>
 
 6. At last, you can use your interpreter !
 

--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -34,12 +34,12 @@ Zeppelin Interpreter is a plug-in which enables Zeppelin users to use a specific
 
 When you click the ```+Create``` button in the interpreter page, the interpreter drop-down list box will show all the available interpreters on your server.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_create.png" width="280px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_create.png" width="280px">
 
 ## What is interpreter setting?
 Zeppelin interpreter setting is the configuration of a given interpreter on Zeppelin server. For example, the properties are required for hive JDBC interpreter to connect to the Hive server.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_setting.png" width="500px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_setting.png" width="500px">
 
 Properties are exported as environment variables when property name is consisted of upper characters, numbers and underscore ([A-Z_0-9]). Otherwise set properties as JVM property. 
 
@@ -71,12 +71,12 @@ You may use parameters from the context of interpreter by add #{contextParameter
 
 If context parameter is null then replaced by empty string.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_setting_with_context_parameters.png" width="800px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_setting_with_context_parameters.png" width="800px">
 
 <br>
 Each notebook can be bound to multiple Interpreter Settings using setting icon on upper right corner of the notebook.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_binding.png" width="800px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_binding.png" width="800px">
 
 
 
@@ -88,7 +88,7 @@ Technically, Zeppelin interpreters from the same group are running in the same J
 
 Each interpreters is belonged to a single group and registered together. All of their properties are listed in the interpreter setting like below image.
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_setting_spark.png" width="500px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_setting_spark.png" width="500px">
 
 
 ## Interpreter binding mode
@@ -98,7 +98,7 @@ In 'shared' mode, every notebook bound to the Interpreter Setting will share the
 
 For more information, check [Interpreter Binding Mode](./interpreter_binding_mode.html).
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_persession.png" width="400px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_persession.png" width="400px">
 
 
 ## Connecting to the existing remote interpreter
@@ -114,12 +114,12 @@ interpreter.start()
 
 The above code will start interpreter thread inside your process. Once the interpreter is started you can configure zeppelin to connect to RemoteInterpreter by checking **Connect to existing process** checkbox and then provide **Host** and **Port** on which interpreter process is listening as shown in the image below:
 
-<img src="/assets/themes/zeppelin/img/screenshots/existing_interpreter.png" width="450px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/existing_interpreter.png" width="450px">
 
 ## Precode
 
 Snippet of code (language of interpreter) that executes after initialization of the interpreter depends on [Binding mode](#interpreter-binding-mode). To configure add parameter with class of interpreter (`zeppelin.<ClassName>.precode`) except JDBCInterpreter ([JDBC precode](../../interpreter/jdbc.html#usage-precode)). 
 
-<img src="/assets/themes/zeppelin/img/screenshots/interpreter_precode.png" width="800px">
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/interpreter_precode.png" width="800px">
 
  

--- a/docs/usage/interpreter/user_impersonation.md
+++ b/docs/usage/interpreter/user_impersonation.md
@@ -63,8 +63,8 @@ bin\zeppelin.cmd
 
 <div class="row">
   <div class="col-md-12" >
-      <a data-lightbox="compiler" href="/assets/themes/zeppelin/img/screenshots/user-impersonation.gif">
-        <img class="img-responsive" src="/assets/themes/zeppelin/img/screenshots/user-impersonation.gif" />
+      <a data-lightbox="compiler" href="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/user-impersonation.gif">
+        <img class="img-responsive" src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/user-impersonation.gif" />
       </a>
 
   </div>

--- a/docs/usage/other_features/customizing_homepage.md
+++ b/docs/usage/other_features/customizing_homepage.md
@@ -47,7 +47,7 @@ the code sections.
 To set the note id in the config file, you should copy it from the last word in the note url.
 For example,
 
-<img src="/assets/themes/zeppelin/img/screenshots/homepage_notebook_id.png" width="400px" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/homepage_notebook_id.png" width="400px" />
 
 Set the note id to the ```ZEPPELIN_NOTEBOOK_HOMESCREEN``` environment variable
 or ```zeppelin.notebook.homescreen``` property.
@@ -82,7 +82,7 @@ println(
 
 After running the paragraph, you will see output similar to this one:
 
-<img src="/assets/themes/zeppelin/img/docs-img/homepage_custom_notebook_list.png" />
+<img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/homepage_custom_notebook_list.png" />
 
 That's it! Voila! You have your note list.
 

--- a/docs/usage/other_features/publishing_paragraphs.md
+++ b/docs/usage/other_features/publishing_paragraphs.md
@@ -30,10 +30,10 @@ It's very straightforward. Just use `<iframe>` tag in your page.
 A first step to publish your paragraph result is **Copy a Paragraph Link**.
 
   * After running a paragraph in your Zeppelin notebook, click a gear button located on the right side. Then, click **Link this Paragraph** menu like below image.
-<center><img src="/assets/themes/zeppelin/img/docs-img/link-the-paragraph.png" height="100%" width="100%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/link-the-paragraph.png" height="100%" width="100%"></center>
   
   * Just copy the provided link. 
-<center><img src="/assets/themes/zeppelin/img/docs-img/copy-the-link.png" height="100%" width="100%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/copy-the-link.png" height="100%" width="100%"></center>
 
 ## Embed the Paragraph to Your Website
 For publishing the copied paragraph, you may use `<iframe>` tag in your website page.
@@ -44,6 +44,6 @@ For example,
 ```
 
 Finally, you can show off your beautiful visualization results in your website. 
-<center><img src="/assets/themes/zeppelin/img/docs-img/your-website.png" height="90%" width="90%"></center>
+<center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/your-website.png" height="90%" width="90%"></center>
 
 > **Note**: To embed the paragraph in a website, Apache Zeppelin needs to be reachable by that website. And please use this feature with caution and in a trusted environment only, as Zeppelin entire Webapp could be accessible by whoever visits your website. 


### PR DESCRIPTION
### What is this PR for?

fix: broken image URLs in 0.8.0-SNAPSHOT doc

using the path `/asset` (the absolute path) for image URLs is actually invalid. That's because each version has its own image directory. So they should use the relative path. `{{BASE_PATH}}`

```
➜  asf-zeppelin tree site | grep asset
├── assets # root asset, we shouldn't use it in versioned doc.
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│   │   ├── assets
│       ├── assets
```


### What type of PR is it?
[Bug Fix]

### Todos
DONE

### What is the Jira issue?
[ZEPPELIN-2707](https://issues.apache.org/jira/browse/ZEPPELIN-2707)

### How should this be tested?

1. cd `docs/`
2. build: `bundle exec jekyll build --safe`
3. check whether links in `_site` include `/docs/0.8.0-SNAPSHOT` as prefix or not

### Screenshots (if appropriate)

#### Current 
http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/usage/interpreter/overview.html

![image](https://user-images.githubusercontent.com/4968473/27685112-bcca5846-5d07-11e7-89bb-3965015cf5a5.png)

#### After

![image](https://user-images.githubusercontent.com/4968473/27685218-3490fad8-5d08-11e7-9133-0e148689986e.png)


### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
