### PR TITLE
[ZEPPELIN-2744] [minor] Increase error handling in JDBC interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -702,6 +702,13 @@ public class JDBCInterpreter extends KerberosInterpreter {
               String results = getResults(resultSet,
                   !containsIgnoreCase(sqlToExecute, EXPLAIN_PREDICATE));
               interpreterResult.add(results);
+              try {
+                if (resultSet.isClosed()) {
+                  break;
+                }
+              } catch (Exception e) {
+                logger.info("Exception checking isClosed on resultSet, nothing to worry");
+              }
               if (resultSet.next()) {
                 interpreterResult.add(ResultMessages.getExceedsLimitRowsMessage(getMaxResult(),
                     String.format("%s.%s", COMMON_KEY, MAX_LINE_KEY)));


### PR DESCRIPTION
### What is this PR for?
At times running a phoenix sql query throws "ResultSet is closed."

```
java.sql.SQLException: ERROR 1101 (XCL01): ResultSet is closed.
at org.apache.phoenix.exception.SQLExceptionCode$Factory$1.newException(SQLExceptionCode.java:442)
at org.apache.phoenix.exception.SQLExceptionInfo.buildException(SQLExceptionInfo.java:145)
at org.apache.phoenix.jdbc.PhoenixResultSet.checkOpen(PhoenixResultSet.java:215)
at org.apache.phoenix.jdbc.PhoenixResultSet.next(PhoenixResultSet.java:772)
at org.apache.commons.dbcp2.DelegatingResultSet.next(DelegatingResultSet.java:191)
at org.apache.commons.dbcp2.DelegatingResultSet.next(DelegatingResultSet.java:191)
at org.apache.zeppelin.jdbc.JDBCInterpreter.executeSql(JDBCInterpreter.java:705)
at org.apache.zeppelin.jdbc.JDBCInterpreter.interpret(JDBCInterpreter.java:775)
at org.apache.zeppelin.interpreter.LazyOpenInterpreter.interpret(LazyOpenInterpreter.java:101)
at org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer$InterpretJob.jobRun(RemoteInterpreterServer.java:503)
at org.apache.zeppelin.scheduler.Job.run(Job.java:181)
at org.apache.zeppelin.scheduler.ParallelScheduler$JobRunner.run(ParallelScheduler.java:162)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)

```

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-2744](https://issues.apache.org/jira/browse/ZEPPELIN-2744)

### How should this be tested?
Try running a Phoenix query like `select * from SYSTEM.CATALOG` for me it was failing on a Kerberos enabled environment (on CentOS6.6 with Hbase-1.1.2).

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
