### PR TITLE
[ZEPPELIN-2817] Support default interpreter setting in create note re…

### DIFF
--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -109,7 +109,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td><pre>
 {
   "name": "name of new note",
-  "interpreter": "python"
+  "defaultInterpreter": "python"
 }</pre></td>
     </tr>
     <tr>
@@ -117,7 +117,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td><pre>
 {
   "name": "name of new note",
-  "interpreter": "python",
+  "defaultInterpreter": "python",
   "paragraphs": [
     {
       "title": "paragraph title1",

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -80,6 +80,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     <tr>
       <td>Description</td>
       <td>This ```POST``` method creates a new note using the given name or default name if none given.
+      Default interpreter and initial paragraphs can also be set.
           The body field of the returned JSON contains the new note id.
       </td>
     </tr>
@@ -96,14 +97,23 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> 500 </td>
     </tr>
     <tr>
-      <td> sample JSON input (without paragraphs) </td>
+      <td> sample JSON input (without interpreter and paragraphs) </td>
       <td><pre>{"name": "name of new note"}</pre></td>
     </tr>
     <tr>
-      <td> sample JSON input (with initial paragraphs) </td>
+      <td> sample JSON input (with interpreter) </td>
+      <td><pre>
+{
+"name": "name of new note",
+"interpreter": "python"
+}</pre></td>
+    </tr>
+    <tr>
+      <td> sample JSON input (with interpreter, initial paragraphs) </td>
       <td><pre>
 {
   "name": "name of new note",
+  "interpreter": "python",
   "paragraphs": [
     {
       "title": "paragraph title1",

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -90,7 +90,11 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>Success code</td>
-      <td>200</td>
+      <td>201</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
     </tr>
     <tr>
       <td> Fail code</td>

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -90,7 +90,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>Success code</td>
-      <td>201</td>
+      <td>200</td>
     </tr>
     <tr>
       <td>Not Found code</td>
@@ -108,8 +108,8 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> sample JSON input (with interpreter) </td>
       <td><pre>
 {
-"name": "name of new note",
-"interpreter": "python"
+  "name": "name of new note",
+  "interpreter": "python"
 }</pre></td>
     </tr>
     <tr>
@@ -146,7 +146,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> sample JSON response </td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": "2AZPHY918"
 }</pre></td>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -383,7 +383,7 @@ public class NotebookRestApi {
     note.persist(subject);
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
-    return new JsonResponse<>(Status.OK, "", note.getId()).build();
+    return new JsonResponse<>(Status.CREATED, "", note.getId()).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -383,7 +383,7 @@ public class NotebookRestApi {
     note.persist(subject);
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
-    return new JsonResponse<>(Status.CREATED, "", note.getId()).build();
+    return new JsonResponse<>(Status.OK, "", note.getId()).build();
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -338,8 +338,8 @@ public class NotebookRestApi {
     Note note;
 
     //set default interpreter
-    if (request != null && request.getInterpreter() != null) {
-      String interpreter = request.getInterpreter();
+    if (request != null && request.getDefaultInterpreter() != null) {
+      String interpreter = request.getDefaultInterpreter();
       InterpreterSettingManager manager = notebook.getInterpreterSettingManager();
       List<String> interpreterIDs = manager.getDefaultInterpreterSettingList();
       String defaultId = null;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -354,8 +354,8 @@ public class NotebookRestApi {
         interpreterIDs.add(0, defaultId);
         note = notebook.createNote(interpreterIDs, subject);
       } else {
-        String errorMsg = String.format("interpreter %s doesn't exist", interpreter);
-        return new JsonResponse<>(Status.BAD_REQUEST, errorMsg).build();
+        String errorMsg = String.format("interpreter %s not found", interpreter);
+        return new JsonResponse<>(Status.NOT_FOUND, errorMsg).build();
       }
     } else {
       note = notebook.createNote(subject);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
@@ -141,7 +142,7 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   /**
    * Check if the current user is either Owner or Writer for the given note.
    */
@@ -153,7 +154,7 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   /**
    * Check if the current user can access (at least he have to be reader) the given note.
    */
@@ -165,19 +166,19 @@ public class NotebookRestApi {
       throw new ForbiddenException(errorMsg);
     }
   }
-  
+
   private void checkIfNoteIsNotNull(Note note) {
     if (note == null) {
       throw new NotFoundException("note not found");
     }
   }
-  
+
   private void checkIfParagraphIsNotNull(Paragraph paragraph) {
     if (paragraph == null) {
       throw new NotFoundException("paragraph not found");
     }
   }
-  
+
   /**
    * set note authorization information
    */
@@ -322,7 +323,7 @@ public class NotebookRestApi {
   /**
    * Create new note REST API
    *
-   * @param message - JSON with new note name
+   * @param message - JSON with new note name, default interpreter and paragraphs
    * @return JSON with new note ID
    * @throws IOException
    */
@@ -334,7 +335,31 @@ public class NotebookRestApi {
     LOG.info("Create new note by JSON {}", message);
     NewNoteRequest request = NewNoteRequest.fromJson(message);
     AuthenticationInfo subject = new AuthenticationInfo(user);
-    Note note = notebook.createNote(subject);
+    Note note;
+
+    //set default interpreter
+    if (request != null && request.getInterpreter() != null) {
+      String interpreter = request.getInterpreter();
+      InterpreterSettingManager manager = notebook.getInterpreterSettingManager();
+      List<String> interpreterIDs = manager.getDefaultInterpreterSettingList();
+      String defaultId = null;
+      for (String id : interpreterIDs) {
+        if (manager.get(id).getName().equals(interpreter)) {
+          defaultId = id;
+          break;
+        }
+      }
+      if (defaultId != null) {
+        interpreterIDs.remove(defaultId);
+        interpreterIDs.add(0, defaultId);
+        note = notebook.createNote(interpreterIDs, subject);
+      } else {
+        String errorMsg = String.format("interpreter %s doesn't exist", interpreter);
+        return new JsonResponse<>(Status.BAD_REQUEST, errorMsg).build();
+      }
+    } else {
+      note = notebook.createNote(subject);
+    }
     if (request != null) {
       List<NewParagraphRequest> initialParagraphs = request.getParagraphs();
       if (initialParagraphs != null) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -370,9 +370,13 @@ public class NotebookRestApi {
       }
     }
     note.addNewParagraph(subject); // add one paragraph to the last
-    String noteName = request.getName();
-    if (noteName.isEmpty()) {
-      noteName = "Note " + note.getId();
+
+    //deal with possible empty note name
+    String noteName = "Note " + note.getId();
+    if (request != null && request.getName() != null) {
+      if (!request.getName().isEmpty()) {
+        noteName = request.getName();
+      }
     }
 
     note.setName(noteName);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
@@ -29,7 +29,7 @@ public class NewNoteRequest implements JsonSerializable {
   private static final Gson gson = new Gson();
 
   private String name;
-  private String interpreter;
+  private String defaultInterpreter;
   private List<NewParagraphRequest> paragraphs;
 
   public NewNoteRequest() {
@@ -40,8 +40,8 @@ public class NewNoteRequest implements JsonSerializable {
     return name;
   }
 
-  public String getInterpreter() {
-    return interpreter;
+  public String getDefaultInterpreter() {
+    return defaultInterpreter;
   }
 
   public List<NewParagraphRequest> getParagraphs() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
@@ -17,29 +17,31 @@
 
 package org.apache.zeppelin.rest.message;
 
-import java.util.List;
-import java.util.Map;
-
 import com.google.gson.Gson;
 import org.apache.zeppelin.common.JsonSerializable;
-import org.apache.zeppelin.interpreter.InterpreterOption;
+
+import java.util.List;
 
 /**
- *  NewNoteRequest rest api request message
- *
+ * NewNoteRequest rest api request message
  */
 public class NewNoteRequest implements JsonSerializable {
   private static final Gson gson = new Gson();
 
-  String name;
-  List<NewParagraphRequest> paragraphs;
+  private String name;
+  private String interpreter;
+  private List<NewParagraphRequest> paragraphs;
 
-  public NewNoteRequest (){
+  public NewNoteRequest() {
 
   }
 
   public String getName() {
     return name;
+  }
+
+  public String getInterpreter() {
+    return interpreter;
   }
 
   public List<NewParagraphRequest> getParagraphs() {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -217,7 +217,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     // prepare data
     Map<String, Object> data = Maps.newHashMap();
     data.put("name", "test");
-    data.put("interpreter", "spark");
+    data.put("interpreter", "python");
     Map<String, String> paragraph = Maps.newHashMap();
     paragraph.put("title", "title");
     paragraph.put("text", "text");
@@ -227,7 +227,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     PostMethod post = httpPost("/notebook", gson.toJson(data));
 
     // test create response
-    assertThat(post, isCreated());
+    assertThat(post, isAllowed());
     LOG.info("Notebook create response {}", post.getResponseBodyAsString());
     Map<String, String> response = (Map<String, String>) gson.fromJson(post.getResponseBodyAsString(), data.getClass());
     String noteId = response.get("body");

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.zeppelin.rest;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -36,6 +38,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -206,5 +209,52 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
 
     //cleanup
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testCreateNote() throws IOException {
+    // prepare data
+    Map<String, Object> data = Maps.newHashMap();
+    data.put("name", "test");
+    data.put("interpreter", "spark");
+    Map<String, String> paragraph = Maps.newHashMap();
+    paragraph.put("title", "title");
+    paragraph.put("text", "text");
+    data.put("paragraphs", Lists.newArrayList(paragraph));
+
+    // request api
+    PostMethod post = httpPost("/notebook", gson.toJson(data));
+
+    // test create response
+    assertThat(post, isCreated());
+    LOG.info("Notebook create response {}", post.getResponseBodyAsString());
+    Map<String, String> response = (Map<String, String>) gson.fromJson(post.getResponseBodyAsString(), data.getClass());
+    String noteId = response.get("body");
+    assertNotNull(noteId);
+    post.releaseConnection();
+
+    // test can get the note
+    GetMethod get = httpGet("/notebook/" + noteId);
+    assertThat(get, isAllowed());
+    Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {
+    }.getType());
+    // test note name
+    Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
+    assertEquals(resp2Body.get("name"), data.get("name"));
+    get.releaseConnection();
+
+    // test default interpreter
+    String interpreter = ZeppelinServer.notebook.getInterpreterSettingManager().getDefaultInterpreterSetting(noteId).getName();
+    assertEquals(interpreter, data.get("interpreter"));
+
+    // test paragraphs
+    List<Paragraph> paragraphs = ZeppelinServer.notebook.getNote(noteId).getParagraphs();
+    assertEquals(paragraphs.size(), 2);
+    assertEquals(paragraphs.get(0).getTitle(), paragraph.get("title"));
+    assertEquals(paragraphs.get(0).getText(), paragraph.get("text"));
+
+    // cleanup
+    ZeppelinServer.notebook.removeNote(noteId, anonymous);
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -217,7 +217,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     // prepare data
     Map<String, Object> data = Maps.newHashMap();
     data.put("name", "test");
-    data.put("interpreter", "python");
+    data.put("defaultInterpreter", "python");
     Map<String, String> paragraph = Maps.newHashMap();
     paragraph.put("title", "title");
     paragraph.put("text", "text");
@@ -246,7 +246,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
 
     // test default interpreter
     String interpreter = ZeppelinServer.notebook.getInterpreterSettingManager().getDefaultInterpreterSetting(noteId).getName();
-    assertEquals(interpreter, data.get("interpreter"));
+    assertEquals(interpreter, data.get("defaultInterpreter"));
 
     // test paragraphs
     List<Paragraph> paragraphs = ZeppelinServer.notebook.getNote(noteId).getParagraphs();


### PR DESCRIPTION
…st api

### What is this PR for?
Can set default interpreter in create note rest api.


### What type of PR is it?
[Improvement]

### Todos
None

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2817

### How should this be tested?
Post name and interpreter to rest api/notebook, a note with the interpreter should be created.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes 
