### PR TITLE
[ZEPPELIN-3080] Removing duplicate Date header

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.text.DateFormat;
-import java.util.Date;
 import java.util.Locale;
 
 import javax.servlet.Filter;
@@ -77,9 +75,7 @@ public class CorsFilter implements Filter {
     response.setHeader("Access-Control-Allow-Credentials", "true");
     response.setHeader("Access-Control-Allow-Headers", "authorization,Content-Type");
     response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, HEAD, DELETE");
-    DateFormat fullDateFormatEN =
-        DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, new Locale("EN", "en"));
-    response.setHeader("Date", fullDateFormatEN.format(new Date()));
+
     ZeppelinConfiguration zeppelinConfiguration = ZeppelinConfiguration.create();
     response.setHeader("X-FRAME-OPTIONS", zeppelinConfiguration.getXFrameOptions());
     if (zeppelinConfiguration.useSsl()) {


### PR DESCRIPTION
### What is this PR for?
Removing the duplicate Date header that is also in the wrong format according to the RFC, currently every request contains the following headers (using `curl -I`)
```
HTTP/1.1 200 OK
Date: Monday, November 27, 2017 3:20:42 PM UTC
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: authorization,Content-Type
Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, HEAD, DELETE
X-FRAME-OPTIONS: SAMEORIGIN
X-XSS-Protection: 1
Content-Type: application/octet-stream
Date: Mon, 27 Nov 2017 15:20:42 GMT
Content-Length: 59
Server: Jetty(9.2.15.v20160210)
```

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3080](https://issues.apache.org/jira/browse/ZEPPELIN-3080)

### Questions:
* Does the licenses files need update?
Nope
* Is there breaking changes for older versions?
Nope
* Does this needs documentation?
Nope
