### PR TITLE
[ZEPPELIN-3284] z.getInterpreterContext().out().clear() broken in Python interpreter

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -388,6 +388,7 @@ public class PythonInterpreter extends Interpreter implements ExecuteResultHandl
 
     zeppelinContext.setGui(context.getGui());
     zeppelinContext.setNoteGui(context.getNoteGui());
+    zeppelinContext.setInterpreterContext(context);
 
     if (!pythonscriptRunning) {
       return new InterpreterResult(Code.ERROR, "python process not running"

--- a/python/src/main/resources/grpc/python/zeppelin_python.py
+++ b/python/src/main/resources/grpc/python/zeppelin_python.py
@@ -33,6 +33,9 @@ class PyZeppelinContext(object):
     self.javaList = gateway.jvm.java.util.ArrayList
     self.max_result = z.getMaxResult()
 
+  def getInterpreterContext(self):
+    return self.z.getInterpreterContext()
+
   def input(self, name, defaultValue=""):
     return self.z.input(name, defaultValue)
 

--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -61,7 +61,7 @@ class PyZeppelinContext(object):
     self._setup_matplotlib()
 
   def getInterpreterContext(self):
-    return self.z.getCurrentInterpreterContext()
+    return self.z.getInterpreterContext()
 
   def input(self, name, defaultValue=""):
     return self.z.input(name, defaultValue)

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -456,6 +456,11 @@ public class IPythonInterpreterTest {
     interpreterResultMessages = context.out.getInterpreterResultMessages();
     assertEquals(InterpreterResult.Type.TABLE, interpreterResultMessages.get(0).getType());
     assertEquals("id\tname\n1\ta\n2\tb\n3\tc\n", interpreterResultMessages.get(0).getData());
+
+    // clear output
+    context = getInterpreterContext();
+    result = interpreter.interpret("import time\nprint(\"Hello\")\ntime.sleep(0.5)\nz.getInterpreterContext().out().clear()\nprint(\"world\")\n", context);
+    assertEquals("%text world\n", context.out.getCurrentOutput().toString());
   }
 
   private static InterpreterContext getInterpreterContext() {

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -123,6 +123,12 @@ public class PythonInterpreterTest implements InterpreterOutputListener {
     assertEquals(InterpreterResult.Code.SUCCESS, pythonInterpreter.interpret(pyValidCode, context).code());
   }
 
+  @Test
+  public void testOutputClear() throws InterpreterException {
+    InterpreterResult result = pythonInterpreter.interpret("print(\"Hello\")\nz.getInterpreterContext().out().clear()\nprint(\"world\")\n", context);
+    assertEquals("%text world\n", out.getCurrentOutput().toString());
+  }
+
   @Override
   public void onUpdateAll(InterpreterOutput out) {
 


### PR DESCRIPTION
### What is this PR for?

```
%python
import time
print("Hello")
time.sleep(0.5)     # in case of Ipython kernel, print may not immediately flushed and cleared.
z.getInterpreterContext().out().clear()
print("world")
```

Expected to print `world` only.
This worked in zeppelin-0.7.x and it'll be nice keep this feature in the future version.

### What type of PR is it?
Bug fix | Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3284

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
