### PR TITLE
[MINOR] overwrite get/set username method for LazyOpenInterpreter and RemoteI…

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -193,4 +193,14 @@ public class LazyOpenInterpreter
   public void unregisterHook(String event) {
     intp.unregisterHook(event);
   }
+
+  @Override
+  public void setUserName(String userName) {
+    this.intp.setUserName(userName);
+  }
+
+  @Override
+  public String getUserName() {
+    return this.intp.getUserName();
+  }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -60,7 +60,6 @@ public class RemoteInterpreter extends Interpreter {
 
   private String className;
   private String sessionId;
-  private String userName;
   private FormType formType;
 
   private RemoteInterpreterProcess interpreterProcess;
@@ -80,7 +79,7 @@ public class RemoteInterpreter extends Interpreter {
     super(properties);
     this.sessionId = sessionId;
     this.className = className;
-    this.userName = userName;
+    this.setUserName(userName);
     this.lifecycleManager = lifecycleManager;
   }
 
@@ -105,7 +104,7 @@ public class RemoteInterpreter extends Interpreter {
     this.interpreterProcess = intpGroup.getOrCreateInterpreterProcess();
     synchronized (interpreterProcess) {
       if (!interpreterProcess.isRunning()) {
-        interpreterProcess.start(userName, false);
+        interpreterProcess.start(this.getUserName(), false);
         interpreterProcess.getRemoteInterpreterEventPoller()
             .setInterpreterProcess(interpreterProcess);
         interpreterProcess.getRemoteInterpreterEventPoller().setInterpreterGroup(intpGroup);
@@ -129,7 +128,7 @@ public class RemoteInterpreter extends Interpreter {
         // depends on other interpreter. e.g. PySparkInterpreter depends on SparkInterpreter.
         // also see method Interpreter.getInterpreterInTheSameSessionByClassName
         for (Interpreter interpreter : getInterpreterGroup()
-                                        .getOrCreateSession(userName, sessionId)) {
+                                        .getOrCreateSession(this.getUserName(), sessionId)) {
           try {
             ((RemoteInterpreter) interpreter).internal_create();
           } catch (IOException e) {
@@ -168,7 +167,7 @@ public class RemoteInterpreter extends Interpreter {
           public Void call(Client client) throws Exception {
             LOGGER.info("Create RemoteInterpreter {}", getClassName());
             client.createInterpreter(getInterpreterGroup().getId(), sessionId,
-                className, (Map) getProperties(), userName);
+                className, (Map) getProperties(), getUserName());
             return null;
           }
         });


### PR DESCRIPTION
### What is this PR for?

* Remove the username property in class RemoteInterpreter, instead reuse the username property in class Interpreter， to avoid get null value with method getUserName in the super class Interpreter

* Overwrite username get/set method  in class LazyOpenInterpreter

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-2981](https://issues.apache.org/jira/browse/ZEPPELIN-2981)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
