### PR TITLE
[ZEPPELIN-2938] Can't build docker image for bin due to missing wget cmd (master, branch-0.7)

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "$LOG_TAG update and install basic packages" && \
     apt-get install -y build-essential
 
 RUN echo "$LOG_TAG install tini related packages" && \
-    apt-get install -y curl grep sed dpkg && \
+    apt-get install -y wget curl grep sed dpkg && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
     curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
     dpkg -i tini.deb && \


### PR DESCRIPTION
### What is this PR for?

Can't build docker image for bin due to missing wget cmd

![image](https://user-images.githubusercontent.com/4968473/30482870-b6c9344a-9a5f-11e7-913f-b67d67a49a66.png)

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?

[ZEPPELIN-2938](https://issues.apache.org/jira/browse/ZEPPELIN-2938)

### How should this be tested?

- `cd scripts/docker/zeppelin/bin/`
- `docker build . -t test`
- should fail here

![image](https://user-images.githubusercontent.com/4968473/30483594-5ee7fc72-9a62-11e7-8472-1fdf3115fa0f.png)

### Screenshots (if appropriate)

#### Before

![image](https://user-images.githubusercontent.com/4968473/30482783-5d344d70-9a5f-11e7-8407-de039ccfd16a.png)

#### After

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
