### PR TITLE
ZEPPELIN-3391 Incorrect status shown for '%livy2.conf' and %spark2.conf' interpreters

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -794,7 +794,7 @@ public class InterpreterSetting {
         if (!intp.getProperties().equals(properties) &&
             interpreterGroup.getRemoteInterpreterProcess() != null &&
             interpreterGroup.getRemoteInterpreterProcess().isRunning()) {
-          throw new IOException("Can not change interpreter properties when interpreter process " +
+          throw new RuntimeException("Can not change interpreter properties when interpreter process " +
               "has already been launched");
         }
         intp.setProperties(properties);


### PR DESCRIPTION
### What is this PR for?
Incorrect status shown for '%livy2.conf' and %spark2.conf' interpreters

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3391](https://issues.apache.org/jira/browse/ZEPPELIN-3391)

### How should this be tested?
* see jira ticket description

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
