### PR TITLE
[ZEPPELIN-2775] Strict-Transport-Security and X-XSS-Protection Headers

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -406,7 +406,7 @@
 <!--
 <property>
   <name>zeppelin.server.xxss.protection</name>
-  <value>1; mode=block</value>
+  <value>1</value>
   <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
 </property>
 -->

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -396,4 +396,18 @@
 </property>
 -->
 
+<!--
+<property>
+  <name>zeppelin.server.strict.transport</name>
+  <value>max-age=631138519</value>
+  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS.Set value is in Seconds equivalent to 20 years.</description>
+</property>
+-->
+<!--
+<property>
+  <name>zeppelin.server.xxss.protection</name>
+  <value>1</value>
+  <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
+</property>
+-->
 </configuration>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -406,7 +406,7 @@
 <!--
 <property>
   <name>zeppelin.server.xxss.protection</name>
-  <value>1</value>
+  <value>1; mode=block</value>
   <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
 </property>
 -->

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -400,7 +400,7 @@
 <property>
   <name>zeppelin.server.strict.transport</name>
   <value>max-age=631138519</value>
-  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS.Set value is in Seconds equivalent to 20 years.</description>
+  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS. Value is in Seconds, the default value is equivalent to 20 years.</description>
 </property>
 -->
 <!--

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -94,6 +94,7 @@
                 <li><a href="{{BASE_PATH}}/setup/security/shiro_authentication.html">Shiro Authentication</a></li>
                 <li><a href="{{BASE_PATH}}/setup/security/notebook_authorization.html">Notebook Authorization</a></li>
                 <li><a href="{{BASE_PATH}}/setup/security/datasource_authorization.html">Data Source Authorization</a></li>
+                <li><a href="{{BASE_PATH}}/setup/security/http_security_headers.html">HTTP Security Headers</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="title"><span>Notebook Storage</span></li>
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-local-git-repository">Git Storage</a></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,7 @@ limitations under the License.
   * [Shiro Authentication](./setup/security/shiro_authentication.html)
   * [Notebook Authorization](./setup/security/notebook_authorization.html)
   * [Data Source Authorization](./setup/security/datasource_authorization.html)
+  * [HTTP Security Headers](./setup/security/http_security_headers.html)
 * Notebook Storage: a guide about saving notebooks to external storage
   * [Git Storage](./setup/storage/storage.html#notebook-storage-in-local-git-repository)
   * [S3 Storage](./setup/storage/storage.html#notebook-storage-in-s3)

--- a/docs/setup/security/http_security_headers.md
+++ b/docs/setup/security/http_security_headers.md
@@ -1,0 +1,110 @@
+---
+layout: page
+title: "Setting up HTTP Response Headers"
+description: "There are multiple HTTP Security Headers which can be configured in Apache Zeppelin. This page describes how to enable them by providing appropriate value in Zeppelin configuration file."
+group: setup/security
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Setting up HTTP Response Headers for Zeppelin 
+
+<div id="toc"></div>
+
+Apache Zeppelin can be configured to include HTTP Headers which aids in preventing Cross Site Scripting (XSS), Cross-Frame Scripting (XFS) and also enforces HTTP Strict Transport Security. Apache Zeppelin also has configuration available to set the Application Server Version to desired value.
+
+## Setting up HTTP Strict Transport Security (HSTS) Response Header
+
+Enabling HSTS Response Header prevents Man-in-the-middle attacks by automatically redirecting HTTP requests to HTTPS when Zeppelin Server is running on SSL. Read on how to configure SSL for Zeppelin [here] (../operation/configuration.html). Even if web page contains any resource which gets served over HTTP or any HTTP links, it will automatically be redirected to HTTPS for the target domain. 
+It also prevents MITM attack by not allowing User to override the invalid certificate message, when Attacker presents invalid SSL certificate to the User.  
+
+The following properties needs to be updated in the zeppelin-site.xml in order to enable HSTS. You can choose appropriate value for "max-age".
+
+```
+<property>
+  <name>zeppelin.server.strict.transport</name>
+  <value>max-age=631138519</value>
+  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS.Set value is in Seconds equivalent to 20 years.</description>
+</property>
+```
+
+
+Possible values are:
+
+* max-age=\<expire-time>
+* max-age=\<expire-time>; includeSubDomains
+* max-age=\<expire-time>; preload
+
+Read more about HSTS [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security).
+
+## Setting up X-XSS-PROTECTION Header
+
+The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari Web browsers that initiates configured action when they detect reflected cross-site scripting (XSS) attacks.
+ 
+The following properties needs to be updated in the zeppelin-site.xml in order to set X-XSS-PROTECTION header. 
+
+```
+<property>
+  <name>zeppelin.server.xxss.protection</name>
+  <value>1; mode=block</value>
+  <description>The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks. When value is set to 1 and a cross-site scripting attack is detected, the browser will sanitize the page (remove the unsafe parts).</description>
+</property>
+```
+
+
+You can choose appropriate value from below.
+
+* 0  (Disables XSS filtering)
+* 1  (Enables XSS filtering. If a cross-site scripting attack is detected, the browser will sanitize the page.)
+* 1; mode=block  (Enables XSS filtering. The browser will prevent rendering of the page if an attack is detected.)
+
+Read more about HTTP X-XSS-Protection response header [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).
+
+## Setting up X-Frame-Options Header
+
+The X-Frame-Options HTTP response header can indicate browser to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites in a \<frame>,\<iframe> or \<object>.
+
+The following properties needs to be updated in the zeppelin-site.xml in order to set X-Frame-Options header.
+
+```
+<property>
+  <name>zeppelin.server.xframe.options</name>
+  <value>SAMEORIGIN</value>
+  <description>The X-Frame-Options HTTP response header can be used to indicate whether or not a browser should be allowed to render a page in a frame/iframe/object.</description>
+</property>
+```
+
+
+You can choose appropriate value from below.
+
+* DENY
+* SAMEORIGIN
+* ALLOW-FROM _uri_
+
+## Setting up Server Header
+
+Security conscious organisations does not want to reveal the Application Server name and version to prevent Script-kiddies from finding the information easily when fingerprinting the Application. The exact version number can tell an Attacker if the current Application Server is patched for or vulnerable to certain publicly known CVE associated to it.
+
+The following properties needs to be updated in the zeppelin-site.xml in order to set Server header.
+
+```
+<property>
+    <name>zeppelin.server.jetty.name</name>
+    <value>Jetty(7.6.0.v20120127)</value>
+    <description>Hardcoding Application Server name to Prevent Fingerprinting</description>
+</property>
+```
+
+The value can be any "String".

--- a/docs/setup/security/http_security_headers.md
+++ b/docs/setup/security/http_security_headers.md
@@ -30,13 +30,13 @@ Apache Zeppelin can be configured to include HTTP Headers which aids in preventi
 Enabling HSTS Response Header prevents Man-in-the-middle attacks by automatically redirecting HTTP requests to HTTPS when Zeppelin Server is running on SSL. Read on how to configure SSL for Zeppelin [here] (../operation/configuration.html). Even if web page contains any resource which gets served over HTTP or any HTTP links, it will automatically be redirected to HTTPS for the target domain. 
 It also prevents MITM attack by not allowing User to override the invalid certificate message, when Attacker presents invalid SSL certificate to the User.  
 
-The following properties needs to be updated in the zeppelin-site.xml in order to enable HSTS. You can choose appropriate value for "max-age".
+The following property needs to be updated in the zeppelin-site.xml in order to enable HSTS. You can choose appropriate value for "max-age".
 
 ```
 <property>
   <name>zeppelin.server.strict.transport</name>
   <value>max-age=631138519</value>
-  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS.Set value is in Seconds equivalent to 20 years.</description>
+  <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS. Value is in Seconds, the default value is equivalent to 20 years.</description>
 </property>
 ```
 
@@ -53,7 +53,7 @@ Read more about HSTS [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/He
 
 The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari Web browsers that initiates configured action when they detect reflected cross-site scripting (XSS) attacks.
  
-The following properties needs to be updated in the zeppelin-site.xml in order to set X-XSS-PROTECTION header. 
+The following property needs to be updated in the zeppelin-site.xml in order to set X-XSS-PROTECTION header. 
 
 ```
 <property>
@@ -74,9 +74,9 @@ Read more about HTTP X-XSS-Protection response header [here](https://developer.m
 
 ## Setting up X-Frame-Options Header
 
-The X-Frame-Options HTTP response header can indicate browser to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites in a \<frame>,\<iframe> or \<object>.
+The X-Frame-Options HTTP response header can indicate browser to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites in a `<frame>`,`<iframe>` or `<object>`.
 
-The following properties needs to be updated in the zeppelin-site.xml in order to set X-Frame-Options header.
+The following property needs to be updated in the zeppelin-site.xml in order to set X-Frame-Options header.
 
 ```
 <property>
@@ -95,9 +95,9 @@ You can choose appropriate value from below.
 
 ## Setting up Server Header
 
-Security conscious organisations does not want to reveal the Application Server name and version to prevent Script-kiddies from finding the information easily when fingerprinting the Application. The exact version number can tell an Attacker if the current Application Server is patched for or vulnerable to certain publicly known CVE associated to it.
+Security conscious organisations does not want to reveal the Application Server name and version to prevent finding this information easily by Attacker while fingerprinting the Application. The exact version number can tell an Attacker if the current Application Server is patched for or vulnerable to certain publicly known CVE associated to it.
 
-The following properties needs to be updated in the zeppelin-site.xml in order to set Server header.
+The following property needs to be updated in the zeppelin-site.xml in order to set Server header.
 
 ```
 <property>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -80,7 +80,12 @@ public class CorsFilter implements Filter {
     DateFormat fullDateFormatEN =
         DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, new Locale("EN", "en"));
     response.addHeader("Date", fullDateFormatEN.format(new Date()));
-    response.addHeader("X-FRAME-OPTIONS", ZeppelinConfiguration.create().getXFrameOptions());
+    ZeppelinConfiguration zeppelinConfiguration = ZeppelinConfiguration.create();
+    response.addHeader("X-FRAME-OPTIONS", zeppelinConfiguration.getXFrameOptions());
+    if (zeppelinConfiguration.useSsl()) {
+      response.addHeader("Strict-Transport-Security", zeppelinConfiguration.getStrictTransport());
+    }
+    response.addHeader("X-XSS-Protection", zeppelinConfiguration.getXxssProtection());
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -515,6 +515,14 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_SERVER_XFRAME_OPTIONS);
   }
 
+  public String getXxssProtection() {
+    return getString(ConfVars.ZEPPELIN_SERVER_X_XSS_PROTECTION);
+  }
+
+  public String getStrictTransport() {
+    return getString(ConfVars.ZEPPELIN_SERVER_STRICT_TRANSPORT);
+  }
+
 
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
@@ -671,7 +679,9 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),
     ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false),
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
-    ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null);
+    ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
+    ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
+    ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", 1);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -681,7 +681,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
-    ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", 1);
+    ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1");
 
     private String varName;
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
### What is this PR for?
The HTTP Strict-Transport-Security response header (often abbreviated as HSTS) is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP.
Note: The Strict-Transport-Security header is ignored by the browser when your site is accessed using HTTP; this is because an attacker may intercept HTTP connections and inject the header or remove it. When your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the Strict-Transport-Security header.

The HTTP X-XSS-Protection response header is a feature of Internet Explorer, Chrome and Safari that stops pages from loading when they detect reflected cross-site scripting (XSS) attacks.

### What type of PR is it?
[Bug Fix | Improvement ]

### What is the Jira issue?
* [ZEPPELIN-2775](https://issues.apache.org/jira/browse/ZEPPELIN-2775)

### How should this be tested?
Make a curl call to Zeppelin? Go to Chrome Browser and select "More Tools" -> "Developer Tools" from the right-side menu. Under Network Section, select any request and check for "Response Headers". You should see below headers along with existing ones.

> strict-transport-security:max-age=631138519
> x-xss-protection:1; mode=block

<img width="1436" alt="screen shot 2017-07-14 at 8 19 14 pm" src="https://user-images.githubusercontent.com/6433184/28217231-16ce6cee-68d2-11e7-91aa-77ad083612c7.png">


### Questions:
* Does this needs documentation?
