### PR TITLE
[ZEPPELIN-3177]Resize charts on paragaph resize

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -673,6 +673,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   $scope.changeColWidth = function (paragraph, width) {
     angular.element('.navbar-right.open').removeClass('open')
     paragraph.config.colWidth = width
+    $scope.$broadcast('paragraphResized', $scope.paragraph.id)
     commitParagraph(paragraph)
   }
 

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -634,6 +634,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
         builtInViz.instance.setConfig(config)
         builtInViz.instance.render(transformed)
         builtInViz.instance.renderSetting(visualizationSettingTargetEl)
+        builtInViz.instance.activate()
       }
     } else {
       afterLoaded = function (loadedElem) {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -755,7 +755,7 @@ function ResultCtrl ($scope, $rootScope, $route, $window, $routeParams, $locatio
     if (paragraphId === paragraph.id) {
       let builtInViz = builtInVisualizations[$scope.graphMode]
       if (builtInViz && builtInViz.instance) {
-        builtInViz.instance.resize()
+        $timeout(_ => builtInViz.instance.resize(), 200)
       }
     }
   })

--- a/zeppelin-web/src/app/visualization/visualization.js
+++ b/zeppelin-web/src/app/visualization/visualization.js
@@ -48,6 +48,7 @@ export default class Visualization {
    */
   refresh () {
     // override this
+    console.warn('A chart is missing refresh function, it might not work preperly')
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
Resize charts on paragraph resize

* Broadcast chart resize on para. resize with a timeout
* Add warning on refresh missing

### What type of PR is it?
[Bug Fix | Improvement]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-3177

### How should this be tested?

Open a paragraph with charts and resize paragraph width(see the gif)
ps- helium charts should be updated accordingly

### Screenshots (if appropriate)
Before:
![zeppelin3](https://user-images.githubusercontent.com/11382805/35181438-ec771338-fe04-11e7-8803-a6b3aa15b149.gif)
After:
![zeppelin3](https://user-images.githubusercontent.com/11382805/35181425-9623d962-fe04-11e7-8660-8dc82c54cd0e.gif)

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N 
* Does this needs documentation? N
