### PR TITLE
ZEPPELIN-3309. Import/Clone user not set in Paragraph causes NPE.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -362,7 +362,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
    *
    * @param srcParagraph source paragraph
    */
-  void addCloneParagraph(Paragraph srcParagraph) {
+  void addCloneParagraph(Paragraph srcParagraph, AuthenticationInfo subject) {
 
     // Keep paragraph original ID
     final Paragraph newParagraph = new Paragraph(srcParagraph.getId(), this, this, factory);
@@ -371,11 +371,17 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     Map<String, Object> param = srcParagraph.settings.getParams();
     LinkedHashMap<String, Input> form = srcParagraph.settings.getForms();
 
+    logger.debug("srcParagraph user: " + srcParagraph.getUser());
+    
+    newParagraph.setAuthenticationInfo(subject);
     newParagraph.setConfig(config);
     newParagraph.settings.setParams(param);
     newParagraph.settings.setForms(form);
     newParagraph.setText(srcParagraph.getText());
     newParagraph.setTitle(srcParagraph.getTitle());
+    
+    logger.debug("newParagraph user: " + newParagraph.getUser());
+
 
     try {
       Gson gson = new Gson();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -211,7 +211,7 @@ public class Notebook implements NoteEventListener {
       newNote.setCronSupported(getConf());
       List<Paragraph> paragraphs = oldNote.getParagraphs();
       for (Paragraph p : paragraphs) {
-        newNote.addCloneParagraph(p);
+        newNote.addCloneParagraph(p, subject);
       }
 
       notebookAuthorization.setNewNotePermissions(newNote.getId(), subject);
@@ -252,7 +252,7 @@ public class Notebook implements NoteEventListener {
 
     List<Paragraph> paragraphs = sourceNote.getParagraphs();
     for (Paragraph p : paragraphs) {
-      newNote.addCloneParagraph(p);
+      newNote.addCloneParagraph(p, subject);
     }
 
     noteSearchService.addIndexDoc(newNote);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1233,7 +1233,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     assertEquals(1, onParagraphCreate.get());
 
-    note1.addCloneParagraph(p1);
+    note1.addCloneParagraph(p1, AuthenticationInfo.ANONYMOUS);
     assertEquals(2, onParagraphCreate.get());
 
     note1.removeParagraph(anonymous.getUser(), p1.getId());
@@ -1400,6 +1400,27 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     //set back public to true
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
     ZeppelinConfiguration.create();
+  }
+  
+  @Test
+  public void testCloneImportCheck() throws IOException {
+    Note sourceNote = notebook.createNote(new AuthenticationInfo("user"));
+    sourceNote.setName("TestNote");
+    
+    assertEquals("TestNote",sourceNote.getName());
+
+    Paragraph sourceParagraph = sourceNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    assertEquals("anonymous", sourceParagraph.getUser());
+
+    Note destNote = notebook.createNote(new AuthenticationInfo("user"));
+    destNote.setName("ClonedNote");
+    assertEquals("ClonedNote",destNote.getName());
+
+    List<Paragraph> paragraphs = sourceNote.getParagraphs();
+    for (Paragraph p : paragraphs) {
+    	  destNote.addCloneParagraph(p, AuthenticationInfo.ANONYMOUS);
+      assertEquals("anonymous", p.getUser());
+    }
   }
 
   private void delete(File file){


### PR DESCRIPTION
What is this PR for?
During Import/Clone Paragraph set "user" to eliminate NPEs thrown in Helium and other functions leaving unusable notebooks.

What type of PR is it?
[Bug Fix]

Todos

What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3309

How should this be tested?
Manually tested using Import/Clone of Notebooks and attempt to adjust bound interpreters

Screenshots (if appropriate)

Questions:
Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? No
Author: Greg Senia gsenia@apache.org