### PR TITLE
ZEPPELIN-3181. Enable impersonation support for kerberized cluster

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -114,6 +114,11 @@ fi
 
 # set spark related env variables
 if [[ "${INTERPRETER_ID}" == "spark" ]]; then
+
+  // # run kinit
+  if [[ -n "${ZEPPELIN_SERVER_KERBEROS_KEYTAB}" ]] && [[ -n "${ZEPPELIN_SERVER_KERBEROS_PRINCIPAL}" ]]; then
+    kinit -kt ${ZEPPELIN_SERVER_KERBEROS_KEYTAB} ${ZEPPELIN_SERVER_KERBEROS_PRINCIPAL}
+  fi
   if [[ -n "${SPARK_HOME}" ]]; then
     export SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
     SPARK_APP_JAR="$(ls ${ZEPPELIN_HOME}/interpreter/spark/zeppelin-spark*.jar)"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -89,6 +89,19 @@ public class SparkInterpreterLauncher extends ShellScriptLauncher {
         env.put(envName, envValue);
       }
     }
+
+    String keytab = zConf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_KEYTAB);
+    String principal =
+        zConf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_PRINCIPAL);
+
+    if (!StringUtils.isBlank(keytab) && !StringUtils.isBlank(principal)) {
+      env.put("ZEPPELIN_SERVER_KERBEROS_KEYTAB", keytab);
+      env.put("ZEPPELIN_SERVER_KERBEROS_PRINCIPAL", principal);
+      LOGGER.info("Run Spark under secure mode with keytab: " + keytab +
+          ", principal: " + principal);
+    } else {
+      LOGGER.info("Run Spark under non-secure mode as no keytab and principal is specified");
+    }
     LOGGER.debug("buildEnvFromProperties: " + env);
     return env;
 


### PR DESCRIPTION
### What is this PR for?
This is to enable kerberos support for spark yarn mode in impersonation. Spark has one limitation that you can not specify keytab & proxyuser together. So this PR would run kinit before launching spark interpreter. so that user can enable impersonation for secured cluster.


### What type of PR is it?
[Improvement | Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3181


### How should this be tested?
* Verified manually,  see the following screenshot.


### Screenshots (if appropriate)
![screen shot 2018-01-22 at 9 45 26 am](https://user-images.githubusercontent.com/164491/35201760-01462290-ff59-11e7-966b-b7b4e4df8b64.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No


