### PR TITLE
[ZEPPELIN-2995] "auto-restart interpreter on cron execution" should restart interpreter to specific note, not all interpreters

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -882,10 +882,14 @@ public class Notebook implements NoteEventListener {
       }
 
       boolean releaseResource = false;
+      String cronExecutingUser = null;
       try {
         Map<String, Object> config = note.getConfig();
-        if (config != null && config.containsKey("releaseresource")) {
-          releaseResource = (boolean) note.getConfig().get("releaseresource");
+        if (config != null) {
+          if (config.containsKey("releaseresource")) {
+            releaseResource = (boolean) config.get("releaseresource");
+          }
+          cronExecutingUser = (String) config.get("cronExecutingUser");
         }
       } catch (ClassCastException e) {
         logger.error(e.getMessage(), e);
@@ -894,7 +898,8 @@ public class Notebook implements NoteEventListener {
         for (InterpreterSetting setting : notebook.getInterpreterSettingManager()
             .getInterpreterSettings(note.getId())) {
           try {
-            notebook.getInterpreterSettingManager().restart(setting.getId());
+            notebook.getInterpreterSettingManager().restart(setting.getId(), noteId,
+                    cronExecutingUser != null ? cronExecutingUser : "anonymous");
           } catch (InterpreterException e) {
             logger.error("Fail to restart interpreter: " + setting.getId(), e);
           }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -451,6 +451,88 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
   }
 
   @Test
+  public void testCronWithReleaseResourceClosesOnlySpecificInterpreters()
+          throws IOException, InterruptedException {
+    // create a cron scheduled note.
+    Note cronNote = notebook.createNote(anonymous);
+    interpreterSettingManager.setInterpreterBinding(anonymous.getUser(), cronNote.getId(),
+            Arrays.asList(interpreterSettingManager.getInterpreterSettingByName("mock1").getId()));
+    cronNote.setConfig(new HashMap() {
+      {
+        put("cron", "1/5 * * * * ?");
+        put("cronExecutingUser", anonymous.getUser());
+        put("releaseresource", true);
+      }
+    });
+    RemoteInterpreter cronNoteInterpreter =
+            (RemoteInterpreter) interpreterFactory.getInterpreter(anonymous.getUser(),
+                    cronNote.getId(), "mock1");
+
+    // create a paragraph of the cron scheduled note.
+    Paragraph cronNoteParagraph = cronNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    cronNoteParagraph.setConfig(new HashMap() {
+      { put("enabled", true); }
+    });
+    cronNoteParagraph.setText("%mock1 sleep 1000");
+
+    // create another note
+    Note anotherNote = notebook.createNote(anonymous);
+    interpreterSettingManager.setInterpreterBinding(anonymous.getUser(), anotherNote.getId(),
+            Arrays.asList(interpreterSettingManager.getInterpreterSettingByName("mock2").getId()));
+    RemoteInterpreter anotherNoteInterpreter =
+            (RemoteInterpreter) interpreterFactory.getInterpreter(anonymous.getUser(),
+                    anotherNote.getId(), "mock2");
+
+    // create a paragraph of another note
+    Paragraph anotherNoteParagraph = anotherNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    anotherNoteParagraph.setConfig(new HashMap() {
+      { put("enabled", true); }
+    });
+    anotherNoteParagraph.setText("%mock2 echo 1");
+
+    // run the paragraph of another note
+    anotherNote.run(anotherNoteParagraph.getId());
+
+    // wait until anotherNoteInterpreter is opened
+    while (!anotherNoteInterpreter.isOpened()) {
+      Thread.yield();
+    }
+
+    // refresh the cron schedule
+    notebook.refreshCron(cronNote.getId());
+
+    // wait until cronNoteInterpreter is opened
+    while (!cronNoteInterpreter.isOpened()) {
+      Thread.yield();
+    }
+
+    // wait until cronNoteInterpreter is closed
+    while (cronNoteInterpreter.isOpened()) {
+      Thread.yield();
+    }
+
+    // wait for a few seconds
+    Thread.sleep(5 * 1000);
+
+    // test that anotherNoteInterpreter is still opened
+    assertTrue(anotherNoteInterpreter.isOpened());
+
+    // remove cron scheduler
+    cronNote.setConfig(new HashMap() {
+      {
+        put("cron", null);
+        put("cronExecutingUser", null);
+        put("releaseresource", null);
+      }
+    });
+    notebook.refreshCron(cronNote.getId());
+
+    // remove notebooks
+    notebook.removeNote(cronNote.getId(), anonymous);
+    notebook.removeNote(anotherNote.getId(), anonymous);
+  }
+
+  @Test
   public void testExportAndImportNote() throws IOException, CloneNotSupportedException,
           InterruptedException, InterpreterException, SchedulerException, RepositoryException {
     Note note = notebook.createNote(anonymous);


### PR DESCRIPTION
### What is this PR for?
Make "auto-restart interpreter on cron execution" restart the interpreters which are specific to the note, not all interpreters.
This issue was reported by https://github.com/apache/zeppelin/pull/1302#issuecomment-336521420.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2995

### How should this be tested?
* Tested Manually.
   * I confirmed that the "auto-restart interpreter on cron execution" feature restarted only the interpreters which were specific to the notebook.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.