### PR TITLE
ZEPPELIN-3209. Preserve thread context classloader when running jobs in RemoteInterpreterServer 

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -604,6 +604,7 @@ public class RemoteInterpreterServer extends Thread
 
     @Override
     protected Object jobRun() throws Throwable {
+      ClassLoader currentThreadContextClassloader = Thread.currentThread().getContextClassLoader();
       try {
         InterpreterContext.set(context);
 
@@ -652,6 +653,7 @@ public class RemoteInterpreterServer extends Thread
         }
         return new InterpreterResult(result.code(), resultMessages);
       } finally {
+        Thread.currentThread().setContextClassLoader(currentThreadContextClassloader);
         InterpreterContext.remove();
       }
     }


### PR DESCRIPTION
### What is this PR for?
Spark jobs may change current thread context classloader sometimes.

For example in case of issue ZEPPELIN-2475 using Spark 2.2 and Scala 2.11.8 when you run DepInterpreter that will start SparkILoop --> ILoop which changes the current thread context classloader, from LauncherAppClassloader to ScalaClassloader@URLClassloader. This result in classloading problems when SparkInterpreter is trying to build up Spark Context, in case SparkInterpreter is started by scheduler on same thread.

In short when running subsequent paragraphs, users will get an ambiguous NullPointerException, which is hard to understand as it hides the root cause of the problem. As a safety measure to prevent such cases RemoteInterpreterServer should save & restore original thread context classloader.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3209

### How should this be tested?
* Use Spark 2.2 and Scala 2.11.8
* create a notebook with two paragraphs
* in first paragraph use %spark.dep interpreter and add load some dependencies
* in second paragraph use %spark interpreter and run some spark code

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
