### PR TITLE
[ZEPPELIN-3252] Update the Apache Flink version to 1.4.1

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -36,8 +36,8 @@
   <properties>
     <!--library versions-->
     <interpreter.name>flink</interpreter.name>
-    <flink.version>1.1.3</flink.version>
-    <flink.akka.version>2.3.7</flink.akka.version>
+    <flink.version>1.3.3</flink.version>
+    <flink.akka.version>2.3.16</flink.akka.version>
     <scala.macros.version>2.0.1</scala.macros.version>
 
     <!--plugin versions-->


### PR DESCRIPTION
Update the flink version to 1.4.1 and the related akka version to 2.4.20.

### What is this PR for?

This updates the flink interpreter to the latest Flink version which is 1.4.1.

### What type of PR is it?
[Improvement]

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-3252

