### PR TITLE
[ZEPPELIN-2708][DOCS] feat: Add v scroll to setup, usage menus in navbar

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -36,7 +36,7 @@
 
             <li>
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Usage<b class="caret"></b></a>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu scrollable-menu">
                 <li class="title"><span>Dynamic Form</span></li>
                 <li><a href="{{BASE_PATH}}/usage/dynamic_form/intro.html">What is Dynamic Form?</a></li>
                 <li role="separator" class="divider"></li>
@@ -75,7 +75,7 @@
 
             <li>
               <a href="#" data-toggle="dropdown" class="dropdown-toggle">Setup<b class="caret"></b></a>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu scrollable-menu">
                 <li class="title"><span>Basics</span></li>
                 <li><a href="{{BASE_PATH}}/setup/basics/how_to_build.html">How to Build Zeppelin</a></li>
                 <li><a href="{{BASE_PATH}}/setup/basics/multi_user_support.html">Multi-user Support</a></li>


### PR DESCRIPTION
### What is this PR for?

Added v scroll to setup, usage menus in the navbar.
Because some users are experiencing trimmed menus (not sure exact OS, browser versions, See the JIRA issue)

### What type of PR is it?
[Bug Fix | Improvement]

### Todos

DONE

### What is the Jira issue?

[ZEPPELIN-2708](https://issues.apache.org/jira/browse/ZEPPELIN-2708)

### How should this be tested?

1. cd `docs/`
2. run: `bundle exec jekyll serve --watch`



### Screenshots (if appropriate)

#### Before (no scrollbar)

![image](https://user-images.githubusercontent.com/4968473/27685495-5bedcba0-5d09-11e7-8e7b-76d15c407626.png)

#### After

![image](https://user-images.githubusercontent.com/4968473/27685496-6032193c-5d09-11e7-88bc-dc0a2a44398b.png)

![image](https://user-images.githubusercontent.com/4968473/27685505-64e7a802-5d09-11e7-91df-17b66cabc147.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
