### PR TITLE
[ZEPPELIN-1967]: New pull request

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -365,6 +365,47 @@ myScalaDataFrame = DataFrame(z.get("myScalaDataFrame"), sqlContext)
   </div>
 </div>
 
+### Object Interpolation
+Some interpreters can interpolate object values from `z` into the command string by using the 
+`{variable-name}` syntax. The value of any object previously `put` into `z` can be 
+interpolated into a command string by using such a pattern containing the object's name. 
+The following example shows one use of this facility:
+
+####In Scala cell:
+```
+z.put("minAge", 35)
+```
+
+####In later SQL cell:
+```
+%sql select * from members where age >= {minAge}
+```
+
+The interpolation of a `{var-name}` pattern is performed only when `z` contains an object with the specified name.
+But the pattern is left unchanged if the named object does not exist in `z`.
+Further, all `{var-name}` patterns within the command must must be translatable for any interpolation to occur -- 
+translation of only some of the patterns in a command line is never done.
+
+In some situations, it is necessary to use { and } characters in a command without invoking the 
+object interpolation mechanism. For these cases an escaping mechanism is available -- 
+doubled braces {{ and }} should be used. The following example shows the use of {{ and }} for passing a 
+regular expression containing just { and } into the command.
+
+```
+%sql select * from members where name rlike '[aeiou]{{3}}'
+```
+
+To summarize, patterns of the form `{var-name}` within commands will be interpolated only if a predefined 
+object of the specified name exists. Additionally, all such patterns within the command line should also 
+be translatable for any interpolation to occur. Patterns of the form `{{any-text}}` are translated into `{any-text}`. 
+These translations are performed only when all occurrences of `{`, `}`, `{{`, and `}}` in any command string confirm to one of the two 
+forms described above. A command containing `{` and/or `}` characters used in any other way 
+(than `{var-name}` and `{{any-text}}`) is used as-is without any changes. 
+No error is flagged in any case. This behavior is identical to the implementation of a similar feature in 
+Jupyter's shell invocation using the `!` magic command.
+
+At present only the SQL and Shell interpreters support object interpolation. 
+
 ### Form Creation
 
 `ZeppelinContext` provides functions for creating forms.

--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -85,7 +85,8 @@ public class ShellInterpreter extends KerberosInterpreter {
 
 
   @Override
-  public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
+  public InterpreterResult interpret(String originalCmd, InterpreterContext contextInterpreter) {
+    String cmd = interpolate(originalCmd, contextInterpreter.getResourcePool());
     LOGGER.debug("Run shell command '" + cmd + "'");
     OutputStream outStream = new ByteArrayOutputStream();
     

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -115,7 +115,7 @@ public class SparkSqlInterpreter extends Interpreter {
       // to    def sql(sqlText: String): DataFrame (1.3 and later).
       // Therefore need to use reflection to keep binary compatibility for all spark versions.
       Method sqlMethod = sqlc.getClass().getMethod("sql", String.class);
-      rdd = sqlMethod.invoke(sqlc, st);
+      rdd = sqlMethod.invoke(sqlc, interpolate(st, context.getResourcePool()));
     } catch (InvocationTargetException ite) {
       if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
         throw new InterpreterException(ite);

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/ZeppCtxtVariableTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/ZeppCtxtVariableTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter;
+
+import org.apache.zeppelin.resource.LocalResourcePool;
+import org.apache.zeppelin.resource.ResourcePool;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+public class ZeppCtxtVariableTest {
+
+  public static class TestInterpreter extends Interpreter {
+
+    TestInterpreter(Properties property) {
+      super(property);
+    }
+
+    @Override
+    public void open() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public InterpreterResult interpret(String st, InterpreterContext context) {
+      return null;
+    }
+
+    @Override
+    public void cancel(InterpreterContext context) {
+    }
+
+    @Override
+    public FormType getFormType() {
+      return null;
+    }
+
+    @Override
+    public int getProgress(InterpreterContext context) {
+      return 0;
+    }
+  }
+
+  private Interpreter interpreter;
+  private ResourcePool resourcePool;
+
+  @Before
+  public void setUp() throws Exception {
+
+    resourcePool = new LocalResourcePool("ZeppelinContextVariableInterpolationTest");
+
+    InterpreterContext.set(new InterpreterContext("InterpolationTestNoteId",
+            "InterpolationTestParagraphTitle",
+            null,
+            "InterpolationTestParagraphTitle",
+            "InterpolationTestParagraphText",
+            new AuthenticationInfo("InterpolationTestUser", null, "testTicket"),
+            null,
+            null,
+            null,
+            null,
+            resourcePool,
+            null,
+            null));
+
+    interpreter = new TestInterpreter(new Properties());
+
+    resourcePool.put("PI", "3.1415");
+
+  }
+
+  @Test
+  public void stringWithoutPatterns() {
+    String result = interpreter.interpolate("The value of PI is not exactly 3.14", resourcePool);
+    assertTrue("String without patterns", "The value of PI is not exactly 3.14".equals(result));
+  }
+
+  @Test
+  public void substitutionInTheMiddle() {
+    String result = interpreter.interpolate("The value of {{PI}} is {PI} now", resourcePool);
+    assertTrue("Substitution in the middle", "The value of {PI} is 3.1415 now".equals(result));
+  }
+
+  @Test
+  public void substitutionAtTheEnds() {
+    String result = interpreter.interpolate("{{PI}} is now {PI}", resourcePool);
+    assertTrue("Substitution at the ends", "{PI} is now 3.1415".equals(result));
+  }
+
+  @Test
+  public void multiLineSubstitution() {
+    String result = interpreter.interpolate("{{PI}}\n{PI}\n{{PI}}\n{PI}", resourcePool);
+    assertTrue("Substitution at the ends", "{PI}\n3.1415\n{PI}\n3.1415".equals(result));
+  }
+
+  @Test
+  public void noUndefinedVariableError() {
+    String result = interpreter.interpolate("This {pi} will pass silently", resourcePool);
+    assertTrue("No partial substitution", "This {pi} will pass silently".equals(result));
+  }
+
+  @Test
+  public void noPartialSubstitution() {
+    String result = interpreter.interpolate("A {PI} and a {PIE} are different", resourcePool);
+    assertTrue("No partial substitution", "A {PI} and a {PIE} are different".equals(result));
+  }
+
+  @Test
+  public void substitutionAndEscapeMixed() {
+    String result = interpreter.interpolate("A {PI} is not a {{PIE}}", resourcePool);
+    assertTrue("Substitution and escape mixed", "A 3.1415 is not a {PIE}".equals(result));
+  }
+
+  @Test
+  public void unbalancedBracesOne() {
+    String result = interpreter.interpolate("A {PI} and a {{PIE} remain unchanged", resourcePool);
+    assertTrue("Unbalanced braces - one", "A {PI} and a {{PIE} remain unchanged".equals(result));
+  }
+
+  @Test
+  public void unbalancedBracesTwo() {
+    String result = interpreter.interpolate("A {PI} and a {PIE}} remain unchanged", resourcePool);
+    assertTrue("Unbalanced braces - one", "A {PI} and a {PIE}} remain unchanged".equals(result));
+  }
+
+  @Test
+  public void tooManyBraces() {
+    String result = interpreter.interpolate("This {{{PI}}} remain unchanged", resourcePool);
+    assertTrue("Too many braces", "This {{{PI}}} remain unchanged".equals(result));
+  }
+
+  @Test
+  public void randomBracesOne() {
+    String result = interpreter.interpolate("A {{ starts an escaped sequence", resourcePool);
+    assertTrue("Random braces - one", "A {{ starts an escaped sequence".equals(result));
+  }
+
+  @Test
+  public void randomBracesTwo() {
+    String result = interpreter.interpolate("A }} ends an escaped sequence", resourcePool);
+    assertTrue("Random braces - two", "A }} ends an escaped sequence".equals(result));
+  }
+
+  @Test
+  public void randomBracesThree() {
+    String result = interpreter.interpolate("Paired { begin an escaped sequence", resourcePool);
+    assertTrue("Random braces - three", "Paired { begin an escaped sequence".equals(result));
+  }
+
+  @Test
+  public void randomBracesFour() {
+    String result = interpreter.interpolate("Paired } end an escaped sequence", resourcePool);
+    assertTrue("Random braces - four", "Paired } end an escaped sequence".equals(result));
+  }
+
+}


### PR DESCRIPTION
### What is this PR for?
The code in this PR enables embedding/interpolating Z variables into command strings passed to Spark's SQL and Shell interpreters. It implements the functionality described in issue [ZEPPELIN-1967](https://issues.apache.org/jira/browse/ZEPPELIN-1967)

This PR resumes a fresh effort while taking into consideration all of the discussion in the context of the earlier [PR-2502](https://github.com/apache/zeppelin/pull/2502). The earlier PR-2502 was closed due to a corruption in my repo that could not be corrected.

The code in this PR resolves all of the discussion and suggestions in the body of the earlier [PR-2502](https://github.com/apache/zeppelin/pull/2502). The following description is a summary of the current implementation: 

Patterns of the form `{var-name}` within commands will be interpolated only if a predefined object of the specified name exists in `z`. Additionally, **all** such patterns within the command line should also be translatable for any interpolation to occur. Partial translation of a command line (where only some of the patterns are translated, and others are not) is never performed.

Patterns of the form `{{any-text}}` are translated into `{any-text}`. 

These translations are performed only when all occurrences of {, }, {{, and }} in any command string confirm to one of the two forms described above. A command containing { and/or } characters used in any other way (than `{var-name}` and `{{any-text}}` described above) is used as-is without any changes. 
No error is flagged in any case. This behavior is identical to the implementation of a similar feature in 
Jupyter's shell invocation using the ! magic command.

At present only the SQL and Shell interpreters support object interpolation. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1967

### How should this be tested?
A new unit-test class ([ZeppCtxtVariableTest.java](https://github.com/apache/zeppelin/compare/master...sanjaydasgupta:master#diff-ad942153fbbad8ac1954b1063eabf920)) has been added. The attached screenshots also show tests of the functionality.

### Screenshots (if appropriate)
![figure-1](https://user-images.githubusercontent.com/477015/36888230-9104d3c4-1e1a-11e8-9399-f98b1246730b.png)
![figure-2](https://user-images.githubusercontent.com/477015/36888237-96843bbe-1e1a-11e8-80ac-4bdfe94ead22.png)
![figure-3](https://user-images.githubusercontent.com/477015/36888240-99fe9c3a-1e1a-11e8-9aa0-9faa32c0fa19.png)
![figure-4](https://user-images.githubusercontent.com/477015/36888246-9dd86f34-1e1a-11e8-8151-4ece9d8af8e8.png)
![figure-5](https://user-images.githubusercontent.com/477015/36888251-a1d21644-1e1a-11e8-8431-c5e59773f60c.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, detailed documentation has been added to the part describing ZeppelinContext variables.
