### PR TITLE
[ZEPPELIN-2900] Close connection on getUserList

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -202,6 +202,7 @@ public class GetUserList {
    */
   public List<String> getUserList(JdbcRealm obj) {
     List<String> userlist = new ArrayList<>();
+    Connection con = null;
     PreparedStatement ps = null;
     ResultSet rs = null;
     DataSource dataSource = null;
@@ -239,7 +240,7 @@ public class GetUserList {
     }
 
     try {
-      Connection con = dataSource.getConnection();
+      con = dataSource.getConnection();
       ps = con.prepareStatement(userquery);
       ps.setString(1, username);
       ps.setString(2, tablename);
@@ -252,6 +253,7 @@ public class GetUserList {
     } finally {
       JdbcUtils.closeResultSet(rs);
       JdbcUtils.closeStatement(ps);
+      JdbcUtils.closeConnection(con);
     }
     return userlist;
   }


### PR DESCRIPTION
### What is this PR for?
This PR fixed a JDBC connection leak on `GetUserList.getUserList` when the Shiro Realm is a JdbcRealm. After a while, it's not possible to even login into zeppelin.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
[ZEPPELIN-2900](https://issues.apache.org/jira/browse/ZEPPELIN-2900)

### How should this be tested?
In order to reproduce the bug follow this steps:

1. Configure zeppelin to use a JdbcRealm for authentication with a low number of connections in the connection pool.
2. Login into zeppelin and open a notebook.
3. Open the permissions form of the notebook.
4. Try to add several users to the owners list (more than the number of connections of the connection pool.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No that I'm aware.
* Does this needs documentation? No.
