### PR TITLE
[ZEPPELIN-3054] Update conf/shiro.ini.template so that non-admin users can restart interpreters on a notebook page

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -96,6 +96,9 @@ admin = *
 # uncomment the line second last line (/** = anon) and comment the last line (/** = authc)
 #
 /api/version = anon
+# Allow all authenticated users to restart interpreters on a notebook page.
+# Comment out the following line if you would like to authorize only admin users to restart interpreters.
+/api/interpreter/setting/restart/** = authc
 /api/interpreter/** = authc, roles[admin]
 /api/configurations/** = authc, roles[admin]
 /api/credential/** = authc, roles[admin]


### PR DESCRIPTION
### What is this PR for?
On the default configuration of `conf/shiro.ini.template`, non admin users cannot restart interpreters on their notebook pages because the path `/api/interpreter/setting/restart/**` is not allowed to being accessed by non admin users.

<img width="1741" alt="screen shot 2017-11-16 at 14 07 05" src="https://user-images.githubusercontent.com/31149688/32875326-b0d1bf66-cada-11e7-98b7-6fd058cff3f6.png">

It is convenient that all authenticated users can restart interpreters on their notebook pages by default, so the following line should be inserted into conf/shiro.ini.template:

```
/api/interpreter/setting/restart/** = authc
```

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3054

### How should this be tested?
* Tested manually. I confirmed that non admin users can restart interpreters on a notebook page but still cannot access to the interpreter settings page by using `conf/shiro.ini.template`.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.