### PR TITLE
[ZEPPELIN-3416] Bump up the version of xercesImpl to 2.11.0.SP5

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
-          <version>2.11.0</version>
+          <version>2.11.0.SP5</version>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -260,12 +260,6 @@
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-core</artifactId>
         <version>${shiro.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,12 @@
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-core</artifactId>
         <version>${shiro.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>
@@ -770,6 +776,10 @@
         <repository>
           <id>cloudera</id>
           <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+        <repository>
+          <id>hortonworks</id>
+          <url>http://repo.hortonworks.com/content/groups/public/</url>
         </repository>
       </repositories>
     </profile>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -165,6 +165,17 @@
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
Update xercesImpl to 2.11.0.SP5 to get some fixes. This is a required dependency for jdbc-phoenix.



### What type of PR is it?
[ Improvement ]

### What is the Jira issue?
* [ZEPPELIN-3416](https://issues.apache.org/jira/browse/ZEPPELIN-3416)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
