### PR TITLE
[ZEPPELIN-2711] basic metrics for paragraphs & notebook view/create/run

### DIFF
--- a/docs/usage/other_features/monitoring.md
+++ b/docs/usage/other_features/monitoring.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: "Monitoring"
+description: ""
+group: usage/other_features
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Monitoring & Metrics
+
+ Zeppelin exposes a few usage metrics in the form of JMX Beans (under the org.apache.zeppelin.metrics package) and also as a JSON endpoint (/metrics).
+
+ The current set of metrics is mainly around execution time of common operations - int includes quantiles (p50 and p99), counts and mean.
+
+<div id="toc"></div>
+

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
   <inceptionYear>2013</inceptionYear>
 
   <modules>
+    <module>zeppelin-metrics</module>
     <module>zeppelin-interpreter</module>
     <module>zeppelin-zengine</module>
     <module>zeppelin-display</module>

--- a/zeppelin-distribution/README.md
+++ b/zeppelin-distribution/README.md
@@ -29,7 +29,7 @@ Zeppelin
  ├── lib
  ├── licenses
  ├── notebook
- └── zeppelin-web-<verion>.war
+ └── zeppelin-web-<version>.war
  
 ```
 

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -217,6 +217,7 @@ The following components are provided under Apache License.
     (Apache 2.0) frontend-maven-plugin 1.3 (com.github.eirslett:frontend-maven-plugin:1.3 - https://github.com/eirslett/frontend-maven-plugin/blob/frontend-plugins-1.3/LICENSE
     (Apache 2.0) frontend-plugin-core 1.3 (com.github.eirslett:frontend-plugin-core) - https://github.com/eirslett/frontend-maven-plugin/blob/frontend-plugins-1.3/LICENSE
     (Apache 2.0) mongo-java-driver 3.4.1 (org.mongodb:mongo-java-driver:3.4.1) - https://github.com/mongodb/mongo-java-driver/blob/master/LICENSE.txt
+    (Apache 2.0) jmxutils 1.9 (org.weakref:jmxutils:1.9) - https://github.com/martint/jmxutils/blob/master/LICENSE
 
 ========================================================================
 MIT licenses
@@ -341,6 +342,8 @@ The following components are provided under the BSD-style License.
     (BSD-3-Clause) Scalamacros Quasiquotes 2.1.0 (org.scalamacros:quasiquotes:2.1.0 - https://mvnrepository.com/artifact/org.scalamacros/quasiquotes_2.10/2.1.0)
     (BSD-2-Clause) JUnit Interface 0.11 (com.novocode:junit-interface:0.11 - https://github.com/sbt/junit-interface)
     (BSD-3-Clause) SBT Test Interface (org.scala-sbt:test-interface:1.0 - https://github.com/sbt/test-interface)
+    (BSD-2-Clause) HDRHistogram 2.1.4 (org.hdrhistogram:HdrHistogram:2.1.4) - https://github.com/HdrHistogram/HdrHistogram/blob/master/LICENSE.txt
+
 
 ========================================================================
 CDDL license

--- a/zeppelin-metrics/pom.xml
+++ b/zeppelin-metrics/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/zeppelin-metrics/pom.xml
+++ b/zeppelin-metrics/pom.xml
@@ -32,10 +32,12 @@
     <name>Zeppelin operational metrics</name>
 
     <properties>
+        <!--library versions -->
+        <commons.lang3.version>3.4</commons.lang3.version>
+        <plugin.hdrhistogram.version>2.1.4</plugin.hdrhistogram.version>
         <!--plugin versions -->
         <plugin.failsafe.version>2.16</plugin.failsafe.version>
         <plugin.jmxutils.version>1.9</plugin.jmxutils.version>
-        <plugin.hdrhistogram.version>2.1.4</plugin.hdrhistogram.version>
     </properties>
 
     <dependencies>
@@ -44,10 +46,17 @@
             <artifactId>jmxutils</artifactId>
             <version>${plugin.jmxutils.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
             <version>${plugin.hdrhistogram.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
         </dependency>
 
         <dependency>

--- a/zeppelin-metrics/pom.xml
+++ b/zeppelin-metrics/pom.xml
@@ -60,6 +60,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/zeppelin-metrics/pom.xml
+++ b/zeppelin-metrics/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.zeppelin</groupId>
+        <artifactId>zeppelin</artifactId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.apache.zeppelin</groupId>
+    <artifactId>zeppelin-metrics</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+    <name>Zeppelin operational metrics</name>
+
+    <properties>
+        <!--plugin versions -->
+        <plugin.failsafe.version>2.16</plugin.failsafe.version>
+        <plugin.jmxutils.version>1.9</plugin.jmxutils.version>
+        <plugin.hdrhistogram.version>2.1.4</plugin.hdrhistogram.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+            <version>${plugin.jmxutils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>${plugin.hdrhistogram.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkMode>always</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
@@ -22,25 +22,17 @@ import org.weakref.jmx.Managed;
  * A stat keeping simple counters only
  */
 public class CounterStat implements Stat {
-  private long count;
-
-  public CounterStat() {
-  }
+  private AtomicLong count = new AtomicLong();
 
   @Override
   @Managed
   public long getCount() {
-    return count;
+    return count.get();
   }
 
   @Override
   @Managed
   public void record(long amount) {
-    setCount(count + amount);
-  }
-
-  @Managed
-  private void setCount(long count) {
-    this.count = count;
+    this.count.addAndGet(amount);
   }
 }

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
@@ -16,6 +16,8 @@
  */
 package org.apache.zeppelin.metrics;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.weakref.jmx.Managed;
 
 /**

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
@@ -1,0 +1,30 @@
+package org.apache.zeppelin.metrics;
+
+import org.weakref.jmx.Managed;
+
+/**
+ * A stat keeping simple counters only
+ */
+public class CounterStat implements Stat {
+  private long count;
+
+  public CounterStat() {
+  }
+
+  @Override
+  @Managed
+  public long getCount() {
+    return count;
+  }
+
+  @Override
+  @Managed
+  public void record(long amount) {
+    setCount(count + amount);
+  }
+
+  @Managed
+  private void setCount(long count) {
+    this.count = count;
+  }
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/CounterStat.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import org.weakref.jmx.Managed;

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
@@ -1,0 +1,37 @@
+package org.apache.zeppelin.metrics;
+
+import org.weakref.jmx.Managed;
+
+/**
+ * A stat that contains a histogram distribution of values
+ */
+public class FailureStat implements Stat {
+  private final Exception exception;
+  private long count;
+
+  public FailureStat(MetricType type, Exception ex) {
+    this.exception = ex;
+  }
+
+  @Managed
+  @Override
+  public long getCount() {
+    return count;
+  }
+
+  @Managed
+  @Override
+  public void record(long q) {
+    setCount(count + q);
+  }
+
+  @Managed
+  public Exception getException() {
+    return exception;
+  }
+
+  @Managed
+  public void setCount(long count) {
+    this.count = count;
+  }
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
@@ -17,6 +17,7 @@
 package org.apache.zeppelin.metrics;
 
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.weakref.jmx.Managed;
 
 /**

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.metrics;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.weakref.jmx.Managed;
 
 /**
@@ -23,31 +24,26 @@ import org.weakref.jmx.Managed;
  */
 public class FailureStat implements Stat {
   private final Exception exception;
-  private long count;
+  private AtomicLong count = new AtomicLong();
 
-  public FailureStat(MetricType type, Exception ex) {
+  public FailureStat(Exception ex) {
     this.exception = ex;
   }
 
   @Managed
   @Override
   public long getCount() {
-    return count;
+    return count.get();
   }
 
   @Managed
   @Override
   public void record(long q) {
-    setCount(count + q);
+    this.count.addAndGet(q);
   }
 
   @Managed
   public Exception getException() {
     return exception;
-  }
-
-  @Managed
-  public void setCount(long count) {
-    this.count = count;
   }
 }

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/FailureStat.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import org.weakref.jmx.Managed;

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
@@ -16,6 +16,9 @@
  */
 package org.apache.zeppelin.metrics;
 
+/*
+ * Business metrics
+ */
 public enum MetricType {
   ParagraphRun,
   NotebookRun,

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
@@ -1,0 +1,11 @@
+package org.apache.zeppelin.metrics;
+
+/**
+ * Created by hfreire on 6/30/17.
+ */
+public enum MetricType {
+  ParagraphRun,
+  NotebookRun,
+  NotebookView,
+  NotebookCreate
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
@@ -16,7 +16,7 @@
  */
 package org.apache.zeppelin.metrics;
 
-/*
+/**
  * Business metrics
  */
 public enum MetricType {

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/MetricType.java
@@ -1,8 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
-/**
- * Created by hfreire on 6/30/17.
- */
 public enum MetricType {
   ParagraphRun,
   NotebookRun,

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
@@ -1,0 +1,106 @@
+package org.apache.zeppelin.metrics;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.weakref.jmx.MBeanExporter;
+
+/**
+ * JMX-backed Metrics manager
+ * <p>
+ * This class is used to instantiate "MBeans" - JMX POJOs you can call getters/setters on in order
+ * to update metrics of all kinds.
+ */
+public class Metrics {
+  private static Metrics instance;
+  private MBeanExporter exporter;
+
+  private final Map<MetricType, Stat> stats = new HashMap<>();
+  private final Map<MetricType, Map<Exception, Stat>> failureStats = new HashMap<>();
+
+  public static Metrics getInstance() {
+    if (instance == null) {
+      instance = new Metrics();
+    }
+
+    return instance;
+  }
+
+  protected Metrics() {
+    exporter = new MBeanExporter(ManagementFactory.getPlatformMBeanServer());
+
+    MetricType[] timedMetrics = {
+      MetricType.ParagraphRun,
+      MetricType.NotebookRun,
+      MetricType.NotebookCreate,
+      MetricType.NotebookView,
+    };
+    for (MetricType timedMetric : timedMetrics) {
+      stats.put(
+        timedMetric,
+        exported(
+          timedMetric.name(),
+          new TimedStat())
+      );
+    }
+
+    MetricType[] countMetrics = {
+    };
+    for (MetricType countMetric : countMetrics) {
+      stats.put(
+        countMetric,
+        exported(
+          countMetric.name(),
+          new CounterStat())
+      );
+    }
+
+  }
+
+  public Map<MetricType, Stat> getStats() {
+    return stats;
+  }
+
+  public Map<MetricType, Map<Exception, Stat>> getFailureStats() {
+    return failureStats;
+  }
+
+  public void increment(MetricType type) {
+    stats.get(type).record(1);
+  }
+
+  public void save(TimedExecution run) {
+    run.finish();
+    stats.get(run.getMetricType()).record(run.getDuration());
+  }
+
+  public void saveFailure(Exception e, MetricType type) {
+    Map<Exception, Stat> exceptions = failureStats.get(type);
+    if (exceptions == null) {
+      exceptions = new HashMap<>();
+      failureStats.put(type, exceptions);
+    }
+
+    Stat stat = exceptions.get(e);
+    if (stat == null) {
+      stat = exported(
+        type.name() + "_" + e.getClass().getSimpleName(),
+        new FailureStat(type, e)
+      );
+      exceptions.put(e, stat);
+    }
+
+    stat.record(1);
+  }
+
+  public TimedExecution startMeasurement(MetricType type) {
+    return new TimedExecution(type);
+  }
+
+  // "manage" a bean, so that changes to it will be saved
+  private <T> T exported(String name, T bean) {
+    exporter.export("org.apache.zeppelin.metrics:name=" + name, bean);
+    return bean;
+  }
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
@@ -87,8 +87,9 @@ public class Metrics {
   }
 
   public void save(TimedExecution run) {
-    run.finish();
-    stats.get(run.getMetricType()).record(run.getDuration());
+    stats.get(run.getMetricType()).record(
+      System.currentTimeMillis() - run.getStart()
+    );
   }
 
   public void saveFailure(Exception e, MetricType type) {

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import java.lang.management.ManagementFactory;

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Metrics.java
@@ -102,7 +102,7 @@ public class Metrics {
     if (stat == null) {
       stat = exported(
         type.name() + "_" + e.getClass().getSimpleName(),
-        new FailureStat(type, e)
+        new FailureStat(e)
       );
       exceptions.put(e, stat);
     }

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Stat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Stat.java
@@ -1,0 +1,10 @@
+package org.apache.zeppelin.metrics;
+
+/**
+ * Base attributes any JMX stat will expose: for now, only count is required. Some stats
+ * may include execution times (eg. p99 latency) - see TimedStat for those
+ */
+public interface Stat {
+  long getCount();
+  void record(long amount);
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Stat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/Stat.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 /**

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
@@ -16,6 +16,9 @@
  */
 package org.apache.zeppelin.metrics;
 
+ /**
+  * Capture an execution of a metric (start & end times). This class is not thread-safe.
+  */
 public class TimedExecution {
   private final MetricType type;
   private long start;
@@ -26,7 +29,7 @@ public class TimedExecution {
     this.type = type;
   }
 
-  public void finish() {
+  protected void finish() {
     this.finish = System.currentTimeMillis();
   }
 

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
@@ -1,8 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
-/**
- * Created by hfreire on 6/30/17.
- */
 public class TimedExecution {
   private final MetricType type;
   private long start;

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
@@ -22,22 +22,17 @@ package org.apache.zeppelin.metrics;
 public class TimedExecution {
   private final MetricType type;
   private long start;
-  private long finish;
 
   public TimedExecution(MetricType type) {
     start = System.currentTimeMillis();
     this.type = type;
   }
 
-  protected void finish() {
-    this.finish = System.currentTimeMillis();
-  }
-
   public MetricType getMetricType() {
     return type;
   }
 
-  public long getDuration() {
-    return finish - start;
+  public long getStart() {
+    return start;
   }
 }

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedExecution.java
@@ -1,0 +1,27 @@
+package org.apache.zeppelin.metrics;
+
+/**
+ * Created by hfreire on 6/30/17.
+ */
+public class TimedExecution {
+  private final MetricType type;
+  private long start;
+  private long finish;
+
+  public TimedExecution(MetricType type) {
+    start = System.currentTimeMillis();
+    this.type = type;
+  }
+
+  public void finish() {
+    this.finish = System.currentTimeMillis();
+  }
+
+  public MetricType getMetricType() {
+    return type;
+  }
+
+  public long getDuration() {
+    return finish - start;
+  }
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
@@ -54,7 +54,7 @@ public class TimedStat implements Stat {
 
   @Managed
   public double getMeanMillis() {
-    return histogram.getMean();
+    return notNan(histogram.getMean());
   }
 
   @Managed
@@ -65,11 +65,6 @@ public class TimedStat implements Stat {
   @Managed
   public double getP99Millis() {
     return histogram.getValueAtPercentile(99);
-  }
-
-  @Managed
-  public double getMeanMillisOneMinute() {
-    return oneMinuteHistogram.getMean();
   }
 
   @Managed
@@ -101,5 +96,9 @@ public class TimedStat implements Stat {
 
   private long nearestMinute() {
     return DateUtils.round(new Date(), Calendar.MINUTE).getTime();
+  }
+
+  private double notNan(double mean) {
+    return Double.isNaN(mean) ? 0.0 : mean;
   }
 }

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
@@ -1,0 +1,80 @@
+package org.apache.zeppelin.metrics;
+
+import org.HdrHistogram.ConcurrentHistogram;
+import org.HdrHistogram.Histogram;
+import org.weakref.jmx.Managed;
+
+/**
+ * A stat that contains a histogram distribution of values
+ */
+public class TimedStat implements Stat {
+  public static final long MAX_MILLIS = 300000;
+
+  private final Histogram histogram;
+  private double maxValue;
+  private double p99Millis;
+  private double meanMillis;
+  private double p50Millis;
+
+  public TimedStat() {
+    // metrics w/ upper bound of 5 minutes
+    this.histogram = new ConcurrentHistogram(TimedStat.MAX_MILLIS, 5);
+  }
+
+  @Managed
+  @Override
+  public long getCount() {
+    return histogram.getTotalCount();
+  }
+
+  @Managed
+  public double getMaxMillis() {
+    return maxValue;
+  }
+
+  @Managed
+  public double getP99Millis() {
+    return p99Millis;
+  }
+
+  @Managed
+  @Override
+  public void record(long duration) {
+    histogram.recordValue(duration);
+
+    setMaxValue(histogram.getMaxValueAsDouble());
+    setP99Millis(histogram.getValueAtPercentile(99));
+    setP50Millis(histogram.getValueAtPercentile(50));
+    setMeanMillis(histogram.getMean());
+  }
+
+  @Managed
+  private void setMaxValue(double maxValue) {
+    this.maxValue = maxValue;
+  }
+
+  @Managed
+  private void setP99Millis(long p99Millis) {
+    this.p99Millis = p99Millis;
+  }
+
+  @Managed
+  public double getMeanMillis() {
+    return meanMillis;
+  }
+
+  @Managed
+  private void setMeanMillis(double meanMillis) {
+    this.meanMillis = meanMillis;
+  }
+
+  @Managed
+  public double getP50Millis() {
+    return p50Millis;
+  }
+
+  @Managed
+  void setP50Millis(long p50Millis) {
+    this.p50Millis = p50Millis;
+  }
+}

--- a/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
+++ b/zeppelin-metrics/src/main/java/org/apache/zeppelin/metrics/TimedStat.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import org.HdrHistogram.ConcurrentHistogram;

--- a/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/MetricsTest.java
+++ b/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/MetricsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import java.lang.management.ManagementFactory;

--- a/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/MetricsTest.java
+++ b/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/MetricsTest.java
@@ -1,0 +1,35 @@
+package org.apache.zeppelin.metrics;
+
+import java.lang.management.ManagementFactory;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MetricsTest {
+
+  @Test
+  public void testExports() throws MalformedObjectNameException, IntrospectionException, InstanceNotFoundException, ReflectionException {
+    MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    Metrics m = Metrics.getInstance();
+
+    // all metrics are exposed as MBeans
+    for (MetricType type : MetricType.values()) {
+      ObjectName name = ObjectName.getInstance("org.apache.zeppelin.metrics:name=" + type.name());
+      assertTrue(mbeanServer.isRegistered(name));
+
+      MBeanInfo info = mbeanServer.getMBeanInfo(name);
+      assertEquals("org.apache.zeppelin.metrics.TimedStat", info.getClassName());
+    }
+  }
+
+}

--- a/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/TimedStatTest.java
+++ b/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/TimedStatTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.metrics;
 
 import org.junit.Test;

--- a/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/TimedStatTest.java
+++ b/zeppelin-metrics/src/test/java/org/apache/zeppelin/metrics/TimedStatTest.java
@@ -1,0 +1,23 @@
+package org.apache.zeppelin.metrics;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TimedStatTest {
+
+  @Test
+  public void recording() throws InterruptedException {
+    TimedStat metric = new TimedStat();
+    for (int i = 0; i < 2000; i++) {
+      metric.record(i);
+    }
+
+    assertEquals(999.5, metric.getMeanMillis(), 0.01);
+    assertEquals(999.0, metric.getP50Millis(), 0.01);
+    assertEquals(1979.0, metric.getP99Millis(), 0.01);
+    assertEquals(1999.0, metric.getMaxMillis(), 0.01);
+    assertEquals(2000, metric.getCount());
+  }
+
+}

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -83,6 +83,11 @@
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
@@ -59,8 +59,8 @@ public class MetricsRestApi {
     return new JsonResponse(Status.OK, metricsMap()).build();
   }
 
-  private Map<String, Number> metricsMap() {
-    Map<String, Number> res = new HashMap<>();
+  private Map<String, Object> metricsMap() {
+    Map<String, Object> res = new HashMap<>();
 
     for (Map.Entry<MetricType, Stat> e : metrics.getStats().entrySet()) {
       Stat val = e.getValue();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
@@ -54,7 +54,7 @@ public class MetricsRestApi {
    * @throws IOException, IllegalArgumentException
    */
   @GET
-  public Response getCredentials(String message) throws
+  public Response getMetrics(String message) throws
     IOException, IllegalArgumentException {
     return new JsonResponse(Status.OK, metricsMap()).build();
   }
@@ -70,6 +70,9 @@ public class MetricsRestApi {
 
       if (val instanceof TimedStat) {
         TimedStat timed = (TimedStat) val;
+        res.put(metricName + "_P99MillisOneMinute", timed.getP99MillisOneMinute());
+        res.put(metricName + "_P50MillisOneMinute", timed.getP50MillisOneMinute());
+        res.put(metricName + "_MaxMillisOneMinute", timed.getMaxMillisOneMinute());
         res.put(metricName + "_P99Millis", timed.getP99Millis());
         res.put(metricName + "_P50Millis", timed.getP50Millis());
         res.put(metricName + "_MaxMillis", timed.getMaxMillis());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.zeppelin.metrics.FailureStat;
+import org.apache.zeppelin.metrics.MetricType;
+import org.apache.zeppelin.metrics.Metrics;
+import org.apache.zeppelin.metrics.Stat;
+import org.apache.zeppelin.metrics.TimedStat;
+import org.apache.zeppelin.server.JsonResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metrics Rest API
+ */
+@Path("/metrics")
+@Produces("application/json")
+public class MetricsRestApi {
+  Logger logger = LoggerFactory.getLogger(MetricsRestApi.class);
+  private Metrics metrics = Metrics.getInstance();
+
+  public MetricsRestApi() {
+  }
+
+  /**
+   * Get metrics list REST API
+   *
+   * @return JSON with status.OK
+   * @throws IOException, IllegalArgumentException
+   */
+  @GET
+  public Response getCredentials(String message) throws
+    IOException, IllegalArgumentException {
+    return new JsonResponse(Status.OK, metricsMap()).build();
+  }
+
+  private Map<String, Number> metricsMap() {
+    Map<String, Number> res = new HashMap<>();
+
+    for (Map.Entry<MetricType, Stat> e : metrics.getStats().entrySet()) {
+      Stat val = e.getValue();
+      String metricName = metricName(e.getKey(), val);
+
+      res.put(metricName + "_Count", val.getCount());
+
+      if (val instanceof TimedStat) {
+        TimedStat timed = (TimedStat) val;
+        res.put(metricName + "_P99Millis", timed.getP99Millis());
+        res.put(metricName + "_P50Millis", timed.getP50Millis());
+        res.put(metricName + "_MaxMillis", timed.getMaxMillis());
+        res.put(metricName + "_MeanMillis", timed.getMeanMillis());
+      }
+    }
+
+    return res;
+  }
+
+  private String metricName(MetricType type, Stat stat) {
+    if (stat instanceof FailureStat) {
+      return type.name() + "_" + ((FailureStat) stat).getException().getClass().getSimpleName();
+    }
+    return type.name();
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/MetricsRestApi.java
@@ -18,19 +18,14 @@
 package org.apache.zeppelin.rest;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.TreeMap;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.apache.zeppelin.metrics.FailureStat;
-import org.apache.zeppelin.metrics.MetricType;
 import org.apache.zeppelin.metrics.Metrics;
-import org.apache.zeppelin.metrics.Stat;
-import org.apache.zeppelin.metrics.TimedStat;
 import org.apache.zeppelin.server.JsonResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,37 +51,6 @@ public class MetricsRestApi {
   @GET
   public Response getMetrics(String message) throws
     IOException, IllegalArgumentException {
-    return new JsonResponse(Status.OK, metricsMap()).build();
-  }
-
-  private Map<String, Object> metricsMap() {
-    Map<String, Object> res = new HashMap<>();
-
-    for (Map.Entry<MetricType, Stat> e : metrics.getStats().entrySet()) {
-      Stat val = e.getValue();
-      String metricName = metricName(e.getKey(), val);
-
-      res.put(metricName + "_Count", val.getCount());
-
-      if (val instanceof TimedStat) {
-        TimedStat timed = (TimedStat) val;
-        res.put(metricName + "_P99MillisOneMinute", timed.getP99MillisOneMinute());
-        res.put(metricName + "_P50MillisOneMinute", timed.getP50MillisOneMinute());
-        res.put(metricName + "_MaxMillisOneMinute", timed.getMaxMillisOneMinute());
-        res.put(metricName + "_P99Millis", timed.getP99Millis());
-        res.put(metricName + "_P50Millis", timed.getP50Millis());
-        res.put(metricName + "_MaxMillis", timed.getMaxMillis());
-        res.put(metricName + "_MeanMillis", timed.getMeanMillis());
-      }
-    }
-
-    return res;
-  }
-
-  private String metricName(MetricType type, Stat stat) {
-    if (stat instanceof FailureStat) {
-      return type.name() + "_" + ((FailureStat) stat).getException().getClass().getSimpleName();
-    }
-    return type.name();
+    return new JsonResponse(Status.OK, new TreeMap(metrics.getAllStats())).build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -45,6 +45,7 @@ import org.apache.zeppelin.rest.CredentialRestApi;
 import org.apache.zeppelin.rest.HeliumRestApi;
 import org.apache.zeppelin.rest.InterpreterRestApi;
 import org.apache.zeppelin.rest.LoginRestApi;
+import org.apache.zeppelin.rest.MetricsRestApi;
 import org.apache.zeppelin.rest.NotebookRepoRestApi;
 import org.apache.zeppelin.rest.NotebookRestApi;
 import org.apache.zeppelin.rest.SecurityRestApi;
@@ -399,6 +400,9 @@ public class ZeppelinServer extends Application {
 
     LoginRestApi loginRestApi = new LoginRestApi();
     singletons.add(loginRestApi);
+
+    MetricsRestApi metricsRestApi = new MetricsRestApi();
+    singletons.add(metricsRestApi);
 
     ConfigurationsRestApi settingsApi = new ConfigurationsRestApi(notebook);
     singletons.add(settingsApi);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -119,7 +119,7 @@ public class NotebookServer extends WebSocketServlet
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final Queue<NotebookSocket> connectedSockets = new ConcurrentLinkedQueue<>();
   final Map<String, Queue<NotebookSocket>> userConnectedSockets = new ConcurrentHashMap<>();
-  private transient Metrics metrics = Metrics.getInstance();
+  private final Metrics metrics = Metrics.getInstance();
 
   /**
    * This is a special endpoint in the notebook websoket, Every connection in this Queue

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -46,6 +46,9 @@ import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.notebook.JobListenerFactory;
+import org.apache.zeppelin.metrics.MetricType;
+import org.apache.zeppelin.metrics.Metrics;
+import org.apache.zeppelin.metrics.TimedExecution;
 import org.apache.zeppelin.notebook.Folder;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
@@ -116,6 +119,7 @@ public class NotebookServer extends WebSocketServlet
   final Map<String, List<NotebookSocket>> noteSocketMap = new HashMap<>();
   final Queue<NotebookSocket> connectedSockets = new ConcurrentLinkedQueue<>();
   final Map<String, Queue<NotebookSocket>> userConnectedSockets = new ConcurrentHashMap<>();
+  private transient Metrics metrics = Metrics.getInstance();
 
   /**
    * This is a special endpoint in the notebook websoket, Every connection in this Queue
@@ -815,6 +819,7 @@ public class NotebookServer extends WebSocketServlet
 
     String user = fromMessage.principal;
 
+    TimedExecution run = metrics.startMeasurement(MetricType.NotebookView);
     Note note = notebook.getNote(noteId);
     if (note != null) {
 
@@ -833,6 +838,7 @@ public class NotebookServer extends WebSocketServlet
     } else {
       conn.send(serializeMessage(new Message(OP.NOTE).put("note", null)));
     }
+    metrics.save(run);
   }
 
   private void sendHomeNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1006,6 +1012,7 @@ public class NotebookServer extends WebSocketServlet
   private void createNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
       Message message) throws IOException {
     AuthenticationInfo subject = new AuthenticationInfo(message.principal);
+    TimedExecution run = metrics.startMeasurement(MetricType.NotebookCreate);
 
     try {
       Note note = null;
@@ -1039,12 +1046,14 @@ public class NotebookServer extends WebSocketServlet
       conn.send(serializeMessage(new Message(OP.NEW_NOTE).put("note", note)));
     } catch (FileSystemException e) {
       LOG.error("Exception from createNote", e);
+      metrics.saveFailure(e, MetricType.NotebookCreate);
       conn.send(serializeMessage(new Message(OP.ERROR_INFO).put("info",
           "Oops! There is something wrong with the notebook file system. "
               + "Please check the logs for more details.")));
       return;
     }
     broadcastNoteList(subject, userAndRoles);
+    metrics.save(run);
   }
 
   private void removeNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1648,6 +1657,7 @@ public class NotebookServer extends WebSocketServlet
   private void runAllParagraphs(NotebookSocket conn, HashSet<String> userAndRoles,
                                 Notebook notebook,
       Message fromMessage) throws IOException {
+    TimedExecution run = metrics.startMeasurement(MetricType.NotebookRun);
     final String noteId = (String) fromMessage.get("noteId");
     if (StringUtils.isBlank(noteId)) {
       return;
@@ -1679,6 +1689,7 @@ public class NotebookServer extends WebSocketServlet
 
       persistAndExecuteSingleParagraph(conn, note, p);
     }
+    metrics.save(run);
   }
 
   private void broadcastSpellExecution(NotebookSocket conn, HashSet<String> userAndRoles,
@@ -1739,6 +1750,7 @@ public class NotebookServer extends WebSocketServlet
 
   private void runParagraph(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
                             Message fromMessage) throws IOException {
+    TimedExecution run = metrics.startMeasurement(MetricType.ParagraphRun);
     final String paragraphId = (String) fromMessage.get("id");
     if (paragraphId == null) {
       return;
@@ -1770,6 +1782,7 @@ public class NotebookServer extends WebSocketServlet
         text, title, params, config);
 
     persistAndExecuteSingleParagraph(conn, note, p);
+    metrics.save(run);
   }
 
   private void addNewParagraphIfLastParagraphIsExecuted(Note note, Paragraph p) {
@@ -1812,6 +1825,7 @@ public class NotebookServer extends WebSocketServlet
       note.run(p.getId());
     } catch (Exception ex) {
       LOG.error("Exception from run", ex);
+      metrics.saveFailure(ex, MetricType.ParagraphRun);
       if (p != null) {
         p.setReturn(new InterpreterResult(InterpreterResult.Code.ERROR, ex.getMessage()), ex);
         p.setStatus(Status.ERROR);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/MetricsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/MetricsRestApiTest.java
@@ -19,7 +19,6 @@ package org.apache.zeppelin.rest;
 
 import java.io.IOException;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterators;
@@ -57,7 +56,7 @@ public class MetricsRestApiTest extends AbstractTestRestApi {
     // contains at least some _Count metrics
     assertTrue(Iterators.filter(body.keySet().iterator(), new Predicate<String>() {
         @Override
-        public boolean apply(@Nullable String s) {
+        public boolean apply(String s) {
           return s.endsWith("_Count");
         }
       }).hasNext());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/MetricsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/MetricsRestApiTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class MetricsRestApiTest extends AbstractTestRestApi {
+  Gson gson = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    AbstractTestRestApi.startUp();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+
+  @Test
+  public void testGetMetrics() throws IOException {
+    GetMethod get = httpGet("/metrics");
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+        new TypeToken<Map<String, Object>>(){}.getType());
+    Map<String, String> body = (Map<String, String>) resp.get("body");
+    assertTrue(body.size() > 0);
+
+    // contains at least some _Count metrics
+    assertTrue(Iterators.filter(body.keySet().iterator(), new Predicate<String>() {
+        @Override
+        public boolean apply(@Nullable String s) {
+          return s.endsWith("_Count");
+        }
+      }).hasNext());
+  }
+}


### PR DESCRIPTION
### What is this PR for?

This exposes JMX metrics for a few operations on Zeppelin. The first step here is to expose them via JMX, then later introduce a JSON endpoint (which would make it easier to integrate these metrics on common monitoring systems such as Prometheus, Graphite, Influx, etc

I'm putting this out as WIP before finishing the tests & JSON bits in order to kick-off any design discussion and address comments sooner than later

### What type of PR is it?
Feature

### Todos
* [x] - Tests
* [x] - JSON endpoint

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2711

### How should this be tested?
- Run Zeppelin
- Open `localhost:8080/api/metrics` for the JSON metrics
- Use `jconsole` and browse `org.apache.zeppelin.metrics` for the JMX metrics

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
Yes

* Is there breaking changes for older versions?
No

* Does this needs documentation?
Yes