### PR TITLE
ZEPPELIN-3009. Don't iterate all the properties when getting property from ZeppelinConfiguration

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -45,10 +45,28 @@ public class ZeppelinConfiguration extends XMLConfiguration {
       "https://s3.amazonaws.com/helium-package/helium.json";
   private static ZeppelinConfiguration conf;
 
+  private Map<String, String> properties = new HashMap<>();
+
   public ZeppelinConfiguration(URL url) throws ConfigurationException {
     setDelimiterParsingDisabled(true);
     load(url);
+    initProperties();
   }
+
+  private void initProperties() {
+    List<ConfigurationNode> nodes = getRootNode().getChildren();
+    if (nodes == null || nodes.isEmpty()) {
+      return;
+    }
+    for (ConfigurationNode p : nodes) {
+      String name = (String) p.getChildren("name").get(0).getValue();
+      String value = (String) p.getChildren("value").get(0).getValue();
+      if (!StringUtils.isEmpty(name)) {
+        properties.put(name, value);
+      }
+    }
+  }
+
 
   public ZeppelinConfiguration() {
     ConfVars[] vars = ConfVars.values();
@@ -122,71 +140,41 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
 
   private String getStringValue(String name, String d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return (String) p.getChildren("value").get(0).getValue();
-      }
+    String value = this.properties.get(name);
+    if (value != null) {
+      return value;
     }
     return d;
   }
 
   private int getIntValue(String name, int d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Integer.parseInt((String) p.getChildren("value").get(0).getValue());
-      }
+    String value = this.properties.get(name);
+    if (value != null) {
+      return Integer.parseInt(value);
     }
     return d;
   }
 
   private long getLongValue(String name, long d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Long.parseLong((String) p.getChildren("value").get(0).getValue());
-      }
+    String value = this.properties.get(name);
+    if (value != null) {
+      return Long.parseLong(value);
     }
     return d;
   }
 
   private float getFloatValue(String name, float d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Float.parseFloat((String) p.getChildren("value").get(0).getValue());
-      }
+    String value = this.properties.get(name);
+    if (value != null) {
+      return Float.parseFloat(value);
     }
     return d;
   }
 
   private boolean getBooleanValue(String name, boolean d) {
-    List<ConfigurationNode> properties = getRootNode().getChildren();
-    if (properties == null || properties.isEmpty()) {
-      return d;
-    }
-    for (ConfigurationNode p : properties) {
-      if (p.getChildren("name") != null && !p.getChildren("name").isEmpty()
-          && name.equals(p.getChildren("name").get(0).getValue())) {
-        return Boolean.parseBoolean((String) p.getChildren("value").get(0).getValue());
-      }
+    String value = this.properties.get(name);
+    if (value != null) {
+      return Boolean.parseBoolean(value);
     }
     return d;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -17,91 +17,79 @@
 package org.apache.zeppelin.conf;
 
 import junit.framework.Assert;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
 import java.util.List;
 
 
-/**
- * Created by joelz on 8/19/15.
- */
 public class ZeppelinConfigurationTest {
-    @Before
-    public void clearSystemVariables() {
-        System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName());
-    }
+  @Before
+  public void clearSystemVariables() {
+    System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName());
+  }
 
-    @Test
-    public void getAllowedOrigins2Test() throws MalformedURLException, ConfigurationException {
+  @Test
+  public void getAllowedOrigins2Test() throws MalformedURLException, ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/test-zeppelin-site2.xml"));
-        List<String> origins = conf.getAllowedOrigins();
-        Assert.assertEquals(2, origins.size());
-        Assert.assertEquals("http://onehost:8080", origins.get(0));
-        Assert.assertEquals("http://otherhost.com", origins.get(1));
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/test-zeppelin-site2.xml"));
+    List<String> origins = conf.getAllowedOrigins();
+    Assert.assertEquals(2, origins.size());
+    Assert.assertEquals("http://onehost:8080", origins.get(0));
+    Assert.assertEquals("http://otherhost.com", origins.get(1));
+  }
 
-    @Test
-    public void getAllowedOrigins1Test() throws MalformedURLException, ConfigurationException {
+  @Test
+  public void getAllowedOrigins1Test() throws MalformedURLException, ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/test-zeppelin-site1.xml"));
-        List<String> origins = conf.getAllowedOrigins();
-        Assert.assertEquals(1, origins.size());
-        Assert.assertEquals("http://onehost:8080", origins.get(0));
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/test-zeppelin-site1.xml"));
+    List<String> origins = conf.getAllowedOrigins();
+    Assert.assertEquals(1, origins.size());
+    Assert.assertEquals("http://onehost:8080", origins.get(0));
+  }
 
-    @Test
-    public void getAllowedOriginsNoneTest() throws MalformedURLException, ConfigurationException {
+  @Test
+  public void getAllowedOriginsNoneTest() throws MalformedURLException, ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-        List<String> origins = conf.getAllowedOrigins();
-        Assert.assertEquals(1, origins.size());
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    List<String> origins = conf.getAllowedOrigins();
+    Assert.assertEquals(1, origins.size());
+  }
 
-    @Test
-    public void isWindowsPathTestTrue() throws ConfigurationException {
+  @Test
+  public void isWindowsPathTestTrue() throws ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-        Boolean isIt = conf.isWindowsPath("c:\\test\\file.txt");
-        Assert.assertTrue(isIt);
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    Boolean isIt = conf.isWindowsPath("c:\\test\\file.txt");
+    Assert.assertTrue(isIt);
+  }
 
-    @Test
-    public void isWindowsPathTestFalse() throws ConfigurationException {
+  @Test
+  public void isWindowsPathTestFalse() throws ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-        Boolean isIt = conf.isWindowsPath("~/test/file.xml");
-        Assert.assertFalse(isIt);
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    Boolean isIt = conf.isWindowsPath("~/test/file.xml");
+    Assert.assertFalse(isIt);
+  }
 
-    @Test
-    public void getNotebookDirTest() throws ConfigurationException {
+  @Test
+  public void getNotebookDirTest() throws ConfigurationException {
 
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-        String notebookLocation = conf.getNotebookDir();
-        Assert.assertEquals("notebook", notebookLocation);
-    }
-    
-    @Test
-    public void isNotebookPublicTest() throws ConfigurationException {
-      
-      ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-      boolean isIt = conf.isNotebookPublic();
-      assertTrue(isIt);
-    }
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    String notebookLocation = conf.getNotebookDir();
+    Assert.assertEquals("notebook", notebookLocation);
+  }
 
-    @Test
-    public void isRequestHeaderSizeDefaultValueCorrect() throws ConfigurationException {
-        ZeppelinConfiguration conf  = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
-        assertEquals((Integer)8192, conf.getJettyRequestHeaderSize());
-    }
+  @Test
+  public void isNotebookPublicTest() throws ConfigurationException {
+
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    boolean isIt = conf.isNotebookPublic();
+    assertTrue(isIt);
+  }
 }


### PR DESCRIPTION
### What is this PR for?

Just read the zeppelin-site when ZeppelinConfiguration is constructed, and look for key when getting property from ZeppelinConfiguration instead of looping over properties each time at runtime. 


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3009

### How should this be tested?
* Unit tested is covered

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
