### PR TITLE
[HotFix] - Incorrect interpreter dir

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -645,7 +645,7 @@ public class InterpreterSetting {
       createLauncher();
     }
     InterpreterLaunchContext launchContext = new
-        InterpreterLaunchContext(getJavaProperties(), option, interpreterRunner, id, name);
+        InterpreterLaunchContext(getJavaProperties(), option, interpreterRunner, id, group);
     RemoteInterpreterProcess process = (RemoteInterpreterProcess) launcher.launch(launchContext);
     process.setRemoteInterpreterEventPoller(
         new RemoteInterpreterEventPoller(remoteInterpreterProcessListener, appEventListener));


### PR DESCRIPTION
### What is this PR for?

This is for the bug hotfix introduced in #2592 . The issue is that new interpreter created can not run properly because the incorrect interpreter dir. Thanks @tinkoff-dwh for reporting this issue.  


### What type of PR is it?
[ Hot Fix]

### Todos
* [ ] - Task

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
