### PR TITLE
[ZEPPELIN-3101] updated network label, added link to network display in index.md

### DIFF
--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -44,7 +44,7 @@
                 <li><a href="{{BASE_PATH}}/usage/display_system/basic.html#text">Text Display</a></li>
                 <li><a href="{{BASE_PATH}}/usage/display_system/basic.html#html">HTML Display</a></li>
                 <li><a href="{{BASE_PATH}}/usage/display_system/basic.html#table">Table Display</a></li>
-                <li><a href="{{BASE_PATH}}/usage/display_system/basic.html#network">Network</a></li>
+                <li><a href="{{BASE_PATH}}/usage/display_system/basic.html#network">Network Display</a></li>
                 <li><a href="{{BASE_PATH}}/usage/display_system/angular_backend.html">Angular Display using Backend API</a></li>
                 <li><a href="{{BASE_PATH}}/usage/display_system/angular_frontend.html">Angular Display using Frontend API</a></li>
                 <li role="separator" class="divider"></li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ limitations under the License.
   * [Text Display (`%text`)](./usage/display_system/basic.html#text)
   * [HTML Display (`%html`)](./usage/display_system/basic.html#html)
   * [Table Display (`%table`)](./usage/display_system/basic.html#table)
+  * [Network Display (`%network`)](./usage/display_system/basic.html#network)
   * [Angular Display using Backend API (`%angular`)](./usage/display_system/angular_backend.html)
   * [Angular Display using Frontend API (`%angular`)](./usage/display_system/angular_frontend.html)
 * Interpreter  


### PR DESCRIPTION
### What is this PR for?
The docs index must show the reference to the network visualization as for the the other types



### What type of PR is it?
[Improvement]

### Todos
* [x] - Add missing link

### What is the Jira issue?
[ZEPPELIN-3101](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3101)

### How should this be tested?
1. cd `docs/`
2. build: `bundle exec jekyll build --safe`
3. check the link is present

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
