### PR TITLE
ZEPPELIN-1070: Inject Credentials in any Interpreter-Code

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
@@ -53,9 +53,11 @@ class CredentialInjector {
     while (matcher.find()) {
       String key = matcher.group(1);
       UsernamePassword usernamePassword = creds.getUsernamePassword(key);
-      String value = usernamePassword == null ? "undef" : usernamePassword.getUsername();
-      replaced = matcher.replaceFirst(value);
-      matcher = userpattern.matcher(replaced);
+      if (usernamePassword != null) {
+        String value = usernamePassword.getUsername();
+        replaced = matcher.replaceFirst(value);
+        matcher = userpattern.matcher(replaced);
+      }
     }
     matcher = passwordpattern.matcher(replaced);
     while (matcher.find()) {
@@ -63,10 +65,10 @@ class CredentialInjector {
       UsernamePassword usernamePassword = creds.getUsernamePassword(key);
       if (usernamePassword != null) {
         passwords.add(usernamePassword.getPassword());
+        String value = usernamePassword.getPassword();
+        replaced = matcher.replaceFirst(value);
+        matcher = passwordpattern.matcher(replaced);
       }
-      String value = usernamePassword == null ? "undef" : usernamePassword.getPassword();
-      replaced = matcher.replaceFirst(value);
-      matcher = passwordpattern.matcher(replaced);
     }
     return replaced;
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.notebook;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.user.UserCredentials;
+import org.apache.zeppelin.user.UsernamePassword;
+
+/**
+ * Class for replacing $[user.&gt;credentialkey&lt;] and
+ * $[password.&gt;credentialkey&lt;] tags with the matching credentials from
+ * zeppelin
+ */
+class CredentialInjector {
+
+  private Set<String> passwords = new HashSet<>();
+  private final UserCredentials creds;
+
+  public CredentialInjector(UserCredentials creds) {
+    this.creds = creds;
+  }
+
+  public String replaceCredentials(String code) {
+    if (code == null) {
+      return null;
+    }
+    String replaced = code;
+    Pattern userpattern = Pattern.compile("\\$\\[user\\.([^\\]]+)\\]");
+    Pattern passwordpattern = Pattern.compile("\\$\\[password\\.([^\\]]+)\\]");
+    Matcher matcher = userpattern.matcher(replaced);
+    while (matcher.find()) {
+      String key = matcher.group(1);
+      UsernamePassword usernamePassword = creds.getUsernamePassword(key);
+      String value = usernamePassword == null ? "undef" : usernamePassword.getUsername();
+      replaced = matcher.replaceFirst(value);
+      matcher = userpattern.matcher(replaced);
+    }
+    matcher = passwordpattern.matcher(replaced);
+    while (matcher.find()) {
+      String key = matcher.group(1);
+      UsernamePassword usernamePassword = creds.getUsernamePassword(key);
+      if (usernamePassword != null) {
+        passwords.add(usernamePassword.getPassword());
+      }
+      String value = usernamePassword == null ? "undef" : usernamePassword.getPassword();
+      replaced = matcher.replaceFirst(value);
+      matcher = passwordpattern.matcher(replaced);
+    }
+    return replaced;
+  }
+
+  public InterpreterResult hidePasswords(InterpreterResult ret) {
+    if (ret == null) {
+      return null;
+    }
+    return new InterpreterResult(ret.code(), replacePasswords(ret.message()));
+  }
+
+  private List<InterpreterResultMessage> replacePasswords(List<InterpreterResultMessage> original) {
+    List<InterpreterResultMessage> replaced = new ArrayList<>();
+    for (InterpreterResultMessage msg : original) {
+      String replacedMessages = replacePasswords(msg.getData());
+      replaced.add(new InterpreterResultMessage(msg.getType(), replacedMessages));
+    }
+    return replaced;
+  }
+
+  private String replacePasswords(String str) {
+    String result = str;
+    for (String password : passwords) {
+      result = result.replace(password, "###");
+    }
+    return result;
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
@@ -29,8 +29,8 @@ import org.apache.zeppelin.user.UserCredentials;
 import org.apache.zeppelin.user.UsernamePassword;
 
 /**
- * Class for replacing $[user.&gt;credentialkey&lt;] and
- * $[password.&gt;credentialkey&lt;] tags with the matching credentials from
+ * Class for replacing {user.&gt;credentialkey&lt;} and
+ * {password.&gt;credentialkey&lt;} tags with the matching credentials from
  * zeppelin
  */
 class CredentialInjector {
@@ -47,8 +47,8 @@ class CredentialInjector {
       return null;
     }
     String replaced = code;
-    Pattern userpattern = Pattern.compile("\\$\\[user\\.([^\\]]+)\\]");
-    Pattern passwordpattern = Pattern.compile("\\$\\[password\\.([^\\]]+)\\]");
+    Pattern userpattern = Pattern.compile("\\{user\\.([^\\}]+)\\}");
+    Pattern passwordpattern = Pattern.compile("\\{password\\.([^\\}]+)\\}");
     Matcher matcher = userpattern.matcher(replaced);
     while (matcher.find()) {
       String key = matcher.group(1);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -437,7 +437,12 @@ public class Paragraph extends Job implements Cloneable, JsonSerializable {
     try {
       InterpreterContext context = getInterpreterContext();
       InterpreterContext.set(context);
-      InterpreterResult ret = interpreter.interpret(script, context);
+      UserCredentials creds = context.getAuthenticationInfo().getUserCredentials();
+
+      CredentialInjector credinjector = new CredentialInjector(creds);
+      String code = credinjector.replaceCredentials(script);
+      InterpreterResult ret = interpreter.interpret(code, context);
+      ret = credinjector.hidePasswords(ret);
 
       if (interpreter.getFormType() == FormType.NATIVE) {
         note.setNoteParams(context.getNoteGui().getParams());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class CredentialInjectorTest {
 
   private static final String TEMPLATE =
-    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=$[user.mysql]&password=$[password.mysql]\"";
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={user.mysql}&password={password.mysql}\"";
   private static final String CORRECT_REPLACED =
     "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=username&password=pwd\"";
   private static final String NOT_REPLACED =

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import org.apache.zeppelin.user.UserCredentials;
+import org.apache.zeppelin.user.UsernamePassword;
+import org.junit.Test;
+
+public class CredentialInjectorTest {
+
+  private static final String TEMPLATE =
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=$[user.mysql]&password=$[password.mysql]\"";
+  private static final String CORRECT_REPLACED =
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=username&password=pwd\"";
+  private static final String NOT_REPLACED =
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=undef&password=undef\"";
+
+  private static final String ANSWER =
+    "jdbcUrl: String = jdbc:mysql://localhost/employees?user=username&password=pwd";
+  private static final String HIDDEN =
+    "jdbcUrl: String = jdbc:mysql://localhost/employees?user=username&password=###";
+
+  @Test
+  public void replaceCredentials() {
+    UserCredentials userCredentials = mock(UserCredentials.class);
+    UsernamePassword usernamePassword = new UsernamePassword("username", "pwd");
+    when(userCredentials.getUsernamePassword("mysql")).thenReturn(usernamePassword);
+    CredentialInjector testee = new CredentialInjector(userCredentials);
+    String actual = testee.replaceCredentials(TEMPLATE);
+    assertEquals(CORRECT_REPLACED, actual);
+
+    InterpreterResult ret = new InterpreterResult(Code.SUCCESS, ANSWER);
+    InterpreterResult hiddenResult = testee.hidePasswords(ret);
+    assertEquals(1, hiddenResult.message().size());
+    assertEquals(HIDDEN, hiddenResult.message().get(0).getData());
+  }
+
+  @Test
+  public void replaceCredentialNoTexts() {
+    UserCredentials userCredentials = mock(UserCredentials.class);
+    CredentialInjector testee = new CredentialInjector(userCredentials);
+    String actual = testee.replaceCredentials(null);
+    assertNull(actual);
+  }
+
+  @Test
+  public void replaceCredentialsNotExisting() {
+    UserCredentials userCredentials = mock(UserCredentials.class);
+    CredentialInjector testee = new CredentialInjector(userCredentials);
+    String actual = testee.replaceCredentials(TEMPLATE);
+    assertEquals(NOT_REPLACED, actual);
+
+    InterpreterResult ret = new InterpreterResult(Code.SUCCESS, ANSWER);
+    InterpreterResult hiddenResult = testee.hidePasswords(ret);
+    assertEquals(1, hiddenResult.message().size());
+    assertEquals(ANSWER, hiddenResult.message().get(0).getData());
+  }
+  
+  @Test
+  public void hidePasswordsNoResult() {
+    UserCredentials userCredentials = mock(UserCredentials.class);
+    CredentialInjector testee = new CredentialInjector(userCredentials);
+    assertNull(testee.hidePasswords(null));
+  }
+
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
@@ -34,8 +34,6 @@ public class CredentialInjectorTest {
     "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={user.mysql}&password={password.mysql}\"";
   private static final String CORRECT_REPLACED =
     "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=username&password=pwd\"";
-  private static final String NOT_REPLACED =
-    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=undef&password=undef\"";
 
   private static final String ANSWER =
     "jdbcUrl: String = jdbc:mysql://localhost/employees?user=username&password=pwd";
@@ -70,7 +68,7 @@ public class CredentialInjectorTest {
     UserCredentials userCredentials = mock(UserCredentials.class);
     CredentialInjector testee = new CredentialInjector(userCredentials);
     String actual = testee.replaceCredentials(TEMPLATE);
-    assertEquals(NOT_REPLACED, actual);
+    assertEquals(TEMPLATE, actual);
 
     InterpreterResult ret = new InterpreterResult(Code.SUCCESS, ANSWER);
     InterpreterResult hiddenResult = testee.hidePasswords(ret);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -30,32 +31,37 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
-
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectBuilder;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.Input;
-import org.apache.zeppelin.interpreter.*;
+import org.apache.zeppelin.interpreter.AbstractInterpreterTest;
+import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.FormType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterResult.Type;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSetting.Status;
+import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.user.UserCredentials;
+import org.apache.zeppelin.user.UsernamePassword;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.mockito.Mockito;
+
+import com.google.common.collect.Lists;
 
 public class ParagraphTest extends AbstractInterpreterTest {
 
@@ -299,4 +305,42 @@ public class ParagraphTest extends AbstractInterpreterTest {
     }
   }
 
+  @Test
+  public void credentialReplacement() throws Throwable {
+    Note mockNote = mock(Note.class);
+    Credentials creds = mock(Credentials.class);
+    when(mockNote.getCredentials()).thenReturn(creds);
+    Paragraph spyParagraph = spy(new Paragraph("para_1", mockNote,  null, null));
+    UserCredentials uc = mock(UserCredentials.class);
+    when(creds.getUserCredentials(anyString())).thenReturn(uc);
+    UsernamePassword up = new UsernamePassword("user", "pwd");
+    when(uc.getUsernamePassword("ent")).thenReturn(up );
+
+    Interpreter mockInterpreter = mock(Interpreter.class);
+    spyParagraph.setInterpreter(mockInterpreter);
+    doReturn(mockInterpreter).when(spyParagraph).getBindedInterpreter();
+
+    ManagedInterpreterGroup mockInterpreterGroup = mock(ManagedInterpreterGroup.class);
+    when(mockInterpreter.getInterpreterGroup()).thenReturn(mockInterpreterGroup);
+    when(mockInterpreterGroup.getId()).thenReturn("mock_id_1");
+    when(mockInterpreterGroup.getAngularObjectRegistry()).thenReturn(mock(AngularObjectRegistry.class));
+    when(mockInterpreterGroup.getResourcePool()).thenReturn(mock(ResourcePool.class));
+    when(mockInterpreter.getFormType()).thenReturn(FormType.NONE);
+
+    ParagraphJobListener mockJobListener = mock(ParagraphJobListener.class);
+    doReturn(mockJobListener).when(spyParagraph).getListener();
+    doNothing().when(mockJobListener).onOutputUpdateAll(Mockito.<Paragraph>any(), Mockito.anyList());
+
+    InterpreterResult mockInterpreterResult = mock(InterpreterResult.class);
+    when(mockInterpreter.interpret(anyString(), Mockito.<InterpreterContext>any())).thenReturn(mockInterpreterResult);
+    when(mockInterpreterResult.code()).thenReturn(Code.SUCCESS);
+
+    AuthenticationInfo user1 = new AuthenticationInfo("user1");
+    spyParagraph.setAuthenticationInfo(user1);
+    
+    spyParagraph.setText("val x = \"usr=$[user.ent]&pass=$[password.ent]\"");
+    spyParagraph.jobRun();
+    
+    verify(mockInterpreter).interpret(eq("val x = \"usr=user&pass=pwd\""), any(InterpreterContext.class));
+  }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -338,7 +338,7 @@ public class ParagraphTest extends AbstractInterpreterTest {
     AuthenticationInfo user1 = new AuthenticationInfo("user1");
     spyParagraph.setAuthenticationInfo(user1);
     
-    spyParagraph.setText("val x = \"usr=$[user.ent]&pass=$[password.ent]\"");
+    spyParagraph.setText("val x = \"usr={user.ent}&pass={password.ent}\"");
     spyParagraph.jobRun();
     
     verify(mockInterpreter).interpret(eq("val x = \"usr=user&pass=pwd\""), any(InterpreterContext.class));


### PR DESCRIPTION
### What is this PR for?
This PR enables a generic syntax for inserting credentials. A username can be inserted by $[user.entry] where "entry" is the name of the credential. A password can be inserted by $[password.entry].
To avoid output of the password all occurences of the password-String in the Interpreter-output will be replaced by "###". This should not be a really secure feature (since the runner of the notebook knows the password anyway), but it should avoid accidential exposure of the used passwords by any sort of interpreter echo.


### What type of PR is it?
Feature

### Todos
* [ ] - Documentation

### What is the Jira issue?
ZEPPELIN-1070 Enable data source authentication in each community interpreters

### How should this be tested?
* unit tests available

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? The new syntax could break notebooks which contain the patterns $[user.*] or $[password.*]. But I assume this pattern is not very common...
* Does this needs documentation? yes, but I didn't find the proper place to document it yet.
