### PR TITLE
[ZEPPELIN-3442] bump up commons-collections to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <commons.configuration.version>1.9</commons.configuration.version>
     <commons.codec.version>1.5</commons.codec.version>
     <commons.io.version>2.4</commons.io.version>
-    <commons.collections.version>3.2.1</commons.collections.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
     <commons.logging.version>1.1.1</commons.logging.version>
     <commons.cli.version>1.3.1</commons.cli.version>
     <shiro.version>1.3.2</shiro.version>


### PR DESCRIPTION
### What is this PR for?
This is to upgrade Apache commons-collections to 3.2.2

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3442](https://issues.apache.org/jira/browse/ZEPPELIN-3442)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
