### PR TITLE
ZEPPELIN-3401. Deadlock while restarting interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -101,6 +101,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   private transient NotebookRepo repo;
   private transient SearchService index;
   private transient ScheduledFuture delayedPersist;
+  private transient Object delayedPersistLock = new Object();
   private transient NoteEventListener noteEventListener;
   private transient Credentials credentials;
   private transient NoteNameListener noteNameListener;
@@ -852,7 +853,7 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   }
 
   private void startDelayedPersistTimer(int maxDelaySec, final AuthenticationInfo subject) {
-    synchronized (this) {
+    synchronized (delayedPersistLock) {
       if (delayedPersist != null) {
         return;
       }
@@ -872,11 +873,10 @@ public class Note implements ParagraphJobListener, JsonSerializable {
   }
 
   private void stopDelayedPersistTimer() {
-    synchronized (this) {
+    synchronized (delayedPersistLock) {
       if (delayedPersist == null) {
         return;
       }
-
       delayedPersist.cancel(false);
     }
   }


### PR DESCRIPTION
### What is this PR for?

I suspect it is due to deadlock issue between LifecycleThread & CronJobThread:
Thread | Locked | Waiting
-- | -- | --
LifecycleThread | InterpreterGroup | Note
CronJobThread | Note | Wait for Paragraph to finish (Paragraph can not finish because it needs the lock of InterpreterGroup

This PR wold eliminate the necessary to lock on Note for LifecycleThread


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3401

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
