### PR TITLE
ZEPPELIN-3325. R interpreter build bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
       env: PYTHON="3" SCALA_VER="2.10" PROFILE="-Pscalding" BUILD_FLAG="package -DskipTests -DskipRat -Pr" TEST_FLAG="test -DskipRat" MODULES="-pl $(echo .,zeppelin-interpreter,${INTERPRETERS} | sed 's/!//g')" TEST_PROJECTS=""
 
     # Run ZeppelinSparkClusterTest & SparkIntegrationTest in one build would exceed the time limitation of travis, so running them separately
-    
+
     # Integration test of spark interpreter with different spark versions under python2, only run ZeppelinSparkClusterTest. Also run spark unit test of spark 2.2 in this build.
     - sudo: required
       jdk: "oraclejdk8"
@@ -97,12 +97,12 @@ matrix:
     # Test spark module for 2.1.0 with scala 2.11
     - jdk: "openjdk7"
       dist: trusty
-      env: PYTHON="2" SCALA_VER="2.11" PROFILE="-Pspark-2.1 -Phadoop2 -Pscala-2.11" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.* -DfailIfNoTests=false"
+      env: PYTHON="2" SCALA_VER="2.11" PROFILE="-Pspark-2.1 -Phadoop2 -Pscala-2.11 -Pr" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies,r" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.*,org.apache.zeppelin.rinterpreter.*,org.apache.spark.api.r.* -DfailIfNoTests=false"
 
     # Test spark module for 2.0.2 with scala 2.11
     - jdk: "oraclejdk8"
       dist: trusty
-      env: PYTHON="2" SCALA_VER="2.11" PROFILE="-Pspark-2.0 -Phadoop3 -Pscala-2.11" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.* -DfailIfNoTests=false"
+      env: PYTHON="2" SCALA_VER="2.11" PROFILE="-Pspark-2.0 -Phadoop3 -Pscala-2.11 -Pr" SPARKR="true" BUILD_FLAG="package -DskipTests -DskipRat -am" TEST_FLAG="test -DskipRat -am" MODULES="-pl spark/interpreter,spark/spark-dependencies,r" TEST_PROJECTS="-Dtest=org.apache.zeppelin.spark.*,org.apache.zeppelin.rinterpreter.*,org.apache.spark.api.r.* -DfailIfNoTests=false"
 
     # Test python/pyspark with python 2, livy 0.5
     - sudo: required

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -21,16 +21,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>zeppelin</artifactId>
+    <artifactId>interpreter-parent</artifactId>
     <groupId>org.apache.zeppelin</groupId>
     <version>0.8.1-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../interpreter-parent</relativePath>
   </parent>
 
-  <artifactId>zeppelin-zrinterpreter_2.10</artifactId>
+  <groupId>org.apache.zeppelin</groupId>
+  <artifactId>zeppelin-zrinterpreter_${scala.binary.version}</artifactId>
   <packaging>jar</packaging>
+  <version>0.8.1-SNAPSHOT</version>
   <name>Zeppelin: R Interpreter</name>
   <description>R Interpreter for Zeppelin</description>
+  <url>http://zeppelin.apache.org</url>
 
   <properties>
     <script.extension>.sh</script.extension>
@@ -77,7 +80,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-spark_${scala.binary.version}</artifactId>
+      <artifactId>spark-interpreter</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -351,7 +354,6 @@
       </plugin>
     </plugins>
   </build>
-
 
   <profiles>
     <profile>


### PR DESCRIPTION
### What is this PR for?
Cherry pick from master bran h. 
Failing to build R interpreter (-Pr) after Spark refactoring


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3325
How should this be tested?
mvn clean package 
--batch-mode package 
-Phelium-dev 
-Pscala-2.11 
-Dscala.version=2.11.8 
-Dscala.binary.version=2.11 
-Pbuild-distr 
-Pspark-2.1 
-Dspark.version=2.1.1 
-Pr 
-Phadoop-2.7 
-Dhadoop.version=2.7.3 
-Dmaven.findbugs.enable=false 
-Drat.skip=true 
-Dcheckstyle.skip=true 
-DskipTests
Questions:
Does the licenses files need update? N
Is there breaking changes for older versions? N
Does this needs documentation? N