### PR TITLE
[ZEPPELIN-2815] Improve interpreter dependencies logging

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -18,7 +18,10 @@
 package org.apache.zeppelin.dep;
 
 import org.apache.commons.lang.Validate;
+import org.apache.log4j.lf5.LogLevel;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.repository.LocalRepository;
@@ -30,6 +33,8 @@ import java.nio.file.Paths;
  * Manage mvn repository.
  */
 public class Booter {
+  private static Logger logger = LoggerFactory.getLogger(Booter.class);
+
   public static RepositorySystem newRepositorySystem() {
     return RepositorySystemFactory.newRepositorySystem();
   }
@@ -43,8 +48,10 @@ public class Booter {
     LocalRepository localRepo = new LocalRepository(resolveLocalRepoPath(localRepoPath));
     session.setLocalRepositoryManager(system.newLocalRepositoryManager(localRepo));
 
-    // session.setTransferListener(new ConsoleTransferListener());
-    // session.setRepositoryListener(new ConsoleRepositoryListener());
+    if (logger.isDebugEnabled()) {
+      session.setTransferListener(new TransferListener());
+      session.setRepositoryListener(new RepositoryListener());
+    }
 
     // uncomment to generate dirty trees
     // session.setDependencyGraphTransformer( null );

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.dep;
 
 import org.apache.commons.lang.Validate;
-import org.apache.log4j.lf5.LogLevel;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +51,6 @@ public class Booter {
       session.setTransferListener(new TransferListener());
       session.setRepositoryListener(new RepositoryListener());
     }
-
     // uncomment to generate dirty trees
     // session.setDependencyGraphTransformer( null );
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -177,8 +177,9 @@ public class DependencyResolver extends AbstractDependencyResolver {
             DependencyFilterUtils.andFilter(exclusionFilter, classpathFilter));
     try {
       return system.resolveDependencies(session, dependencyRequest).getArtifactResults();
-    } catch (NullPointerException ex) {
-      throw new RepositoryException(String.format("Cannot fetch dependencies for %s", dependency));
+    } catch (Exception ex) {
+      throw new RepositoryException(
+              String.format("Cannot fetch dependencies for %s", dependency), ex);
     }
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -19,7 +19,6 @@ package org.apache.zeppelin.dep;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -33,25 +32,23 @@ import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositoryException;
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.collection.CollectRequest;
-import org.sonatype.aether.collection.DependencyCollectionException;
 import org.sonatype.aether.graph.Dependency;
 import org.sonatype.aether.graph.DependencyFilter;
 import org.sonatype.aether.repository.RemoteRepository;
 import org.sonatype.aether.resolution.ArtifactResult;
 import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResolutionException;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
 import org.sonatype.aether.util.artifact.JavaScopes;
 import org.sonatype.aether.util.filter.DependencyFilterUtils;
 import org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter;
-import org.sonatype.aether.util.graph.DefaultDependencyNode;
-
 
 /**
  * Deps resolver.
  * Add new dependencies from mvn repo (at runtime) to Zeppelin.
  */
 public class DependencyResolver extends AbstractDependencyResolver {
-  Logger logger = LoggerFactory.getLogger(DependencyResolver.class);
+  private Logger logger = LoggerFactory.getLogger(DependencyResolver.class);
 
   private final String[] exclusions = new String[] {"org.apache.zeppelin:zeppelin-zengine",
                                                     "org.apache.zeppelin:zeppelin-interpreter",
@@ -177,7 +174,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
             DependencyFilterUtils.andFilter(exclusionFilter, classpathFilter));
     try {
       return system.resolveDependencies(session, dependencyRequest).getArtifactResults();
-    } catch (Exception ex) {
+    } catch (NullPointerException | DependencyResolutionException ex) {
       throw new RepositoryException(
               String.format("Cannot fetch dependencies for %s", dependency), ex);
     }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
@@ -120,7 +120,7 @@ public class TransferListener extends AbstractTransferListener {
   @Override
   public void transferFailed(TransferEvent event) {
     transferCompleted(event);
-    logger.warn(event.getException().getMessage());
+    logger.warn("Unsuccessful transfer", event.getException());
   }
 
   private void transferCompleted(TransferEvent event) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.dep;
 
-import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
@@ -34,8 +33,7 @@ import org.sonatype.aether.transfer.TransferResource;
  * Simple listener that show deps downloading progress.
  */
 public class TransferListener extends AbstractTransferListener {
-  Logger logger = LoggerFactory.getLogger(TransferListener.class);
-  private PrintStream out;
+  private Logger logger = LoggerFactory.getLogger(TransferListener.class);
 
   private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
 
@@ -55,13 +53,13 @@ public class TransferListener extends AbstractTransferListener {
   @Override
   public void transferProgressed(TransferEvent event) {
     TransferResource resource = event.getResource();
-    downloads.put(resource, Long.valueOf(event.getTransferredBytes()));
+    downloads.put(resource, event.getTransferredBytes());
 
     StringBuilder buffer = new StringBuilder(64);
 
     for (Map.Entry<TransferResource, Long> entry : downloads.entrySet()) {
       long total = entry.getKey().getContentLength();
-      long complete = entry.getValue().longValue();
+      long complete = entry.getValue();
 
       buffer.append(getStatus(complete, total)).append("  ");
     }
@@ -122,7 +120,7 @@ public class TransferListener extends AbstractTransferListener {
   @Override
   public void transferFailed(TransferEvent event) {
     transferCompleted(event);
-    event.getException().printStackTrace(out);
+    logger.warn(event.getException().getMessage());
   }
 
   private void transferCompleted(TransferEvent event) {
@@ -135,10 +133,10 @@ public class TransferListener extends AbstractTransferListener {
 
   @Override
   public void transferCorrupted(TransferEvent event) {
-    event.getException().printStackTrace(out);
+    logger.error(event.getException().getMessage());
   }
 
-  protected long toKB(long bytes) {
+  private long toKB(long bytes) {
     return (bytes + 1023) / 1024;
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
@@ -133,7 +133,7 @@ public class TransferListener extends AbstractTransferListener {
 
   @Override
   public void transferCorrupted(TransferEvent event) {
-    logger.error(event.getException().getMessage());
+    logger.error("Corrupted transfer", event.getException());
   }
 
   private long toKB(long bytes) {


### PR DESCRIPTION
### What is this PR for?
As a developer, I want to be able to debug issues on dependency resolution "easier". 
To achieve this, making available (in debug mode), existing listeners. 
Also, exposing exceptions on dependency resolver.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2815

### How should this be tested?
Enable DEBUG logging mode. Import dependencies. Check detailed info. from dependency loading being logged.

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
