### PR TITLE
add zeppelin.livy.share_existing_session option

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -280,7 +280,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
         // to check session status again in this sync block
         synchronized (this) {
           if (isSessionExpired()) {
-            createSession();
+            this.open();
           }
         }
         stmtInfo = executeStatement(new ExecuteRequest(code));


### PR DESCRIPTION
If you want to share livy session between multiple zeppelin user, There is no option now.
After this commit, setting zeppelin.livy.share_existing_session to true
make LivyInterpreter use an existing livy session
(first session returned by /sessions)

### What is this PR for?
add zeppelin.livy.share_existing_session option. 
zeppelin.livy.share_existing_session is true, list exsiting livy session and select first session. 
by doing so, we can share livy session between zeppelin livy interpreters. 

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?

### How should this be tested?

* setup livy server 
* run zeppelin server
* setup zeppelin livy interpreter(change zeppelin.livy.share_existing_session to true) 
* make new note 
* make another note 
* audit logs/zeppelin-interpreter-*.log

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No 
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
