### PR TITLE
[ZEPPELIN-3240] Zeppelin server fail to start if interpreter has mixed properties

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.internal.StringMap;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
@@ -45,19 +44,13 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventPoller;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
-import org.apache.zeppelin.interpreter.remote.RemoteInterpreterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -906,6 +899,13 @@ public class InterpreterSetting {
               // in case user forget to specify type in interpreter-setting.json
           );
           newProperties.put(key, property);
+        } else if (value instanceof String) {
+          InterpreterProperty newProperty = new InterpreterProperty(
+              key,
+              value,
+              "string");
+
+          newProperties.put(newProperty.getName(), newProperty);
         } else {
           throw new RuntimeException("Can not convert this type of property: " +
               value.getClass());


### PR DESCRIPTION
### What is this PR for?
I found that Zeppelin server is failing to start when there is a mix of both kind of properties in interpreter;

```
"properties": {
        "shell.command.timeout.millisecs": {
          "type": "string",
          "name": "shell.command.timeout.millisecs",
          "value": "60000"
        },
        "shell.working.directory.user.home": {
          "type": "checkbox",
          "name": "shell.working.directory.user.home",
          "value": false
        },
        "zeppelin.shell.auth.type": "KERBEROS",
        "zeppelin.shell.keytab.location": "/etc/security/keytabs/zeppelin.server.kerberos.keytab",
        "zeppelin.shell.principal": "zeppelin@EXAMPLE.COM"
      }
```

Mix as in these two kind of properties:

 - Where key is string and value is object
```
"shell.command.timeout.millisecs": {
          "type": "string",
          "name": "shell.command.timeout.millisecs",
          "value": "60000"
        }
```

 - Where key and value both are string
```
"zeppelin.shell.auth.type": "KERBEROS"
```

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3240](https://issues.apache.org/jira/browse/ZEPPELIN-3240)

### How should this be tested?
* Place this [interpreter.json](https://issues.apache.org/jira/secure/attachment/12910862/interpreter.json) in Z-server conf folder and try to start Z-Server, with this patch it should start.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
