### PR TITLE
[ZEPPELIN-3478] Download Data as CSV downloads data as a single line

### DIFF
--- a/zeppelin-web/src/app/notebook/save-as/save-as.service.js
+++ b/zeppelin-web/src/app/notebook/save-as/save-as.service.js
@@ -39,8 +39,10 @@ function SaveAsService(browserDetectService) {
       angular.element('body > iframe#SaveAsId').remove();
     } else {
       const fileName = filename + '.' + extension;
-      const json = JSON.stringify(content);
-      const blob = new Blob([json], {type: 'octet/stream'});
+      let binaryData = [];
+      binaryData.push(BOM);
+      binaryData.push(content);
+      let blob = new Blob(binaryData, {type: 'octet/stream'});
       const url = window.URL.createObjectURL(blob);
       let a = document.createElement('a');
       document.body.appendChild(a);


### PR DESCRIPTION
### What is this PR for?
All data is in one single line - lines separated with backslash and "n" sequence and not actual newline characters "\n".


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-3478](https://issues.apache.org/jira/browse/ZEPPELIN-3478)

### How should this be tested?
All the exports should work in all browsers
 * Export this notebook
 * Export as CVS
 * Export as TSV


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
