### PR TITLE
[ZEPPELIN-3492] The paragraph's table does not scroll if there is a large cell

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -136,6 +136,7 @@ export default class TableVisualization extends Visualization {
       saveTreeView: true,
       saveFilter: true,
       saveSelection: false,
+      customScroller: (uiGrid) => uiGrid.on('wheel', (event) => event.stopPropagation()),
     };
 
     return gridOptions;


### PR DESCRIPTION
### What is this PR for?
When scrolling (with the mouse wheel), the contents of the table jump and do not scroll down. The scroll bar is working fine. Often this happens if the table has a cell with a large height.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-3492](https://issues.apache.org/jira/browse/ZEPPELIN-3492)

### How should this be tested?
[Text](https://github.com/apache/zeppelin/files/2030555/paragraphText.txt) of the paragraph (python interpreter)

### Screenshots
#### <p align="center">Before</p>
![peek_before](https://user-images.githubusercontent.com/30798933/40417963-c3d158a4-5e89-11e8-8c68-5a0397281c75.gif)

#### <p align="center">After</p>
![peek_after](https://user-images.githubusercontent.com/30798933/40417977-ccf60f1a-5e89-11e8-88b3-c7855a198e2d.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
