### PR TITLE
[ZEPPELIN-3415] Fix export notebook functionality

### DIFF
--- a/zeppelin-web/src/app/notebook/save-as/save-as.service.js
+++ b/zeppelin-web/src/app/notebook/save-as/save-as.service.js
@@ -38,19 +38,17 @@ function SaveAsService(browserDetectService) {
       }
       angular.element('body > iframe#SaveAsId').remove();
     } else {
-      let binaryData = [];
-      binaryData.push(BOM);
-      binaryData.push(content);
-      content = window.URL.createObjectURL(new Blob(binaryData));
-
-      angular.element('body').append('<a id="SaveAsId"></a>');
-      let saveAsElement = angular.element('body > a#SaveAsId');
-      saveAsElement.attr('href', content);
-      saveAsElement.attr('download', filename + '.' + extension);
-      saveAsElement.attr('target', '_blank');
-      saveAsElement[0].click();
-      saveAsElement.remove();
-      window.URL.revokeObjectURL(content);
+      const fileName = filename + '.' + extension;
+      const json = JSON.stringify(content);
+      const blob = new Blob([json], {type: 'octet/stream'});
+      const url = window.URL.createObjectURL(blob);
+      let a = document.createElement('a');
+      document.body.appendChild(a);
+      a.style = 'display: none';
+      a.href = url;
+      a.download = fileName;
+      a.click();
+      window.URL.revokeObjectURL(url);
     }
   };
 }


### PR DESCRIPTION
### What is this PR for?
Export functionality for both notebook and download data as CSV stopped working for Chrome.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3415](https://issues.apache.org/jira/browse/ZEPPELIN-3415)

### How should this be tested?
* Try exporting notebook and/or download data as CSV for any table.

### Screenshots (if appropriate)
Before:
![download button before](https://user-images.githubusercontent.com/674497/38939688-1d397dd6-4346-11e8-8738-d3d0a00dc333.gif)


After:
![download button after](https://user-images.githubusercontent.com/674497/38939687-1d04681c-4346-11e8-8183-c46042ede815.gif)



### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
