### PR TITLE
[ZEPPELIN-2880] - Fix username output when OIDC is enabled

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -47,6 +47,7 @@
     <!--test library versions-->
     <selenium.java.version>2.48.2</selenium.java.version>
     <xml.apis.version>1.4.01</xml.apis.version>
+    <powermock.version>1.6.6</powermock.version>
 
     <!--plugin library versions-->
     <plugin.failsafe.version>2.16</plugin.failsafe.version>
@@ -374,8 +375,35 @@
       <scope>test</scope>
     </dependency>
 
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -88,9 +89,20 @@ public class SecurityUtils {
 
     String principal;
     if (subject.isAuthenticated()) {
-      principal = subject.getPrincipal().toString();
+      principal = extractPrincipal(subject);
     } else {
       principal = ANONYMOUS;
+    }
+    return principal;
+  }
+
+  private static String extractPrincipal(Subject subject) {
+    String principal;
+    Object principalObject = subject.getPrincipal();
+    if (principalObject instanceof Principal) {
+      principal = ((Principal) principalObject).getName();
+    } else {
+      principal = String.valueOf(principalObject);
     }
     return principal;
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
@@ -35,7 +35,7 @@ import java.net.UnknownHostException;
 import java.net.InetAddress;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(org.apache.shiro.SecurityUtils.class) // Static.class contains static methods
+@PrepareForTest(org.apache.shiro.SecurityUtils.class)
 public class SecurityUtilsTest {
 
   @Mock

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
@@ -17,17 +17,29 @@
 package org.apache.zeppelin.security;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import sun.security.acl.PrincipalImpl;
 
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.net.InetAddress;
 
-
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(org.apache.shiro.SecurityUtils.class) // Static.class contains static methods
 public class SecurityUtilsTest {
+
+  @Mock
+  org.apache.shiro.subject.Subject subject;
 
   @Test
   public void isInvalid() throws URISyntaxException, UnknownHostException {
@@ -86,5 +98,18 @@ public class SecurityUtilsTest {
   public void notAURIOrigin() throws URISyntaxException, UnknownHostException, ConfigurationException {
     assertFalse(SecurityUtils.isValidOrigin("test123",
           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+
+  @Test
+  public void canGetPrincipalName()  {
+    String expectedName = "java.security.Principal.getName()";
+    SecurityUtils.setIsEnabled(true);
+    PowerMockito.mockStatic(org.apache.shiro.SecurityUtils.class);
+    when(org.apache.shiro.SecurityUtils.getSubject()).thenReturn(subject);
+    when(subject.isAuthenticated()).thenReturn(true);
+    when(subject.getPrincipal()).thenReturn(new PrincipalImpl(expectedName));
+
+    assertEquals(expectedName, SecurityUtils.getPrincipal());
   }
 }


### PR DESCRIPTION
### What is this PR for?
When OIDC is enabled, user's roles/permissions/tokens are sent to Zeppelin's client via websocket and appears in the web browser when running a paragraph in a notebook.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-2880](https://issues.apache.org/jira/browse/ZEPPELIN-2880)

### How should this be tested?
Enable OIDC , login to Zeppelin and run a paragraph.  Check the text "Last updated by". 

### Questions:
* Does the licenses files need update?  N/A
* Is there breaking changes for older versions?  N/A
* Does this needs documentation?  N/A
