### PR TITLE
[ZEPPELIN-3350] Don't allow set cronExecutionUser

### DIFF
--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -41,7 +41,7 @@ You can set a cron schedule easily by clicking each option such as `1m` and `5m`
 
 You can set the cron schedule by filling in this form. Please see [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.2.x/tutorials/crontrigger) for the available cron syntax.
 
-### Cron executing user
+### Cron executing user (It is removed from 0.8 where it enforces the cron execution user to be the note owner for security purpose)
 
 You can set the cron executing user by filling in this form and press the enter key.
 

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -281,13 +281,6 @@ limitations under the License.
                 </p>
               </div>
               <div>
-                <span>- Cron executing user (click enter in field to submit)</span>
-                <input type="text"
-                       ng-model="note.config.cronExecutingUser"
-                       ng-enter="setCronExecutingUser(note.config.cronExecutingUser)"
-                       dropdown-input />
-              </div>
-              <div>
                 <span>- auto-restart interpreter on cron execution </span>
                 <input type="checkbox"
                        ng-model="note.config.releaseresource"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -642,16 +642,10 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   }
 
   /**
-   * Run all paragraphs sequentially.
+   * Run all paragraphs sequentially. Only used for CronJob
    */
   public synchronized void runAll() {
-    String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
-    if (null == cronExecutingUser) {
-      cronExecutingUser = "anonymous";
-    }
-    AuthenticationInfo authenticationInfo = new AuthenticationInfo();
-    authenticationInfo.setUser(cronExecutingUser);
-    runAll(authenticationInfo, true);
+    runAll(null, true);
   }
 
   public void runAll(AuthenticationInfo authenticationInfo, boolean blocking) {
@@ -659,7 +653,9 @@ public class Note implements ParagraphJobListener, JsonSerializable {
       if (!p.isEnabled()) {
         continue;
       }
-      p.setAuthenticationInfo(authenticationInfo);
+      if (authenticationInfo != null) {
+        p.setAuthenticationInfo(authenticationInfo);
+      }
       if (!run(p.getId(), blocking)) {
         logger.warn("Skip running the remain notes because paragraph {} fails", p.getId());
         break;


### PR DESCRIPTION
### What is this PR for?
This PR just does a quick fix this security issue. 
1. Remove the setting cron user in frontend
2. Run the note via owner.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3350

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
![screen shot 2018-04-09 at 3 04 06 pm](https://user-images.githubusercontent.com/164491/38483974-707dca56-3c07-11e8-918a-cd47ed94ee99.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
