### PR TITLE
ZEPPELIN-2527 Changed editor cursor to thin

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -396,6 +396,11 @@ table.table-shortcut {
  opacity: 0 !important;
 }
 
+#main .emacs-mode .ace_cursor {
+  background: #C0C0C0!important;
+  border: none !important;
+}
+
 /*
   Table Display CSS
 */

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -384,7 +384,7 @@ table.table-shortcut {
 #main .emacs-mode .ace_cursor {
   background: #000 !important;
   border: none !important;
-  width: 1px !important;
+  width: 2px !important;
 }
 
 .ace_text-input, .ace_gutter, .ace_layer,

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -382,8 +382,9 @@ table.table-shortcut {
 
 /** set cursor color */
 #main .emacs-mode .ace_cursor {
-  background: #C0C0C0!important;
+  background: #000 !important;
   border: none !important;
+  width: 1px !important;
 }
 
 .ace_text-input, .ace_gutter, .ace_layer,
@@ -394,11 +395,6 @@ table.table-shortcut {
 
 .ace_text-input.ace_composition {
  opacity: 0 !important;
-}
-
-#main .emacs-mode .ace_cursor {
-  background: #C0C0C0!important;
-  border: none !important;
 }
 
 /*


### PR DESCRIPTION
### What is this PR for?
Previously, it's hard to recognize the cursor since it was too thick. After this PR, it will show the cursor same as other input boxes for consistency.

See the attached GIFs for comparison.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2527

### How should this be tested?

1. Build: mvn clean package -Denforcer.skip -DskipTests -Drat.skip
2. Open a paragraph
3. Check the cursor

### Screenshots (if appropriate)
Before
![cursor-change-pr-before](https://user-images.githubusercontent.com/1881135/27830832-cd55ec8e-60e5-11e7-8a0e-f75caecaba30.gif)

After
![cursor-change-pr](https://user-images.githubusercontent.com/1881135/27830837-d01fba30-60e5-11e7-8722-8056f7abaebc.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
