### PR TITLE
[ZEPPELIN-2855] The Color of Pause Icon on Job Manager Change

### DIFF
--- a/zeppelin-web/src/app/jobmanager/job/job.html
+++ b/zeppelin-web/src/app/jobmanager/job/job.html
@@ -27,7 +27,8 @@ limitations under the License.
         class="job-control-btn" tooltip-placement="left"
         uib-tooltip-html="!$ctrl.isRunning() ? 'Start All Paragraphs' : 'Stop All Paragraphs'"
         ng-click="!$ctrl.isRunning() ? $ctrl.runJob() : $ctrl.stopJob()"
-        ng-class="!$ctrl.isRunning() ? 'icon-control-play' : 'icon-control-pause'">
+        ng-class="!$ctrl.isRunning() ? 'icon-control-play' : 'icon-control-pause'"
+        ng-style="{'color': $ctrl.isRunning() ? '#CD5C5C' : '#3071A9'}">
       </span>
     </div>
     <!-- job control: end -->


### PR DESCRIPTION
### What is this PR for?
The color of pause icon on Job Manager webpage will be changed from #3071A9 to #CD5C5C since the color has to be the same as it on notebook page.
Please refer to http://localhost:9000/#/jobmanager if running on localhost.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2855

### How should this be tested?
Please see below attached screenshot images.

### Screenshots (if appropriate)

Before
![before](https://user-images.githubusercontent.com/6982251/29305446-cc737c0a-81d3-11e7-98b0-a8050b93e9a0.png)

After
![after](https://user-images.githubusercontent.com/6982251/29305450-d7248838-81d3-11e7-9d6a-8c00688a0dc0.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no