### PR TITLE
Remove Zeppelin help and community links on zeppelin start page

### DIFF
--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -55,21 +55,7 @@ limitations under the License.
             </ul>
           </div>
         </div>
-        <div class="col-md-6">
-          <h4>Help</h4>
-          Get started with <a style="text-decoration: none;" target="_blank"
-                              href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html">Zeppelin documentation</a><br/>
 
-          <h4>Community</h4>
-          Please feel free to help us to improve Zeppelin, <br/>
-          Any contribution are welcome!<br/><br/>
-          <a style="text-decoration: none;" href="http://zeppelin.apache.org/community.html"
-             target="_blank"><i style="font-size: 15px;" class="fa fa-users"></i> Mailing list</a><br/>
-          <a style="text-decoration: none;" href="https://issues.apache.org/jira/browse/ZEPPELIN"
-             target="_blank"><i style="font-size: 15px;" class="fa fa-bug"></i> Issues tracking</a><br/>
-          <a style="text-decoration: none;" href="https://github.com/apache/zeppelin"
-             target="_blank"><i style="font-size: 20px;" class="fa fa-github"></i> Github</a>
-        </div>
       </div>
     </div>
     <br/><br/><br/>


### PR DESCRIPTION
The links weren't pointing correctly to the zeppelin docs and they
cause confusion about which community and project they link to.

This page will be less important once users are logged into Zeppelin
automatically, but it's one we can customize better if we want.
