### PR TITLE
Fix Missing import

### DIFF
--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -24,6 +24,7 @@ import ast
 import traceback
 import warnings
 import signal
+import base64
 
 from io import BytesIO
 try:


### PR DESCRIPTION
### What is this PR for?
The python interpreter has a bug when trying to render matplotlib images from the z.show() function.  Line 139 of `python/src/main/resources/python/zeppelin_python.py` references un-imported package `base64`.  `import base64` was added to the file to prevent this error in the future.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add missing `base64` module to `python/src/main/resources/python/zeppelin_python.py`

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2821

* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
Display a matplotlib image with zeppelin:
```python
import matplotlib.pyplot as plt
plt.plot([1,2,3,4])
z.show(plt)
```

### Questions:
* Does the licenses files need update?
no
* Is there breaking changes for older versions?
no
* Does this needs documentation?
no
