### PR TITLE
ZEPPELIN-3246. Need option for automatically restart the livy interpreter automatically as zeppelin does not start new Livy session if yarn livy session application is killed

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyException.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyException.java
@@ -17,10 +17,12 @@
 
 package org.apache.zeppelin.livy;
 
+import org.apache.zeppelin.interpreter.InterpreterException;
+
 /**
  * Livy api related exception
  */
-public class LivyException extends Exception {
+public class LivyException extends InterpreterException {
   public LivyException() {
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkBaseInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyPySparkBaseInterpreter.java
@@ -32,7 +32,7 @@ public abstract class LivyPySparkBaseInterpreter extends BaseLivyInterpreter {
   @Override
   protected String extractAppId() throws LivyException {
     return extractStatementResult(
-        interpret("sc.applicationId", null, false, false).message()
+        interpret("sc.applicationId", null, false, false, false).message()
             .get(0).getData());
   }
 
@@ -40,7 +40,7 @@ public abstract class LivyPySparkBaseInterpreter extends BaseLivyInterpreter {
   protected String extractWebUIAddress() throws LivyException {
     return extractStatementResult(
         interpret(
-            "sc._jsc.sc().ui().get().appUIAddress()", null, false, false)
+            "sc._jsc.sc().ui().get().appUIAddress()", null, false, false, false)
             .message().get(0).getData());
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySharedInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySharedInterpreter.java
@@ -78,7 +78,7 @@ public class LivySharedInterpreter extends BaseLivyInterpreter {
     }
 
     try {
-      return interpret(st, codeType, context.getParagraphId(), this.displayAppInfo, true);
+      return interpret(st, codeType, context.getParagraphId(), this.displayAppInfo, true, true);
     } catch (LivyException e) {
       LOGGER.error("Fail to interpret:" + st, e);
       return new InterpreterResult(InterpreterResult.Code.ERROR,

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkInterpreter.java
@@ -36,7 +36,7 @@ public class LivySparkInterpreter extends BaseLivyInterpreter {
   @Override
   protected String extractAppId() throws LivyException {
     return extractStatementResult(
-        interpret("sc.applicationId", null, false, false).message()
+        interpret("sc.applicationId", null, false, false, false).message()
             .get(0).getData());
   }
 
@@ -45,10 +45,10 @@ public class LivySparkInterpreter extends BaseLivyInterpreter {
     interpret(
         "val webui=sc.getClass.getMethod(\"ui\").invoke(sc).asInstanceOf[Some[_]].get",
         null,
-        null, false, false);
+        null, false, false, false);
     return extractStatementResult(
         interpret(
-            "webui.getClass.getMethod(\"appUIAddress\").invoke(webui)", null, false, false)
+            "webui.getClass.getMethod(\"appUIAddress\").invoke(webui)", null, false, false, false)
             .message().get(0).getData());
   }
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/SessionDeadException.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/SessionDeadException.java
@@ -15,32 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.interpreter;
+package org.apache.zeppelin.livy;
 
+public class SessionDeadException extends LivyException {
 
-/**
- * General Exception for interpreters.
- *
- */
-public class InterpreterException extends Exception {
-
-  public InterpreterException() {
-  }
-
-  public InterpreterException(Throwable e) {
-    super(e);
-  }
-
-  public InterpreterException(String m) {
-    super(m);
-  }
-
-  public InterpreterException(String msg, Throwable t) {
-    super(msg, t);
-  }
-
-  public InterpreterException(String message, Throwable cause, boolean enableSuppression,
-                       boolean writableStackTrace) {
-    super(message, cause, enableSuppression, writableStackTrace);
-  }
 }

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -108,6 +108,12 @@
         "defaultValue": "true",
         "description": "Whether display app info",
         "type": "checkbox"
+      },
+      "zeppelin.livy.restart_dead_session": {
+        "propertyName": "zeppelin.livy.restart_dead_session",
+        "defaultValue": "false",
+        "description": "Whether restart a dead session",
+        "type": "checkbox"
       }
     },
     "option": {


### PR DESCRIPTION
### What is this PR for?
Add one new property `zeppelin.livy.restart_dead_session` to allow livy session to be created automatically. By default it is false, because there's many reason that session is dead, it is encouraged to ask user to check why it is dead and restart interpreter by themselves. 


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3246

### How should this be tested?
* Manually tested. 

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/36651473-089ea458-1ae4-11e8-84d0-a0bed3e0ea4e.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
