### PR TITLE
[ZEPPELIN-3263] Do not use Firefox >=55 for integration testing

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -18,6 +18,8 @@
 package org.apache.zeppelin;
 
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -171,6 +173,50 @@ abstract public class AbstractZeppelinIT {
     LOG.info("Waiting for the main page (" + mainPage + ")...");
     wait.until(ExpectedConditions.urlToBe(mainPage));
     LOG.info("Logout successful!");
+  }
+
+  protected void restartPythonInterpreter() {
+    clickAndWait(By.xpath("//*[@id='actionbar']//span[contains(@uib-tooltip, 'Interpreter binding')]"));
+    clickAndWait(By.xpath("//div[@data-ng-repeat='item in interpreterBindings' and contains(., 'python')]//a"));
+    clickAndWait(By.xpath("//div[@class='modal-dialog']" +
+        "[contains(.,'Do you want to restart python interpreter?')]" +
+        "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
+    By locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
+    LOG.info("Holding on until if interpreter restart dialog is disappeared");
+    boolean invisibilityStatus;
+    ZeppelinITUtils.turnOffImplicitWaits(driver);
+    try {
+      invisibilityStatus = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
+          .until(ExpectedConditions.invisibilityOfElementLocated(locator));
+    } finally {
+      ZeppelinITUtils.turnOnImplicitWaits(driver);
+    }
+    assertTrue("interpreter setting dialog visibility status", invisibilityStatus);
+    locator = By.xpath("//*[@id='actionbar']//span[contains(@uib-tooltip, 'Interpreter binding')]");
+    WebElement element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
+        .until(ExpectedConditions.visibilityOfElementLocated(locator));
+    if (element.isDisplayed()) {
+      clickAndWait(By.xpath("//*[@id='actionbar']//span[contains(@uib-tooltip, 'Interpreter binding')]"));
+    }
+  }
+
+  protected void restartThisInterpreter() {
+    clickAndWait(By.xpath("//div[contains(@id, 'python')]" +
+        "//button[contains(@ng-click, 'restartInterpreterSetting(setting.id)')]"));
+    clickAndWait(By.xpath("//div[@class='modal-dialog']" +
+        "[contains(.,'Do you want to restart this interpreter?')]" +
+        "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
+    By locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
+    LOG.info("Holding on until if interpreter restart dialog is disappeared");
+    boolean invisibilityStatus;
+    ZeppelinITUtils.turnOffImplicitWaits(driver);
+    try {
+      invisibilityStatus = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
+          .until(ExpectedConditions.invisibilityOfElementLocated(locator));
+    } finally {
+      ZeppelinITUtils.turnOnImplicitWaits(driver);
+    }
+    assertTrue("interpreter setting dialog visibility status", invisibilityStatus);
   }
 
   protected void createNewNote() {

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -135,4 +135,13 @@ abstract public class AbstractZeppelinIT {
     throw e;
   }
 
+  protected static void handleBrowserLogs() {
+    try {
+      for (LogEntry entry : driver.manage().logs().get(LogType.BROWSER)) {
+        LOG.info(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
+      }
+    } catch (WebDriverException e) {
+      // Log retrieval is not available for our browser, ignore.
+    }
+  }
 }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -219,6 +219,35 @@ abstract public class AbstractZeppelinIT {
     assertTrue("interpreter setting dialog visibility status", invisibilityStatus);
   }
 
+  protected static Object js(final WebDriver driver, final String script, final Object... args) {
+    return ((JavascriptExecutor)driver).executeScript(script, args);
+  }
+
+  protected void goToNote(final String noteId) {
+    final WebDriverWait wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
+    final By linkLocator = By.xpath(
+        "//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
+    wait.until(new Function<WebDriver, WebElement>() {
+      @Override
+      public WebElement apply(final WebDriver driver) {
+        ZeppelinITUtils.turnOffImplicitWaits(driver);
+        try {
+          final WebElement link = ExpectedConditions.elementToBeClickable(
+              linkLocator).apply(driver);
+          if (link == null) {
+            // Scroll down to trigger async page loading.
+            js(driver, "window.scrollBy(0, document.body.scrollHeight)");
+            // FIXME: deal with load without race conditions
+            ZeppelinITUtils.sleep(1000, false);
+          }
+          return link;
+        } finally {
+          ZeppelinITUtils.turnOnImplicitWaits(driver);
+        }
+      }
+    }).click();
+  }
+
   protected void createNewNote() {
     clickAndWait(By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new" +
         " note')]"));

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -26,18 +26,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxDriver.SystemProperty;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.GeckoDriverService;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -121,7 +127,11 @@ public class WebDriverManager {
 
     if (driver == null) {
       try {
-        driver = new ChromeDriver();
+        LoggingPreferences logPrefs = new LoggingPreferences();
+        logPrefs.enable(LogType.BROWSER, Level.ALL);
+        ChromeOptions opts = new ChromeOptions();
+        opts.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
+        driver = new ChromeDriver(opts);
       } catch (Exception e) {
         LOG.error("Exception in WebDriverManager while ChromeDriver ", e);
       }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/WebDriverManager.java
@@ -104,6 +104,14 @@ public class WebDriverManager {
     }
   }
 
+  public static String getUrl() {
+    if (System.getenv("url") != null) {
+      return System.getenv("url");
+    } else {
+      return "http://localhost:8080";
+    }
+  }
+
   public static WebDriver getWebDriver() {
     WebDriver driver = null;
 
@@ -127,12 +135,7 @@ public class WebDriverManager {
       }
     }
 
-    String url;
-    if (System.getenv("url") != null) {
-      url = System.getenv("url");
-    } else {
-      url = "http://localhost:8080";
-    }
+    String url = getUrl();
 
     long start = System.currentTimeMillis();
     boolean loaded = false;

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -109,6 +109,7 @@ public class AuthenticationIT extends AbstractZeppelinIT {
     } catch (IOException e) {
       LOG.error("Error in AuthenticationIT tearDown::", e);
     }
+    handleBrowserLogs();
     ZeppelinITUtils.restartZeppelin();
     driver.quit();
   }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterIT.java
@@ -27,7 +27,9 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,16 +53,22 @@ public class InterpreterIT extends AbstractZeppelinIT {
   @Test
   public void testShowDescriptionOnInterpreterCreate() throws Exception {
     try {
-      // navigate to interpreter page
-      WebElement settingButton = driver.findElement(By.xpath("//button[@class='nav-btn dropdown-toggle ng-scope']"));
-      settingButton.click();
-      WebElement interpreterLink = driver.findElement(By.xpath("//a[@href='#/interpreter']"));
-      interpreterLink.click();
-
-      WebElement createButton = driver.findElement(By.xpath("//button[contains(., 'Create')]"));
-      createButton.click();
-
-      Select select = new Select(driver.findElement(By.xpath("//select[@ng-change='newInterpreterGroupChange()']")));
+      final WebDriverWait wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
+      LOG.info("Opening drop-down menu...");
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(
+          "//button[@class='nav-btn dropdown-toggle ng-scope']")))
+          .click();
+      LOG.info("Opening interpreter menu...");
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(
+          "//a[@href='#/interpreter']")))
+          .click();
+      LOG.info("Clicking create button...");
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(
+          "//button[contains(., 'Create')]")))
+          .click();
+      LOG.info("Selecting spark interpreter...");
+      Select select = new Select(wait.until(ExpectedConditions.elementToBeClickable(By.xpath(
+          "//select[@ng-change='newInterpreterGroupChange()']"))));
       select.selectByVisibleText("spark");
 
       collector.checkThat("description of interpreter property is displayed",

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterIT.java
@@ -44,6 +44,7 @@ public class InterpreterIT extends AbstractZeppelinIT {
 
   @After
   public void tearDown() {
+    handleBrowserLogs();
     driver.quit();
   }
 

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
@@ -122,6 +122,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
     } catch (IOException e) {
       LOG.error("Error in InterpreterModeActionsIT tearDown::", e);
     }
+    handleBrowserLogs();
     ZeppelinITUtils.restartZeppelin();
     driver.quit();
   }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
@@ -127,34 +127,6 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
     driver.quit();
   }
 
-  private void authenticationUser(String userName, String password) {
-    pollingWait(By.xpath(
-        "//div[contains(@class, 'navbar-collapse')]//li//button[contains(.,'Login')]"),
-        MAX_BROWSER_TIMEOUT_SEC).click();
-    ZeppelinITUtils.sleep(500, false);
-    pollingWait(By.xpath("//*[@id='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(userName);
-    pollingWait(By.xpath("//*[@id='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(password);
-    pollingWait(By.xpath("//*[@id='loginModalContent']//button[contains(.,'Login')]"),
-        MAX_BROWSER_TIMEOUT_SEC).click();
-    ZeppelinITUtils.sleep(1000, false);
-  }
-
-  private void logoutUser(String userName) throws URISyntaxException {
-    ZeppelinITUtils.sleep(500, false);
-    driver.findElement(By.xpath("//div[contains(@class, 'navbar-collapse')]//li[contains(.,'" +
-        userName + "')]")).click();
-    ZeppelinITUtils.sleep(500, false);
-    driver.findElement(By.xpath("//div[contains(@class, 'navbar-collapse')]//li[contains(.,'" +
-        userName + "')]//a[@ng-click='navbar.logout()']")).click();
-    ZeppelinITUtils.sleep(2000, false);
-    if (driver.findElement(By.xpath("//*[@id='loginModal']//div[contains(@class, 'modal-header')]/button"))
-        .isDisplayed()) {
-      driver.findElement(By.xpath("//*[@id='loginModal']//div[contains(@class, 'modal-header')]/button")).click();
-    }
-    driver.get(new URI(driver.getCurrentUrl()).resolve("/#/").toString());
-    ZeppelinITUtils.sleep(500, false);
-  }
-
   private void setPythonParagraph(int num, String text) {
     setTextOfParagraph(num, "%python\\n " + text);
     runParagraph(num);
@@ -171,8 +143,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
   public void testGloballyAction() throws Exception {
     try {
       //step 1: (admin) login, set 'globally in shared' mode of python interpreter, logout
-      InterpreterModeActionsIT interpreterModeActionsIT = new InterpreterModeActionsIT();
-      interpreterModeActionsIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       pollingWait(By.xpath("//div/button[contains(@class, 'nav-btn dropdown-toggle ng-scope')]"),
           MAX_BROWSER_TIMEOUT_SEC).click();
       clickAndWait(By.xpath("//li/a[contains(@href, '#/interpreter')]"));
@@ -190,12 +161,12 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       clickAndWait(By.xpath(
           "//div[@class='modal-dialog']//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       clickAndWait(By.xpath("//a[@class='navbar-brand navbar-title'][contains(@href, '#/')]"));
-      interpreterModeActionsIT.logoutUser("admin");
+      logoutUser("admin");
       //step 2: (user1) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //paragraph: Check if the result is 'user1' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       By locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebElement element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -205,9 +176,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       }
       String user1noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
+      setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -221,13 +192,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
 
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
       //step 3: (user2) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //paragraph: Check if the result is 'user2' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -236,9 +207,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
         createNewNote();
       }
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
+      setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -251,14 +222,14 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 4: (user1) login, come back note user1 made, run second paragraph, check result, check process,
       //restart python interpreter, check process again, logout
       //paragraph: Check if the result is 'user2' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -310,7 +281,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("0"));
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
     } catch (Exception e) {
       handleException("Exception in InterpreterModeActionsIT while testGloballyAction ", e);
     }
@@ -320,8 +291,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
   public void testPerUserScopedAction() throws Exception {
     try {
       //step 1: (admin) login, set 'Per user in scoped' mode of python interpreter, logout
-      InterpreterModeActionsIT interpreterModeActionsIT = new InterpreterModeActionsIT();
-      interpreterModeActionsIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       pollingWait(By.xpath("//div/button[contains(@class, 'nav-btn dropdown-toggle ng-scope')]"),
           MAX_BROWSER_TIMEOUT_SEC).click();
 
@@ -345,13 +315,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "//div[@class='modal-dialog']//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       clickAndWait(By.xpath("//a[@class='navbar-brand navbar-title'][contains(@href, '#/')]"));
 
-      interpreterModeActionsIT.logoutUser("admin");
+      logoutUser("admin");
 
       //step 2: (user1) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //paragraph: Check if the result is 'user1' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       By locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebElement element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -362,9 +332,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       String user1noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
 
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
+      setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
@@ -379,13 +349,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
       //step 3: (user2) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //                paragraph: Check if the result is 'user2' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '2'
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -395,9 +365,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       }
       String user2noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
+      setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -418,7 +388,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //paragraph: Check if the result is 'user1' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -466,12 +436,12 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
       //step 5: (user2) login, come back note user2 made, restart python interpreter in note, check process, logout
       //System: Check if the number of python interpreter process is '0'
       //System: Check if the number of python process is '0'
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -506,13 +476,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("0"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 6: (user1) login, come back note user1 made, run first paragraph,logout
       //        (user2) login, come back note user2 made, run first paragraph, check process, logout
       //System: Check if the number of python process is '2'
       //System: Check if the number of python interpreter process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -529,9 +499,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
         collector.checkThat("Exception in InterpreterModeActionsIT while running Python Paragraph",
             "ERROR", CoreMatchers.equalTo("FINISHED"));
       }
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -555,12 +525,12 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 7: (admin) login, restart python interpreter in interpreter tab, check process, logout
       //System: Check if the number of python interpreter process is 0
       //System: Check if the number of python process is 0
-      interpreterModeActionsIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       pollingWait(By.xpath("//div/button[contains(@class, 'nav-btn dropdown-toggle ng-scope')]"),
           MAX_BROWSER_TIMEOUT_SEC).click();
 
@@ -591,7 +561,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("0"));
 
-      interpreterModeActionsIT.logoutUser("admin");
+      logoutUser("admin");
 
     } catch (Exception e) {
       handleException("Exception in InterpreterModeActionsIT while testPerUserScopedAction ", e);
@@ -602,8 +572,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
   public void testPerUserIsolatedAction() throws Exception {
     try {
       //step 1: (admin) login, set 'Per user in isolated' mode of python interpreter, logout
-      InterpreterModeActionsIT interpreterModeActionsIT = new InterpreterModeActionsIT();
-      interpreterModeActionsIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       pollingWait(By.xpath("//div/button[contains(@class, 'nav-btn dropdown-toggle ng-scope')]"),
           MAX_BROWSER_TIMEOUT_SEC).click();
       clickAndWait(By.xpath("//li/a[contains(@href, '#/interpreter')]"));
@@ -623,13 +592,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       clickAndWait(By.xpath(
           "//div[@class='modal-dialog']//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       clickAndWait(By.xpath("//a[@class='navbar-brand navbar-title'][contains(@href, '#/')]"));
-      interpreterModeActionsIT.logoutUser("admin");
+      logoutUser("admin");
 
       //step 2: (user1) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //paragraph: Check if the result is 'user1' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       By locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebElement element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -639,9 +608,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       }
       String user1noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
+      setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
@@ -656,13 +625,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
       //step 3: (user2) login, create a new note, run two paragraph with 'python', check result, check process, logout
       //                paragraph: Check if the result is 'user2' in the second paragraph
       //System: Check if the number of python interpreter process is '2'
       //System: Check if the number of python process is '2'
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//div[contains(@class, 'col-md-4')]/div/h5/a[contains(.,'Create new" +
           " note')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
@@ -672,9 +641,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       }
       String user2noteId = driver.getCurrentUrl().substring(driver.getCurrentUrl().lastIndexOf("/") + 1);
       waitForParagraph(1, "READY");
-      interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
+      setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
+      setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
@@ -689,14 +658,14 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("2"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 4: (user1) login, come back note user1 made, run second paragraph, check result,
       //                restart python interpreter in note, check process again, logout
       //paragraph: Check if the result is 'user1' in the second paragraph
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -745,12 +714,12 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("1"));
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
       //step 5: (user2) login, come back note user2 made, restart python interpreter in note, check process, logout
       //System: Check if the number of python interpreter process is '0'
       //System: Check if the number of python process is '0'
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -786,13 +755,13 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("0"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 6: (user1) login, come back note user1 made, run first paragraph,logout
       //        (user2) login, come back note user2 made, run first paragraph, check process, logout
       //System: Check if the number of python process is '2'
       //System: Check if the number of python interpreter process is '2'
-      interpreterModeActionsIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -809,9 +778,9 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
         collector.checkThat("Exception in InterpreterModeActionsIT while running Python Paragraph",
             "ERROR", CoreMatchers.equalTo("FINISHED"));
       }
-      interpreterModeActionsIT.logoutUser("user1");
+      logoutUser("user1");
 
-      interpreterModeActionsIT.authenticationUser("user2", "password3");
+      authenticationUser("user2", "password3");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
       element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
           .until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -835,12 +804,12 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("2"));
-      interpreterModeActionsIT.logoutUser("user2");
+      logoutUser("user2");
 
       //step 7: (admin) login, restart python interpreter in interpreter tab, check process, logout
       //System: Check if the number of python interpreter process is 0
       //System: Check if the number of python process is 0
-      interpreterModeActionsIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       pollingWait(By.xpath("//div/button[contains(@class, 'nav-btn dropdown-toggle ng-scope')]"),
           MAX_BROWSER_TIMEOUT_SEC).click();
 
@@ -870,7 +839,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           false, ProcessData.Types_Of_Data.OUTPUT);
       resultProcessNum = resultProcessNum.trim().replaceAll("\n", "");
       collector.checkThat("The number of python interpreter process is", resultProcessNum, CoreMatchers.equalTo("0"));
-      interpreterModeActionsIT.logoutUser("admin");
+      logoutUser("admin");
     } catch (Exception e) {
       handleException("Exception in InterpreterModeActionsIT while testPerUserIsolatedAction ", e);
     }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
@@ -16,10 +16,14 @@
  */
 package org.apache.zeppelin.integration;
 
+import com.google.common.base.Function;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.AbstractZeppelinIT;
 import org.apache.zeppelin.CommandExecutor;
 import org.apache.zeppelin.ProcessData;
-import org.apache.zeppelin.AbstractZeppelinIT;
 import org.apache.zeppelin.WebDriverManager;
 import org.apache.zeppelin.ZeppelinITUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -30,19 +34,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.commons.io.FileUtils;
-import java.io.File;
-import java.io.IOException;
-
-import static org.junit.Assert.assertTrue;
 
 public class InterpreterModeActionsIT extends AbstractZeppelinIT {
   private static final Logger LOG = LoggerFactory.getLogger(InterpreterModeActionsIT.class);
@@ -240,13 +239,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user1noteId);
       waitForParagraph(2, "FINISHED");
       runParagraph(2);
       try {
@@ -352,13 +345,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user1noteId);
       runParagraph(2);
       try {
         waitForParagraph(2, "FINISHED");
@@ -381,13 +368,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python interpreter process is '0'
       //System: Check if the number of python process is '0'
       authenticationUser("user2", "password3");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user2noteId);
 
       restartPythonInterpreter();
       checkProcessCount(0, 0);
@@ -399,13 +380,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python process is '2'
       //System: Check if the number of python interpreter process is '1'
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user1noteId);
       waitForParagraph(1, "FINISHED");
       runParagraph(1);
       try {
@@ -418,13 +393,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       logoutUser("user1");
 
       authenticationUser("user2", "password3");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user2noteId);
       runParagraph(1);
       try {
         waitForParagraph(1, "FINISHED");
@@ -543,13 +512,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python interpreter process is '1'
       //System: Check if the number of python process is '1'
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user1noteId);
       runParagraph(2);
       try {
         waitForParagraph(2, "FINISHED");
@@ -572,13 +535,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python interpreter process is '0'
       //System: Check if the number of python process is '0'
       authenticationUser("user2", "password3");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user2noteId);
 
       restartPythonInterpreter();
       checkProcessCount(0, 0);
@@ -589,13 +546,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       //System: Check if the number of python process is '2'
       //System: Check if the number of python interpreter process is '2'
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user1noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user1noteId);
       waitForParagraph(1, "FINISHED");
       runParagraph(1);
       try {
@@ -608,13 +559,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       logoutUser("user1");
 
       authenticationUser("user2", "password3");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]");
-      element = (new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC))
-          .until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + user2noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(user2noteId);
       runParagraph(1);
       try {
         waitForParagraph(1, "FINISHED");

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
@@ -207,7 +207,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -238,7 +238,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -364,7 +364,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
@@ -397,7 +397,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
               getParagraphXPath(2) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
@@ -641,7 +641,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user1\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(
@@ -674,7 +674,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
       interpreterModeActionsIT.setPythonParagraph(1, "user=\"user2\"");
       waitForParagraph(2, "READY");
-      interpreterModeActionsIT.setPythonParagraph(2, "print user");
+      interpreterModeActionsIT.setPythonParagraph(2, "print(user)");
 
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -50,6 +50,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
 
   @After
   public void tearDown() {
+    handleBrowserLogs();
     driver.quit();
   }
 

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
@@ -18,7 +18,6 @@ package org.apache.zeppelin.integration;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.AbstractZeppelinIT;
-import org.apache.zeppelin.integration.AuthenticationIT;
 import org.apache.zeppelin.WebDriverManager;
 import org.apache.zeppelin.ZeppelinITUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -115,9 +114,8 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
   public void testSimpleAction() throws Exception {
     try {
       // step 1 : (admin) create a new note, run a paragraph and turn on personalized mode
-      AuthenticationIT authenticationIT = new AuthenticationIT();
       PersonalizeActionsIT personalizeActionsIT = new PersonalizeActionsIT();
-      authenticationIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       By locator = By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebDriverWait wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
@@ -135,10 +133,10 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
           "//button[contains(@uib-tooltip, 'Switch to personal mode')]"), MAX_BROWSER_TIMEOUT_SEC).click();
       clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to personalize your analysis?')" +
           "]//div[@class='modal-footer']//button[contains(.,'OK')]"));
-      authenticationIT.logoutUser("admin");
+      logoutUser("admin");
 
       // step 2 : (user1) make sure it is on personalized mode and 'Before' in result of paragraph
-      authenticationIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
       wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
       element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
@@ -155,10 +153,10 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'markdown-body')]")).getText(),
           CoreMatchers.equalTo("Before"));
-      authenticationIT.logoutUser("user1");
+      logoutUser("user1");
 
       // step 3 : (admin) change paragraph contents to 'After' and check result of paragraph
-      authenticationIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
       element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
       if (element.isDisplayed()) {
@@ -169,10 +167,10 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'markdown-body')]")).getText(),
           CoreMatchers.equalTo("After"));
-      authenticationIT.logoutUser("admin");
+      logoutUser("admin");
 
       // step 4 : (user1) check whether result is 'Before' or not
-      authenticationIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
       element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
       if (element.isDisplayed()) {
@@ -181,7 +179,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'markdown-body')]")).getText(),
           CoreMatchers.equalTo("Before"));
-      authenticationIT.logoutUser("user1");
+      logoutUser("user1");
     } catch (Exception e) {
       handleException("Exception in PersonalizeActionsIT while testSimpleAction ", e);
     }
@@ -191,8 +189,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
   public void testGraphAction() throws Exception {
     try {
       // step 1 : (admin) create a new note, run a paragraph, change active graph to 'Bar chart', turn on personalized mode
-      AuthenticationIT authenticationIT = new AuthenticationIT();
-      authenticationIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       By locator = By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebDriverWait wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
@@ -226,11 +223,11 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
           "//button[contains(@uib-tooltip, 'Switch to personal mode')]"), MAX_BROWSER_TIMEOUT_SEC).click();
       clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to personalize your analysis?')" +
           "]//div[@class='modal-footer']//button[contains(.,'OK')]"));
-      authenticationIT.logoutUser("admin");
+      logoutUser("admin");
 
       // step 2 : (user1) make sure it is on personalized mode and active graph is 'Bar chart',
       // try to change active graph to 'Table' and then check result
-      authenticationIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
       element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
       if (element.isDisplayed()) {
@@ -253,7 +250,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
           driver.findElement(By.xpath(getParagraphXPath(1) + "//button[contains(@class," +
               "'btn btn-default btn-sm ng-binding ng-scope active')]//i")).getAttribute("class"),
           CoreMatchers.equalTo("fa fa-bar-chart"));
-      authenticationIT.logoutUser("user1");
+      logoutUser("user1");
 
     } catch (Exception e) {
       handleException("Exception in PersonalizeActionsIT while testGraphAction ", e);
@@ -264,8 +261,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
   public void testDynamicFormAction() throws Exception {
     try {
       // step 1 : (admin) login, create a new note, run a paragraph with data of spark tutorial, logout.
-      AuthenticationIT authenticationIT = new AuthenticationIT();
-      authenticationIT.authenticationUser("admin", "password1");
+      authenticationUser("admin", "password1");
       By locator = By.xpath("//div[contains(@class, \"col-md-4\")]/div/h5/a[contains(.,'Create new" +
           " note')]");
       WebDriverWait wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
@@ -293,11 +289,11 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
           "//button[contains(@uib-tooltip, 'Switch to personal mode')]"), MAX_BROWSER_TIMEOUT_SEC).click();
       clickAndWait(By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to personalize your analysis?')" +
           "]//div[@class='modal-footer']//button[contains(.,'OK')]"));
-      authenticationIT.logoutUser("admin");
+      logoutUser("admin");
 
       // step 2 : (user1) make sure it is on personalized mode and  dynamic form value is 'Before',
       // try to change dynamic form value to 'After' and then check result
-      authenticationIT.authenticationUser("user1", "password2");
+      authenticationUser("user1", "password2");
       locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
       element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
       if (element.isDisplayed()) {
@@ -331,7 +327,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       collector.checkThat("The output of graph mode is changed",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
           CoreMatchers.equalTo("Status: Before"));
-      authenticationIT.logoutUser("user1");
+      logoutUser("user1");
 
     } catch (Exception e) {
       handleException("Exception in PersonalizeActionsIT while testGraphAction ", e);

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
@@ -100,6 +100,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
     } catch (IOException e) {
       LOG.error("Error in PersonalizeActionsIT tearDown::", e);
     }
+    handleBrowserLogs();
     ZeppelinITUtils.restartZeppelin();
     driver.quit();
   }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
@@ -137,13 +137,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
 
       // step 2 : (user1) make sure it is on personalized mode and 'Before' in result of paragraph
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
-      wait = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
-      element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(noteId);
       collector.checkThat("The personalized mode enables",
           driver.findElement(By.xpath("//*[@id='actionbar']" +
               "//button[contains(@class, 'btn btn-default btn-xs ng-scope ng-hide')]")).getAttribute("uib-tooltip"),
@@ -157,11 +151,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
 
       // step 3 : (admin) change paragraph contents to 'After' and check result of paragraph
       authenticationUser("admin", "password1");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
-      element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]"), MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(noteId);
       waitForParagraph(1, "FINISHED");
       personalizeActionsIT.setParagraphText("After");
       collector.checkThat("The output field paragraph contains",
@@ -171,11 +161,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
 
       // step 4 : (user1) check whether result is 'Before' or not
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
-      element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]"), MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(noteId);
       collector.checkThat("The output field paragraph contains",
           driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'markdown-body')]")).getText(),
           CoreMatchers.equalTo("Before"));
@@ -228,12 +214,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       // step 2 : (user1) make sure it is on personalized mode and active graph is 'Bar chart',
       // try to change active graph to 'Table' and then check result
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
-      element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(noteId);
       collector.checkThat("The personalized mode enables",
           driver.findElement(By.xpath("//*[@id='actionbar']" +
               "//button[contains(@class, 'btn btn-default btn-xs ng-scope ng-hide')]")).getAttribute("uib-tooltip"),
@@ -294,12 +275,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
       // step 2 : (user1) make sure it is on personalized mode and  dynamic form value is 'Before',
       // try to change dynamic form value to 'After' and then check result
       authenticationUser("user1", "password2");
-      locator = By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]");
-      element = wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
-      if (element.isDisplayed()) {
-        pollingWait(By.xpath("//*[@id='notebook-names']//a[contains(@href, '" + noteId + "')]"),
-            MAX_BROWSER_TIMEOUT_SEC).click();
-      }
+      goToNote(noteId);
       collector.checkThat("The personalized mode enables",
           driver.findElement(By.xpath("//*[@id='actionbar']" +
               "//button[contains(@class, 'btn btn-default btn-xs ng-scope ng-hide')]")).getAttribute("uib-tooltip"),

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -50,6 +50,7 @@ public class SparkParagraphIT extends AbstractZeppelinIT {
   @After
   public void tearDown() {
     deleteTestNotebook(driver);
+    handleBrowserLogs();
     driver.quit();
   }
 

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -62,6 +62,7 @@ public class ZeppelinIT extends AbstractZeppelinIT {
 
   @After
   public void tearDown() {
+    handleBrowserLogs();
     driver.quit();
   }
 

--- a/zeppelin-web/src/components/login/login.controller.js
+++ b/zeppelin-web/src/components/login/login.controller.js
@@ -60,8 +60,9 @@ function LoginCtrl($scope, $rootScope, $http, $httpParamSerializer, baseUrlSrv, 
   };
 
   // handle session logout message received from WebSocket
+  $rootScope.isLoggingOut = false;
   $rootScope.$on('session_logout', function(event, data) {
-    if ($rootScope.userName !== '') {
+    if (!$rootScope.isLoggingOut && $rootScope.userName !== '') {
       $rootScope.userName = '';
       $rootScope.ticket = undefined;
 

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -143,7 +143,9 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
         logoutURL = logoutURL.replace('//', '//false:false@');
       }
 
-      $http.post(logoutURL).error(function() {
+      $rootScope.isLoggingOut = true;
+      function onLogout() {
+        $rootScope.isLoggingOut = false;
         $rootScope.userName = '';
         $rootScope.ticket.principal = '';
         $rootScope.ticket.screenUsername = '';
@@ -155,7 +157,8 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
         setTimeout(function() {
           window.location = baseUrlSrv.getBase();
         }, 1000);
-      });
+      }
+      $http.post(logoutURL).success(onLogout).error(onLogout);
     });
   }
 


### PR DESCRIPTION
### What is this PR for?
According to https://seleniumhq.wordpress.com/2017/08/09/firefox-55-and-selenium-ide , Firefox versions 55+ do not work with Selenium, so I would like to propose to skip them when creating the WebDriver.


### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3263

### How should this be tested?
* Run zeppelin-integration tests on the machine, where Firefox 55+ is installed.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
