### PR TITLE
[ZEPPELIN-2808] remember me support

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -46,6 +46,12 @@ user3 = password4, role2
 #ldapRealm.userDnTemplate = uid={0},ou=Users,dc=COMPANY,dc=COM
 #ldapRealm.contextFactory.authenticationMechanism = simple
 
+### If you want "remember me" to keep used logged in between sessions
+# securityManager = org.apache.zeppelin.security.CookieBasedSecurityManager
+# rememberMeManager = org.apache.shiro.web.mgt.CookieRememberMeManager
+# securityManager.rememberMeManager = $rememberMeManager
+# securityManager.rememberMeManager.cipherKey = <generate a cypher key here>
+
 ### A sample PAM configuration
 #pamRealm=org.apache.zeppelin.realm.PamRealm
 #pamRealm.service=sshd

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -63,7 +63,8 @@ public class LoginRestApi {
   @POST
   @ZeppelinApi
   public Response postLogin(@FormParam("userName") String userName,
-                            @FormParam("password") String password) {
+                            @FormParam("password") String password,
+                            @FormParam("rememberMe") boolean rememberMe) {
     JsonResponse response = null;
     // ticket set to anonymous for anonymous user. Simplify testing.
     Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
@@ -72,8 +73,7 @@ public class LoginRestApi {
     }
     if (!currentUser.isAuthenticated()) {
       try {
-        UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
-        //      token.setRememberMe(true);
+        UsernamePasswordToken token = new UsernamePasswordToken(userName, password, rememberMe);
 
         currentUser.getSession().stop();
         currentUser.getSession(true);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/security/CookieBasedSecurityManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/security/CookieBasedSecurityManager.java
@@ -1,0 +1,25 @@
+package org.apache.zeppelin.security;
+
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.subject.SubjectContext;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+
+/**
+ * A Security Manager implementing a slightly more relaxed behavior around "remember me" cookies
+ */
+public class CookieBasedSecurityManager extends DefaultWebSecurityManager {
+
+  @Override
+  public Subject createSubject(SubjectContext subjectContext) {
+    Subject subject = super.createSubject(subjectContext);
+    if (subject.isRemembered()) {
+      return createSubject(
+        subjectContext.getAuthenticationToken(),
+        subjectContext.getAuthenticationInfo(),
+        subject);
+    }
+    return subject;
+  }
+}

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -29,7 +29,8 @@ function LoginCtrl ($scope, $rootScope, $http, $httpParamSerializer, baseUrlSrv,
       },
       data: $httpParamSerializer({
         'userName': $scope.loginParams.userName,
-        'password': $scope.loginParams.password
+        'password': $scope.loginParams.password,
+        'rememberMe': $scope.loginParams.rememberMe,
       })
     }).then(function successCallback (response) {
       $rootScope.ticket = response.data.body
@@ -55,7 +56,8 @@ function LoginCtrl ($scope, $rootScope, $http, $httpParamSerializer, baseUrlSrv,
   let initValues = function () {
     $scope.loginParams = {
       userName: '',
-      password: ''
+      password: '',
+      rememberMe: false,
     }
   }
 

--- a/zeppelin-web/src/components/login/login.html
+++ b/zeppelin-web/src/components/login/login.html
@@ -39,7 +39,10 @@ limitations under the License.
                    ng-keypress="loginParams.errorText = ''"
                    ng-model="loginParams.password" />
           </div>
-
+          <div class="form-group">
+            <input id="rememberMe" ng-model="loginParams.rememberMe" type="checkbox"/>
+            <label for="rememberMe">Remember Me</label>
+          </div>
         </div>
         <div class="modal-footer" ng-switch on="SigningIn">
           <div ng-switch-when="true">


### PR DESCRIPTION
### What is this PR for?
Add support for "remember me" cookies, so we can activate LDAP without forcing users to re-login every time


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2808

### How should this be tested?
- Activate "rememberMe" by following the steps on the `shiro.ini.template`
- Log in with the "remember me" option checked
- Close the browser
- Reopen the browser
- You should still be logged in

### Questions:
* While this is standard behavior on many web-apps, some folks (as exemplified on the Shiro documentation) find it "not secure". I'd like to know Zeppelin folks' opinion on this.
* The "remember me" checkbox will show, regardless of whether you configure the rememberMeManager or not. Should this be a default? Should we hide it from the UI based on some config?
