### PR TITLE
ZEPPELIN-3302. Update SparkVersion.java to support Spark 2.3

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -34,10 +34,10 @@ public class SparkVersion {
   public static final SparkVersion SPARK_1_6_0 = SparkVersion.fromVersionString("1.6.0");
 
   public static final SparkVersion SPARK_2_0_0 = SparkVersion.fromVersionString("2.0.0");
-  public static final SparkVersion SPARK_2_3_0 = SparkVersion.fromVersionString("2.3.0");
+  public static final SparkVersion SPARK_2_4_0 = SparkVersion.fromVersionString("2.4.0");
 
   public static final SparkVersion MIN_SUPPORTED_VERSION =  SPARK_1_0_0;
-  public static final SparkVersion UNSUPPORTED_FUTURE_VERSION = SPARK_2_3_0;
+  public static final SparkVersion UNSUPPORTED_FUTURE_VERSION = SPARK_2_4_0;
 
   private int version;
   private String versionString;


### PR DESCRIPTION
### What is this PR for?

Trivial PR to support 2.3 via updating SparkVersion.java. Unfortunately we cannot download spark 2.3 from http://d3kbcqa49mib13.cloudfront.net, will leave it in ZEPPELIN-3305


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3302

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
