### PR TITLE
[ZEPPELIN-2762] Use regex to retrieve interpreter/repl name, and to retrieve property key; add and fix tests

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
@@ -94,6 +96,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   private Logger logger = LoggerFactory.getLogger(JDBCInterpreter.class);
 
+  static final Pattern PROPERTY_KEY_PATTERN = Pattern.compile("^\\(([a-zA-Z0-9-_]+)\\)");
   static final String INTERPRETER_NAME = "jdbc";
   static final String COMMON_KEY = "common";
   static final String MAX_LINE_KEY = "max_count";
@@ -667,7 +670,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
     try {
       connection = getConnection(propertyKey, interpreterContext);
       if (connection == null) {
-        return new InterpreterResult(Code.ERROR, "Prefix not found.");
+        return new InterpreterResult(Code.ERROR,
+          String.format("Prefix(%s) not found in %s.",
+            propertyKey, interpreterContext.getReplName()));
       }
 
 
@@ -682,7 +687,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
         if (statement == null) {
-          return new InterpreterResult(Code.ERROR, "Prefix not found.");
+          return new InterpreterResult(Code.ERROR,
+            String.format("Prefix(%s) not found in %s.",
+              propertyKey, interpreterContext.getReplName()));
+
         }
 
         try {
@@ -789,19 +797,13 @@ public class JDBCInterpreter extends KerberosInterpreter {
   }
 
   public String getPropertyKey(String cmd) {
-    boolean firstLineIndex = cmd.startsWith("(");
+    Matcher m = PROPERTY_KEY_PATTERN.matcher(cmd);
 
-    if (firstLineIndex) {
-      int configStartIndex = cmd.indexOf("(");
-      int configLastIndex = cmd.indexOf(")");
-      if (configStartIndex != -1 && configLastIndex != -1) {
-        return cmd.substring(configStartIndex + 1, configLastIndex);
-      } else {
-        return null;
-      }
-    } else {
-      return DEFAULT_KEY;
+    if (m.find()) {
+      return m.group(1);
     }
+
+    return DEFAULT_KEY;
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -70,6 +70,18 @@ public class ParagraphTest {
 
     text = "%table 1234567";
     assertEquals("1234567", Paragraph.getScriptBody(text));
+
+    text = "%presto (testPropertyKey) 1234567";
+    assertEquals("(testPropertyKey) 1234567", Paragraph.getScriptBody(text));
+
+    text = "%spark (1234567)";
+    assertEquals("(1234567)", Paragraph.getScriptBody(text));
+
+    text = "%jdbc(presto) (testPropertyKey) 1234567";
+    assertEquals("(testPropertyKey) 1234567", Paragraph.getScriptBody(text));
+
+    text = "%jdbc(presto) (testPropertyKey) (select 1234567)";
+    assertEquals("(testPropertyKey) (select 1234567)", Paragraph.getScriptBody(text));
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
Make logic to parse interpreter or repl name more robust by using regex.
Make logic to parse property name in JDBC interpreter more robust by using regex.
Add tests for cases missed before that the regexes would catch now.
Fix failing tests in Paragraph and JDBCInterpreter.

### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2762

### How should this be tested?
Appropriate unit tests should be added to fully test regexes. They are added as part of this PR.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
