### PR TITLE
ZEPPELIN-3347. Fix "PYTHONPATH" for spark.pyspark

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -214,11 +214,7 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
     // yarn-cluster will setup PYTHONPATH automatically.
     SparkConf conf = getSparkConf();
     if (!conf.get("spark.submit.deployMode", "client").equals("cluster")) {
-      if (!env.containsKey("PYTHONPATH")) {
-        env.put("PYTHONPATH", PythonUtils.sparkPythonPath());
-      } else {
-        env.put("PYTHONPATH", PythonUtils.sparkPythonPath());
-      }
+      env.put("PYTHONPATH", PythonUtils.sparkPythonPath());
     }
 
     // get additional class paths when using SPARK_SUBMIT and not using YARN-CLIENT

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PythonUtils.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PythonUtils.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +42,7 @@ public class PythonUtils {
     List<String> pythonPath = new ArrayList<String>();
     String sparkHome = System.getenv("SPARK_HOME");
     String zeppelinHome = System.getenv("ZEPPELIN_HOME");
+    String pythonPathEnv = System.getenv("PYTHONPATH");
     if (zeppelinHome == null) {
       zeppelinHome = new File("..").getAbsolutePath();
     }
@@ -89,6 +91,9 @@ public class PythonUtils {
       }
     }
 
+    if (pythonPathEnv.length() > 0) {
+      pythonPath.addAll(Arrays.asList(pythonPathEnv.split(":")));
+    }
     // add ${ZEPPELIN_HOME}/interpreter/lib/python for all the cases
     pythonPath.add(zeppelinHome + "/interpreter/lib/python");
     return StringUtils.join(pythonPath, ":");

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PythonUtils.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PythonUtils.java
@@ -90,8 +90,7 @@ public class PythonUtils {
         pythonPath.add(py4j[0].getAbsolutePath());
       }
     }
-
-    if (pythonPathEnv.length() > 0) {
+    if (pythonPathEnv != null) {
       pythonPath.addAll(Arrays.asList(pythonPathEnv.split(":")));
     }
     // add ${ZEPPELIN_HOME}/interpreter/lib/python for all the cases


### PR DESCRIPTION
### What is this PR for?
Use system PYTHONPATH in spark.pyspark interpreter, if PYTHONPATH already exists in environment variables.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3347

### How should this be tested?
* Add some directories to PYTHONPATH
`export PYTHONPATH="/opt/python/dir1:/opt/python/dir2:$PYTHONPATH"`
* Build branch "ZEPPELIN-3347"
* Run in %spark.pyspark
```
import sys
print('\n'.join(sys.path))
```

* Check that the directories are in the output list.
Compare with the result in %python.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No