### PR TITLE
ZEPPELIN-3347 Fix "PYTHONPATH" for spark.pyspark in branch-0.8

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
@@ -27,6 +27,9 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Properties;
 
+/**
+ * ConfInterpreter for session level
+ */
 public class SessionConfInterpreter extends ConfInterpreter {
 
   private static Logger LOGGER = LoggerFactory.getLogger(SessionConfInterpreter.class);


### PR DESCRIPTION
### What is this PR for?
Use system PYTHONPATH in spark.pyspark interpreter, if PYTHONPATH already exists in environment variables.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3347

### How should this be tested?
* Add some directories to PYTHONPATH
`export PYTHONPATH="/opt/python/dir1:/opt/python/dir2:$PYTHONPATH"`
* Build branch "ZEPPELIN-3347_0.8"
* Run in %spark.pyspark
```
import sys
print('\n'.join(sys.path))
```
* Check that the directories are in the output list.
Compare with the result in %python.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No