### PR TITLE
ZEPPELIN-3037 Configure Http Request Header Size Limit for Jetty

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -437,6 +437,15 @@
     <description>Hardcoding Application Server name to Prevent Fingerprinting</description>
 </property>
 -->
+
+<!--
+<property>
+    <name>zeppelin.server.jetty.request.header.size</name>
+    <value>8192</value>
+    <description>Http Request Header Size Limit (to prevent HTTP 413)</description>
+</property>
+-->
+
 <!--
 <property>
   <name>zeppelin.server.xframe.options</name>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -525,6 +525,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_SERVER_JETTY_NAME);
   }
 
+  public Integer getJettyRequestHeaderSize() {
+    return getInt(ConfVars.ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE);
+  }
+
 
   public String getXFrameOptions() {
     return getString(ConfVars.ZEPPELIN_SERVER_XFRAME_OPTIONS);
@@ -702,6 +706,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false),
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
+    ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE("zeppelin.server.jetty.request.header.size", 8192),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -56,12 +56,7 @@ import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.http.HttpVersion;
-import org.eclipse.jetty.server.HttpConfiguration;
-import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.SecureRequestCustomizer;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -241,7 +236,6 @@ public class ZeppelinServer extends Application {
       httpConfig.setSecureScheme("https");
       httpConfig.setSecurePort(conf.getServerSslPort());
       httpConfig.setOutputBufferSize(32768);
-      httpConfig.setRequestHeaderSize(8192);
       httpConfig.setResponseHeaderSize(8192);
       httpConfig.setSendServerVersion(true);
 
@@ -260,6 +254,7 @@ public class ZeppelinServer extends Application {
       connector = new ServerConnector(server);
     }
 
+    configureRequestHeaderSize(conf, connector);
     // Set some timeout options to make debugging easier.
     int timeout = 1000 * 30;
     connector.setIdleTimeout(timeout);
@@ -274,6 +269,14 @@ public class ZeppelinServer extends Application {
     server.addConnector(connector);
 
     return server;
+  }
+
+  private static void configureRequestHeaderSize(ZeppelinConfiguration conf,
+                                                 ServerConnector connector) {
+    HttpConnectionFactory cf = (HttpConnectionFactory)
+            connector.getConnectionFactory(HttpVersion.HTTP_1_1.toString());
+    int requestHeaderSize = conf.getJettyRequestHeaderSize();
+    cf.getHttpConfiguration().setRequestHeaderSize(requestHeaderSize);
   }
 
   private static void setupNotebookServer(WebAppContext webapp,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/configuration/RequestHeaderSizeTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/configuration/RequestHeaderSizeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.configuration;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RequestHeaderSizeTest extends AbstractTestRestApi {
+    private static final int REQUEST_HEADER_MAX_SIZE = 20000;
+
+    @Before
+    public void startZeppelin() throws Exception {
+        System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE.getVarName(), String.valueOf(REQUEST_HEADER_MAX_SIZE));
+        startUp(RequestHeaderSizeTest.class.getSimpleName());
+    }
+
+    @After
+    public void stopZeppelin() throws Exception {
+        shutDown();
+    }
+
+
+    @Test
+    public void increased_request_header_size_do_not_cause_413_when_request_size_is_over_8K() throws Exception {
+        HttpClient httpClient = new HttpClient();
+
+        GetMethod getMethod = new GetMethod(getUrlToTest() + "/version");
+        String headerValue = RandomStringUtils.randomAlphanumeric(REQUEST_HEADER_MAX_SIZE - 2000);
+        getMethod.setRequestHeader("not_too_large_header", headerValue);
+        int httpCode = httpClient.executeMethod(getMethod);
+        assertThat(httpCode, is(HttpStatus.SC_OK));
+
+
+        getMethod = new GetMethod(getUrlToTest() + "/version");
+        headerValue = RandomStringUtils.randomAlphanumeric(REQUEST_HEADER_MAX_SIZE + 2000);
+        getMethod.setRequestHeader("too_large_header", headerValue);
+        httpCode = httpClient.executeMethod(getMethod);
+        assertThat(httpCode, is(HttpStatus.SC_REQUEST_TOO_LONG));
+    }
+
+
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -24,6 +24,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
@@ -96,5 +97,11 @@ public class ZeppelinConfigurationTest {
       ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
       boolean isIt = conf.isNotebokPublic();
       assertTrue(isIt);
+    }
+
+    @Test
+    public void isRequestHeaderSizeDefaultValueCorrect() throws ConfigurationException {
+        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+        assertEquals((Integer)8192, conf.getJettyRequestHeaderSize());
     }
 }


### PR DESCRIPTION
### What is this PR for?
In some deployment scenarios it is necessary to increase jetty.request.header.size, which default value is 8192. This will reduce the chance of HTTP Error 413 Request entity too large.
There should be a mechanism to configure this setting.


### What type of PR is it?
[Feature]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3037

### How should this be tested?
* There is an integration test (automated unit test included) for testing this feature.
* To test manually, after increasing setting, make any http request to zeppelin with a request header bigger than 8K , you should not get an HTTP Error 413 Request entity too large.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes.
