### PR TITLE
[ZEPPELIN-2944] Cannot launch Spark interpreter for non-local mode

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -738,7 +738,7 @@ public class InterpreterSetting {
     }
 
     setupPropertiesForPySpark(sparkProperties);
-    setupPropertiesForSparkR(sparkProperties, javaProperties.getProperty("SPARK_HOME"));
+    setupPropertiesForSparkR(sparkProperties, System.getenv("SPARK_HOME"));
     if (isYarnMode() && getDeployMode().equals("cluster")) {
       env.put("SPARK_YARN_CLUSTER", "true");
     }


### PR DESCRIPTION
### What is this PR for?
When I used Spark interpreter for non-local mode, I got
```
java.lang.RuntimeException: SPARK_HOME is not specified for non-local mode
	at org.apache.zeppelin.interpreter.InterpreterSetting.setupPropertiesForSparkR(InterpreterSetting.java:783)
	at org.apache.zeppelin.interpreter.InterpreterSetting.getEnvFromInterpreterProperty(InterpreterSetting.java:741)
	at org.apache.zeppelin.interpreter.InterpreterSetting.createInterpreterProcess(InterpreterSetting.java:712)
	at org.apache.zeppelin.interpreter.ManagedInterpreterGroup.getOrCreateInterpreterProcess(ManagedInterpreterGroup.java:58)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getOrCreateInterpreterProcess(RemoteInterpreter.java:98)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.internal_create(RemoteInterpreter.java:153)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.open(RemoteInterpreter.java:126)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getFormType(RemoteInterpreter.java:265)
	at org.apache.zeppelin.notebook.Paragraph.jobRun(Paragraph.java:423)
	at org.apache.zeppelin.scheduler.Job.run(Job.java:182)
	at org.apache.zeppelin.scheduler.RemoteScheduler$JobRunner.run(RemoteScheduler.java:307)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:473)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```
And I fixed it! 😄 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-2944](https://issues.apache.org/jira/browse/ZEPPELIN-2944)

### How should this be tested?
Build and launch Spark interpreter

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
