### PR TITLE
[ZEPPELIN-3048] Add the option which prevents paragraphs from being edited while their notebook is cron scheduled

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -406,6 +406,18 @@
 </property>
 
 <property>
+  <name>zeppelin.notebook.cron.restrictEdit</name>
+  <value>false</value>
+  <description>Restrict editable interpreters of cron scheduled notebooks' paragraphs. The cron executing user still can edit all paragraphs of the notebook even if this property is set to true.</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.cron.editableInterpreters</name>
+  <value></value>
+  <description>Editable interpreters of cron scheduled notebooks' paragraphs. This property is in effect when zeppelin.notebook.cron.restrictEdit is set to true. This property value should be a fully qualified class name such as "org.apache.zeppelin.angular.AngularInterpreter". Comma separated value such as "org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.markdown.Markdown" is acceptable.</description>
+</property>
+
+<property>
   <name>zeppelin.websocket.max.text.message.size</name>
   <value>1024000</value>
   <description>Size in characters of the maximum text message to be received by websocket. Defaults to 1024000</description>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -258,6 +258,18 @@ If both are defined, then the **environment variables** will take priority.
     <td>Make notebook public (set only <code>owners</code>) by default when created/imported. If set to <code>false</code> will add <code>user</code> to <code>readers</code> and <code>writers</code> as well, making it private and invisible to other users unless permissions are granted.</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_CRON_RESTRICT_EDIT</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.cron.restrictEdit</h6></td>
+    <td>false</td>
+    <td>Restrict editable interpreters of cron scheduled notebooks' paragraphs. The cron executing user still can edit all paragraphs of the notebook even if this property is set to true.</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_CRON_EDITABLE_INTERPRETERS</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.cron.editableInterpreters</h6></td>
+    <td>true</td>
+    <td>Editable interpreters of cron scheduled notebooks' paragraphs. This property is in effect when zeppelin.notebook.cron.restrictEdit is set to true. This property value should be a fully qualified class name such as "org.apache.zeppelin.angular.AngularInterpreter". Comma separated value such as "org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.markdown.Markdown" is acceptable.</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_INTERPRETERS</h6></td>
     <td><h6 class="properties">zeppelin.interpreters</h6></td>
   <description></description>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -504,6 +504,20 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC);
   }
 
+  public boolean isNotebookCronRestrictEdit() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_CRON_RESTRICT_EDIT);
+  }
+
+  public boolean isNotebookCronEditableInterpreter(String interpreter) {
+    String editableInterpreters = getString(ConfVars.ZEPPELIN_NOTEBOOK_CRON_EDITABLE_INTERPRETERS);
+    for (String editableInterpreter : editableInterpreters.split(",")) {
+      if (editableInterpreter.equals(interpreter)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public String getConfDir() {
     return getRelativeDir(ConfVars.ZEPPELIN_CONF_DIR);
   }
@@ -678,6 +692,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC("zeppelin.notebook.one.way.sync", false),
     // whether by default note is public or private
     ZEPPELIN_NOTEBOOK_PUBLIC("zeppelin.notebook.public", true),
+    ZEPPELIN_NOTEBOOK_CRON_RESTRICT_EDIT("zeppelin.notebook.cron.restrictEdit", false),
+    ZEPPELIN_NOTEBOOK_CRON_EDITABLE_INTERPRETERS("zeppelin.notebook.cron.editableInterpreters", ""),
     ZEPPELIN_INTERPRETER_REMOTE_RUNNER("zeppelin.interpreter.remoterunner",
         System.getProperty("os.name")
                 .startsWith("Windows") ? "bin/interpreter.cmd" : "bin/interpreter.sh"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -725,6 +725,18 @@ public class NotebookServer extends WebSocketServlet
             .toString())));
   }
 
+  void cronParagraphUpdatePermissionError(NotebookSocket conn, String cronExecutingUser,
+                                          String user, String interpreter) throws IOException {
+    LOG.info("Cannot update the cron scheduled notebook's paragraph " +
+            "[cron executing user: {}, user: {}, interpreter: {}]",
+            cronExecutingUser, user, interpreter);
+
+    conn.send(serializeMessage(new Message(OP.AUTH_INFO).put("info",
+            "Cron scheduled notebook's paragraphs cannot be updated by users other than " +
+                    "the cron executing user.\n\ncron executing user: " + cronExecutingUser +
+                    ", user: " + user)));
+  }
+
   /**
    * @return false if user doesn't have reader permission for this paragraph
    */
@@ -799,6 +811,67 @@ public class NotebookServer extends WebSocketServlet
     }
 
     return true;
+  }
+
+  /**
+   *
+   * @param notebook
+   * @param note
+   * @param paragraphId
+   * @param fromMessage
+   * @param conn
+   * @return true if user has update permission for the cron scheduled notebook's paragraph
+   */
+  private boolean hasCronParagraphUpdatePermission(Notebook notebook, Note note,
+                                                   String paragraphId, Message fromMessage,
+                                                   NotebookSocket conn) throws IOException {
+    ZeppelinConfiguration conf = notebook.getConf();
+    String cronExecutingUser = note.getCronExecutingUser();
+    String user = fromMessage.principal;
+    String interpreter = extractInterpreter(user, note, paragraphId, fromMessage);
+
+    if (hasCronParagraphUpdatePermission(conf.isNotebookCronRestrictEdit(),
+            conf.isNotebookCronEditableInterpreter(interpreter),
+            cronExecutingUser, user)) {
+      return true;
+    }
+
+    cronParagraphUpdatePermissionError(conn, cronExecutingUser, user, interpreter);
+    return false;
+  }
+
+  /**
+   *
+   * @param isNotebookCronRestrictEdit
+   * @param isNotebookCronEditableInterpreter
+   * @param cronExecutingUser
+   * @param user
+   * @return true if user has update permission for the cron scheduled notebook's paragraph
+   */
+  private boolean hasCronParagraphUpdatePermission(boolean isNotebookCronRestrictEdit,
+                                                   boolean isNotebookCronEditableInterpreter,
+                                                   String cronExecutingUser,
+                                                   String user) {
+    if (!isNotebookCronRestrictEdit) {
+      return true;
+    }
+
+    if (isNotebookCronEditableInterpreter) {
+      return true;
+    }
+
+    return cronExecutingUser.equals(user);
+  }
+
+  private String extractInterpreter(String user, Note note, String paragraphId,
+                                    Message fromMessage) {
+    Paragraph p = note.getParagraph(paragraphId);
+    if (note.isPersonalizedMode()) {
+      p = p.getUserParagraph(user);
+    }
+    Matcher matcher = Paragraph.REPL_PATTERN.matcher((String) fromMessage.get("paragraph"));
+    String intpText = matcher.matches() ? matcher.group(2) : "";
+    return p.getBindedInterpreter(intpText).getClassName();
   }
 
   private void sendNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
@@ -1208,6 +1281,12 @@ public class NotebookServer extends WebSocketServlet
     }
 
     final Note note = notebook.getNote(noteId);
+
+    if (note.isCronSet() &&
+            !hasCronParagraphUpdatePermission(notebook, note, paragraphId, fromMessage, conn)) {
+      return;
+    }
+
     Paragraph p = note.getParagraph(paragraphId);
 
     p.settings.setParams(params);
@@ -1755,9 +1834,17 @@ public class NotebookServer extends WebSocketServlet
       return;
     }
 
+    final Note note = notebook.getNote(noteId);
+
+    if (isParagraphTextChanged(note, paragraphId, fromMessage)) {
+      if (note.isCronSet() &&
+              !hasCronParagraphUpdatePermission(notebook, note, paragraphId, fromMessage, conn)) {
+        return;
+      }
+    }
+
     // 1. clear paragraph only if personalized,
     // otherwise this will be handed in `onOutputClear`
-    final Note note = notebook.getNote(noteId);
     if (note.isPersonalizedMode()) {
       String user = fromMessage.principal;
       Paragraph p = note.clearPersonalizedParagraphOutput(paragraphId, user);
@@ -1774,6 +1861,19 @@ public class NotebookServer extends WebSocketServlet
         text, title, params, config);
 
     persistAndExecuteSingleParagraph(conn, note, p, false);
+  }
+
+  private boolean isParagraphTextChanged(Note note, String paragraphId, Message fromMessage) {
+    Paragraph p = note.getParagraph(paragraphId);
+    if (note.isPersonalizedMode()) {
+      p = p.getUserParagraph(fromMessage.principal);
+    }
+    String curText = p.getText();
+    String submittedText = (String) fromMessage.get("paragraph");
+    if (StringUtils.isEmpty(curText)) {
+      return StringUtils.isNotEmpty(submittedText);
+    }
+    return !curText.equals(submittedText);
   }
 
   private void addNewParagraphIfLastParagraphIsExecuted(Note note, Paragraph p) {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.socket;
 
 import com.google.gson.Gson;
 
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -41,8 +42,11 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
@@ -418,5 +422,17 @@ public class NotebookServerTest extends AbstractTestRestApi {
     return sock;
   }
 
+  @Test
+  public void testHasCronParagraphUpdatePermission() throws IOException, NoSuchMethodException,
+          InvocationTargetException, IllegalAccessException {
+    Method method = NotebookServer.class.getDeclaredMethod("hasCronParagraphUpdatePermission",
+            boolean.class, boolean.class, String.class, String.class);
+    method.setAccessible(true);
+
+    assertTrue((boolean) method.invoke(notebookServer, false, false, "user1", "user2"));
+    assertTrue((boolean) method.invoke(notebookServer, true, true, "user1", "user2"));
+    assertTrue((boolean) method.invoke(notebookServer, true, false, "user1", "user1"));
+    assertFalse((boolean) method.invoke(notebookServer, true, false, "user1", "user2"));
+  }
 }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -581,12 +581,8 @@ public class Note implements ParagraphJobListener, JsonSerializable {
    * Run all paragraphs sequentially.
    */
   public synchronized void runAll() {
-    String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
-    if (null == cronExecutingUser) {
-      cronExecutingUser = "anonymous";
-    }
     AuthenticationInfo authenticationInfo = new AuthenticationInfo();
-    authenticationInfo.setUser(cronExecutingUser);
+    authenticationInfo.setUser(getCronExecutingUser());
     runAll(authenticationInfo, true);
   }
 
@@ -966,5 +962,17 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   @VisibleForTesting
   public static Gson getGson() {
     return gson;
+  }
+
+  public boolean isCronSet() {
+    return StringUtils.isNotEmpty((String) getConfig().get("cron"));
+  }
+
+  public String getCronExecutingUser() {
+    String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
+    if (cronExecutingUser == null) {
+      cronExecutingUser = "anonymous";
+    }
+    return cronExecutingUser;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -74,7 +74,7 @@ import com.google.common.collect.Maps;
 public class Paragraph extends Job implements Cloneable, JsonSerializable {
 
   private static Logger logger = LoggerFactory.getLogger(Paragraph.class);
-  private static Pattern REPL_PATTERN = Pattern.compile("(\\s*)%([\\w\\.]+).*", Pattern.DOTALL);
+  public static Pattern REPL_PATTERN = Pattern.compile("(\\s*)%([\\w\\.]+).*", Pattern.DOTALL);
 
   private transient InterpreterFactory interpreterFactory;
   private transient Interpreter interpreter;
@@ -235,6 +235,10 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
   }
 
   public Interpreter getBindedInterpreter() {
+    return getBindedInterpreter(intpText);
+  }
+
+  public Interpreter getBindedInterpreter(String intpText) {
     return this.interpreterFactory.getInterpreter(user, note.getId(), intpText);
   }
 


### PR DESCRIPTION
### What is this PR for?

Add the option which prevents paragraphs from being edited by users other than the cron executing user while their notebook is cron scheduled.

Now, the cron scheduled notebook's paragraphs can be edited by users who have the "writer" authority. That could cause a security issue when the Hadoop cluster has data access control (managed by Apache Ranger and so forth) because the "writer" users can abuse the access right of the "cron executing user" and can access the data which they ordinary cannot access by updating the paragraphs whose notebook is cron scheduled and its cron executing user is set to other users.

Thus, under the circumstances strict data access control is required, it is necessary to add the option to Zeppelin, that prevents paragraphs from being edited by users other than the cron executing user while their notebook is cron scheduled.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3048

### How should this be tested?
* Tested manually.
    * I confirmed that when `zeppelin.notebook.cron.restrictEdit` was set to `true` and users other than the cron executing user tried to edit the paragraph whose interpreter was not on `zeppelin.notebook.cron.editableInterpreters`,  the "Insufficient privileged" dialog was shown and the paragraph was not updated.
    * <img width="1184" alt="screen shot 2017-11-17 at 12 31 41" src="https://user-images.githubusercontent.com/31149688/32928980-55ea34ca-cb98-11e7-9798-af36f98a99d8.png">


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. `docs/setup/operation/configuration.md` was updated.