### PR TITLE
[ZEPPELIN-2716] Change the default value of zeppelin.livy.displayAppInfo to true

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -43,7 +43,7 @@ We added some common configurations for spark, and you can set any configuration
 You can find all Spark configurations in [here](http://spark.apache.org/docs/latest/configuration.html#available-properties).
 And instead of starting property with `spark.` it should be replaced with `livy.spark.`.
 Example: `spark.driver.memory` to `livy.spark.driver.memory`
-  
+
 <table class="table-configuration">
   <tr>
     <th>Property</th>
@@ -72,7 +72,7 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
   </tr>
   <tr>
     <td>zeppelin.livy.displayAppInfo</td>
-    <td>false</td>
+    <td>true</td>
     <td>Whether to display app info</td>
   </tr>
   <tr>
@@ -150,7 +150,7 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
 **We remove livy.spark.master in zeppelin-0.7. Because we sugguest user to use livy 0.3 in zeppelin-0.7. And livy 0.3 don't allow to specify livy.spark.master, it enfornce yarn-cluster mode.**
 
 ## Adding External libraries
-You can load dynamic library to livy interpreter by set `livy.spark.jars.packages` property to comma-separated list of maven coordinates of jars to include on the driver and executor classpaths. The format for the coordinates should be groupId:artifactId:version. 
+You can load dynamic library to livy interpreter by set `livy.spark.jars.packages` property to comma-separated list of maven coordinates of jars to include on the driver and executor classpaths. The format for the coordinates should be groupId:artifactId:version.
 
 Example
 
@@ -166,7 +166,7 @@ Example
       <td>Adding extra libraries to livy interpreter</td>
     </tr>
   </table>
-  
+
 ## How to use
 Basically, you can use
 
@@ -197,9 +197,9 @@ hello("livy")
 ```
 
 ## Impersonation
-When Zeppelin server is running with authentication enabled, 
-then this interpreter utilizes Livy’s user impersonation feature 
-i.e. sends extra parameter for creating and running a session ("proxyUser": "${loggedInUser}"). 
+When Zeppelin server is running with authentication enabled,
+then this interpreter utilizes Livy’s user impersonation feature
+i.e. sends extra parameter for creating and running a session ("proxyUser": "${loggedInUser}").
 This is particularly useful when multi users are sharing a Notebook server.
 
 ## Apply Zeppelin Dynamic Forms
@@ -228,4 +228,4 @@ The session would have timed out, you may need to restart the interpreter.
 Edit `conf/spark-blacklist.conf` file in livy server and comment out `#spark.master` line.
 
 If you choose to work on livy in `apps/spark/java` directory in [https://github.com/cloudera/hue](https://github.com/cloudera/hue),
-copy `spark-user-configurable-options.template` to `spark-user-configurable-options.conf` file in livy server and comment out `#spark.master`. 
+copy `spark-user-configurable-options.template` to `spark-user-configurable-options.conf` file in livy server and comment out `#spark.master`.

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -89,7 +89,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     super(property);
     this.livyURL = property.getProperty("zeppelin.livy.url");
     this.displayAppInfo = Boolean.parseBoolean(
-        property.getProperty("zeppelin.livy.displayAppInfo", "false"));
+        property.getProperty("zeppelin.livy.displayAppInfo", "true"));
     this.sessionCreationTimeout = Integer.parseInt(
         property.getProperty("zeppelin.livy.session.create_timeout", 120 + ""));
     this.pullStatusInterval = Integer.parseInt(

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -105,7 +105,7 @@
       },
       "zeppelin.livy.displayAppInfo": {
         "propertyName": "zeppelin.livy.displayAppInfo",
-        "defaultValue": false,
+        "defaultValue": "true",
         "description": "Whether display app info",
         "type": "checkbox"
       }
@@ -188,7 +188,7 @@
     "name": "pyspark3",
     "className": "org.apache.zeppelin.livy.LivyPySpark3Interpreter",
     "properties": {
-    },    
+    },
     "option": {
       "remote": true,
       "port": -1,
@@ -202,7 +202,7 @@
       "language": "python",
       "editOnDblClick": false
     }
-  },  
+  },
   {
     "group": "livy",
     "name": "sparkr",

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -51,6 +51,7 @@ public class LivyInterpreterIT {
     properties.setProperty("zeppelin.livy.url", cluster.livyEndpoint());
     properties.setProperty("zeppelin.livy.session.create_timeout", "120");
     properties.setProperty("zeppelin.livy.spark.sql.maxResult", "100");
+    properties.setProperty("zeppelin.livy.displayAppInfo", "false");
   }
 
   @AfterClass


### PR DESCRIPTION
### What is this PR for?

Since it is quite useful to expose the application info for user to monitor and debug, so here propose to enable "zeppelin.livy.displayAppInfo" to true as default.

### What type of PR is it?

Improvement

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-2716

### How should this be tested?

Manual verification.
