### PR TITLE
[ZEPPELIN-3321] isRevisionSupported not working for importing notebooks.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -389,7 +389,6 @@ public class NotebookRestApi {
     note.setName(noteName);
     note.persist(subject);
     note.setCronSupported(notebook.getConf());
-    note.setRevisionSupported();
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
     return new JsonResponse<>(Status.OK, "", note.getId()).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -389,6 +389,7 @@ public class NotebookRestApi {
     note.setName(noteName);
     note.persist(subject);
     note.setCronSupported(notebook.getConf());
+    note.setRevisionSupported();
     notebookServer.broadcastNote(note);
     notebookServer.broadcastNoteList(subject, SecurityUtils.getRoles());
     return new JsonResponse<>(Status.OK, "", note.getId()).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1048,7 +1048,6 @@ public class NotebookServer extends WebSocketServlet
         note.setName(noteName);
         note.setCronSupported(notebook.getConf());
       }
-      note.setRevisionSupported();
 
       note.persist(subject);
       addConnectionToNote(note.getId(), (NotebookSocket) conn);
@@ -1909,7 +1908,7 @@ public class NotebookServer extends WebSocketServlet
                     .getVarName());
           }
         });
-
+    configurations.put("isRevisionSupported", String.valueOf(notebook.isRevisionSupported()));
     conn.send(serializeMessage(
         new Message(OP.CONFIGURATIONS_INFO).put("configurations", configurations)));
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1048,6 +1048,7 @@ public class NotebookServer extends WebSocketServlet
         note.setName(noteName);
         note.setCronSupported(notebook.getConf());
       }
+      note.setRevisionSupported();
 
       note.persist(subject);
       addConnectionToNote(note.getId(), (NotebookSocket) conn);

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -100,7 +100,7 @@ limitations under the License.
       </button>
     </span>
 
-    <span class="labelBtn btn-group" role="group" ng-if="note.config.isRevisionSupported">
+    <span class="labelBtn btn-group" role="group" ng-if="isRevisionSupported()" >
       <div class="btn-group" role="group">
         <button type="button"
                 class="btn btn-default btn-xs dropdown-toggle"

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -31,6 +31,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
   vm.TRASH_FOLDER_ID = TRASH_FOLDER_ID;
   vm.isFilterNote = isFilterNote;
   vm.numberOfNotesDisplayed = 10;
+  let revisionSupported = false;
 
   $scope.query = {q: ''};
 
@@ -244,5 +245,16 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
       }
     }
     return 'top';
+  };
+
+  $scope.$on('configurationsInfo', function(scope, event) {
+    // Server send this parameter is String
+    if(event.configurations['isRevisionSupported']==='true') {
+      revisionSupported = true;
+    }
+  });
+
+  $rootScope.isRevisionSupported = function() {
+    return revisionSupported;
   };
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -301,7 +301,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     this.repo = repo;
   }
 
-  void setRevisionSupported(NotebookRepo repo) {
+  public void setRevisionSupported() {
     if (repo instanceof NotebookRepoSync) {
       getConfig()
           .put("isRevisionSupported", ((NotebookRepoSync) repo).isRevisionSupportedInDefaultRepo());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -301,17 +301,6 @@ public class Note implements ParagraphJobListener, JsonSerializable {
     this.repo = repo;
   }
 
-  public void setRevisionSupported() {
-    if (repo instanceof NotebookRepoSync) {
-      getConfig()
-          .put("isRevisionSupported", ((NotebookRepoSync) repo).isRevisionSupportedInDefaultRepo());
-    } else if (repo instanceof NotebookRepoWithVersionControl) {
-      getConfig().put("isRevisionSupported", true);
-    } else {
-      getConfig().put("isRevisionSupported", false);
-    }
-  }
-
   public Boolean isCronSupported(ZeppelinConfiguration config) {
     if (config.isZeppelinNotebookCronEnable()) {
       config.getZeppelinNotebookCronFolders();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -209,6 +209,7 @@ public class Notebook implements NoteEventListener {
         newNote.setName(oldNote.getName());
       }
       newNote.setCronSupported(getConf());
+      newNote.setRevisionSupported();
       List<Paragraph> paragraphs = oldNote.getParagraphs();
       for (Paragraph p : paragraphs) {
         newNote.addCloneParagraph(p, subject);
@@ -246,6 +247,7 @@ public class Notebook implements NoteEventListener {
       newNote.setName("Note " + newNote.getId());
     }
     newNote.setCronSupported(getConf());
+    newNote.setRevisionSupported();
     // Copy the interpreter bindings
     List<String> boundInterpreterSettingsIds = getBindedInterpreterSettingsIds(sourceNote.getId());
     bindInterpretersToNote(subject.getUser(), newNote.getId(), boundInterpreterSettingsIds);
@@ -521,7 +523,7 @@ public class Notebook implements NoteEventListener {
 
     note.setJobListenerFactory(jobListenerFactory);
     note.setNotebookRepo(notebookRepo);
-    note.setRevisionSupported(notebookRepo);
+    note.setRevisionSupported();
     note.setCronSupported(getConf());
 
     Map<String, SnapshotAngularObject> angularObjectSnapshot = new HashMap<>();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -209,7 +209,6 @@ public class Notebook implements NoteEventListener {
         newNote.setName(oldNote.getName());
       }
       newNote.setCronSupported(getConf());
-      newNote.setRevisionSupported();
       List<Paragraph> paragraphs = oldNote.getParagraphs();
       for (Paragraph p : paragraphs) {
         newNote.addCloneParagraph(p, subject);
@@ -247,7 +246,6 @@ public class Notebook implements NoteEventListener {
       newNote.setName("Note " + newNote.getId());
     }
     newNote.setCronSupported(getConf());
-    newNote.setRevisionSupported();
     // Copy the interpreter bindings
     List<String> boundInterpreterSettingsIds = getBindedInterpreterSettingsIds(sourceNote.getId());
     bindInterpretersToNote(subject.getUser(), newNote.getId(), boundInterpreterSettingsIds);
@@ -523,7 +521,6 @@ public class Notebook implements NoteEventListener {
 
     note.setJobListenerFactory(jobListenerFactory);
     note.setNotebookRepo(notebookRepo);
-    note.setRevisionSupported();
     note.setCronSupported(getConf());
 
     Map<String, SnapshotAngularObject> angularObjectSnapshot = new HashMap<>();
@@ -1060,6 +1057,16 @@ public class Notebook implements NoteEventListener {
   private void fireUnbindInterpreter(Note note, InterpreterSetting setting) {
     for (NotebookEventListener listener : notebookEventListeners) {
       listener.onUnbindInterpreter(note, setting);
+    }
+  }
+
+  public Boolean isRevisionSupported() {
+    if (notebookRepo instanceof NotebookRepoSync) {
+      return ((NotebookRepoSync) notebookRepo).isRevisionSupportedInDefaultRepo();
+    } else if (notebookRepo instanceof NotebookRepoWithVersionControl) {
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -31,6 +31,8 @@ import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.notebook.repo.FileSystemNotebookRepo;
+import org.apache.zeppelin.notebook.repo.GitHubNotebookRepo;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.VFSNotebookRepo;
@@ -108,6 +110,31 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
   @After
   public void tearDown() throws Exception {
     super.tearDown();
+  }
+
+  @Test
+  public void testRevisionSupported() throws IOException, SchedulerException {
+    NotebookRepo notebookRepo;
+    Notebook notebook;
+
+    notebookRepo = new VFSNotebookRepo(conf);
+    notebook = new Notebook(conf, notebookRepo, schedulerFactory, interpreterFactory,
+        interpreterSettingManager, this, null,
+        notebookAuthorization, credentials);
+    assertFalse("Revision is not supported in VFSNotebookRepo", notebook.isRevisionSupported());
+
+    notebookRepo = new GitHubNotebookRepo(conf);
+    notebook = new Notebook(conf, notebookRepo, schedulerFactory, interpreterFactory,
+        interpreterSettingManager, this, null,
+        notebookAuthorization, credentials);
+    assertTrue("Revision is supported in GitHubNotebookRepo", notebook.isRevisionSupported());
+
+    notebookRepo = new FileSystemNotebookRepo(conf);
+    notebook = new Notebook(conf, notebookRepo, schedulerFactory, interpreterFactory,
+        interpreterSettingManager, this, null,
+        notebookAuthorization, credentials);
+    assertFalse("Revision is not supported in FileSystemNotebookRepo",
+        notebook.isRevisionSupported());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
 when importing note of from one zeppelin instance that don't support revision to another zeppelin instance where revision is supported, the imported note still don't support revision.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3321](https://issues.apache.org/jira/browse/ZEPPELIN-3321)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
