### PR TITLE
[ZEPPELIN-2896] Replacing addHeader with setHeader method in CorsFilter.java

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -73,19 +73,19 @@ public class CorsFilter implements Filter {
   }
 
   private void addCorsHeaders(HttpServletResponse response, String origin) {
-    response.addHeader("Access-Control-Allow-Origin", origin);
-    response.addHeader("Access-Control-Allow-Credentials", "true");
-    response.addHeader("Access-Control-Allow-Headers", "authorization,Content-Type");
-    response.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, HEAD, DELETE");
+    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Access-Control-Allow-Credentials", "true");
+    response.setHeader("Access-Control-Allow-Headers", "authorization,Content-Type");
+    response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, HEAD, DELETE");
     DateFormat fullDateFormatEN =
         DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, new Locale("EN", "en"));
-    response.addHeader("Date", fullDateFormatEN.format(new Date()));
+    response.setHeader("Date", fullDateFormatEN.format(new Date()));
     ZeppelinConfiguration zeppelinConfiguration = ZeppelinConfiguration.create();
-    response.addHeader("X-FRAME-OPTIONS", zeppelinConfiguration.getXFrameOptions());
+    response.setHeader("X-FRAME-OPTIONS", zeppelinConfiguration.getXFrameOptions());
     if (zeppelinConfiguration.useSsl()) {
-      response.addHeader("Strict-Transport-Security", zeppelinConfiguration.getStrictTransport());
+      response.setHeader("Strict-Transport-Security", zeppelinConfiguration.getStrictTransport());
     }
-    response.addHeader("X-XSS-Protection", zeppelinConfiguration.getXxssProtection());
+    response.setHeader("X-XSS-Protection", zeppelinConfiguration.getXxssProtection());
   }
 
   @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/CorsFilterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/CorsFilterTest.java
@@ -58,7 +58,7 @@ public class CorsFilterTest {
                 count++;
                 return null;
             }
-        }).when(mockResponse).addHeader(anyString(), anyString());
+        }).when(mockResponse).setHeader(anyString(), anyString());
 
         filter.doFilter(mockRequest, mockResponse, mockedFilterChain);
         Assert.assertTrue(headers[0].equals("http://localhost:8080"));
@@ -82,7 +82,7 @@ public class CorsFilterTest {
                 count++;
                 return null;
             }
-        }).when(mockResponse).addHeader(anyString(), anyString());
+        }).when(mockResponse).setHeader(anyString(), anyString());
 
         filter.doFilter(mockRequest, mockResponse, mockedFilterChain);
         Assert.assertTrue(headers[0].equals(""));


### PR DESCRIPTION
### What is this PR for?
HTTP Response Headers were being added multiple times. Replacing addHeader method with setHeader overrides the Response Header value with new/existing value instead of adding another duplicate response Header.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2896

### How should this be tested?
Open the Zeppelin URL in Chrome Browser. Select "More Tools" -> "Developer Tools" from the right-side menu. Under Network Section, select the request with name "localhost" and check for "Response Headers". You should see response headers appearing only once.

![screen shot 2017-09-04 at 3 21 32 pm](https://user-images.githubusercontent.com/6433184/30021436-feb7a6e4-9184-11e7-9161-f9f8350b7df2.png)
