### PR TITLE
ZEPPELIN-3281. Apply getRelativePath when it is LocalConfigStorage

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -524,7 +524,13 @@ public class ZeppelinConfiguration extends XMLConfiguration {
           "conf directory " + ConfVars.ZEPPELIN_CONF_DIR.varName);
       return getConfDir();
     }
-    return fsConfigDir;
+    if (getString(ConfVars.ZEPPELIN_CONFIG_STORAGE_CLASS)
+                .equals("org.apache.zeppelin.storage.LocalConfigStorage")) {
+      // only apply getRelativeDir when it is LocalConfigStorage
+      return getRelativeDir(fsConfigDir);
+    } else {
+      return fsConfigDir;
+    }
   }
 
   public List<String> getAllowedOrigins()

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -50,6 +50,7 @@ public class LocalConfigStorage extends ConfigStorage {
 
   @Override
   public void save(InterpreterInfoSaving settingInfos) throws IOException {
+    LOGGER.info("Save Interpreter Setting to " + interpreterSettingPath.getAbsolutePath());
     writeToFile(settingInfos.toJson(), interpreterSettingPath);
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -22,6 +22,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
@@ -99,5 +100,16 @@ public class ZeppelinConfigurationTest {
     ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
     Assert.assertEquals("/usr/lib/zeppelin", conf.getZeppelinHome());
     Assert.assertEquals("/usr/lib/zeppelin/conf", conf.getConfDir());
+  }
+
+  @Test
+  public void getConfigFSPath() throws ConfigurationException {
+    System.setProperty(ConfVars.ZEPPELIN_HOME.getVarName(), "/usr/lib/zeppelin");
+    System.setProperty(ConfVars.ZEPPELIN_CONFIG_FS_DIR.getVarName(), "conf");
+    ZeppelinConfiguration conf = new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"));
+    assertEquals("/usr/lib/zeppelin/conf", conf.getConfigFSDir());
+
+    System.setProperty(ConfVars.ZEPPELIN_CONFIG_STORAGE_CLASS.getVarName(), "org.apache.zeppelin.storage.FileSystemConfigStorage");
+    assertEquals("conf", conf.getConfigFSDir());
   }
 }


### PR DESCRIPTION
### What is this PR for?
When it is LocalConfigStorage, we should use getRelativePath to get the config path.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3281

### How should this be tested?
* Unit test added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
