### PR TITLE
Hotfix: ambiguous reference to overloaded definition

### DIFF
--- a/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
+++ b/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
@@ -67,7 +67,7 @@ class SparkScala210Interpreter(override val conf: SparkConf,
     settings.usejavacp.value = true
     settings.classpath.value = getUserJars.mkString(File.pathSeparator)
     Console.setOut(interpreterOutput)
-    sparkILoop = new SparkILoop(null, new JPrintWriter(Console.out, true))
+    sparkILoop = new SparkILoop()
 
     setDeclaredField(sparkILoop, "settings", settings)
     callMethod(sparkILoop, "createInterpreter")


### PR DESCRIPTION
### What is this PR for?
Minor bugfix on Zeppelin build from sources


### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3324

### How should this be tested?
* mvn clean package \
  --batch-mode package \
  -Phelium-dev \
  -Pscala-2.11 \
  -Dscala.version=2.11.8 \
  -Dscala.binary.version=2.11 \
  -Pbuild-distr \
  -Pspark-2.1 \
  -Dspark.version=2.1.1 \
  -Pr \
  -Pcassandra-spark-1.5 \
  -Psparkr \
  -Ppyspark \
  -Phadoop-2.7 \
  -Dhadoop.version=2.7.3 \
  -Dmaven.findbugs.enable=false \
  -Drat.skip=true \
  -Dcheckstyle.skip=true \
  -DskipTests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
