### PR TITLE
[ZEPPELIN-3467] two-step, atomic configuration file writes

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.storage;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterInfoSaving;
 import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
@@ -51,7 +52,7 @@ public class LocalConfigStorage extends ConfigStorage {
   @Override
   public void save(InterpreterInfoSaving settingInfos) throws IOException {
     LOGGER.info("Save Interpreter Setting to " + interpreterSettingPath.getAbsolutePath());
-    writeToFile(settingInfos.toJson(), interpreterSettingPath);
+    atomicWriteToFile(settingInfos.toJson(), interpreterSettingPath);
   }
 
   @Override
@@ -68,7 +69,7 @@ public class LocalConfigStorage extends ConfigStorage {
   @Override
   public void save(NotebookAuthorizationInfoSaving authorizationInfoSaving) throws IOException {
     LOGGER.info("Save notebook authorization to file: " + authorizationPath);
-    writeToFile(authorizationInfoSaving.toJson(), authorizationPath);
+    atomicWriteToFile(authorizationInfoSaving.toJson(), authorizationPath);
   }
 
   @Override
@@ -95,17 +96,21 @@ public class LocalConfigStorage extends ConfigStorage {
   @Override
   public void saveCredentials(String credentials) throws IOException {
     LOGGER.info("Save Credentials to file: " + credentialPath);
-    writeToFile(credentials, credentialPath);
+    atomicWriteToFile(credentials, credentialPath);
   }
 
   private String readFromFile(File file) throws IOException {
     return IOUtils.toString(new FileInputStream(file));
   }
 
-  private void writeToFile(String content, File file) throws IOException {
-    FileOutputStream out = new FileOutputStream(file);
+  private void atomicWriteToFile(String content, File file) throws IOException {
+    File directory = file.getParentFile();
+    String fileName = file.getName() + ".tmp";
+    File tempFile = new File(directory, fileName);
+    FileOutputStream out = new FileOutputStream(tempFile);
     IOUtils.write(content, out);
     out.close();
+    FileUtils.moveFile(tempFile, file);
   }
 
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.storage;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterInfoSaving;
 import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
@@ -29,7 +28,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.FileSystems;
+import java.nio.file.FileSystem;
+import java.nio.file.StandardCopyOption;
 
 /**
  * Storing config in local file system
@@ -105,12 +108,15 @@ public class LocalConfigStorage extends ConfigStorage {
 
   private void atomicWriteToFile(String content, File file) throws IOException {
     File directory = file.getParentFile();
-    String fileName = file.getName() + ".tmp";
-    File tempFile = new File(directory, fileName);
+    String fileNameParts[] = file.getName().split("\\.");
+    File tempFile = File.createTempFile(fileNameParts[0], fileNameParts[1], directory);
     FileOutputStream out = new FileOutputStream(tempFile);
     IOUtils.write(content, out);
     out.close();
-    FileUtils.moveFile(tempFile, file);
+    FileSystem defaultFileSystem = FileSystems.getDefault();
+    Path tempFilePath = defaultFileSystem.getPath(tempFile.getCanonicalPath());
+    Path destinationFilePath = defaultFileSystem.getPath(file.getCanonicalPath());
+    Files.move(tempFilePath, destinationFilePath, StandardCopyOption.ATOMIC_MOVE);
   }
 
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -113,6 +113,7 @@ public class LocalConfigStorage extends ConfigStorage {
     try {
       IOUtils.write(content, out);
     } catch (IOException iox) {
+      if (out != null) out.close();
       tempFile.delete();
       throw iox;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -111,7 +111,12 @@ public class LocalConfigStorage extends ConfigStorage {
     String fileNameParts[] = file.getName().split("\\.");
     File tempFile = File.createTempFile(fileNameParts[0], fileNameParts[1], directory);
     FileOutputStream out = new FileOutputStream(tempFile);
-    IOUtils.write(content, out);
+    try {
+      IOUtils.write(content, out);
+    } catch (IOException iox) {
+      tempFile.delete();
+      throw iox;
+    }
     out.close();
     FileSystem defaultFileSystem = FileSystems.getDefault();
     Path tempFilePath = defaultFileSystem.getPath(tempFile.getCanonicalPath());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -108,8 +108,7 @@ public class LocalConfigStorage extends ConfigStorage {
 
   private void atomicWriteToFile(String content, File file) throws IOException {
     File directory = file.getParentFile();
-    String fileNameParts[] = file.getName().split("\\.");
-    File tempFile = File.createTempFile(fileNameParts[0], fileNameParts[1], directory);
+    File tempFile = File.createTempFile(file.getName(), null, directory);
     FileOutputStream out = new FileOutputStream(tempFile);
     try {
       IOUtils.write(content, out);
@@ -121,7 +120,12 @@ public class LocalConfigStorage extends ConfigStorage {
     FileSystem defaultFileSystem = FileSystems.getDefault();
     Path tempFilePath = defaultFileSystem.getPath(tempFile.getCanonicalPath());
     Path destinationFilePath = defaultFileSystem.getPath(file.getCanonicalPath());
-    Files.move(tempFilePath, destinationFilePath, StandardCopyOption.ATOMIC_MOVE);
+    try {
+      Files.move(tempFilePath, destinationFilePath, StandardCopyOption.ATOMIC_MOVE);
+    } catch (IOException iox) {
+      tempFile.delete();
+      throw iox;
+    }
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
This PR prevents the total loss of configuration information that happens when zeppelin attempts to write out modified configuration information into an already full file-system. The approach taken here is to first write the modified information to a temporary file (in the same directory), and then to rename the successfully written file to its eventual name. 

The rename operation is not attempted if there is an error while writing the temporary file, thus leaving the pre-existing configuration file untouched.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3467

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
