### PR TITLE
[ZEPPELIN-2924] Fix broken javascript source map

### DIFF
--- a/zeppelin-web/webpack.config.js
+++ b/zeppelin-web/webpack.config.js
@@ -120,6 +120,7 @@ module.exports = function makeWebpackConfig () {
    * Reference: http://webpack.github.io/docs/configuration.html#devtool
    * Type of sourcemap to use per build type
    */
+  config.devtool = 'eval-source-map';
   if (isTest) {
     config.devtool = 'inline-source-map';
   } else if (isProd) {
@@ -127,7 +128,6 @@ module.exports = function makeWebpackConfig () {
   } else {
     config.devtool = 'eval-source-map';
   }
-  config.devtool = 'source-map';
 
   /**
    * Loaders
@@ -196,14 +196,6 @@ module.exports = function makeWebpackConfig () {
         }
       ]})
     }],
-    postLoaders: [
-      {
-        // COVERAGE
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components|\.test\.js)/,
-        loader: 'istanbul-instrumenter'
-      }
-    ]
   };
 
   /**
@@ -249,6 +241,17 @@ module.exports = function makeWebpackConfig () {
         }
       })
     )
+  }
+  
+  if (isTest) {
+    config.module.postLoaders = [
+      {
+        // COVERAGE
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components|\.test\.js)/,
+        loader: 'istanbul-instrumenter'
+      }
+    ]
   }
 
   // Add build specific plugins


### PR DESCRIPTION
### What is this PR for?

Fixed broken javascript source map. The coverage loader should be used only for test env.

**that's really annoying because we can't set breakpoint and even can't see the original source code.**

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-2924](https://issues.apache.org/jira/browse/ZEPPELIN-2924)

### How should this be tested?

1. run the webapp as dev mode: `localhost:9000`
2. open the developer console and click any log message
3. check whether source is minified or not.
4. execute `yarn run test` in the terminal to check that coverage feature works well.

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/30260684-cc095240-9703-11e7-9fd6-fe5bd370a6bd.png)

![image](https://user-images.githubusercontent.com/4968473/30260690-d4f3494c-9703-11e7-854b-29d6020eaa3c.png)



#### After

![image](https://user-images.githubusercontent.com/4968473/30260654-a27579d6-9703-11e7-9d2a-a37c7ae7b148.png)

![image](https://user-images.githubusercontent.com/4968473/30260655-a9c62802-9703-11e7-9d29-be10df0302d7.png)

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
