### PR TITLE
[ZEPPELIN-2921] does not work conda environment in python interpreter 

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -235,8 +235,12 @@ public class PythonCondaInterpreter extends Interpreter {
 
   private String runCondaList() throws IOException, InterruptedException {
     List<String> commands = new ArrayList<String>();
-    commands.add("conda");
-    commands.add("list");
+    commands.add(0, "conda");
+    commands.add(1, "list");
+    if (!getCurrentCondaEnvName().isEmpty()) {
+      commands.add(2, "-n");
+      commands.add(3, getCurrentCondaEnvName());
+    }
 
     return runCondaCommandForTableOutput("Installed Package List", commands);
   }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -50,6 +50,8 @@ public class PythonCondaInterpreter extends Interpreter {
   public static final Pattern PATTERN_COMMAND_HELP = Pattern.compile("help");
   public static final Pattern PATTERN_COMMAND_INFO = Pattern.compile("info");
 
+  private String currentCondaEnvName = StringUtils.EMPTY;
+
   public PythonCondaInterpreter(Properties property) {
     super(property);
   }
@@ -112,6 +114,17 @@ public class PythonCondaInterpreter extends Interpreter {
     }
   }
 
+  public String getCurrentCondaEnvName() {
+    return currentCondaEnvName;
+  }
+
+  public void setCurrentCondaEnvName(String currentCondaEnvName) {
+    if (currentCondaEnvName == null) {
+      currentCondaEnvName = StringUtils.EMPTY;
+    }
+    this.currentCondaEnvName = currentCondaEnvName;
+  }
+
   private void changePythonEnvironment(String envName)
       throws IOException, InterruptedException {
     PythonInterpreter python = getPythonInterpreter();
@@ -130,6 +143,7 @@ public class PythonCondaInterpreter extends Interpreter {
         }
       }
     }
+    setCurrentCondaEnvName(envName);
     python.setPythonCommand(binPath);
   }
 
@@ -259,6 +273,10 @@ public class PythonCondaInterpreter extends Interpreter {
     restArgs.add(0, "conda");
     restArgs.add(1, "install");
     restArgs.add(2, "--yes");
+    if (!getCurrentCondaEnvName().isEmpty()) {
+      restArgs.add(3, "-n");
+      restArgs.add(4, getCurrentCondaEnvName());
+    }
 
     return runCondaCommandForTextOutput("Package Installation", restArgs);
   }
@@ -269,6 +287,10 @@ public class PythonCondaInterpreter extends Interpreter {
     restArgs.add(0, "conda");
     restArgs.add(1, "uninstall");
     restArgs.add(2, "--yes");
+    if (!getCurrentCondaEnvName().isEmpty()) {
+      restArgs.add(3, "-n");
+      restArgs.add(4, getCurrentCondaEnvName());
+    }
 
     return runCondaCommandForTextOutput("Package Uninstallation", restArgs);
   }

--- a/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonCondaInterpreterTest.java
@@ -74,12 +74,13 @@ public class PythonCondaInterpreterTest {
   @Test
   public void testActivateEnv() throws IOException, InterruptedException {
     setMockCondaEnvList();
-
+    String envname = "env1";
     InterpreterContext context = getInterpreterContext();
-    conda.interpret("activate env1", context);
+    conda.interpret("activate " + envname, context);
     verify(python, times(1)).open();
     verify(python, times(1)).close();
     verify(python).setPythonCommand("/path1/bin/python");
+    assertTrue(envname.equals(conda.getCurrentCondaEnvName()));
   }
 
   @Test
@@ -89,6 +90,7 @@ public class PythonCondaInterpreterTest {
     verify(python, times(1)).open();
     verify(python, times(1)).close();
     verify(python).setPythonCommand("python");
+    assertTrue(conda.getCurrentCondaEnvName().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
Fixed a problem where conda's library was not installed and reflected properly due to changed python interpreter execution  flow and structures.

ORIGINAL : https://github.com/apache/zeppelin/pull/2574

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2921

### How should this be tested?
Please run the following command line for each paragraph.
If the module such as scipy is normally imported, it is a success.
`%python.conda create --name Hello6 python=2.7`
`%python.conda activate Hello6`
`%python.conda install seaborn pandas numpy scipy matplotlib`
```
%python
import scipy as sp
import seaborn as sns
```
`%python.conda deactivate`

### Screenshots (if appropriate)
#### Before
![image](https://user-images.githubusercontent.com/10525473/30199920-c75022ca-94af-11e7-8811-0c22310f1bac.png)

#### After
![image](https://user-images.githubusercontent.com/10525473/30198880-23aaceb2-94ab-11e7-8bc6-bfad76c675f7.png)


### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no
