### PR TITLE
[ZEPPELIN-2865] upgrade Beam interpreter to latest version

### DIFF
--- a/beam/README.md
+++ b/beam/README.md
@@ -8,11 +8,8 @@ Current interpreter implementation supports the static repl. It compiles the cod
 You have to first build the Beam interpreter by enable the **beam** profile as follows:
 
 ```
-mvn clean package -Pbeam -DskipTests
+mvn clean package -Pbeam -DskipTests -Pscala-2.10
 ```
-
-### Notice
-- Flink runner comes with binary compiled for scala 2.10. So, currently we support only Scala 2.10
 
 ### Technical overview
 

--- a/beam/README.md
+++ b/beam/README.md
@@ -11,6 +11,9 @@ You have to first build the Beam interpreter by enable the **beam** profile as f
 mvn clean package -Pbeam -DskipTests -Pscala-2.10
 ```
 
+### Notice
+- Flink runner comes with binary compiled for scala 2.10. So, currently we support only Scala 2.10
+
 ### Technical overview
 
  * Upon starting an interpreter, an instance of `JavaCompiler` is created. 

--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <beam.hadoop.version>2.3.0</beam.hadoop.version>
     <beam.spark.version>1.6.2</beam.spark.version>
-    <beam.beam.version>0.2.0-incubating</beam.beam.version>
+    <beam.beam.version>2.0.0</beam.beam.version>
 
     <!-- library versions -->
     <netty.version>4.1.1.Final</netty.version>
@@ -210,6 +210,14 @@
       <artifactId>beam-runners-spark</artifactId>
       <version>${beam.beam.version}</version>
       <type>jar</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-flink_${scala.binary.version}</artifactId>
+      <version>${beam.beam.version}</version>
+      <exclusions>
+      </exclusions>
     </dependency>
   
     <dependency>


### PR DESCRIPTION
### What is this PR for?
upgrade Beam interpreter to use the latest version of Apache Beam.

### What type of PR is it?
[Improvement]

### Todos
* 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2865

### How should this be tested?
* Start the Zeppelin server
* The prefix of interpreter is %beam and then write your code with required imports and the runner

Refer to `docs/interpreter/beam.md` for an example;

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?  no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes, updated `docs/interpreter/beam.md` and `README.md` 
