### PR TITLE
Zeppelin-2835 add ssl doco

### DIFF
--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -788,6 +788,29 @@ Below are the configuration parameters and their default value.
      </td>
      <td>DEFAULT</td>
    </tr>
+   <tr>
+     <td>cassandra.ssl.enabled</td>
+     <td>
+        Enable support for connecting to Cassandra configured with SSL.
+        To connect to Cassandra configured with SSL use <strong>true</string>
+        and provide a truststore file and password with following options.
+     </td>
+     <td>false</td>
+   </tr>
+   <tr>
+     <td>cassandra.ssl.truststore.path</td>
+     <td>
+        Filepath for truststore file to use for connection to Cassandra with SSL.
+     </td>
+     <td></td>
+   </tr>
+   <tr>
+     <td>cassandra.ssl.truststore.password</td>
+     <td>
+        Password for truststore file to use for connection to Cassandra with SSL.
+     </td>
+     <td></td>
+   </tr>
  </table>
 
 ## Change Log

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -791,7 +791,7 @@ Below are the configuration parameters and their default value.
    <tr>
      <td>cassandra.ssl.enabled</td>
      <td>
-        Enable support for connecting to Cassandra configured with SSL.
+        Enable support for connecting to the Cassandra configured with SSL.
         To connect to Cassandra configured with SSL use <strong>true</strong>
         and provide a truststore file and password with following options.
      </td>
@@ -800,14 +800,14 @@ Below are the configuration parameters and their default value.
    <tr>
      <td>cassandra.ssl.truststore.path</td>
      <td>
-        Filepath for truststore file to use for connection to Cassandra with SSL.
+        Filepath for the truststore file to use for connection to Cassandra with SSL.
      </td>
      <td></td>
    </tr>
    <tr>
      <td>cassandra.ssl.truststore.password</td>
      <td>
-        Password for truststore file to use for connection to Cassandra with SSL.
+        Password for the truststore file to use for connection to Cassandra with SSL.
      </td>
      <td></td>
    </tr>

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -792,7 +792,7 @@ Below are the configuration parameters and their default value.
      <td>cassandra.ssl.enabled</td>
      <td>
         Enable support for connecting to Cassandra configured with SSL.
-        To connect to Cassandra configured with SSL use <strong>true</string>
+        To connect to Cassandra configured with SSL use <strong>true</strong>
         and provide a truststore file and password with following options.
      </td>
      <td>false</td>


### PR DESCRIPTION
### What is this PR for?
Complementing Zeppelin-1501 (support for Cassandra with SSL in interpreter) with documentation updates.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2835
* [Zeppelin-2835]

### How should this be tested?
Check that documentation for cassandra interpreter includes cassandra.ssl options.

### Questions:
* Does the licenses files need update? 
No
* Is there breaking changes for older versions? 
No
* Does this needs documentation? 
No
