### PR TITLE
[ZEPPELIN-3204] FIX: cursor in paragraph editor jumps

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1028,8 +1028,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
   const autoAdjustEditorHeight = function (editor) {
     let height =
       editor.getSession().getScreenLength() *
-      editor.renderer.lineHeight +
-      editor.renderer.scrollBar.getWidth()
+      editor.renderer.lineHeight
 
     angular.element('#' + editor.container.id).height(height.toString() + 'px')
     editor.resize()


### PR DESCRIPTION
### What is this PR for?
Sometimes when a user enters text in the paragraph field the lower part of the paragraph starts to jump. This PR fixes this.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-3204](https://issues.apache.org/jira/browse/ZEPPELIN-3204)

### Screenshots
![gif](https://user-images.githubusercontent.com/30798933/35732168-812f4274-0829-11e8-9fd6-45c2665f9646.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
