### PR TITLE
[ZEPPELIN-2952] encrypt credentials.json with AES

### DIFF
--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -77,7 +77,19 @@ If both are defined, then the **environment variables** will take priority.
     <td>*</td>
     <td>Enables a way to specify a ',' separated list of allowed origins for REST and websockets. <br /> e.g. http://localhost:8080</td>
   </tr>
-    <tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_CREDENTIALS_PERSIST</h6></td>
+    <td><h6 class="properties">zeppelin.credentials.persist</h6></td>
+    <td>true</td>
+    <td>Persist credentials on a JSON file (credentials.json)</td>
+  </tr>  
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_CREDENTIALS_ENCRYPT_KEY</h6></td>
+    <td><h6 class="properties">zeppelin.credentials.encryptKey</h6></td>
+    <td></td>
+    <td>If provided, encrypt passwords on the credentials.json file (passwords will be stored as plain-text otherwise</td>
+  </tr>  
+  <tr>
     <td>N/A</td>
     <td><h6 class="properties">zeppelin.anonymous.allowed</h6></td>
     <td>true</td>
@@ -410,6 +422,20 @@ The following properties needs to be updated in the `zeppelin-site.xml` in order
   <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password</description>
 </property>
 ```
+
+### Storing user credentials
+
+In order to avoid having to re-enter credentials every time you restart/redeploy Zeppelin, you can store the user credentials. Zeppelin supports this via the ZEPPELIN_CREDENTIALS_PERSIST configuration.
+
+Please notice that passwords will be stored in *plain text* by default. To encrypt the passwords, use the ZEPPELIN_CREDENTIALS_ENCRYPT_KEY config variable. This will encrypt passwords using the AES-128 algorithm.
+
+You can generate an appropriate encryption key any way you'd like - for instance, by using the openssl tool:
+
+```
+openssl enc -aes-128-cbc -k secret -P -md sha1
+```
+
+*Important*: storing your encryption key in a configuration file is _not advised_. Depending on your environment security needs, you may want to consider utilizing a credentials server, storing the ZEPPELIN_CREDENTIALS_ENCRYPT_KEY as an OS env variable, or any other approach that would not colocate the encryption key and the encrypted content (the credentials.json file).
 
 
 ### Obfuscating Passwords using the Jetty Password Tool

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -273,6 +273,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) headroom.js 0.9.3 (https://github.com/WickyNilliams/headroom.js) - https://github.com/WickyNilliams/headroom.js/blob/master/LICENSE
     (The MIT License) angular-viewport-watch 0.135 (https://github.com/wix/angular-viewport-watch) - https://github.com/wix/angular-viewport-watch/blob/master/LICENSE
     (The MIT License) ansi-up 2.0.2 (https://github.com/drudru/ansi_up) - https://github.com/drudru/ansi_up#license
+    (The MIT License) bcpkix-jdk15on 1.52 (org.bouncycastle:bcpkix-jdk15on:1.52 https://github.com/bcgit/bc-java) - https://github.com/bcgit/bc-java/blob/master/LICENSE.html
 
 ========================================================================
 BSD-style licenses

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -133,6 +133,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.52</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
       <version>${maven.aeither.provider.version}</version>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -47,7 +47,21 @@ public class Credentials {
   private Boolean credentialsPersist = true;
   File credentialsFile;
 
-  public Credentials(Boolean credentialsPersist, String credentialsPath) {
+  private Encryptor encryptor;
+
+  /**
+   * Wrapper fro user credentials. It can load credentials from a file if credentialsPath is
+   * supplied, and will encrypt the file if an encryptKey is supplied.
+   *
+   * @param credentialsPersist
+   * @param credentialsPath
+   * @param encryptKey
+   */
+  public Credentials(Boolean credentialsPersist, String credentialsPath, String encryptKey) {
+    if (encryptKey != null) {
+      this.encryptor = new Encryptor(encryptKey);
+    }
+
     this.credentialsPersist = credentialsPersist;
     if (credentialsPath != null) {
       credentialsFile = new File(credentialsPath);
@@ -119,6 +133,11 @@ public class Credentials {
       fis.close();
 
       String json = sb.toString();
+
+      if (encryptor != null) {
+        json = encryptor.decrypt(json);
+      }
+
       CredentialsInfoSaving info = CredentialsInfoSaving.fromJson(json);
       this.credentialsMap = info.credentialsMap;
     } catch (IOException e) {
@@ -146,6 +165,11 @@ public class Credentials {
 
       FileOutputStream fos = new FileOutputStream(credentialsFile, false);
       OutputStreamWriter out = new OutputStreamWriter(fos);
+
+      if (encryptor != null) {
+        jsonString = encryptor.encrypt(jsonString);
+      }
+
       out.append(jsonString);
       out.close();
       fos.close();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Encryptor.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Encryptor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.user;
 
 import java.io.IOException;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Encryptor.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/Encryptor.java
@@ -1,0 +1,63 @@
+package org.apache.zeppelin.user;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
+import org.bouncycastle.crypto.paddings.ZeroBytePadding;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.util.encoders.Base64;
+
+/**
+ * Encrypt/decrypt arrays of bytes!
+ */
+public class Encryptor {
+  private final BufferedBlockCipher encryptCipher;
+  private final BufferedBlockCipher decryptCipher;
+
+  public Encryptor(String encryptKey) {
+    encryptCipher = new PaddedBufferedBlockCipher(new AESEngine(), new ZeroBytePadding());
+    encryptCipher.init(true, new KeyParameter(encryptKey.getBytes()));
+
+    decryptCipher = new PaddedBufferedBlockCipher(new AESEngine(), new ZeroBytePadding());
+    decryptCipher.init(false, new KeyParameter(encryptKey.getBytes()));
+  }
+
+
+  public String encrypt(String inputString) throws IOException {
+    byte[] input = inputString.getBytes();
+    byte[] result = new byte[encryptCipher.getOutputSize(input.length)];
+    int size = encryptCipher.processBytes(input, 0, input.length, result, 0);
+
+    try {
+      size += encryptCipher.doFinal(result, size);
+
+      byte[] out = new byte[size];
+      System.arraycopy(result, 0, out, 0, size);
+      return new String(Base64.encode(out));
+    } catch (InvalidCipherTextException e) {
+      throw new IOException("Cannot encrypt: " + e.getMessage(), e);
+    }
+  }
+
+  public String decrypt(String base64Input) throws IOException {
+    byte[] input = Base64.decode(base64Input);
+    byte[] result = new byte[decryptCipher.getOutputSize(input.length)];
+    int size = decryptCipher.processBytes(input, 0, input.length, result, 0);
+
+    try {
+      size += decryptCipher.doFinal(result, size);
+
+      byte[] out = new byte[size];
+      System.arraycopy(result, 0, out, 0, size);
+      return new String(out);
+    } catch (InvalidCipherTextException e) {
+      throw new IOException("Cannot decrypt: " + e.getMessage(), e);
+    }
+  }
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/EncryptorTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/EncryptorTest.java
@@ -17,24 +17,25 @@
 
 package org.apache.zeppelin.user;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
 
 import org.junit.Test;
 
-import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
-public class CredentialsTest {
+public class EncryptorTest {
 
   @Test
-  public void testDefaultProperty() throws IOException {
-    Credentials credentials = new Credentials(false, null, null);
-    UserCredentials userCredentials = new UserCredentials();
-    UsernamePassword up1 = new UsernamePassword("user2", "password");
-    userCredentials.putUsernamePassword("hive(vertica)", up1);
-    credentials.putUserCredentials("user1", userCredentials);
-    UserCredentials uc2 = credentials.getUserCredentials("user1");
-    UsernamePassword up2 = uc2.getUsernamePassword("hive(vertica)");
-    assertEquals(up1.getUsername(), up2.getUsername());
-    assertEquals(up1.getPassword(), up2.getPassword());
+  public void testEncryption() throws IOException {
+    Encryptor encryptor = new Encryptor("foobar1234567890");
+
+    String input = "test";
+
+    String encrypted = encryptor.encrypt(input);
+    assertNotEquals(input, encrypted);
+
+    String decrypted = encryptor.decrypt(encrypted);
+    assertEquals(input, decrypted);
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -132,7 +132,10 @@ public class ZeppelinServer extends Application {
     this.notebookRepo = new NotebookRepoSync(conf);
     this.noteSearchService = new LuceneSearch();
     this.notebookAuthorization = NotebookAuthorization.init(conf);
-    this.credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath());
+    this.credentials = new Credentials(
+        conf.credentialsPersist(),
+        conf.getCredentialsPath(),
+        conf.getCredentialsEncryptKey());
     notebook = new Notebook(conf,
         notebookRepo, schedulerFactory, replFactory, interpreterSettingManager, notebookWsServer,
             noteSearchService, notebookAuthorization, credentials);
@@ -152,7 +155,7 @@ public class ZeppelinServer extends Application {
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
     }
-
+    
     // to update notebook from application event from remote process.
     heliumApplicationFactory.setNotebook(notebook);
     // to update fire websocket event on application event.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -443,6 +443,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_CREDENTIALS_PERSIST);
   }
 
+  public String getCredentialsEncryptKey() {
+    return getString(ConfVars.ZEPPELIN_CREDENTIALS_ENCRYPT_KEY);
+  }
+
   public String getCredentialsPath() {
     return getRelativeDir(String.format("%s/credentials.json", getConfDir()));
   }
@@ -680,6 +684,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
     ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
     ZEPPELIN_CREDENTIALS_PERSIST("zeppelin.credentials.persist", true),
+    ZEPPELIN_CREDENTIALS_ENCRYPT_KEY("zeppelin.credentials.encryptKey", null),
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),
     ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false),
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -77,7 +77,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest implem
         this,
         search,
         notebookAuthorization,
-        new Credentials(false, null));
+        new Credentials(false, null, null));
 
     heliumAppFactory.setNotebook(notebook);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -98,7 +98,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo(conf);
     notebookAuthorization = NotebookAuthorization.init(conf);
-    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath());
+    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
 
     notebook = new Notebook(conf, notebookRepo, schedulerFactory, interpreterFactory, interpreterSettingManager, this, search,
         notebookAuthorization, credentials);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -103,7 +103,7 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
     search = mock(SearchService.class);
     notebookRepoSync = new NotebookRepoSync(conf);
     notebookAuthorization = NotebookAuthorization.init(conf);
-    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath());
+    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
     notebookSync = new Notebook(conf, notebookRepoSync, schedulerFactory, factory, interpreterSettingManager, this, search,
             notebookAuthorization, credentials);
     anonymous = new AuthenticationInfo("anonymous");


### PR DESCRIPTION
### What is this PR for?
Support encrypting passwords using a private key

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2952

### How should this be tested?
- Set the env variable `ZEPPELIN_CREDENTIALS_ENCRYPT_KEY=something`
- Save a few credentials
- Check that the `credentials.json` file is storing encrypted passwords
- Restart server using the same env variable for `ZEPPELIN_CREDENTIALS_ENCRYPT_KEY`
- The credentials should still be decryptable

### Questions:
* Does the licenses files need update?
No

* Is there breaking changes for older versions?
No

* Does this needs documentation?
Yes
