### PR TITLE
ZEPPELIN-3312 Add option to convert username to lower case

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -411,6 +411,12 @@
 </property>
 
 <property>
+  <name>zeppelin.username.force.lowercase</name>
+  <value>false</value>
+  <description>Force convert username case to lower case, useful for Active Directory. Default is not to change case</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.default.owner.username</name>
   <value></value>
   <description>Set owner role by default</description>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -413,7 +413,7 @@
 <property>
   <name>zeppelin.username.force.lowercase</name>
   <value>false</value>
-  <description>Force convert username case to lower case, useful for Active Directory. Default is not to change case</description>
+  <description>Force convert username case to lower case, useful for Active Directory/LDAP. Default is not to change case</description>
 </property>
 
 <property>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -517,6 +517,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_ANONYMOUS_ALLOWED);
   }
 
+  public boolean isUsernameForceLowerCase() {
+    return getBoolean(ConfVars.ZEPPELIN_USERNAME_FORCE_LOWERCASE);
+  }
+
   public boolean isNotebookPublic() {
     return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC);
   }
@@ -767,6 +771,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     // i.e. http://localhost:8080
     ZEPPELIN_ALLOWED_ORIGINS("zeppelin.server.allowed.origins", "*"),
     ZEPPELIN_ANONYMOUS_ALLOWED("zeppelin.anonymous.allowed", true),
+    ZEPPELIN_USERNAME_FORCE_LOWERCASE("zeppelin.username.force.lowercase", false),
     ZEPPELIN_CREDENTIALS_PERSIST("zeppelin.credentials.persist", true),
     ZEPPELIN_CREDENTIALS_ENCRYPT_KEY("zeppelin.credentials.encryptKey", null),
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.interpreter;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 
 /**
  *
@@ -27,6 +28,7 @@ public class InterpreterOption {
   public static final transient String SHARED = "shared";
   public static final transient String SCOPED = "scoped";
   public static final transient String ISOLATED = "isolated";
+  private static ZeppelinConfiguration conf =  ZeppelinConfiguration.create();
 
   // always set it as true, keep this field just for backward compatibility
   boolean remote = true;
@@ -66,6 +68,13 @@ public class InterpreterOption {
   }
 
   public List<String> getOwners() {
+    if (null != owners && conf.isUsernameForceLowerCase()) {
+      List<String> lowerCaseUsers = new ArrayList<String>();
+      for (String owner : owners) {
+        lowerCaseUsers.add(owner.toLowerCase());
+      }
+      return lowerCaseUsers;
+    }
     return owners;
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -94,7 +94,7 @@ public class SecurityUtils {
       principal = extractPrincipal(subject);
       if (ZeppelinServer.notebook.getConf().isUsernameForceLowerCase()) {
         log.debug("Converting principal name " + principal
-          + " to lower case:" + principal.toLowerCase());
+            + " to lower case:" + principal.toLowerCase());
         principal = principal.toLowerCase();
       }
     } else {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/SecurityUtils.java
@@ -44,6 +44,7 @@ import javax.naming.NamingException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.realm.ActiveDirectoryGroupRealm;
 import org.apache.zeppelin.realm.LdapRealm;
+import org.apache.zeppelin.server.ZeppelinServer;
 
 /**
  * Tools for securing Zeppelin.
@@ -91,6 +92,11 @@ public class SecurityUtils {
     String principal;
     if (subject.isAuthenticated()) {
       principal = extractPrincipal(subject);
+      if (ZeppelinServer.notebook.getConf().isUsernameForceLowerCase()) {
+        log.debug("Converting principal name " + principal
+          + " to lower case:" + principal.toLowerCase());
+        principal = principal.toLowerCase();
+      }
     } else {
       principal = ANONYMOUS;
     }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/SecurityUtilsTest.java
@@ -21,22 +21,25 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-
-import sun.security.acl.PrincipalImpl;
-
+import org.apache.commons.configuration.ConfigurationException;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.utils.SecurityUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import sun.security.acl.PrincipalImpl;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(org.apache.shiro.SecurityUtils.class)
@@ -113,12 +116,49 @@ public class SecurityUtilsTest {
   @Test
   public void canGetPrincipalName()  {
     String expectedName = "java.security.Principal.getName()";
+    setupPrincipalName(expectedName);
+    assertEquals(expectedName, SecurityUtils.getPrincipal());
+  }
+
+  @Test
+  public void testUsernameForceLowerCase() throws IOException, InterruptedException {
+    String expectedName = "java.security.Principal.getName()";
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_USERNAME_FORCE_LOWERCASE
+        .getVarName(), String.valueOf(true));
+    setupPrincipalName(expectedName);
+    assertEquals(expectedName.toLowerCase(), SecurityUtils.getPrincipal());
+
+  }
+
+  private void setupPrincipalName(String expectedName) {
     SecurityUtils.setIsEnabled(true);
     PowerMockito.mockStatic(org.apache.shiro.SecurityUtils.class);
     when(org.apache.shiro.SecurityUtils.getSubject()).thenReturn(subject);
     when(subject.isAuthenticated()).thenReturn(true);
     when(subject.getPrincipal()).thenReturn(new PrincipalImpl(expectedName));
 
-    assertEquals(expectedName, SecurityUtils.getPrincipal());
+    Notebook notebook = Mockito.mock(Notebook.class);
+    try {
+      setFinalStatic(ZeppelinServer.class.getDeclaredField("notebook"), notebook);
+      when(ZeppelinServer.notebook.getConf())
+          .thenReturn(new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml")));
+    } catch (NoSuchFieldException e) {
+      e.printStackTrace();
+    } catch (IllegalAccessException e) {
+      e.printStackTrace();
+    } catch (ConfigurationException e) {
+      e.printStackTrace();
+    }
   }
+
+  private void setFinalStatic(Field field, Object newValue)
+      throws NoSuchFieldException, IllegalAccessException {
+    field.setAccessible(true);
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+    field.set(null, newValue);
+  }
+
+
 }

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -56,11 +56,6 @@
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-server</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zeppelin-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
-import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.storage.ConfigStorage;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -210,7 +209,7 @@ public class NotebookAuthorization {
   * If case conversion is enforced, then change entity names to lower case
   */
   private Set<String> checkCaseAndConvert(Set<String> entities) {
-    if (ZeppelinServer.notebook.getConf().isUsernameForceLowerCase()) {
+    if (conf.isUsernameForceLowerCase()) {
       Set<String> set2 = new HashSet<String>();
       for (String name : entities) {
         set2.add(name.toLowerCase());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NotebookAuthorization.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
+import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.storage.ConfigStorage;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
@@ -205,6 +206,21 @@ public class NotebookAuthorization {
     saveToFile();
   }
 
+  /*
+  * If case conversion is enforced, then change entity names to lower case
+  */
+  private Set<String> checkCaseAndConvert(Set<String> entities) {
+    if (ZeppelinServer.notebook.getConf().isUsernameForceLowerCase()) {
+      Set<String> set2 = new HashSet<String>();
+      for (String name : entities) {
+        set2.add(name.toLowerCase());
+      }
+      return set2;
+    } else {
+      return entities;
+    }
+  }
+
   public Set<String> getOwners(String noteId) {
     Map<String, Set<String>> noteAuthInfo = authInfo.get(noteId);
     Set<String> entities = null;
@@ -214,6 +230,8 @@ public class NotebookAuthorization {
       entities = noteAuthInfo.get("owners");
       if (entities == null) {
         entities = new HashSet<>();
+      } else {
+        entities = checkCaseAndConvert(entities);
       }
     }
     return entities;
@@ -228,6 +246,8 @@ public class NotebookAuthorization {
       entities = noteAuthInfo.get("readers");
       if (entities == null) {
         entities = new HashSet<>();
+      } else {
+        entities = checkCaseAndConvert(entities);
       }
     }
     return entities;
@@ -242,6 +262,8 @@ public class NotebookAuthorization {
       entities = noteAuthInfo.get("runners");
       if (entities == null) {
         entities = new HashSet<>();
+      } else {
+        entities = checkCaseAndConvert(entities);
       }
     }
     return entities;
@@ -256,6 +278,8 @@ public class NotebookAuthorization {
       entities = noteAuthInfo.get("writers");
       if (entities == null) {
         entities = new HashSet<>();
+      } else {
+        entities = checkCaseAndConvert(entities);
       }
     }
     return entities;


### PR DESCRIPTION
### What is this PR for?
This PR introduces a new configuration property to convert username to lower case. This is useful when the users (from external sources like AD/LDAP) are coming in with mixed-case names and Hadoop services (like Hive) can't authorize them correctly because Hadoop services recognize users only in lower case (like Linux). 

Adding a new config option "zeppelin.username.force.lowercase" to handle such scenarios.

Behavior without this PR:
Access is denied to CaMel case user while running a Hive paragraph

Behavior with this PR:
User is allowed to run query when proposed configuration set to true.
By default, keeping zeppelin.username.force.lowercase=false to retain the current behavior.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Unit test

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3312

### How should this be tested?
* Travis CI should pass
* Manual steps to test:
1. Configure Zeppelin with Active Directory authentication
2. Login to Zeppelin as a CaMel case user
3. Try to run a simple JDBC note with a Hive query (like a select * query). This would fail with "user [CaMel] does not have proper privileges to [USE] operation" error message.
4. Now set zeppelin.username.force.lowercase=true in custom zeppelin-site.xml configuration.
5. Once again, login as CaMel case user. This time the same Hive query would run as expected. Because the username is now passed in lower case.
6. Also notice that after successful login, the login username (in the top-right corner) will be in lower case too.

### Screenshots (if appropriate)
* Login as CaMel case user:
<img width="596" alt="screen shot 2018-04-12 at 3 33 01 am" src="https://user-images.githubusercontent.com/15668387/38672744-faf00f8e-3e03-11e8-86b2-cc5981d380d2.png">
* Notice the converted username post login:
<img width="806" alt="screen shot 2018-04-12 at 3 33 43 am" src="https://user-images.githubusercontent.com/15668387/38672777-108c7b66-3e04-11e8-8c97-467b4b73fe3d.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
