### PR TITLE
[ZEPPELIN-3022] The "Default Interpreter" select box on the "Create new note" modal dialog has no contents when it is opened via the "Create new note" link on ${ZEPPELIN_HOME}/webapps/webapp/app/home/notebook.html

### DIFF
--- a/zeppelin-web/src/app/home/notebook.html
+++ b/zeppelin-web/src/app/home/notebook.html
@@ -23,7 +23,7 @@ limitations under the License.
       </h4>
         <h5><a href="" data-toggle="modal" data-target="#noteImportModal" style="text-decoration: none;">
            <i style="font-size: 15px;" class="fa fa-upload"></i> Import note</a></h5>
-         <h5><a href="" data-toggle="modal" data-target="#noteCreateModal" style="text-decoration: none;">
+         <h5 ng-controller="NoteCreateCtrl as noteCreateCtrl"><a href="" data-toggle="modal" data-target="#noteCreateModal" style="text-decoration: none;" ng-click="noteCreateCtrl.getInterpreterSettings();">
            <i style="font-size: 15px;" class="icon-notebook"></i> Create new note</a></h5>
        <ul id="notebook-names">
          <li class="filter-names" ng-include="'components/note-name-filter/note-name-filter.html'"></li>


### PR DESCRIPTION
### What is this PR for?
The "Default Interpreter" select box on the "Create new note" modal dialog has no contents when it is opened via the "Create new note" link on $
{ZEPPELIN_HOME}/webapps/webapp/app/home/notebook.html.

Fix $
{ZEPPELIN_HOME}/webapps/webapp/app/home/notebook.html so that NoteCreateCtrl.getInterpreterSettings() is invoked when the "Create new note" link is clicked.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3022

### How should this be tested?
* Tested manually
    * Before: "Default Interpreter" select box has no options
        * <img width="1204" alt="zeppelin-3022_before" src="https://user-images.githubusercontent.com/31149688/32265997-daaad0ba-bf28-11e7-92d0-b0d53db25d7f.png">
    * After: "Default Interpreter" select box has options successfully
        * <img width="1209" alt="zeppelin-3022_after" src="https://user-images.githubusercontent.com/31149688/32266019-fcf4a5e2-bf28-11e7-8be3-7b02ace2d613.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
