### PR TITLE
ZEPPELIN-3112: Markdown interpreter fails with NPE

### DIFF
--- a/markdown/src/main/java/org/apache/zeppelin/markdown/PegdownParser.java
+++ b/markdown/src/main/java/org/apache/zeppelin/markdown/PegdownParser.java
@@ -41,8 +41,10 @@ public class PegdownParser implements MarkdownParser {
   @Override
   public String render(String markdownText) {
     String html = "";
-    String parsed = processor.markdownToHtml(markdownText);
-
+    String parsed;
+    synchronized (processor) {
+      parsed = processor.markdownToHtml(markdownText);
+    }
     if (null == parsed) {
       throw new RuntimeException("Cannot parse markdown text to HTML using pegdown");
     }


### PR DESCRIPTION
### What is this PR for?
Since pegdown-parser is not thread-safe while trying to run multiple MarkDown paragraphs at once, sometimes it fails to render HTML.
Ref: https://github.com/sirthias/pegdown/blob/master/src/main/java/org/pegdown/PegDownProcessor.java#L32

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3112](https://issues.apache.org/jira/browse/ZEPPELIN-3112)

### How should this be tested?
* This happens rarely, when you try to run all paragraph from UI which has more the 5-6 `%md` paragraph. This is hard to reproduce in 0.8.0, but can easily be done via 0.7.3. Also, have added a sample [notebook](https://issues.apache.org/jira/secure/attachment/12903037/Test%20MD%20fail.json) in the parent JIRA 

* Have added test case to verify.


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
