### PR TITLE
ZEPPELIN-3171. Restart of interpreter in note also aborts running interpreter in another note

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -380,15 +380,16 @@ public class RemoteInterpreter extends Interpreter {
         });
   }
 
-  //TODO(zjffdu) Share the Scheduler in the same session or in the same InterpreterGroup ?
+
   @Override
   public Scheduler getScheduler() {
     int maxConcurrency = Integer.parseInt(
         getProperty("zeppelin.interpreter.max.poolsize",
             ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE.getIntValue() + ""));
-
+    // one session own one Scheduler, so that when one session is closed, all the jobs/paragraphs
+    // running under the scheduler of this session will be aborted.
     Scheduler s = new RemoteScheduler(
-        RemoteInterpreter.class.getName() + "-" + sessionId,
+        RemoteInterpreter.class.getName() + "-" + getInterpreterGroup().getId() + "-" + sessionId,
         SchedulerFactory.singleton().getExecutor(),
         sessionId,
         this,

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -93,6 +93,8 @@ public class RemoteInterpreterTest {
     assertTrue(interpreter2 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter2 = (RemoteInterpreter) interpreter2;
 
+    assertEquals(remoteInterpreter1.getScheduler(), remoteInterpreter2.getScheduler());
+
     InterpreterContext context1 = new InterpreterContext("noteId", "paragraphId", "repl",
         "title", "text", AuthenticationInfo.ANONYMOUS, new HashMap<String, Object>(), new GUI(), new GUI(),
         null, null, new ArrayList<InterpreterContextRunner>(), null);
@@ -135,6 +137,8 @@ public class RemoteInterpreterTest {
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     assertTrue(interpreter2 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter2 = (RemoteInterpreter) interpreter2;
+
+    assertNotEquals(interpreter1.getScheduler(), interpreter2.getScheduler());
 
     InterpreterContext context1 = new InterpreterContext("noteId", "paragraphId", "repl",
         "title", "text", AuthenticationInfo.ANONYMOUS, new HashMap<String, Object>(), new GUI(), new GUI(),
@@ -181,6 +185,8 @@ public class RemoteInterpreterTest {
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     assertTrue(interpreter2 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter2 = (RemoteInterpreter) interpreter2;
+
+    assertNotEquals(interpreter1.getScheduler(), interpreter2.getScheduler());
 
     InterpreterContext context1 = new InterpreterContext("noteId", "paragraphId", "repl",
         "title", "text", AuthenticationInfo.ANONYMOUS, new HashMap<String, Object>(), new GUI(), new GUI(),


### PR DESCRIPTION

### What is this PR for?

The root cause is that in isolated mode interpreters will share the same scheduler. That means when one interpreter is terminated, all the running jobs under the scheduler of this interpreter will be aborted too. This PR will create one scheduler for each session. So when one session is closed, only the running jobs under this session's scheduler is aborted. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3171

### How should this be tested?
* Unit test is added.
* Also verify it manually. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
