### PR TITLE
ZEPPELIN-1897 REST API - Update paragraph text/title via API

### DIFF
--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -753,6 +753,59 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   </table>
 
 <br/>
+
+### Update paragraph
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```PUT``` method update paragraph contents using given id, e.g. <code>{"text": "hello"}</code>
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/[noteId]/paragraph/[paragraphId]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Bad Request code</td>
+      <td>400</td>
+    </tr>
+    <tr>
+      <td>Forbidden code</td>
+      <td>403</td>
+    </tr>
+    <tr>
+      <td>Not Found code</td>
+      <td>404</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td>500</td>
+    </tr>
+    <tr>
+      <td>sample JSON input</td>
+      <td><pre>
+{
+  "title": "Hello world",
+  "text": "println(\"hello world\")"
+}</pre></td>
+    </tr>
+    <tr>
+      <td>sample JSON response</td>
+      <td><pre>
+{
+  "status": "OK",
+  "message": ""
+  }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Update paragraph configuration
   <table class="table-configuration">
     <col width="200">

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -41,10 +41,7 @@ import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.rest.exception.BadRequestException;
 import org.apache.zeppelin.rest.exception.NotFoundException;
 import org.apache.zeppelin.rest.exception.ForbiddenException;
-import org.apache.zeppelin.rest.message.CronRequest;
-import org.apache.zeppelin.rest.message.NewNoteRequest;
-import org.apache.zeppelin.rest.message.NewParagraphRequest;
-import org.apache.zeppelin.rest.message.RunParagraphWithParametersRequest;
+import org.apache.zeppelin.rest.message.*;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.socket.NotebookServer;
@@ -496,6 +493,37 @@ public class NotebookRestApi {
     return new JsonResponse<>(Status.OK, "", p).build();
   }
 
+  /**
+   * Update paragraph
+   *
+   * @param message json containing the "text" and optionally the "title" of the paragraph, e.g.
+   *                {"text" : "updated text", "title" : "Updated title" }
+   *
+   */
+  @PUT
+  @Path("{noteId}/paragraph/{paragraphId}")
+  @ZeppelinApi
+  public Response updateParagraph(@PathParam("noteId") String noteId,
+                                  @PathParam("paragraphId") String paragraphId,
+                                  String message) throws IOException {
+    String user = SecurityUtils.getPrincipal();
+    LOG.info("{} will update paragraph {} {}", user, noteId, paragraphId);
+
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    checkIfUserCanWrite(noteId, "Insufficient privileges you cannot update this paragraph");
+    Paragraph p = note.getParagraph(paragraphId);
+    checkIfParagraphIsNotNull(p);
+
+    UpdateParagraphRequest updatedParagraph = gson.fromJson(message, UpdateParagraphRequest.class);
+    p.setText(updatedParagraph.getText());
+    if (updatedParagraph.getTitle() != null) { p.setTitle(updatedParagraph.getTitle()); }
+    AuthenticationInfo subject = new AuthenticationInfo(user);
+    note.persist(subject);
+    notebookServer.broadcastParagraph(note, p);
+    return new JsonResponse<>(Status.OK, "").build();
+  }
+
   @PUT
   @Path("{noteId}/paragraph/{paragraphId}/config")
   @ZeppelinApi
@@ -514,7 +542,6 @@ public class NotebookRestApi {
     configureParagraph(p, newConfig, user);
     AuthenticationInfo subject = new AuthenticationInfo(user);
     note.persist(subject);
-
     return new JsonResponse<>(Status.OK, "", p).build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/UpdateParagraphRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/UpdateParagraphRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest.message;
+
+/**
+ * UpdateParagraphRequest
+ */
+public class UpdateParagraphRequest {
+  String title;
+  String text;
+
+  public UpdateParagraphRequest() {
+
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+
+}


### PR DESCRIPTION
### What is this PR for?
Support updating paragraph text/title via REST API
https://issues.apache.org/jira/browse/ZEPPELIN-1897

### What type of PR is it?
Improvement

### Todos


### What is the Jira issue?
[ZEPPELIN-1897]

### How should this be tested?
1. Create a note and paragraph
2. Hit REST API to update the paragraph, e.g. `curl -X PUT http://localhost:8080/api/notebook/NOTE_ID/paragraph/PARAGRAPH_ID -d '{"text": "some updated text"}'`


### Screenshots (if appropriate)
![update paragraph api](https://user-images.githubusercontent.com/7852/31032284-543af3dc-a553-11e7-89ce-f388a7097d74.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, doc update included in the change.