### PR TITLE
[ZEPPELIN-3243] fix IndexOutOfBoundsException when 'No interpreter is binded to this note'

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -414,7 +414,8 @@ public class InterpreterSettingManager {
 
   @VisibleForTesting
   public InterpreterSetting getDefaultInterpreterSetting(String noteId) {
-    return getInterpreterSettings(noteId).get(0);
+    List<InterpreterSetting> allInterpreterSettings = getInterpreterSettings(noteId);
+    return allInterpreterSettings.size() > 0 ? allInterpreterSettings.get(0) : null;
   }
 
   public List<InterpreterSetting> getInterpreterSettings(String noteId) {
@@ -470,7 +471,7 @@ public class InterpreterSettingManager {
           group = replNameSplit[0];
         }
         // when replName is 'name' of interpreter
-        if (defaultSettingName.equals(intpSetting.getName())) {
+        if (intpSetting.getName().equals(defaultSettingName)) {
           editor = intpSetting.getEditorFromSettingByClassName(interpreter.getClassName());
         }
         // when replName is 'alias name' of interpreter or 'group' of interpreter


### PR DESCRIPTION
### What is this PR for?
I observed IndexOutOfBoundsException when using zeppelin locally on an existing notebook repository and with fresh interpreter.json file.
The default Zeppelin behavior when using existing notebooks is the manual binding of the interpreter settings, which works fine. This PR simply avoids the IndexOutOfBoundsException.

### What type of PR is it?
Bug Fix

### Todos
-

### What is the Jira issue?
[https://issues.apache.org/jira/browse/ZEPPELIN-3243](https://issues.apache.org/jira/browse/ZEPPELIN-3243)

### How should this be tested?
- manual

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
