### PR TITLE
ZEPPELIN-2943 Streaming output will be closed in 30 seconds for IPythonInterpreter

### DIFF
--- a/python/src/main/resources/grpc/python/ipython_server.py
+++ b/python/src/main/resources/grpc/python/ipython_server.py
@@ -35,7 +35,7 @@ else:
     import queue as queue
 
 
-TIMEOUT = 30
+TIMEOUT = 60*60*24*365*100  # 100 years
 
 class IPython(ipython_pb2_grpc.IPythonServicer):
 
@@ -50,7 +50,8 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
         self._status = ipython_pb2.RUNNING
 
     def execute(self, request, context):
-        print("execute code: " + request.code)
+        print("execute code:\n")
+        print(request.code)
         sys.stdout.flush()
         stdout_queue = queue.Queue(maxsize = 10)
         stderr_queue = queue.Queue(maxsize = 10)

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -56,6 +56,7 @@ public abstract class AbstractInterpreterTest {
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), notebookDir.getAbsolutePath());
 
     conf = new ZeppelinConfiguration();
+    conf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_ORDER.getVarName(), "test,mock1,mock2,mock_resource_pool");
     interpreterSettingManager = new InterpreterSettingManager(conf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));
     interpreterFactory = new InterpreterFactory(interpreterSettingManager);


### PR DESCRIPTION
### What is this PR for?
Straightforward fix to set the timeout as 100 years so that spark streaming app won't be stopped unless 100 years later. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2943

### How should this be tested?
Tested manually, see screenshot. 

### Screenshots (if appropriate)
![streaming](https://user-images.githubusercontent.com/164491/30589783-789a99c6-9d01-11e7-88a3-c36d49321541.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
