### PR TITLE
[ZEPPELIN-3066] Make the welcome header of the homepage for non login users customizable

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -95,6 +95,7 @@ admin = *
 # To allow anonymous access to all but the stated urls,
 # uncomment the line second last line (/** = anon) and comment the last line (/** = authc)
 #
+/api/configurations/key/zeppelin.homescreen.header = anon
 /api/version = anon
 /api/interpreter/** = authc, roles[admin]
 /api/configurations/** = authc, roles[admin]

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -67,6 +67,11 @@
   <description>hide homescreen notebook from list when this value set to true</description>
 </property>
 
+<property>
+  <name>zeppelin.homescreen.header</name>
+  <value>app/home/header.html</value>
+  <description>Path of the header HTML file which is shown on the top of the default homescreen</description>
+</property>
 
 <!-- Amazon S3 notebook storage -->
 <!-- Creates the following directory structure: s3://{bucket}/{username}/{notebook-id}/note.json -->

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -168,6 +168,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Hide the note ID set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Apache Zeppelin homescreen. <br />For the further information, please read <a href="../usage/other_features/customizing_homepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_HOMESCREEN_HEADER</h6></td>
+    <td><h6 class="properties">zeppelin.homescreen.header</h6></td>
+    <td>app/home/header.html</td>
+    <td>Path of the header HTML file which is shown on the top of the default homescreen</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_WAR_TEMPDIR</h6></td>
     <td><h6 class="properties">zeppelin.war.tempdir</h6></td>
     <td>webapps</td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -574,6 +574,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return configurations;
   }
 
+  public String getHomescreenHeader() {
+    return getString(ConfVars.ZEPPELIN_HOMESCREEN_HEADER);
+  }
+
   /**
    * Predication whether key/value pair should be included or not
    */
@@ -658,6 +662,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_HOMESCREEN("zeppelin.notebook.homescreen", null),
     // whether homescreen notebook will be hidden from notebook list or not
     ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE("zeppelin.notebook.homescreen.hide", false),
+    ZEPPELIN_HOMESCREEN_HEADER("zeppelin.homescreen.header", "app/home/header.html"),
     ZEPPELIN_NOTEBOOK_S3_BUCKET("zeppelin.notebook.s3.bucket", "zeppelin"),
     ZEPPELIN_NOTEBOOK_S3_ENDPOINT("zeppelin.notebook.s3.endpoint", "s3.amazonaws.com"),
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
@@ -90,4 +90,26 @@ public class ConfigurationsRestApi {
     return new JsonResponse(Status.OK, "", configurations).build();
   }
 
+  @GET
+  @Path("key/{key}")
+  @ZeppelinApi
+  public Response getByKey(@PathParam("key") final String keyParam) {
+    ZeppelinConfiguration conf = notebook.getConf();
+
+    Map<String, String> configurations = conf.dumpConfigurations(conf,
+        new ZeppelinConfiguration.ConfigurationKeyPredicate() {
+        @Override
+        public boolean apply(String key) {
+          return !key.contains("password") &&
+              !key.equals(ZeppelinConfiguration
+                  .ConfVars
+                  .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING
+                  .getVarName()) &&
+              key.equals(keyParam);
+        }
+      }
+    );
+
+    return new JsonResponse(Status.OK, "", configurations).build();
+  }
 }

--- a/zeppelin-web/src/app/home/header.html
+++ b/zeppelin-web/src/app/home/header.html
@@ -1,0 +1,18 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<h1 class="box-heading" id="welcome">
+  Welcome to Zeppelin!
+</h1>
+Zeppelin is web-based notebook that enables interactive data analytics.<br/>
+You can make beautiful data-driven, interactive, collaborative document with SQL, code and even more!<br/>

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -15,7 +15,7 @@
 angular.module('zeppelinWebApp').controller('HomeCtrl', HomeCtrl)
 
 function HomeCtrl ($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOrderingSrv,
-                  ngToast, noteActionService, TRASH_FOLDER_ID) {
+                  ngToast, noteActionService, TRASH_FOLDER_ID, $http, baseUrlSrv) {
   'ngInject'
 
   ngToast.dismiss()
@@ -40,6 +40,20 @@ function HomeCtrl ($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOr
   $scope.initHome = function () {
     websocketMsgSrv.getHomeNote()
     vm.noteCustomHome = false
+    $scope.setHeader()
+  }
+
+  $scope.setHeader = function() {
+    $http.get(baseUrlSrv.getRestApiBase() + '/configurations/key/zeppelin.homescreen.header').success(
+      function (data, status, headers, config) {
+        $scope.header = data.body['zeppelin.homescreen.header']
+      }
+    ).error(
+      function (data, status, headers, config) {
+        $scope.header = 'app/home/header.html'
+        console.log('Error %o %o', status, data.message)
+      }
+    )
   }
 
   $scope.reloadNoteList = function () {

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -17,12 +17,7 @@ limitations under the License.
       <div class="zeppelin2"></div>
     </div>
     <div style="margin-top: -380px;">
-      <h1 class="box-heading" id="welcome">
-        Welcome to Zeppelin!
-      </h1>
-      Zeppelin is web-based notebook that enables interactive data analytics.<br/>
-      You can make beautiful data-driven, interactive, collaborative document with SQL, code and even more!<br/>
-
+      <div ng-include="header"></div>
       <div class="row">
         <div class="col-md-4" ng-if="ticket">
           <h4>Notebook


### PR DESCRIPTION
### What is this PR for?
Make the welcome header of the homepage for non login users customizable.

In our company's use case, we would like to customize the contents of the welcome header of the homepage for non login users so that we can introduce how to create an LDAP account to login Zeppelin to them.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3066


### How should this be tested?
* Tested manually.
    * I confirmed that the content of the HTML file whose path was set by `zeppelin.homescreen.header` was shown on the top of the home screen page.
        * <img width="986" alt="screen shot 2017-11-20 at 18 13 33" src="https://user-images.githubusercontent.com/31149688/33010922-953cec1a-ce1f-11e7-9aad-b7f953736036.png">
    * I also confirmed that if `zeppelin.homescreen.header` was not set, the default contents (`app/home/header.html`) was shown.
        * <img width="984" alt="screen shot 2017-11-20 at 18 14 30" src="https://user-images.githubusercontent.com/31149688/33010954-b59f5b64-ce1f-11e7-9b1b-481ee9ba207f.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. `docs/setup/operation/configuration.md` was updated.
