### PR TITLE
[ZEPPELIN-3320] upgrade the flink interpreter from 1.1.3 to 1.4.0

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -35,8 +35,8 @@
 
   <properties>
     <!--library versions-->
-    <flink.version>1.1.3</flink.version>
-    <flink.akka.version>2.3.7</flink.akka.version>
+    <flink.version>1.4.0</flink.version>
+    <flink.akka.version>2.4.20</flink.akka.version>
     <scala.macros.version>2.0.1</scala.macros.version>
 
     <!--plugin versions-->

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -383,7 +383,7 @@ public class FlinkInterpreter extends Interpreter {
       localFlinkCluster = new LocalFlinkMiniCluster(flinkConf,
               HighAvailabilityServicesUtils.createHighAvailabilityServices(flinkConf,
               org.apache.flink.runtime.concurrent.Executors.directExecutor(),
-              HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION),false);
+              HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION), false);
       localFlinkCluster.start(true);
     } catch (Exception e){
       throw new RuntimeException("Could not start Flink mini cluster.", e);

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
@@ -378,9 +379,11 @@ public class FlinkInterpreter extends Interpreter {
   }
 
   private void startFlinkMiniCluster() {
-    localFlinkCluster = new LocalFlinkMiniCluster(flinkConf, false);
-
     try {
+      localFlinkCluster = new LocalFlinkMiniCluster(flinkConf,
+              HighAvailabilityServicesUtils.createHighAvailabilityServices(flinkConf,
+              org.apache.flink.runtime.concurrent.Executors.directExecutor(),
+              HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION),false);
       localFlinkCluster.start(true);
     } catch (Exception e){
       throw new RuntimeException("Could not start Flink mini cluster.", e);

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -4,6 +4,18 @@
     "name": "flink",
     "className": "org.apache.zeppelin.flink.FlinkInterpreter",
     "properties": {
+      "host": {
+        "envName": "host",
+        "propertyName": null,
+        "defaultValue": "local",
+        "description": "host name of running JobManager. 'local' runs flink in local mode."
+      },
+      "port": {
+        "envName": "port",
+        "propertyName": null,
+        "defaultValue": "6123",
+        "description": "port of running JobManager."
+      },
       "jobmanager.rpc.address": {
         "envName": "jobmanager.rpc.address",
         "propertyName": null,

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -4,17 +4,17 @@
     "name": "flink",
     "className": "org.apache.zeppelin.flink.FlinkInterpreter",
     "properties": {
-      "host": {
-        "envName": "host",
+      "jobmanager.rpc.address": {
+        "envName": "jobmanager.rpc.address",
         "propertyName": null,
-        "defaultValue": "local",
-        "description": "host name of running JobManager. 'local' runs flink in local mode."
+        "defaultValue": "localhost",
+        "description": "host name of running JobManager"
       },
-      "port": {
-        "envName": "port",
+      "jobmanager.rpc.port": {
+        "envName": "jobmanager.rpc.port",
         "propertyName": null,
         "defaultValue": "6123",
-        "description": "port of running JobManager."
+        "description": "port of running JobManager"
       }
     },
     "editor": {

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
@@ -38,6 +38,8 @@ public class FlinkInterpreterTest {
   @BeforeClass
   public static void setUp() {
     Properties p = new Properties();
+    p.setProperty("jobmanager.rpc.address", "localhost");
+    p.setProperty("jobmanager.rpc.port", "6123");
     flink = new FlinkInterpreter(p);
     flink.open();
     context = new InterpreterContext(null, null, null, null, null, null, null, null, null, null, null, null);


### PR DESCRIPTION
### What is this PR for?
upgrade the flink interpreter from 1.1.3 to 1.4.0，the LocalFlinkMiniCluster default haService is EmbeddedHaServices in 1.4.0, so use HighAvailabilityServicesUtils.createHighAvailabilityServices to create StandaloneHaServices


### What type of PR is it?
Improvement
### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3320

### How should this be tested?
* no tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
