### PR TITLE
Fix zeppelin-web development mode

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -146,8 +146,10 @@ let zeppelinWebApp = angular.module('zeppelinWebApp', requiredModules)
   })
 
   // handel logout on API failure
-  .config(function ($httpProvider, $provide) {
-    $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
+    .config(function ($httpProvider, $provide) {
+    if (process.env.PROD) {
+      $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
+    }
     $provide.factory('httpInterceptor', function ($q, $rootScope) {
       return {
         'responseError': function (rejection) {
@@ -177,7 +179,7 @@ function auth () {
     },
     crossDomain: true
   })
-  let config = {headers: { 'X-Requested-With': 'XMLHttpRequest' }}
+  let config = (process.env.PROD) ? {headers: { 'X-Requested-With': 'XMLHttpRequest' }} : {}
   return $http.get(baseUrlSrv.getRestApiBase() + '/security/ticket', config).then(function (response) {
     zeppelinWebApp.run(function ($rootScope) {
       $rootScope.ticket = angular.fromJson(response.data).body

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -147,24 +147,24 @@ let zeppelinWebApp = angular.module('zeppelinWebApp', requiredModules)
 
   // handel logout on API failure
     .config(function ($httpProvider, $provide) {
-    if (process.env.PROD) {
-      $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
-    }
-    $provide.factory('httpInterceptor', function ($q, $rootScope) {
-      return {
-        'responseError': function (rejection) {
-          if (rejection.status === 405) {
-            let data = {}
-            data.info = ''
-            $rootScope.$broadcast('session_logout', data)
-          }
-          $rootScope.$broadcast('httpResponseError', rejection)
-          return $q.reject(rejection)
-        }
+      if (process.env.PROD) {
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
       }
+      $provide.factory('httpInterceptor', function ($q, $rootScope) {
+        return {
+          'responseError': function (rejection) {
+            if (rejection.status === 405) {
+              let data = {}
+              data.info = ''
+              $rootScope.$broadcast('session_logout', data)
+            }
+            $rootScope.$broadcast('httpResponseError', rejection)
+            return $q.reject(rejection)
+          }
+        }
+      })
+      $httpProvider.interceptors.push('httpInterceptor')
     })
-    $httpProvider.interceptors.push('httpInterceptor')
-  })
   .constant('TRASH_FOLDER_ID', '~Trash')
 
 function auth () {

--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -236,6 +236,7 @@ module.exports = function makeWebpackConfig () {
           HELIUM_BUNDLE_DEV: process.env.HELIUM_BUNDLE_DEV,
           SERVER_PORT: serverPort,
           WEB_PORT: webPort,
+          PROD: isProd,
           BUILD_CI: (isCI) ? JSON.stringify(true) : JSON.stringify(false)
         }
       })


### PR DESCRIPTION
### What is this PR for?

After https://github.com/apache/zeppelin/pull/2373, zeppelin-web dev mode does not work properly.
Dev mode always ask user login (even if authentication is turned off) and any login attempt will fail. So it makes difficult to develop front-end.

This PR fixes problem by not adding `X-Requested-With: XMLHttpRequest` header in dev mode.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix devmode

### How should this be tested?
run zeppelin-web dev mode and see if you can login / open notebook

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
