### PR TITLE
[Zeppelin 3388] Correcting documentation link to zeppelin-context documentation

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -753,7 +753,7 @@ z.put("country_code", "KR")
 Object interpolation is disabled by default, and can be enabled for all instances of the JDBC interpreter by 
 setting the value of the property `zeppelin.jdbc.interpolation` to `true` (see _More Properties_ above). 
 More details of this feature can be found in the Spark interpreter documentation under 
-[Object Interpolation](spark.html#object-interpolation)
+[Zeppelin-Context](../usage/other_features/zeppelin_context.html)
 
 ## Bug reporting
 If you find a bug using JDBC interpreter, please create a [JIRA](https://issues.apache.org/jira/browse/ZEPPELIN) ticket.


### PR DESCRIPTION
### What is this PR for?
A small change was needed in the documentation of the JDBC interpreter also, but had been missed.

The change required is the same as the change made in the documentation of the Shell interpreter (as seen [here](https://github.com/apache/zeppelin/commit/0c3260e91f4c1ec58e67856d466ea9cba89d0085#diff-5a017ebfb7e890a2b475f9c8c7844fb0))

### What type of PR is it?
[Documentation]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3388

### How should this be tested?
Documentation only.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No, this _is_ documentation.
