### PR TITLE
[ZEPPELIN-3423] Fix deprecated dynamic forms document URL on Python README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -17,12 +17,7 @@ mvn -Dpython.test.exclude='' test -pl python -am
  - **Py4j support**
 
   [Py4j](https://www.py4j.org/) enables Python programs to dynamically access Java objects in a JVM.
-  It is required in order to use Zeppelin [dynamic forms](http://zeppelin.apache.org/docs/0.6.0-SNAPSHOT/manual/dynamicform.html) feature.
-
- - bootstrap process
-
-  Interpreter environment is setup with thex [bootstrap.py](https://github.com/apache/zeppelin/blob/master/python/src/main/resources/bootstrap.py)
-  It defines `help()` and `z` convenience functions
+  It is required in order to use Zeppelin [dynamic forms](https://zeppelin.apache.org/docs/latest/manual/dynamicform.html) feature.
 
 
 ### Dev prerequisites


### PR DESCRIPTION
[ZEPPELIN-3423] Fix deprecated dynamic forms document URL on Python README.md

### What is this PR for?
Python dynamic forms document URL is based on "0.6.0-SNAPSHOT" and already deprecated.
Replace the deprecated URL with the latest URL.

### What type of PR is it?
Documentation

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3423

### How should this be tested?
N/A

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No