### PR TITLE
[ZEPPELIN-2903] Make setting of working directory to user-home optional for shell interpreter

### DIFF
--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -44,6 +44,11 @@ At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property v
     <td>Shell command time out in millisecs</td>
   </tr>
   <tr>
+    <td>shell.working.directory.user.home</td>
+    <td>false</td>
+    <td>If this set to true, the shell's working directory will be set to user home</td>
+  </tr>
+  <tr>
     <td>zeppelin.shell.auth.type</td>
     <td></td>
     <td>Types of authentications' methods supported are SIMPLE, and KERBEROS</td>

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 public class ShellInterpreter extends KerberosInterpreter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShellInterpreter.class);
   private static final String TIMEOUT_PROPERTY = "shell.command.timeout.millisecs";
+  private static final String DIRECTORY_USER_HOME = "shell.working.directory.user.home";
   private final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
   private final String shell = isWindows ? "cmd /c" : "bash -c";
   ConcurrentHashMap<String, DefaultExecutor> executors;
@@ -99,7 +100,10 @@ public class ShellInterpreter extends KerberosInterpreter {
         contextInterpreter.out, contextInterpreter.out));
       executor.setWatchdog(new ExecuteWatchdog(Long.valueOf(getProperty(TIMEOUT_PROPERTY))));
       executors.put(contextInterpreter.getParagraphId(), executor);
-      executor.setWorkingDirectory(new File(System.getProperty("user.home")));
+      if (Boolean.valueOf(getProperty(DIRECTORY_USER_HOME))) {
+        executor.setWorkingDirectory(new File(System.getProperty("user.home")));
+      }
+
       int exitVal = executor.execute(cmdLine);
       LOGGER.info("Paragraph " + contextInterpreter.getParagraphId() 
         + " return with exit value: " + exitVal);

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -31,6 +31,13 @@
         "defaultValue": "",
         "description": "Kerberos principal",
         "type": "string"
+      },
+      "shell.working.directory.user.home": {
+        "envName": "SHELL_WORKING_DIRECTORY_USER_HOME",
+        "propertyName": "shell.working.directory.user.home",
+        "defaultValue": false,
+        "description": "If this set to true, the shell's working directory will be set to user home",
+        "type": "checkbox"
       }
     },
     "editor": {

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -11,6 +11,13 @@
         "description": "Shell command time out in millisecs. Default = 60000",
         "type": "number"
       },
+      "shell.working.directory.user.home": {
+        "envName": "SHELL_WORKING_DIRECTORY_USER_HOME",
+        "propertyName": "shell.working.directory.user.home",
+        "defaultValue": false,
+        "description": "If this set to true, the shell's working directory will be set to user home",
+        "type": "checkbox"
+      },
       "zeppelin.shell.auth.type": {
         "envName": null,
         "propertyName": "zeppelin.shell.auth.type",
@@ -31,13 +38,6 @@
         "defaultValue": "",
         "description": "Kerberos principal",
         "type": "string"
-      },
-      "shell.working.directory.user.home": {
-        "envName": "SHELL_WORKING_DIRECTORY_USER_HOME",
-        "propertyName": "shell.working.directory.user.home",
-        "defaultValue": false,
-        "description": "If this set to true, the shell's working directory will be set to user home",
-        "type": "checkbox"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
With ZEPPELIN-2841, it had changed the default working directory of Shell Interpreter from the relative path where Zeppelin is running to user-home. This is to make the configuration optional.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2903

### How should this be tested?
by default when the user runs shell interpreter and executes `pwd` will the path where Zeppelin server is running, but when `shell.working.directory.user.home` is set to true in Zeppelin's interpreter setting, it will point to the user's home directory by which the interpreter is running.
