### PR TITLE
[ZEPPELIN-3351] Fix build error with 'spark-2.3' profile

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -71,12 +71,6 @@
 
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
-      <artifactId>spark-scala-2.10</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -578,4 +572,78 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>spark-2.3</id>
+    </profile>
+
+    <profile>
+      <id>spark-2.2</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-2.1</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-2.0</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-1.6</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-1.5</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>spark-1.4</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>spark-scala-2.10</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
@@ -25,7 +25,6 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.ui.jobs.JobProgressListener;
 import org.apache.zeppelin.interpreter.BaseZeppelinContext;
 import org.apache.zeppelin.interpreter.DefaultInterpreterProperty;
 import org.apache.zeppelin.interpreter.Interpreter;

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -198,7 +198,7 @@
             <properties>
                 <spark.version>2.3.0</spark.version>
                 <protobuf.version>2.5.0</protobuf.version>
-                <spark.py4j.version>0.10.6</spark.py4j.version>
+                <py4j.version>0.10.6</py4j.version>
             </properties>
         </profile>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -199,6 +199,12 @@
                 <spark.version>2.3.0</spark.version>
                 <protobuf.version>2.5.0</protobuf.version>
                 <py4j.version>0.10.6</py4j.version>
+                <spark.src.download.url>
+                    http://www-us.apache.org/dist/spark/${spark.archive}/${spark.archive}.tgz
+                </spark.src.download.url>
+                <spark.bin.download.url>
+                    http://www-us.apache.org/dist/spark/${spark.archive}/${spark.archive}-bin-without-hadoop.tgz
+                </spark.bin.download.url>
             </properties>
         </profile>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -60,7 +60,6 @@
     <modules>
         <module>interpreter</module>
         <module>spark-scala-parent</module>
-        <module>scala-2.10</module>
         <module>scala-2.11</module>
         <module>spark-dependencies</module>
         <module>spark-shims</module>
@@ -217,6 +216,9 @@
                 <spark.version>2.2.0</spark.version>
                 <py4j.version>0.10.4</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
         <profile>
@@ -225,6 +227,9 @@
                 <spark.version>2.1.0</spark.version>
                 <py4j.version>0.10.4</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
         <profile>
@@ -233,6 +238,9 @@
                 <spark.version>2.0.2</spark.version>
                 <py4j.version>0.10.3</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
         <profile>
@@ -241,6 +249,9 @@
                 <spark.version>1.6.3</spark.version>
                 <py4j.version>0.9</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
         <profile>
@@ -249,6 +260,9 @@
                 <spark.version>1.5.2</spark.version>
                 <py4j.version>0.8.2.1</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
         <profile>
@@ -257,6 +271,9 @@
                 <spark.version>1.4.1</spark.version>
                 <py4j.version>0.8.2.1</py4j.version>
             </properties>
+            <modules>
+                <module>scala-2.10</module>
+            </modules>
         </profile>
 
     </profiles>


### PR DESCRIPTION
### What is this PR for?
I failed to build with this option (specially `spark-2.3` profile)
```mvn package -DskipTests -Pspark-2.3 -Phadoop-2.7 -Pyarn -Ppyspark -Pscala-2.11```

It is caused these reason

* Spark 2.3 remove support scala 2.10
    * https://spark.apache.org/releases/spark-release-2-3-0.html
    * https://issues.apache.org/jira/browse/SPARK-19810
* Unused import in 'NewSparkInterpreter'
    * https://github.com/apache/zeppelin/blob/master/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java#L28
* wrong properties name in maven description in spark
    * https://github.com/apache/zeppelin/blob/master/spark/pom.xml#L201
* Spark 2.3 Source wasn't cached in d3kbcqa49mib13.cloudfront.net
    * https://github.com/apache/zeppelin/blob/master/spark/pom.xml#L53

This PR can fix their error.


### What type of PR is it?
Bug Fix

### Todos
* [x] - Remove unused import in 'NewSparkInterpreter'
* [x] - Fix wrong properties name in maven description in spark 
* [x] - Replace download url for spark 2.3
* [x] - support only scala 2.11 for spark 2.3

### What is the Jira issue?
* [ZEPPELIN-3351]
* https://issues.apache.org/jira/browse/ZEPPELIN-3351

### How should this be tested?
* build with this option
    ```
    mvn package -DskipTests -Pspark-2.3 -Phadoop-2.7 -Pyarn -Ppyspark -Pscala-2.11
    ```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No
