### PR TITLE
[ZEPPELIN-3042] updating jgit to support post-commit hooks

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -311,7 +311,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
 
 The following components are provided under the BSD-style License.
 
-    (New BSD License) JGit (org.eclipse.jgit:org.eclipse.jgit:jar:4.1.1.201511131810-r - https://eclipse.org/jgit/)
+    (New BSD License) JGit (org.eclipse.jgit:org.eclipse.jgit:jar:4.9.0.201710071750-r - https://eclipse.org/jgit/)
     (New BSD License) Kryo (com.esotericsoftware.kryo:kryo:3.0.3 - http://code.google.com/p/kryo/)
     (New BSD License) MinLog (com.esotericsoftware.minlog:minlog:1.3 - http://code.google.com/p/minlog/)
     (New BSD License) ReflectASM (com.esotericsoftware.reflectasm:reflectasm:1.07 - http://code.google.com/p/reflectasm/)

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -46,7 +46,7 @@
     <lucene.version>5.3.1</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
-    <eclipse.jgit.version>4.1.1.201511131810-r</eclipse.jgit.version>
+    <eclipse.jgit.version>4.9.0.201710071750-r</eclipse.jgit.version>
     <frontend.maven.plugin.version>1.3</frontend.maven.plugin.version>
 
     <!--test library versions-->


### PR DESCRIPTION
### What is this PR for?
Git functionality in Zeppelin is provided by `jgit`, but it's fixed to an old version. A newer version of said library supports new things, primarily post-commit hooks.


### What type of PR is it?
Improvement

### Todos
* [ x ] - CI ([two failed, but due to yarn](https://travis-ci.org/kokes/zeppelin))

### What is the Jira issue?

[ZEPPELIN-3042](https://issues.apache.org/jira/browse/ZEPPELIN-3042)

### Questions:
* Does the licenses files need update? -- Yes, only because the license file notes the exact version of included libraries. `jgit` hasn't changed, license-wise, so it's only a matter of updating the version information
* Is there breaking changes for older versions? -- nope
* Does this needs documentation? -- possibly, to let people know they get use post-commit hooks now?