### PR TITLE
[ZEPPELIN-3228] Currently interpreter dependencies are not downloaded on zeppelin start - regression issue

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -266,6 +266,12 @@ public class InterpreterSettingManager {
           this.interpreterRepositories.add(repo);
         }
       }
+
+      // force interpreter dependencies loading once the
+      // repositories have been loaded.
+      for (InterpreterSetting setting : interpreterSettings.values()) {
+        setting.setDependencies(setting.getDependencies());
+      }
     }
   }
 


### PR DESCRIPTION
Currently interpreter dependencies are not downloaded on zeppelin start. This was solved in [ZEPPELIN-3228], but it is happening again.

### What is this PR for?
When zeppelin is started/restarted, server should try and download interpreter dependencies.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3228] 

### How should this be tested?
*  Put a dependency (say "org.apache.commons:commons-csv:1.1") in any of the interpreter.
*  From command line delete local-repo directory
*  Restart zeppelin server

Expectation is local-repo should be recreated with all the dependencies that were mentioned in any of the interpreters.

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
