### PR TITLE
Broken link on Apache Zeppelin website

### DIFF
--- a/_includes/themes/zeppelin/_navigation.html
+++ b/_includes/themes/zeppelin/_navigation.html
@@ -44,7 +44,7 @@
         <li class="docs">
           <a href="#" data-toggle="dropdown" class="dropdown-toggle">Community<b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <li><a href="community.html">Contributors</a></li>
+            <li><a href="/community.html">Contributors</a></li>
             <li><a href="https://github.com/apache/zeppelin">GitHub</a></li>
           </ul>
         </li>


### PR DESCRIPTION
### What is this PR for?
problem reported
https://lists.apache.org/thread.html/ad0ccb80a9c4adc404801b4752ff1cb939759c912ce04671c6a40163@%3Cdev.zeppelin.apache.org%3E

### What type of PR is it?
Hot Fix

### Todos
* [x] - Make link absolute


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
