### PR TITLE
[ZEPPELIN-3384] Reduce the number of calls that are made to `loginUserFromKeytab` in JDBC interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
@@ -46,10 +46,16 @@ public class JDBCSecurityImpl {
         conf.set("hadoop.security.authentication", KERBEROS.toString());
         UserGroupInformation.setConfiguration(conf);
         try {
-          UserGroupInformation.loginUserFromKeytab(
-              properties.getProperty("zeppelin.jdbc.principal"),
-              properties.getProperty("zeppelin.jdbc.keytab.location")
-          );
+          // Check TGT before calling login
+          // Ref: https://github.com/apache/hadoop/blob/release-3.0.1-RC1/hadoop-common-project/
+          // hadoop-common/src/main/java/org/apache/hadoop/security/UserGroupInformation.java#L1232
+          if (!UserGroupInformation.isSecurityEnabled()
+              || UserGroupInformation.getCurrentUser().getAuthenticationMethod() != KERBEROS
+              || !UserGroupInformation.isLoginKeytabBased()) {
+            UserGroupInformation.loginUserFromKeytab(
+                properties.getProperty("zeppelin.jdbc.principal"),
+                properties.getProperty("zeppelin.jdbc.keytab.location"));
+          }
         } catch (IOException e) {
           LOGGER.error("Failed to get either keytab location or principal name in the " +
               "interpreter", e);

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
@@ -55,6 +55,9 @@ public class JDBCSecurityImpl {
             UserGroupInformation.loginUserFromKeytab(
                 properties.getProperty("zeppelin.jdbc.principal"),
                 properties.getProperty("zeppelin.jdbc.keytab.location"));
+          } else {
+            LOGGER.info("The user has already logged in using Keytab and principal, " +
+              "no action required");
           }
         } catch (IOException e) {
           LOGGER.error("Failed to get either keytab location or principal name in the " +


### PR DESCRIPTION
### What is this PR for?
In JDBC interpreter every time `getConnection` has requested a call is made to `UserGroupInformation.loginUserFromKeytab` this PR is created to reduce the number of time it gets called.


### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3384](https://issues.apache.org/jira/browse/ZEPPELIN-3384)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
