### PR TITLE
ZEPPELIN-3128: The autocomplete in Note Permissions does not work correctly

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -139,7 +139,7 @@ public class GetUserList {
       constraints.setReturningAttributes(attrIDs);
       NamingEnumeration result = ctx.search(userSearchRealm, "(&(objectclass=" + 
             userObjectClass + ")(" 
-            + userAttribute + "=" + searchText + "))", constraints);
+            + userAttribute + "=" + searchText + "*))", constraints);
       while (result.hasMore()) {
         Attributes attrs = ((SearchResult) result.next()).getAttributes();
         if (attrs.get(userAttribute) != null) {


### PR DESCRIPTION
### What is this PR for?
The autocomplete in Note Permissions does not work correctly, even if the user exists 
in ldap directory, zeppelin can't show him after writing the first three letters.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* [ZEPPELIN-3128](https://issues.apache.org/jira/browse/ZEPPELIN-3128)

### Screenshots
with Bug : 
<img width="909" alt="screen shot 2018-01-05 at 15 30 13" src="https://user-images.githubusercontent.com/4679929/34613296-8bbb34bc-f22d-11e7-815e-174a6a1e7ed5.png">
with Fix : 
<img width="708" alt="screen shot 2018-01-05 at 15 33 00" src="https://user-images.githubusercontent.com/4679929/34613366-cf60b0a2-f22d-11e7-9579-a13735295fb8.png">
