### PR TITLE
ZEPPELIN-3482 Incorrect user is picked up by Zeppelin during relogin after Knox SSO token expiry

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxJwtRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/jwt/KnoxJwtRealm.java
@@ -121,7 +121,7 @@ public class KnoxJwtRealm extends AuthorizingRealm {
     return null;
   }
 
-  private String getName(JWTAuthenticationToken upToken) throws ParseException {
+  public String getName(JWTAuthenticationToken upToken) throws ParseException {
     SignedJWT signed = SignedJWT.parse(upToken.getToken());
     String userName = signed.getJWTClaimsSet().getSubject();
     return userName;
@@ -138,6 +138,14 @@ public class KnoxJwtRealm extends AuthorizingRealm {
       boolean expValid = validateExpiration(signed);
       if (!expValid) {
         LOGGER.warn("Expiration time validation of JWT token failed.");
+        return false;
+      }
+      String currentUser = (String) org.apache.shiro.SecurityUtils.getSubject().getPrincipal();
+      if (currentUser == null) {
+        return true;
+      }
+      String cookieUser = signed.getJWTClaimsSet().getSubject();
+      if (!cookieUser.equals(currentUser)) {
         return false;
       }
       return true;


### PR DESCRIPTION
### What is this PR for?
Incorrect user is picked up by Zeppelin during relogin after Knox SSO token expiry

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3482

### How should this be tested?
* steps in JIRA description.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
