### PR TITLE
[ZEPPELIN-3021] fix bugs for paragraph terminated status judgement

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -235,7 +235,7 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
     //avoid NullPointException when method isTerminated
     //invoked in ParagraphListenerImpl.afterStatusChange
     if (config == null) {
-      return true;
+      return false;
     }
     Boolean enabled = (Boolean) config.get("enabled");
     return enabled == null || enabled.booleanValue();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -232,6 +232,11 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
   }
 
   public boolean isEnabled() {
+    //avoid NullPointException when method isTerminated
+    //invoked in ParagraphListenerImpl.afterStatusChange
+    if (config == null) {
+      return true;
+    }
     Boolean enabled = (Boolean) config.get("enabled");
     return enabled == null || enabled.booleanValue();
   }
@@ -306,6 +311,11 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
 
   public Object getPreviousResultFormat() {
     return result;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return !this.isEnabled() || super.isTerminated();
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
fix bugs: [ZEPPELIN-3021]
Paragraph terminated status judgement error if it's called for a disabled paragraph with status ready. As we know the method isTerminated of  class Paragraph extends from the super class Job, it only consider the status of job

```java
 public boolean isTerminated() {
    return !this.status.isReady() && !this.status.isRunning() && !this.status.isPending();
  }
```
If we call this method in a disabled paragraph with status ready, it return false forever. If we schedule a note which have a paragraph like that, the cron job will be blocked by the code:

```java
while (!note.isTerminated()) {
        try {
          Thread.sleep(1000);
        } catch (InterruptedException e) {
          logger.error(e.toString(), e);
        }
      }
```

if too many cron jobs blocked by that problem, all cron jobs will be blocked because the quartz schedule thread pool is full.

* overwrite metod isTerminated in class Paragraph, add disable/enable status considered, if paragraph disabled return true directly

* add config null value judgement to avoid NullPointException, because when we create a paragraph the method isTerminated will be invoked in ParagraphListenerImpl.afterStatusChange before propery config initialized

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-3021](https://issues.apache.org/jira/browse/ZEPPELIN-3021)

### How should this be tested?

Schedule a note which have a disabled paragraph with status ready， test weather the cron job will get blocked by the code block mentioned above

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no