### PR TITLE
[ZEPPELIN-3241] fix NPE when restarting Interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -728,7 +728,7 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
    * @param settingId
    */
   public void clearRuntimeInfo(String settingId) {
-    if (settingId != null) {
+    if (settingId != null && runtimeInfos != null) {
       Set<String> keys = runtimeInfos.keySet();
       if (keys.size() > 0) {
         List<String> infosToRemove = new ArrayList<>();


### PR DESCRIPTION
### What is this PR for?
We often (but not always) face an NPE when restarting Spark interpreter. Our Spark interpreter run in scoped mode per note. The restart then is not possible, only restart of whole zeppelin daemon helps out.

This PR fixes this NPE.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[https://issues.apache.org/jira/browse/ZEPPELIN-3241](https://issues.apache.org/jira/browse/ZEPPELIN-3241)

### How should this be tested?
- manual

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
