### PR TITLE
[ZEPPELIN-3049] Add the notebook id and user name to the paragraph running log

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -378,7 +378,8 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
 
   @Override
   protected Object jobRun() throws Throwable {
-    logger.info("Run paragraph {} using {} ", getId(), intpText);
+    logger.info("Run paragraph [paragraph_id: {}, interpreter: {}, note_id: {}, user: {}]",
+            getId(), intpText, note.getId(), authenticationInfo.getUser());
     this.interpreter = getBindedInterpreter();
     if (this.interpreter == null) {
       logger.error("Can not find interpreter name " + intpText);


### PR DESCRIPTION
### What is this PR for?
Add the notebook id and user name to the paragraph running log so that Zeppelin administrators can check who ran which notebook's paragraph.


### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3049

### How should this be tested?
* Tested manually
* I confirmed that the following logs are printed:
    * `INFO [2017-11-14 17:19:36,917] ({pool-2-thread-2} Paragraph.java[jobRun]:381) - Run paragraph [paragraph_id: 20171114-171822_2006383248, interpreter: md, note_id: 2CZQ23DM7, user: user1]`
    * `INFO [2017-11-14 17:50:59,803] ({pool-2-thread-2} Paragraph.java[jobRun]:381) - Run paragraph [paragraph_id: 20171101-170859_1328485804, interpreter: md, note_id: 2CYVGQ2WW, user: anonymous]`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No