### PR TITLE
ZEPPELIN-3211. REST API: Enable running all paragraphs without waiting for finish

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -661,16 +661,18 @@ public class NotebookRestApi {
   @POST
   @Path("job/{noteId}")
   @ZeppelinApi
-  public Response runNoteJobs(@PathParam("noteId") String noteId)
+  public Response runNoteJobs(@PathParam("noteId") String noteId,
+                              @QueryParam("waitToFinish") Boolean waitToFinish)
           throws IOException, IllegalArgumentException {
-    LOG.info("run note jobs {} ", noteId);
+    boolean blocking = waitToFinish == null ? true : waitToFinish.booleanValue();
+    LOG.info("run note jobs {} waitToFinish: {}", noteId, blocking);
     Note note = notebook.getNote(noteId);
     AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
     checkIfNoteIsNotNull(note);
     checkIfUserCanRun(noteId, "Insufficient privileges you cannot run job for this note");
 
     try {
-      note.runAll(subject, true);
+      note.runAll(subject, blocking);
     } catch (Exception ex) {
       LOG.error("Exception from run", ex);
       return new JsonResponse<>(Status.PRECONDITION_FAILED,


### PR DESCRIPTION
### What is this PR for?
At the moment there is no possibility on Notebook REST API to run all paragraphs in a notebook and return without waiting for finish. Would be useful to have an optional extra param `waitToFinish` on `api/notebook/job/{noteId}` which is true by default.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3211

### How should this be tested?
* can be tested manually, invoking REST API: curl -s -X POST "http://{{zeppelin_server}}/api/notebook/job/{noteId}?waitToFinish=false"

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
