### PR TITLE
[HOTFIX] Avoid trimming from non-string type when loading InterpreterSetting from file

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -492,10 +492,14 @@ public class InterpreterSetting {
 
   public void setProperties(Object object) {
     if (object instanceof StringMap) {
-      StringMap<String> map = (StringMap) properties;
+      StringMap<Object> map = (StringMap) properties;
       Properties newProperties = new Properties();
       for (String key : map.keySet()) {
-        newProperties.put(StringUtils.trim(key), StringUtils.trim(map.get(key)));
+        Object value = map.get(key);
+        if (value instanceof String) {
+          value = StringUtils.trim((String) value);
+        }
+        newProperties.put(StringUtils.trim(key), value);
       }
       this.properties = newProperties;
     } else {


### PR DESCRIPTION
### What is this PR for?
Fixing bug loading InterpreterSetting from file

### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Fix a bug

### What is the Jira issue?
N/A

### How should this be tested?
You cannot run a Zeppelin server with conf/interpreter.json from the second time.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
