### PR TITLE
[ZEPPELIN-2963] Fix paragraph aborting on next run after cancel

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -493,6 +493,7 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
 
   @Override
   protected boolean jobAbort() {
+    boolean aborted = true;
     Interpreter repl = getRepl(getRequiredReplName());
     if (repl == null) {
       // when interpreters are already destroyed
@@ -507,10 +508,11 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
     Job job = scheduler.removeFromWaitingQueue(getId());
     if (job != null) {
       job.setStatus(Status.ABORT);
+      aborted = false;
     } else {
       repl.cancel(getInterpreterContextWithoutRunner(null));
     }
-    return true;
+    return aborted;
   }
 
   private InterpreterContext getInterpreterContext() {


### PR DESCRIPTION
### What is this PR for?
As mentioned in ZEPPELIN-2963, if a paragraph is cancelled while it was in scheduler's waiting queue, the next run of the paragraph always ends up in abort status. This change fixes this issue.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2963

### How should this be tested?
The scenario that we want to reproduce is that a paragraph in the notebook should be cancelled when it is still in the remote scheduler's waiting queue. This can be reproduced in various ways. Following is the approach that I used:
1. Start zeppelin server.
2. Create a notebook with around 10-15 paragraphs with a few paragraphs being long running (at least a few seconds)
3. Do a "Run All" on the notebook
4. Cancel the last paragraph (non-empty) by clicking the "Pause" button. It will move to abort status.
5. After all paragraphs finish running, run the cancelled paragraph again. It should start running.

### Screenshots (if appropriate)
Before

![paragraph_abort](https://user-images.githubusercontent.com/6438072/31125615-7fa5f9a2-a866-11e7-9f1d-0ffa509ab3c4.gif)

After

![paragraph_abort_fixed](https://user-images.githubusercontent.com/6438072/31126292-ea1b7df0-a868-11e7-9b21-fafdeda96da8.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
