### PR TITLE
[ZEPPELIN-2999] Cannot create shell interpreter without timeout property

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -49,7 +49,7 @@ public class ShellInterpreter extends KerberosInterpreter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShellInterpreter.class);
 
   private static final String TIMEOUT_PROPERTY = "shell.command.timeout.millisecs";
-  private Long DEFAULT_TIMEOUT_PROPERTY = 60000l;
+  private String DEFAULT_TIMEOUT_PROPERTY = "60000";
 
   private static final String DIRECTORY_USER_HOME = "shell.working.directory.user.home";
   private final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
@@ -102,14 +102,8 @@ public class ShellInterpreter extends KerberosInterpreter {
       executor.setStreamHandler(new PumpStreamHandler(
         contextInterpreter.out, contextInterpreter.out));
 
-      Long timeOutProperty;
-      try {
-        timeOutProperty = Long.valueOf(getProperty(TIMEOUT_PROPERTY));
-      } catch (Exception e) {
-        timeOutProperty = DEFAULT_TIMEOUT_PROPERTY;
-        LOGGER.error("Cannot convert TIMEOUT_PROPERTY to Long value, switching to default value", e);
-      }
-      executor.setWatchdog(new ExecuteWatchdog(timeOutProperty));
+      executor.setWatchdog(new ExecuteWatchdog(
+          Long.valueOf(getProperty(TIMEOUT_PROPERTY, DEFAULT_TIMEOUT_PROPERTY))));
       executors.put(contextInterpreter.getParagraphId(), executor);
       if (Boolean.valueOf(getProperty(DIRECTORY_USER_HOME))) {
         executor.setWorkingDirectory(new File(System.getProperty("user.home")));

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -47,7 +47,10 @@ import org.slf4j.LoggerFactory;
  */
 public class ShellInterpreter extends KerberosInterpreter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShellInterpreter.class);
+
   private static final String TIMEOUT_PROPERTY = "shell.command.timeout.millisecs";
+  private Long DEFAULT_TIMEOUT_PROPERTY = 60000l;
+
   private static final String DIRECTORY_USER_HOME = "shell.working.directory.user.home";
   private final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
   private final String shell = isWindows ? "cmd /c" : "bash -c";
@@ -98,7 +101,15 @@ public class ShellInterpreter extends KerberosInterpreter {
       DefaultExecutor executor = new DefaultExecutor();
       executor.setStreamHandler(new PumpStreamHandler(
         contextInterpreter.out, contextInterpreter.out));
-      executor.setWatchdog(new ExecuteWatchdog(Long.valueOf(getProperty(TIMEOUT_PROPERTY))));
+
+      Long timeOutProperty;
+      try {
+        timeOutProperty = Long.valueOf(getProperty(TIMEOUT_PROPERTY));
+      } catch (Exception e) {
+        timeOutProperty = DEFAULT_TIMEOUT_PROPERTY;
+        LOGGER.error("Cannot convert TIMEOUT_PROPERTY to Long value, switching to default value", e);
+      }
+      executor.setWatchdog(new ExecuteWatchdog(timeOutProperty));
       executors.put(contextInterpreter.getParagraphId(), executor);
       if (Boolean.valueOf(getProperty(DIRECTORY_USER_HOME))) {
         executor.setWorkingDirectory(new File(System.getProperty("user.home")));


### PR DESCRIPTION
### What is this PR for?
A user can not run any shell interpreter if "shell.command.timeout.millisecs" is not present in interpreter setting.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [https://issues.apache.org/jira/browse/ZEPPELIN-2999](https://issues.apache.org/jira/browse/ZEPPELIN-2999)

### How should this be tested?
* Remove "shell.command.timeout.millisecs" from sh interpreter settings and then try to run any sh paragraph, it should run without any error.

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
