### PR TITLE
ZEPPELIN-2873 - Add documentation on secure cookie in Shiro

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -210,6 +210,21 @@ securityManager.realms = $zeppelinHubRealm
 
 > Note: ZeppelinHub is not releated to Apache Zeppelin project.
 
+## Secure Cookie for Zeppelin Sessions (optional)
+Zeppelin can be configured to set `HttpOnly` flag in the session cookie. With this configuration, Zeppelin cookies can 
+not be accessed via client side scripts thus preventing Cross-site scripting (XSS) attacks.
+
+To enable secure cookie support via Shiro, add the following lines in `conf/shiro.ini` under `[main]` section, after
+defining a `sessionManager`.
+
+```
+cookie = org.apache.shiro.web.servlet.SimpleCookie
+cookie.name = JSESSIONID
+cookie.secure = true
+cookie.httpOnly = true
+sessionManager.sessionIdCookie = $cookie
+```
+
 ## Secure your Zeppelin information (optional)
 By default, anyone who defined in `[users]` can share **Interpreter Setting**, **Credential** and **Configuration** information in Apache Zeppelin.
 Sometimes you might want to hide these information for your use case.

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -212,7 +212,7 @@ securityManager.realms = $zeppelinHubRealm
 
 ## Secure Cookie for Zeppelin Sessions (optional)
 Zeppelin can be configured to set `HttpOnly` flag in the session cookie. With this configuration, Zeppelin cookies can 
-not be accessed via client side scripts thus preventing Cross-site scripting (XSS) attacks.
+not be accessed via client side scripts thus preventing majority of Cross-site scripting (XSS) attacks.
 
 To enable secure cookie support via Shiro, add the following lines in `conf/shiro.ini` under `[main]` section, after
 defining a `sessionManager`.


### PR DESCRIPTION
### What is this PR for?
Adding a section in Shiro Authentication about how to enable secure cookie via Shiro. Shiro do support configuring 'HttpOnly' flag in response cookie. A Zeppelin user, who is security conscious, should know how to enable this in Zeppelin's Shiro configuration.

### What type of PR is it?
Documentation

### What is the Jira issue?
ZEPPELIN-2873

### How should this be tested?
Doc changes. CI test should pass.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
