### PR TITLE
ZEPPELIN-3315. Merge beforeStatusChange and afterStatusChange to onStatusChange

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -513,11 +513,7 @@ public class RemoteInterpreterServer extends Thread
     }
 
     @Override
-    public void beforeStatusChange(Job job, Status before, Status after) {
-    }
-
-    @Override
-    public void afterStatusChange(Job job, Status before, Status after) {
+    public void onStatusChange(Job job, Status before, Status after) {
       synchronized (this) {
         notifyAll();
       }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -152,12 +152,9 @@ public abstract class Job {
     }
     Status before = this.status;
     Status after = status;
-    if (listener != null) {
-      listener.beforeStatusChange(this, before, after);
-    }
     this.status = status;
-    if (listener != null) {
-      listener.afterStatusChange(this, before, after);
+    if (listener != null && before != after) {
+      listener.onStatusChange(this, before, after);
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/JobListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/JobListener.java
@@ -18,12 +18,10 @@
 package org.apache.zeppelin.scheduler;
 
 /**
- * TODO(moon) : add description.
+ * Listener for job execution.
  */
 public interface JobListener {
   void onProgressUpdate(Job job, int progress);
 
-  void beforeStatusChange(Job job, Job.Status before, Job.Status after);
-
-  void afterStatusChange(Job job, Job.Status before, Job.Status after);
+  void onStatusChange(Job job, Job.Status before, Job.Status after);
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -2279,11 +2279,7 @@ public class NotebookServer extends WebSocketServlet
     }
 
     @Override
-    public void beforeStatusChange(Job job, Status before, Status after) {
-    }
-
-    @Override
-    public void afterStatusChange(Job job, Status before, Status after) {
+    public void onStatusChange(Job job, Status before, Status after) {
       if (after == Status.ERROR) {
         if (job.getException() != null) {
           LOG.error("Error", job.getException());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -906,23 +906,13 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   public void setInfo(Map<String, Object> info) {
     this.info = info;
   }
-
+  
   @Override
-  public void beforeStatusChange(Job job, Status before, Status after) {
+  public void onStatusChange(Job job, Status before, Status after) {
     if (jobListenerFactory != null) {
       ParagraphJobListener listener = jobListenerFactory.getParagraphJobListener(this);
       if (listener != null) {
-        listener.beforeStatusChange(job, before, after);
-      }
-    }
-  }
-
-  @Override
-  public void afterStatusChange(Job job, Status before, Status after) {
-    if (jobListenerFactory != null) {
-      ParagraphJobListener listener = jobListenerFactory.getParagraphJobListener(this);
-      if (listener != null) {
-        listener.afterStatusChange(job, before, after);
+        listener.onStatusChange(job, before, after);
       }
     }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
@@ -253,12 +253,10 @@ public class RemoteScheduler implements Scheduler {
       if (status == Status.UNKNOWN) {
         // not found this job in the remote schedulers.
         // maybe not submitted, maybe already finished
-        //Status status = getLastStatus();
-        listener.afterStatusChange(job, null, null);
         return job.getStatus();
       }
       lastStatus = status;
-      listener.afterStatusChange(job, null, status);
+      listener.onStatusChange(job, null, status);
       return status;
     }
   }
@@ -350,11 +348,7 @@ public class RemoteScheduler implements Scheduler {
     }
 
     @Override
-    public void beforeStatusChange(Job job, Status before, Status after) {
-    }
-
-    @Override
-    public void afterStatusChange(Job job, Status before, Status after) {
+    public void onStatusChange(Job job, Status before, Status after) {
       // Update remoteStatus
       if (jobExecuted == false) {
         if (after == Status.FINISHED || after == Status.ABORT

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -322,12 +322,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest implem
       }
 
       @Override
-      public void beforeStatusChange(Job job, Job.Status before, Job.Status after) {
-
-      }
-
-      @Override
-      public void afterStatusChange(Job job, Job.Status before, Job.Status after) {
+      public void onStatusChange(Job job, Job.Status before, Job.Status after) {
 
       }
     };

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1439,11 +1439,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
       }
 
       @Override
-      public void beforeStatusChange(Job job, Status before, Status after) {
-      }
-
-      @Override
-      public void afterStatusChange(Job job, Status before, Status after) {
+      public void onStatusChange(Job job, Status before, Status after) {
         if (afterStatusChangedListener != null) {
           afterStatusChangedListener.onStatusChanged(job, before, after);
         }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -428,11 +428,8 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
       }
 
       @Override
-      public void beforeStatusChange(Job job, Status before, Status after) {
-      }
+      public void onStatusChange(Job job, Status before, Status after) {
 
-      @Override
-      public void afterStatusChange(Job job, Status before, Status after) {
       }
     };
   }


### PR DESCRIPTION
### What is this PR for?
The signature of `beforeStatusChange` & `afterStatusChange` include both the status of before and after, so it is not necessary to create both `beforeStatusChange` & `afterStatusChange`. Only one method `onStatusChange` is sufficient. 

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3315

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
