### PR TITLE
[ZEPPELIN-2706] Fix unable to remove selected keys in Pie chart

### DIFF
--- a/zeppelin-web/src/app/tabledata/pivot_settings.html
+++ b/zeppelin-web/src/app/tabledata/pivot_settings.html
@@ -48,7 +48,7 @@ limitations under the License.
         <ul ng-model="config.keys"
             data-drop="true" jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
-            style="border-radius: 6px; margin-top: 7px; overflow: visible !important;">
+            style="border-radius: 6px; margin-top: 7px;">
           <li ng-repeat="item in config.keys">
             <div class="btn btn-default btn-xs"
                  style="background-color: #EFEFEF; margin: 2px 0px 0px 2px;">
@@ -68,7 +68,7 @@ limitations under the License.
             ng-model="config.groups"
             jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
-            style="border-radius: 6px; margin-top: 7px; overflow: visible !important;">
+            style="border-radius: 6px; margin-top: 7px;">
           <li ng-repeat="item in config.groups">
             <div class="btn btn-default btn-xs"
                  style="background-color: #EFEFEF; margin: 2px 0px 0px 2px;">
@@ -88,7 +88,7 @@ limitations under the License.
             ng-model="config.values"
             jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
-            style="border-radius: 6px; margin-top: 7px; overflow: visible !important;">
+            style="border-radius: 6px; margin-top: 7px;">
           <li ng-repeat="item in config.values">
             <div class="btn-group">
               <div class="btn btn-default btn-xs dropdown-toggle"


### PR DESCRIPTION
### What is this PR for?
Fix bug: unable to remove selected keys in Pie chart

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2706

### How should this be tested?
Now if name in keys, groups or values lists in Pie chart is too long, scrolling appears

### Screenshots
#### Before
![2017-06-29_12-40-57](https://user-images.githubusercontent.com/25951039/27689359-9c80c9d8-5ce6-11e7-8bf7-45b07baeba51.png)
#### After
![2017-06-29_16-22-04](https://user-images.githubusercontent.com/25951039/27689537-2690867c-5ce7-11e7-9cce-61ad9e0f45d1.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
