### PR TITLE
ZEPPELIN-3208. Use interpreter setting's name as its id

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -268,6 +268,7 @@ public class InterpreterSetting {
 
   void postProcessing() {
     this.status = Status.READY;
+    this.id = this.name;
     if (this.lifecycleManager == null) {
       this.lifecycleManager = new NullLifecycleManager(conf);
     }
@@ -287,7 +288,7 @@ public class InterpreterSetting {
    */
   public InterpreterSetting(InterpreterSetting o) {
     this();
-    this.id = generateId();
+    this.id = o.name;
     this.name = o.name;
     this.group = o.group;
     this.properties = convertInterpreterProperties(


### PR DESCRIPTION
### What is this PR for?
Interpreter setting's name is unique, so it is not necessary to use id to identify it. For now we use a random string to represent such id which is not easy to read especially when you read log for diagnose. But for backward compatibility, I will keep id and set it as the same as interpreter setting's name


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3208

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
