### PR TITLE
[ZEPPELIN-2827] Spark's pyspark fails if unsupported version of matplotlib is present

### DIFF
--- a/interpreter/lib/python/mpl_config.py
+++ b/interpreter/lib/python/mpl_config.py
@@ -71,7 +71,11 @@ def _on_config_change():
     supported_formats = _config['supported_formats']
     if fmt not in supported_formats:
         raise ValueError("Unsupported format %s" %fmt)
-    matplotlib.rcParams['savefig.format'] = fmt
+
+    if matplotlib.__version__ < '1.2.0':
+        matplotlib.rcParams.update({'savefig.format': fmt})
+    else:
+        matplotlib.rcParams['savefig.format'] = fmt
     
     # Interactive mode
     interactive = _config['interactive']
@@ -80,6 +84,8 @@ def _on_config_change():
     
 def _init_config():
     dpi = matplotlib.rcParams['figure.dpi']
+    if matplotlib.__version__ < '1.2.0':
+        matplotlib.rcParams.update({'savefig.format': 'png'})
     fmt = matplotlib.rcParams['savefig.format']
     width, height = matplotlib.rcParams['figure.figsize']
     fontsize = matplotlib.rcParams['font.size']

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -120,6 +120,11 @@ class PyZeppelinContext(dict):
     # If we don't have matplotlib installed don't bother continuing
     try:
       import matplotlib
+
+      #matplotlib.rcParams['savefig.format'] is only avail in version 1.2.0 and above
+      from distutils.version import LooseVersion
+      if LooseVersion("1.2.0") >= LooseVersion(matplotlib.__version__):
+        return
     except ImportError:
       return
     

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -120,11 +120,6 @@ class PyZeppelinContext(dict):
     # If we don't have matplotlib installed don't bother continuing
     try:
       import matplotlib
-
-      #matplotlib.rcParams['savefig.format'] is only avail in version 1.2.0 and above
-      from distutils.version import LooseVersion
-      if LooseVersion("1.2.0") >= LooseVersion(matplotlib.__version__):
-        return
     except ImportError:
       return
     


### PR DESCRIPTION
### What is this PR for?
%spark.pyspark paragraphs keep running for more than > 5 minutes and then at the end, throw TTransportException.

```
org.apache.thrift.transport.TTransportException
	at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:132)
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
	at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
	at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
	at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:69)
```

This happens because Zeppelin refers to `matplotlib.rcParams['savefig.format']` https://github.com/apache/zeppelin/blob/master/interpreter/lib/python/mpl_config.py#L83 which is only present in matplotlib 1.2.0 (https://github.com/matplotlib/matplotlib/blob/v1.2.0/matplotlibrc.template#L355) and onwards.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2827](https://issues.apache.org/jira/browse/ZEPPELIN-2827)

### How should this be tested?
Try running spark.pyspark on a machine with matplotlib==1.1.1 installed, pyspark should work as expected.


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
