### PR TITLE
[ZEPPELIN-2768]. Bump up Spark version to 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ matrix:
     # Several tests were excluded from this configuration due to the following issues:
     # HeliumApplicationFactoryTest - https://issues.apache.org/jira/browse/ZEPPELIN-2470
     # After issues are fixed these tests need to be included back by removing them from the "-Dtests.to.exclude" property
-    - jdk: "oraclejdk7"
-      env: SCALA_VER="2.11" SPARK_VER="2.1.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java -DfailIfNoTests=false"
+    - jdk: "oraclejdk8"
+      env: SCALA_VER="2.11" SPARK_VER="2.2.0" HADOOP_VER="2.6" PROFILE="-Pspark-2.2 -Pweb-ci -Pscalding -Phelium-dev -Pexamples -Pscala-2.11" BUILD_FLAG="package -Pbuild-distr -DskipRat" TEST_FLAG="verify -Pusing-packaged-distr -DskipRat" MODULES="-pl ${INTERPRETERS}" TEST_PROJECTS="-Dtests.to.exclude=**/ZeppelinSparkClusterTest.java,**/org.apache.zeppelin.spark.*,**/HeliumApplicationFactoryTest.java -DfailIfNoTests=false"
 
     # Test selenium with spark module for 1.6.3
     - jdk: "oraclejdk7"
@@ -60,6 +60,10 @@ matrix:
     # Test interpreter modules
     - jdk: "oraclejdk7"
       env: SCALA_VER="2.10" PROFILE="-Pscalding" BUILD_FLAG="package -DskipTests -DskipRat -Pr" TEST_FLAG="test -DskipRat" MODULES="-pl $(echo .,zeppelin-interpreter,${INTERPRETERS} | sed 's/!//g')" TEST_PROJECTS=""
+
+    # Test spark module for 2.2.0 with scala 2.11, livy
+    - jdk: "oraclejdk8"
+      env: SCALA_VER="2.11" SPARK_VER="2.2.0" HADOOP_VER="2.6" PROFILE="-Pweb-ci -Pspark-2.2 -Phadoop-2.6 -Pscala-2.11" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl .,zeppelin-interpreter,zeppelin-zengine,zeppelin-server,zeppelin-display,spark-dependencies,spark,livy" TEST_PROJECTS="-Dtest=ZeppelinSparkClusterTest,org.apache.zeppelin.spark.*,org.apache.zeppelin.livy.* -DfailIfNoTests=false"
 
     # Test spark module for 2.1.0 with scala 2.11, livy
     - jdk: "oraclejdk7"

--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -546,11 +546,21 @@
 
     <profile>
       <id>spark-2.1</id>
+      <properties>
+        <spark.version>2.1.0</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <spark.py4j.version>0.10.4</spark.py4j.version>
+        <scala.version>2.11.8</scala.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.2</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <spark.version>2.1.0</spark.version>
+        <spark.version>2.2.0</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.4</spark.py4j.version>
         <scala.version>2.11.8</scala.version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -556,11 +556,21 @@
 
     <profile>
       <id>spark-2.1</id>
+      <properties>
+        <spark.version>2.1.0</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <spark.py4j.version>0.10.4</spark.py4j.version>
+        <scala.version>2.11.8</scala.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.2</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <spark.version>2.1.0</spark.version>
+        <spark.version>2.2.0</spark.version>
         <protobuf.version>2.5.0</protobuf.version>
         <spark.py4j.version>0.10.4</spark.py4j.version>
         <scala.version>2.11.8</scala.version>

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -34,10 +34,10 @@ public class SparkVersion {
   public static final SparkVersion SPARK_1_6_0 = SparkVersion.fromVersionString("1.6.0");
 
   public static final SparkVersion SPARK_2_0_0 = SparkVersion.fromVersionString("2.0.0");
-  public static final SparkVersion SPARK_2_2_0 = SparkVersion.fromVersionString("2.2.0");
+  public static final SparkVersion SPARK_2_3_0 = SparkVersion.fromVersionString("2.3.0");
 
   public static final SparkVersion MIN_SUPPORTED_VERSION =  SPARK_1_0_0;
-  public static final SparkVersion UNSUPPORTED_FUTURE_VERSION = SPARK_2_2_0;
+  public static final SparkVersion UNSUPPORTED_FUTURE_VERSION = SPARK_2_3_0;
 
   private int version;
   private String versionString;


### PR DESCRIPTION
### What is this PR for?
Spark 2.2.0 is just released, this PR is to support spark 2.2.0. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2768

### How should this be tested?
Travis is updated

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
