### PR TITLE
[ZEPPELIN-3448] Bump up version of org.scala-lang:scala-library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -759,7 +759,7 @@
     <profile>
       <id>scala-2.11</id>
       <properties>
-        <scala.version>2.11.8</scala.version>
+        <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
       </properties>
     </profile>

--- a/spark/scala-2.11/pom.xml
+++ b/spark/scala-2.11/pom.xml
@@ -33,7 +33,7 @@
   <name>Zeppelin: Spark Interpreter Scala_2.11</name>
 
   <properties>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.compile.version>${scala.version}</scala.compile.version>
   </properties>


### PR DESCRIPTION
### What is this PR for?
This is to upgrade the package org.scala-lang:scala-library to 2.11.12

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3448](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3448)

### Questions:
* Does the licenses files need an update? N?A
* Is there breaking changes for older versions? N?A
* Does this needs documentation? N?A
