### PR TITLE
[Zeppelin-2571] & [Zeppelin-465] Run paragraphs: from first/current to current/last

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -164,7 +164,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
     for (let i = 0; i < $scope.note.paragraphs.length; i++) {
       let paragraphId = $scope.note.paragraphs[i].id
       if (jQuery.contains(angular.element('#' + paragraphId + '_container')[0], clickEvent.target)) {
-        $scope.$broadcast('focusParagraph', paragraphId, 0, true)
+        $scope.$broadcast('focusParagraph', paragraphId, 0, null, true)
         break
       }
     }
@@ -504,7 +504,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
         para.focus = true
 
         // we need `$timeout` since angular DOM might not be initialized
-        $timeout(() => { $scope.$broadcast('focusParagraph', para.id, 0, false) })
+        $timeout(() => { $scope.$broadcast('focusParagraph', para.id, 0, null, false) })
       }
     })
   }
@@ -1213,6 +1213,8 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
         }
       })
     }
+
+    $scope.saveCursorPosition(paragraph)
   })
 
   $scope.$on('runAllBelowAndCurrent', function (event, paragraph, isNeedConfirm) {
@@ -1251,7 +1253,18 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
         }
       })
     }
+
+    $scope.saveCursorPosition(paragraph)
   })
+
+  $scope.saveCursorPosition = function (paragraph) {
+    let angParagEditor = angular
+      .element('#' + paragraph.id + '_paragraphColumn_main')
+      .scope().editor
+    let col = angParagEditor.selection.lead.column
+    let row = angParagEditor.selection.lead.row
+    $scope.$broadcast('focusParagraph', paragraph.id, row + 1, col)
+  }
 
   $scope.$on('setConnectedStatus', function (event, param) {
     if (connectedOnce && param) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1180,6 +1180,81 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
    ** $scope.$on functions below
    */
 
+  $scope.$on('runAllFromFirstToThis', function (event, paragraph, isNeedConfirm) {
+    let allParagraphs = $scope.note.paragraphs
+    let toRunParagraphs = []
+
+    for (let i = 0; allParagraphs[i] !== paragraph; i++) {
+      if (i === allParagraphs.length - 1) { return } // if paragraph not in array of all paragraphs
+      toRunParagraphs.push(allParagraphs[i])
+    }
+
+    toRunParagraphs.push(paragraph)
+
+    const paragraphs = toRunParagraphs.map(p => {
+      return {
+        id: p.id,
+        title: p.title,
+        paragraph: p.text,
+        config: p.config,
+        params: p.settings.params
+      }
+    })
+
+    if (!isNeedConfirm) {
+      websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)
+    } else {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Run all paragraphs from first to this?',
+        callback: function (result) {
+          if (result) {
+            websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)
+          }
+        }
+      })
+    }
+  })
+
+  $scope.$on('runAllFromThisToLast', function (event, paragraph, isNeedConfirm) {
+    let allParagraphs = $scope.note.paragraphs
+    let toRunParagraphs = []
+
+    for (let i = allParagraphs.length - 1; allParagraphs[i] !== paragraph; i--) {
+      if (i < 0) { return } // if paragraph not in array of all paragraphs
+      toRunParagraphs.push(allParagraphs[i])
+    }
+
+    toRunParagraphs.push(paragraph)
+    toRunParagraphs.reverse()
+
+    const paragraphs = toRunParagraphs.map(p => {
+      return {
+        id: p.id,
+        title: p.title,
+        paragraph: p.text,
+        config: p.config,
+        params: p.settings.params
+      }
+    })
+
+    if (!isNeedConfirm) {
+      websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)
+    } else {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: '',
+        message: 'Run all paragraphs from this to this?',
+        callback: function (result) {
+          if (result) {
+            websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)
+          }
+        }
+      })
+    }
+  })
+
   $scope.$on('setConnectedStatus', function (event, param) {
     if (connectedOnce && param) {
       initNotebook()

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1180,7 +1180,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
    ** $scope.$on functions below
    */
 
-  $scope.$on('runAllFromFirstToThis', function (event, paragraph, isNeedConfirm) {
+  $scope.$on('runAllAbove', function (event, paragraph, isNeedConfirm) {
     let allParagraphs = $scope.note.paragraphs
     let toRunParagraphs = []
 
@@ -1188,8 +1188,6 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
       if (i === allParagraphs.length - 1) { return } // if paragraph not in array of all paragraphs
       toRunParagraphs.push(allParagraphs[i])
     }
-
-    toRunParagraphs.push(paragraph)
 
     const paragraphs = toRunParagraphs.map(p => {
       return {
@@ -1207,7 +1205,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
       BootstrapDialog.confirm({
         closable: true,
         title: '',
-        message: 'Run all paragraphs from first to this?',
+        message: 'Run all above?',
         callback: function (result) {
           if (result) {
             websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)
@@ -1217,7 +1215,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
     }
   })
 
-  $scope.$on('runAllFromThisToLast', function (event, paragraph, isNeedConfirm) {
+  $scope.$on('runAllBelowAndCurrent', function (event, paragraph, isNeedConfirm) {
     let allParagraphs = $scope.note.paragraphs
     let toRunParagraphs = []
 
@@ -1245,7 +1243,7 @@ function NotebookCtrl ($scope, $route, $routeParams, $location, $rootScope,
       BootstrapDialog.confirm({
         closable: true,
         title: '',
-        message: 'Run all paragraphs from this to this?',
+        message: 'Run current and all below?',
         callback: function (result) {
           if (result) {
             websocketMsgSrv.runAllParagraphs($scope.note.id, paragraphs)

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -155,7 +155,7 @@ limitations under the License.
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
-             Run current and all below
+             Run all below
           </a>
         </li>
         <li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -145,7 +145,7 @@ limitations under the License.
             <span class="icon-action-redo shortcut-icon"
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
+            <span class="shortcut-keys">Ctrl+Shift+Enter</span>
             Run all above
           </a>
         </li>
@@ -154,7 +154,7 @@ limitations under the License.
             <span class="icon-action-undo shortcut-icon"
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
-            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
+            <span class="shortcut-keys">Ctrl+Shift+Enter</span>
              Run all below
           </a>
         </li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -146,7 +146,7 @@ limitations under the License.
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
-            Run: from first to this
+            Run all above
           </a>
         </li>
         <li>
@@ -155,7 +155,7 @@ limitations under the License.
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
-             Run: from this to last
+             Run current and all below
           </a>
         </li>
         <li>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -141,6 +141,24 @@ limitations under the License.
           </a>
         </li>
         <li>
+          <a ng-click="runAllToThis(paragraph)" ng-hide="$first">
+            <span class="icon-action-redo shortcut-icon"
+                  style="position: relative; transform: rotate(-90deg); left: -4px;">
+            </span>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
+            Run: from first to this
+          </a>
+        </li>
+        <li>
+          <a ng-click="runAllFromThis(paragraph)" ng-hide="$last">
+            <span class="icon-action-undo shortcut-icon"
+                  style="position: relative; transform: rotate(-90deg); left: -4px;">
+            </span>
+            <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Shift'}}+Enter</span>
+             Run: from this to last
+          </a>
+        </li>
+        <li>
           <a ng-click="copyParagraph(getEditorValue())"><span class="fa fa-copy shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+Shift+C</span>
             Clone paragraph

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -490,7 +490,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         }
       },
       {
-        label: 'From first to this',
+        label: 'Run all above',
         cssClass: 'btn-primary',
         action: function(dialog) {
           $scope.$emit('runAllAbove', paragraph, false)
@@ -498,7 +498,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         }
       },
       {
-        label: 'From this to the last',
+        label: 'Run current and all below',
         cssClass: 'btn-primary',
         action: function(dialog) {
           $scope.$emit('runAllBelowAndCurrent', paragraph, false)
@@ -1539,7 +1539,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     }
   })
 
-  $scope.$on('focusParagraph', function (event, paragraphId, cursorPos, mouseEvent) {
+  $scope.$on('focusParagraph', function (event, paragraphId, cursorPosRow, cursorPosCol, mouseEvent) {
+    if (cursorPosCol === null || cursorPosCol === undefined) {
+      cursorPosCol = 0
+    }
     if ($scope.paragraph.id === paragraphId) {
       // focus editor
       if (!$scope.paragraph.config.editorHide) {
@@ -1547,14 +1550,14 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
           $scope.editor.focus()
           // move cursor to the first row (or the last row)
           let row
-          if (cursorPos >= 0) {
-            row = cursorPos
-            $scope.editor.gotoLine(row, 0)
+          if (cursorPosRow >= 0) {
+            row = cursorPosRow
+            $scope.editor.gotoLine(row, cursorPosCol)
           } else {
             row = $scope.editor.session.getLength()
-            $scope.editor.gotoLine(row, 0)
+            $scope.editor.gotoLine(row, cursorPosCol)
           }
-          $scope.scrollToCursor($scope.paragraph.id, 0)
+          $scope.scrollToCursor($scope.paragraph.id, cursorPosCol)
         }
       }
       handleFocus(true)

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -472,11 +472,11 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   }
 
   $scope.runAllToThis = function(paragraph) {
-    $scope.$emit('runAllFromFirstToThis', paragraph, true)
+    $scope.$emit('runAllAbove', paragraph, true)
   }
 
   $scope.runAllFromThis = function(paragraph) {
-    $scope.$emit('runAllFromThisToLast', paragraph, true)
+    $scope.$emit('runAllBelowAndCurrent', paragraph, true)
   }
 
   $scope.runAllToOrFromThis = function (paragraph) {
@@ -493,7 +493,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         label: 'From first to this',
         cssClass: 'btn-primary',
         action: function(dialog) {
-          $scope.$emit('runAllFromFirstToThis', paragraph, false)
+          $scope.$emit('runAllAbove', paragraph, false)
           dialog.close()
         }
       },
@@ -501,7 +501,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         label: 'From this to the last',
         cssClass: 'btn-primary',
         action: function(dialog) {
-          $scope.$emit('runAllFromThisToLast', paragraph, false)
+          $scope.$emit('runAllBelowAndCurrent', paragraph, false)
           dialog.close()
         }
       }]

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -471,6 +471,43 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     $scope.runParagraph($scope.getEditorValue(), false, false)
   }
 
+  $scope.runAllToThis = function(paragraph) {
+    $scope.$emit('runAllFromFirstToThis', paragraph, true)
+  }
+
+  $scope.runAllFromThis = function(paragraph) {
+    $scope.$emit('runAllFromThisToLast', paragraph, true)
+  }
+
+  $scope.runAllToOrFromThis = function (paragraph) {
+    BootstrapDialog.show({
+      message: 'Run paragraphs:',
+      title: '',
+      buttons: [{
+        label: 'Close',
+        action: function(dialog) {
+          dialog.close()
+        }
+      },
+      {
+        label: 'From first to this',
+        cssClass: 'btn-primary',
+        action: function(dialog) {
+          $scope.$emit('runAllFromFirstToThis', paragraph, false)
+          dialog.close()
+        }
+      },
+      {
+        label: 'From this to the last',
+        cssClass: 'btn-primary',
+        action: function(dialog) {
+          $scope.$emit('runAllFromThisToLast', paragraph, false)
+          dialog.close()
+        }
+      }]
+    })
+  }
+
   $scope.turnOnAutoRun = function (paragraph) {
     paragraph.config.runOnSelectionChange = !paragraph.config.runOnSelectionChange
     commitParagraph(paragraph)
@@ -1446,8 +1483,10 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
         // move focus to next paragraph
         // $timeout stops chaining effect of focus propogation
         $timeout(() => $scope.$emit('moveFocusToNextParagraph', paragraphId))
-      } else if (keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
+      } else if (!keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue())
+      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13) { // Ctrl + Shift + Enter
+        $scope.runAllToOrFromThis($scope.paragraph)
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c
         $scope.cancelParagraph($scope.paragraph)
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 68) { // Ctrl + Alt + d

--- a/zeppelin-web/src/app/notebook/shortcut.html
+++ b/zeppelin-web/src/app/notebook/shortcut.html
@@ -39,6 +39,17 @@ limitations under the License.
 
           <tr>
             <td>
+              <div class="col-md-8">Run: from first/this to this/last</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">Enter</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
               <div class="col-md-8">Cancel</div>
             </td>
             <td>

--- a/zeppelin-web/src/app/notebook/shortcut.html
+++ b/zeppelin-web/src/app/notebook/shortcut.html
@@ -39,7 +39,7 @@ limitations under the License.
 
           <tr>
             <td>
-              <div class="col-md-8">Run: from first/this to this/last</div>
+              <div class="col-md-8">Run all above/below</div>
             </td>
             <td>
               <div class="keys">

--- a/zeppelin-web/src/app/notebook/shortcut.html
+++ b/zeppelin-web/src/app/notebook/shortcut.html
@@ -39,7 +39,7 @@ limitations under the License.
 
           <tr>
             <td>
-              <div class="col-md-8">Run all above/below</div>
+              <div class="col-md-8">Run all above/below paragraphs</div>
             </td>
             <td>
               <div class="keys">


### PR DESCRIPTION
### What is this PR for?
This pr add the ability to run all paragraphs from the first to the current and from the current to the last. This makes it easier to update the data if changes are made in one of the related paragraphs.

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-2571](https://issues.apache.org/jira/browse/ZEPPELIN-2571) - (Add a "Run to here" option on paragraphs)
[ZEPPELIN-465](https://issues.apache.org/jira/browse/ZEPPELIN-465)     - (Capability to run all cells below the current cell)

### How should this be tested?
1. Click on the "Run: from first to this" or "Run: from this to last" in the dropdown menu. Paragraphs from the first/current to the current/last will be started in order.
2. Press the key combination: CTRL + SHIFT + ENTER.
A window will appear with the choice of the desired action. 
![capture2](https://user-images.githubusercontent.com/25951039/33269914-58eff828-d393-11e7-9ebf-6437ec11c8f2.PNG)
Choose one of two actions. The selected action will be performed.

### Screenshots (if appropriate)

![capture1_edit](https://user-images.githubusercontent.com/25951039/33269915-5951b19e-d393-11e7-831b-42d4523908ae.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
