### PR TITLE
ZEPPELIN-3497. Improve error message when livy session is failed to create

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -94,6 +94,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
   private String livyURL;
   private int sessionCreationTimeout;
   private int pullStatusInterval;
+  private int maxLogLines;
   protected boolean displayAppInfo;
   private boolean restartDeadSession;
   protected LivyVersion livyVersion;
@@ -119,6 +120,8 @@ public abstract class BaseLivyInterpreter extends Interpreter {
         property.getProperty("zeppelin.livy.session.create_timeout", 120 + ""));
     this.pullStatusInterval = Integer.parseInt(
         property.getProperty("zeppelin.livy.pull_status.interval.millis", 1000 + ""));
+    this.maxLogLines = Integer.parseInt(property.getProperty("zeppelin.livy.maxLogLines",
+        "1000"));
     this.restTemplate = createRestTemplate();
     if (!StringUtils.isBlank(property.getProperty("zeppelin.livy.http.headers"))) {
       String[] headers = property.getProperty("zeppelin.livy.http.headers").split(";");
@@ -338,7 +341,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
         if ((System.currentTimeMillis() - start) / 1000 > sessionCreationTimeout) {
           String msg = "The creation of session " + sessionInfo.id + " is timeout within "
               + sessionCreationTimeout + " seconds, appId: " + sessionInfo.appId
-              + ", log: " + sessionInfo.log;
+              + ", log:\n" + StringUtils.join(getSessionLog(sessionInfo.id).log, "\n");
           throw new LivyException(msg);
         }
         Thread.sleep(pullStatusInterval);
@@ -347,7 +350,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
             sessionInfo.appId);
         if (sessionInfo.isFinished()) {
           String msg = "Session " + sessionInfo.id + " is finished, appId: " + sessionInfo.appId
-              + ", log: " + sessionInfo.log;
+              + ", log:\n" + StringUtils.join(getSessionLog(sessionInfo.id).log, "\n");
           throw new LivyException(msg);
         }
       }
@@ -360,6 +363,11 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   private SessionInfo getSessionInfo(int sessionId) throws LivyException {
     return SessionInfo.fromJson(callRestAPI("/sessions/" + sessionId, "GET"));
+  }
+
+  private SessionLog getSessionLog(int sessionId) throws LivyException {
+    return SessionLog.fromJson(callRestAPI("/sessions/" + sessionId + "/log?size=" + maxLogLines,
+        "GET"));
   }
 
   public InterpreterResult interpret(String code,
@@ -819,6 +827,20 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
     public static SessionInfo fromJson(String json) {
       return gson.fromJson(json, SessionInfo.class);
+    }
+  }
+
+  private static class SessionLog {
+    public int id;
+    public int from;
+    public int size;
+    public List<String> log;
+
+    SessionLog() {
+    }
+
+    public static SessionLog fromJson(String json) {
+      return gson.fromJson(json, SessionLog.class);
     }
   }
 

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -97,6 +97,12 @@
         "description": "The interval for checking paragraph execution status",
         "type": "number"
       },
+      "zeppelin.livy.maxLogLines": {
+        "propertyName": "zeppelin.livy.maxLogLines",
+        "defaultValue": "1000",
+        "description": "Max number of lines of logs",
+        "type": "number"
+      },
       "livy.spark.jars.packages": {
         "propertyName": "livy.spark.jars.packages",
         "defaultValue": "",


### PR DESCRIPTION
### What is this PR for?
The current behavior we will only return 10 lines of log to frontend which is not enough for user. This PR would invoke another livy api to get more logs (by default it is 1000 lines)


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3497

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
Before
![screen shot 2018-05-24 at 2 09 09 pm](https://user-images.githubusercontent.com/164491/40473592-2c7cccfe-5f6f-11e8-8212-9bc7b5404bcc.png)

After
![screen shot 2018-05-24 at 4 25 51 pm](https://user-images.githubusercontent.com/164491/40473602-34452170-5f6f-11e8-967e-4956042aceec.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
