### PR TITLE
[ZEPPELIN-1249] build all submodules w/ the same scala version

### DIFF
--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -52,7 +52,7 @@
     
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${beam.spark.version}</version>
       <exclusions>
         <exclusion>
@@ -64,15 +64,15 @@
           <groupId>io.netty</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-actor_2.10</artifactId>
+          <artifactId>akka-actor_${scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-remote_2.10</artifactId>
+          <artifactId>akka-remote_${scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-slf4j_2.10</artifactId>
+          <artifactId>akka-slf4j_${scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
       </exclusions>
@@ -80,7 +80,7 @@
   
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
+      <artifactId>spark-streaming_${scala.binary.version}</artifactId>
       <version>${beam.spark.version}</version>
     </dependency>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>org.apache.zeppelin</groupId>
-    <artifactId>zeppelin-cassandra_2.10</artifactId>
+    <artifactId>zeppelin-cassandra_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <version>0.8.0-SNAPSHOT</version>
     <name>Zeppelin: Apache Cassandra interpreter</name>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -34,6 +34,7 @@
     <description>Zeppelin cassandra support</description>
 
     <properties>
+        <cassandra.scala.version>${scala.version}</cassandra.scala.version>
         <cassandra.driver.version>3.0.1</cassandra.driver.version>
         <snappy.version>1.0.5.4</snappy.version>
         <lz4.version>1.3.0</lz4.version>
@@ -91,19 +92,19 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${cassandra.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${cassandra.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-reflect</artifactId>
-            <version>${scala.version}</version>
+            <version>${cassandra.scala.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -35,6 +35,7 @@
 
   <properties>
     <!--library versions-->
+    <flink.scala.version>${scala.version}</flink.scala.version>
     <flink.version>1.1.3</flink.version>
     <flink.akka.version>2.3.7</flink.akka.version>
     <scala.macros.version>2.0.1</scala.macros.version>
@@ -126,19 +127,19 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${flink.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${flink.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${flink.scala.version}</version>
     </dependency>
 
     <dependency>
@@ -185,7 +186,7 @@
 	  <compilerPlugins combine.children="append">
 	    <compilerPlugin>
 	      <groupId>org.scalamacros</groupId>
-	      <artifactId>paradise_${scala.version}</artifactId>
+	      <artifactId>paradise_${flink.scala.version}</artifactId>
 	      <version>${scala.macros.version}</version>
 	    </compilerPlugin>
 	  </compilerPlugins>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-flink_2.10</artifactId>
+  <artifactId>zeppelin-flink_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Flink</name>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>zeppelin-ignite_2.10</artifactId>
+  <artifactId>zeppelin-ignite_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Apache Ignite interpreter</name>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -32,6 +32,7 @@
   <name>Zeppelin: Apache Ignite interpreter</name>
 
   <properties>
+    <ignite.scala.version>${scala.version}</ignite.scala.version>
     <ignite.version>1.9.0</ignite.version>
   </properties>
 
@@ -70,19 +71,19 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
 
   <properties>
     <!-- language versions -->
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.7</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
   <properties>
     <!-- language versions -->
-    <scala.version>2.11.7</scala.version>
+    <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>2.2.4</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
@@ -743,7 +743,7 @@
     <profile>
       <id>scala-2.11</id>
       <properties>
-        <scala.version>2.11.7</scala.version>
+        <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
       </properties>
     </profile>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -27,7 +27,7 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>zeppelin-zrinterpreter_2.10</artifactId>
+  <artifactId>zeppelin-zrinterpreter_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <name>Zeppelin: R Interpreter</name>
   <description>R Interpreter for Zeppelin</description>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -38,6 +38,7 @@
     <!--library versions-->
     <spark.version>1.4.1</spark.version>
     <jsoup.version>[1.8.0,)</jsoup.version>
+    <r.scala.version>${scala.version}</r.scala.version>
 
     <!--test library versions-->
     <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${r.scala.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-scalding_2.10</artifactId>
+  <artifactId>zeppelin-scalding_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Scalding interpreter</name>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -37,6 +37,7 @@
     <hadoop.version>2.6.0</hadoop.version>
     <scalding.version>0.16.1-RC1</scalding.version>
     <commons.exec.version>1.3</commons.exec.version>
+    <scalding.scala.version>${scala.version}</scalding.scala.version>
 
     <!--plugin versions-->
     <plugin.scala.version>2.15.2</plugin.scala.version>
@@ -120,19 +121,19 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${scalding.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${scalding.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${scalding.scala.version}</version>
     </dependency>
 
     <dependency>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-scio_2.10</artifactId>
+  <artifactId>zeppelin-scio_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Scio</name>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -37,6 +37,7 @@
     <!--library versions-->
     <scio.version>0.2.4</scio.version>
     <guava.version>14.0.1</guava.version> <!-- update needed -->
+    <scio.scala.version>${scala.version}</scio.scala.version>
 
     <!--plugin versions-->
     <plugin.shade.version>2.3</plugin.shade.version>
@@ -71,19 +72,19 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${scio.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${scio.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${scio.scala.version}</version>
     </dependency>
 
     <!-- test libraries -->

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-spark-dependencies_2.10</artifactId>
+  <artifactId>zeppelin-spark-dependencies_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Spark dependencies</name>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,6 +43,7 @@
     <maven.plugin.api.version>3.0</maven.plugin.api.version>
     <aether.version>1.12</aether.version>
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
+    <spark.scala.version>${scala.version}</spark.scala.version>
     <wagon.version>1.0</wagon.version>
 
     <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
@@ -227,21 +228,21 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${spark.scala.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${spark.scala.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${spark.scala.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-spark_2.10</artifactId>
+  <artifactId>zeppelin-spark_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Spark</name>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-display_2.10</artifactId>
+  <artifactId>zeppelin-display_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
   <version>0.8.0-SNAPSHOT</version>
   <name>Zeppelin: Display system apis</name>


### PR DESCRIPTION
### What is this PR for?
This uses the same Scala version throughout modules, allowing us to use only Scala 2.11.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1249
https://issues.apache.org/jira/browse/ZEPPELIN-2681

### Questions:
* Does the licenses files need update?
No

* Is there breaking changes for older versions?
No

* Does this needs documentation?
No