### PR TITLE
[ZEPPELIN-2885] Have Logger subclass StringIO and override write method

### DIFF
--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -34,7 +34,11 @@ except ImportError:
 
 # for back compatibility
 
-class Logger(StringIO):
+class Logger(StringIO, object):
+  def __init__(self, *args, **kwargs):
+    if sys.version_info < (3, 0):
+      self.encoding = None
+    super(Logger, self).__init__(*args, **kwargs)
   def write(self, message):
     intp.appendOutput(message)
     StringIO.write(self, message)

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -34,19 +34,12 @@ except ImportError:
 
 # for back compatibility
 
-class Logger(object):
-  def __init__(self):
-    pass
-
+class Logger(StringIO):
   def write(self, message):
     intp.appendOutput(message)
-
+    StringIO.write(self, message)
   def reset(self):
     pass
-
-  def flush(self):
-    pass
-
 
 class PyZeppelinContext(object):
   """ A context impl that uses Py4j to communicate to JVM

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -32,13 +32,16 @@ except ImportError:
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, Row
 
-class Logger(StringIO):
+class Logger(StringIO, object):
+  def __init__(self, *args, **kwargs):
+    if sys.version_info < (3, 0):
+      self.encoding = None
+    super(Logger, self).__init__(*args, **kwargs)
   def write(self, message):
     intp.appendOutput(message)
     StringIO.write(self, message)
   def reset(self):
     pass
-
 
 class PyZeppelinContext(dict):
   def __init__(self, zc):

--- a/spark/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/src/main/resources/python/zeppelin_pyspark.py
@@ -24,20 +24,19 @@ from pyspark.context import SparkContext
 import ast
 import warnings
 
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 # for back compatibility
 from pyspark.sql import SQLContext, HiveContext, Row
 
-class Logger(object):
-  def __init__(self):
-    pass
-
+class Logger(StringIO):
   def write(self, message):
     intp.appendOutput(message)
-
+    StringIO.write(self, message)
   def reset(self):
-    pass
-
-  def flush(self):
     pass
 
 


### PR DESCRIPTION
### What is this PR for?
H2O python module uses the `isatty` method when outputting to stdout. As Zeppelin replaces stdout with a custom Logger class, the lack of this method causes H2O to fail with most operations.

Subclassing StringIO and overriding the write method fixes this ensures other behavior in the TextIO classes used for stdout is present as well, obviating the need to keep adding method stubs to workaround other modules in the future.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Does `reset` still need to be present?

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2885

### How should this be tested?
* Python/Pyspark interpreter output still works
* Running the following paragraph should return `False`

```
%python
import sys
sys.stdout.isatty()
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?			No
* Is there breaking changes for older versions?		No
* Does this needs documentation?      			No
