### PR TITLE
ZEPPELIN-3225: Add a bunch of missing annotations to ActiveDirectoryGroupRealm.java.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -46,7 +46,6 @@ import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 import java.util.*;
 
-
 /**
  * A {@link Realm} that authenticates with an active directory LDAP
  * server to determine the roles for a particular user.  This implementation
@@ -93,6 +92,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   LdapContextFactory ldapContextFactory;
 
+  @Override
   protected void onInit() {
     super.onInit();
     this.getLdapContextFactory();
@@ -116,6 +116,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     return this.ldapContextFactory;
   }
 
+  @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
       throws AuthenticationException {
     try {
@@ -130,6 +131,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     }
   }
 
+  @Override
   protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
     try {
       AuthorizationInfo info = this.queryForAuthorizationInfo(principals,
@@ -177,6 +179,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
    * @return an {@link AuthenticationInfo} instance containing information retrieved from LDAP.
    * @throws NamingException if any LDAP errors occur during the search.
    */
+  @Override
   protected AuthenticationInfo queryForAuthenticationInfo(
       AuthenticationToken token, LdapContextFactory ldapContextFactory) throws NamingException {
 
@@ -239,6 +242,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
    * @return the AuthorizationInfo for the given Subject principal.
    * @throws NamingException if an error occurs when searching the LDAP server.
    */
+  @Override
   protected AuthorizationInfo queryForAuthorizationInfo(
       PrincipalCollection principals,
       LdapContextFactory ldapContextFactory) throws NamingException {
@@ -387,4 +391,3 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
   }
 
 }
-


### PR DESCRIPTION
### What is this PR for?
Add a bunch of missing annotations to ActiveDirectoryGroupRealm.java. Those annotations are missing and generate a lot of warnings in my IDE (NetBeans).

### What type of PR is it?
Improvement.

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3225

### How should this be tested?
There's not much to test.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
