### PR TITLE
[gh-pages] fix hover event in technologies section on mobile

### DIFF
--- a/_includes/themes/zeppelin/default.html
+++ b/_includes/themes/zeppelin/default.html
@@ -7,7 +7,7 @@
     <meta name="author" content="{{ site.author.name }}">
 
     <!-- Enable responsive viewport -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>

--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -1305,6 +1305,10 @@ and (max-width: 1024px) {
 */
 
 @media (max-width: 991px) {
+  body, html {
+    overflow-x:hidden;
+  }
+
   .navbar-inverse .navbar-brand {
     font-size: 24px;
   }

--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -1310,7 +1310,7 @@ and (max-width: 1024px) {
   }
 
   .navbar-inverse .navbar-brand {
-    font-size: 24px;
+    font-size: 23px;
   }
 
   .content {

--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -1004,7 +1004,6 @@ a.anchorjs-link:hover { text-decoration: none; }
 
   .tech_deploy .panel-content ._hover-text,
   .tech_deploy .panel-content:hover ._hover-text {
-
     font-size: 16px;
     padding: 10px;
   }
@@ -1464,7 +1463,8 @@ and (max-width: 631px) {
   margin-top: 65px;
 }
 
-.tech_deploy .panel-content:hover ._default-text {
+.tech_deploy .panel-content:hover ._default-text,
+ .tech_deploy .panel-content:active ._default-text {
   opacity: 0;
   -webkit-transform: scale(0.3);
   -moz-transform: scale(0.3);
@@ -1493,7 +1493,8 @@ and (max-width: 631px) {
   min-height: 200px;
 }
 
-.tech_deploy .panel-content:hover ._hover-text {
+.tech_deploy .panel-content:hover ._hover-text,
+ .tech_deploy .panel-content:active ._hover-text {
   opacity: 1;
   position: absolute;
   font-weight: 500;
@@ -1509,7 +1510,9 @@ and (max-width: 631px) {
 }
 
 .tech_deploy .panel-content:hover:before,
-.tech_deploy .panel-content:hover:after {
+.tech_deploy .panel-content:hover:after,
+ .tech_deploy .panel-content:active:before,
+ .tech_deploy .panel-content:active:after {
   content: '';
   position: absolute;
   top: 0.67em;

--- a/assets/themes/zeppelin/js/docs.js
+++ b/assets/themes/zeppelin/js/docs.js
@@ -52,3 +52,6 @@ $(document).click(function (event) {
     $("button.navbar-toggle").click();
   }
 });
+
+// fix hover class on mobile TouchEvents
+document.addEventListener("touchstart", function() {}, false);


### PR DESCRIPTION
### What is this PR for?
This is for fixing for `hover event` in the technologies section on mobile (I'm using Iphone 6).
A hover doesn't work properly when you touch whatever `spark` or `sql` or `python`.

### What type of PR is it?
[Bug Fix | Improvement]

### What is the Jira issue?
* [ZEPPELIN-2723](https://issues.apache.org/jira/browse/ZEPPELIN-2723)

### How should this be tested?
This way is mobile test.
1. check your internal IP, (for example my case is 192.168.x.x)
2. run `bundle exec jekyll serve --watch --host=0.0.0.0` in your terminal
3. connect your local server(192.168.x.x:4000) and check work well

### Screenshots (if appropriate)
(Sorry, I don't know how I can record that in iphone..)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, this is
