### PR TITLE
[ZEPPELIN-2848] Added new type of user to only run notebook

### DIFF
--- a/docs/setup/security/notebook_authorization.md
+++ b/docs/setup/security/notebook_authorization.md
@@ -36,13 +36,15 @@ As you can see, each Zeppelin notebooks has 3 entities :
 * Owners ( users or groups )
 * Readers ( users or groups )
 * Writers ( users or groups )
+* Runners ( users or groups )
 
 <center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/permission_setting.png"></center>
 
 Fill out the each forms with comma seperated **users** and **groups** configured in `conf/shiro.ini` file.
 If the form is empty (*), it means that any users can perform that operation.
 
-If someone who doesn't have **read** permission is trying to access the notebook or someone who doesn't have **write** permission is trying to edit the notebook, Zeppelin will ask to login or block the user.
+If someone who doesn't have **read** permission is trying to access the notebook or someone who doesn't have **write** permission is trying to edit the notebook,
+or someone who doesn't have **run** permission is trying to run a paragraph Zeppelin will ask to login or block the user.
 
 <center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/insufficient_privileges.png"></center>
 
@@ -63,13 +65,13 @@ or set `zeppelin.notebook.public` property to `false` in `conf/zeppelin-site.xml
 </property>
 ```
 
-Behind the scenes, when you create a new note only the `owners` field is filled with current user, leaving `readers` and `writers` fields empty. All the notes with at least one empty authorization field are considered to be in `public` workspace. Thus when setting `zeppelin.notebook.public` (or corresponding `ZEPPELIN_NOTEBOOK_PUBLIC`) to false, newly created notes have `readers` and `writers` fields filled with current user, making note appear as in `private` workspace.
+Behind the scenes, when you create a new note only the `owners` field is filled with current user, leaving `readers`, `runners` and `writers` fields empty. All the notes with at least one empty authorization field are considered to be in `public` workspace. Thus when setting `zeppelin.notebook.public` (or corresponding `ZEPPELIN_NOTEBOOK_PUBLIC`) to false, newly created notes have `readers`, `runners`, `writers` fields filled with current user, making note appear as in `private` workspace.
 
 ## How it works
 In this section, we will explain the detail about how the notebook authorization works in backend side.
 
 ### NotebookServer
-The [NotebookServer](https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java) classifies every notebook operations into three categories: **Read**, **Write**, **Manage**.
+The [NotebookServer](https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java) classifies every notebook operations into three categories: **Read**, **Run**, **Write**, **Manage**.
 Before executing a notebook operation, it checks if the user and the groups associated with the `NotebookSocket` have permissions.
 For example, before executing a **Read** operation, it checks if the user and the groups have at least one entity that belongs to the **Reader** entities.
 

--- a/docs/setup/security/notebook_authorization.md
+++ b/docs/setup/security/notebook_authorization.md
@@ -46,7 +46,7 @@ If the form is empty (*), it means that any users can perform that operation.
 If someone who doesn't have **read** permission is trying to access the notebook or someone who doesn't have **write** permission is trying to edit the notebook,
 or someone who doesn't have **run** permission is trying to run a paragraph Zeppelin will ask to login or block the user.
 
-By default, owners and writers have **write** permissions, owners, writers and runners have **run** permissions, owners, writers, runners and readers have read permission
+By default, owners and writers have **write** permission, owners, writers and runners have **run** permission, owners, writers, runners and readers have **read** permission
 
 <center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/insufficient_privileges.png"></center>
 

--- a/docs/setup/security/notebook_authorization.md
+++ b/docs/setup/security/notebook_authorization.md
@@ -46,6 +46,8 @@ If the form is empty (*), it means that any users can perform that operation.
 If someone who doesn't have **read** permission is trying to access the notebook or someone who doesn't have **write** permission is trying to edit the notebook,
 or someone who doesn't have **run** permission is trying to run a paragraph Zeppelin will ask to login or block the user.
 
+By default, owners and writers have **write** permissions, owners, writers and runners have **run** permissions, owners, writers, runners and readers have read permission
+
 <center><img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/insufficient_privileges.png"></center>
 
 ## Separate notebook workspaces (public vs. private)

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -1215,6 +1215,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "owners":[  
          "user1"
       ],
+      "runners":[
+         "user2"
+      ],
       "writers":[  
          "user2"
       ]
@@ -1257,6 +1260,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     "user1"
   ],
   "owners": [
+    "user2"
+  ],
+  "runners":[
     "user2"
   ],
   "writers": [

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -752,6 +752,25 @@ public class NotebookServer extends WebSocketServlet
   }
 
   /**
+   * @return false if user doesn't have runner permission for this paragraph
+   */
+  private boolean hasParagraphRunnerPermission(NotebookSocket conn,
+                                               Notebook notebook, String noteId,
+                                               HashSet<String> userAndRoles,
+                                               String principal, String op)
+      throws IOException {
+
+    NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
+    if (!notebookAuthorization.isRunner(noteId, userAndRoles)) {
+      permissionError(conn, op, principal, userAndRoles,
+              notebookAuthorization.getOwners(noteId));
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * @return false if user doesn't have writer permission for this paragraph
    */
   private boolean hasParagraphWriterPermission(NotebookSocket conn,
@@ -1618,7 +1637,7 @@ public class NotebookServer extends WebSocketServlet
 
     String noteId = getOpenNoteId(conn);
 
-    if (!hasParagraphWriterPermission(conn, notebook, noteId,
+    if (!hasParagraphRunnerPermission(conn, notebook, noteId,
         userAndRoles, fromMessage.principal, "write")) {
       return;
     }
@@ -1636,7 +1655,7 @@ public class NotebookServer extends WebSocketServlet
       return;
     }
 
-    if (!hasParagraphWriterPermission(conn, notebook, noteId,
+    if (!hasParagraphRunnerPermission(conn, notebook, noteId,
         userAndRoles, fromMessage.principal, "run all paragraphs")) {
       return;
     }
@@ -1729,7 +1748,7 @@ public class NotebookServer extends WebSocketServlet
 
     String noteId = getOpenNoteId(conn);
 
-    if (!hasParagraphWriterPermission(conn, notebook, noteId,
+    if (!hasParagraphRunnerPermission(conn, notebook, noteId,
         userAndRoles, fromMessage.principal, "write")) {
       return;
     }
@@ -2057,7 +2076,7 @@ public class NotebookServer extends WebSocketServlet
       Set<String> userAndRoles = Sets.newHashSet();
       userAndRoles.add(SecurityUtils.getPrincipal());
       userAndRoles.addAll(SecurityUtils.getRoles());
-      if (!notebookIns.getNotebookAuthorization().hasWriteAuthorization(userAndRoles, noteId)) {
+      if (!notebookIns.getNotebookAuthorization().hasRunAuthorization(userAndRoles, noteId)) {
         throw new ForbiddenException(String.format("can't execute note %s", noteId));
       }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -200,6 +200,8 @@ public class AuthenticationIT extends AbstractZeppelinIT {
           MAX_BROWSER_TIMEOUT_SEC).sendKeys("finance ");
       pollingWait(By.xpath(".//*[@id='selectReaders']/following::span//input"),
           MAX_BROWSER_TIMEOUT_SEC).sendKeys("finance ");
+      pollingWait(By.xpath(".//*[@id='selectRunners']/following::span//input"),
+              MAX_BROWSER_TIMEOUT_SEC).sendKeys("finance ");
       pollingWait(By.xpath(".//*[@id='selectWriters']/following::span//input"),
           MAX_BROWSER_TIMEOUT_SEC).sendKeys("finance ");
       pollingWait(By.xpath("//button[@ng-click='savePermissions()']"), MAX_BROWSER_TIMEOUT_SEC)

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -81,7 +81,7 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     String noteId = createNoteForUser("test", "admin", "password1");
     
     //set permission
-    String payload = "{ \"owners\": [\"admin\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
+    String payload = "{ \"owners\": [\"admin\"], \"readers\": [\"user2\"], \"runners\": [\"user2\"], \"writers\": [\"user2\"] }";
     PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
     assertThat("test set note permission method:", put, isAllowed());
     put.releaseConnection();
@@ -98,7 +98,7 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     String noteId = createNoteForUser("test", "admin", "password1");
     
     //set permission
-    String payload = "{ \"owners\": [\"admin\", \"user1\"], \"readers\": [\"user2\"], \"writers\": [\"user2\"] }";
+    String payload = "{ \"owners\": [\"admin\", \"user1\"], \"readers\": [\"user2\"], \"runners\": [\"user2\"], \"writers\": [\"user2\"] }";
     PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
     assertThat("test set note permission method:", put, isAllowed());
     put.releaseConnection();
@@ -180,7 +180,7 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
   }
 
   private void setPermissionForNote(String noteId, String user, String pwd) throws IOException {
-    String payload = "{\"owners\":[\"" + user + "\"],\"readers\":[\"" + user + "\"],\"writers\":[\"" + user + "\"]}";
+    String payload = "{\"owners\":[\"" + user + "\"],\"readers\":[\"" + user + "\"],\"runners\":[\"" + user + "\"],\"writers\":[\"" + user + "\"]}";
     PutMethod put = httpPut(("/notebook/" + noteId + "/permissions"), payload, user, pwd);
     put.releaseConnection();
   }
@@ -206,10 +206,11 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
       ArrayList owners = permissions.get("owners");
       ArrayList readers = permissions.get("readers");
       ArrayList writers = permissions.get("writers");
+      ArrayList runners = permissions.get("runners");
 
-      if (owners.size() != 0 && readers.size() != 0 && writers.size() != 0) {
+      if (owners.size() != 0 && readers.size() != 0 && writers.size() != 0 && runners.size() != 0) {
         assertEquals("User has permissions  ", true, (owners.contains(user) || readers.contains(user) ||
-          writers.contains(user)));
+          writers.contains(user) || runners.contains(user)));
       }
       getPermission.releaseConnection();
     }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -700,6 +700,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
       $scope.setIamOwner()
       angular.element('#selectOwners').select2(selectJson)
       angular.element('#selectReaders').select2(selectJson)
+      angular.element('#selectRunners').select2(selectJson)
       angular.element('#selectWriters').select2(selectJson)
       if (callback) {
         callback()
@@ -739,6 +740,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   function convertPermissionsToArray () {
     $scope.permissions.owners = angular.element('#selectOwners').val()
     $scope.permissions.readers = angular.element('#selectReaders').val()
+    $scope.permissions.runners = angular.element('#selectRunners').val()
     $scope.permissions.writers = angular.element('#selectWriters').val()
     angular.element('.permissionsForm select').find('option:not([is-select2="false"])').remove()
   }
@@ -1017,7 +1019,8 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
           closable: true,
           title: 'Permissions Saved Successfully',
           message: 'Owners : ' + $scope.permissions.owners + '\n\n' + 'Readers : ' +
-          $scope.permissions.readers + '\n\n' + 'Writers  : ' + $scope.permissions.writers
+           $scope.permissions.readers + '\n\n' + 'Runners : ' + $scope.permissions.runners +
+           '\n\n' + 'Writers  : ' + $scope.permissions.writers
         })
         $scope.showPermissions = false
       })
@@ -1062,6 +1065,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
         $scope.closePermissions()
         angular.element('#selectOwners').select2({})
         angular.element('#selectReaders').select2({})
+        angular.element('#selectRunners').select2({})
         angular.element('#selectWriters').select2({})
       } else {
         $scope.openPermissions()

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -219,6 +219,11 @@
     display: inline-block;
 }
 
+.permissions .runners {
+    width:60px;
+    display: inline-block;
+}
+
 .permissions .writers {
     width:60px;
     display: inline-block;

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -93,7 +93,7 @@ limitations under the License.
           <select id="selectRunners" multiple="multiple">
             <option is-select2="false" ng-repeat="runners in permissions.runners" selected="selected">{{runners}}</option>
           </select>
-          Writers can read, run and write the note.
+            Runners can read and run the note.
         </p>
         <p><span class="readers">Readers </span>
           <select id="selectReaders" multiple="multiple">

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -81,13 +81,19 @@ limitations under the License.
           <select id="selectOwners" multiple="multiple">
             <option is-select2="false" ng-repeat="owner in permissions.owners" selected="selected">{{owner}}</option>
           </select>
-          Owners can change permissions,read and write the note.
+          Owners can change permissions,read, run and write the note.
         </p>
         <p><span class="writers">Writers </span>
           <select id="selectWriters" multiple="multiple">
             <option is-select2="false" ng-repeat="writers in permissions.writers" selected="selected">{{writers}}</option>
           </select>
-            Writers can read and write the note.
+            Writers can read, run and write the note.
+        </p>
+        <p><span class="runners">Runners </span>
+          <select id="selectRunners" multiple="multiple">
+            <option is-select2="false" ng-repeat="runners in permissions.runners" selected="selected">{{runners}}</option>
+          </select>
+          Writers can read, run and write the note.
         </p>
         <p><span class="readers">Readers </span>
           <select id="selectReaders" multiple="multiple">

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -284,6 +284,7 @@ public class NotebookRepoSync implements NotebookRepo {
     NotebookAuthorization notebookAuthorization = NotebookAuthorization.getInstance();
     return notebookAuthorization.getOwners(noteId).isEmpty()
         && notebookAuthorization.getReaders(noteId).isEmpty()
+            && notebookAuthorization.getRunners(noteId).isEmpty()
         && notebookAuthorization.getWriters(noteId).isEmpty();
   }
 
@@ -299,6 +300,9 @@ public class NotebookRepoSync implements NotebookRepo {
     users = notebookAuthorization.getReaders(noteId);
     users.add(subject.getUser());
     notebookAuthorization.setReaders(noteId, users);
+    users = notebookAuthorization.getRunners(noteId);
+    users.add(subject.getUser());
+    notebookAuthorization.setRunners(noteId, users);
     users = notebookAuthorization.getWriters(noteId);
     users.add(subject.getUser());
     notebookAuthorization.setWriters(noteId, users);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1115,7 +1115,7 @@ public class NotebookTest implements JobListenerFactory{
     notebook.getNotebookAuthorization().setOwners(note2.getId(), Sets.newHashSet("user2"));
     notebook.getNotebookAuthorization().setWriters(note2.getId(), Sets.newHashSet("user2"));
     notebook.getNotebookAuthorization().setReaders(note2.getId(), Sets.newHashSet("user2"));
-      notebook.getNotebookAuthorization().setRunners(note1.getId(), Sets.newHashSet("user2"));
+      notebook.getNotebookAuthorization().setRunners(note2.getId(), Sets.newHashSet("user2"));
     assertEquals(0, notebook.getAllNotes(Sets.newHashSet("anonymous")).size());
     assertEquals(1, notebook.getAllNotes(Sets.newHashSet("user1")).size());
     assertEquals(1, notebook.getAllNotes(Sets.newHashSet("user2")).size());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -721,6 +721,8 @@ public class NotebookTest implements JobListenerFactory{
             new HashSet<>(Arrays.asList("user2"))), true);
     assertEquals(notebookAuthorization.isReader(note.getId(),
             new HashSet<>(Arrays.asList("user2"))), true);
+    assertEquals(notebookAuthorization.isRunner(note.getId(),
+            new HashSet<>(Arrays.asList("user2"))), true);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
             new HashSet<>(Arrays.asList("user2"))), true);
 
@@ -728,6 +730,8 @@ public class NotebookTest implements JobListenerFactory{
             new HashSet<>(Arrays.asList("user1")));
     notebookAuthorization.setReaders(note.getId(),
             new HashSet<>(Arrays.asList("user1", "user2")));
+      notebookAuthorization.setRunners(note.getId(),
+              new HashSet<>(Arrays.asList("user3")));
     notebookAuthorization.setWriters(note.getId(),
             new HashSet<>(Arrays.asList("user1")));
 
@@ -737,21 +741,26 @@ public class NotebookTest implements JobListenerFactory{
             new HashSet<>(Arrays.asList("user1"))), true);
 
     assertEquals(notebookAuthorization.isReader(note.getId(),
-        new HashSet<>(Arrays.asList("user3"))), false);
+        new HashSet<>(Arrays.asList("user4"))), false);
     assertEquals(notebookAuthorization.isReader(note.getId(),
         new HashSet<>(Arrays.asList("user2"))), true);
+
+    assertEquals(notebookAuthorization.isRunner(note.getId(),
+            new HashSet<>(Arrays.asList("user3"))), true);
+    assertEquals(notebookAuthorization.isRunner(note.getId(),
+            new HashSet<>(Arrays.asList("user2"))), false);
 
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         new HashSet<>(Arrays.asList("user2"))), false);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         new HashSet<>(Arrays.asList("user1"))), true);
 
-    // Test clearing of permssions
+    // Test clearing of permissions
     notebookAuthorization.setReaders(note.getId(), Sets.<String>newHashSet());
     assertEquals(notebookAuthorization.isReader(note.getId(),
         new HashSet<>(Arrays.asList("user2"))), true);
     assertEquals(notebookAuthorization.isReader(note.getId(),
-        new HashSet<>(Arrays.asList("user3"))), true);
+        new HashSet<>(Arrays.asList("user4"))), true);
 
     notebook.removeNote(note.getId(), anonymous);
   }
@@ -767,11 +776,13 @@ public class NotebookTest implements JobListenerFactory{
     
     Note note = notebook.createNote(new AuthenticationInfo(user1));
     
-    // check that user1 is owner, reader and writer
+    // check that user1 is owner, reader, runner and writer
     assertEquals(notebookAuthorization.isOwner(note.getId(),
         Sets.newHashSet(user1)), true);
     assertEquals(notebookAuthorization.isReader(note.getId(),
         Sets.newHashSet(user1)), true);
+    assertEquals(notebookAuthorization.isRunner(note.getId(),
+        Sets.newHashSet(user2)), true);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         Sets.newHashSet(user1)), true);
     
@@ -779,6 +790,8 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(notebookAuthorization.isOwner(note.getId(),
         Sets.newHashSet(user2)), false);
     assertEquals(notebookAuthorization.isReader(note.getId(),
+        Sets.newHashSet(user2)), true);
+    assertEquals(notebookAuthorization.isRunner(note.getId(),
         Sets.newHashSet(user2)), true);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         Sets.newHashSet(user2)), true);
@@ -790,7 +803,7 @@ public class NotebookTest implements JobListenerFactory{
     assertEquals(user1Notes.size(), 1);
     assertEquals(user1Notes.get(0).getId(), note.getId());
     
-    // check that user2 has note listed in his workbech because of admin role
+    // check that user2 has note listed in his workbench because of admin role
     Set<String> user2AndRoles = notebookAuthorization.getRoles(user2);
     user2AndRoles.add(user2);
     List<Note> user2Notes = notebook.getAllNotes(user2AndRoles);
@@ -1094,6 +1107,7 @@ public class NotebookTest implements JobListenerFactory{
 
     notebook.getNotebookAuthorization().setOwners(note1.getId(), Sets.newHashSet("user1"));
     notebook.getNotebookAuthorization().setWriters(note1.getId(), Sets.newHashSet("user1"));
+    notebook.getNotebookAuthorization().setRunners(note1.getId(), Sets.newHashSet("user1"));
     notebook.getNotebookAuthorization().setReaders(note1.getId(), Sets.newHashSet("user1"));
     assertEquals(1, notebook.getAllNotes(Sets.newHashSet("anonymous")).size());
     assertEquals(2, notebook.getAllNotes(Sets.newHashSet("user1")).size());
@@ -1101,6 +1115,7 @@ public class NotebookTest implements JobListenerFactory{
     notebook.getNotebookAuthorization().setOwners(note2.getId(), Sets.newHashSet("user2"));
     notebook.getNotebookAuthorization().setWriters(note2.getId(), Sets.newHashSet("user2"));
     notebook.getNotebookAuthorization().setReaders(note2.getId(), Sets.newHashSet("user2"));
+      notebook.getNotebookAuthorization().setRunners(note1.getId(), Sets.newHashSet("user2"));
     assertEquals(0, notebook.getAllNotes(Sets.newHashSet("anonymous")).size());
     assertEquals(1, notebook.getAllNotes(Sets.newHashSet("user1")).size());
     assertEquals(1, notebook.getAllNotes(Sets.newHashSet("user2")).size());
@@ -1129,6 +1144,12 @@ public class NotebookTest implements JobListenerFactory{
     
     notebook.getNotebookAuthorization().setReaders(note.getId(), Sets.newHashSet("user1"));
     //note is public since writers empty
+    notes1 = notebook.getAllNotes(user1);
+    notes2 = notebook.getAllNotes(user2);
+    assertEquals(notes1.size(), 1);
+    assertEquals(notes2.size(), 1);
+
+    notebook.getNotebookAuthorization().setRunners(note.getId(), Sets.newHashSet("user1"));
     notes1 = notebook.getAllNotes(user1);
     notes2 = notebook.getAllNotes(user2);
     assertEquals(notes1.size(), 1);
@@ -1169,6 +1190,7 @@ public class NotebookTest implements JobListenerFactory{
     // user1 is only owner
     assertEquals(notebookAuthorization.getOwners(notePublic.getId()).size(), 1);
     assertEquals(notebookAuthorization.getReaders(notePublic.getId()).size(), 0);
+    assertEquals(notebookAuthorization.getRunners(notePublic.getId()).size(), 0);
     assertEquals(notebookAuthorization.getWriters(notePublic.getId()).size(), 0);
 
     // case of private note
@@ -1197,6 +1219,7 @@ public class NotebookTest implements JobListenerFactory{
     // user1 have all rights
     assertEquals(notebookAuthorization.getOwners(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getReaders(notePrivate.getId()).size(), 1);
+    assertEquals(notebookAuthorization.getRunners(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getWriters(notePrivate.getId()).size(), 1);
     
     //set back public to true

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -330,6 +330,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(true, authInfo.isOwner(note.getId(), entity));
     assertEquals(1, authInfo.getOwners(note.getId()).size());
     assertEquals(0, authInfo.getReaders(note.getId()).size());
+    assertEquals(0, authInfo.getRunners(note.getId()).size());
     assertEquals(0, authInfo.getWriters(note.getId()).size());
     
     /* update note and save on secondary storage */
@@ -354,6 +355,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(true, authInfo.isOwner(note.getId(), entity));
     assertEquals(1, authInfo.getOwners(note.getId()).size());
     assertEquals(0, authInfo.getReaders(note.getId()).size());
+    assertEquals(0, authInfo.getRunners(note.getId()).size());
     assertEquals(0, authInfo.getWriters(note.getId()).size());
     
     /* scenario 2 - note doesn't exist on main storage */
@@ -364,6 +366,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     authInfo.removeNote(note.getId());
     assertEquals(0, authInfo.getOwners(note.getId()).size());
     assertEquals(0, authInfo.getReaders(note.getId()).size());
+    assertEquals(0, authInfo.getRunners(note.getId()).size());
     assertEquals(0, authInfo.getWriters(note.getId()).size());
     
     /* now sync - should bring note from secondary storage with added acl */
@@ -372,9 +375,11 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     assertEquals(1, notebookRepoSync.list(1, null).size());
     assertEquals(1, authInfo.getOwners(note.getId()).size());
     assertEquals(1, authInfo.getReaders(note.getId()).size());
+    assertEquals(1, authInfo.getRunners(note.getId()).size());
     assertEquals(1, authInfo.getWriters(note.getId()).size());
     assertEquals(true, authInfo.isOwner(note.getId(), entity));
     assertEquals(true, authInfo.isReader(note.getId(), entity));
+    assertEquals(true, authInfo.isRunner(note.getId(), entity));
     assertEquals(true, authInfo.isWriter(note.getId(), entity));
   }
 


### PR DESCRIPTION
### What is this PR for?

The idea of this PR is to provide a new kind of user : Runner.

Basically, what it does is that it just removes write authorization and allow user to read and run note.

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-2848] https://issues.apache.org/jira/browse/ZEPPELIN-2848

### How should this be tested?
- Log in as admin
- Create new notebook and create a paragraph with the interpreter you want
- Assign runner right to user1
- Log in as user1
- Try to run the paragraph (should work)
- Try to modify the paragraph (should fail)
- Log in as user2
- Try to run the paragraph (should fail)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No
