### PR TITLE
[ZEPPELIN-3076]Chart field is also draggable and sortable in the 'keys', 'groups' and 'values'

### DIFF
--- a/zeppelin-web/src/app/tabledata/pivot_settings.html
+++ b/zeppelin-web/src/app/tabledata/pivot_settings.html
@@ -49,7 +49,11 @@ limitations under the License.
             data-drop="true" jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
             style="border-radius: 6px; margin-top: 7px;">
-          <li ng-repeat="item in config.keys">
+          <li ng-repeat="item in config.keys track by $index"
+              ng-model="config.keys"
+              data-drag="true"
+              jqyoui-draggable="{index: {{$index}}, animate: false}"
+              data-jqyoui-options="{revert: 'invalid', placeholder: 'keep', helper: 'clone'}">
             <div class="btn btn-default btn-xs"
                  style="background-color: #EFEFEF; margin: 2px 0px 0px 2px;">
               {{item.name}}
@@ -69,7 +73,11 @@ limitations under the License.
             jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
             style="border-radius: 6px; margin-top: 7px;">
-          <li ng-repeat="item in config.groups">
+          <li ng-repeat="item in config.groups track by $index"
+              ng-model="config.groups"
+              data-drag="true"
+              jqyoui-draggable="{index: {{$index}}, animate: false}"
+              data-jqyoui-options="{revert: 'invalid', placeholder: 'keep', helper: 'clone'}">
             <div class="btn btn-default btn-xs"
                  style="background-color: #EFEFEF; margin: 2px 0px 0px 2px;">
               {{item.name}}
@@ -89,7 +97,11 @@ limitations under the License.
             jqyoui-droppable="{multiple:true, onDrop:'save()'}"
             class="list-unstyled"
             style="border-radius: 6px; margin-top: 7px;">
-          <li ng-repeat="item in config.values">
+          <li ng-repeat="item in config.values track by $index"
+              ng-model="config.values"
+              data-drag="true"
+              jqyoui-draggable="{index: {{$index}}, animate: false}"
+              data-jqyoui-options="{revert: 'invalid', placeholder: 'keep', helper: 'clone'}">
             <div class="btn-group">
               <div class="btn btn-default btn-xs dropdown-toggle"
                    style="background-color: #EFEFEF;"

--- a/zeppelin-web/src/app/tabledata/pivot_settings.html
+++ b/zeppelin-web/src/app/tabledata/pivot_settings.html
@@ -124,3 +124,4 @@ limitations under the License.
     </div>
   </div> <!-- panel-body -->
 </div> <!-- panel -->
+


### PR DESCRIPTION
### What is this PR for?
Current the `keys`, `groups` and `values` is only droppable. It is a little inconvenient if I want to drag it to other place or sort it.
This feature let `keys`, `groups` and `values` not only `droppable`, but also `draggable` and `sorttable`.


### What type of PR is it?
[Feature]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3076 [ZEPPELIN-3076]

### How should this be tested?
I have Add the Screenshots for the test. Just as the Screenshots showing, all the element in `keys`, `groups` and `values` is draggable and sorttable.

![untitled project4](https://user-images.githubusercontent.com/5969176/33252922-ed1ab0b4-d37b-11e7-8a5c-b3dbb6765d18.gif)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
