### PR TITLE
[ZEPPELIN-3200] Move R LIB_DIR into subdirectory of zeppelin/r (1 line fix)

### DIFF
--- a/r/R/install-dev.sh
+++ b/r/R/install-dev.sh
@@ -25,7 +25,7 @@ set -e
 set -x
 
 FWDIR="$(cd `dirname $0`; pwd)"
-LIB_DIR="$FWDIR/../../R/lib"
+LIB_DIR="$FWDIR/lib"
 
 mkdir -p $LIB_DIR
 


### PR DESCRIPTION
### What is this PR for?
Move R LIB_DIR into subdirectory of zeppelin/r

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3200


### How should this be tested?
* "mvn package -Pr" and check the R install params

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NA
* Is there breaking changes for older versions? NA
* Does this needs documentation? NA
