### PR TITLE
Run all paragraphs sequentially

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -56,8 +56,10 @@ import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.ParagraphJobListener;
 import org.apache.zeppelin.notebook.ParagraphRuntimeInfo;
 import org.apache.zeppelin.notebook.SequentialNoteRunInfo;
+import org.apache.zeppelin.notebook.SequentialNoteRunListener;
 import org.apache.zeppelin.notebook.repo.NotebookRepo.Revision;
 import org.apache.zeppelin.notebook.socket.Message;
+import org.apache.zeppelin.notebook.socket.NoteRunUpdateMessage;
 import org.apache.zeppelin.notebook.socket.Message.OP;
 import org.apache.zeppelin.notebook.socket.WatcherMessage;
 import org.apache.zeppelin.rest.exception.ForbiddenException;
@@ -2306,6 +2308,28 @@ public class NotebookServer extends WebSocketServlet
     }
   }
 
+  /**
+   * Listener class for sequential note runs
+   */
+  public static class SequentialNoteRunListenerImpl implements SequentialNoteRunListener {
+    private NotebookServer notebookServer;
+
+    public SequentialNoteRunListenerImpl(NotebookServer notebookServer) {
+      this.notebookServer = notebookServer;
+    }
+
+    @Override
+    public void onSequentialRunFinished(Note note) {
+      notebookServer.broadcast(note.getId(),
+          new Message(OP.NOTE_RUN_UPDATE)
+          .put("noteRunUpdate", new NoteRunUpdateMessage(note.getId(), false)));
+    }
+  }
+
+  public SequentialNoteRunListener getSequentialNoteRunListener() {
+    return new SequentialNoteRunListenerImpl(this);
+  }
+
   @Override
   public ParagraphJobListener getParagraphJobListener(Note note) {
     SequentialNoteRunInfo sequentialNoteRunInfo = note.getSequentialNoteRunInfo();
@@ -2569,6 +2593,8 @@ public class NotebookServer extends WebSocketServlet
       }
     }
     // Run all sequentially in a new thread
-    note.runAllSequentially();
+    note.runAllSequentially(getSequentialNoteRunListener());
+    broadcast(note.getId(), new Message(OP.NOTE_RUN_UPDATE)
+        .put("noteRunUpdate", new NoteRunUpdateMessage(noteId, true)));
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -2296,13 +2296,11 @@ public class NotebookServer extends WebSocketServlet
 
     @Override
     public void afterStatusChange(Job job, Status before, Status after) {
-      LOG.info("after status change. STatus= {}", after);
       super.afterStatusChange(job, before, after);
-      LOG.info("after super afterStatusChange");
       Note note = super.note;
       Object synchronizer = note.getSequentialNoteRunInfo().getSynchronizer();
       synchronized (synchronizer) {
-        LOG.info("notifying");
+        LOG.debug("Notifying waiting thread");
         synchronizer.notify();
       }
     }
@@ -2333,9 +2331,7 @@ public class NotebookServer extends WebSocketServlet
   @Override
   public ParagraphJobListener getParagraphJobListener(Note note) {
     SequentialNoteRunInfo sequentialNoteRunInfo = note.getSequentialNoteRunInfo();
-    LOG.info("is Sequential Run: {}", sequentialNoteRunInfo.isRunningSequentially());
     if (sequentialNoteRunInfo != null && sequentialNoteRunInfo.isRunningSequentially()) {
-      LOG.info("Returning ParagraphListenerForSequentialRun");
       return new ParagraphListenerForSequentialRun(this, note);
     }
     return new ParagraphListenerImpl(this, note);

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -29,7 +29,7 @@ limitations under the License.
       <span class="labelBtn btn-group">
       <button type="button"
               class="btn btn-default btn-xs"
-              ng-click="runAllParagraphs(note.id)"
+              ng-click="runAllParagraphsSequentially(note.id)"
               ng-class="{'disabled':isNoteRunning()}"
               tooltip-placement="bottom" uib-tooltip="Run all paragraphs"
               ng-disabled="revisionView">

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -433,6 +433,23 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     if (!paragraphText || $scope.isRunning($scope.paragraph)) {
       return
     }
+
+    if ($scope.$parent.runningSequentially) {
+      BootstrapDialog.show({
+        closable: false,
+        closeByBackdrop: false,
+        closeByKeyboard: false,
+        title: 'Not allowed',
+        message: 'Cannot Run paragraph as Run All is in progress for this note.',
+        buttons: [{
+          label: 'Close',
+          action: function(dialog) {
+            dialog.close()
+          }
+        }]
+      })
+      return
+    }
     const magic = SpellResult.extractMagic(paragraphText)
 
     if (heliumService.getSpellByMagic(magic)) {

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -173,6 +173,8 @@ function WebsocketEventFactory ($rootScope, $websocket, $location, baseUrlSrv) {
       $rootScope.$broadcast('setNoteRevisionResult', data)
     } else if (op === 'PARAS_INFO') {
       $rootScope.$broadcast('updateParaInfos', data)
+    } else if (op === 'NOTE_RUN_UPDATE') {
+      $rootScope.$broadcast('updateNoteRunStatus', data)
     } else {
       console.error(`unknown websocket op: ${op}`)
     }

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -210,6 +210,16 @@ function WebsocketMessageService ($rootScope, websocketEvents) {
       })
     },
 
+    runAllParagraphsSequentially: function (noteId, paragraphs) {
+      websocketEvents.sendNewEvent({
+        op: 'RUN_ALL_SEQUENTIALLY',
+        data: {
+          noteId: noteId,
+          paragraphs: JSON.stringify(paragraphs)
+        }
+      })
+    },
+
     removeParagraph: function (paragraphId) {
       websocketEvents.sendNewEvent({op: 'PARAGRAPH_REMOVE', data: {id: paragraphId}})
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -81,6 +81,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   private transient ZeppelinConfiguration conf = ZeppelinConfiguration.create();
 
   private Map<String, List<AngularObject>> angularObjects = new HashMap<>();
+  private SequentialNoteRunInfo sequentialRunInfo = new SequentialNoteRunInfo();
 
   private transient InterpreterFactory factory;
   private transient InterpreterSettingManager interpreterSettingManager;
@@ -91,7 +92,6 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   private transient NoteEventListener noteEventListener;
   private transient Credentials credentials;
   private transient NoteNameListener noteNameListener;
-  private SequentialNoteRunInfo sequentialNoteRunInfo = new SequentialNoteRunInfo();
 
   /*
    * note configurations.
@@ -230,7 +230,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   }
 
   public SequentialNoteRunInfo getSequentialNoteRunInfo() {
-    return sequentialNoteRunInfo;
+    return sequentialRunInfo;
   }
 
   void setInterpreterFactory(InterpreterFactory factory) {
@@ -651,10 +651,12 @@ public class Note implements ParagraphJobListener, JsonSerializable {
 
   /**
    * Run all paragraphs sequentially.
+   * @param sequentialNoteRunListener
    */
-  public void runAllSequentially() {
+  public void runAllSequentially(SequentialNoteRunListener sequentialNoteRunListener) {
     this.getSequentialNoteRunInfo().setRunningSequentially(true);
-    SequentialNoteRunner sequentialRunner = new SequentialNoteRunner(this);
+    SequentialNoteRunner sequentialRunner =
+        new SequentialNoteRunner(this, sequentialNoteRunListener);
     runAllExecutorService.execute(sequentialRunner);
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -21,6 +21,8 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +66,8 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   // threadpool for delayed persist of note
   private static final ScheduledThreadPoolExecutor delayedPersistThreadPool =
       new ScheduledThreadPoolExecutor(0);
+  // Executor service for sequential paragraph run
+  private static final ExecutorService runAllExecutorService = Executors.newCachedThreadPool();
 
   static {
     delayedPersistThreadPool.setRemoveOnCancelPolicy(true);
@@ -87,6 +91,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   private transient NoteEventListener noteEventListener;
   private transient Credentials credentials;
   private transient NoteNameListener noteNameListener;
+  private SequentialNoteRunInfo sequentialNoteRunInfo = new SequentialNoteRunInfo();
 
   /*
    * note configurations.
@@ -222,6 +227,10 @@ public class Note implements ParagraphJobListener, JsonSerializable {
 
   public void setNoteNameListener(NoteNameListener listener) {
     this.noteNameListener = listener;
+  }
+
+  public SequentialNoteRunInfo getSequentialNoteRunInfo() {
+    return sequentialNoteRunInfo;
   }
 
   void setInterpreterFactory(InterpreterFactory factory) {
@@ -638,6 +647,15 @@ public class Note implements ParagraphJobListener, JsonSerializable {
       p.setAuthenticationInfo(p.getAuthenticationInfo());
       intp.getScheduler().submit(p);
     }
+  }
+
+  /**
+   * Run all paragraphs sequentially.
+   */
+  public void runAllSequentially() {
+    this.getSequentialNoteRunInfo().setRunningSequentially(true);
+    SequentialNoteRunner sequentialRunner = new SequentialNoteRunner(this);
+    runAllExecutorService.execute(sequentialRunner);
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -464,6 +464,7 @@ public class Notebook implements NoteEventListener {
       return null;
     }
 
+    clearSequentialRunState(note);
     convertFromSingleResultToMultipleResultsFormat(note);
 
     //Manually inject ALL dependencies, as DI constructor was NOT used
@@ -534,6 +535,12 @@ public class Notebook implements NoteEventListener {
     }
 
     return note;
+  }
+
+  private void clearSequentialRunState(Note note) {
+    if (note.getSequentialNoteRunInfo() != null) {
+      note.getSequentialNoteRunInfo().setRunningSequentially(false);
+    }
   }
 
   void loadAllNotes(AuthenticationInfo subject) throws IOException {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunInfo.java
@@ -1,0 +1,22 @@
+package org.apache.zeppelin.notebook;
+
+/**
+ * Info about sequential run of all paragraphs
+ */
+public class SequentialNoteRunInfo {
+
+  private boolean runningSequentially = false;
+  private transient Object synchronizer = new Object();
+
+  public boolean isRunningSequentially() {
+    return runningSequentially;
+  }
+
+  public void setRunningSequentially(boolean runningSequentially) {
+    this.runningSequentially = runningSequentially;
+  }
+
+  public Object getSynchronizer() {
+    return synchronizer;
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunInfo.java
@@ -1,7 +1,7 @@
 package org.apache.zeppelin.notebook;
 
 /**
- * Info about sequential run of all paragraphs
+ * Info about sequential run of note
  */
 public class SequentialNoteRunInfo {
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunListener.java
@@ -1,0 +1,8 @@
+package org.apache.zeppelin.notebook;
+
+/**
+ * Listener interface for sequential note run events
+ */
+public interface SequentialNoteRunListener {
+  public void onSequentialRunFinished(Note note);
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunner.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunner.java
@@ -1,0 +1,50 @@
+package org.apache.zeppelin.notebook;
+
+import org.apache.zeppelin.scheduler.Job.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs all paragraphs of a notebook in a sequential manner.
+ */
+public class SequentialNoteRunner implements Runnable {
+  private static final Logger logger = LoggerFactory.getLogger(SequentialNoteRunner.class);
+
+  private Note note;
+
+  public SequentialNoteRunner(Note note) {
+    this.note = note;
+  }
+
+  @Override
+  public void run() {
+    logger.info("Sequential run for note {} started", note.getId());
+    for (Paragraph paragraph: note.getParagraphs()) {
+      String paragraphId = paragraph.getId();
+      logger.info("Running paragraph {}", paragraphId);
+      note.run(paragraphId);
+      logger.info("after run");
+      Object synchronizer = note.getSequentialNoteRunInfo().getSynchronizer();
+      synchronized (synchronizer) {
+        Status paragraphStatus = paragraph.getStatus();
+        logger.info("status = {}", paragraphStatus);
+        while (paragraphStatus == null || (paragraphStatus != Status.FINISHED
+            && paragraphStatus != Status.ERROR)) {
+          try {
+            logger.info("waiting on {}", synchronizer);
+            synchronizer.wait();
+            paragraphStatus = paragraph.getStatus();
+            logger.info("status: {}", paragraphStatus);
+          } catch (InterruptedException e) {
+            logger.error("Exception while waiting for status of paragraph {} to change",
+                paragraphId, e);
+          }
+        }
+        logger.info("Paragraph {} execution complete", paragraphId);
+      }
+    }
+    note.getSequentialNoteRunInfo().setRunningSequentially(false);
+    logger.info("Sequential run for note {} finished", note.getId());
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunner.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/SequentialNoteRunner.java
@@ -26,18 +26,14 @@ public class SequentialNoteRunner implements Runnable {
       logger.info("Running paragraph {}", paragraphId);
       try {
         note.run(paragraphId);
-        logger.info("after run");
         Object synchronizer = note.getSequentialNoteRunInfo().getSynchronizer();
         synchronized (synchronizer) {
           Status paragraphStatus = paragraph.getStatus();
-          logger.info("status = {}", paragraphStatus);
           while (paragraphStatus == null || paragraphStatus == Status.PENDING
                  || paragraphStatus == Status.RUNNING) {
             try {
-              logger.info("waiting on {}", synchronizer);
               synchronizer.wait();
               paragraphStatus = paragraph.getStatus();
-              logger.info("status: {}", paragraphStatus);
             } catch (InterruptedException e) {
               logger.error("Exception while waiting for status of paragraph {} to change",
                   paragraphId, e);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -179,7 +179,8 @@ public class Message implements JsonSerializable {
     RUN_ALL_PARAGRAPHS,           // [c-s] run all paragraphs
     PARAGRAPH_EXECUTED_BY_SPELL,  // [c-s] paragraph was executed by spell
     RUN_PARAGRAPH_USING_SPELL,     // [s-c] run paragraph using spell
-    PARAS_INFO                    // [s-c] paragraph runtime infos
+    PARAS_INFO,                   // [s-c] paragraph runtime infos
+    RUN_ALL_SEQUENTIALLY          // [c-s] run all paragraphs sequentially
   }
 
   private static final Gson gson = new Gson();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -180,7 +180,8 @@ public class Message implements JsonSerializable {
     PARAGRAPH_EXECUTED_BY_SPELL,  // [c-s] paragraph was executed by spell
     RUN_PARAGRAPH_USING_SPELL,     // [s-c] run paragraph using spell
     PARAS_INFO,                   // [s-c] paragraph runtime infos
-    RUN_ALL_SEQUENTIALLY          // [c-s] run all paragraphs sequentially
+    RUN_ALL_SEQUENTIALLY,         // [c-s] run all paragraphs sequentially
+    NOTE_RUN_UPDATE               // [s-c] running status of note updated
   }
 
   private static final Gson gson = new Gson();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/NoteRunUpdateMessage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/NoteRunUpdateMessage.java
@@ -1,0 +1,14 @@
+package org.apache.zeppelin.notebook.socket;
+
+/**
+ * Websocket message for updating note run status
+ */
+public class NoteRunUpdateMessage {
+  String noteId;
+  boolean runningSequentially;
+
+  public NoteRunUpdateMessage(String noteId, boolean runningSequentially) {
+    this.noteId = noteId;
+    this.runningSequentially = runningSequentially;
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This PR introduces "run all" behaviour for a note in a sequential manner. The "Run All paragraphs" button will now run the notebook sequentially. There is a UX change as part of this PR, which is discussed below. Any suggestions to make it better are welcome.
Following is the approach taken in brief:
- Replace the behaviour of "Run All paragraphs" to "Run All sequentially"
- Submit paragraphs to the respective scheduler only after the previous one completes execution (via wait-notify mechanism)
- Communicate the status of the sequential run to client over websocket
- Since the paragraphs won't be submitted immediately, changing their status is a challenge while keeping the code maintaining it at one place. Therefore, the approach I have taken is to keep the status of the paragrahs as-is and disallow explicit run of individual paragraphs when sequential run is in progress (see GIF for details).

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2368

### How should this be tested?
* Have a notebook with different interpreter types (e.g. sh, md, spark etc.)
* Click "Run All paragraphs"
* The paragraphs should run sequentially
* While sequential run is in progress, explicit run of paragraphs should not be allowed
* Correct sequential run state should be communicated to the browser when note is loaded

### Screenshots (if appropriate)
![sequential_run_all_1](https://user-images.githubusercontent.com/6438072/31424317-262d237a-ae77-11e7-81fe-8eda0d14c01c.gif)

![sequential_run_all_2](https://user-images.githubusercontent.com/6438072/31424322-29b4a23e-ae77-11e7-80dc-b6b9d84d2624.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Probably not, but the UX would be different
* Does this needs documentation? Yes
