### PR TITLE
[HotFix] No Error message displayed in frontend when no interpreter binded

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -188,11 +188,9 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
       if (matcher.matches()) {
         String headingSpace = matcher.group(1);
         this.intpText = matcher.group(2);
-        this.interpreter = interpreterFactory.getInterpreter(user, note.getId(), intpText);
         this.scriptText = this.text.substring(headingSpace.length() + intpText.length() + 1).trim();
       } else {
         this.intpText = "";
-        this.interpreter = interpreterFactory.getInterpreter(user, note.getId(), "");
         this.scriptText = this.text;
       }
     }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -87,7 +87,7 @@ public class NoteTest {
 
     ArgumentCaptor<Paragraph> pCaptor = ArgumentCaptor.forClass(Paragraph.class);
     verify(scheduler, only()).submit(pCaptor.capture());
-    verify(interpreterFactory, times(2)).getInterpreter(anyString(), anyString(), eq("spark"));
+    verify(interpreterFactory, times(1)).getInterpreter(anyString(), anyString(), eq("spark"));
 
     assertEquals("Paragraph text", pText, pCaptor.getValue().getText());
   }


### PR DESCRIPTION
### What is this PR for?

It is bug of ZEPPELIN-3013. HotFix for the No Error message displayed in frontend when no interpreter binded


### What type of PR is it?
[Hot Fix ]

### Todos
* [ ] - Task



### How should this be tested?
Verified manually

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
