### PR TITLE
[ZEPPELIN-2648] Fix spark module build problem with scala-2.10 profile

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -540,7 +540,6 @@
         <spark.version>2.0.2</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.3</spark.py4j.version>
-        <scala.version>2.11.8</scala.version>
       </properties>
     </profile>
 
@@ -553,7 +552,6 @@
         <spark.version>2.1.0</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.4</spark.py4j.version>
-        <scala.version>2.11.8</scala.version>
       </properties>
     </profile>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -424,6 +424,7 @@
         <artifactId>maven-scala-plugin</artifactId>
         <version>${plugin.scala.version}</version>
         <configuration>
+            <scalaVersion>${scala.version}</scalaVersion>
           <excludes>
             <exclude>**/ZeppelinR.scala</exclude>
             <exclude>**/SparkRBackend.scala</exclude>
@@ -550,7 +551,6 @@
         <spark.version>2.0.2</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.3</spark.py4j.version>
-        <scala.version>2.11.8</scala.version>
       </properties>
     </profile>
 
@@ -563,7 +563,6 @@
         <spark.version>2.1.0</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.4</spark.py4j.version>
-        <scala.version>2.11.8</scala.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
*  remove scala version in spark2 profile , we should compose scala profile and spark profile to address scala and spark version
*  address scalaVersion evidently in maven-scala-plugin

### What is this PR for?
details by ZEPPELIN-2648


### What type of PR is it?
[Bug Fix]

### Todos
None

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2648


### How should this be tested?
execute below command and check whether the zeppelin-spark artifact is build based on specified scala  and spark version.
 
mvn clean package -Pscala-2.10 -Pspark-2.1

mvn clean package -Pscala-2.11 -Pspark-2.1

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
