### PR TITLE
ZEPPELIN-3239. unicode characters in an iPython paragraph makes Spark interpreter irresponsive

### DIFF
--- a/python/src/main/resources/grpc/python/ipython_server.py
+++ b/python/src/main/resources/grpc/python/ipython_server.py
@@ -27,7 +27,6 @@ import ipython_pb2_grpc
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
-
 is_py2 = sys.version[0] == '2'
 if is_py2:
     import Queue as queue
@@ -51,7 +50,7 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
 
     def execute(self, request, context):
         print("execute code:\n")
-        print(request.code)
+        print(request.code.encode('utf-8'))
         sys.stdout.flush()
         stdout_queue = queue.Queue(maxsize = 10)
         stderr_queue = queue.Queue(maxsize = 10)

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -81,18 +81,33 @@ public class IPythonInterpreterTest {
     InterpreterResult result = interpreter.interpret("from __future__ import print_function", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
-    result = interpreter.interpret("import sys\nprint(sys.version_info)", getInterpreterContext());
+
+    InterpreterContext context = getInterpreterContext();
+    result = interpreter.interpret("import sys\nprint(sys.version[0])", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    Thread.sleep(100);
+    List<InterpreterResultMessage> interpreterResultMessages = context.out.getInterpreterResultMessages();
+    assertEquals(1, interpreterResultMessages.size());
+    boolean isPython2 = interpreterResultMessages.get(0).getData().equals("2\n");
 
     // single output without print
-    InterpreterContext context = getInterpreterContext();
+    context = getInterpreterContext();
     result = interpreter.interpret("'hello world'", context);
     Thread.sleep(100);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    List<InterpreterResultMessage> interpreterResultMessages = context.out.getInterpreterResultMessages();
+    interpreterResultMessages = context.out.getInterpreterResultMessages();
     assertEquals(1, interpreterResultMessages.size());
     assertEquals("'hello world'", interpreterResultMessages.get(0).getData());
 
+    // unicode
+    context = getInterpreterContext();
+    result = interpreter.interpret("print(u'你好')", context);
+    Thread.sleep(100);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    interpreterResultMessages = context.out.getInterpreterResultMessages();
+    assertEquals(1, interpreterResultMessages.size());
+    assertEquals("你好\n", interpreterResultMessages.get(0).getData());
+    
     // only the last statement is printed
     context = getInterpreterContext();
     result = interpreter.interpret("'hello world'\n'hello world2'", context);


### PR DESCRIPTION
### What is this PR for?

Fix the unicode issues in python2.

### What type of PR is it?
[Bug Fix | Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3239

### How should this be tested?
* Unit test is added

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
