### PR TITLE
ZEPPELIN-3378 Dependency errors on hadoop 2.8 with hadoop2 profile

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -429,6 +429,10 @@
           <version>${hadoop.version}</version>
           <exclusions>
             <exclusion>
+              <groupId>com.nimbusds</groupId>
+              <artifactId>nimbus-jose-jwt</artifactId>
+            </exclusion>
+            <exclusion>
               <groupId>com.sun.jersey</groupId>
               <artifactId>jersey-core</artifactId>
             </exclusion>
@@ -761,6 +765,10 @@
               <artifactId>aws-java-sdk</artifactId>
             </exclusion>
             <exclusion>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-java-sdk-s3</artifactId>
+            </exclusion>
+            <exclusion>
               <groupId>com.fasterxml.jackson.core</groupId>
               <artifactId>jackson-annotations</artifactId>
             </exclusion>
@@ -883,6 +891,10 @@
             <exclusion>
               <groupId>com.amazonaws</groupId>
               <artifactId>aws-java-sdk</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-java-sdk-s3</artifactId>
             </exclusion>
             <exclusion>
               <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### What is this PR for?
Fix dependency errors caused by different versions of the same libraries on zeppelin-zengine

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3378

### How should this be tested?
* Travis CI
* Build command:
`mvn clean package -Dhadoop.version=2.8.1 -Phadoop2 -Pspark-2.1 -Pscala-2.11 -Pbuild-distr`
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
