### PR TITLE
[ZEPPELIN-3195] Remove the limit on the number of run paragraphs at cron

### DIFF
--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -258,18 +258,6 @@ If both are defined, then the **environment variables** will take priority.
     <td>Make notebook public (set only <code>owners</code>) by default when created/imported. If set to <code>false</code> will add <code>user</code> to <code>readers</code> and <code>writers</code> as well, making it private and invisible to other users unless permissions are granted.</td>
   </tr>
   <tr>
-    <td><h6 class="properties">ZEPPELIN_INTERPRETERS</h6></td>
-    <td><h6 class="properties">zeppelin.interpreters</h6></td>
-  <description></description>
-    <td>org.apache.zeppelin.spark.SparkInterpreter,<br />org.apache.zeppelin.spark.PySparkInterpreter,<br />org.apache.zeppelin.spark.SparkSqlInterpreter,<br />org.apache.zeppelin.spark.DepInterpreter,<br />org.apache.zeppelin.markdown.Markdown,<br />org.apache.zeppelin.shell.ShellInterpreter,<br />
-    ...
-    </td>
-    <td>
-      Comma separated interpreter configurations [Class] <br/><br />
-      <span style="font-style:italic; color: gray">NOTE: This property is deprecated since Zeppelin-0.6.0 and will not be supported from Zeppelin-0.7.0.</span>
-    </td>
-  </tr>
-  <tr>
     <td><h6 class="properties">ZEPPELIN_INTERPRETER_DIR</h6></td>
     <td><h6 class="properties">zeppelin.interpreter.dir</h6></td>
     <td>interpreter</td>
@@ -280,6 +268,12 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">zeppelin.interpreter.dep.mvnRepo</h6></td>
     <td>http://repo1.maven.org/maven2/</td>
     <td>Remote principal repository for interpreter's additional dependency loading</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_INTERPRETER_MAX_POOL_SIZE</h6></td>
+    <td><h6 class="properties">zeppelin.interpreter.max.poolsize</h6></td>
+    <td>10</td>
+    <td>The maximum number of paragraphs that will be run at cron.</td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_INTERPRETER_OUTPUT_LIMIT</h6></td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -666,7 +666,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_DEP_MVNREPO("zeppelin.interpreter.dep.mvnRepo",
         "http://repo1.maven.org/maven2/"),
     ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 30000),
-    ZEPPELIN_INTERPRETER_MAX_POOL_SIZE("zeppelin.interpreter.max.poolsize", 65535),
+    ZEPPELIN_INTERPRETER_MAX_POOL_SIZE("zeppelin.interpreter.max.poolsize", 10),
     ZEPPELIN_INTERPRETER_GROUP_ORDER("zeppelin.interpreter.group.order", "spark,md,angular,sh,"
         + "livy,alluxio,file,psql,flink,python,ignite,lens,cassandra,geode,kylin,elasticsearch,"
         + "scalding,jdbc,hbase,bigquery,beam,pig,scio,groovy,neo4j"),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -666,7 +666,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_DEP_MVNREPO("zeppelin.interpreter.dep.mvnRepo",
         "http://repo1.maven.org/maven2/"),
     ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 30000),
-    ZEPPELIN_INTERPRETER_MAX_POOL_SIZE("zeppelin.interpreter.max.poolsize", 10),
+    ZEPPELIN_INTERPRETER_MAX_POOL_SIZE("zeppelin.interpreter.max.poolsize", 65535),
     ZEPPELIN_INTERPRETER_GROUP_ORDER("zeppelin.interpreter.group.order", "spark,md,angular,sh,"
         + "livy,alluxio,file,psql,flink,python,ignite,lens,cassandra,geode,kylin,elasticsearch,"
         + "scalding,jdbc,hbase,bigquery,beam,pig,scio,groovy,neo4j"),


### PR DESCRIPTION
### What is this PR for?
Increase interpreter pool size for unlimit the number of paragraph that run at cron schedule.

### What type of PR is it?
[Hot Fix]

### What is the Jira issue?
*https://issues.apache.org/jira/browse/ZEPPELIN-3195

### How should this be tested?
* Create note with 15 paragraphs
* Check that at cron will be executed only 10 paragraphs
* Checkout this branch and rebuild app
* Check that all paragraphs are executed at cron

### Questions:
* Does the licenses files need update? NA
* Is there breaking changes for older versions? NA
* Does this needs documentation? NA