### PR TITLE
[ZEPPELIN-2714] Soft-code Spark UI button visualization

### DIFF
--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -615,7 +615,7 @@ The role of registered interpreters, settings and interpreters group are describ
     </tr>
     <tr>
       <td>URL</td>
-      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/getmetainfos/[setting ID]```</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/metadata/[setting ID]```</td>
     </tr>
     <tr>
       <td>Success code</td>

--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -604,3 +604,26 @@ The role of registered interpreters, settings and interpreters group are describ
     </td>        
   </table>  
   
+<br/>
+### Get interpreter settings metadata info
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns interpreter settings metadata info. </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/getmetainfos/[setting ID]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+  </table>
+  

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -1046,8 +1046,9 @@ public class SparkInterpreter extends Interpreter {
     sparkUrl = getSparkUIUrl();
     Map<String, String> infos = new java.util.HashMap<>();
     infos.put("url", sparkUrl);
+    String uiEnabledProp = property.getProperty("spark.ui.enabled", "true");
     java.lang.Boolean uiEnabled = java.lang.Boolean.parseBoolean(
-            property.getProperty("spark.ui.enabled", "true"));
+            uiEnabledProp.trim());
     if (!uiEnabled) {
       infos.put("message", "Spark UI disabled");
     } else {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -250,24 +250,15 @@ public class InterpreterRestApi {
    */
   @GET
   @Path("getmetainfos/{settingId}")
+  @ZeppelinApi
   public Response getMetaInfo(@Context HttpServletRequest req,
       @PathParam("settingId") String settingId) {
-    String propName = req.getParameter("propName");
-    if (propName == null) {
-      return new JsonResponse<>(Status.BAD_REQUEST).build();
-    }
-    String propValue = null;
     InterpreterSetting interpreterSetting = interpreterSettingManager.get(settingId);
-    Map<String, String> infos = interpreterSetting.getInfos();
-    if (infos != null) {
-      propValue = infos.get(propName);
+    if (interpreterSetting == null) {
+      return new JsonResponse<>(Status.NOT_FOUND).build();
     }
-    Map<String, String> respMap = new HashMap<>();
-    respMap.put(propName, propValue);
-    logger.debug("Get meta info");
-    logger.debug("Interpretersetting Id: {}, property Name:{}, property value: {}", settingId,
-        propName, propValue);
-    return new JsonResponse<>(Status.OK, respMap).build();
+    Map<String, String> infos = interpreterSetting.getInfos();
+    return new JsonResponse<>(Status.OK, "metainfo", infos).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -246,10 +246,10 @@ public class InterpreterRestApi {
   }
 
   /**
-   * get the metainfo property value
+   * get metadata values
    */
   @GET
-  @Path("getmetainfos/{settingId}")
+  @Path("metadata/{settingId}")
   @ZeppelinApi
   public Response getMetaInfo(@Context HttpServletRequest req,
       @PathParam("settingId") String settingId) {
@@ -258,7 +258,7 @@ public class InterpreterRestApi {
       return new JsonResponse<>(Status.NOT_FOUND).build();
     }
     Map<String, String> infos = interpreterSetting.getInfos();
-    return new JsonResponse<>(Status.OK, "metainfo", infos).build();
+    return new JsonResponse<>(Status.OK, "metadata", infos).build();
   }
 
   /**

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -54,7 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class InterpreterRestApiTest extends AbstractTestRestApi {
-  Gson gson = new Gson();
+  private Gson gson = new Gson();
   private AuthenticationInfo anonymous;
 
   @BeforeClass
@@ -367,13 +367,12 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testGetMetadataInfo() throws IOException {
-    String rawRequest = "{\"name\":\"spark\",\"group\":\"spark\"," +
-            "\"properties\":{\"propname\":\"propvalue\"}," +
+    String jsonRequest = "{\"name\":\"spark\",\"group\":\"spark\"," +
+            "\"properties\":{\"propname\": {\"value\": \"propvalue\", \"name\": \"propname\", \"type\": \"textarea\"}}," +
             "\"interpreterGroup\":[{\"class\":\"org.apache.zeppelin.markdown.Markdown\",\"name\":\"md\"}]," +
             "\"dependencies\":[]," +
             "\"option\": { \"remote\": true, \"session\": false }}";
-    JsonObject jsonRequest = gson.fromJson(rawRequest, JsonElement.class).getAsJsonObject();
-    PostMethod post = httpPost("/interpreter/setting/", jsonRequest.toString());
+    PostMethod post = httpPost("/interpreter/setting/", jsonRequest);
     InterpreterSetting created = convertResponseToInterpreterSetting(post.getResponseBodyAsString());
     String settingId = created.getId();
     Map<String, String> infos = new java.util.HashMap<>();

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -367,7 +366,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testGetMetaInfo() throws IOException {
+  public void testGetMetadataInfo() throws IOException {
     String rawRequest = "{\"name\":\"spark\",\"group\":\"spark\"," +
             "\"properties\":{\"propname\":\"propvalue\"}," +
             "\"interpreterGroup\":[{\"class\":\"org.apache.zeppelin.markdown.Markdown\",\"name\":\"md\"}]," +
@@ -381,10 +380,16 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
     infos.put("key1", "value1");
     infos.put("key2", "value2");
     ZeppelinServer.notebook.getInterpreterSettingManager().get(settingId).setInfos(infos);
-    GetMethod get = httpGet("/interpreter/getmetainfos/" + settingId);
+    GetMethod get = httpGet("/interpreter/metadata/" + settingId);
     assertThat(get, isAllowed());
     JsonObject body = getBodyFieldFromResponse(get.getResponseBodyAsString());
     assertEquals(body.entrySet().size(), infos.size());
+    java.util.Map.Entry<String, JsonElement> item = body.entrySet().iterator().next();
+    if (item.getKey().equals("key1")) {
+      assertEquals(item.getValue().getAsString(), "value1");
+    } else {
+      assertEquals(item.getValue().getAsString(), "value2");
+    }
     get.releaseConnection();
   }
 

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -754,21 +754,21 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
   }
 
   $scope.showSparkUI = function (settingId) {
-    $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId)
+    $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/metadata/' + settingId)
       .success(function (data, status, headers, config) {
-        if (data.body === undefined || !data.body.url) {
-          if (data.body !== undefined && data.body.sparkUiEnabled === 'false') {
-            BootstrapDialog.alert({
-              message: 'Spark Web UI disabled. Set spark.ui.enabled property'
-            })
-          } else {
-            BootstrapDialog.alert({
-              message: 'No spark application running'
-            })
-          }
+        if (data.body === undefined) {
+          BootstrapDialog.alert({
+            message: 'No spark application running'
+          })
           return
         }
-        window.open(data.body.url, '_blank')
+        if (data.body.url) {
+          window.open(data.body.url, '_blank')
+        } else {
+          BootstrapDialog.alert({
+            message: data.body.message
+          })
+        }
       }).error(function (data, status, headers, config) {
         console.log('Error %o %o', status, data.message)
       })

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -754,16 +754,21 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
   }
 
   $scope.showSparkUI = function (settingId) {
-    $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId + '?propName=url')
+    $http.get(baseUrlSrv.getRestApiBase() + '/interpreter/getmetainfos/' + settingId)
       .success(function (data, status, headers, config) {
-        let url = data.body.url
-        if (!url) {
-          BootstrapDialog.alert({
-            message: 'No spark application running'
-          })
+        if (data.body === undefined || !data.body.url) {
+          if (data.body !== undefined && data.body.sparkUiEnabled === 'false') {
+            BootstrapDialog.alert({
+              message: 'Spark Web UI disabled. Set spark.ui.enabled property'
+            })
+          } else {
+            BootstrapDialog.alert({
+              message: 'No spark application running'
+            })
+          }
           return
         }
-        window.open(url, '_blank')
+        window.open(data.body.url, '_blank')
       }).error(function (data, status, headers, config) {
         console.log('Error %o %o', status, data.message)
       })


### PR DESCRIPTION
### What is this PR for?
When "spark.ui.enabled" property is set to "false" we should not show the Spark UI button.
We keep the same behaviour when this property does not exist or when it exists and it's set to true.

### What type of PR is it?
[ Improvement]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2714

### How should this be tested?
1. Open Zeppelin, go to Interpreter > Spark
1. Click spark ui > msg: "No spark application running"
1. Go to a paragraph, run "sc.parallelize(1 to 100).count()", check "SPARK JOB" button
1. Go to Interpreter > Spark > Set "spark.ui.enabled" to "false"
1. Rerun paragraph > "SPARK JOB" button not visible
1. Go to Interpreter > Spark > "spark ui" button not visible
Also, test with "spark.ui.enabled"="true" and other workflow combinations

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
