### PR TITLE
[ZEPPELIN-2825] - Fix Zeppelin to support any of the Shiro roles

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -226,6 +226,26 @@ Since Shiro provides **url-based security**, you can hide the information by com
 In this case, only who have `admin` role can see **Interpreter Setting**, **Credential** and **Configuration** information.
 If you want to grant this permission to other users, you can change **roles[ ]** as you defined at `[users]` section.
 
+### Apply multiple roles in Shiro configuration
+By default, Shiro will allow access to a URL if only user is part of all the roles defined like this:
+```
+[urls]
+
+/api/interpreter/** = authc, roles[admin, role1]
+```
+
+If there is a need that user with "any of the defined roles" should be allowed, then following Shiro configuration can be used:
+```
+[main]
+anyofroles = org.apache.zeppelin.utils.AnyOfRolesAuthorizationFilter
+
+[urls]
+
+/api/interpreter/** = authc, anyofroles[admin, role1]
+/api/configurations/** = authc, roles[admin]
+/api/credential/** = authc, roles[admin]
+```
+
 <br/>
 > **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file.
 

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -227,14 +227,14 @@ In this case, only who have `admin` role can see **Interpreter Setting**, **Cred
 If you want to grant this permission to other users, you can change **roles[ ]** as you defined at `[users]` section.
 
 ### Apply multiple roles in Shiro configuration
-By default, Shiro will allow access to a URL if only user is part of all the roles defined like this:
+By default, Shiro will allow access to a URL if only user is part of "**all the roles**" defined like this:
 ```
 [urls]
 
 /api/interpreter/** = authc, roles[admin, role1]
 ```
 
-If there is a need that user with "any of the defined roles" should be allowed, then following Shiro configuration can be used:
+If there is a need that user with "**any of the defined roles**" should be allowed, then following Shiro configuration can be used:
 ```
 [main]
 anyofroles = org.apache.zeppelin.utils.AnyOfRolesAuthorizationFilter

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -247,6 +247,7 @@ anyofroles = org.apache.zeppelin.utils.AnyOfRolesAuthorizationFilter
 ```
 
 <br/>
+
 > **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file.
 
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/AnyOfRolesAuthorizationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/AnyOfRolesAuthorizationFilter.java
@@ -1,0 +1,37 @@
+package org.apache.zeppelin.utils;
+
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.filter.authz.RolesAuthorizationFilter;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+/**
+ * Allows access if current user has at least one role of the specified list.
+ * <p>
+ * Basically, it's the same as {@link RolesAuthorizationFilter} but using {@literal OR} instead
+ * of {@literal AND} on the specified roles.
+ */
+public class AnyOfRolesAuthorizationFilter extends RolesAuthorizationFilter {
+
+  @Override
+  public boolean isAccessAllowed(ServletRequest request, ServletResponse response,
+                                 Object mappedValue) throws IOException {
+
+    final Subject subject = getSubject(request, response);
+    final String[] rolesArray = (String[]) mappedValue;
+
+    if (rolesArray == null || rolesArray.length == 0) {
+      //no roles specified, so nothing to check - allow access.
+      return true;
+    }
+
+    for (String roleName : rolesArray) {
+      if (subject.hasRole(roleName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/AnyOfRolesAuthorizationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/AnyOfRolesAuthorizationFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.utils;
 
 import org.apache.shiro.subject.Subject;


### PR DESCRIPTION
### What is this PR for?
This PR adds support for such a configuration which can give access to user who belongs to "any of" the roles defined in Shiro configuration. By default, as per Shiro implementation, user is allowed only when he/she belongs to "all" the roles defined.

This PR fixes the problem for static users/roles in Shiro as well as Active Directory and/or LDAP based user-group-roles mapping.

### What type of PR is it?
Improvement

### TODO
* [x] - Add documentation

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2825

### How should this be tested?
Add the following in shiro.ini:
[main]
...
anyofroles = org.apache.zeppelin.utils.AnyOfRolesAuthorizationFilter

[urls]
...
/api/interpreter/** = authc, **anyofroles**[admin, role1]
/api/configurations/** = authc, roles[admin]
/api/credential/** = authc, roles[admin]

### Screenshots (if appropriate)
Not applicable

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
