### PR TITLE
[ZEPPELIN-3089] Delete all notes for current user

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1088,7 +1088,7 @@ public class NotebookServer extends WebSocketServlet
       return;
     }
 
-    List<Note> notes = notebook.getNotesUnderFolder(folderId);
+    List<Note> notes = notebook.getNotesUnderFolder(folderId, userAndRoles);
     for (Note note : notes) {
       String noteId = note.getId();
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Folder.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.notebook;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,6 +214,25 @@ public class Folder {
       notes.addAll(child.getNotesRecursively());
     }
 
+    return notes;
+  }
+
+  public List<Note> getNotesRecursively(Set<String> userAndRoles,
+      NotebookAuthorization notebookAuthorization) {
+    final Set<String> entities = Sets.newHashSet();
+    if (userAndRoles != null) {
+      entities.addAll(userAndRoles);
+    }
+
+    List<Note> notes = new ArrayList<>();
+    for (Note note : getNotes()) {
+      if (notebookAuthorization.isOwner(note.getId(), entities)) {
+        notes.add(note);
+      }
+    }
+    for (Folder child : children.values()) {
+      notes.addAll(child.getNotesRecursively(userAndRoles, notebookAuthorization));
+    }
     return notes;
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -651,6 +651,11 @@ public class Notebook implements NoteEventListener {
     return folders.getFolder(folderId).getNotesRecursively();
   }
 
+  public List<Note> getNotesUnderFolder(String folderId,
+      Set<String> userAndRoles) {
+    return folders.getFolder(folderId).getNotesRecursively(userAndRoles, notebookAuthorization);
+  }
+
   public List<Note> getAllNotes() {
     synchronized (notes) {
       List<Note> noteList = new ArrayList<>(notes.values());


### PR DESCRIPTION
### What is this PR for?
"Empty Trash" is not working when multi-user create a notebook and move it to trash.
Because all notebooks are in the same trash folder even though the user doesn't have permission to the notebook, and on clicking "Empty Trash" button next to Trash folder, Zeppelin tries to delete all notebooks in the Trash folder, which includes no permission notebook, but cannot delete those because of no permission.

This has slightly different implementation than that is there is https://github.com/apache/zeppelin/pull/2695


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Add unit test case

### What is the Jira issue?
* [ZEPPELIN-3089](https://issues.apache.org/jira/browse/ZEPPELIN-3089)

### How should this be tested?
* Login as user 'A' and create a notebook 'A'
* Move notebook 'A' to Trash
* Login as user 'B' and create a notebook 'B'
* Move notebook 'B' to Trash
* Click 'Empty Trash' button next to 'Trash' folder


### Screenshots (if appropriate)
![zeppelin-3249-python](https://user-images.githubusercontent.com/674497/37451922-229533ea-2859-11e8-9a76-085c5cb8b9d1.gif)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
