### PR TITLE
Zeppelin npm error: getaddrinfo ENOTFOUND

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <!-- frontend maven plugin related versions-->
     <node.version>v8.9.3</node.version>
     <npm.version>5.5.1</npm.version>
-    <plugin.frontend.version>1.3</plugin.frontend.version>
+    <plugin.frontend.version>1.4</plugin.frontend.version>
 
     <!-- common library versions -->
     <slf4j.version>1.7.10</slf4j.version>


### PR DESCRIPTION
### What is this PR for?
Zeppelin npm error: getaddrinfo ENOTFOUND
- upgrade frontend-maven-plugin to 1.4

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3400

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
