### PR TITLE
[ZEPPELIN-2961] Remove unnecessary 'interpreter-setting.json' file in the spark interpreter.

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -340,19 +340,6 @@
   </dependencies>
 
   <build>
-    <!-- sparkr resources -->
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <excludes>
-          <exclude>interpreter-setting.json</exclude>
-        </excludes>
-      </resource>
-      <resource>
-        <directory>src/main/sparkr-resources</directory>
-      </resource>
-    </resources>
-
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -172,5 +172,44 @@
       "language": "python",
       "editOnDblClick": false
     }
+  },
+  {
+    "group": "spark",
+    "name": "r",
+    "className": "org.apache.zeppelin.spark.SparkRInterpreter",
+    "properties": {
+      "zeppelin.R.knitr": {
+        "envName": "ZEPPELIN_R_KNITR",
+        "propertyName": "zeppelin.R.knitr",
+        "defaultValue": true,
+        "description": "whether use knitr or not",
+        "type": "checkbox"
+      },
+      "zeppelin.R.cmd": {
+        "envName": "ZEPPELIN_R_CMD",
+        "propertyName": "zeppelin.R.cmd",
+        "defaultValue": "R",
+        "description": "R repl path",
+        "type": "string"
+      },
+      "zeppelin.R.image.width": {
+        "envName": "ZEPPELIN_R_IMAGE_WIDTH",
+        "propertyName": "zeppelin.R.image.width",
+        "defaultValue": "100%",
+        "description": "",
+        "type": "number"
+      },
+      "zeppelin.R.render.options": {
+        "envName": "ZEPPELIN_R_RENDER_OPTIONS",
+        "propertyName": "zeppelin.R.render.options",
+        "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F",
+        "description": "",
+        "type": "textarea"
+      }
+    },
+    "editor": {
+      "language": "r",
+      "editOnDblClick": false
+    }
   }
 ]


### PR DESCRIPTION
### What is this PR for?
Spark interpreter has two interpreter-setting.json files.
one in `spark/src/main/resources`, another in `spark/src/sparkr-resources`.

And `spark/src/main/resources/interpreter-setting.json` is always ignored.
This PR make `spark/src/main/resources/interpreter-setting.json` effective and remove `spark/src/sparkr-resources`

### What type of PR is it?
Improvement

### Todos
* [x] - Make `spark/src/resources/interpreter-setting.json` effective

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2961

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
