### PR TITLE
ZEPPELIN-3414. branch-0.8 - download py4j from main repo

### DIFF
--- a/python/pom.xml
+++ b/python/pom.xml
@@ -40,8 +40,6 @@
         **/PythonInterpreterPandasSqlTest.java,
         **/PythonInterpreterMatplotlibTest.java
     </python.test.exclude>
-    <pypi.repo.url>https://pypi.python.org/packages</pypi.repo.url>
-    <python.py4j.repo.folder>/64/5c/01e13b68e8caafece40d549f232c9b5677ad1016071a48d04cc3895acaa3</python.py4j.repo.folder>
     <grpc.version>1.4.0</grpc.version>
     <plugin.shade.version>2.4.1</plugin.shade.version>
   </properties>
@@ -138,34 +136,11 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>wagon-maven-plugin</artifactId>
-        <version>1.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals><goal>download-single</goal></goals>
-            <configuration>
-              <url>${pypi.repo.url}${python.py4j.repo.folder}</url>
-              <fromFile>py4j-${python.py4j.version}.zip</fromFile>
-              <toFile>${project.build.directory}/../../interpreter/python/py4j-${python.py4j.version}.zip</toFile>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.7</version>
         <executions>
           <execution>
             <phase>package</phase>
-            <configuration>
-              <target>
-                <unzip src="${project.build.directory}/../../interpreter/python/py4j-${python.py4j.version}.zip"
-                       dest="${project.build.directory}/../../interpreter/python"/>
-              </target>
-            </configuration>
             <goals>
               <goal>run</goal>
             </goals>


### PR DESCRIPTION
### What is this PR for?
Now py4j-0.9.2 is downloaded from "pypi.python.org". Seems that "pypi.python.org" needs new version of OpenSSL.
There are some troubles to build Zeppelin on old CentOS/RHEL because is not easy to update OpenSSL.
It's good to change repo for py4j.

### What type of PR is it?
Small Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3414

### How should this be tested?
* Tests pass

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no