### PR TITLE
ZEPPELIN-3332 Zeppelin login fails with NPE if ldapRealm.authorizationEnabled is not set true

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -56,6 +56,7 @@ public class SecurityUtils {
   private static boolean isEnabled = false;
   private static final Logger log = LoggerFactory.getLogger(SecurityUtils.class);
   
+
   public static void setIsEnabled(boolean value) {
     isEnabled = value;
   }
@@ -149,7 +150,9 @@ public class SecurityUtils {
               new SimplePrincipalCollection(subject.getPrincipal(), realm.getName()),
               ((LdapRealm) realm).getContextFactory()
             );
-            roles = new HashSet<>(auth.getRoles());
+            if (auth != null) {
+              roles = new HashSet<>(auth.getRoles());
+            }
           } catch (NamingException e) {
             log.error("Can't fetch roles", e);
           }


### PR DESCRIPTION
### What is this PR for?
Simply fixes NPE by checking for null

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3332

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
