### PR TITLE
[ZEPPELIN-2647] Bypass auth logic when a user logins as admin role

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -396,7 +396,7 @@
 <property>
   <name>zeppelin.notebook.default.owner.username</name>
   <value></value>
-  <description>Set owner role by default in private mode</description>
+  <description>Set owner role by default</description>
 </property>
 
 <property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -394,6 +394,12 @@
 </property>
 
 <property>
+  <name>zeppelin.owner.role</name>
+  <value>admin</value>
+  <description>Set owner role by default in private mode</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.public</name>
   <value>true</value>
   <description>Make notebook public by default when created, private otherwise</description>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -395,7 +395,7 @@
 
 <property>
   <name>zeppelin.notebook.default.owner.username</name>
-  <value>admin</value>
+  <value></value>
   <description>Set owner role by default in private mode</description>
 </property>
 

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -394,7 +394,7 @@
 </property>
 
 <property>
-  <name>zeppelin.owner.role</name>
+  <name>zeppelin.notebook.default.owner.username</name>
   <value>admin</value>
   <description>Set owner role by default in private mode</description>
 </property>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -713,7 +713,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD(
         "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L),
 
-    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "admin");
+    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "");
 
 
     private String varName;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -711,7 +711,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_CHECK_INTERVAL(
         "zeppelin.interpreter.lifecyclemanager.timeout.checkinterval", 6000L),
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD(
-        "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L);
+        "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L),
+    ZEPPELIN_OWNER_ROLE("zeppelin.owner.role", "admin");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -712,7 +712,9 @@ public class ZeppelinConfiguration extends XMLConfiguration {
         "zeppelin.interpreter.lifecyclemanager.timeout.checkinterval", 6000L),
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD(
         "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L),
-    ZEPPELIN_OWNER_ROLE("zeppelin.owner.role", "admin");
+
+    ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", "admin");
+
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -319,7 +319,7 @@ public class NotebookAuthorization {
 
   private boolean isAdmin(Set<String> entities) {
     String adminRole = conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE);
-    if (adminRole.isEmpty()) {
+    if (StringUtils.isBlank(adminRole)) {
       return false;
     }
     return entities.contains(adminRole);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -318,7 +318,11 @@ public class NotebookAuthorization {
   }
 
   private boolean isAdmin(Set<String> entities) {
-    return entities.contains(conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE));
+    String adminRole = conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE);
+    if (adminRole.isEmpty()) {
+      return false;
+    }
+    return entities.contains(adminRole);
   }
 
   // return true if b is empty or if (a intersection b) is non-empty

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -24,7 +24,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -35,6 +34,7 @@ import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -293,24 +293,32 @@ public class NotebookAuthorization {
   }
 
   public boolean isOwner(String noteId, Set<String> entities) {
-    return isMember(entities, getOwners(noteId));
+    return isMember(entities, getOwners(noteId)) || isAdmin(entities);
   }
 
   public boolean isWriter(String noteId, Set<String> entities) {
-    return isMember(entities, getWriters(noteId)) || isMember(entities, getOwners(noteId));
+    return isMember(entities, getWriters(noteId)) ||
+           isMember(entities, getOwners(noteId)) ||
+           isAdmin(entities);
   }
 
   public boolean isReader(String noteId, Set<String> entities) {
     return isMember(entities, getReaders(noteId)) ||
-            isMember(entities, getOwners(noteId)) ||
-            isMember(entities, getWriters(noteId)) ||
-            isMember(entities, getRunners(noteId));
+           isMember(entities, getOwners(noteId)) ||
+           isMember(entities, getWriters(noteId)) ||
+           isMember(entities, getRunners(noteId)) ||
+           isAdmin(entities);
   }
 
   public boolean isRunner(String noteId, Set<String> entities) {
     return isMember(entities, getRunners(noteId)) ||
-            isMember(entities, getWriters(noteId)) ||
-            isMember(entities, getOwners(noteId));
+           isMember(entities, getWriters(noteId)) ||
+           isMember(entities, getOwners(noteId)) ||
+           isAdmin(entities);
+  }
+
+  private boolean isAdmin(Set<String> entities) {
+    return entities.contains(conf.getString(ConfVars.ZEPPELIN_OWNER_ROLE));
   }
 
   // return true if b is empty or if (a intersection b) is non-empty


### PR DESCRIPTION
### What is this PR for?
For administrator, make new admin role that assigned user can see all notebooks.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2647

### How should this be tested?
1. Set role name to use as admin through ZEPPELIN_OWNER_ROLE = <role name> or zeppelin.owner.role = <role name>.
Default role name is admin
2. Login as user who is not assigned as admin and create notebook.
3. Logout the user and login another user who is assigned as admin, open the created notebook.

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? Y/N
* Does this needs documentation? Y
