### PR TITLE
[ZEPPELIN-3089] Create user folders under Trash folder

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1109,7 +1109,8 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null && !note.isTrash()){
-      fromMessage.put("name", Folder.getTrashFolderPath(fromMessage.principal) + "/" + note.getName());
+      fromMessage.put("name", Folder.getTrashFolderPath(fromMessage.principal) +
+                              "/" + note.getName());
       renameNote(conn, userAndRoles, notebook, fromMessage, "move");
       notebook.moveNoteToTrash(note.getId());
     }
@@ -1148,7 +1149,9 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null && note.isTrash()) {
-      fromMessage.put("name", note.getName().replaceFirst(Folder.getTrashFolderPath(fromMessage.principal) + "/", ""));
+      fromMessage.put("name", note.getName()
+                                  .replaceFirst(Folder.getTrashFolderPath(fromMessage.principal) +
+                                                "/", ""));
       renameNote(conn, userAndRoles, notebook, fromMessage, "restore");
     }
   }
@@ -1173,7 +1176,9 @@ public class NotebookServer extends WebSocketServlet
       return;
     }
     if (folder.isUnderTrash()) {
-      String restoreName = folder.getId().replaceFirst(Folder.getTrashFolderPath(fromMessage.principal) + "/", "").trim();
+      String restoreName = folder.getId()
+                                 .replaceFirst(Folder.getTrashFolderPath(fromMessage.principal) +
+                                               "/", "").trim();
 
       // if the folder had conflict when it had moved to trash before
       Pattern p = Pattern.compile("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$");

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -412,6 +412,38 @@ public class NotebookServerTest extends AbstractTestRestApi {
     notebook.removeNote(createdNote.getId(), anonymous);
   }
 
+  @Test
+  public void testMoveToTrash() {
+    NotebookSocket sock1 = createWebSocket();
+    notebookServer.onOpen(sock1);
+
+    notebookServer.onMessage(sock1,new Message(OP.NEW_NOTE).put("name", "test/note1").toJson());
+    Note note1 = findNoteFromName("test/note1");
+    assertNotNull(note1);
+    assertFalse(note1.isTrash());
+    String origId = note1.getId();
+
+    notebookServer.onMessage(sock1,
+                             new Message(OP.MOVE_NOTE_TO_TRASH).put("id", note1.getId()).toJson());
+    assertTrue(note1.isTrash());
+
+    notebookServer.onMessage(sock1,
+                             new Message(OP.RESTORE_FOLDER).put("id", note1.getFolderId()).toJson());
+    Note noteRestored = notebook.getNote(origId);
+    assertFalse(noteRestored.isTrash());
+    notebook.removeNote(note1.getId(), anonymous);
+  }
+
+  private Note findNoteFromName(String name) {
+    List<Note> notes = notebook.getAllNotes();
+    for (Note note : notes) {
+      if (note.getName().equals(name)) {
+        return note;
+      }
+    }
+    return null;
+  }
+
   private NotebookSocket createWebSocket() {
     NotebookSocket sock = mock(NotebookSocket.class);
     when(sock.getRequest()).thenReturn(mockRequest);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
@@ -228,10 +228,18 @@ public class Folder {
     return getId().equals(ROOT_FOLDER_ID);
   }
 
-  public boolean isTrash() {
+  public boolean isUnderTrash() {
     if (isRoot())
       return false;
 
     return getId().split("/")[0].equals(TRASH_FOLDER_ID);
+  }
+
+  public boolean isTrashFolder(String userName) {
+    return getId().equals(getTrashFolderPath(userName));
+  }
+
+  public static String getTrashFolderPath(String loginUser) {
+    return TRASH_FOLDER_ID + "/" + loginUser;
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/FolderTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/FolderTest.java
@@ -194,21 +194,21 @@ public class FolderTest {
   }
 
   @Test
-  public void isTrashTest() {
+  public void isUnderTrashTest() {
     Folder folder;
     // Not trash
     folder = new Folder(Folder.ROOT_FOLDER_ID);
-    assertFalse(folder.isTrash());
+    assertFalse(folder.isUnderTrash());
     folder = new Folder("a");
-    assertFalse(folder.isTrash());
+    assertFalse(folder.isUnderTrash());
     folder = new Folder("a/b");
-    assertFalse(folder.isTrash());
+    assertFalse(folder.isUnderTrash());
     // trash
     folder = new Folder(Folder.TRASH_FOLDER_ID);
-    assertTrue(folder.isTrash());
+    assertTrue(folder.isUnderTrash());
     folder = new Folder(Folder.TRASH_FOLDER_ID + "/a");
-    assertTrue(folder.isTrash());
+    assertTrue(folder.isUnderTrash());
     folder = new Folder(Folder.TRASH_FOLDER_ID + "/a/b");
-    assertTrue(folder.isTrash());
+    assertTrue(folder.isUnderTrash());
   }
 }


### PR DESCRIPTION
### What is this PR for?
In the situation where multi users a create notebook, "Empty Trash" button next to "Trash" folder on Top page is not working because "Empty Trash" button tries to delete all notebooks in Trash folder. which includes notebook no owner and no writer permission.

For resolving this issue, create a user folder under Trash folder, and "Empty Trash" button deletes all notebooks in a user folder, while "Restore" button restore all notebooks in a user folder.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3089

### How should this be tested?
1. Login as user 'A' and create a notebook 'A'
2. Move notebook 'A' to Trash
3. Login as user 'B' and create a notebook 'B'
4. Move notebook 'B' to Trash
5. Click 'Empty Trash' button next to 'Trash' folder

### Screenshots (if appropriate)
<img width="265" alt="screen_shot_2017-12-05_at_00_59_05" src="https://user-images.githubusercontent.com/4197465/33562137-ccc3e358-d957-11e7-980e-253efaa5cd62.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
