### PR TITLE
ZEPPELIN-3345. Don't load interpreter setting when it exist interpreter.json but no interpreter-setting.json found

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -215,7 +215,9 @@ public class InterpreterSettingManager {
       List<String> oldSettingIdList = entry.getValue();
       List<String> newSettingIdList = new ArrayList<>();
       for (String oldId : oldSettingIdList) {
-        newSettingIdList.add(infoSaving.interpreterSettings.get(oldId).getName());
+        if (infoSaving.interpreterSettings.containsKey(oldId)) {
+          newSettingIdList.add(infoSaving.interpreterSettings.get(oldId).getName());
+        };
       }
       newBindingMap.put(noteId, newSettingIdList);
     }
@@ -256,7 +258,19 @@ public class InterpreterSettingManager {
             interpreterSettingTemplate.getInterpreterRunner());
       } else {
         LOGGER.warn("No InterpreterSetting Template found for InterpreterSetting: "
-            + savedInterpreterSetting.getGroup());
+            + savedInterpreterSetting.getGroup() + ", but it is found in interpreter.json, "
+            + "it would be skipped.");
+        // also delete its binding
+        for (Map.Entry<String, List<String>> entry : interpreterBindings.entrySet()) {
+          List<String> ids = entry.getValue();
+          Iterator<String> iter = ids.iterator();
+          while(iter.hasNext()) {
+            if (iter.next().equals(savedInterpreterSetting.getId())) {
+              iter.remove();
+            }
+          }
+        }
+        continue;
       }
 
       // Overwrite the default InterpreterSetting we registered from InterpreterSetting Templates


### PR DESCRIPTION
### What is this PR for?
It usually happens in dev enviroment. e.g. I have livy interpreter in interpreter.json due to history testing but no livy folder under `{ZEPPELIN_HOME}/interpreter` after I rebuilt the project without building livy module. This PR would just remove that invalid interpreter setting when loading from interpreter.json


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3345

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
