### PR TITLE
[HOTFIX]: Fix IPythonInterpreter unit test

### DIFF
--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -44,6 +44,6 @@ if [[ -n "$PYTHON" ]] ; then
   conda update -q conda
   conda info -a
   conda config --add channels conda-forge
-  conda install -q matplotlib pandasql ipython jupyter_client ipykernel matplotlib bokeh=0.12.6
+  conda install -q matplotlib pandasql ipython=5.4.1 jupyter_client ipykernel matplotlib bokeh=0.12.6
   pip install -q grpcio ggplot
 fi


### PR DESCRIPTION
### What is this PR for?

This is for hotfix of `IPythonInterpreter` unit test failure. Just specify the version of ipython in `install_external_dependencies.sh`, otherwise latest ipython version will be installed, and the behavior may change. 


### What type of PR is it?
[Hot Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* 

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
