### PR TITLE
[ZEPPELIN-2975] Fix e2e CI test profile

### DIFF
--- a/zeppelin-web/e2e/searchBlock.spec.js
+++ b/zeppelin-web/e2e/searchBlock.spec.js
@@ -99,7 +99,7 @@ describe('Search block e2e Test', function() {
     waitVisibility(element(by.repeater('currentParagraph in note.paragraphs')))
     browser.switchTo().activeElement().sendKeys(testData.textInFirstP)
     let addBelow = element(
-      by.xpath('//div[@class="new-paragraph" and @ng-click="insertNew(\'below\');"]'))
+      by.xpath('//div[@class="new-paragraph last-paragraph" and @ng-click="insertNew(\'below\');"]'))
     clickAndWait(addBelow)
     browser.switchTo().activeElement().sendKeys(testData.textInSecondP)
   }
@@ -123,7 +123,6 @@ describe('Search block e2e Test', function() {
   }
 
   /*Tests*/
-
   it('shortcut works', function() {
     waitVisibility(element(by.repeater('currentParagraph in note.paragraphs')))
     openSearchBoxByShortcut()


### PR DESCRIPTION
### What is this PR for?
e2e CI test profile is failing after merge https://github.com/apache/zeppelin/pull/2569.
There were [css class list change] for paragraph add button element.
That results e2e test unable to locate the button element.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2975

### How should this be tested?
CI green

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
