### PR TITLE
ZEPPELIN-3496 Notebook title not visible in simple and report mode

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -17,10 +17,11 @@ limitations under the License.
     <div style="float: left; width: auto; max-width: 40%"
       ng-controller="ElasticInputCtrl as input">
       <input type="text" pu-elastic-input class="form-control2" placeholder="New name"
-             style="min-width: 0px; max-width: 85%; margin-left: 2em;"
+             style="min-width: 0px; max-width: 85%;"
              ng-if="input.showEditor" ng-model="input.value" ng-escape="input.showEditor = false" focus-if="input.showEditor"
              ng-blur="updateNoteName(input.value);input.showEditor = false;" ng-enter="updateNoteName(input.value);input.showEditor = false;" />
-      <p class="form-control-static2 reverse-ellipsis ellipsis"
+      <p class="form-control-static2"
+         ng-class="{'reverse-ellipsis ellipsis':noteName(note).length > 45}"
          tooltip-placement="bottom"
          uib-tooltip={{noteName(note)}}
          ng-click="input.showEditor = !revisionView; input.value = note.name"

--- a/zeppelin-web/src/assets/styles/looknfeel/report.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/report.css
@@ -58,6 +58,10 @@ body {
   visibility: hidden;
 }
 
+.noteAction .form-control-static2 > span {
+  visibility: visible;
+}
+
 .noteAction:hover span,
 .noteAction:hover button,
 .noteAction:hover form {

--- a/zeppelin-web/src/assets/styles/looknfeel/simple.css
+++ b/zeppelin-web/src/assets/styles/looknfeel/simple.css
@@ -89,6 +89,10 @@ body {
   visibility: hidden;
 }
 
+.noteAction .form-control-static2 > span {
+  visibility: visible;
+}
+
 .noteAction:hover span,
 .noteAction:hover button,
 .noteAction:hover form {


### PR DESCRIPTION
### What is this PR for?
Notebook title not visible in simple and report mode
- fix title visibility
- fix title alignment

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3496

### How should this be tested?
manually switch views between default, simple and report

### Screenshots (if appropriate)
**Simple view before**
<img width="1020" alt="simple-view-before" src="https://user-images.githubusercontent.com/2031306/40469731-1b873c7e-5f4f-11e8-8bba-5958e963b53f.png">
**Simple view hover before** (left alignment is off)
<img width="1029" alt="simple-view-hover-before" src="https://user-images.githubusercontent.com/2031306/40469730-1b4254c4-5f4f-11e8-9166-c2da6b0cc130.png">


**Simple view after**
<img width="1009" alt="simple-view-after" src="https://user-images.githubusercontent.com/2031306/40469812-4b3b6b70-5f4f-11e8-87e2-474de25372d8.png">
**Simple view hover after**
<img width="943" alt="simple-view-hover-after" src="https://user-images.githubusercontent.com/2031306/40469811-4b0a04fe-5f4f-11e8-8d2a-5435f722afd1.png">



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
