### PR TITLE
[ZEPPELIN-2826] support for carriage return '\r', on result window

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -12,12 +12,11 @@
  * limitations under the License.
  */
 
-import { SpellResult, } from '../../spell'
-import {
-  ParagraphStatus, isParagraphRunning,
-} from './paragraph.status'
+import {SpellResult} from '../../spell'
+import {isParagraphRunning, ParagraphStatus} from './paragraph.status'
 
 import moment from 'moment'
+
 require('moment-duration-format')
 
 const ParagraphExecutor = {
@@ -1466,6 +1465,30 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   $scope.$on('updateProgress', function (event, data) {
     if (data.id === $scope.paragraph.id) {
       $scope.currentProgress = data.progress
+    }
+  })
+
+  $scope.$on('appendParagraphOutput', function (event, data) {
+    if (data.paragraphId === $scope.paragraph.id) {
+      if (!$scope.paragraph.results) {
+        $scope.paragraph.results = {}
+
+        if (!$scope.paragraph.results.msg) {
+          $scope.paragraph.results.msg = []
+        }
+
+        $scope.paragraph.results.msg[data.index] = {
+          data: data.data,
+          type: data.type
+        }
+
+        $rootScope.$broadcast(
+          'updateResult',
+          $scope.paragraph.results.msg[data.index],
+          $scope.paragraph.config.results[data.index],
+          $scope.paragraph,
+          data.index)
+      }
     }
   })
 

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -22,11 +22,8 @@ import AreachartVisualization from '../../../visualization/builtins/visualizatio
 import LinechartVisualization from '../../../visualization/builtins/visualization-linechart'
 import ScatterchartVisualization from '../../../visualization/builtins/visualization-scatterchart'
 import NetworkVisualization from '../../../visualization/builtins/visualization-d3network'
-import {
-  DefaultDisplayType,
-  SpellResult,
-} from '../../../spell'
-import { ParagraphStatus, } from '../paragraph.status'
+import {DefaultDisplayType, SpellResult} from '../../../spell'
+import {ParagraphStatus} from '../paragraph.status'
 
 const AnsiUp = require('ansi_up')
 const AnsiUpConverter = new AnsiUp.default // eslint-disable-line new-parens,new-cap
@@ -319,7 +316,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
       } else if (type === DefaultDisplayType.ANGULAR) {
         renderAngular(targetElemId, data)
       } else if (type === DefaultDisplayType.TEXT) {
-        renderText(targetElemId, data)
+        renderText(targetElemId, data, refresh)
       } else if (type === DefaultDisplayType.ELEMENT) {
         renderElem(targetElemId, data)
       } else {
@@ -464,7 +461,26 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     return `p${resultId}_text`
   }
 
-  const renderText = function (targetElemId, data) {
+  const checkAndReplaceCarriageReturn = function (str) {
+    if (/\r/.test(str)) {
+      let newGenerated = ''
+      let strArr = str.split('\n')
+      for (let str of strArr) {
+        if (/\r/.test(str)) {
+          let splitCR = str.split('\r')
+          newGenerated += splitCR[splitCR.length - 1] + '\n'
+        } else {
+          newGenerated += str + '\n'
+        }
+      }
+      // remove last "\n" character
+      return newGenerated.slice(0, -1)
+    } else {
+      return str
+    }
+  }
+
+  const renderText = function (targetElemId, data, refresh) {
     const elem = angular.element(`#${targetElemId}`)
     handleData(data, DefaultDisplayType.TEXT,
       (generated) => {
@@ -472,9 +488,16 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
         removeChildrenDOM(targetElemId)
 
         if (generated) {
+          generated = checkAndReplaceCarriageReturn(generated)
           const escaped = AnsiUpConverter.ansi_to_html(generated)
           const divDOM = angular.element('<div></div>').innerHTML = escaped
-          elem.append(divDOM)
+          if (refresh) {
+            elem.html(divDOM)
+          } else {
+            elem.append(divDOM)
+          }
+        } else if (refresh) {
+          elem.html('')
         }
 
         elem.bind('mousewheel', (e) => { $scope.keepScrollDown = false })
@@ -503,9 +526,8 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
 
     // pop all stacked data and append to the DOM
     while (textResultQueueForAppend.length > 0) {
-      const line = textResultQueueForAppend.pop()
-      elem.append(angular.element('<div></div>').text(line))
-
+      const line = elem.html() + textResultQueueForAppend.pop()
+      elem.html(checkAndReplaceCarriageReturn(line))
       if ($scope.keepScrollDown) {
         const doc = angular.element(`#${elemId}`)
         doc[0].scrollTop = doc[0].scrollHeight

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -526,8 +526,10 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
 
     // pop all stacked data and append to the DOM
     while (textResultQueueForAppend.length > 0) {
-      const line = elem.html() + textResultQueueForAppend.pop()
-      elem.html(checkAndReplaceCarriageReturn(line))
+      const line = checkAndReplaceCarriageReturn(textResultQueueForAppend.pop())
+      const escaped = AnsiUpConverter.ansi_to_html(line)
+      const divDOM = angular.element('<div></div>').innerHTML = escaped
+      elem.append(divDOM)
       if ($scope.keepScrollDown) {
         const doc = angular.element(`#${elemId}`)
         doc[0].scrollTop = doc[0].scrollHeight


### PR DESCRIPTION
### What is this PR for?
This PR implements carriage return '\r' on result window, currently since HTML treats "\n", "\r" and "\r\n"  equally.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
* [ZEPPELIN-2826](https://issues.apache.org/jira/browse/ZEPPELIN-2826)

### How should this be tested?
Here is a sample code to test it
```
%python
import time,sys
end_val = 10
bar_length = 20
for i in xrange(0, end_val + 1):
    time.sleep(0.5)
    percent = float(i) / end_val
    hashes = '#' * int(round(percent * bar_length))
    spaces = ' ' * (bar_length - len(hashes))
    sys.stdout.write("\rPercent: [{0}] {1}%".format(hashes + spaces, int(round(percent * 100))))
    #print "Percent: [{0}] {1}%".format(hashes + spaces, int(round(percent * 100)))
```

### Screenshots (if appropriate)
![after2](https://user-images.githubusercontent.com/674497/34886813-55e6e2d8-f7ea-11e7-9e40-24ded6631d75.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
