### PR TITLE
[hotfix] Downgrade JGit from 4.9.0 to 4.5.4

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -311,7 +311,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
 
 The following components are provided under the BSD-style License.
 
-    (New BSD License) JGit (org.eclipse.jgit:org.eclipse.jgit:jar:4.9.0.201710071750-r - https://eclipse.org/jgit/)
+    (New BSD License) JGit (org.eclipse.jgit:org.eclipse.jgit:jar:4.5.4.201711221230-r - https://eclipse.org/jgit/)
     (New BSD License) Kryo (com.esotericsoftware.kryo:kryo:3.0.3 - http://code.google.com/p/kryo/)
     (New BSD License) MinLog (com.esotericsoftware.minlog:minlog:1.3 - http://code.google.com/p/minlog/)
     (New BSD License) ReflectASM (com.esotericsoftware.reflectasm:reflectasm:1.07 - http://code.google.com/p/reflectasm/)

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -46,7 +46,7 @@
     <lucene.version>5.3.1</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
-    <eclipse.jgit.version>4.9.0.201710071750-r</eclipse.jgit.version>
+    <eclipse.jgit.version>4.5.4.201711221230-r</eclipse.jgit.version>
     <frontend.maven.plugin.version>1.3</frontend.maven.plugin.version>
 
     <!--test library versions-->


### PR DESCRIPTION
### What is this PR for?
The version of JGit was updated to 4.9.0 at https://github.com/apache/zeppelin/pull/2658. 

However, this version does not support Java 7 and Travis CI test always fails now: https://travis-ci.org/kjmrknsn/zeppelin/builds/310104872

To fix this issue, downgrade JGit from 4.9.0 to 4.5.4 which is the latest JGit version which supports Java 7: https://projects.eclipse.org/projects/technology.jgit.

I confirmed that Travis CI test was passed with JGit 4.5.4: https://travis-ci.org/kjmrknsn/zeppelin/builds/310107611

Now, all PRs to Zeppelin don't pass Travis CI tests, so it's preferable that this PR is merged soon. 

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?

### How should this be tested?
I confirmed that Travis CI test passed with JGit 4.5.4: https://travis-ci.org/kjmrknsn/zeppelin/builds/310107611

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes. zeppelin-distribution/src/bin_license/LICENSE was updated at this PR.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
