### PR TITLE
[ZEPPELIN-3091] Correct aggregation functionality in charts

### DIFF
--- a/zeppelin-web/src/app/tabledata/pivot.js
+++ b/zeppelin-web/src/app/tabledata/pivot.js
@@ -137,8 +137,8 @@ export default class PivotTransformation extends Transformation {
   pivot (data, keys, groups, values) {
     let aggrFunc = {
       sum: function (a, b) {
-        let varA = (a !== undefined) ? (isNaN(a) ? 1 : parseFloat(a)) : 0
-        let varB = (b !== undefined) ? (isNaN(b) ? 1 : parseFloat(b)) : 0
+        let varA = (a !== undefined) ? (isNaN(a) ? 0 : parseFloat(a)) : 0
+        let varB = (b !== undefined) ? (isNaN(b) ? 0 : parseFloat(b)) : 0
         return varA + varB
       },
       count: function (a, b) {
@@ -147,20 +147,36 @@ export default class PivotTransformation extends Transformation {
         return varA + varB
       },
       min: function (a, b) {
-        let varA = (a !== undefined) ? (isNaN(a) ? 1 : parseFloat(a)) : 0
-        let varB = (b !== undefined) ? (isNaN(b) ? 1 : parseFloat(b)) : 0
-        return Math.min(varA, varB)
+        let aIsValid = isValidNumber(a)
+        let bIsValid = isValidNumber(b)
+        if (!aIsValid) {
+          return parseFloat(b)
+        } else if (!bIsValid) {
+          return parseFloat(a)
+        } else {
+          return Math.min(parseFloat(a), parseFloat(b))
+        }
       },
       max: function (a, b) {
-        let varA = (a !== undefined) ? (isNaN(a) ? 1 : parseFloat(a)) : 0
-        let varB = (b !== undefined) ? (isNaN(b) ? 1 : parseFloat(b)) : 0
-        return Math.max(varA, varB)
+        let aIsValid = isValidNumber(a)
+        let bIsValid = isValidNumber(b)
+        if (!aIsValid) {
+          return parseFloat(b)
+        } else if (!bIsValid) {
+          return parseFloat(a)
+        } else {
+          return Math.max(parseFloat(a), parseFloat(b))
+        }
       },
       avg: function (a, b, c) {
-        let varA = (a !== undefined) ? (isNaN(a) ? 1 : parseFloat(a)) : 0
-        let varB = (b !== undefined) ? (isNaN(b) ? 1 : parseFloat(b)) : 0
+        let varA = (a !== undefined) ? (isNaN(a) ? 0 : parseFloat(a)) : 0
+        let varB = (b !== undefined) ? (isNaN(b) ? 0 : parseFloat(b)) : 0
         return varA + varB
       }
+    }
+
+    let isValidNumber = function(num) {
+      return num !== undefined && !isNaN(num)
     }
 
     let aggrFuncDiv = {

--- a/zeppelin-web/src/app/tabledata/tabledata.test.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.test.js
@@ -83,4 +83,49 @@ describe('PivotTransformation build', function() {
     expect(config.common.pivot.keys[1].index).toBe(3)
     expect(config.common.pivot.keys[2].index).toBe(5)
   })
+
+  it('should aggregate values correctly', function() {
+    let td = new TableData()
+    td.loadParagraphResult({
+      type: 'TABLE',
+      msg: 'key\tvalue\na\t10\na\tnull\na\t0\na\t1\n'
+    })
+
+    let config = {
+      common: {
+        pivot: {
+          keys: [
+            {
+              'name': 'key',
+              'index': 0.0,
+            }
+          ],
+          groups: [],
+          values: [
+            {
+              'name': 'value',
+              'index': 1.0,
+              'aggr': 'sum'
+            }
+          ]
+        }
+      }
+    }
+
+    pt.setConfig(config)
+    let transformed = pt.transform(td)
+    expect(transformed.rows['a']['value(sum)'].value).toBe(11)
+
+    pt.config.common.pivot.values[0].aggr = 'max'
+    transformed = pt.transform(td)
+    expect(transformed.rows['a']['value(max)'].value).toBe(10)
+
+    pt.config.common.pivot.values[0].aggr = 'min'
+    transformed = pt.transform(td)
+    expect(transformed.rows['a']['value(min)'].value).toBe(0)
+
+    pt.config.common.pivot.values[0].aggr = 'count'
+    transformed = pt.transform(td)
+    expect(transformed.rows['a']['value(count)'].value).toBe(4)
+  })
 })


### PR DESCRIPTION
### What is this PR for?
The aggregation functions interpret NaN columns as 1 which leads to incorrect output being shown in charts. This PR fixes this by correcting the sum, min, max and average aggregation method.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3091

### How should this be tested?
* Update the data field of a paragraph results with %table to contain null values, e.g.
`"data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n20\t5\n20\tnull\n"`

The "null" values should be ignored for sum, min, max but included for count (and hence average).

### Screenshots (if appropriate)
![correct_sum](https://user-images.githubusercontent.com/6438072/33609178-14e05988-d9ed-11e7-9f1b-99e0141c5153.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
