### PR TITLE
ZEPPELIN-3166. R plotting resolution and image width is not proper

### DIFF
--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -213,7 +213,7 @@
       "zeppelin.R.render.options": {
         "envName": "ZEPPELIN_R_RENDER_OPTIONS",
         "propertyName": "zeppelin.R.render.options",
-        "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F",
+        "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F, fig.retina = 2",
         "description": "",
         "type": "textarea"
       }


### PR DESCRIPTION
### What is this PR for?
Change the resolution and image width, because the previous default value is not proper.

By adding `fig.retina = 2` for high resolution. And use `40%` as default image width. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3166

### How should this be tested?
* Manually verfifed

### Screenshots (if appropriate)

Before

![screen shot 2018-01-15 at 2 27 01 pm](https://user-images.githubusercontent.com/164491/34930418-46680e38-fa04-11e7-9b73-b12bd61986f2.png)

After 

![screen shot 2018-01-15 at 2 27 11 pm](https://user-images.githubusercontent.com/164491/34930430-509204e0-fa04-11e7-927c-c9b4982f8373.png)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
