### PR TITLE
[HOTFIX][ZEPPELIN-2760] fix JDBC regression caused after ZEPPELIN-2698

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -210,9 +210,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
 
   protected boolean isKerboseEnabled() {
-    UserGroupInformation.AuthenticationMethod authType = JDBCSecurityImpl.getAuthtype(property);
-    if (authType.equals(KERBEROS)) {
-      return true;
+    if (!isEmpty(property.getProperty("zeppelin.jdbc.auth.type"))) {
+      UserGroupInformation.AuthenticationMethod authType = JDBCSecurityImpl.getAuthtype(property);
+      if (authType.equals(KERBEROS)) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
### What is this PR for?
This is WRT to https://github.com/apache/zeppelin/commit/e1f0a3205eb5aede0b2d80c9d3de59b3f47b699c#commitcomment-23016062

> This caused a regression:
https://github.com/apache/zeppelin/blame/master/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java#L212
Leads to:
java.lang.NoClassDefFoundError: org/apache/hadoop/security/UserGroupInformation$AuthenticationMethod
	at org.apache.zeppelin.jdbc.security.JDBCSecurityImpl.getAuthtype(JDBCSecurityImpl.java:64)
	at org.apache.zeppelin.jdbc.JDBCInterpreter.isKerboseEnabled(JDBCInterpreter.java:213)


### What type of PR is it?
[Bug Fix | Hot Fix]

### What is the Jira issue?
* [ZEPPELIN-2760](https://issues.apache.org/jira/browse/ZEPPELIN-2760)


### How should this be tested?
Check JDBC interpreter without any Kerberos setting 


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
 