### PR TITLE
[ZEPPELIN-2804] Fix shiro_authentication documentation

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -143,7 +143,8 @@ ldapRealm.contextFactory.authenticationMechanism = simple
 
 The other more flexible option is to use the LdapRealm. It allows for mapping of ldapgroups to roles and also allows for
  role/group based authentication into the zeppelin server. Sample configuration for this realm is given below.
- ```
+
+```
 [main]
 ldapRealm=org.apache.zeppelin.realm.LdapRealm
 
@@ -179,7 +180,7 @@ ldapRealm.allowedRolesForAuthentication = admin_role,user_role
 ldapRealm.permissionsByRole= user_role = *:ToDoItemsJdo:*:*, *:ToDoItem:*:*; admin_role = *
 securityManager.sessionManager = $sessionManager
 securityManager.realms = $ldapRealm
- ```
+```
 
 ### PAM
 [PAM](https://en.wikipedia.org/wiki/Pluggable_authentication_module) authentication support allows the reuse of existing authentication


### PR DESCRIPTION
The github preview is fine but the html on https://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/security/shiroauthentication.html#ldap is not displaying the code fragment correctly.

### What is this PR for?
Fixes the documentation orientation for shiro LDAPRealm

### What type of PR is it?
[Documentation]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2804

### How should this be tested?
Build the documentation and verify that the problem as stated in image is resolved.

### Screenshots (if appropriate)
<img width="856" alt="screen shot 2017-07-21 at 10 08 04 am" src="https://user-images.githubusercontent.com/5103613/28454775-c91fbe1e-6dfc-11e7-9601-6279be44f124.png">


### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
