### PR TITLE
[ZEPPELIN-2731] GetUserList with JDBCRealm should read field authenti…

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -212,7 +212,7 @@ public class GetUserList {
     String userquery = "";
     try {
       dataSource = (DataSource) FieldUtils.readField(obj, "dataSource", true);
-      authQuery = (String) FieldUtils.readField(obj, "DEFAULT_AUTHENTICATION_QUERY", true);
+      authQuery = (String) FieldUtils.readField(obj, "authenticationQuery", true);
       LOG.info(authQuery);
       String authQueryLowerCase = authQuery.toLowerCase();
       retval = authQueryLowerCase.split("from", 2);


### PR DESCRIPTION
…cationQuery

### What is this PR for?
GetUserList with JDBCRealm should read field authenticationQuery but not DEFAULT_AUTHENTICATION_QUERY,
or it will assume that the query must be "select password from users where username = ?"

### What type of PR is it?
[Bug Fix]

### Todos
None

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-2731

### How should this be tested?
1. In shiro.ini config the JDBCRealm like:

ds = org.apache.commons.dbcp2.BasicDataSource
ds.driverClassName = com.mysql.jdbc.Driver
ds.url= jdbc:mysql://localhost:3306/shiro
ds.username = root
ds.password = 123456

jdbcRealm = org.apache.shiro.realm.jdbc.JdbcRealm
jdbcRealm.dataSource = $ds
jdbcRealm.permissionsLookupEnabled = false
jdbcRealm.authenticationQuery = SELECT password FROM user WHERE name = ?
jdbcRealm.userRolesQuery = SELECT role_name FROM user_roles WHERE name  = ?
jdbcRealm.permissionsQuery = SELECT permission FROM roles_permissions WHERE role_name = ?

2. login and request the rest
Get /security/userlist/youruser


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
