### PR TITLE
[Bug Fix] fix exceptions in jdbc interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -38,6 +38,7 @@ import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.PoolingDriver;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
@@ -59,8 +60,6 @@ import org.apache.zeppelin.user.UserCredentials;
 import org.apache.zeppelin.user.UsernamePassword;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Throwables;
 
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
 import static org.apache.commons.lang.StringUtils.isEmpty;
@@ -679,7 +678,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     try {
       connection = getConnection(propertyKey, interpreterContext);
     } catch (Exception e) {
-      String errorMsg = Throwables.getStackTraceAsString(e);
+      String errorMsg = ExceptionUtils.getStackTrace(e);
       try {
         closeDBPool(user, propertyKey);
       } catch (SQLException e1) {
@@ -757,7 +756,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
       }
     } catch (Throwable e) {
       logger.error("Cannot run " + sql, e);
-      String errorMsg = Throwables.getStackTraceAsString(e);
+      String errorMsg = ExceptionUtils.getStackTrace(e);
       interpreterResult.add(errorMsg);
       return new InterpreterResult(Code.ERROR, interpreterResult.message());
     } finally {


### PR DESCRIPTION
### What is this PR for?
Now used class Throwables to convert stack trace into String. This class from guava which is dependency of hadoop-common. hadoop-common is **provided**. Throwables changed to ExceptionsUtils (from commons-lang), commons-lang there is in **zeppelin-interpreter**.

### What type of PR is it?
[Bug Fix]

### How should this be tested?
Run incorrect query

### Screenshots (if appropriate)
before
![2017-10-26 10-21-26](https://user-images.githubusercontent.com/25951039/32036385-f086b498-ba38-11e7-958d-6d76ec1569b6.png)

after
![2017-10-26 10-24-05](https://user-images.githubusercontent.com/25951039/32036384-f05eb59c-ba38-11e7-9d4a-e6a1ca0897bc.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
