### PR TITLE
[ZEPPELIN-2647] Make admin role to bypass auth logic

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -384,6 +384,12 @@
 </property>
 
 <property>
+  <name>zeppelin.owner.role</name>
+  <value>admin</value>
+  <description>Set owner role by default in private mode</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.public</name>
   <value>true</value>
   <description>Make notebook public by default when created, private otherwise</description>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -686,11 +686,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
-
     ZEPPELIN_HDFS_KEYTAB("zeppelin.hdfs.keytab", ""),
     ZEPPELIN_HDFS_PRINCIPAL("zeppelin.hdfs.principal", ""),
-
-    ZEPPELIN_INTERPRETER_CALLBACK_PORTRANGE("zeppelin.interpreter.callback.portRange", ":");
+    ZEPPELIN_INTERPRETER_CALLBACK_PORTRANGE("zeppelin.interpreter.callback.portRange", ":"),
+    ZEPPELIN_OWNER_ROLE("zeppelin.owner.role", "admin");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -297,7 +296,8 @@ public class NotebookAuthorization {
   }
 
   public boolean isWriter(String noteId, Set<String> entities) {
-    return isMember(entities, getWriters(noteId)) || isMember(entities, getOwners(noteId));
+    return isMember(entities, getWriters(noteId)) ||
+           isMember(entities, getOwners(noteId));
   }
 
   public boolean isReader(String noteId, Set<String> entities) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -403,6 +403,7 @@ public class NotebookAuthorization {
         setReaders(noteId, entities);
         entities = getRunners(noteId);
         entities.add(subject.getUser());
+        entities.add(admin);
         setRunners(noteId, entities);
         entities = getWriters(noteId);
         entities.add(subject.getUser());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -384,24 +384,29 @@ public class NotebookAuthorization {
   
   public void setNewNotePermissions(String noteId, AuthenticationInfo subject) {
     if (!AuthenticationInfo.isAnonymous(subject)) {
+      String admin = conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE);
       if (isPublic()) {
         // add current user to owners - can be public
         Set<String> owners = getOwners(noteId);
         owners.add(subject.getUser());
+        owners.add(admin);
         setOwners(noteId, owners);
       } else {
         // add current user to owners, readers, runners, writers - private note
         Set<String> entities = getOwners(noteId);
         entities.add(subject.getUser());
+        entities.add(admin);
         setOwners(noteId, entities);
         entities = getReaders(noteId);
         entities.add(subject.getUser());
+        entities.add(admin);
         setReaders(noteId, entities);
         entities = getRunners(noteId);
         entities.add(subject.getUser());
         setRunners(noteId, entities);
         entities = getWriters(noteId);
         entities.add(subject.getUser());
+        entities.add(admin);
         setWriters(noteId, entities);
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -34,6 +34,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -319,6 +319,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
   public void testSyncWithAcl() throws IOException {
     /* scenario 1 - note exists with acl on main storage */
     AuthenticationInfo user1 = new AuthenticationInfo("user1");
+    AuthenticationInfo admin = new AuthenticationInfo(conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE));
     Note note = notebookSync.createNote(user1);
     assertEquals(0, note.getParagraphs().size());
 
@@ -330,8 +331,9 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     NotebookAuthorization authInfo = NotebookAuthorization.getInstance();
     Set<String> entity = new HashSet<String>();
     entity.add(user1.getUser());
+    entity.add(admin.getUser());
     assertEquals(true, authInfo.isOwner(note.getId(), entity));
-    assertEquals(1, authInfo.getOwners(note.getId()).size());
+    assertEquals(2, authInfo.getOwners(note.getId()).size());
     assertEquals(0, authInfo.getReaders(note.getId()).size());
     assertEquals(0, authInfo.getRunners(note.getId()).size());
     assertEquals(0, authInfo.getWriters(note.getId()).size());
@@ -356,7 +358,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(1, notebookRepoSync.get(0,
         notebookRepoSync.list(0, null).get(0).getId(), null).getParagraphs().size());
     assertEquals(true, authInfo.isOwner(note.getId(), entity));
-    assertEquals(1, authInfo.getOwners(note.getId()).size());
+    assertEquals(2, authInfo.getOwners(note.getId()).size());
     assertEquals(0, authInfo.getReaders(note.getId()).size());
     assertEquals(0, authInfo.getRunners(note.getId()).size());
     assertEquals(0, authInfo.getWriters(note.getId()).size());


### PR DESCRIPTION
### What is this PR for?
For administrator, make new admin role that assigned user can see all notebooks.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2647

### How should this be tested?
1. Change Notebook workspace to private through whether ZEPPELIN_NOTEBOOK_PUBLIC = false or zeppelin.notebook.public = false.
2. Set role name to use as admin through ZEPPELIN_OWNER_ROLE = <role name> or zeppelin.owner.role = <role name>.
Default role name is admin
3. Login as user who is not assigned as admin and create notebook.
4. Logout the user and login another user who is assigned as admin, open the created notebook.

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? Y/N
* Does this needs documentation? Y
