### PR TITLE
ZEPPELIN-3137. Improve code style check

### DIFF
--- a/_tools/checkstyle.xml
+++ b/_tools/checkstyle.xml
@@ -59,7 +59,7 @@ limitations under the License.
       <property name="severity" value="error"/>
     </module>
     <module name="ImportOrder"> Checks for out of order import statements
-      <property name="severity" value="warning"/> <property name="groups" value="com.google,android,junit,net,org,java,javax"/>
+      <property name="severity" value="warning"/> <property name="groups" value="com.google,junit,net,org,java,javax,*,org.apache.zeppelin"/>
       This ensures that static imports go first <property name="option" value="top"/>
       <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
     </module>

--- a/_tools/checkstyle.xml
+++ b/_tools/checkstyle.xml
@@ -58,10 +58,11 @@ limitations under the License.
       <!-- Checks for redundant import statements. -->
       <property name="severity" value="error"/>
     </module>
-    <!-- <module name="ImportOrder"> Checks for out of order import statements
+    <module name="ImportOrder"> Checks for out of order import statements
       <property name="severity" value="warning"/> <property name="groups" value="com.google,android,junit,net,org,java,javax"/>
       This ensures that static imports go first <property name="option" value="top"/>
-      <property name="tokens" value="STATIC_IMPORT, IMPORT"/> </module> -->
+      <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+    </module>
     <!-- JAVADOC CHECKS -->
 
     <!-- Checks for Javadoc comments. -->
@@ -279,5 +280,14 @@ limitations under the License.
       <property name="basicOffset" value="2"/>
       <property name="caseIndent" value="2"/>
     </module>
+
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation"/>
+    <module name="UnusedImports"/>
+    <module name="RedundantImport"/>
+    <module name="RedundantModifier"/>
+    <module name="AvoidStarImport"/>
   </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -384,9 +384,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
         <configuration>
+          <skip>true</skip>
+          <failOnViolation>false</failOnViolation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <sourceDirectories>${basedir}/src/main/java,${basedir}/src/main/scala</sourceDirectories>
+          <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
           <configLocation>_tools/checkstyle.xml</configLocation>
-          <enableRSS>false</enableRSS>
+          <outputFile>${basedir}/target/checkstyle-output.xml</outputFile>
+          <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
+          <outputEncoding>${project.reporting.outputEncoding}</outputEncoding>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### What is this PR for?

Although currently zeppelin has code check style, it is very weak. Such as unused import is not detected. The is the first PR for adding code style check. It just improve the code style check file , but just disable it for now. I have created subtask under ZEPPELIN-3137 for each module.  This `checkstyle.xml` is from spark project. I think code style of spark is also fit for zeppelin project, just remove some spark related content in this `checkstyle.xml`


### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3137

### How should this be tested?
* Travis build pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
