### PR TITLE
[ZEPPELIN-3215] Fix to remove pid of interpreter when interpreter shu…

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -251,14 +251,14 @@ function shutdown_hook() {
       sleep 3
       let "count+=1"
     else
-      rm -f "${ZEPPELIN_PID}"
       break
     fi
   if [[ "${count}" == "5" ]]; then
     $(kill -9 ${pid} > /dev/null 2> /dev/null)
-    rm -f "${ZEPPELIN_PID}"
   fi
   done
 }
 
 wait
+
+rm -f "${ZEPPELIN_PID}" > /dev/null 2> /dev/null


### PR DESCRIPTION
### What is this PR for?
When user click 'restart interpreter', pid file about interpreter can be remained.
This PR is for fix this.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3215

### How should this be tested?
After interpreter shuted down, pid file of interpreter could be removed.

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No