### PR TITLE
ZEPPELIN-3435. Interpreter timeout lifecycle leads to interpreter process orphans

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/LifecycleManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/LifecycleManager.java
@@ -24,10 +24,7 @@ package org.apache.zeppelin.interpreter;
  */
 public interface LifecycleManager {
 
-  void onInterpreterGroupCreated(ManagedInterpreterGroup interpreterGroup);
-
-  void onInterpreterSessionCreated(ManagedInterpreterGroup interpreterGroup,
-                                   String sessionId);
+  void onInterpreterProcessStarted(ManagedInterpreterGroup interpreterGroup);
 
   void onInterpreterUse(ManagedInterpreterGroup interpreterGroup,
                         String sessionId);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -48,7 +48,6 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
   ManagedInterpreterGroup(String id, InterpreterSetting interpreterSetting) {
     super(id);
     this.interpreterSetting = interpreterSetting;
-    interpreterSetting.getLifecycleManager().onInterpreterGroupCreated(this);
   }
 
   public InterpreterSetting getInterpreterSetting() {
@@ -63,6 +62,7 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
       remoteInterpreterProcess = interpreterSetting.createInterpreterProcess(id, userName,
           properties);
       remoteInterpreterProcess.start(userName);
+      interpreterSetting.getLifecycleManager().onInterpreterProcessStarted(this);
       remoteInterpreterProcess.getRemoteInterpreterEventPoller()
           .setInterpreterProcess(remoteInterpreterProcess);
       remoteInterpreterProcess.getRemoteInterpreterEventPoller().setInterpreterGroup(this);
@@ -156,7 +156,6 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
         interpreter.setInterpreterGroup(this);
       }
       LOGGER.info("Create Session: {} in InterpreterGroup: {} for user: {}", sessionId, id, user);
-      interpreterSetting.getLifecycleManager().onInterpreterSessionCreated(this, sessionId);
       sessions.put(sessionId, interpreters);
       return interpreters;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/NullLifecycleManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/NullLifecycleManager.java
@@ -32,13 +32,7 @@ public class NullLifecycleManager implements LifecycleManager {
   }
 
   @Override
-  public void onInterpreterGroupCreated(ManagedInterpreterGroup interpreterGroup) {
-
-  }
-
-  @Override
-  public void onInterpreterSessionCreated(ManagedInterpreterGroup interpreterGroup,
-                                          String sessionId) {
+  public void onInterpreterProcessStarted(ManagedInterpreterGroup interpreterGroup) {
 
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
@@ -58,18 +58,14 @@ public class TimeoutLifecycleManager implements LifecycleManager {
   }
 
   @Override
-  public void onInterpreterGroupCreated(ManagedInterpreterGroup interpreterGroup) {
+  public void onInterpreterProcessStarted(ManagedInterpreterGroup interpreterGroup) {
+    LOGGER.info("Process of InterpreterGroup {} is started", interpreterGroup.getId());
     interpreterGroups.put(interpreterGroup, System.currentTimeMillis());
   }
 
   @Override
-  public void onInterpreterSessionCreated(ManagedInterpreterGroup interpreterGroup,
-                                          String sessionId) {
-
-  }
-
-  @Override
   public void onInterpreterUse(ManagedInterpreterGroup interpreterGroup, String sessionId) {
+    LOGGER.debug("InterpreterGroup {} is used in session {}", interpreterGroup.getId(), sessionId);
     interpreterGroups.put(interpreterGroup, System.currentTimeMillis());
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManagerTest.java
@@ -54,13 +54,18 @@ public class TimeoutLifecycleManagerTest extends AbstractInterpreterTest {
     interpreterSettingManager.setInterpreterBinding("user1", "note1", interpreterSettingManager.getSettingIds());
     assertTrue(interpreterFactory.getInterpreter("user1", "note1", "test.echo") instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter = (RemoteInterpreter) interpreterFactory.getInterpreter("user1", "note1", "test.echo");
+    assertFalse(remoteInterpreter.isOpened());
+    InterpreterSetting interpreterSetting = interpreterSettingManager.getInterpreterSettingByName("test");
+    assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
+    Thread.sleep(15*1000);
+    // InterpreterGroup is not removed after 15 seconds, as TimeoutLifecycleManager only manage it after it is started
+    assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
+
     InterpreterContext context = new InterpreterContext("noteId", "paragraphId", "repl",
         "title", "text", AuthenticationInfo.ANONYMOUS, new HashMap<String, Object>(), new GUI(),
         new GUI(), null, null, new ArrayList<InterpreterContextRunner>(), null);
     remoteInterpreter.interpret("hello world", context);
     assertTrue(remoteInterpreter.isOpened());
-    InterpreterSetting interpreterSetting = interpreterSettingManager.getInterpreterSettingByName("test");
-    assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
 
     Thread.sleep(15 * 1000);
     // interpreterGroup is timeout, so is removed.


### PR DESCRIPTION
### What is this PR for?
This issue happens when LifecycleManager try to close InterpreterGroup when it is in the middle of starting. 
This PR change the interface of LifecycleManager, and only add InterpreterGroup to LifecycleManager only when its interpreter process is started. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3435

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
