### PR TITLE
[ZEPPELIN-3012] Interpreter Permissions not working properly for groups

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -57,8 +57,10 @@ public class AuthenticationInfo implements JsonSerializable {
     this.user = user;
     this.ticket = ticket;
     if (StringUtils.isNotBlank(roles) && roles.length() > 2) {
-      String[] r = roles.substring(1, roles.length() - 1).split(",");
-      this.roles = Arrays.asList(r);
+        this.roles = new ArrayList<>();
+        for (final String role : roles.substring(1, roles.length() - 1).split(",")) {
+            this.roles.add(role.trim());
+        }
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -20,13 +20,14 @@ package org.apache.zeppelin.user;
 
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import com.google.gson.Gson;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.common.JsonSerializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
 
 /***
  *
@@ -57,10 +58,11 @@ public class AuthenticationInfo implements JsonSerializable {
     this.user = user;
     this.ticket = ticket;
     if (StringUtils.isNotBlank(roles) && roles.length() > 2) {
-        this.roles = new ArrayList<>();
-        for (final String role : roles.substring(1, roles.length() - 1).split(",")) {
-            this.roles.add(role.trim());
-        }
+      this.roles = new ArrayList<>();
+      for (final String role : roles.substring(1, roles.length() - 1)
+          .split(",")) {
+        this.roles.add(role.trim());
+      }
     }
   }
 
@@ -122,6 +124,7 @@ public class AuthenticationInfo implements JsonSerializable {
         || StringUtils.isEmpty(this.getUser());
   }
 
+  @Override
   public String toJson() {
     return gson.toJson(this);
   }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/AuthenticationInfoTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/AuthenticationInfoTest.java
@@ -33,8 +33,9 @@ public class AuthenticationInfoTest {
     final AuthenticationInfo authenticationInfo = new AuthenticationInfo("foo",
         roles, "bar");
 
-    assertEquals(authenticationInfo.getRoles(),
-        new ArrayList<>(Arrays.asList("role1", "role2", "role with space")));
+    assertEquals(
+        new ArrayList<>(Arrays.asList("role1", "role2", "role with space")),
+        authenticationInfo.getRoles());
 
   }
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/AuthenticationInfoTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/user/AuthenticationInfoTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.user;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class AuthenticationInfoTest {
+
+  @Test
+  public void testRoles() {
+    final String roles = "[role1, role2, role with space]";
+
+    final AuthenticationInfo authenticationInfo = new AuthenticationInfo("foo",
+        roles, "bar");
+
+    assertEquals(authenticationInfo.getRoles(),
+        new ArrayList<>(Arrays.asList("role1", "role2", "role with space")));
+
+  }
+
+}


### PR DESCRIPTION
### What is this PR for?
This fixes issues when using Zeppelin with permissions for users belonging to more than one roles / groups. Constructor of org.apache.zeppelin.user.AuthenticationInfo didn't consider that the roles String will contain spaces, in case there is more than one role, e.g. 'role1, role2'.

This change fixes the issue, by invoking trim() on each role.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3012

### How should this be tested?
* Enable shiro.ini, including 'admin' user
* Login with 'admin' and enable Interpreter Permissions for any Interpreter, granting access to 'role2'
* Try to use this Interpreter with 'user1', who belongs to role2.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
