### PR TITLE
ZEPPELIN-3404. Fail to run cronjob when user doesn't run it manually before cronjob

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -76,6 +76,10 @@ public class AuthenticationInfo implements JsonSerializable {
     this.roles = roles;
   }
 
+  public void setRoles(String roles) {
+    this.roles = gson.fromJson(roles, ArrayList.class);
+  }
+
   public List<String> getUsersAndRoles() {
     List<String> usersAndRoles = new ArrayList<>();
     if (roles != null) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -447,16 +447,14 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
       if (!$scope.note.config.cronExecutingUser) {
         $scope.note.config.cronExecutingUser = $rootScope.ticket.principal;
       }
+      if (!$scope.note.config.cronExecutingRoles) {
+        $scope.note.config.cronExecutingRoles = $rootScope.ticket.roles;
+      }
     } else {
       $scope.note.config.cronExecutingUser = '';
+      $scope.note.config.cronExecutingRoles = '';
     }
     $scope.note.config.cron = cronExpr;
-    $scope.setConfig();
-  };
-
-  /** Set the username of the user to be used to execute all notes in notebook **/
-  $scope.setCronExecutingUser = function(cronExecutingUser) {
-    $scope.note.config.cronExecutingUser = cronExecutingUser;
     $scope.setConfig();
   };
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -645,7 +647,16 @@ public class Note implements ParagraphJobListener, JsonSerializable {
    * Run all paragraphs sequentially. Only used for CronJob
    */
   public synchronized void runAll() {
-    runAll(null, true);
+    String cronExecutingUser = (String) getConfig().get("cronExecutingUser");
+    String cronExecutingRoles = (String) getConfig().get("cronExecutingRoles");
+    if (null == cronExecutingUser) {
+      cronExecutingUser = "anonymous";
+    }
+    AuthenticationInfo authenticationInfo = new AuthenticationInfo(
+        cronExecutingUser,
+        StringUtils.isEmpty(cronExecutingRoles) ? null : cronExecutingRoles,
+        null);
+    runAll(authenticationInfo, true);
   }
 
   public void runAll(AuthenticationInfo authenticationInfo, boolean blocking) {
@@ -653,9 +664,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
       if (!p.isEnabled()) {
         continue;
       }
-      if (authenticationInfo != null) {
-        p.setAuthenticationInfo(authenticationInfo);
-      }
+      p.setAuthenticationInfo(authenticationInfo);
       if (!run(p.getId(), blocking)) {
         logger.warn("Skip running the remain notes because paragraph {} fails", p.getId());
         break;


### PR DESCRIPTION
### What is this PR for?

This bug is introduced by #2914, this PR will set authenticationInfo using its user as we will store user into note.json.  


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3404

### How should this be tested?
* Manually tested

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
