### PR TITLE
Fix trivial typo

### DIFF
--- a/travis_check.py
+++ b/travis_check.py
@@ -57,7 +57,7 @@ def getBuildStatus(author, commit):
     build = None
 
     if len(data) == 0:
-        return build;
+        return build
 
     for b in data:
         if b["commit"][:len(commit)] == commit:
@@ -102,7 +102,7 @@ def printBuildStatus(build):
 
 for sleep in check:
     info("--------------------------------")
-    time.sleep(sleep);
+    time.sleep(sleep)
     info("Get build status ...")
     build = getBuildStatus(author, commit)
     if build == None:


### PR DESCRIPTION
### What is this PR for?
Fixes a trivial typo in travis_check.py.

The semicolon does nothing in travis_check.py.
Python use semicolon when several statements on the same line, here is [python doc.](https://docs.python.org/3/reference/compound_stmts.html)


### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
