### PR TITLE
Add missing build dependencies.

### DIFF
--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -254,6 +254,8 @@ sudo apt-get install git
 sudo apt-get install openjdk-7-jdk
 sudo apt-get install npm
 sudo apt-get install libfontconfig
+sudo apt-get install r-base-dev
+sudo apt-get install r-cran-evaluate
 ```
 
 


### PR DESCRIPTION
Add `apt-get install` lines for R dependencies that are needed to build
successfully.

### What is this PR for?
This pull request adds installation instructions for building which relate to missing dependencies resulting in failing to build (if using R).

### What type of PR is it?
[Documentation]
