### PR TITLE
[ZEPPELIN-2579] Flaky Test: InterpreterOutputChangeWatcher.test

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputChangeWatcherTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputChangeWatcherTest.java
@@ -22,14 +22,15 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class InterpreterOutputChangeWatcherTest implements InterpreterOutputChangeListener {
   private File tmpDir;
-  private File fileChanged;
-  private int numChanged;
+  private Set<File> fileChanged;
   private InterpreterOutputChangeWatcher watcher;
 
   @Before
@@ -39,8 +40,7 @@ public class InterpreterOutputChangeWatcherTest implements InterpreterOutputChan
 
     tmpDir = new File(System.getProperty("java.io.tmpdir")+"/ZeppelinLTest_"+System.currentTimeMillis());
     tmpDir.mkdirs();
-    fileChanged = null;
-    numChanged = 0;
+    fileChanged = new HashSet<>();
   }
 
   @After
@@ -65,8 +65,7 @@ public class InterpreterOutputChangeWatcherTest implements InterpreterOutputChan
 
   @Test
   public void test() throws IOException, InterruptedException {
-    assertNull(fileChanged);
-    assertEquals(0, numChanged);
+    assertTrue(fileChanged.isEmpty());
 
     Thread.sleep(1000);
     // create new file
@@ -91,15 +90,13 @@ public class InterpreterOutputChangeWatcherTest implements InterpreterOutputChan
       wait(30*1000);
     }
 
-    assertNotNull(fileChanged);
-    assertEquals(1, numChanged);
+    assertTrue(fileChanged.contains(file1));
   }
 
 
   @Override
   public void fileChanged(File file) {
-    fileChanged = file;
-    numChanged++;
+    fileChanged.add(file);
 
     synchronized(this) {
       notify();


### PR DESCRIPTION
### What is this PR for?
Fixing flaky test
```
Running org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcherTest
15:12:09,215  INFO org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcher:71 - watch /tmp/ZeppelinLTest_1498403528213
15:12:10,223  INFO org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcher:125 - File change detected /tmp/ZeppelinLTest_1498403528213/test1
15:12:10,224  INFO org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcher:125 - File change detected /tmp/ZeppelinLTest_1498403528213/test1
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 32.034 sec <<< FAILURE! - in org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcherTest
test(org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcherTest)  Time elapsed: 32.031 sec  <<< FAILURE!
java.lang.AssertionError: expected:<1> but was:<2>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.apache.zeppelin.interpreter.InterpreterOutputChangeWatcherTest.test(InterpreterOutputChangeWatcherTest.java:95)
```

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2759

### How should this be tested?
Pass CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
