### PR TITLE
[ZEPPELIN-2806] New paragraph does not displayed before refresh the page

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -112,8 +112,11 @@ limitations under the License.
        ng-controller="ParagraphCtrl"
        ng-init="init(currentParagraph, note)"
        ng-class="columnWidthClass(currentParagraph.config.colWidth)"
-       style="margin: 0; padding: 0;"
+       style="margin: 0; padding: 0;">
+
+       <!-- see ZEPPELIN-2806
        viewport-watch>
+       -->
     <div class="new-paragraph" ng-click="insertNew('above')" ng-hide="viewOnly || asIframe || revisionView">
       <h4 class="plus-sign">&#43;</h4>
     </div>


### PR DESCRIPTION
### What is this PR for?
Problem reported in [ZEPPELIN-2806](https://issues.apache.org/jira/browse/ZEPPELIN-2806).
New paragraph is not displayed before page refresh.

The problem came from change made
https://issues.apache.org/jira/browse/ZEPPELIN-2519

I'm commenting out `viewport-watch` as a hotfix.

### What type of PR is it?
Hot Fix

### Todos
* [x] - Comment-out viewport-watch

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2806

### Questions:
* Does the licenses files need updates? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
