### PR TITLE
[ZEPPELIN-3271] Option for disabling scheduler

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -540,5 +540,11 @@
   <value>origin</value>
   <description>Git repository remote</description>
 </property>
+
+<property>
+  <name>zeppelin.notebook.cron.enable</name>
+  <value>true</value>
+  <description>Notebook enable cron scheduler feature</description>
+</property>
 -->
 </configuration>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -543,7 +543,7 @@
 
 <property>
   <name>zeppelin.notebook.cron.enable</name>
-  <value>true</value>
+  <value>false</value>
   <description>Notebook enable cron scheduler feature</description>
 </property>
 <property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -546,5 +546,10 @@
   <value>true</value>
   <description>Notebook enable cron scheduler feature</description>
 </property>
+<property>
+  <name>zeppelin.notebook.cron.folders</name>
+  <value></value>
+  <description>Notebook cron folders</description>
+</property>
 -->
 </configuration>

--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -51,9 +51,9 @@ When this checkbox is set to "on", the interpreters which are binded to the note
 
 > **Note**: A cron execution is skipped if one of the paragraphs is in a state of `RUNNING` or `PENDING` no matter whether it is executed automatically (i.e. by the cron scheduler) or manually by a user opening this notebook.
 
-### Disable cron
+### Enable cron
 
-Set property **zeppelin.notebook.cron.enable** to **false** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` to disable Cron feature completely.
+Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` to enable Cron feature.
 
 ### Run cron selectively on folders
 

--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -50,3 +50,11 @@ You can set the cron executing user by filling in this form and press the enter 
 When this checkbox is set to "on", the interpreters which are binded to the notebook are stopped automatically after the cron execution. This feature is useful if you want to release the interpreter resources after the cron execution.
 
 > **Note**: A cron execution is skipped if one of the paragraphs is in a state of `RUNNING` or `PENDING` no matter whether it is executed automatically (i.e. by the cron scheduler) or manually by a user opening this notebook.
+
+### Disable cron
+
+Set property **zeppelin.notebook.cron.enable** to **false** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` to disable Cron feature completely.
+
+### Run cron selectively on folders
+
+In `$ZEPPELIN_HOME/conf/zeppelin-site.xml` make sure the property **zeppelin.notebook.cron.enable** is set to **true**, and then set property **zeppelin.notebook.cron.folders** to the desired folder as comma-separated values, e.g. `*yst*, Sys?em, System`. This property accepts wildcard and joker.

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -585,6 +585,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE);
   }
 
+  public String getZeppelinNotebookCronFolders() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -776,7 +780,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN("zeppelin.notebook.git.remote.origin", "origin"),
-    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", true);
+    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", true),
+    ZEPPELIN_NOTEBOOK_CRON_FOLDERS("zeppelin.notebook.cron.folders", null);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -581,6 +581,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN);
   }
 
+  public Boolean isZeppelinNotebookCronEnable() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE);
+  }
+
   public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
                                                 ConfigurationKeyPredicate predicate) {
     Map<String, String> configurations = new HashMap<>();
@@ -771,7 +775,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", ""),
-    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN("zeppelin.notebook.git.remote.origin", "origin");
+    ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN("zeppelin.notebook.git.remote.origin", "origin"),
+    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", true);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -780,7 +780,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ORIGIN("zeppelin.notebook.git.remote.origin", "origin"),
-    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", true),
+    ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", false),
     ZEPPELIN_NOTEBOOK_CRON_FOLDERS("zeppelin.notebook.cron.folders", null);
 
     private String varName;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -381,6 +381,7 @@ public class NotebookRestApi {
 
     note.setName(noteName);
     note.persist(subject);
+    note.setCronSupported(notebook.getConf());
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
     return new JsonResponse<>(Status.OK, "", note.getId()).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -848,11 +848,9 @@ public class NotebookRestApi {
   public Response registerCronJob(@PathParam("noteId") String noteId, String message)
       throws IOException, IllegalArgumentException {
     LOG.info("Register cron job note={} request cron msg={}", noteId, message);
-    ZeppelinConfiguration conf = notebook.getConf();
-    if (conf.isZeppelinNotebookCronEnable()) {
+    Note note = notebook.getNote(noteId);
+    if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
       CronRequest request = CronRequest.fromJson(message);
-
-      Note note = notebook.getNote(noteId);
       checkIfNoteIsNotNull(note);
       checkIfUserCanRun(noteId, "Insufficient privileges you cannot set a cron job for this note");
 
@@ -885,9 +883,8 @@ public class NotebookRestApi {
   public Response removeCronJob(@PathParam("noteId") String noteId)
       throws IOException, IllegalArgumentException {
     LOG.info("Remove cron job note {}", noteId);
-    ZeppelinConfiguration conf = notebook.getConf();
-    if (conf.isZeppelinNotebookCronEnable()) {
-      Note note = notebook.getNote(noteId);
+    Note note = notebook.getNote(noteId);
+    if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
       checkIfNoteIsNotNull(note);
       checkIfUserIsOwner(noteId,
           "Insufficient privileges you cannot remove this cron job from this note");
@@ -917,9 +914,8 @@ public class NotebookRestApi {
   public Response getCronJob(@PathParam("noteId") String noteId)
       throws IOException, IllegalArgumentException {
     LOG.info("Get cron job note {}", noteId);
-    ZeppelinConfiguration conf = notebook.getConf();
-    if (conf.isZeppelinNotebookCronEnable()) {
-      Note note = notebook.getNote(noteId);
+    Note note = notebook.getNote(noteId);
+    if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
       checkIfNoteIsNotNull(note);
       checkIfUserCanRead(noteId, "Insufficient privileges you cannot get cron information");
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -867,6 +867,7 @@ public class NotebookRestApi {
 
       return new JsonResponse<>(Status.OK).build();
     } else {
+      LOG.error("Cron is not enabled from Zeppelin server");
       throw new ForbiddenException("Cron is not enabled from Zeppelin server");
     }
   }
@@ -898,6 +899,7 @@ public class NotebookRestApi {
 
       return new JsonResponse<>(Status.OK).build();
     } else {
+      LOG.error("Cron is not enabled from Zeppelin server");
       throw new ForbiddenException("Cron is not enabled from Zeppelin server");
     }
   }
@@ -923,6 +925,7 @@ public class NotebookRestApi {
 
       return new JsonResponse<>(Status.OK, note.getConfig().get("cron")).build();
     } else {
+      LOG.error("Cron is not enabled from Zeppelin server");
       throw new ForbiddenException("Cron is not enabled from Zeppelin server");
     }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -869,7 +869,7 @@ public class NotebookServer extends WebSocketServlet
   }
 
   private void updateNote(NotebookSocket conn, HashSet<String> userAndRoles, Notebook notebook,
-      Message fromMessage) throws SchedulerException, IOException {
+      Message fromMessage) throws IOException {
     String noteId = (String) fromMessage.get("id");
     String name = (String) fromMessage.get("name");
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
@@ -887,6 +887,11 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null) {
+      if (!notebook.getConf().isZeppelinNotebookCronEnable()) {
+        if (config.get("cron") != null) {
+          config.remove("cron");
+        }
+      }
       boolean cronUpdated = isCronUpdated(config, note.getConfig());
       note.setName(name);
       note.setConfig(config);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -887,7 +887,7 @@ public class NotebookServer extends WebSocketServlet
 
     Note note = notebook.getNote(noteId);
     if (note != null) {
-      if (!notebook.getConf().isZeppelinNotebookCronEnable()) {
+      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
         if (config.get("cron") != null) {
           config.remove("cron");
         }
@@ -955,6 +955,7 @@ public class NotebookServer extends WebSocketServlet
     Note note = notebook.getNote(noteId);
     if (note != null) {
       note.setName(name);
+      note.setCronSupported(notebook.getConf());
 
       AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
       note.persist(subject);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1046,6 +1046,7 @@ public class NotebookServer extends WebSocketServlet
           noteName = "Note " + note.getId();
         }
         note.setName(noteName);
+        note.setCronSupported(notebook.getConf());
       }
 
       note.persist(subject);

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -249,7 +249,7 @@ limitations under the License.
       </span>
 
       <span ng-hide="viewOnly">
-      <div class="labelBtn btn-group">
+      <div class="labelBtn btn-group" ng-if="note.config.isZeppelinNotebookCronEnable">
         <div class="btn btn-default btn-xs dropdown-toggle"
              type="button"
              data-toggle="dropdown"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -312,24 +312,25 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     }
   }
 
-  public void setCronSupported(ZeppelinConfiguration config) {
+  public Boolean isCronSupported(ZeppelinConfiguration config) {
     if (config.isZeppelinNotebookCronEnable()) {
       config.getZeppelinNotebookCronFolders();
       if (config.getZeppelinNotebookCronFolders() == null) {
-        getConfig().put("isZeppelinNotebookCronEnable", true);
+        return true;
       } else {
-        getConfig().put("isZeppelinNotebookCronEnable", false);
         for (String folder : config.getZeppelinNotebookCronFolders().split(",")) {
           folder = folder.replaceAll("\\*", "\\.*").replaceAll("\\?", "\\.");
           if (getName().matches(folder)) {
-            getConfig().put("isZeppelinNotebookCronEnable", true);
-            break;
+            return true;
           }
         }
       }
-    } else {
-      getConfig().put("isZeppelinNotebookCronEnable", false);
     }
+    return false;
+  }
+
+  public void setCronSupported(ZeppelinConfiguration config) {
+    getConfig().put("isZeppelinNotebookCronEnable", isCronSupported(config));
   }
 
   public void setIndex(SearchService index) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -19,6 +19,10 @@ package org.apache.zeppelin.notebook;
 
 import static java.lang.String.format;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
@@ -30,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.common.JsonSerializable;
 import org.apache.zeppelin.completer.CompletionType;
@@ -47,9 +50,9 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
-import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.utility.IdHashes;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
@@ -58,11 +61,6 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 
 /**
  * Binded interpreters for a note
@@ -135,6 +133,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     this.noteEventListener = noteEventListener;
     this.credentials = credentials;
     generateId();
+    setCronSupported(conf);
   }
 
   private void generateId() {
@@ -314,9 +313,20 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     }
   }
 
-  void setCronSupported(ZeppelinConfiguration config) {
+  public void setCronSupported(ZeppelinConfiguration config) {
     if (config.isZeppelinNotebookCronEnable()) {
-      getConfig().put("isZeppelinNotebookCronEnable", true);
+      config.getZeppelinNotebookCronFolders();
+      if (config.getZeppelinNotebookCronFolders() == null) {
+        getConfig().put("isZeppelinNotebookCronEnable", true);
+      } else {
+        for (String folder : config.getZeppelinNotebookCronFolders().split(",")) {
+          folder = folder.replaceAll("\\*", "\\.*").replaceAll("\\?", "\\.");
+          if (getName().matches(folder)) {
+            getConfig().put("isZeppelinNotebookCronEnable", true);
+            break;
+          }
+        }
+      }
     } else {
       getConfig().put("isZeppelinNotebookCronEnable", false);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -133,7 +133,6 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     this.noteEventListener = noteEventListener;
     this.credentials = credentials;
     generateId();
-    setCronSupported(conf);
   }
 
   private void generateId() {
@@ -319,6 +318,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
       if (config.getZeppelinNotebookCronFolders() == null) {
         getConfig().put("isZeppelinNotebookCronEnable", true);
       } else {
+        getConfig().put("isZeppelinNotebookCronEnable", false);
         for (String folder : config.getZeppelinNotebookCronFolders().split(",")) {
           folder = folder.replaceAll("\\*", "\\.*").replaceAll("\\?", "\\.");
           if (getName().matches(folder)) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -314,6 +314,14 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     }
   }
 
+  void setCronSupported(ZeppelinConfiguration config) {
+    if (config.isZeppelinNotebookCronEnable()) {
+      getConfig().put("isZeppelinNotebookCronEnable", true);
+    } else {
+      getConfig().put("isZeppelinNotebookCronEnable", false);
+    }
+  }
+
   public void setIndex(SearchService index) {
     this.index = index;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -21,29 +21,50 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
-import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl.Revision;
-import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
-import org.quartz.*;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Collection of Notes.
@@ -498,6 +519,7 @@ public class Notebook implements NoteEventListener {
     note.setJobListenerFactory(jobListenerFactory);
     note.setNotebookRepo(notebookRepo);
     note.setRevisionSupported(notebookRepo);
+    note.setCronSupported(getConf());
 
     Map<String, SnapshotAngularObject> angularObjectSnapshot = new HashMap<>();
 
@@ -899,6 +921,11 @@ public class Notebook implements NoteEventListener {
         return;
       }
 
+      if (!notebook.getConf().isZeppelinNotebookCronEnable()) {
+        logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
+        return;
+      }
+
       note.runAll();
 
       boolean releaseResource = false;
@@ -938,6 +965,11 @@ public class Notebook implements NoteEventListener {
       }
       Map<String, Object> config = note.getConfig();
       if (config == null) {
+        return;
+      }
+
+      if (!getConf().isZeppelinNotebookCronEnable()) {
+        logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
         return;
       }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -203,10 +203,12 @@ public class Notebook implements NoteEventListener {
       Note oldNote = Note.fromJson(sourceJson);
       convertFromSingleResultToMultipleResultsFormat(oldNote);
       newNote = createNote(subject);
-      if (noteName != null)
+      if (noteName != null) {
         newNote.setName(noteName);
-      else
+      } else {
         newNote.setName(oldNote.getName());
+      }
+      newNote.setCronSupported(getConf());
       List<Paragraph> paragraphs = oldNote.getParagraphs();
       for (Paragraph p : paragraphs) {
         newNote.addCloneParagraph(p);
@@ -243,6 +245,7 @@ public class Notebook implements NoteEventListener {
     } else {
       newNote.setName("Note " + newNote.getId());
     }
+    newNote.setCronSupported(getConf());
     // Copy the interpreter bindings
     List<String> boundInterpreterSettingsIds = getBindedInterpreterSettingsIds(sourceNote.getId());
     bindInterpretersToNote(subject.getUser(), newNote.getId(), boundInterpreterSettingsIds);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -921,7 +921,7 @@ public class Notebook implements NoteEventListener {
         return;
       }
 
-      if (!notebook.getConf().isZeppelinNotebookCronEnable()) {
+      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
         logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
         return;
       }
@@ -968,7 +968,7 @@ public class Notebook implements NoteEventListener {
         return;
       }
 
-      if (!getConf().isZeppelinNotebookCronEnable()) {
+      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
         logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
         return;
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -924,7 +924,7 @@ public class Notebook implements NoteEventListener {
         return;
       }
 
-      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
+      if (!note.isCronSupported(notebook.getConf())) {
         logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
         return;
       }
@@ -971,7 +971,7 @@ public class Notebook implements NoteEventListener {
         return;
       }
 
-      if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
+      if (!note.isCronSupported(getConf())) {
         logger.warn("execution of the cron job is skipped cron is not enabled from Zeppelin server");
         return;
       }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -86,6 +86,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
   public void setUp() throws Exception {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
     System.setProperty(ConfVars.ZEPPELIN_INTERPRETER_GROUP_ORDER.getVarName(), "mock1,mock2");
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
     super.setUp();
 
     schedulerFactory = SchedulerFactory.singleton();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -226,7 +226,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
       fail("Subject is non-emtpy anonymous, shouldn't fail");
     }
   }
-  
+
   @Test
   public void testPersist() throws IOException, SchedulerException, RepositoryException {
     Note note = notebook.createNote(anonymous);
@@ -434,13 +434,93 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     notebook.refreshCron(note.getId());
   }
 
+  @Test
+  public void testScheduleDisabled() throws InterruptedException, IOException {
+
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "false");
+    try {
+      final int timeout = 10;
+      final String everySecondCron = "* * * * * ?";
+      final CountDownLatch jobsToExecuteCount = new CountDownLatch(5);
+      final Note note = notebook.createNote(anonymous);
+
+      executeNewParagraphByCron(note, everySecondCron);
+      afterStatusChangedListener = new StatusChangedListener() {
+        @Override
+        public void onStatusChanged(Job job, Status before, Status after) {
+          if (after == Status.FINISHED) {
+            jobsToExecuteCount.countDown();
+          }
+        }
+      };
+
+      //This job should not run because "ZEPPELIN_NOTEBOOK_CRON_ENABLE" is set to false
+      assertFalse(jobsToExecuteCount.await(timeout, TimeUnit.SECONDS));
+
+      terminateScheduledNote(note);
+      afterStatusChangedListener = null;
+    } finally {
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
+    }
+  }
+
+  @Test
+  public void testScheduleDisabledWithName() throws InterruptedException, IOException {
+
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "System/*");
+    try {
+      final int timeout = 10;
+      final String everySecondCron = "* * * * * ?";
+      final CountDownLatch jobsToExecuteCount = new CountDownLatch(5);
+      final Note note = notebook.createNote(anonymous);
+
+      executeNewParagraphByCron(note, everySecondCron);
+      afterStatusChangedListener = new StatusChangedListener() {
+        @Override
+        public void onStatusChanged(Job job, Status before, Status after) {
+          if (after == Status.FINISHED) {
+            jobsToExecuteCount.countDown();
+          }
+        }
+      };
+
+      //This job should not run because it's name does not matches "ZEPPELIN_NOTEBOOK_CRON_FOLDERS"
+      assertFalse(jobsToExecuteCount.await(timeout, TimeUnit.SECONDS));
+
+      terminateScheduledNote(note);
+      afterStatusChangedListener = null;
+
+      final Note noteNameSystem = notebook.createNote(anonymous);
+      noteNameSystem.setName("System/test1");
+      final CountDownLatch jobsToExecuteCountNameSystem = new CountDownLatch(5);
+
+      executeNewParagraphByCron(noteNameSystem, everySecondCron);
+      afterStatusChangedListener = new StatusChangedListener() {
+        @Override
+        public void onStatusChanged(Job job, Status before, Status after) {
+          if (after == Status.FINISHED) {
+            jobsToExecuteCountNameSystem.countDown();
+          }
+        }
+      };
+
+      //This job should run because it's name contains "System/"
+      assertTrue(jobsToExecuteCountNameSystem.await(timeout, TimeUnit.SECONDS));
+
+      terminateScheduledNote(noteNameSystem);
+      afterStatusChangedListener = null;
+    } finally {
+      System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName());
+    }
+  }
+
   private void terminateScheduledNote(Note note) {
     note.getConfig().remove("cron");
     notebook.refreshCron(note.getId());
     notebook.removeNote(note.getId(), anonymous);
   }
 
-  
+
   @Test
   public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException{
     // create a note and a paragraph
@@ -859,9 +939,9 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     // set admin roles for both user1 and user2
     notebookAuthorization.setRoles(user1, roles);
     notebookAuthorization.setRoles(user2, roles);
-    
+
     Note note = notebook.createNote(new AuthenticationInfo(user1));
-    
+
     // check that user1 is owner, reader, runner and writer
     assertEquals(notebookAuthorization.isOwner(note.getId(),
         Sets.newHashSet(user1)), true);
@@ -871,7 +951,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
         Sets.newHashSet(user2)), true);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         Sets.newHashSet(user1)), true);
-    
+
     // since user1 and user2 both have admin role, user2 will be reader and writer as well
     assertEquals(notebookAuthorization.isOwner(note.getId(),
         Sets.newHashSet(user2)), false);
@@ -881,14 +961,14 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
         Sets.newHashSet(user2)), true);
     assertEquals(notebookAuthorization.isWriter(note.getId(),
         Sets.newHashSet(user2)), true);
-    
+
     // check that user1 has note listed in his workbench
     Set<String> user1AndRoles = notebookAuthorization.getRoles(user1);
     user1AndRoles.add(user1);
     List<Note> user1Notes = notebook.getAllNotes(user1AndRoles);
     assertEquals(user1Notes.size(), 1);
     assertEquals(user1Notes.get(0).getId(), note.getId());
-    
+
     // check that user2 has note listed in his workbench because of admin role
     Set<String> user2AndRoles = notebookAuthorization.getRoles(user2);
     user2AndRoles.add(user2);
@@ -896,7 +976,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     assertEquals(user2Notes.size(), 1);
     assertEquals(user2Notes.get(0).getId(), note.getId());
   }
-  
+
   @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws InterruptedException,
       IOException, InterpreterException {
@@ -1225,7 +1305,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     notes2 = notebook.getAllNotes(user2);
     assertEquals(notes1.size(), 1);
     assertEquals(notes2.size(), 1);
-    
+
     notebook.getNotebookAuthorization().setReaders(note.getId(), Sets.newHashSet("user1"));
     //note is public since writers empty
     notes1 = notebook.getAllNotes(user1);
@@ -1238,7 +1318,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     notes2 = notebook.getAllNotes(user2);
     assertEquals(notes1.size(), 1);
     assertEquals(notes2.size(), 1);
-    
+
     notebook.getNotebookAuthorization().setWriters(note.getId(), Sets.newHashSet("user1"));
     notes1 = notebook.getAllNotes(user1);
     notes2 = notebook.getAllNotes(user2);
@@ -1250,19 +1330,19 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
   public void testPublicPrivateNewNote() throws IOException, SchedulerException {
     HashSet<String> user1 = Sets.newHashSet("user1");
     HashSet<String> user2 = Sets.newHashSet("user2");
-    
+
     // case of public note
     assertTrue(conf.isNotebookPublic());
     assertTrue(notebookAuthorization.isPublic());
-    
+
     List<Note> notes1 = notebook.getAllNotes(user1);
     List<Note> notes2 = notebook.getAllNotes(user2);
     assertEquals(notes1.size(), 0);
     assertEquals(notes2.size(), 0);
-    
+
     // user1 creates note
     Note notePublic = notebook.createNote(new AuthenticationInfo("user1"));
-    
+
     // both users have note
     notes1 = notebook.getAllNotes(user1);
     notes2 = notebook.getAllNotes(user2);
@@ -1270,7 +1350,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     assertEquals(notes2.size(), 1);
     assertEquals(notes1.get(0).getId(), notePublic.getId());
     assertEquals(notes2.get(0).getId(), notePublic.getId());
-    
+
     // user1 is only owner
     assertEquals(notebookAuthorization.getOwners(notePublic.getId()).size(), 1);
     assertEquals(notebookAuthorization.getReaders(notePublic.getId()).size(), 0);
@@ -1283,13 +1363,13 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     assertFalse(conf2.isNotebookPublic());
     // notebook authorization reads from conf, so no need to re-initilize
     assertFalse(notebookAuthorization.isPublic());
-    
+
     // check that still 1 note per user
     notes1 = notebook.getAllNotes(user1);
     notes2 = notebook.getAllNotes(user2);
     assertEquals(notes1.size(), 1);
     assertEquals(notes2.size(), 1);
-    
+
     // create private note
     Note notePrivate = notebook.createNote(new AuthenticationInfo("user1"));
 
@@ -1299,18 +1379,18 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     assertEquals(notes1.size(), 2);
     assertEquals(notes2.size(), 1);
     assertEquals(true, notes1.contains(notePrivate));
-    
+
     // user1 have all rights
     assertEquals(notebookAuthorization.getOwners(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getReaders(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getRunners(notePrivate.getId()).size(), 1);
     assertEquals(notebookAuthorization.getWriters(notePrivate.getId()).size(), 1);
-    
+
     //set back public to true
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
     ZeppelinConfiguration.create();
   }
-  
+
   private void delete(File file){
     if(file.isFile()) file.delete();
     else if(file.isDirectory()){


### PR DESCRIPTION
### What is this PR for?
Zeppelin server should have an option to enable/disable cron scheduler from Zeppelin config.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3271](https://issues.apache.org/jira/browse/ZEPPELIN-3271)

### How should this be tested?
* On adding below mentioned property in `zeppelin-site.xml`, this feature should get disabled from both web-socket and REST-APIs.

```
<property>
  <name>zeppelin.notebook.cron.enable</name>
  <value>false</value>
  <description>Notebook enable cron scheduler feature</description>
</property>
```


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? Yes
* Does this needs documentation? Yes
