### PR TITLE
[ZEPPELIN-3062] Removes ctrl+s default behavior from notebook

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -173,15 +173,23 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
   // register mouseevent handler for focus paragraph
   document.addEventListener('click', $scope.focusParagraphOnClick)
 
-  $scope.keyboardShortcut = function (keyEvent) {
+  let keyboardShortcut = function (keyEvent) {
     // handle keyevent
     if (!$scope.viewOnly && !$scope.revisionView) {
       $scope.$broadcast('keyEvent', keyEvent)
     }
   }
 
+  $scope.keydownEvent = function (keyEvent) {
+    if ((keyEvent.ctrlKey || keyEvent.metaKey) && String.fromCharCode(keyEvent.which).toLowerCase() === 's') {
+      keyEvent.preventDefault()
+    }
+
+    keyboardShortcut(keyEvent)
+  }
+
   // register mouseevent handler for focus paragraph
-  document.addEventListener('keydown', $scope.keyboardShortcut)
+  document.addEventListener('keydown', $scope.keydownEvent)
 
   $scope.paragraphOnDoubleClick = function (paragraphId) {
     $scope.$broadcast('doubleClickParagraph', paragraphId)


### PR DESCRIPTION
### What is this PR for?
As a programmer I habitually press CTRL + S out of fear for my sanity.
Other web text editing tools (google docs, jupyter notebooks) ignore the base functionality of CTRL + S of saving the HTML page, and do nothing instead.
This is a small change that will makes the user experience of Zeppelin notebooks much much better.

### What type of PR is it?
Improvement 

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3062

### How should this be tested?
* I tested manually:
  1. Ran `yarn run dev`
  2. Went to `localhost:9000`
  3. Created a new note, now anytime a user presses 'CTRL+S' in the scope of the note nothing happens, and the user can continue coding uninterrupted.

### Screenshots (if appropriate)

### Questions:
