### PR TITLE
[ZEPPELIN-2766] Make online resources url configurable at compile time

### DIFF
--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -2,7 +2,7 @@
 layout: page
 title: "How to Build Zeppelin from source"
 description: "How to build Zeppelin from source"
-group: setup/basics 
+group: setup/basics
 ---
 <!--
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -207,8 +207,39 @@ Scalding Interpreter
 mvn clean package -Pscalding -DskipTests
 ```
 
+### Optional configurations
+
+Here are additional configurations that could be optionally tuned using the trailing `-D` option for maven commands
 
 
+Spark package
+
+```bash
+spark.archive # default spark-${spark.version}
+spark.src.download.url # default http://d3kbcqa49mib13.cloudfront.net/${spark.archive}.tgz
+spark.bin.download.url # default http://d3kbcqa49mib13.cloudfront.net/${spark.archive}-bin-without-hadoop.tgz
+```
+
+Py4J package
+
+```bash
+python.py4j.version # default 0.9.2
+pypi.repo.url # default https://pypi.python.org/packages
+python.py4j.repo.folder # default /64/5c/01e13b68e8caafece40d549f232c9b5677ad1016071a48d04cc3895acaa3
+```
+
+final URL location for Py4J package will be produced as following:
+
+`${pypi.repo.url}${python.py4j.repo.folder}py4j-${python.py4j.version}.zip`
+
+
+Frontend Maven Plugin configurations
+
+```
+plugin.frontend.nodeDownloadRoot # default https://nodejs.org/dist/
+plugin.frontend.npmDownloadRoot # default http://registry.npmjs.org/npm/-/
+plugin.frontend.yarnDownloadRoot # default https://github.com/yarnpkg/yarn/releases/download/
+```
 
 ## Build requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <node.version>v6.9.1</node.version>
     <yarn.version>v0.18.1</yarn.version>
     <npm.version>4.2.0</npm.version>
-    <plugin.frontned.version>1.3</plugin.frontned.version>
+    <plugin.frontend.version>1.3</plugin.frontend.version>
 
     <!-- common library versions -->
     <slf4j.version>1.7.10</slf4j.version>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -39,6 +39,8 @@
         **/PythonInterpreterPandasSqlTest.java,
         **/PythonInterpreterMatplotlibTest.java
     </python.test.exclude>
+    <pypi.repo.url>https://pypi.python.org/packages</pypi.repo.url>
+    <python.py4j.repo.folder>/64/5c/01e13b68e8caafece40d549f232c9b5677ad1016071a48d04cc3895acaa3</python.py4j.repo.folder>
   </properties>
 
   <dependencies>
@@ -107,7 +109,7 @@
             <phase>package</phase>
             <goals><goal>download-single</goal></goals>
             <configuration>
-              <url>https://pypi.python.org/packages/64/5c/01e13b68e8caafece40d549f232c9b5677ad1016071a48d04cc3895acaa3</url>
+              <url>${pypi.repo.url}${python.py4j.repo.folder}</url>
               <fromFile>py4j-${python.py4j.version}.zip</fromFile>
               <toFile>${project.build.directory}/../../interpreter/python/py4j-${python.py4j.version}.zip</toFile>
             </configuration>

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -60,7 +60,7 @@
       http://d3kbcqa49mib13.cloudfront.net/${spark.archive}.tgz
     </spark.src.download.url>
     <spark.bin.download.url>
-      http://d3kbcqa49mib13.cloudfront.net/spark-${spark.version}-bin-without-hadoop.tgz
+      http://d3kbcqa49mib13.cloudfront.net/${spark.archive}-bin-without-hadoop.tgz
     </spark.bin.download.url>
     <spark.py4j.version>0.8.2.1</spark.py4j.version>
 

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -42,6 +42,12 @@
     <web.e2e.enabled>false</web.e2e.enabled>
     <zeppelin.daemon.package.base>../bin</zeppelin.daemon.package.base>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!--plugin versions-->
+    <plugin.frontend.downloadRoot>https://nodejs.org/dist/</plugin.frontend.downloadRoot>
+    <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
+    <plugin.frontend.npmDownloadRoot>http://registry.npmjs.org/npm/-/</plugin.frontend.npmDownloadRoot>
+    <plugin.frontend.yarnDownloadRoot>https://github.com/yarnpkg/yarn/releases/download/</plugin.frontend.yarnDownloadRoot>
   </properties>
 
   <build>
@@ -58,7 +64,14 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>${plugin.frontned.version}</version>
+        <version>${plugin.frontend.version}</version>
+        <configuration>
+          <downloadRoot>${plugin.frontend.downloadRoot}</downloadRoot>
+          <nodeDownloadRoot>${plugin.frontend.nodeDownloadRoot}</nodeDownloadRoot>
+          <npmDownloadRoot>${plugin.frontend.npmDownloadRoot}</npmDownloadRoot>
+          <yarnDownloadRoot>${plugin.frontend.yarnDownloadRoot}</yarnDownloadRoot>
+        </configuration>
+
         <executions>
 
           <execution>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -44,7 +44,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!--plugin versions-->
-    <plugin.frontend.downloadRoot>https://nodejs.org/dist/</plugin.frontend.downloadRoot>
     <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
     <plugin.frontend.npmDownloadRoot>http://registry.npmjs.org/npm/-/</plugin.frontend.npmDownloadRoot>
     <plugin.frontend.yarnDownloadRoot>https://github.com/yarnpkg/yarn/releases/download/</plugin.frontend.yarnDownloadRoot>
@@ -66,7 +65,6 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${plugin.frontend.version}</version>
         <configuration>
-          <downloadRoot>${plugin.frontend.downloadRoot}</downloadRoot>
           <nodeDownloadRoot>${plugin.frontend.nodeDownloadRoot}</nodeDownloadRoot>
           <npmDownloadRoot>${plugin.frontend.npmDownloadRoot}</npmDownloadRoot>
           <yarnDownloadRoot>${plugin.frontend.yarnDownloadRoot}</yarnDownloadRoot>


### PR DESCRIPTION
### What is this PR for?
At compile time Zeppelin is downloading several external resources.
I want to be able to provide alternative URLs to compile when internet is not available(i.e. behind corporate proxy).

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-2766]

### How should this be tested?
```
mvn -DskipTests -Dplugin.frontend.downloadRoot=<alernative-url> -Dplugin.frontend.nodeDownloadRoot=<alernative-url> -Dplugin.frontend.yarnDownloadRoot=<alernative-url> -Dplugin.frontend.npmDownloadRoot=<alernative-url> -Dpypi.repo.url=<alernative-url> clean package
```

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
