### PR TITLE
[ZEPPELIN-3172] Support for carriage return '\r', on result window

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -526,10 +526,8 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
 
     // pop all stacked data and append to the DOM
     while (textResultQueueForAppend.length > 0) {
-      const line = checkAndReplaceCarriageReturn(textResultQueueForAppend.pop())
-      const escaped = AnsiUpConverter.ansi_to_html(line)
-      const divDOM = angular.element('<div></div>').innerHTML = escaped
-      elem.append(divDOM)
+      const line = elem.html() + AnsiUpConverter.ansi_to_html(textResultQueueForAppend.pop())
+      elem.html(checkAndReplaceCarriageReturn(line))
       if ($scope.keepScrollDown) {
         const doc = angular.element(`#${elemId}`)
         doc[0].scrollTop = doc[0].scrollHeight


### PR DESCRIPTION
### What is this PR for?
This got introduced while trying to fix html/xml rendering https://github.com/apache/zeppelin/pull/2729/commits/7851c130cf62fc7ff2281d1cf2c6f25658829fe5


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-3172]

### How should this be tested?
Here is a sample code to test it

```
%python
import time,sys
end_val = 10
bar_length = 20
for i in xrange(0, end_val + 1):
    time.sleep(0.5)
    percent = float(i) / end_val
    hashes = '#' * int(round(percent * bar_length))
    spaces = ' ' * (bar_length - len(hashes))
    sys.stdout.write("\rPercent: [{0}] {1}%".format(hashes + spaces, int(round(percent * 100))))
    #print "Percent: [{0}] {1}%".format(hashes + spaces, int(round(percent * 100)))
```

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
