### PR TITLE
[ZEPPELIN-2777] Unit test for configuration module (zeppelin-web)

### DIFF
--- a/zeppelin-web/src/app/configuration/configuration.controller.js
+++ b/zeppelin-web/src/app/configuration/configuration.controller.js
@@ -14,11 +14,10 @@
 
 angular.module('zeppelinWebApp').controller('ConfigurationCtrl', ConfigurationCtrl)
 
-function ConfigurationCtrl ($scope, $rootScope, $http, baseUrlSrv, ngToast) {
+function ConfigurationCtrl ($scope, $http, baseUrlSrv, ngToast) {
   'ngInject'
 
   $scope.configrations = []
-  $scope._ = _
   ngToast.dismiss()
 
   let getConfigurations = function () {

--- a/zeppelin-web/src/app/configuration/configuration.html
+++ b/zeppelin-web/src/app/configuration/configuration.html
@@ -35,19 +35,21 @@ limitations under the License.
       <div class="col-md-12">
         <table class="table table-striped">
           <thead>
-          <tr>
-            <th style="width:30%">name</th>
-            <th>value</th>
-          </tr>
+            <tr>
+              <th style="width:30%">name</th>
+              <th>value</th>
+            </tr>
           </thead>
-          <tr ng-repeat="key in configurations | sortByKey" >
-            <td>{{key}}</td>
-            <td>
-              <div class="hiding_overflow">
-                {{configurations[key]}}
-              </div>
-            </td>
-          </tr>
+          <tbody>
+            <tr ng-repeat="key in configurations | sortByKey" >
+              <td>{{key}}</td>
+              <td>
+                <div class="hiding_overflow">
+                  {{configurations[key]}}
+                </div>
+              </td>
+            </tr>
+          </tbody>
         </table>
       </div>
     </div>

--- a/zeppelin-web/src/app/configuration/configuration.test.js
+++ b/zeppelin-web/src/app/configuration/configuration.test.js
@@ -3,32 +3,62 @@ import template from './configuration.html'
 describe('Controller: Configuration', function () {
   beforeEach(angular.mock.module('zeppelinWebApp'))
 
-  let ctrl
-  let scope
-  let compile
-  let controllerGen
+  let baseUrlSrvMock = { getRestApiBase: () => '' }
 
-  beforeEach(inject(($controller, $rootScope, $compile) => {
-    scope = $rootScope.$new()
-    compile = $compile
-    controllerGen = $controller
+  let ctrl // controller instance
+  let $scope
+  let $compile
+  let $controller // controller generator
+  let $httpBackend
+  let ngToast
+
+  beforeEach(inject((_$controller_, _$rootScope_, _$compile_, _$httpBackend_, _ngToast_) => {
+    $scope = _$rootScope_.$new()
+    $compile = _$compile_
+    $controller = _$controller_
+    $httpBackend = _$httpBackend_
+    ngToast = _ngToast_
   }))
 
-  it('ConfigurationCtrl to toBeDefined', () => {
-    ctrl = controllerGen('ConfigurationCtrl', { $scope: scope })
+  afterEach (function () {
+    $httpBackend.verifyNoOutstandingExpectation()
+    $httpBackend.verifyNoOutstandingRequest()
+  })
+
+  it('should get configuration initially', () => {
+    const conf = { 'conf1': 'value1' }
+    ctrl = $controller('ConfigurationCtrl', { $scope: $scope, baseUrlSrv: baseUrlSrvMock, })
     expect(ctrl).toBeDefined()
+
+    $httpBackend.when("GET", '/configurations/all').respond(200, { body: conf, })
+    $httpBackend.expectGET('/configurations/all')
+    $httpBackend.flush()
+
+    expect($scope.configurations).toEqual(conf) // scope is updated after $httpBackend.flush()
+  })
+
+  it('should display ngToast when failed to get configuration properly', () => {
+    ctrl = $controller('ConfigurationCtrl', { $scope: $scope, baseUrlSrv: baseUrlSrvMock, })
+    spyOn(ngToast, 'danger')
+
+    $httpBackend.when("GET", '/configurations/all').respond(401, {})
+    $httpBackend.expectGET('/configurations/all')
+    $httpBackend.flush()
+
+    expect(ngToast.danger).toHaveBeenCalled()
   })
 
   it('should render list of configurations as the sorted order', () => {
-    scope.configurations = {
+    $scope.configurations = {
       'zeppelin.server.port': '8080',
       'zeppelin.server.addr': '0.0.0.0',
     }
-    const elem = compile(template)(scope);
-    scope.$digest();
+    const elem = $compile(template)($scope)
+    $scope.$digest()
     const tbody = elem.find('tbody')
     const tds = tbody.find('td')
 
+    // should be sorted
     expect(tds[0].innerText.trim()).toBe('zeppelin.server.addr')
     expect(tds[1].innerText.trim()).toBe('0.0.0.0')
     expect(tds[2].innerText.trim()).toBe('zeppelin.server.port')

--- a/zeppelin-web/src/app/configuration/configuration.test.js
+++ b/zeppelin-web/src/app/configuration/configuration.test.js
@@ -20,7 +20,7 @@ describe('Controller: Configuration', function () {
     ngToast = _ngToast_
   }))
 
-  afterEach (function () {
+  afterEach(function () {
     $httpBackend.verifyNoOutstandingExpectation()
     $httpBackend.verifyNoOutstandingRequest()
   })
@@ -30,7 +30,9 @@ describe('Controller: Configuration', function () {
     ctrl = $controller('ConfigurationCtrl', { $scope: $scope, baseUrlSrv: baseUrlSrvMock, })
     expect(ctrl).toBeDefined()
 
-    $httpBackend.when("GET", '/configurations/all').respond(200, { body: conf, })
+    $httpBackend
+      .when('GET', '/configurations/all')
+      .respond(200, { body: conf, })
     $httpBackend.expectGET('/configurations/all')
     $httpBackend.flush()
 
@@ -41,7 +43,7 @@ describe('Controller: Configuration', function () {
     ctrl = $controller('ConfigurationCtrl', { $scope: $scope, baseUrlSrv: baseUrlSrvMock, })
     spyOn(ngToast, 'danger')
 
-    $httpBackend.when("GET", '/configurations/all').respond(401, {})
+    $httpBackend.when('GET', '/configurations/all').respond(401, {})
     $httpBackend.expectGET('/configurations/all')
     $httpBackend.flush()
 

--- a/zeppelin-web/src/app/configuration/configuration.test.js
+++ b/zeppelin-web/src/app/configuration/configuration.test.js
@@ -1,0 +1,37 @@
+import template from './configuration.html'
+
+describe('Controller: Configuration', function () {
+  beforeEach(angular.mock.module('zeppelinWebApp'))
+
+  let ctrl
+  let scope
+  let compile
+  let controllerGen
+
+  beforeEach(inject(($controller, $rootScope, $compile) => {
+    scope = $rootScope.$new()
+    compile = $compile
+    controllerGen = $controller
+  }))
+
+  it('ConfigurationCtrl to toBeDefined', () => {
+    ctrl = controllerGen('ConfigurationCtrl', { $scope: scope })
+    expect(ctrl).toBeDefined()
+  })
+
+  it('should render list of configurations as the sorted order', () => {
+    scope.configurations = {
+      'zeppelin.server.port': '8080',
+      'zeppelin.server.addr': '0.0.0.0',
+    }
+    const elem = compile(template)(scope);
+    scope.$digest();
+    const tbody = elem.find('tbody')
+    const tds = tbody.find('td')
+
+    expect(tds[0].innerText.trim()).toBe('zeppelin.server.addr')
+    expect(tds[1].innerText.trim()).toBe('0.0.0.0')
+    expect(tds[2].innerText.trim()).toBe('zeppelin.server.port')
+    expect(tds[3].innerText.trim()).toBe('8080')
+  })
+})


### PR DESCRIPTION
### What is this PR for?

Added few test cases for the configuration module under `zeppelin-web/`

Additionally, I modified `configuration.html` to add the missing `tbody`.

### What type of PR is it?
[Improvement]

### What is the Jira issue?

[ZEPPELIN-2777](https://issues.apache.org/jira/browse/ZEPPELIN-2777)

### How should this be tested?

1. cd `zeppelin-web`
2. `yarn install` (or `npm install`)
3. `yarn run test` (or `npm run test`)

The test should pass.

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
