### PR TITLE
ZEPPELIN-3484. sc.setJobGroup() shows up in error stack and shifts line numbering

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -117,7 +117,11 @@ public class IPySparkInterpreter extends IPythonInterpreter {
     String jobGroupId = Utils.buildJobGroupId(context);
     String jobDesc = "Started by: " + Utils.getUserName(context.getAuthenticationInfo());
     String setJobGroupStmt = "sc.setJobGroup('" +  jobGroupId + "', '" + jobDesc + "')";
-    return super.interpret(setJobGroupStmt +"\n" + st, context);
+    InterpreterResult result = super.interpret(setJobGroupStmt, context);
+    if (result.code().equals(InterpreterResult.Code.ERROR)) {
+      return new InterpreterResult(InterpreterResult.Code.ERROR, "Fail to setJobGroup");
+    }
+    return super.interpret(st, context);
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
This PR would call sc.setJobGroup and the user code separately.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3483

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![screen shot 2018-05-23 at 8 56 40 am](https://user-images.githubusercontent.com/164491/40397801-3c364d18-5e67-11e8-8fb5-4369d1d78e62.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
