### PR TITLE
[ZEPPELIN-771] Escape tab and CR when the result is shown in table

### DIFF
--- a/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
+++ b/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
@@ -207,7 +207,10 @@ class InterpreterLogic(val session: Session)  {
         .append("%table ")
         .append(columnsDefinitions.map { case (columnName, _) => columnName }.mkString("\t")).append("\n")
 
-      val escape: AnyRef => String = _.toString.replaceAllLiterally("\t", " ").replaceAllLiterally("\n", " ")
+      val escape: AnyRef => String = {
+        case null => null
+        case x => x.toString.replaceAllLiterally("\t", " ").replaceAllLiterally("\n", " ")
+      }
       // Deserialize Data
       rows.foreach {
         row => {

--- a/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
+++ b/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
@@ -207,6 +207,7 @@ class InterpreterLogic(val session: Session)  {
         .append("%table ")
         .append(columnsDefinitions.map { case (columnName, _) => columnName }.mkString("\t")).append("\n")
 
+      val escape: AnyRef => String = _.toString.replaceAllLiterally("\t", " ").replaceAllLiterally("\n", " ")
       // Deserialize Data
       rows.foreach {
         row => {
@@ -215,7 +216,7 @@ class InterpreterLogic(val session: Session)  {
               if (row.isNull(name)) null else row.getObject(name)
             }
           }
-          output.append(data.mkString("\t")).append("\n")
+          output.append(data.map(escape).mkString("\t")).append("\n")
         }
       }
     } else {

--- a/cassandra/src/test/java/org/apache/zeppelin/cassandra/CassandraInterpreterTest.java
+++ b/cassandra/src/test/java/org/apache/zeppelin/cassandra/CassandraInterpreterTest.java
@@ -320,6 +320,22 @@ public class CassandraInterpreterTest {
     }
 
     @Test
+    public void should_escape_tabs_and_newlines() throws Exception {
+        //Given
+        String queries = "INSERT INTO zeppelin.prepared(key,val)" +
+                " VALUES('withTabAndNewLines','my\t\nValue');\n" +
+                "SELECT * FROM zeppelin.prepared WHERE key='withTabAndNewLines';\n";
+
+        //When
+        final InterpreterResult actual = interpreter.interpret(queries, intrContext);
+
+        //Then
+        assertThat(actual.code()).isEqualTo(Code.SUCCESS);
+        assertThat(actual.message().get(0).getData()).isEqualTo("key\tval\n" +
+                "withTabAndNewLines\tmy  Value\n");
+    }
+
+    @Test
     public void should_execute_bound_statement() throws Exception {
         //Given
         String queries = "@prepare[users_insert]=INSERT INTO zeppelin.users" +

--- a/geode/src/main/java/org/apache/zeppelin/geode/GeodeOqlInterpreter.java
+++ b/geode/src/main/java/org/apache/zeppelin/geode/GeodeOqlInterpreter.java
@@ -18,7 +18,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -85,12 +84,6 @@ import org.apache.geode.pdx.PdxInstance;
 public class GeodeOqlInterpreter extends Interpreter {
 
   private Logger logger = LoggerFactory.getLogger(GeodeOqlInterpreter.class);
-
-  private static final char NEWLINE = '\n';
-  private static final char TAB = '\t';
-  private static final char WHITESPACE = ' ';
-
-  private static final String TABLE_MAGIC_TAG = "%table ";
 
   private ClientCache clientCache = null;
   private QueryService queryService = null;
@@ -195,20 +188,6 @@ public class GeodeOqlInterpreter extends Interpreter {
       logger.error("Cannot run " + oql, ex);
       return new InterpreterResult(Code.ERROR, ex.getMessage());
     }
-  }
-
-  /**
-   * Zeppelin's %TABLE convention uses tab (\t) to delimit fields and new-line (\n) to delimit rows
-   * To complain with this convention we need to replace any occurrences of tab and/or newline
-   * characters in the content.
-   */
-  private String replaceReservedChars(String str) {
-
-    if (StringUtils.isBlank(str)) {
-      return str;
-    }
-
-    return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
   }
 
   private void handleStructEntry(boolean isHeaderSet, Object entry, StringBuilder msg) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -112,10 +112,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String PRECODE_KEY_TEMPLATE = "%s.precode";
   static final String DOT = ".";
 
-  private static final char WHITESPACE = ' ';
-  private static final char NEWLINE = '\n';
-  private static final char TAB = '\t';
-  private static final String TABLE_MAGIC_TAG = "%table ";
   private static final String EXPLAIN_PREDICATE = "EXPLAIN ";
 
   static final String COMMON_MAX_LINE = COMMON_KEY + DOT + MAX_LINE_KEY;
@@ -125,8 +121,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String DEFAULT_USER = DEFAULT_KEY + DOT + USER_KEY;
   static final String DEFAULT_PASSWORD = DEFAULT_KEY + DOT + PASSWORD_KEY;
   static final String DEFAULT_PRECODE = DEFAULT_KEY + DOT + PRECODE_KEY;
-
-  static final String EMPTY_COLUMN_VALUE = "";
 
   private final String CONCURRENT_EXECUTION_KEY = "zeppelin.jdbc.concurrent.use";
   private final String CONCURRENT_EXECUTION_COUNT = "zeppelin.jdbc.concurrent.max_connection";
@@ -772,16 +766,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
       getJDBCConfiguration(user).removeStatement(paragraphId);
     }
     return interpreterResult;
-  }
-
-  /**
-   * For %table response replace Tab and Newline characters from the content.
-   */
-  private String replaceReservedChars(String str) {
-    if (str == null) {
-      return EMPTY_COLUMN_VALUE;
-    }
-    return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
   }
 
   @Override

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -233,6 +233,28 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
+  public void testQueryWithReservedCharacters() throws SQLException, IOException {
+    String sqlQuery = "select '\n', '\t', 'a';";
+
+    Properties properties = new Properties();
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+    assertEquals("STRINGDECODE('\\n')\tSTRINGDECODE('\\t')\t'a'\n \t \ta\n",
+            interpreterResult.message().get(0).getData());
+
+  }
+
+  @Test
   public void testSelectMultipleQueries() throws SQLException, IOException {
     Properties properties = new Properties();
     properties.setProperty("common.max_count", "1000");

--- a/kylin/src/main/java/org/apache/zeppelin/kylin/KylinInterpreter.java
+++ b/kylin/src/main/java/org/apache/zeppelin/kylin/KylinInterpreter.java
@@ -53,7 +53,7 @@ public class KylinInterpreter extends Interpreter {
   static final String KYLIN_QUERY_ACCEPT_PARTIAL = "kylin.query.ispartial";
   static final Pattern KYLIN_TABLE_FORMAT_REGEX_LABEL = Pattern.compile("\"label\":\"(.*?)\"");
   static final Pattern KYLIN_TABLE_FORMAT_REGEX_RESULTS =
-          Pattern.compile("\"results\":\\[\\[(.*?)]]");
+          Pattern.compile("\"results\":\\[\\[(.*?)]]", Pattern.DOTALL);
 
   public KylinInterpreter(Properties property) {
     super(property);
@@ -191,13 +191,13 @@ public class KylinInterpreter extends Interpreter {
   }
 
   String formatResult(String msg) {
-    StringBuilder res = new StringBuilder("%table ");
+    StringBuilder res = new StringBuilder(TABLE_MAGIC_TAG);
     
     Matcher ml = KYLIN_TABLE_FORMAT_REGEX_LABEL.matcher(msg);
     while (!ml.hitEnd() && ml.find()) {
-      res.append(ml.group(1) + " \t");
+      res.append(ml.group(1) + TAB);
     } 
-    res.append(" \n");
+    res.append(NEWLINE);
     
     Matcher mr = KYLIN_TABLE_FORMAT_REGEX_RESULTS.matcher(msg);
     String table = null;
@@ -212,9 +212,9 @@ public class KylinInterpreter extends Interpreter {
         if (col[j] != null) {
           col[j] = col[j].replaceAll("^\"|\"$", "");
         }
-        res.append(col[j] + " \t");
+        res.append(replaceReservedChars(col[j]) + TAB);
       }
-      res.append(" \n");
+      res.append(NEWLINE);
     }
     return res.toString();
   }

--- a/kylin/src/test/java/org/apache/zeppelin/kylin/KylinInterpreterTest.java
+++ b/kylin/src/test/java/org/apache/zeppelin/kylin/KylinInterpreterTest.java
@@ -98,11 +98,33 @@ public class KylinInterpreterTest {
             + "\"cube\":\"Sample_Cube\",\"affectedRowCount\":0,\"isException\":false,\"exceptionMessage\":null,"
             + "\"duration\":134,\"totalScanCount\":1,\"hitExceptionCache\":false,\"storageCacheUsed\":false,"
             + "\"partial\":false}";
-    String expected="%table COUNTRY \tCURRENCY \tCOUNT__ \t \n" +
-            "AMERICA \tUSD \tnull \t \n" +
-            "null \tRMB \t0 \t \n" +
-            "KOR \tnull \t100 \t \n" +
-            "\\\"abc\\\" \ta,b,c \t-1 \t \n";
+    String expected="%table COUNTRY\tCURRENCY\tCOUNT__\t\n" +
+            "AMERICA\tUSD\tnull\t\n" +
+            "null\tRMB\t0\t\n" +
+            "KOR\tnull\t100\t\n" +
+            "\\\"abc\\\"\ta,b,c\t-1\t\n";
+    KylinInterpreter t = new MockKylinInterpreter(getDefaultProperties());
+    String actual = t.formatResult(msg);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testParseResultWithReservedCharacters() {
+    String msg = "{\"columnMetas\":[{\"isNullable\":1,\"displaySize\":256,\"label\":\"TEXT\",\"name\":\"COUNTRY\","
+            + "\"schemaName\":\"DEFAULT\",\"catelogName\":null,\"tableName\":\"TEST_TABLE\",\"precision\":256,"
+            + "\"scale\":0,\"columnType\":12,\"columnTypeName\":\"VARCHAR\",\"writable\":false,\"readOnly\":true,"
+            + "\"definitelyWritable\":false,\"autoIncrement\":false,\"caseSensitive\":true,\"searchable\":false,"
+            + "\"currency\":false,\"signed\":true},{\"isNullable\":0,\"displaySize\":19,"
+            + "\"label\":\"COUNT__\",\"name\":\"COUNT__\",\"schemaName\":\"DEFAULT\",\"catelogName\":null,"
+            + "\"tableName\":\"TEST_TABLE\",\"precision\":19,\"scale\":0,\"columnType\":-5,\"columnTypeName\":"
+            + "\"BIGINT\",\"writable\":false,\"readOnly\":true,\"definitelyWritable\":false,\"autoIncrement\":false,"
+            + "\"caseSensitive\":true,\"searchable\":false,\"currency\":false,\"signed\":true}],\"results\":"
+            + "[[\"a\ttab\",null],[\"a\nCR\",0]],\"cube\":\"Sample_Cube\",\"affectedRowCount\":0,"
+            + "\"isException\":false,\"exceptionMessage\":null,\"duration\":134,\"totalScanCount\":1,"
+            + "\"hitExceptionCache\":false,\"storageCacheUsed\":false,\"partial\":false}";
+    String expected="%table TEXT\tCOUNT__\t\n" +
+            "a tab\tnull\t\n" +
+            "a CR\t0\t\n";
     KylinInterpreter t = new MockKylinInterpreter(getDefaultProperties());
     String actual = t.formatResult(msg);
     Assert.assertEquals(expected, actual);

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -23,6 +23,7 @@ import java.security.KeyStore;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -441,16 +442,23 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
         for (Map header : stmtInfo.output.data.application_livy_table_json.headers) {
           if (notFirstColumn) {
-            outputBuilder.append("\t");
+            outputBuilder.append(TAB);
           }
           outputBuilder.append(header.get("name"));
           notFirstColumn = true;
         }
 
-        outputBuilder.append("\n");
+        outputBuilder.append(NEWLINE);
         for (List<Object> row : stmtInfo.output.data.application_livy_table_json.records) {
-          outputBuilder.append(StringUtils.join(row, "\t"));
-          outputBuilder.append("\n");
+          Iterator<Object> fieldsIter = row.iterator();
+          while (fieldsIter.hasNext()) {
+            Object field = fieldsIter.next();
+            outputBuilder.append(replaceReservedChars(field.toString()));
+            if (fieldsIter.hasNext()) {
+              outputBuilder.append(TAB);
+            }
+          }
+          outputBuilder.append(NEWLINE);
         }
         return new InterpreterResult(InterpreterResult.Code.SUCCESS,
             InterpreterResult.Type.TABLE, outputBuilder.toString());

--- a/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreter.java
+++ b/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreter.java
@@ -52,7 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * Neo4j interpreter for Zeppelin.
  */
 public class Neo4jCypherInterpreter extends Interpreter {
-
   private static final String MAP_KEY_TEMPLATE = "%s.%s";
 
   private Map<String, String> labels;

--- a/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreter.java
+++ b/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreter.java
@@ -52,9 +52,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * Neo4j interpreter for Zeppelin.
  */
 public class Neo4jCypherInterpreter extends Interpreter {
-  private static final String TABLE = "%table";
-  public static final String NEW_LINE = "\n";
-  public static final String TAB = "\t";
 
   private static final String MAP_KEY_TEMPLATE = "%s.%s";
 
@@ -217,18 +214,19 @@ public class Neo4jCypherInterpreter extends Interpreter {
     if (cols.isEmpty()) {
       msg = new StringBuilder();
     } else {
-      msg = new StringBuilder(TABLE);
-      msg.append(NEW_LINE);
+      msg = new StringBuilder(TABLE_MAGIC_TAG);
       msg.append(StringUtils.join(cols, TAB));
-      msg.append(NEW_LINE);
+      msg.append(NEWLINE);
       for (List<String> line : lines) {
-        if (line.size() < cols.size()) {
-          for (int i = line.size(); i < cols.size(); i++) {
-            line.add(null);
+        for (int i = 0; i < cols.size(); i++) {
+          if (i < line.size()) {
+            msg.append(replaceReservedChars(line.get(i)));
+          }
+          if (i < cols.size() - 1) {
+            msg.append(TAB);
           }
         }
-        msg.append(StringUtils.join(line, TAB));
-        msg.append(NEW_LINE);
+        msg.append(NEWLINE);
       }
     }
     return new InterpreterResult(Code.SUCCESS, msg.toString());

--- a/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
+++ b/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
@@ -52,6 +52,9 @@ import com.google.gson.Gson;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class Neo4jCypherInterpreterTest {
 
+  private static final String NEW_LINE = "\n";
+  private static final String TAB = "\t";
+
   private Neo4jCypherInterpreter interpreter;
 
   private InterpreterContext context;
@@ -138,6 +141,17 @@ public class Neo4jCypherInterpreterTest {
   }
 
   @Test
+  public void testRenderTableWithReservedChars() {
+    interpreter.open();
+    InterpreterResult result = interpreter.interpret("MATCH (n:Person) "
+            + "WHERE n.name IN ['name1'] "
+            + "RETURN n.name AS name, n.age AS age, '\t' as tab, '\n' as cr", context);
+    assertEquals(Code.SUCCESS, result.code());
+    final String tableResult = "name\tage\ttab\tcr\n\"name1\"\t1\t\" \"\t\" \"\n";
+    assertEquals(tableResult, result.toString().replace("%table ", StringUtils.EMPTY));
+  }
+
+  @Test
   public void testRenderMap() {
     interpreter.open();
     final String jsonQuery = "RETURN {key: \"value\", listKey: [{inner: \"Map1\"}, {inner: \"Map2\"}]} as object";
@@ -145,12 +159,12 @@ public class Neo4jCypherInterpreterTest {
     final String objectListKey = "object.listKey";
     InterpreterResult result = interpreter.interpret(jsonQuery, context);
     assertEquals(Code.SUCCESS, result.code());
-    String[] rows = result.toString().replace("%table ", StringUtils.EMPTY).split(Neo4jCypherInterpreter.NEW_LINE);
+    String[] rows = result.toString().replace("%table ", StringUtils.EMPTY).split(NEW_LINE);
     assertEquals(rows.length, 2);
-    List<String> header = Arrays.asList(rows[0].split(Neo4jCypherInterpreter.TAB));
+    List<String> header = Arrays.asList(rows[0].split(TAB));
     assertEquals(header.contains(objectKey), true);
     assertEquals(header.contains(objectListKey), true);
-    List<String> row = Arrays.asList(rows[1].split(Neo4jCypherInterpreter.TAB));
+    List<String> row = Arrays.asList(rows[1].split(TAB));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value");
     assertEquals(row.get(header.indexOf(objectListKey)), "[{\"inner\":\"Map1\"},{\"inner\":\"Map2\"}]");
@@ -160,16 +174,16 @@ public class Neo4jCypherInterpreterTest {
     		+ "AS array UNWIND array AS object RETURN object";
     result = interpreter.interpret(query, context);
     assertEquals(Code.SUCCESS, result.code());
-    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(Neo4jCypherInterpreter.NEW_LINE);
+    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(NEW_LINE);
     assertEquals(rows.length, 3);
-    header = Arrays.asList(rows[0].split(Neo4jCypherInterpreter.TAB));
+    header = Arrays.asList(rows[0].split(TAB));
     assertEquals(header.contains(objectKey), true);
     assertEquals(header.contains(objectListKey), true);
-    row = Arrays.asList(rows[1].split(Neo4jCypherInterpreter.TAB));
+    row = Arrays.asList(rows[1].split(TAB));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value");
     assertEquals(row.get(header.indexOf(objectListKey)), "[{\"inner\":\"Map1\"},{\"inner\":\"Map2\"}]");
-    row = Arrays.asList(rows[2].split(Neo4jCypherInterpreter.TAB));
+    row = Arrays.asList(rows[2].split(TAB));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value2");
     assertEquals(row.get(header.indexOf(objectListKey)), "[{\"inner\":\"Map12\"},{\"inner\":\"Map22\"}]");
@@ -179,17 +193,17 @@ public class Neo4jCypherInterpreterTest {
     		+ "AS array UNWIND array AS object RETURN object";
     result = interpreter.interpret(jsonListWithNullQuery, context);
     assertEquals(Code.SUCCESS, result.code());
-    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(Neo4jCypherInterpreter.NEW_LINE);
+    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(NEW_LINE);
     assertEquals(rows.length, 3);
-    header = Arrays.asList(rows[0].split(Neo4jCypherInterpreter.TAB, -1));
+    header = Arrays.asList(rows[0].split(TAB, -1));
     assertEquals(header.contains(objectKey), true);
     assertEquals(header.contains(objectListKey), true);
-    row = Arrays.asList(rows[1].split(Neo4jCypherInterpreter.TAB, -1));
+    row = Arrays.asList(rows[1].split(TAB, -1));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value");
     assertEquals(row.get(header.indexOf(objectListKey)), StringUtils.EMPTY);
     assertEquals(row.get(header.indexOf(objectListKey)), "");
-    row = Arrays.asList(rows[2].split(Neo4jCypherInterpreter.TAB, -1));
+    row = Arrays.asList(rows[2].split(TAB, -1));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value2");
     assertEquals(row.get(header.indexOf(objectListKey)), "[{\"inner\":\"Map1\"},{\"inner\":\"Map2\"}]");
@@ -199,16 +213,16 @@ public class Neo4jCypherInterpreterTest {
     		+ "AS array UNWIND array AS object RETURN object";
     result = interpreter.interpret(jsonListWithoutListKeyQuery, context);
     assertEquals(Code.SUCCESS, result.code());
-    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(Neo4jCypherInterpreter.NEW_LINE);
+    rows = result.toString().replace("%table ", StringUtils.EMPTY).split(NEW_LINE);
     assertEquals(rows.length, 3);
-    header = Arrays.asList(rows[0].split(Neo4jCypherInterpreter.TAB, -1));
+    header = Arrays.asList(rows[0].split(TAB, -1));
     assertEquals(header.contains(objectKey), true);
     assertEquals(header.contains(objectListKey), true);
-    row = Arrays.asList(rows[1].split(Neo4jCypherInterpreter.TAB, -1));
+    row = Arrays.asList(rows[1].split(TAB, -1));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value");
     assertEquals(row.get(header.indexOf(objectListKey)), StringUtils.EMPTY);
-    row = Arrays.asList(rows[2].split(Neo4jCypherInterpreter.TAB, -1));
+    row = Arrays.asList(rows[2].split(TAB, -1));
     assertEquals(row.size(), header.size());
     assertEquals(row.get(header.indexOf(objectKey)), "value2");
     assertEquals(row.get(header.indexOf(objectListKey)), "[{\"inner\":\"Map1\"},{\"inner\":\"Map2\"}]");

--- a/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
+++ b/pig/src/main/java/org/apache/zeppelin/pig/PigQueryInterpreter.java
@@ -19,7 +19,6 @@
 package org.apache.zeppelin.pig;
 
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.pig.PigServer;
 import org.apache.pig.data.Tuple;
@@ -78,7 +77,7 @@ public class PigQueryInterpreter extends BasePigInterpreter {
       queries.add(lines[i]);
     }
 
-    StringBuilder resultBuilder = new StringBuilder("%table ");
+    StringBuilder resultBuilder = new StringBuilder(TABLE_MAGIC_TAG);
     try {
       pigServer.setJobName(createJobName(st, context));
       File tmpScriptFile = PigUtils.createTempPigScript(queries);
@@ -116,7 +115,14 @@ public class PigQueryInterpreter extends BasePigInterpreter {
           resultBuilder.append("\n");
           firstRow = false;
         }
-        resultBuilder.append(StringUtils.join(tuple.iterator(), "\t"));
+        Iterator<Object> fieldsIter = tuple.iterator();
+        while (fieldsIter.hasNext()) {
+          Object field = fieldsIter.next();
+          resultBuilder.append(replaceReservedChars(field.toString()));
+          if (fieldsIter.hasNext()) {
+            resultBuilder.append("\t");
+          }
+        }
         resultBuilder.append("\n");
       }
       if (index >= maxResult && iter.hasNext()) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.spark;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
@@ -153,7 +154,7 @@ public class SparkZeppelinContext extends BaseZeppelinContext {
 
         for (int i = 0; i < columns.size(); i++) {
           if (!(Boolean) isNullAt.invoke(row, i)) {
-            msg.append(apply.invoke(row, i).toString());
+            msg.append(replaceReservedChars(apply.invoke(row, i).toString()));
           } else {
             msg.append("null");
           }
@@ -276,5 +277,19 @@ public class SparkZeppelinContext extends BaseZeppelinContext {
       }
     };
     angularWatch(name, noteId, w);
+  }
+
+  /**
+   * Zeppelin's %TABLE convention uses tab (\t) to delimit fields and new-line (\n) to delimit rows
+   * To complain with this convention we need to replace any occurrences of tab and/or newline
+   * characters in the content.
+   */
+  private String replaceReservedChars(String str) {
+
+    if (StringUtils.isBlank(str)) {
+      return str;
+    }
+
+    return str.replace("\t", " ").replace("\n", " ");
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -51,6 +51,12 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Interpreter {
 
+  protected static final char NEWLINE = '\n';
+  protected static final char TAB = '\t';
+  protected static final char WHITESPACE = ' ';
+
+  protected static final String TABLE_MAGIC_TAG = "%table ";
+
   /**
    * Opens interpreter. You may want to place your initialize routine here.
    * open() is called only once
@@ -500,5 +506,19 @@ public abstract class Interpreter {
       }
     }
     return null;
+  }
+
+  /**
+   * Zeppelin's %TABLE convention uses tab (\t) to delimit fields and new-line (\n) to delimit rows
+   * To complain with this convention we need to replace any occurrences of tab and/or newline
+   * characters in the content.
+   */
+  protected String replaceReservedChars(String str) {
+
+    if (str == null || str.equals("")) {
+      return "";
+    }
+
+    return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
   }
 }


### PR DESCRIPTION
### What is this PR for?

The presence of the characters `\t` and `'n` in the data to be displayed can cause the failure of successfully displaying a table. Indeed, these two characters are used as separators in a table. Some interpreters, don't escape the data to be shown.
This PR address the issue replacing the characters as previosly done for some of the interpreters like geode.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-771

### How should this be tested?
added UTs

### Screenshots (if appropriate)

I am not uploading the screenshot since I think it is not necessary to understand the issue and the PR.
