### PR TITLE
[ZEPPELIN-3430] fix logic of loading githubnotebookrepo

### DIFF
--- a/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
@@ -45,13 +45,14 @@ import java.net.URISyntaxException;
  * - When commit the changes (saving the notebook)
  */
 public class GitHubNotebookRepo extends GitNotebookRepo {
-  private static final Logger LOG = LoggerFactory.getLogger(GitNotebookRepo.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GitHubNotebookRepo.class);
   private ZeppelinConfiguration zeppelinConfiguration;
   private Git git;
 
-  public GitHubNotebookRepo(ZeppelinConfiguration conf) throws IOException {
-    super(conf);
-
+  @Override
+  public void init(ZeppelinConfiguration conf) throws IOException {
+    super.init(conf);
+    LOG.debug("initializing GitHubNotebookRepo");
     this.git = super.getGit();
     this.zeppelinConfiguration = conf;
 
@@ -91,7 +92,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
   private void pullFromRemoteStream() {
     try {
-      LOG.debug("Pull latest changed from remote stream");
+      LOG.debug("Pulling latest changes from remote stream");
       PullCommand pullCommand = git.pull();
       pullCommand.setCredentialsProvider(
         new UsernamePasswordCredentialsProvider(
@@ -109,7 +110,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
   private void pushToRemoteSteam() {
     try {
-      LOG.debug("Push latest changed from remote stream");
+      LOG.debug("Pushing latest changes to remote stream");
       PushCommand pushCommand = git.push();
       pushCommand.setCredentialsProvider(
         new UsernamePasswordCredentialsProvider(
@@ -120,7 +121,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
       pushCommand.call();
     } catch (GitAPIException e) {
-      LOG.error("Error when pushing latest changes from remote repository", e);
+      LOG.error("Error when pushing latest changes to remote repository", e);
     }
   }
 }

--- a/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
@@ -43,6 +43,9 @@ import java.net.URISyntaxException;
  *
  * The logic for updating the remote repository on GitHub from local repository is the following:
  * - When commit the changes (saving the notebook)
+ *
+ * You should be able to use this integration with all remote git repositories that accept
+ * username + password authentication, not just GitHub.
  */
 public class GitHubNotebookRepo extends GitNotebookRepo {
   private static final Logger LOG = LoggerFactory.getLogger(GitHubNotebookRepo.class);

--- a/zeppelin-plugins/notebookrepo/github/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/github/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
@@ -119,7 +119,8 @@ public class GitHubNotebookRepoTest {
             "access-token");
 
     // Create the Notebook repository (configured for the local repository)
-    gitHubNotebookRepo = new GitHubNotebookRepo(conf);
+    gitHubNotebookRepo = new GitHubNotebookRepo();
+    gitHubNotebookRepo.init(conf);
   }
 
   @After

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
@@ -83,8 +83,13 @@ public class PluginManager {
       return null;
     }
     URLClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[0]));
-    Iterator<NotebookRepo> iter = ServiceLoader.load(NotebookRepo.class, classLoader).iterator();
-    NotebookRepo notebookRepo = iter.next();
+    NotebookRepo notebookRepo = null;
+    try {
+      notebookRepo = (NotebookRepo) (Class.forName(notebookRepoClassName, true, classLoader)).newInstance();
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      LOGGER.warn("Fail to instantiate notebookrepo from plugin classpath:" + notebookRepoClassName, e);
+    }
+
     if (notebookRepo == null) {
       LOGGER.warn("Unable to load NotebookRepo Plugin: " + notebookRepoClassName);
     }


### PR DESCRIPTION
### What is this PR for?
loadNotebookRepo(String notebookRepoClassName) does not actually load notebookRepoClassName but instead it loads the first NotebookRepo class that it finds on the plugins classpath. In case of NotebookRepos that depend/extend other NotebookRepos, this results in the wrong class being loaded.


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3430

### How should this be tested?
* set up notebook that uses githubrepo and check if the class actually gets initialized (look for debug log entry)

