### PR TITLE
[ZEPPELIN-2710] Programmatically update progress bar

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterContext.java
@@ -62,7 +62,9 @@ public class InterpreterContext {
   private String className;
   private RemoteEventClientWrapper client;
   private RemoteWorksController remoteWorksController;
+  private final Map<String, Integer> progressMap;
 
+  // visible for testing
   public InterpreterContext(String noteId,
                             String paragraphId,
                             String replName,
@@ -77,7 +79,7 @@ public class InterpreterContext {
                             InterpreterOutput out
                             ) {
     this(noteId, paragraphId, replName, paragraphTitle, paragraphText, authenticationInfo,
-        config, gui, angularObjectRegistry, resourcePool, runners, out, null);
+        config, gui, angularObjectRegistry, resourcePool, runners, out, null, null);
   }
 
   public InterpreterContext(String noteId,
@@ -92,7 +94,8 @@ public class InterpreterContext {
                             ResourcePool resourcePool,
                             List<InterpreterContextRunner> runners,
                             InterpreterOutput out,
-                            RemoteWorksController remoteWorksController
+                            RemoteWorksController remoteWorksController,
+                            Map<String, Integer> progressMap
                             ) {
     this.noteId = noteId;
     this.paragraphId = paragraphId;
@@ -107,6 +110,7 @@ public class InterpreterContext {
     this.runners = runners;
     this.out = out;
     this.remoteWorksController = remoteWorksController;
+    this.progressMap = progressMap;
   }
 
   public InterpreterContext(String noteId,
@@ -122,10 +126,11 @@ public class InterpreterContext {
                             List<InterpreterContextRunner> contextRunners,
                             InterpreterOutput output,
                             RemoteWorksController remoteWorksController,
-                            RemoteInterpreterEventClient eventClient) {
+                            RemoteInterpreterEventClient eventClient,
+                            Map<String, Integer> progressMap) {
     this(noteId, paragraphId, replName, paragraphTitle, paragraphText, authenticationInfo,
         config, gui, angularObjectRegistry, resourcePool, contextRunners, output,
-        remoteWorksController);
+        remoteWorksController, progressMap);
     this.client = new RemoteEventClient(eventClient);
   }
 
@@ -195,5 +200,17 @@ public class InterpreterContext {
 
   public InterpreterOutput out() {
     return out;
+  }
+
+  /**
+   * Set progress of paragraph manually
+   * @param n integer from 0 to 100
+   */
+  public void setProgress(int n) {
+    if (progressMap != null) {
+      n = Math.max(n, 0);
+      n = Math.min(n, 100);
+      progressMap.put(paragraphId, new Integer(n));
+    }
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/mock/MockInterpreterA.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/mock/MockInterpreterA.java
@@ -54,7 +54,6 @@ public class MockInterpreterA extends Interpreter {
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     if (property.containsKey("progress")) {
-      System.err.println("SET PROGRESS");
       context.setProgress(Integer.parseInt(getProperty("progress")));
     }
     try {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/mock/MockInterpreterA.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/mock/MockInterpreterA.java
@@ -53,6 +53,10 @@ public class MockInterpreterA extends Interpreter {
 
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
+    if (property.containsKey("progress")) {
+      System.err.println("SET PROGRESS");
+      context.setProgress(Integer.parseInt(getProperty("progress")));
+    }
     try {
       Thread.sleep(Long.parseLong(st));
       this.lastSt = st;


### PR DESCRIPTION
### What is this PR for?
This PR adds setProgress(n) method to InterpreterContext.
So user can simply update progress bar manually in the code.

This can be useful when user runs some loops that takes lots of time (e.g. training) and user want to display progress with progress bar.

### What type of PR is it?
Feature

### Todos
* [x] - add setProgress() method
* [x] - Unittest

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2710

### How should this be tested?
run following example and see if progress bar is updating
```
%python
import time

ic = z.getInterpreterContext()

for i in range(0, 100):
    time.sleep(0.05)
    ic.setProgress(i)
```

### Screenshots (if appropriate)
![zeppelin_progress](https://user-images.githubusercontent.com/1540981/27714525-5ac8b7c2-5d6c-11e7-91dd-d383ec9295ec.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
