### PR TITLE
sc.setLocalProperty(...) should be more deterministic

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.slf4j.Logger;
@@ -63,6 +64,10 @@ public class SchedulerFactory implements SchedulerListener {
   }
 
   public Scheduler createOrGetFIFOScheduler(String name) {
+    return createOrGetFIFOScheduler(name, this.executor);
+  }
+
+  public Scheduler createOrGetFIFOScheduler(String name, ExecutorService executor) {
     synchronized (schedulers) {
       if (schedulers.containsKey(name) == false) {
         Scheduler s = new FIFOScheduler(name, executor, this);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
@@ -67,7 +67,7 @@ public class SchedulerFactory implements SchedulerListener {
       if (schedulers.containsKey(name) == false) {
         Scheduler s = new FIFOScheduler(name, executor, this);
         schedulers.put(name, s);
-        executor.execute(s);
+        startScheduler(s);
       }
       return schedulers.get(name);
     }
@@ -78,7 +78,7 @@ public class SchedulerFactory implements SchedulerListener {
       if (schedulers.containsKey(name) == false) {
         Scheduler s = new ParallelScheduler(name, executor, this, maxConcurrency);
         schedulers.put(name, s);
-        executor.execute(s);
+        startScheduler(s);
       }
       return schedulers.get(name);
     }
@@ -100,10 +100,14 @@ public class SchedulerFactory implements SchedulerListener {
             this,
             maxConcurrency);
         schedulers.put(name, s);
-        executor.execute(s);
+        startScheduler(s);
       }
       return schedulers.get(name);
     }
+  }
+
+  public void startScheduler(Scheduler s) {
+    new Thread(s).start();
   }
 
   public Scheduler removeScheduler(String name) {


### PR DESCRIPTION
### What is this PR for?
executing these two pagragraph in spark interperter 
```
sc.setLocalProperty("a", "1")
```

```
sc.getLocalProerty("a") 
```

evaluated to unexpected result "null". fix that confusion.

---

sc.setLocalProperty(...) should be more deterministic.

and honor design of SparkContext. SparkContext.setLocalProperty(...) is using ThreadLocal. So let me say that design of SparkContext has assumtion single-thread user.

But before this commit, SparkInterpreter's ExecutorService is created with Executor.newSchedulerService(100). So User might perceive situation like sc.setLocalProperty(...) is not working.

fix by using singleThread for Schduler.



### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?

### How should this be tested?
make note with two paragraph 

```
sc.setLocalProperty("a", "1")
```

```
sc.getLocalProerty("a") 
```

run paragraph separatly 

### Screenshots (if appropriate)

### Questions:
