### PR TITLE
[ZEPPELIN-3025] Windows Build Error

### DIFF
--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -262,7 +262,7 @@
                 <goal>copy-dependencies</goal>
               </goals>
               <configuration>
-                <outputDirectory>${basedir}/interpreter/${project.name}</outputDirectory>
+                <outputDirectory>${basedir}/interpreter/${project.artifactId}</outputDirectory>
                 <overWriteReleases>false</overWriteReleases>
                 <overWriteSnapshots>false</overWriteSnapshots>
                 <overWriteIfNewer>true</overWriteIfNewer>
@@ -276,7 +276,7 @@
                 <goal>copy</goal>
               </goals>
               <configuration>
-                <outputDirectory>${basedir}/interpreter/${project.name}</outputDirectory>
+                <outputDirectory>${basedir}/interpreter/${project.artifactId}</outputDirectory>
                 <overWriteReleases>false</overWriteReleases>
                 <overWriteSnapshots>false</overWriteSnapshots>
                 <overWriteIfNewer>true</overWriteIfNewer>
@@ -303,7 +303,7 @@
                 <goal>resources</goal>
               </goals>
               <configuration>
-                <outputDirectory>${basedir}/interpreter/{project.name}</outputDirectory>
+                <outputDirectory>${basedir}/interpreter/{project.artifactId}</outputDirectory>
               </configuration>
             </execution>
           </executions>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -241,7 +241,6 @@
   <build>
     <pluginManagement>
       <plugins>
-
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
           <executions>
@@ -251,8 +250,6 @@
             </execution>
           </executions>
         </plugin>
-
-        
       </plugins>
     </pluginManagement>
   </build>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -252,62 +252,7 @@
           </executions>
         </plugin>
 
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-dependencies</id>
-              <phase>package</phase>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-              <configuration>
-                <outputDirectory>${basedir}/interpreter/${project.artifactId}</outputDirectory>
-                <overWriteReleases>false</overWriteReleases>
-                <overWriteSnapshots>false</overWriteSnapshots>
-                <overWriteIfNewer>true</overWriteIfNewer>
-                <includeScope>runtime</includeScope>
-              </configuration>
-            </execution>
-            <execution>
-              <id>copy-artifact</id>
-              <phase>package</phase>
-              <goals>
-                <goal>copy</goal>
-              </goals>
-              <configuration>
-                <outputDirectory>${basedir}/interpreter/${project.artifactId}</outputDirectory>
-                <overWriteReleases>false</overWriteReleases>
-                <overWriteSnapshots>false</overWriteSnapshots>
-                <overWriteIfNewer>true</overWriteIfNewer>
-                <artifactItems>
-                  <artifactItem>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>${project.artifactId}</artifactId>
-                    <version>${project.version}</version>
-                    <type>${project.packaging}</type>
-                  </artifactItem>
-                </artifactItems>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-resources</id>
-              <phase>package</phase>
-              <goals>
-                <goal>resources</goal>
-              </goals>
-              <configuration>
-                <outputDirectory>${basedir}/interpreter/{project.artifactId}</outputDirectory>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
+        
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
### What is this PR for?
When i try to build Zeppelin from apache master repo on Windows 10 i get this error:
```bash
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.8:copy (copy-artifact) on project zeppelin-interpreter: Error copying artifact from C:\Users\Andrea\workspace_zeppelin\zeppelin-master\zeppelin-interpreter\target\zeppelin-interpreter-0.8.0-SNAPSHOT.jar to C:\Users\Andrea\workspace_zeppelin\zeppelin-master\zeppelin-interpreter\interpreter\Zeppelin: Interpreter\zeppelin-interpreter-0.8.0-SNAPSHOT.jar
```

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Change build dir

### What is the Jira issue?
[ZEPPELIN-3025](https://issues.apache.org/jira/browse/ZEPPELIN-3025)

### How should this be tested?
* Build the project in Windows env

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
