### PR TITLE
[ZEPPELIN-3060] Unable to use interpreter names with special characters (e.g. dash or underscore)

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.notebook;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -26,12 +27,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.security.SecureRandom;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.common.JsonSerializable;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -74,7 +73,8 @@ import com.google.common.collect.Maps;
 public class Paragraph extends Job implements Cloneable, JsonSerializable {
 
   private static Logger logger = LoggerFactory.getLogger(Paragraph.class);
-  private static Pattern REPL_PATTERN = Pattern.compile("(\\s*)%([\\w\\.]+).*", Pattern.DOTALL);
+  private static Pattern REPL_PATTERN = Pattern
+      .compile("(\\s*)%([^\\s\\(]+).*", Pattern.DOTALL);
 
   private transient InterpreterFactory interpreterFactory;
   private transient Interpreter interpreter;
@@ -801,6 +801,7 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
     return result1;
   }
 
+  @Override
   public String toJson() {
     return Note.getGson().toJson(this);
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -21,7 +21,6 @@ package org.apache.zeppelin.notebook;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -30,32 +29,35 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
-
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.Input;
-import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.interpreter.AbstractInterpreterTest;
+import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.FormType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSetting.Status;
+import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.mockito.Mockito;
+
+import com.google.common.collect.Lists;
 
 public class ParagraphTest extends AbstractInterpreterTest {
 
@@ -70,6 +72,10 @@ public class ParagraphTest extends AbstractInterpreterTest {
     paragraph.setText("%test 1234567");
     assertEquals("test", paragraph.getIntpText());
     assertEquals("1234567", paragraph.getScriptText());
+    
+    paragraph.setText("%t-e_st 1234567");
+    assertEquals("t-e_st", paragraph.getIntpText());
+    assertEquals("1234567", paragraph.getScriptText());    
   }
 
   @Test


### PR DESCRIPTION
[ZEPPELIN-3060] Unable to use interpreter names with special characters
(e.g. dash or underscore)

### What is this PR for?
This fixes a regression which was introduced with ZEPPELIN-3013. There
is no restriction regarding characters when creating new interpreters.
But when running a note the interpreter name was parsed using the regex
%([\w\.]+).*, which only considered the word character class and dots.
Interpreter names with special characters (e.g. _ or -) were not matched
correctly. This change enables usage of interpreter names that use other
characters by changing the regex group to %([^\s\(]+).*, which means:
parse the interpreter name from % until any whitespace or open
parenthesis.

### What type of PR is it?
Bug Fix

### Todos
-

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3060

### How should this be tested?
Create an interpreter with a name containing one or more special
characters, e.g. dash or underscore. Try running that interpreter.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no 
* Is there breaking changes for older versions? no
* Does this needs documentation? no