### PR TITLE
[ZEPPELIN-3212] delete extra ">" in notebook-actionBar.html

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -24,7 +24,7 @@ limitations under the License.
          tooltip-placement="bottom"
          uib-tooltip={{noteName(note)}}
          ng-click="input.showEditor = !revisionView; input.value = note.name"
-         ng-show="!input.showEditor"><span>{{noteName(note)}}</span>></p>
+         ng-show="!input.showEditor"><span>{{noteName(note)}}</span></p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">


### PR DESCRIPTION
### What is this PR for?
Delete extra ">" in  notebook-actionBar.html after `</span>`


### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-3212](https://issues.apache.org/jira/browse/ZEPPELIN-3212)

### Screenshots (if appropriate)
![1](https://user-images.githubusercontent.com/30798933/35930861-1ba8369e-0c44-11e8-8ebf-9328cb21a6e5.PNG)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
