### PR TITLE
ZEPPELIN-2515. After 100 minutes R process quits silently and spark.r interpreter becomes unresponsive

### DIFF
--- a/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
+++ b/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
@@ -22,6 +22,7 @@ hashCode <- as.integer(args[1])
 port <- as.integer(args[2])
 libPath <- args[3]
 version <- as.integer(args[4])
+timeout <- as.integer(args[5])
 rm(args)
 
 print(paste("Port ", toString(port)))
@@ -31,7 +32,7 @@ print(paste("LibPath ", libPath))
 library(SparkR)
 
 
-SparkR:::connectBackend("localhost", port, 6000)
+SparkR:::connectBackend("localhost", port, timeout)
 
 # scStartTime is needed by R/pkg/R/sparkR.R
 assign(".scStartTime", as.integer(Sys.time()), envir = SparkR:::.sparkREnv)

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkRInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkRInterpreterTest.java
@@ -47,7 +47,7 @@ public class SparkRInterpreterTest {
   private RemoteEventClient mockRemoteEventClient = mock(RemoteEventClient.class);
 
   @Test
-  public void testSparkRInterpreter() throws IOException, InterruptedException, InterpreterException {
+  public void testSparkRInterpreter() throws InterpreterException, InterruptedException {
     Properties properties = new Properties();
     properties.setProperty("spark.master", "local");
     properties.setProperty("spark.app.name", "test");
@@ -55,6 +55,7 @@ public class SparkRInterpreterTest {
     properties.setProperty("zeppelin.spark.test", "true");
     properties.setProperty("zeppelin.spark.useNew", "true");
     properties.setProperty("zeppelin.R.knitr", "true");
+    properties.setProperty("spark.r.backendConnectionTimeout", "10");
 
     sparkRInterpreter = new SparkRInterpreter(properties);
     sparkInterpreter = new SparkInterpreter(properties);
@@ -91,6 +92,12 @@ public class SparkRInterpreterTest {
       // spark job url is sent
       verify(mockRemoteEventClient, atLeastOnce()).onParaInfosReceived(any(String.class), any(String.class), any(Map.class));
     }
+
+    // sparkr backend would be timeout after 10 seconds
+    Thread.sleep(15 * 1000);
+    result = sparkRInterpreter.interpret("1+1", getInterpreterContext());
+    assertEquals(InterpreterResult.Code.ERROR, result.code());
+    assertTrue(result.message().get(0).getData().contains("sparkR backend is dead"));
   }
 
   private InterpreterContext getInterpreterContext() {


### PR DESCRIPTION
### What is this PR for?

This PR would 2 features:
1. Make timeout of sparkr backend configurable.
2. Detect R backend dead and display proper message to frontend. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2515

### How should this be tested?
* unit test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
