### PR TITLE
ZEPPELIN-3340 Streaming support in builtin visualizations

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -552,18 +552,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       if (!$scope.$parent.result.data[data.index]) {
         $scope.$parent.result.data[data.index] = '';
       }
-      if (!tableData) {
-        $scope.$parent.result.data[data.index] = $scope.$parent.result.data[data.index].concat(
-          data.data);
-        $rootScope.$broadcast(
-          'updateResult',
-          {'data': $scope.$parent.result.data[data.index], 'type': 'TABLE'},
-          undefined,
-          paragraph,
-          data.index);
-        let elemId = `p${$scope.id}_table`;
-        renderGraph(elemId, 'table', true);
-      } else {
+      if (tableData) {
         let textRows = data.data.split('\n');
         for (let i = 0; i < textRows.length; i++) {
           if (textRows[i] !== '') {
@@ -575,6 +564,19 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
             }
           }
         }
+      }
+      if (!tableData
+        || !builtInVisualizations[$scope.graphMode].instance.append) {
+        $scope.$parent.result.data[data.index] = $scope.$parent.result.data[data.index].concat(
+          data.data);
+        $rootScope.$broadcast(
+          'updateResult',
+          {'data': $scope.$parent.result.data[data.index], 'type': 'TABLE'},
+          $scope.config,
+          paragraph,
+          data.index);
+        let elemId = `p${$scope.id}_` + $scope.graphMode;
+        renderGraph(elemId, $scope.graphMode, true);
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
Support for streaming visualizations. This PR is an addition to [ZEPPELIN-3249](https://issues.apache.org/jira/browse/ZEPPELIN-3249)
Limitations: 1) Initial chart selection and setup is required _(see the testing steps below)_, 2) Switching of visualization during progress is not possible

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
[ZEPPELIN-3340](https://issues.apache.org/jira/browse/ZEPPELIN-3340)

### How should this be tested?
1) Run a paragraph which outputs table
2) Select a visualization
3) Set necessary keys/groups/values and other visualization settings
4) Replace the paragraph code with streaming content and run again

### Screenshots (if appropriate)
![mar-15-2018 18-25-11](https://user-images.githubusercontent.com/2031306/37464667-0e2a5824-287f-11e8-833c-34429567b06c.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
