### PR TITLE
[ZEPPELIN-3399] Tests failing with no changes - ShellScriptLauncherTest and SparkInterpreterLaunchTest

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/ShellScriptLauncherTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/ShellScriptLauncherTest.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.interpreter.launcher;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -29,6 +30,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ShellScriptLauncherTest {
+  @Before
+  public void setUp() {
+    for (final ZeppelinConfiguration.ConfVars confVar : ZeppelinConfiguration.ConfVars.values()) {
+      System.clearProperty(confVar.getVarName());
+    }
+  }
 
   @Test
   public void testLauncher() throws IOException {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.interpreter.launcher;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -29,6 +30,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SparkInterpreterLauncherTest {
+  @Before
+  public void setUp() {
+    for (final ZeppelinConfiguration.ConfVars confVar : ZeppelinConfiguration.ConfVars.values()) {
+      System.clearProperty(confVar.getVarName());
+    }
+  }
 
   @Test
   public void testLocalMode() throws IOException {


### PR DESCRIPTION
### What is this PR for?
When I run all of the tests zeppelin-zengine in IntelliJ, the tests in ShellScriptLauncherTest and SparkInterpreterLaunchTest fail, but if I run these tests by themselves, they pass.
There is a problem with the tests in ShellScripterLauncherTest and SparkInterpreterLaunchTest, which is that if some of the ConfVars are set (such as ZEPPELIN_HOME) in other tests, then these tests will fail, because they expect that these variables are not set. 

To fix this, I have added a setUp() method that clears all of the ConfVars to both ShellScripterLauncherTest and SparkInterpreterLauncherTest. This way, none of the ConfVars will be set when these tests are run.

### What type of PR is it?
Bug Fix for tests ShellScripterLauncherTest and SparkInterpreterLauncherTest.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3399

### How should this be tested?
Can verify tests still work after pull request by running them, and can verify that they failed before by running all tests in IntelliJ in the default order that IntelliJ runs them.
