### PR TITLE
[ZEPPELIN-2770] Zeppelin is not working in IE-11

### DIFF
--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -185,7 +185,7 @@ function auth () {
       $rootScope.ticket = angular.fromJson(response.data).body
 
       $rootScope.ticket.screenUsername = $rootScope.ticket.principal
-      if ($rootScope.ticket.principal.startsWith('#Pac4j')) {
+      if ($rootScope.ticket.principal.toString().indexOf('#Pac4j') === 0) {
         let re = ', name=(.*?),'
         $rootScope.ticket.screenUsername = $rootScope.ticket.principal.match(re)[1]
       }

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -185,7 +185,7 @@ function auth () {
       $rootScope.ticket = angular.fromJson(response.data).body
 
       $rootScope.ticket.screenUsername = $rootScope.ticket.principal
-      if ($rootScope.ticket.principal.toString().indexOf('#Pac4j') === 0) {
+      if ($rootScope.ticket.principal.indexOf('#Pac4j') === 0) {
         let re = ', name=(.*?),'
         $rootScope.ticket.screenUsername = $rootScope.ticket.principal.match(re)[1]
       }


### PR DESCRIPTION
### What is this PR for?
There is a javascript error while loading zeppelin homepage in IE-11, causing a blank page to appear. 

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-2770](https://issues.apache.org/jira/browse/ZEPPELIN-2770)

### How should this be tested?
Try opening Zeppelin homepage in IE-11.

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
