### PR TITLE
ZEPPELIN-3099 Livy Interpreter doesn't support German Special Character - Encoding Issue

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.livy;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.security.KeyStore;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.Interpreter.FormType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -68,6 +70,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.security.kerberos.client.KerberosRestTemplate;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -652,19 +655,21 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       }
     }
 
-
+    RestTemplate restTemplate = null;
     if (isSpnegoEnabled) {
       if (httpClient == null) {
-        return new KerberosRestTemplate(keytabLocation, principal);
+        restTemplate = new KerberosRestTemplate(keytabLocation, principal);
       } else {
-        return new KerberosRestTemplate(keytabLocation, principal, httpClient);
+        restTemplate = new KerberosRestTemplate(keytabLocation, principal, httpClient);
       }
     }
     if (httpClient == null) {
-      return new RestTemplate();
+      restTemplate = new RestTemplate();
     } else {
-      return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+      restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
     }
+    restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(Charset.forName("UTF-8")));
+    return restTemplate;
   }
 
   private String callRestAPI(String targetURL, String method) throws LivyException {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -372,9 +372,9 @@ public class LivyInterpreterIT {
 
     // test utf-8 Encoding
     String utf8Str = "你你你你你你好";
-    InterpreterResult result = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    assertTrue(result.message().get(0).getData().contains(utf8Str));
+    InterpreterResult reslt = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, reslt.code());
+    assertTrue(reslt.message().get(0).getData().contains(utf8Str));
 
     //test special characters
     String charStr = "açñiñíûÑoç";

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -379,6 +379,15 @@ public class LivyInterpreterIT {
     } catch (Exception e) {
       e.printStackTrace();
     }
+        //test special characters
+    try {
+      String utf8Str = "açñiñíûÑoç";
+      InterpreterResult result = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+      assertTrue(result.message().get(0).getData().contains(utf8Str));
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
 
     try {
       InterpreterResult result = pysparkInterpreter.interpret("sc.version", context);

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -371,23 +371,16 @@ public class LivyInterpreterIT {
     }
 
     // test utf-8 Encoding
-    try {
-      String utf8Str = "你你你你你你好";
-      InterpreterResult result = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
-      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-      assertTrue(result.message().get(0).getData().contains(utf8Str));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-        //test special characters
-    try {
-      String utf8Str = "açñiñíûÑoç";
-      InterpreterResult result = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
-      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-      assertTrue(result.message().get(0).getData().contains(utf8Str));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    String utf8Str = "你你你你你你好";
+    InterpreterResult result = pysparkInterpreter.interpret("print(\"" + utf8Str + "\")", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertTrue(result.message().get(0).getData().contains(utf8Str));
+
+    //test special characters
+    String charStr = "açñiñíûÑoç";
+    InterpreterResult res = pysparkInterpreter.interpret("print(\"" + charStr + "\")", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, res.code());
+    assertTrue(res.message().get(0).getData().contains(charStr));
 
     try {
       InterpreterResult result = pysparkInterpreter.interpret("sc.version", context);


### PR DESCRIPTION
### What is this PR for?
ZEPPELIN-3099 Livy Interpreter doesn't support German Special Character - Encoding Issue

### What type of PR is it?
BUG FIX for : ZEPPELIN-3099

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3099

### How should this be tested?
test with German Special Characters like ß, ü, Ü, ä, Ä, ö, Ö .