### PR TITLE
[ZEPPELIN-3417] fix dependency in zeppelin-web/package.json

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "angular-ui-grid": "^4.2.4",
-    "angular-viewport-watch": "github:shahata/angular-viewport-watch",
+    "angular-viewport-watch": "github:wix/angular-viewport-watch",
     "ansi_up": "^2.0.2",
     "github-markdown-css": "2.6.0",
     "grunt-angular-templates": "^0.5.7",


### PR DESCRIPTION
### What is this PR for?
The address of the dependency in zeppelin-web/package.json changed from "shahata/angular-viewport-watch" to "wix/angular-viewport-watch"

[LINK](https://github.com/wix/angular-viewport-watch) to current repository of angular-viewport-watch

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-3417](https://issues.apache.org/jira/browse/ZEPPELIN-3417)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no