### PR TITLE
[Zeppelin-2964] Stop execution on schedule if the note has been moved to the trash

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1141,7 +1141,10 @@ public class NotebookServer extends WebSocketServlet
 
       List<Note> noteList = folder.getNotesRecursively();
       for (Note note: noteList) {
-        notebook.removeCron(note.getId());
+        Map<String, Object> config = note.getConfig();
+        if (config.get("cron") != null) {
+          notebook.removeCron(note.getId());
+        }
       }
 
       fromMessage.put("name", trashFolderId);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1108,6 +1108,15 @@ public class NotebookServer extends WebSocketServlet
     }
 
     Note note = notebook.getNote(noteId);
+
+    // drop cron
+    Map<String, Object> config = note.getConfig();
+    if (config.get("cron") != null) {
+      config.remove("cron");
+      note.setConfig(config);
+      notebook.refreshCron(note.getId());
+    }
+
     if (note != null && !note.isTrash()){
       fromMessage.put("name", Folder.TRASH_FOLDER_ID + "/" + note.getName());
       renameNote(conn, userAndRoles, notebook, fromMessage, "move");

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -254,7 +254,7 @@ limitations under the License.
              data-toggle="dropdown"
              ng-class="{ 'btn-info' : note.config.cron, 'btn-danger' : note.info.cron, 'btn-default' : !note.config.cron}"
              tooltip-placement="bottom" uib-tooltip="Run scheduler"
-             ng-disabled="revisionView">
+             ng-disabled="revisionView || isTrash(note)">
           <span class="fa fa-clock-o"></span> {{getCronOptionNameFromValue(note.config.cron)}}
         </div>
         <ul class="dropdown-menu" role="menu" style="width:300px">

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -974,7 +974,7 @@ public class Notebook implements NoteEventListener {
     }
   }
 
-  private void removeCron(String id) {
+  public void removeCron(String id) {
     try {
       quartzSched.deleteJob(new JobKey(id, "note"));
     } catch (SchedulerException e) {


### PR DESCRIPTION
### What is this PR for?
When you put the note (or folder) in the trash, the note continues to run on schedule.
This PR fixes this. Now when you put the note into the trash, the task is removed, and when you restore the note, it runs again.


### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-3007](https://issues.apache.org/jira/browse/ZEPPELIN-3007)

### How should this be tested?
- Create a scheduled launch for the note.
- Put the note in the trash.
- Look through the logs. 
- Note must stop running.
- Restore the note from the trash.
- Running on a schedule should continue again.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
