### PR TITLE
[ZEPPELIN-2756] Support ansi escape code for colorizing output in browser

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -272,6 +272,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) ngclipboard v1.1.1 (https://github.com/sachinchoolur/ngclipboard) - https://github.com/sachinchoolur/ngclipboard/blob/1.1.1/LICENSE
     (The MIT License) headroom.js 0.9.3 (https://github.com/WickyNilliams/headroom.js) - https://github.com/WickyNilliams/headroom.js/blob/master/LICENSE
     (The MIT License) angular-viewport-watch 0.135 (https://github.com/wix/angular-viewport-watch) - https://github.com/wix/angular-viewport-watch/blob/master/LICENSE
+    (The MIT License) ansi-up 2.0.2 (https://github.com/drudru/ansi_up) - https://github.com/drudru/ansi_up#license
 
 ========================================================================
 BSD-style licenses

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "angular-ui-grid": "^4.0.4",
     "angular-viewport-watch": "github:shahata/angular-viewport-watch",
+    "ansi_up": "^2.0.2",
     "github-markdown-css": "2.6.0",
     "grunt-angular-templates": "^0.5.7",
     "grunt-dom-munger": "^3.4.0",

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -28,6 +28,8 @@ import {
 } from '../../../spell'
 import { ParagraphStatus, } from '../paragraph.status'
 
+const AnsiUp = require('ansi_up')
+const AnsiUpConverter = new AnsiUp.default // eslint-disable-line new-parens,new-cap
 const TableGridFilterTemplate = require('../../../visualization/builtins/visualization-table-grid-filter.html')
 
 angular.module('zeppelinWebApp').controller('ResultCtrl', ResultCtrl)
@@ -470,7 +472,8 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
         removeChildrenDOM(targetElemId)
 
         if (generated) {
-          const divDOM = angular.element('<div></div>').text(generated)
+          const escaped = AnsiUpConverter.ansi_to_html(generated)
+          const divDOM = angular.element('<div></div>').innerHTML = escaped
           elem.append(divDOM)
         }
 


### PR DESCRIPTION
### What is this PR for?

Support ANSI escape code for colorizing output in browser using [ansi-up](https://github.com/drudru/ansi_up#license)

This feature is written based on #2474 

### What type of PR is it?
[Improvement]


### What is the Jira issue?

[ZEPPELIN-2756](https://github.com/apache/zeppelin/pull/2474)

### How should this be tested?

 Setup ipython interpreter (or use any interpreter can return ansi escape code)

```
%python.ipython

import pandas as pd
df = pd.DataFrame({'id':[1,2,3], 'name': ['a', 'b', 'c']})
z.show(df)
```

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/28761648-1e2fcc6e-75eb-11e7-8fc6-bf7a07ccf23f.png)


#### After

![image](https://user-images.githubusercontent.com/4968473/28761645-142d0074-75eb-11e7-903e-e0a79864ce80.png)

### Questions:
* Does the licenses files need update? - YES, updated
* Is there breaking changes for older versions? - YES, all outputs will be escaped 
* Does this needs documentation? - NO
