### PR TITLE
[MINOR] Updated shiro.ini.template to include secure cookie option

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -62,10 +62,12 @@ sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
 #cacheManager = org.apache.shiro.cache.MemoryConstrainedCacheManager
 #securityManager.cacheManager = $cacheManager
 
+### Enables 'HttpOnly' flag in Zeppelin cookies
 cookie = org.apache.shiro.web.servlet.SimpleCookie
 cookie.name = JSESSIONID
-cookie.secure = true
 cookie.httpOnly = true
+### Uncomment the below line only when Zeppelin is running over HTTPS
+#cookie.secure = true
 sessionManager.sessionIdCookie = $cookie
 
 securityManager.sessionManager = $sessionManager

--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -62,6 +62,12 @@ sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
 #cacheManager = org.apache.shiro.cache.MemoryConstrainedCacheManager
 #securityManager.cacheManager = $cacheManager
 
+cookie = org.apache.shiro.web.servlet.SimpleCookie
+cookie.name = JSESSIONID
+cookie.secure = true
+cookie.httpOnly = true
+sessionManager.sessionIdCookie = $cookie
+
 securityManager.sessionManager = $sessionManager
 # 86,400,000 milliseconds = 24 hour
 securityManager.sessionManager.globalSessionTimeout = 86400000


### PR DESCRIPTION
### What is this PR for?
Based on discussion in https://github.com/apache/zeppelin/pull/2545 , I'm updating the shiro.ini.template to include secure cookie option. With this change, Zeppelin Shiro will always set 'HttpOnly' flag in cookie. This will help to prevent majority of cross-site scripting (XSS) attacks.


### What type of PR is it?
Minor Improvement


### What is the Jira issue?
Minor change in shiro.ini


### How should this be tested?
CI tests should pass


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Doc changes already done in https://github.com/apache/zeppelin/pull/2545
