### PR TITLE
[ZEPPELIN-3063] Notebook loses formatting when importing from 0.6.x

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -447,6 +447,24 @@ public class Notebook implements NoteEventListener {
             }
             config.put("results", results);
           }
+        } else if (ret == null && p.getConfig() != null) {
+          if (p.getConfig().get("graph") != null && p.getConfig().get("graph") instanceof Map
+            && !((Map) p.getConfig().get("graph")).get("mode").equals("table")) {
+            Map<String, Object> config = p.getConfig();
+            Object graph = config.remove("graph");
+            Object apps = config.remove("apps");
+            Object helium = config.remove("helium");
+
+            List<Object> results = new LinkedList<>();
+
+            HashMap<Object, Object> res = new HashMap<>();
+            res.put("graph", graph);
+            res.put("apps", apps);
+            res.put("helium", helium);
+            results.add(res);
+
+            config.put("results", results);
+          }
         }
       } catch (Exception e) {
         logger.error("Conversion failure", e);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -448,6 +448,7 @@ public class Notebook implements NoteEventListener {
             config.put("results", results);
           }
         } else if (ret == null && p.getConfig() != null) {
+          //ZEPPELIN-3063 Notebook loses formatting when importing from 0.6.x
           if (p.getConfig().get("graph") != null && p.getConfig().get("graph") instanceof Map
             && !((Map) p.getConfig().get("graph")).get("mode").equals("table")) {
             Map<String, Object> config = p.getConfig();


### PR DESCRIPTION
### What is this PR for?
Notebook loses formatting (shows table instead of the graph) when importing from 0.6.x if the respective paragraph doesn't have result in it.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3063](https://issues.apache.org/jira/browse/ZEPPELIN-3063)

### Screenshots (if appropriate)
Before:
![before](https://user-images.githubusercontent.com/674497/32978117-8d4d581a-cc61-11e7-8b48-af389f4be90d.gif)

After:
![after](https://user-images.githubusercontent.com/674497/32978119-95ca87c4-cc61-11e7-8276-9e1eab8711ef.gif)

### How should this be tested?
* Try importing [this](https://issues.apache.org/jira/secure/attachment/12898326/oldnotebook-0.6-clear.json) notebook, and then on running this notebook, the second paragraph should display BarChart instead of a table.
