### PR TITLE
ZEPPELIN-3322. Update interpreterBind when restarting zeppelin server

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -208,6 +208,19 @@ public class InterpreterSettingManager {
       return;
     }
 
+    // update interpreter binding first as we change interpreter setting id in ZEPPELIN-3208.
+    Map<String, List<String>> newBindingMap = new HashMap<>();
+    for (Map.Entry<String, List<String>> entry : infoSaving.interpreterBindings.entrySet()) {
+      String noteId = entry.getKey();
+      List<String> oldSettingIdList = entry.getValue();
+      List<String> newSettingIdList = new ArrayList<>();
+      for (String oldId : oldSettingIdList) {
+        newSettingIdList.add(infoSaving.interpreterSettings.get(oldId).getName());
+      }
+      newBindingMap.put(noteId, newSettingIdList);
+    }
+    interpreterBindings.putAll(newBindingMap);
+
     //TODO(zjffdu) still ugly (should move all to InterpreterInfoSaving)
     for (InterpreterSetting savedInterpreterSetting : infoSaving.interpreterSettings.values()) {
       savedInterpreterSetting.setProperties(InterpreterSetting.convertInterpreterProperties(
@@ -258,8 +271,6 @@ public class InterpreterSettingManager {
           savedInterpreterSetting.getName());
       interpreterSettings.put(savedInterpreterSetting.getId(), savedInterpreterSetting);
     }
-
-    interpreterBindings.putAll(infoSaving.interpreterBindings);
 
     if (infoSaving.interpreterRepositories != null) {
       for (RemoteRepository repo : infoSaving.interpreterRepositories) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -72,6 +72,12 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     assertEquals(2, repositories.size());
     assertEquals("central", repositories.get(0).getId());
 
+    // verify interpreter binding
+    List<String> interpreterSettingIds = interpreterSettingManager.getInterpreterBinding("2C6793KRV");
+    assertEquals(2, interpreterSettingIds.size());
+    assertEquals("test", interpreterSettingIds.get(0));
+    assertEquals("test2", interpreterSettingIds.get(1));
+
     // Load it again
     InterpreterSettingManager interpreterSettingManager2 = new InterpreterSettingManager(conf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));

--- a/zeppelin-zengine/src/test/resources/conf/interpreter.json
+++ b/zeppelin-zengine/src/test/resources/conf/interpreter.json
@@ -124,27 +124,8 @@
   },
   "interpreterBindings": {
     "2C6793KRV": [
-      "2C48Y7FSJ",
-      "2C63XW4XE",
-      "2C66GE1VB",
-      "2C5VH924X",
-      "2C4BJDRRZ",
-      "2C3SQSB7V",
-      "2C4HKDCQW",
-      "2C3DR183X",
-      "2C66Z9XPQ",
-      "2C3PTPMUH",
-      "2C69WE69N",
-      "2C5SRRXHM",
-      "2C4ZD49PF",
-      "2C6V3D44K",
-      "2C4UB1UZA",
-      "2C5S1R21W",
-      "2C5DCRVGM",
-      "2C686X8ZH",
       "2C3RWCVAG",
-      "2C3JKFMJU",
-      "2C3VECEG2"
+      "2CKWE7B19"
     ]
   },
   "interpreterRepositories": [


### PR DESCRIPTION
### What is this PR for?
When loading interpreter.json, also update interpreterBindings as we change change interpreter setting id in ZEPPELIN-3208. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3322

### How should this be tested?
* Unit test is added. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
