### PR TITLE
[MINOR] Fix notebook title bar margin

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -130,8 +130,8 @@
 }
 
 .noteAction {
-  margin-left: -10px;
-  margin-right: -10px;
+  margin-left: 0px;
+  margin-right: 0px;
   font-family: 'Roboto', sans-serif;
   background: white;
   position: fixed;


### PR DESCRIPTION
### What is this PR for?
Notebook title bar location is little bit shifted to left.
This minor fix notebook title bar margin. See screenshots below.

### What type of PR is it?
Bug Fix

### Todos
* [x] - fix margin

### Screenshots (if appropriate)
Before
![image](https://user-images.githubusercontent.com/1540981/33742650-3469c2fe-db5e-11e7-8aa6-936d0a28de3a.png)

After
![image](https://user-images.githubusercontent.com/1540981/33742640-250c3dc8-db5e-11e7-8af3-e8a9d7105963.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
