### PR TITLE
[ZEPPELIN-2854] provide tooltip in notebook title

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -19,7 +19,11 @@ limitations under the License.
       <input type="text" pu-elastic-input class="form-control2" placeholder="New name" style="min-width: 0px; max-width: 95%;"
            ng-if="input.showEditor" ng-model="input.value" ng-escape="input.showEditor = false" focus-if="input.showEditor"
            ng-blur="updateNoteName(input.value);input.showEditor = false;" ng-enter="updateNoteName(input.value);input.showEditor = false;" />
-      <p class="form-control-static2" ng-click="input.showEditor = !revisionView; input.value = note.name" ng-show="!input.showEditor">{{noteName(note)}}</p>
+      <p class="form-control-static2" 
+         tooltip-placement="bottom" 
+         uib-tooltip={{noteName(note)}}
+         ng-click="input.showEditor = !revisionView; input.value = note.name" 
+         ng-show="!input.showEditor">{{noteName(note)}}</p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">


### PR DESCRIPTION
### What is this PR for?
when title's length is too long it is hard to read full name.
in case i think that it is good for tooltip


### What type of PR is it?
Improvement

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2854

### How should this be tested?
1. Build: mvn clean package -Denforcer.skip -DskipTests -Drat.skip
2. create new notebook with long title
3. hover mouse on the title.
4. check tooltip providing full title

### Screenshots (if appropriate)
before
<img width="379" alt="2017-08-15 3 38 26" src="https://user-images.githubusercontent.com/18265697/29304775-e4eb96c2-81cf-11e7-9bc5-9595beb9d282.png">


after
<img width="436" alt="2017-08-15 3 36 06" src="https://user-images.githubusercontent.com/18265697/29304719-89b392fa-81cf-11e7-982b-9f219715db6e.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
