### PR TITLE
[ZEPPELIN-2894] Show users in notebook permission using Shiro JDBC

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -231,7 +231,7 @@ public class GetUserList {
         return userlist;
       }
 
-      userquery = "select ? from ?";
+      userquery = String.format("SELECT %s FROM %s", username, tablename);
 
     } catch (IllegalAccessException e) {
       LOG.error("Error while accessing dataSource for JDBC Realm", e);
@@ -241,8 +241,6 @@ public class GetUserList {
     try {
       Connection con = dataSource.getConnection();
       ps = con.prepareStatement(userquery);
-      ps.setString(1, username);
-      ps.setString(2, tablename);
       rs = ps.executeQuery();
       while (rs.next()) {
         userlist.add(rs.getString(1).trim());


### PR DESCRIPTION
### What is this PR for?
Show user list/suggestions in the notebook permission form when using Shiro and JDBC Realm.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-2894](https://issues.apache.org/jira/browse/ZEPPELIN-2894)

### How should this be tested?
- Shiro with JDBC Realm (e.g. PostgreSQL JDBC Driver)
- Login to any account
- Open Notebook permission form
- Try to get any user suggestion in the dropdown menu by typing an existing name  

### Screenshots 
**After:**
![userlist_working](https://user-images.githubusercontent.com/1479098/29970688-ccb2fb8c-8f25-11e7-903c-4a917830bc5c.gif)

**Before:**
![userlist_error](https://user-images.githubusercontent.com/1479098/29970676-c13936f4-8f25-11e7-9494-6c0aeb1f383a.gif)

### Questions:
* Does the licenses files need update? 
No.
* Is there breaking changes for older versions? 
No.
* Does this needs documentation?
No.
