### PR TITLE
ZEPPELIN-3356: Zeppelin FileSystemStorage reloginFromKeytab needed

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FileSystemStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FileSystemStorage.java
@@ -12,6 +12,8 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jline.internal.Log;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -156,6 +158,11 @@ public class FileSystemStorage {
   public synchronized <T> T callHdfsOperation(final HdfsOperation<T> func) throws IOException {
     if (isSecurityEnabled) {
       try {
+    	    if (isSecurityEnabled) {
+    	      if (UserGroupInformation.isLoginKeytabBased()) {
+            UserGroupInformation.getCurrentUser().checkTGTAndReloginFromKeytab();
+    	      } 
+    	    }
         return UserGroupInformation.getCurrentUser().doAs(new PrivilegedExceptionAction<T>() {
           @Override
           public T run() throws Exception {


### PR DESCRIPTION
What is this PR for?
During long runs of Apache Zeppelin using HDFS as the backing configuration and notebook storage. We noticed that when the Zeppelin Server ticket had reached 7 days our max renewal time the keytab is not re-logged in leaving the Zeppelin Server in an unusable state. The solution is to reLoginFromKeytab before any operations as it will check if the ticket needs to be relogged in.

What type of PR is it?
[Bug Fix]

Todos

What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3356

How should this be tested?
Run Zeppelin Server for the max kerberos renewal time

Screenshots (if appropriate)

Questions:
Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this needs documentation? No
Author: Greg Senia gsenia@apache.org