### PR TITLE
Set ExecutorFactory 65536

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
@@ -52,7 +52,7 @@ public class SchedulerFactory implements SchedulerListener {
   }
 
   SchedulerFactory() throws Exception {
-    executor = ExecutorFactory.singleton().createOrGet("SchedulerFactory", 100);
+    executor = ExecutorFactory.singleton().createOrGet("SchedulerFactory", 65536);
   }
 
   public void destroy() {


### PR DESCRIPTION
### What is this PR for?
The number at ExecutorFactory limits the maximum number of interpreters. When the number of interpreters becomes equal to the schedulers number, zeppelin will be fully stuck: no paragraph can run now even if the paragraph run a few minutes ago.
This HF makes the number of schedulers very big.

### What type of PR is it?
[Hot Fix]

### Todos
* [ ] - Task

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A