### PR TITLE
[ZEPPELIN-2853] Change the order of contents in index document.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,11 +123,6 @@ limitations under the License.
   * [Useful Developer Tools](./development/contribution/useful_developer_tools.html)
   * [How to Contribute (code)](./development/contribution/how_to_contribute_code.html)
   * [How to Contribute (website)](./development/contribution/how_to_contribute_website.html)
-
-#### External Resources
-  * [Mailing List](https://zeppelin.apache.org/community.html)
-  * [Apache Zeppelin Wiki](https://cwiki.apache.org/confluence/display/ZEPPELIN/Zeppelin+Home)
-  * [Stackoverflow Questions about Zeppelin (tag: `apache-zeppelin`)](http://stackoverflow.com/questions/tagged/apache-zeppelin)
   
 #### Available Interpreters 
   * [Alluxio](./interpreter/alluxio.html)
@@ -156,3 +151,7 @@ limitations under the License.
   * [Shell](./interpreter/Shell.html)
   * [Spark](./interpreter/spark.html)
   
+#### External Resources
+  * [Mailing List](https://zeppelin.apache.org/community.html)
+  * [Apache Zeppelin Wiki](https://cwiki.apache.org/confluence/display/ZEPPELIN/Zeppelin+Home)
+  * [Stackoverflow Questions about Zeppelin (tag: `apache-zeppelin`)](http://stackoverflow.com/questions/tagged/apache-zeppelin)


### PR DESCRIPTION
### What is this PR for?
To change the order of content in index documentation. Now the last two contents is "External Resources" and "Available Interpreters". This PR change the order to "Available Interpreters" and "External Resources".

### What type of PR is it?
[Documentation]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2853

### How should this be tested?
1. Read the doc

### Screenshots (if appropriate)
Before

<img width="726" alt="screen shot 2017-08-15 at 3 08 14 pm" src="https://user-images.githubusercontent.com/19610222/29304040-d9f9adac-81cb-11e7-9aa3-0a325511e267.png">

After

<img width="615" alt="screen shot 2017-08-15 at 3 04 44 pm" src="https://user-images.githubusercontent.com/19610222/29304001-a26fca6a-81cb-11e7-8cf2-be10eef781d9.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
