### PR TITLE
ZEPPELIN-3344. Revert comments in queries in JDBC interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -618,7 +618,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
         }
       }
 
-      if (character == ';' && !quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
+      if (character == ';' && !quoteString && !doubleQuoteString && !multiLineComment
+          && !singleLineComment) {
         queries.add(StringUtils.trim(query.toString()));
         query = new StringBuilder();
       } else if (item == sql.length() - 1) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -585,18 +585,12 @@ public class JDBCInterpreter extends KerberosInterpreter {
     for (int item = 0; item < sql.length(); item++) {
       character = sql.charAt(item);
 
-      if ((singleLineComment && (character == '\n' || item == sql.length() - 1))
-          || (multiLineComment && character == '/' && sql.charAt(item - 1) == '*')) {
+      if (singleLineComment && (character == '\n' || item == sql.length() - 1)) {
         singleLineComment = false;
-        multiLineComment = false;
-        if (item == sql.length() - 1 && query.length() > 0) {
-          queries.add(StringUtils.trim(query.toString()));
-        }
-        continue;
       }
 
-      if (singleLineComment || multiLineComment) {
-        continue;
+      if (multiLineComment && character == '/' && sql.charAt(item - 1) == '*') {
+        multiLineComment = false;
       }
 
       if (character == '\'') {
@@ -619,16 +613,12 @@ public class JDBCInterpreter extends KerberosInterpreter {
           && sql.length() > item + 1) {
         if (character == '-' && sql.charAt(item + 1) == '-') {
           singleLineComment = true;
-          continue;
-        }
-
-        if (character == '/' && sql.charAt(item + 1) == '*') {
+        } else if (character == '/' && sql.charAt(item + 1) == '*') {
           multiLineComment = true;
-          continue;
         }
       }
 
-      if (character == ';' && !quoteString && !doubleQuoteString) {
+      if (character == ';' && !quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
         queries.add(StringUtils.trim(query.toString()));
         query = new StringBuilder();
       } else if (item == sql.length() - 1) {

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -189,13 +189,16 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
         "select '\n', ';';" +
         "select replace('A\\;B', '\\', 'text');" +
         "select '\\', ';';" +
-        "select '''', ';'";
+        "select '''', ';';" +
+        "select /*+ scan */ * from test_table;" +
+        "--singleLineComment\nselect * from test_table";
+
 
     Properties properties = new Properties();
     JDBCInterpreter t = new JDBCInterpreter(properties);
     t.open();
     List<String> multipleSqlArray = t.splitSqlQueries(sqlQuery);
-    assertEquals(8, multipleSqlArray.size());
+    assertEquals(10, multipleSqlArray.size());
     assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray.get(0));
     assertEquals("select * from test_table", multipleSqlArray.get(1));
     assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray.get(2));
@@ -204,6 +207,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("select replace('A\\;B', '\\', 'text')", multipleSqlArray.get(5));
     assertEquals("select '\\', ';'", multipleSqlArray.get(6));
     assertEquals("select '''', ';'", multipleSqlArray.get(7));
+    assertEquals("select /*+ scan */ * from test_table", multipleSqlArray.get(8));
+    assertEquals("--singleLineComment\nselect * from test_table", multipleSqlArray.get(9));
   }
 
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -534,7 +534,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
-  public void testExcludingComments() throws SQLException, IOException {
+  public void testSplitSqlQueryWithComments() throws SQLException, IOException {
     Properties properties = new Properties();
     properties.setProperty("common.max_count", "1000");
     properties.setProperty("common.max_retry", "3");


### PR DESCRIPTION
### What is this PR for?
The original purpose of https://github.com/apache/zeppelin/pull/2158 was correct processing of ';'. This was done via full removing comments from code.
Unfortunately Apache Phoenix uses hooks in comments https://forcedotcom.github.io/phoenix/#hintml.
Thus we should not delete comments in scripts.
There was discussion about comment rules for different databases (solr). The right way is keep style. Thus analysts can copy queries to another tool and can get same results and errors.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3344

### How should this be tested?
* Unit tests pass: testSplitSqlQueryWithComments and testSplitSqlQuery

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No