### PR TITLE
ZEPPELIN-3279. [FlakyTest] NotebookTest.testPerSessionInterpreterCloseOnUnbindInterpreterSetting

### DIFF
--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -44,6 +44,6 @@ if [[ -n "$PYTHON" ]] ; then
   conda update -q conda
   conda info -a
   conda config --add channels conda-forge
-  conda install -q matplotlib pandasql ipython=5.4.1 jupyter_client ipykernel matplotlib bokeh=0.12.10
+  conda install -q matplotlib=2.1.2 pandasql ipython=5.4.1 jupyter_client ipykernel matplotlib bokeh=0.12.10
   pip install -q grpcio ggplot bkzep==0.4.0
 fi

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter1.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/mock/MockInterpreter1.java
@@ -24,18 +24,27 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 
+import java.lang.management.ManagementFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MockInterpreter1 extends Interpreter {
 
+	private static AtomicInteger IdGenerator = new AtomicInteger();
+
+	private int object_id;
+	private String pid;
 	Map<String, Object> vars = new HashMap<>();
 
 	public MockInterpreter1(Properties property) {
 		super(property);
+		this.object_id = IdGenerator.getAndIncrement();
+		this.pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
 	}
+
 	boolean open;
 
 
@@ -60,7 +69,7 @@ public class MockInterpreter1 extends Interpreter {
 
 		if ("getId".equals(st)) {
 			// get unique id of this interpreter instance
-			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "" + this.hashCode());
+			result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "" + this.object_id + "-" + this.pid);
 		} else if (st.startsWith("sleep")) {
 			try {
 				Thread.sleep(Integer.parseInt(st.split(" ")[1]));

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -43,6 +43,10 @@ import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
+import org.mockito.internal.runners.JUnit44RunnerImpl;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1444,4 +1448,5 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
   private interface StatusChangedListener {
     void onStatusChanged(Job job, Status before, Status after);
   }
+
 }


### PR DESCRIPTION
### What is this PR for?
The root cause of this flaky test is that hashCode doesn't represent an unique id of object. This PR just use IdGenerator for unique id and also combine process id. 
This PR also fix the flaky test caused by matplotlib. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3279

### How should this be tested?
* CI Pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
