### PR TITLE
[ZEPPELIN-3045] Add the option which prevents the cron executing user from being changed to users other than the login user

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -400,6 +400,12 @@
 </property>
 
 <property>
+  <name>zeppelin.notebook.cronExecutingUser.loginUserOnly</name>
+  <value>true</value>
+  <description>Restrict the cron executing user to the login user if this property is set to true. This restriction prevents users from impersonating other users via the cron scheduler intentionally or accidentally.</description>
+</property>
+
+<property>
   <name>zeppelin.websocket.max.text.message.size</name>
   <value>1024000</value>
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -258,6 +258,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Make notebook public (set only <code>owners</code>) by default when created/imported. If set to <code>false</code> will add <code>user</code> to <code>readers</code> and <code>writers</code> as well, making it private and invisible to other users unless permissions are granted.</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_CRON_EXECUTING_USER_LOGIN_USER_ONLY</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.cronExecutingUser.loginUserOnly</h6></td>
+    <td>true</td>
+    <td>Restrict the cron executing user to the login user if this property is set to true. This restriction prevents users from impersonating other users via the cron scheduler intentionally or accidentally.</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_INTERPRETERS</h6></td>
     <td><h6 class="properties">zeppelin.interpreters</h6></td>
   <description></description>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -504,6 +504,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC);
   }
 
+  public boolean isNotebookCronExecutingUserLoginUserOnly() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_CRON_EXECUTING_USER_LOGIN_USER_ONLY);
+  }
+
   public String getConfDir() {
     return getRelativeDir(ConfVars.ZEPPELIN_CONF_DIR);
   }
@@ -678,6 +682,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC("zeppelin.notebook.one.way.sync", false),
     // whether by default note is public or private
     ZEPPELIN_NOTEBOOK_PUBLIC("zeppelin.notebook.public", true),
+    ZEPPELIN_NOTEBOOK_CRON_EXECUTING_USER_LOGIN_USER_ONLY(
+            "zeppelin.notebook.cronExecutingUser.loginUserOnly", true),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner",
         System.getProperty("os.name")
                 .startsWith("Windows") ? "bin/interpreter.cmd" : "bin/interpreter.sh"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -726,8 +726,7 @@ public class NotebookServer extends WebSocketServlet
   }
 
   private void cronExecutingUserUpdatePermissionError(NotebookSocket conn, String op, String user,
-                                                      String cronExecutingUser)
-      throws IOException {
+                                                      String cronExecutingUser) throws IOException {
     LOG.info("Cannot {} due to the cron executing user update permission error. user: {}, " +
                     "submitted cron executing user: {}", op, user, cronExecutingUser);
 
@@ -1059,8 +1058,8 @@ public class NotebookServer extends WebSocketServlet
                                            Map<String, Object> configA,
                                            Map<String, Object> configB) {
     boolean updated = false;
-    if (configA.get(key) != null && configB.get(key) != null && configA.get(key)
-        .equals(configB.get(key))) {
+    if (configA.get(key) != null && configB.get(key) != null &&
+            configA.get(key).equals(configB.get(key))) {
       updated = false;
     } else if (configA.get(key) == null && configB.get(key) == null) {
       updated = false;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -725,6 +725,18 @@ public class NotebookServer extends WebSocketServlet
             .toString())));
   }
 
+  private void cronExecutingUserUpdatePermissionError(NotebookSocket conn, String op, String user,
+                                                      String cronExecutingUser)
+      throws IOException {
+    LOG.info("Cannot {} due to the cron executing user update permission error. user: {}, " +
+                    "submitted cron executing user: {}", op, user, cronExecutingUser);
+
+    conn.send(serializeMessage(new Message(OP.AUTH_INFO).put("info",
+            "Cron executing user cannot be set to users other than the login user.\n\n" +
+                    "user: " + user + ", submitted cron executing user: " +
+                    cronExecutingUser)));
+  }
+
   /**
    * @return false if user doesn't have reader permission for this paragraph
    */
@@ -799,6 +811,48 @@ public class NotebookServer extends WebSocketServlet
     }
 
     return true;
+  }
+
+  /**
+   *
+   * @param isLoginUserOnly
+   * @param curConf
+   * @param newConf
+   * @return true if the cron executing user update permission check is needed.
+   */
+  private boolean isCronExecutingUserUpdatePermissionCheckNeeded(boolean isLoginUserOnly,
+                                                                 Map<String, Object> curConf,
+                                                                 Map<String, Object> newConf) {
+    // Permission check is not needed if the cron executing user is not
+    // restricted to the login user.
+    if (!isLoginUserOnly) {
+      return false;
+    }
+
+    // Permission check is not needed if the cron executing user is not updated.
+    if (!isNoteConfigValueUpdated("cronExecutingUser", curConf, newConf)) {
+      return false;
+    }
+
+    // Permission check is not needed if the cron configuration is cleared.
+    if (StringUtils.isEmpty((String) newConf.get("cron"))
+            && StringUtils.isEmpty((String) newConf.get("cronExecutingUser"))) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * @return false if user doesn't have cron executing user update permission
+   */
+  private boolean hasCronExecutingUserUpdatePermission(String user,
+                                                       String cronExecutingUser) {
+    if (cronExecutingUser == null) {
+      return true;
+    }
+
+    return cronExecutingUser.equals(user);
   }
 
   private void sendNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -879,7 +933,19 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null) {
-      boolean cronUpdated = isCronUpdated(config, note.getConfig());
+      if (isCronExecutingUserUpdatePermissionCheckNeeded(
+              notebook.getConf().isNotebookCronExecutingUserLoginUserOnly(),
+              note.getConfig(),
+              config)) {
+        String cronExecutingUser = (String) config.get("cronExecutingUser");
+        if (!hasCronExecutingUserUpdatePermission(fromMessage.principal, cronExecutingUser)) {
+          cronExecutingUserUpdatePermissionError(conn, "update", fromMessage.principal,
+                  cronExecutingUser);
+          return;
+        }
+      }
+
+      boolean cronUpdated = isNoteConfigValueUpdated("cron", config, note.getConfig());
       note.setName(name);
       note.setConfig(config);
       if (cronUpdated) {
@@ -989,18 +1055,20 @@ public class NotebookServer extends WebSocketServlet
     }
   }
 
-  private boolean isCronUpdated(Map<String, Object> configA, Map<String, Object> configB) {
-    boolean cronUpdated = false;
-    if (configA.get("cron") != null && configB.get("cron") != null && configA.get("cron")
-        .equals(configB.get("cron"))) {
-      cronUpdated = true;
-    } else if (configA.get("cron") == null && configB.get("cron") == null) {
-      cronUpdated = false;
-    } else if (configA.get("cron") != null || configB.get("cron") != null) {
-      cronUpdated = true;
+  private boolean isNoteConfigValueUpdated(String key,
+                                           Map<String, Object> configA,
+                                           Map<String, Object> configB) {
+    boolean updated = false;
+    if (configA.get(key) != null && configB.get(key) != null && configA.get(key)
+        .equals(configB.get(key))) {
+      updated = false;
+    } else if (configA.get(key) == null && configB.get(key) == null) {
+      updated = false;
+    } else if (configA.get(key) != null || configB.get(key) != null) {
+      updated = true;
     }
 
-    return cronUpdated;
+    return updated;
   }
 
   private void createNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -417,27 +417,6 @@ public class NotebookServerTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void testHasCronExecutingUserUpdatePermission()
-          throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Method method = NotebookServer.class.getDeclaredMethod("hasCronExecutingUserUpdatePermission",
-            String.class, String.class);
-    method.setAccessible(true);
-
-    final NotebookServer server = new NotebookServer();
-
-    assertTrue((boolean) method.invoke(server, null, null));
-    assertFalse((boolean) method.invoke(server, null, ""));
-    assertFalse((boolean) method.invoke(server, null, "user1"));
-    assertTrue((boolean) method.invoke(server, "", null));
-    assertTrue((boolean) method.invoke(server, "", ""));
-    assertFalse((boolean) method.invoke(server, "", "user1"));
-    assertTrue((boolean) method.invoke(server, "user1", null));
-    assertFalse((boolean) method.invoke(server, "user1", ""));
-    assertTrue((boolean) method.invoke(server, "user1", "user1"));
-    assertFalse((boolean) method.invoke(server, "user1", "user2"));
-  }
-
-  @Test
   public void testIsCronExecutingUserUpdatePermissionCheckNeeded()
           throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
      Method method = NotebookServer.class.getDeclaredMethod(


### PR DESCRIPTION
### What is this PR for?
Add the option to Zeppelin, that prevents the cron executing user from being changed to users other than the login user.

Now, the cron executing user can be set to any users. That could cause a security issue when the Hadoop cluster has data access control (managed by Apache Ranger and so forth) because Zeppelin users can access the data which they ordinary cannot access by setting other users as the cron executing user.

Thus, under the circumstances strict data access control is required, it is necessary to add the option to Zeppelin, that prevents the cron executing user from being changed to users other than the login user.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3045

### How should this be tested?
* Tested manually
    * I confirmed that when `zeppelin.notebook.cronExecutingUser.loginUserOnly` was true and "Cron executing user" was changed to users other than the login user, the "Insufficient privileges" dialog was shown and "Cron executing user" was not updated.
    * <img width="1229" alt="screen shot 2017-11-15 at 22 15 29" src="https://user-images.githubusercontent.com/31149688/32838348-f1cbdfc4-ca53-11e7-9ed5-8362cba10d25.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. `docs/setup/operation/configuration.md` was updated.
