### PR TITLE
[ZEPPELIN-2919] fix: Fallback to table when vis is not available

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -529,8 +529,13 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
 
     if (!graphMode) { graphMode = 'table' }
 
-    const builtInViz = builtInVisualizations[graphMode]
-    if (!builtInViz) { return }
+    let builtInViz = builtInVisualizations[graphMode]
+    if (!builtInViz) {
+      /** helium package is not available, fallback to table vis */
+      graphMode = 'table'
+      $scope.graphMode = graphMode /** html depends on this scope value */
+      builtInViz = builtInVisualizations[graphMode]
+    }
 
     // deactive previsouly active visualization
     for (let t in builtInVisualizations) {


### PR DESCRIPTION
### What is this PR for?

fallback to table when vis is not available. 

The erroneous situation can happen when

- user enabled helium visualization
- and open the visualization in paragraph
- and disabled the helium visualization
- and open again the paragraph. 
- then you will see the empty paragraph because the specific visualization is now not available

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?

[ZEPPELIN-2919](https://issues.apache.org/jira/browse/ZEPPELIN-2919)

### How should this be tested?

- user enabled helium visualization
- and open the visualization in paragraph
- and disabled the helium visualization
- and open again the paragraph with **refresh**

### Screenshots (if appropriate)

#### Before

![2919_before](https://user-images.githubusercontent.com/4968473/30196276-66a182da-949a-11e7-8208-6bb4e4643833.gif)

#### After

![2919_after](https://user-images.githubusercontent.com/4968473/30196278-68cced10-949a-11e7-8527-1c233f5fbbc1.gif)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
