### PR TITLE
ZEPPELIN-2221 Show `Jobs` page when `jobId` is missing

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
@@ -23,10 +23,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.ui.jobs.JobProgressListener;
-import org.apache.zeppelin.interpreter.BaseZeppelinContext;
 import org.apache.zeppelin.interpreter.DefaultInterpreterProperty;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -34,7 +31,6 @@ import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterHookRegistry;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.WrappedInterpreter;
-import org.apache.zeppelin.interpreter.remote.RemoteEventClientWrapper;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.spark.dep.SparkDependencyContext;
 import org.slf4j.Logger;
@@ -42,8 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -119,7 +113,7 @@ public class NewSparkInterpreter extends AbstractSparkInterpreter {
       sparkSession = this.innerInterpreter.sparkSession();
       sparkUrl = this.innerInterpreter.sparkUrl();
       sparkShims = SparkShims.getInstance(sc.version());
-      sparkShims.setupSparkListener(sparkUrl);
+      sparkShims.setupSparkListener(sc.master(), sparkUrl);
 
       hooks = getInterpreterGroup().getInterpreterHookRegistry();
       z = new SparkZeppelinContext(sc, hooks,

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
@@ -163,7 +163,7 @@ public class OldSparkInterpreter extends AbstractSparkInterpreter {
     this.sc = sc;
     env = SparkEnv.get();
     sparkShims = SparkShims.getInstance(sc.version());
-    sparkShims.setupSparkListener(sparkUrl);
+    sparkShims.setupSparkListener(sc.master(), sparkUrl);
   }
 
   public SparkContext getSparkContext() {
@@ -872,7 +872,7 @@ public class OldSparkInterpreter extends AbstractSparkInterpreter {
 
     sparkUrl = getSparkUIUrl();
     sparkShims = SparkShims.getInstance(sc.version());
-    sparkShims.setupSparkListener(sparkUrl);
+    sparkShims.setupSparkListener(sc.master(), sparkUrl);
 
     numReferenceOfSparkContext.incrementAndGet();
   }

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -75,7 +75,7 @@ public class SparkShimsTest {
     SparkShims sparkShims;
     try {
       sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
-    } catch (Exception e) {
+    } catch (Throwable ignore) {
       sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString());
     }
     sparkShims.setHttpClient(mockHttpClient);
@@ -114,7 +114,7 @@ public class SparkShimsTest {
     SparkShims sparkShims;
     try {
       sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
-    } catch (Exception e) {
+    } catch (Throwable ignore) {
       sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString());
     }
     sparkShims.setHttpClient(mockHttpClient);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -72,7 +72,12 @@ public class SparkShimsTest {
 
     when(mockProperties.getProperty("spark.jobGroup.id")).thenReturn("job-note-paragraph");
 
-    SparkShims sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    SparkShims sparkShims;
+    try {
+      sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    } catch (Exception e) {
+      sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString());
+    }
     sparkShims.setHttpClient(mockHttpClient);
 
     sparkShims.buildSparkJobUrl("http://sparkurl", 0, mockProperties);
@@ -96,7 +101,7 @@ public class SparkShimsTest {
 
     when(mockHttpClient.execute(Matchers.<HttpUriRequest>any())).thenReturn(mockHttpResponse);
     when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
-    when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_MOVED_TEMPORARILY);
+    when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
 
     when(BaseZeppelinContext.getEventClient()).thenReturn(mockRemoteEventClientWrapper);
     ArgumentCaptor<Map<String, String>> mapArgumentCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>)(Class)Map.class);
@@ -106,7 +111,12 @@ public class SparkShimsTest {
 
     when(mockProperties.getProperty("spark.jobGroup.id")).thenReturn("job-note-paragraph");
 
-    SparkShims sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    SparkShims sparkShims;
+    try {
+      sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    } catch (Exception e) {
+      sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString());
+    }
     sparkShims.setHttpClient(mockHttpClient);
 
     sparkShims.buildSparkJobUrl("http://sparkurl", 0, mockProperties);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.spark;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.zeppelin.interpreter.BaseZeppelinContext;
+import org.apache.zeppelin.interpreter.remote.RemoteEventClientWrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BaseZeppelinContext.class})
+@PowerMockIgnore({"javax.net.ssl.*","javax.security.*"})
+public class SparkShimsTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void buildSparkJobUrlTest() throws IOException {
+    HttpClient mockHttpClient = mock(HttpClient.class);
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+
+    PowerMockito.mockStatic(BaseZeppelinContext.class);
+    RemoteEventClientWrapper mockRemoteEventClientWrapper = mock(RemoteEventClientWrapper.class);
+
+    Properties mockProperties = mock(Properties.class);
+
+    when(mockHttpClient.execute(Matchers.<HttpUriRequest>any())).thenReturn(mockHttpResponse);
+    when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+    when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+    when(BaseZeppelinContext.getEventClient()).thenReturn(mockRemoteEventClientWrapper);
+    ArgumentCaptor<Map<String, String>> mapArgumentCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>)(Class)Map.class);
+    doNothing()
+        .when(mockRemoteEventClientWrapper)
+        .onParaInfosReceived(anyString(), anyString(), mapArgumentCaptor.capture());
+
+    when(mockProperties.getProperty("spark.jobGroup.id")).thenReturn("job-note-paragraph");
+
+    SparkShims sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    sparkShims.setHttpClient(mockHttpClient);
+
+    sparkShims.buildSparkJobUrl("http://sparkurl", 0, mockProperties);
+
+    Map<String, String> mapValue = mapArgumentCaptor.getValue();
+    assertTrue(mapValue.keySet().contains("jobUrl"));
+    assertTrue(mapValue.get("jobUrl").contains("/jobs/job?id="));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void buildSparkJobUrlWithoutJobIdTest() throws IOException {
+    HttpClient mockHttpClient = mock(HttpClient.class);
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+
+    PowerMockito.mockStatic(BaseZeppelinContext.class);
+    RemoteEventClientWrapper mockRemoteEventClientWrapper = mock(RemoteEventClientWrapper.class);
+
+    Properties mockProperties = mock(Properties.class);
+
+    when(mockHttpClient.execute(Matchers.<HttpUriRequest>any())).thenReturn(mockHttpResponse);
+    when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+    when(mockStatusLine.getStatusCode()).thenReturn(HttpStatus.SC_MOVED_TEMPORARILY);
+
+    when(BaseZeppelinContext.getEventClient()).thenReturn(mockRemoteEventClientWrapper);
+    ArgumentCaptor<Map<String, String>> mapArgumentCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>)(Class)Map.class);
+    doNothing()
+        .when(mockRemoteEventClientWrapper)
+        .onParaInfosReceived(anyString(), anyString(), mapArgumentCaptor.capture());
+
+    when(mockProperties.getProperty("spark.jobGroup.id")).thenReturn("job-note-paragraph");
+
+    SparkShims sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+    sparkShims.setHttpClient(mockHttpClient);
+
+    sparkShims.buildSparkJobUrl("http://sparkurl", 0, mockProperties);
+
+    Map<String, String> mapValue = mapArgumentCaptor.getValue();
+    assertTrue(mapValue.keySet().contains("jobUrl"));
+    assertFalse(mapValue.get("jobUrl").contains("/jobs/job?id="));
+    assertTrue(mapValue.get("jobUrl").contains("/jobs"));
+  }
+}

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -41,6 +41,17 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!--
+      This is for ZEPPELIN-2221 using VersionInfo for check the version of Yarn.
+      It's checked that VersionInfo is compatible at least 2.2.0 to the latest one.
+    -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.2.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
+++ b/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
@@ -19,38 +19,17 @@
 package org.apache.zeppelin.spark;
 
 import org.apache.spark.SparkContext;
-import org.apache.spark.scheduler.SparkListener;
-import org.apache.spark.scheduler.SparkListenerApplicationEnd;
-import org.apache.spark.scheduler.SparkListenerApplicationStart;
-import org.apache.spark.scheduler.SparkListenerBlockManagerAdded;
-import org.apache.spark.scheduler.SparkListenerBlockManagerRemoved;
-import org.apache.spark.scheduler.SparkListenerBlockUpdated;
-import org.apache.spark.scheduler.SparkListenerEnvironmentUpdate;
-import org.apache.spark.scheduler.SparkListenerExecutorAdded;
-import org.apache.spark.scheduler.SparkListenerExecutorMetricsUpdate;
-import org.apache.spark.scheduler.SparkListenerExecutorRemoved;
-import org.apache.spark.scheduler.SparkListenerJobEnd;
 import org.apache.spark.scheduler.SparkListenerJobStart;
-import org.apache.spark.scheduler.SparkListenerStageCompleted;
-import org.apache.spark.scheduler.SparkListenerStageSubmitted;
-import org.apache.spark.scheduler.SparkListenerTaskEnd;
-import org.apache.spark.scheduler.SparkListenerTaskGettingResult;
-import org.apache.spark.scheduler.SparkListenerTaskStart;
-import org.apache.spark.scheduler.SparkListenerUnpersistRDD;
 import org.apache.spark.ui.jobs.JobProgressListener;
-import org.apache.zeppelin.interpreter.BaseZeppelinContext;
-import org.apache.zeppelin.interpreter.remote.RemoteEventClientWrapper;
-
-import java.util.Map;
 
 public class Spark1Shims extends SparkShims {
 
-  public void setupSparkListener(final String sparkWebUrl) {
+  public void setupSparkListener(final String master, final String sparkWebUrl) {
     SparkContext sc = SparkContext.getOrCreate();
     sc.addSparkListener(new JobProgressListener(sc.getConf()) {
       @Override
       public void onJobStart(SparkListenerJobStart jobStart) {
-        buildSparkJobUrl(sparkWebUrl, jobStart.jobId(), jobStart.properties());
+        buildSparkJobUrl(master, sparkWebUrl, jobStart.jobId(), jobStart.properties());
       }
     });
   }

--- a/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
+++ b/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
@@ -24,12 +24,12 @@ import org.apache.spark.scheduler.SparkListenerJobStart;
 
 public class Spark2Shims extends SparkShims {
 
-  public void setupSparkListener(final String sparkWebUrl) {
+  public void setupSparkListener(final String master, final String sparkWebUrl) {
     SparkContext sc = SparkContext.getOrCreate();
     sc.addSparkListener(new SparkListener() {
       @Override
       public void onJobStart(SparkListenerJobStart jobStart) {
-        buildSparkJobUrl(sparkWebUrl, jobStart.jobId(), jobStart.properties());
+        buildSparkJobUrl(master, sparkWebUrl, jobStart.jobId(), jobStart.properties());
       }
     });
   }


### PR DESCRIPTION
### What is this PR for?
Because of yarn's bug, Spark's `jobId` is not passed. This causes some Spark UI link looks broken. In this kind of case, showing `Jobs` page looks reasonable. Yarn's bug is already fixed with the latest version only, so we need to handle it in Zeppelin side.


### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Return `Jobs` page when `Job` page is not available

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-2221

### How should this be tested?
1. Install outdated yarn
2. Run script
3. Click `Spark UI` to show `Jobs` page instead of 404

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
