### PR TITLE
[ZEPPELIN-3429] Fix python version on dev/merge_zeppelin_pr.py

### DIFF
--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
 ### What is this PR for?
Current merge_zeppelin_pr.py shebang has user env dependent.
Which means python version would be different from each user's environment.

However this script is unavailable with python 3.
Therefore I think it needs to be fixed with available python version.

 ### What type of PR is it?
[Bug]

 ### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3429

 ### How should this be tested?
Run merge_zeppelin_pr.py on the system using default python version 3.

 ### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
