### PR TITLE
ZEPPELIN-3405 Zeppelin fails to display the User home page if user belongs to roles with space in its name

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.rest;
 
+import com.google.gson.Gson;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.IncorrectCredentialsException;
@@ -59,6 +60,7 @@ import org.apache.zeppelin.utils.SecurityUtils;
 @Produces("application/json")
 public class LoginRestApi {
   private static final Logger LOG = LoggerFactory.getLogger(LoginRestApi.class);
+  private static final Gson gson = new Gson();
 
   /**
    * Required by Swagger.
@@ -78,7 +80,7 @@ public class LoginRestApi {
         Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
         if (!currentUser.isAuthenticated()) {
           JWTAuthenticationToken token = new JWTAuthenticationToken(null, cookie.getValue());
-          response = procedeToLogin(currentUser, token);
+          response = proceedToLogin(currentUser, token);
         }
       }
       if (response == null) {
@@ -123,7 +125,7 @@ public class LoginRestApi {
     return false;
   }
 
-  private JsonResponse procedeToLogin(Subject currentUser, AuthenticationToken token) {
+  private JsonResponse proceedToLogin(Subject currentUser, AuthenticationToken token) {
     JsonResponse response = null;
     try {
       currentUser.getSession().stop();
@@ -141,7 +143,7 @@ public class LoginRestApi {
 
       Map<String, String> data = new HashMap<>();
       data.put("principal", principal);
-      data.put("roles", roles.toString());
+      data.put("roles", gson.toJson(roles));
       data.put("ticket", ticket);
 
       response = new JsonResponse(Response.Status.OK, "", data);
@@ -187,7 +189,7 @@ public class LoginRestApi {
 
       UsernamePasswordToken token = new UsernamePasswordToken(userName, password);
 
-      response = procedeToLogin(currentUser, token);
+      response = proceedToLogin(currentUser, token);
     }
 
     if (response == null) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.rest;
 
+import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.realm.jdbc.JdbcRealm;
@@ -55,6 +56,7 @@ import org.apache.zeppelin.utils.SecurityUtils;
 @Produces("application/json")
 public class SecurityRestApi {
   private static final Logger LOG = LoggerFactory.getLogger(SecurityRestApi.class);
+  private static final Gson gson = new Gson();
 
   /**
    * Required by Swagger.
@@ -89,7 +91,7 @@ public class SecurityRestApi {
 
     Map<String, String> data = new HashMap<>();
     data.put("principal", principal);
-    data.put("roles", roles.toString());
+    data.put("roles", gson.toJson(roles));
     data.put("ticket", ticket);
 
     response = new JsonResponse(Response.Status.OK, "", data);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
@@ -84,4 +84,16 @@ public class SecurityRestApiTest extends AbstractTestRestApi {
 
     notUser.releaseConnection();
   }
+
+  @Test
+  public void testRolesEscaped() throws IOException {
+    GetMethod get = httpGet("/security/ticket", "admin", "password1");
+    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+            new TypeToken<Map<String, Object>>(){}.getType());
+    String roles = (String) ((Map) resp.get("body")).get("roles");
+    collector.checkThat("Paramater roles", roles,
+            CoreMatchers.equalTo("[\"admin\"]"));
+    get.releaseConnection();
+  }
+
 }


### PR DESCRIPTION
- escape roles value in login and ticket json response
- fix method name typo

### What is this PR for?
Fix string escape issue in roles. More details in JIRA description.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3405

### How should this be tested?
see JIRA description

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
