### PR TITLE
[ZEPPELIN-3447] Bump up version of jackson-databind

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -36,10 +36,10 @@
 
     <!--library versions-->
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
-    <jersey.version>2.22.2</jersey.version>
+    <jersey.version>2.27</jersey.version>
     <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
     <jersey.servlet.version>1.13</jersey.servlet.version>
-    <javax.ws.rsapi.version>2.0.1</javax.ws.rsapi.version>
+    <javax.ws.rsapi.version>2.1</javax.ws.rsapi.version>
     <libpam4j.version>1.8</libpam4j.version>
     <jna.version>4.1.0</jna.version>
 
@@ -143,7 +143,21 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.8.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${jersey.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
@@ -205,7 +219,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.5.4</version>
+      <version>2.8.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
This is to upgrade the package jackson-databind libary to 2.27

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3447](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3447)

### Questions:
* Does the licenses files need an update? N?A
* Is there breaking changes for older versions? N?A
* Does this needs documentation? N?A
