### PR TITLE
[ZEPPELIN-2928] Hotfix on maven set version functionality

### DIFF
--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -75,13 +75,13 @@
 
   <dependencies>
     <dependency>
-      <artifactId>zeppelin-server</artifactId>
       <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-server</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <artifactId>zeppelin-web</artifactId>
       <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-web</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>

--- a/zeppelin-jupyter/pom.xml
+++ b/zeppelin-jupyter/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-markdown</artifactId>
-      <version>${zeppelin.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- Test -->

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-zengine</artifactId>
-      <version>0.8.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
-      <version>0.8.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
Hotfix on a recent commit that removed the version soft-coded variable and introduced hard-coded references to version tag.

### What type of PR is it?
[Bug Fix | Hot Fix ]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2928

### How should this be tested?
Run "mvn versions:set -DprocessDependencies=false -DnewVersion=0.8.0-SNAPSHOT-123"

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
