### PR TITLE
ZEPPELIN-3472 No interpreter status is shown after restarting the individual interpreter.

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1034,12 +1034,13 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
               checkInterpreterStatus(data.body);
               thisConfirm.close();
             }).error(function(data, status, headers, config) {
+              checkInterpreterStatus({
+                id: interpreter.id,
+                errorReason: 'Not able to restart the interpreter.',
+                status: 'YELLOW',
+              });
               thisConfirm.close();
               console.log('Error %o %o', status, data.message);
-              BootstrapDialog.show({
-                title: 'Error restart interpreter.',
-                message: _.escape(data.message),
-              });
             });
           return false;
         }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1002,6 +1002,14 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     $timeout(makeSearchBoxVisible());
   });
 
+  const checkInterpreterStatus = function(interpreterObj) {
+    const index = _.findIndex($scope.interpreterBindings, {'id': interpreterObj.id});
+    if(interpreterObj.errorReason) {
+      $scope.interpreterBindings[index].errorReason = interpreterObj.errorReason;
+    }
+    $scope.interpreterBindings[index].status = interpreterObj.status;
+  };
+
   $scope.restartInterpreter = function(interpreter) {
     const thisConfirm = BootstrapDialog.confirm({
       closable: false,
@@ -1023,6 +1031,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
             .success(function(data, status, headers, config) {
               let index = _.findIndex($scope.interpreterSettings, {'id': interpreter.id});
               $scope.interpreterSettings[index] = data.body;
+              checkInterpreterStatus(data.body);
               thisConfirm.close();
             }).error(function(data, status, headers, config) {
               thisConfirm.close();

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -61,6 +61,18 @@ limitations under the License.
                 </span>
               </small>
             </div>
+            <small ng-switch="item.status">
+              <small ng-switch-when="READY">
+                <i style="color: green; margin-right: 3px;" class="fa fa-circle"
+                   uib-tooltip="Interpreter restart successfully">
+                </i>
+              </small>
+              <small ng-switch-when="ERROR">
+                <i style="color: red; cursor: pointer" class="fa fa-circle"
+                   uib-tooltip="{{item.errorReason}}">
+                </i>
+              </small>
+            </small>
           </div>
         </div>
       </div>

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -72,6 +72,11 @@ limitations under the License.
                    uib-tooltip="{{item.errorReason}}">
                 </i>
               </small>
+              <small ng-switch-when="YELLOW">
+                <i style="color: yellow; cursor: pointer" class="fa fa-circle"
+                   uib-tooltip="{{item.errorReason}}">
+                </i>
+              </small>
             </small>
           </div>
         </div>


### PR DESCRIPTION


### What is this PR for?
Shows the interpreter status after restarting the individual interpreter.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3472](https://issues.apache.org/jira/browse/ZEPPELIN-3472)

### How should this be tested?
Click on setting icon on note-book interpreter panel will be shown. click on refresh icon for the specific interpreter from the list user will promt to confirm do he want's to restart the interpreter. If yes depending on the api response the status has been shown in the form of (circle) color mapping below.

- GREEN -> Interpreter successfully restarted
- RED -> Error has been occure while restarting

on hovering the (circle) you will see success / error  message for the respective interpreter.

### Screenshots (if appropriate)
![zeppelin-3472](https://user-images.githubusercontent.com/6010694/40219574-a4379264-5a93-11e8-80c6-89e9489fb8cb.png)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
