### PR TITLE
[ZEPPELIN-2659] Let WebEnvironment initialize SecurityManager.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -328,8 +328,9 @@ public class ZeppelinServer extends Application {
     String shiroIniPath = conf.getShiroPath();
     if (!StringUtils.isBlank(shiroIniPath)) {
       webapp.setInitParameter("shiroConfigLocations", new File(shiroIniPath).toURI().toString());
-      SecurityUtils.initSecurityManager(shiroIniPath);
-      webapp.addFilter(ShiroFilter.class, "/api/*", EnumSet.allOf(DispatcherType.class));
+      SecurityUtils.setIsEnabled(true);
+      webapp.addFilter(ShiroFilter.class, "/api/*", EnumSet.allOf(DispatcherType.class))
+              .setInitParameter("staticSecurityManagerEnabled", "true");
       webapp.addEventListener(new EnvironmentLoaderListener());
     }
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -52,11 +52,8 @@ public class SecurityUtils {
   private static boolean isEnabled = false;
   private static final Logger log = LoggerFactory.getLogger(SecurityUtils.class);
   
-  public static void initSecurityManager(String shiroPath) {
-    IniSecurityManagerFactory factory = new IniSecurityManagerFactory("file:" + shiroPath);
-    SecurityManager securityManager = factory.getInstance();
-    org.apache.shiro.SecurityUtils.setSecurityManager(securityManager);
-    isEnabled = true;
+  public static void setIsEnabled(boolean value) {
+    isEnabled = value;
   }
 
   public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)


### PR DESCRIPTION
### What is this PR for?
This commit disables generating a Shiro `SecurityManager` from the `IniSecurityManagerFactory`, and instead let's the `WebEnvironment` instantiate the `SecurityManager`. The `initParameter` "staticSecurityManagerEnabled" ensures this `SecurityManager` is set and available for use.

Overall, this prevents the double parsing of `shiro.ini`, which can cause double instantiation. This is particularly thorny with things like EHCache, which need uniquely named caches, and will throw an exception if a cache with the same name already exists.

### What type of PR is it?
[Bug Fix ]

### Todos

### What is the Jira issue?
[ZEPPELIN-2659](https://issues.apache.org/jira/browse/ZEPPELIN-2659)

### How should this be tested?
- Enable Shiro by copying the shiro.ini.template to shiro.ini. Attempt logging in as a user. 
- Enable WebSessions and EHCache by adding the following lines to the `[main]` section of shiro.ini, and attempt logging in.
```
[main]
...
sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
securityManager.sessionManager = $sessionManager

sessionDAO = org.apache.shiro.session.mgt.eis.EnterpriseCacheSessionDAO
securityManager.sessionManager.sessionDAO = $sessionDAO

cacheManager = org.apache.shiro.cache.ehcache.EhCacheManager
securityManager.cacheManager = $cacheManager
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    * No.
* Is there breaking changes for older versions?
    * No.
* Does this needs documentation?
    * No.
