### PR TITLE
ZEPPELIN-3034. Only apply dynamic form for LivySqlnterpreter

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -208,12 +208,13 @@ i.e. sends extra parameter for creating and running a session ("proxyUser": "${l
 This is particularly useful when multi users are sharing a Notebook server.
 
 ## Apply Zeppelin Dynamic Forms
-You can leverage [Zeppelin Dynamic Form](../usage/dynamic_form/intro.html). You can use both the `text input` and `select form` parameterization features.
+You can leverage [Zeppelin Dynamic Form](../usage/dynamic_form/intro.html). Form templates is only avalible for livy sql interpreter.
+```
+%livy.sql
+select * from products where ${product_id=1}
+```
 
-```
-%livy.pyspark
-print "${group_by=product_id,product_id|product_name|customer_id|store_id}"
-```
+And creating dynamic formst programmatically is not feasible in livy interpreter, because ZeppelinContext is not available in livy interpreter.
 
 ## FAQ
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -212,7 +212,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   @Override
   public FormType getFormType() {
-    return FormType.SIMPLE;
+    return FormType.NATIVE;
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -159,6 +159,11 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
     }
   }
 
+  @Override
+  public FormType getFormType() {
+    return FormType.SIMPLE;
+  }
+
   protected List<String> parseSQLOutput(String output) {
     List<String> rows = new ArrayList<>();
     String[] lines = output.split("\n");


### PR DESCRIPTION
### What is this PR for?

Simple PR to only apply dynamic forms for LivySqlInterpreter, this make the behavior consistent with zeppelin's built-in spark interpreter.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3034

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?  No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
