### PR TITLE
[ZEPPELIN-3213] Support for KNOXSSO logout url as API

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -61,6 +61,7 @@ user3 = password4, role2
 #knoxJwtRealm.providerUrl = https://domain.example.com/
 #knoxJwtRealm.login = gateway/knoxsso/knoxauth/login.html
 #knoxJwtRealm.logout = gateway/knoxssout/api/v1/webssout
+#knoxJwtRealm.logoutAPI = true
 #knoxJwtRealm.redirectParam = originalUrl
 #knoxJwtRealm.cookieName = hadoop-jwt
 #knoxJwtRealm.publicKeyPath = /etc/zeppelin/conf/knox-sso.pem

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxJwtRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxJwtRealm.java
@@ -60,6 +60,7 @@ public class KnoxJwtRealm extends AuthorizingRealm {
   private String publicKeyPath;
   private String login;
   private String logout;
+  private Boolean logoutAPI;
 
   private String principalMapping;
   private String groupPrincipalMapping;
@@ -268,6 +269,14 @@ public class KnoxJwtRealm extends AuthorizingRealm {
 
   public void setLogout(String logout) {
     this.logout = logout;
+  }
+
+  public Boolean getLogoutAPI() {
+    return logoutAPI;
+  }
+
+  public void setLogoutAPI(Boolean logoutAPI) {
+    this.logoutAPI = logoutAPI;
   }
 
   public String getPrincipalMapping() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -211,6 +211,7 @@ public class LoginRestApi {
       KnoxJwtRealm knoxJwtRealm = getJTWRealm();
       Map<String, String> data = new HashMap<>();
       data.put("redirectURL", constructKnoxUrl(knoxJwtRealm, knoxJwtRealm.getLogout()));
+      data.put("isLogoutAPI", knoxJwtRealm.getLogoutAPI().toString());
       response = new JsonResponse(Status.UNAUTHORIZED, "", data);
     } else {
       response = new JsonResponse(Status.UNAUTHORIZED, "", "");

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -93,7 +93,15 @@ function NavCtrl ($scope, $rootScope, $http, $routeParams, $location,
       if (response.data) {
         let res = angular.fromJson(response.data).body
         if (res['redirectURL']) {
-          window.location.href = res['redirectURL'] + window.location.href
+          if (res['isLogoutAPI'] === 'true') {
+            $http.get(res['redirectURL']).then(function () {
+            }, function () {
+              window.location = baseUrlSrv.getBase()
+            })
+          } else {
+            window.location.href = res['redirectURL'] + window.location.href
+          }
+          return undefined
         }
       }
 


### PR DESCRIPTION
### What is this PR for?
KNOXSSO logout URL can be an API or it can be a redirect URL, Zeppelin should support both.


### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3213](https://issues.apache.org/jira/browse/ZEPPELIN-3213)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
