### PR TITLE
ZEPPELIN-3489. Yarn cluster mode doesn't work for multiple node cluster

### DIFF
--- a/interpreter-parent/pom.xml
+++ b/interpreter-parent/pom.xml
@@ -38,7 +38,6 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>zeppelin-interpreter</artifactId>
         <version>${project.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -45,6 +45,6 @@ if [[ -n "$PYTHON" ]] ; then
   conda update -q conda
   conda info -a
   conda config --add channels conda-forge
-  conda install -q matplotlib=2.1.2 pandasql ipython=5.4.1 jupyter_client ipykernel matplotlib bokeh=0.12.10
-  pip install -q grpcio ggplot bkzep==0.4.0 statsmodels==0.8.0
+  conda install -q pandas=0.21.1 matplotlib=2.1.1 pandasql=0.7.3 ipython=5.4.1 jupyter_client=5.1.0 ipykernel=4.7.0 bokeh=0.12.10
+  pip install -q ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
 fi


### PR DESCRIPTION
### What is this PR for?
Change the scope of zeppelin-interpreter to compile, so that it will be packaged into the spark interpreter jar


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3489

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
