### PR TITLE
[ZEPPELIN-2921 : 0.7x] does not work conda environment in python interpreter

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -135,9 +135,13 @@ public class PythonCondaInterpreter extends Interpreter {
         }
       }
     }
-    python.setCurrentCondaEnvName(envName);
-    python.setPythonCondaLibPath(condaLibraryPath);
-    python.setPythonCommand(binPath);
+
+    File pythonBin = new File(binPath);
+    if (pythonBin.exists() && pythonBin.isFile() && pythonBin.canExecute()) {
+      python.setCurrentCondaEnvName(envName);
+      python.setPythonCondaLibPath(condaLibraryPath);
+      python.setPythonCommand(binPath);
+    }
   }
 
   private void restartPythonProcess() {

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -44,6 +44,7 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
@@ -57,7 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import py4j.GatewayServer;
-import py4j.commands.Command;
 
 /**
  * Python interpreter for Zeppelin.
@@ -76,6 +76,9 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
   private int maxResult;
   private String py4jLibPath;
   private String pythonLibPath;
+
+  private String currentCondaEnvName = StringUtils.EMPTY;
+  private String currentCondaEnvLibPath = StringUtils.EMPTY;
 
   private String pythonCommand;
 
@@ -152,6 +155,10 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
       Path workingPath = Paths.get("..").toAbsolutePath();
       py4jLibPath = workingPath + File.separator + ZEPPELIN_PY4JPATH;
       pythonLibPath = workingPath + File.separator + ZEPPELIN_PYTHON_LIBS;
+    }
+
+    if (currentCondaEnvLibPath != null && !currentCondaEnvLibPath.isEmpty()) {
+      pythonLibPath = String.format("%s:%s", pythonLibPath, currentCondaEnvLibPath);
     }
 
     port = findRandomOpenPortOnAllLocalInterfaces();
@@ -450,6 +457,28 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
     } else {
       return pythonCommand;
     }
+  }
+
+  public void setCurrentCondaEnvName(String envName) {
+    if (envName == null) {
+      envName = StringUtils.EMPTY;
+    }
+    this.currentCondaEnvName = envName;
+  }
+
+  public String getCurrentCondaEnvName() {
+    return currentCondaEnvName;
+  }
+
+  public void setPythonCondaLibPath(String path) {
+    if (path == null) {
+      path = StringUtils.EMPTY;
+    }
+    this.currentCondaEnvLibPath = path;
+  }
+
+  public String getPythonCondaLibPath() {
+    return this.currentCondaEnvLibPath;
   }
 
   public String getPythonBindPath() {


### PR DESCRIPTION
### What is this PR for?
It seems that the environment of the python interpreter has changed to the py4j environment, causing problems with the library path and the default environment.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2921

### How should this be tested?
Please run the following command line for each paragraph.
If the module such as scipy is normally imported, it is a success.
`%python.conda create --name Hello6 python=2.7`
`%python.conda activate Hello6`
`%python.conda install seaborn pandas numpy scipy matplotlib`
```
%python
import scipy as sp
import seaborn as sns
```
`%python.conda deactivate`

### Screenshots (if appropriate)
#### Before
![image](https://user-images.githubusercontent.com/10525473/30199920-c75022ca-94af-11e7-8811-0c22310f1bac.png)

#### After
![image](https://user-images.githubusercontent.com/10525473/30198880-23aaceb2-94ab-11e7-8bc6-bfad76c675f7.png)


### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no
