### PR TITLE
[ZEPPELIN-3066] Make the welcome header of the homepage for non login users customizable

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -67,6 +67,11 @@
   <description>hide homescreen notebook from list when this value set to true</description>
 </property>
 
+<property>
+  <name>zeppelin.homescreen.header</name>
+  <value>app/home/header.html</value>
+  <description>Path of the header HTML file which is shown on the top of the default homescreen</description>
+</property>
 
 <!-- Amazon S3 notebook storage -->
 <!-- Creates the following directory structure: s3://{bucket}/{username}/{notebook-id}/note.json -->

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -168,6 +168,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>Hide the note ID set by <code>ZEPPELIN_NOTEBOOK_HOMESCREEN</code> on the Apache Zeppelin homescreen. <br />For the further information, please read <a href="../usage/other_features/customizing_homepage.html">Customize your Zeppelin homepage</a>.</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_HOMESCREEN_HEADER</h6></td>
+    <td><h6 class="properties">zeppelin.homescreen.header</h6></td>
+    <td>app/home/header.html</td>
+    <td>Path of the header HTML file which is shown on the top of the default homescreen</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_WAR_TEMPDIR</h6></td>
     <td><h6 class="properties">zeppelin.war.tempdir</h6></td>
     <td>webapps</td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -574,6 +574,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return configurations;
   }
 
+  public String getHomescreenHeader() {
+    return getString(ConfVars.ZEPPELIN_HOMESCREEN_HEADER);
+  }
+
   /**
    * Predication whether key/value pair should be included or not
    */
@@ -658,6 +662,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_HOMESCREEN("zeppelin.notebook.homescreen", null),
     // whether homescreen notebook will be hidden from notebook list or not
     ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE("zeppelin.notebook.homescreen.hide", false),
+    ZEPPELIN_HOMESCREEN_HEADER("zeppelin.homescreen.header", "app/home/header.html"),
     ZEPPELIN_NOTEBOOK_S3_BUCKET("zeppelin.notebook.s3.bucket", "zeppelin"),
     ZEPPELIN_NOTEBOOK_S3_ENDPOINT("zeppelin.notebook.s3.endpoint", "s3.amazonaws.com"),
     ZEPPELIN_NOTEBOOK_S3_USER("zeppelin.notebook.s3.user", "user"),

--- a/zeppelin-web/src/app/home/header.html
+++ b/zeppelin-web/src/app/home/header.html
@@ -1,0 +1,16 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<h1 class="box-heading" id="welcome">
+  Welcome to Zeppelin!
+</h1>
+Zeppelin is web-based notebook that enables interactive data analytics.<br/>
+You can make beautiful data-driven, interactive, collaborative document with SQL, code and even more!<br/>

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -39,6 +39,7 @@ function HomeCtrl ($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOr
 
   $scope.initHome = function () {
     websocketMsgSrv.getHomeNote()
+    websocketMsgSrv.getHomescreenHeader()
     vm.noteCustomHome = false
   }
 
@@ -83,6 +84,10 @@ function HomeCtrl ($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOr
       vm.staticHome = true
       vm.notebookHome = false
     }
+  })
+
+  $scope.$on('setHomescreenHeader', function (event, header) {
+    $scope.header = header
   })
 
   $scope.renameNote = function (nodeId, nodePath) {

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -17,12 +17,7 @@ limitations under the License.
       <div class="zeppelin2"></div>
     </div>
     <div style="margin-top: -380px;">
-      <h1 class="box-heading" id="welcome">
-        Welcome to Zeppelin!
-      </h1>
-      Zeppelin is web-based notebook that enables interactive data analytics.<br/>
-      You can make beautiful data-driven, interactive, collaborative document with SQL, code and even more!<br/>
-
+      <div ng-include="header"></div>
       <div class="row">
         <div class="col-md-4" ng-if="ticket">
           <h4>Notebook

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -177,6 +177,8 @@ function WebsocketEventFactory ($rootScope, $websocket, $location, baseUrlSrv) {
       $rootScope.$broadcast('setNoteRevisionResult', data)
     } else if (op === 'PARAS_INFO') {
       $rootScope.$broadcast('updateParaInfos', data)
+    } else if (op === 'HOMESCREEN_HEADER') {
+      $rootScope.$broadcast('setHomescreenHeader', data.homescreen_header)
     } else {
       console.error(`unknown websocket op: ${op}`)
     }

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -23,6 +23,10 @@ function WebsocketMessageService ($rootScope, websocketEvents) {
       websocketEvents.sendNewEvent({op: 'GET_HOME_NOTE'})
     },
 
+    getHomescreenHeader: function () {
+      websocketEvents.sendNewEvent({op: 'GET_HOMESCREEN_HEADER'})
+    },
+
     createNotebook: function (noteName, defaultInterpreterId) {
       websocketEvents.sendNewEvent({
         op: 'NEW_NOTE',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -185,7 +185,13 @@ public class Message implements JsonSerializable {
     RUN_PARAGRAPH_USING_SPELL,    // [s-c] run paragraph using spell
     PARAS_INFO,                   // [s-c] paragraph runtime infos
     SAVE_NOTE_FORMS,              // save note forms
-    REMOVE_NOTE_FORMS             // remove note forms
+    REMOVE_NOTE_FORMS,            // remove note forms
+    GET_HOMESCREEN_HEADER,        // [c-s] get homescreen header
+    HOMESCREEN_HEADER;            // [s-c] homescreen header
+
+    public boolean isAnonymousAllowed() {
+      return this == GET_HOMESCREEN_HEADER;
+    }
   }
 
   private static final Gson gson = new Gson();


### PR DESCRIPTION
### What is this PR for?
Make the welcome header of the homepage for non login users customizable.

In our company's use case, we would like to customize the contents of the welcome header of the homepage for non login users so that we can introduce how to create an LDAP account to login Zeppelin to them.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3066


### How should this be tested?
* Tested manually.
    * I confirmed that the content of the HTML file whose path was set by `zeppelin.homescreen.header` was shown on the top of the home screen page.
        * <img width="986" alt="screen shot 2017-11-20 at 18 13 33" src="https://user-images.githubusercontent.com/31149688/33010922-953cec1a-ce1f-11e7-9aad-b7f953736036.png">
        * <img width="1073" alt="screen shot 2017-11-23 at 16 29 44" src="https://user-images.githubusercontent.com/31149688/33162237-beacbed8-d06b-11e7-8b9a-d1335d347d3b.png">
    * I also confirmed that if `zeppelin.homescreen.header` was not set, the default contents (`app/home/header.html`) was shown.
        * <img width="984" alt="screen shot 2017-11-20 at 18 14 30" src="https://user-images.githubusercontent.com/31149688/33010954-b59f5b64-ce1f-11e7-9b1b-481ee9ba207f.png">
        * <img width="1069" alt="screen shot 2017-11-23 at 16 30 45" src="https://user-images.githubusercontent.com/31149688/33162241-d590e69c-d06b-11e7-8bcf-109e073271ef.png">

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. `docs/setup/operation/configuration.md` was updated.
