### PR TITLE
ZEPPELIN-3295. Remove build of profile spark-1.6 and scala-2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,11 +114,6 @@ matrix:
       dist: trusty
       env: PYTHON="3" SCALA_VER="2.10" SPARK_VER="1.6.3" HADOOP_VER="2.6" PROFILE="-Pspark-1.6 -Phadoop2 -Phadoop-2.6 -Pscala-2.10" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.* -DfailIfNoTests=false"
 
-    # Test spark module for 1.6.3 with scala 2.11
-    - jdk: "oraclejdk8"
-      dist: trusty
-      env: PYTHON="2" SCALA_VER="2.11" SPARK_VER="1.6.3" HADOOP_VER="2.6" PROFILE="-Pspark-1.6 -Phadoop3 -Phadoop-2.6 -Pscala-2.11" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.* -DfailIfNoTests=false"
-
     # Test python/pyspark with python 2, livy 0.5
     - sudo: required
       dist: trusty


### PR DESCRIPTION
### What is this PR for?
Trivial PR to remove the build of profile spark-1.6 and scala-2.11, The travis build of profile spark-1.6 and scala-2.11 only test the embedded mode of spark instead real spark binary distribution of spark 1.6 with scala-2.11, so IMHO it is safe for us to just remove that build and only keep spark 1.6 with scala-2.10


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3295

### How should this be tested?
* Travis CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
