### PR TITLE
[ZEPPELIN-2733] Remove System Information Leak in Authentication.java.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/security/Authentication.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/security/Authentication.java
@@ -134,7 +134,6 @@ public class Authentication implements Runnable {
 
   // returns login:password
   private String getAuthKey(String userKey) {
-    LOG.debug("Encrypted user key is {}", userKey);
     if (StringUtils.isBlank(userKey)) {
       LOG.warn("ZEPPELINHUB_USER_KEY is blank");
       return StringUtils.EMPTY;
@@ -145,7 +144,6 @@ public class Authentication implements Runnable {
   }
 
   private String decrypt(String value, String initVector) {
-    LOG.debug("IV is {}, IV length is {}", initVector, initVector.length());
     if (StringUtils.isBlank(value) || StringUtils.isBlank(initVector)) {
       LOG.error("String to decode or salt is not provided");
       return StringUtils.EMPTY;


### PR DESCRIPTION
### What is this PR for?
An information leak occurs when system data or debugging information leaves the program through an output stream or logging function.
In the file Authentication.java,
```
Line 137: LOG.debug("Encrypted user key is {}", userKey);
Line 148: LOG.debug("IV is {}, IV length is {}", initVector, initVector.length());
```
These lines may print information which can reveal some important data to user making it vulnerable to attacks, we should not log this sensitive information.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2733


### How should this be tested?
Existing tests.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
