### PR TITLE
ZEPPELIN-3395 Fix impersonate spark interpreter without proxy-user option

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -205,7 +205,8 @@ fi
 
 addJarInDirForIntp "${LOCAL_INTERPRETER_REPO}"
 
-if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" && "${INTERPRETER_ID}" != "spark" ]]; then
+if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]]; then
+  if [[ "${INTERPRETER_ID}" != "spark" || "$ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER" == "false" ]]; then
     suid="$(id -u ${ZEPPELIN_IMPERSONATE_USER})"
     if [[ -n  "${suid}" || -z "${SPARK_SUBMIT}" ]]; then
        INTERPRETER_RUN_COMMAND=${ZEPPELIN_IMPERSONATE_RUN_CMD}" '"
@@ -213,6 +214,7 @@ if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" && "${INTERPRETER_ID}" != "spark" ]]; th
            INTERPRETER_RUN_COMMAND+=" source "${ZEPPELIN_CONF_DIR}'/zeppelin-env.sh;'
        fi
     fi
+  fi
 fi
 
 if [[ -n "${SPARK_SUBMIT}" ]]; then


### PR DESCRIPTION
### What is this PR for?
Fix impersonate spark interpreter.
Currently, impersonate spark interpreter always runs as zeppelin user, not impersonated user when disable proxy-user option.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3395

### How should this be tested?
1. ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER=false in zeppelin-env.sh
2. set up user impersonation flag
3. run some job using that spark interpreter
4. spark interpreter process should be created with currently logged-in user

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
