### PR TITLE
replace pegdown to markdown zeppelin interpreter

### DIFF
--- a/zeppelin-jupyter/pom.xml
+++ b/zeppelin-jupyter/pom.xml
@@ -35,7 +35,7 @@
   <description>Jupyter support for Apache Zeppelin</description>
 
   <properties>
-    <pegdown.version>1.6.0</pegdown.version>
+    <zeppelin.version>0.8.0-SNAPSHOT</zeppelin.version>
   </properties>
 
   <dependencies>
@@ -60,9 +60,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.pegdown</groupId>
-      <artifactId>pegdown</artifactId>
-      <version>${pegdown.version}</version>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-markdown</artifactId>
+      <version>${zeppelin.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/zeppelin-jupyter/src/main/java/org/apache/zeppelin/jupyter/JupyterUtil.java
+++ b/zeppelin-jupyter/src/main/java/org/apache/zeppelin/jupyter/JupyterUtil.java
@@ -53,7 +53,8 @@ import org.apache.zeppelin.jupyter.zformat.Note;
 import org.apache.zeppelin.jupyter.zformat.Paragraph;
 import org.apache.zeppelin.jupyter.zformat.Result;
 import org.apache.zeppelin.jupyter.zformat.TypeData;
-import org.pegdown.PegDownProcessor;
+import org.apache.zeppelin.markdown.MarkdownParser;
+import org.apache.zeppelin.markdown.PegdownParser;
 
 /**
  *
@@ -63,7 +64,7 @@ public class JupyterUtil {
   private final RuntimeTypeAdapterFactory<Cell> cellTypeFactory;
   private final RuntimeTypeAdapterFactory<Output> outputTypeFactory;
 
-  private final PegDownProcessor markdownProcessor;
+  private final MarkdownParser markdownProcessor;
 
   public JupyterUtil() {
     this.cellTypeFactory = RuntimeTypeAdapterFactory.of(Cell.class, "cell_type")
@@ -73,7 +74,7 @@ public class JupyterUtil {
         .registerSubtype(ExecuteResult.class, "execute_result")
         .registerSubtype(DisplayData.class, "display_data").registerSubtype(Stream.class, "stream")
         .registerSubtype(Error.class, "error");
-    this.markdownProcessor = new PegDownProcessor();
+    this.markdownProcessor = new PegdownParser();
   }
 
   public Nbformat getNbformat(Reader in) {
@@ -141,7 +142,7 @@ public class JupyterUtil {
         }
       } else if (cell instanceof MarkdownCell || cell instanceof HeadingCell) {
         interpreterName = markdownReplaced;
-        String markdownContent = markdownProcessor.markdownToHtml(codeText);
+        String markdownContent = markdownProcessor.render(codeText);
         typeDataList.add(new TypeData(TypeData.HTML, markdownContent));
         paragraph.setUpMarkdownConfig(true);
       } else {

--- a/zeppelin-jupyter/src/test/java/org/apache/zeppelin/jupyter/nbformat/JupyterUtilTest.java
+++ b/zeppelin-jupyter/src/test/java/org/apache/zeppelin/jupyter/nbformat/JupyterUtilTest.java
@@ -86,7 +86,14 @@ public class JupyterUtilTest {
     assertTrue(((boolean) markdownConfig.get("editorHide")) == true);
     assertTrue(markdownParagraph.getResults().getCode().equals("SUCCESS"));
     List<TypeData> results = markdownParagraph.getResults().getMsg();
-    assertTrue(results.get(0).getData().equals("\u003cdiv class\u003d\"alert\" style\u003d\"border: 1px solid #aaa; background: radial-gradient(ellipse at center, #ffffff 50%, #eee 100%);\"\u003e\n\u003cdiv class\u003d\"row\"\u003e\n    \u003cdiv class\u003d\"col-sm-1\"\u003e\u003cimg src\u003d\"https://knowledgeanyhow.org/static/images/favicon_32x32.png\" style\u003d\"margin-top: -6px\"/\u003e\u003c/div\u003e\n    \u003cdiv class\u003d\"col-sm-11\"\u003eThis notebook was created using \u003ca href\u003d\"https://knowledgeanyhow.org\"\u003eIBM Knowledge Anyhow Workbench\u003c/a\u003e.  To learn more, visit us at \u003ca href\u003d\"https://knowledgeanyhow.org\"\u003ehttps://knowledgeanyhow.org\u003c/a\u003e.\u003c/div\u003e\n    \u003c/div\u003e\n\u003c/div\u003e"));
+    assertTrue(results.get(0).getData().equals("<div class=\"markdown-body\">\n" +
+            "<div class=\"alert\" style=\"border: 1px solid #aaa; background: radial-gradient(ellipse at center, #ffffff 50%, #eee 100%);\">\n" +
+            "<div class=\"row\">\n" +
+            "    <div class=\"col-sm-1\"><img src=\"https://knowledgeanyhow.org/static/images/favicon_32x32.png\" style=\"margin-top: -6px\"/></div>\n" +
+            "    <div class=\"col-sm-11\">This notebook was created using <a href=\"https://knowledgeanyhow.org\">IBM Knowledge Anyhow Workbench</a>.  To learn more, visit us at <a href=\"https://knowledgeanyhow.org\">https://knowledgeanyhow.org</a>.</div>\n" +
+            "    </div>\n" +
+            "</div>\n" +
+            "</div>"));
     assertTrue(results.get(0).getType().equals("HTML"));
   }
 }


### PR DESCRIPTION
### What is this PR for?
I was change markdown render librarry for Jupyter note convertor.
currently, we can got a same result for markdown.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2824

### How should this be tested?
1. build jupyter module
  `mvn clean package -DskipTests -pl 'zeppelin-jupyter' --am`
2. `cd zeppelin-jupyter/target`
3. `java -classpath zeppelin-jupyter-0.8.0-SNAPSHOT.jar org.apache.zeppelin.jupyter.JupyterUtil -i {your ipynb note file path!/getting_started.ipynb`
    (good sample : [go to sample](https://github.com/SciRuby/sciruby-notebooks/blob/master/getting_started.ipynb)
4. get a `note.json` and import to zeppelin on frontend!
5. enjoy
### Screenshots (if appropriate)

#### problem
![28689484-9b13f3d2-72ca-11e7-9bda-02d33b30f036](https://user-images.githubusercontent.com/10525473/28861908-0d05c592-779e-11e7-9a4e-94e3fd2bd176.png)

#### after
![image](https://user-images.githubusercontent.com/10525473/28807730-029510e6-76b2-11e7-9111-0e18569b1630.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
