### PR TITLE
[ZEPPELIN-3466] Table export to excel is not working due to missing dependencies

### DIFF
--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -34,7 +34,9 @@
     "MathJax": "2.7.0",
     "ngclipboard": "^1.1.1",
     "jsdiff": "3.3.0",
-    "ngInfiniteScroll": "^1.3.4"
+    "ngInfiniteScroll": "^1.3.4",
+    "jszip": "2.6.1",
+    "excel-builder-js": "excelbuilder#2.0.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.7"

--- a/zeppelin-web/karma.conf.js
+++ b/zeppelin-web/karma.conf.js
@@ -88,6 +88,8 @@ module.exports = function(config) {
       'bower_components/ngclipboard/dist/ngclipboard.js',
       'bower_components/jsdiff/diff.js',
       'bower_components/ngInfiniteScroll/build/ng-infinite-scroll.js',
+      'bower_components/jszip/dist/jszip.js',
+      'bower_components/excel-builder-js/dist/excel-builder.dist.js',
       'bower_components/angular-mocks/angular-mocks.js',
       // endbower
 

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -25,7 +25,7 @@
     "test": "karma start karma.conf.js"
   },
   "dependencies": {
-    "angular-ui-grid": "^4.2.4",
+    "angular-ui-grid": "4.4.6",
     "angular-viewport-watch": "github:wix/angular-viewport-watch",
     "ansi_up": "^2.0.2",
     "github-markdown-css": "2.6.0",

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -102,6 +102,7 @@ export default class TableVisualization extends Visualization {
       flatEntityAccess: true,
       fastWatch: false,
       treeRowHeaderAlwaysVisible: false,
+      exporterExcelFilename: 'myFile.xlsx',
 
       columnDefs: columnNames.map((colName) => {
         return {

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -167,6 +167,8 @@ limitations under the License.
     <script src="bower_components/ngclipboard/dist/ngclipboard.js"></script>
     <script src="bower_components/jsdiff/diff.js"></script>
     <script src="bower_components/ngInfiniteScroll/build/ng-infinite-scroll.js"></script>
+    <script src="bower_components/jszip/dist/jszip.js"></script>
+    <script src="bower_components/excel-builder-js/dist/excel-builder.dist.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
   </body>


### PR DESCRIPTION
### What is this PR for?
Table export to excel is not working due to missing dependencies.
angular-ui-grid 4.4.7 onwards comes pre-packaged with jszip and excel-builder, but have few noticeable bugs hence not upgrading to latest.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3466](https://issues.apache.org/jira/browse/ZEPPELIN-3466)

### How should this be tested?
* Export to excel should work.

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
