### PR TITLE
[ZEPPELIN-3441] Fix license check failure in r

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     # Test License compliance using RAT tool
     - jdk: "openjdk7"
       dist: trusty
-      env: BUILD_PLUGINS="false" SCALA_VER="2.11" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
+      env: BUILD_PLUGINS="false" SCALA_VER="2.11" PROFILE="-Prat -Pr" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
     # Run e2e tests (in zeppelin-web)
     # chrome dropped the support for precise (ubuntu 12.04), so need to use trusty

--- a/pom.xml
+++ b/pom.xml
@@ -1087,16 +1087,11 @@
 
               <!-- compiled R packages (binaries) -->
               <exclude>**/R/lib/**</exclude>
-              <exclude>**/r/lib/**</exclude>
+              <exclude>**/lib/rzeppelin/**</exclude>
 
-               <!--R-related files with alternative licenses-->
+              <!--R-related files with alternative licenses-->
 
-              <exclude>**/R/rzeppelin/R/globals.R</exclude>
-              <exclude>**/R/rzeppelin/R/common.R</exclude>
-              <exclude>**/R/rzeppelin/R/protocol.R</exclude>
-              <exclude>**/R/rzeppelin/R/rServer.R</exclude>
-              <exclude>**/R/rzeppelin/R/scalaInterpreter.R</exclude>
-              <exclude>**/R/rzeppelin/R/zzz.R</exclude>
+              <exclude>**/R/rzeppelin/R/*.R</exclude>
               <exclude>**/src/main/scala/scala/Console.scala</exclude>
               <exclude>**/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/Package.scala</exclude>
               <exclude>**/src/main/scala/org/apache/zeppelin/rinterpreter/rscala/RClient.scala</exclude>


### PR DESCRIPTION
### What is this PR for?
rat plugin for r interpreter fail, seems to be related with #2089
It doesn't need to be included in 0.8.0 release, but want it to be cherry-picked into `branch-0.8` for 0.8.x releases, so release manager doesn't have issue with running `dev/publish_release.sh`

### What type of PR is it?
Hot Fix

### What is the Jira issue?
[ZEPPELIN-3441](https://issues.apache.org/jira/browse/ZEPPELIN-3441)

### How should this be tested?
Run `mvn verify -Pr` should pass
In CI, first matrix should pass. (https://travis-ci.org/minahlee/zeppelin/builds/374917837)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
