### PR TITLE
ZEPPELIN-3463 pip freeze statsmodel 0.8.0

### DIFF
--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -46,5 +46,5 @@ if [[ -n "$PYTHON" ]] ; then
   conda info -a
   conda config --add channels conda-forge
   conda install -q matplotlib=2.1.2 pandasql ipython=5.4.1 jupyter_client ipykernel matplotlib bokeh=0.12.10
-  pip install -q grpcio ggplot bkzep==0.4.0
+  pip install -q grpcio ggplot bkzep==0.4.0 statsmodels==0.8.0
 fi


### PR DESCRIPTION
### What is this PR for?
pip freeze statsmodel 0.8.0.   The new version statsmodel 0.9.0 fails to install using install_external_dependencies.sh

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* [ZEPPELIN-3463]
* https://issues.apache.org/jira/browse/ZEPPELIN-3463

### How should this be tested?
* sh testing/install_external_dependencies.sh

### Questions:
* Does the licenses files need update?
   No
* Is there breaking changes for older versions?
   No
* Does this needs documentation?
   No