### PR TITLE
ZEPPELIN-3179. Improve error message when IPython is not available

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -44,6 +44,7 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.display.GUI;
 import org.apache.zeppelin.interpreter.*;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
@@ -228,7 +229,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
         getInterpreterGroup().getInterpreterHookRegistry(),
         Integer.parseInt(getProperty("zeppelin.python.maxResult", "1000")));
     if (getProperty("zeppelin.python.useIPython", "true").equals("true") &&
-      iPythonInterpreter.checkIPythonPrerequisite()) {
+        StringUtils.isEmpty(iPythonInterpreter.checkIPythonPrerequisite(getPythonBindPath()))) {
       try {
         iPythonInterpreter.open();
         if (InterpreterContext.get() != null) {

--- a/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -116,7 +116,8 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     // try IPySparkInterpreter first
     iPySparkInterpreter = getIPySparkInterpreter();
     if (getProperty("zeppelin.pyspark.useIPython", "true").equals("true") &&
-        iPySparkInterpreter.checkIPythonPrerequisite()) {
+        StringUtils.isEmpty(
+            iPySparkInterpreter.checkIPythonPrerequisite(getPythonExec(getProperties())))) {
       try {
         iPySparkInterpreter.open();
         if (InterpreterContext.get() != null) {


### PR DESCRIPTION
### What is this PR for?
Minor change to improve the error message when IPython is not available. See the following screenshot. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3179

### How should this be tested?
* Manually
![screen shot 2018-01-20 at 5 00 25 pm](https://user-images.githubusercontent.com/164491/35190572-baec39a6-fe9f-11e7-9f8c-f92f8ed01d38.png)
![screen shot 2018-01-20 at 5 00 19 pm](https://user-images.githubusercontent.com/164491/35190573-bb169890-fe9f-11e7-9702-9998485e4899.png)

 verified

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
