### PR TITLE
[ZEPPELIN-2713] Fix NPE of notebook creat rest api  if message is nul…

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -332,14 +332,16 @@ public class NotebookRestApi {
   public Response createNote(String message) throws IOException {
     String user = SecurityUtils.getPrincipal();
     LOG.info("Create new note by JSON {}", message);
-    NewNoteRequest request = gson.fromJson(message, NewNoteRequest.class);
     AuthenticationInfo subject = new AuthenticationInfo(user);
     Note note = notebook.createNote(subject);
-    List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
-    if (initialParagraphs != null) {
-      for (NewParagraphRequest paragraphRequest : initialParagraphs) {
-        Paragraph p = note.addNewParagraph(subject);
-        initParagraph(p, paragraphRequest, user);
+    NewNoteRequest request = gson.fromJson(message, NewNoteRequest.class);
+    if (request != null) {
+      List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
+      if (initialParagraphs != null) {
+        for (NewParagraphRequest paragraphRequest : initialParagraphs) {
+          Paragraph p = note.addNewParagraph(subject);
+          initParagraph(p, paragraphRequest, user);
+        }
       }
     }
     note.addNewParagraph(subject); // add one paragraph to the last


### PR DESCRIPTION
…l or empty

### What is this PR for?
Notebook create rest api will cause NPE when the message is null or empty.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-2713?filter=allopenissues

### How should this be tested?
Post to rest api (api/notebook) with nothing, test if NPE

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?   No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
