### PR TITLE
ZEPPELIN-3506. DepInterpreter is broken

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkInterpreter.java
@@ -31,6 +31,8 @@ import java.util.Properties;
  */
 public abstract class AbstractSparkInterpreter extends Interpreter {
 
+  private SparkInterpreter parentSparkInterpreter;
+
   public AbstractSparkInterpreter(Properties properties) {
     super(properties);
   }
@@ -54,4 +56,12 @@ public abstract class AbstractSparkInterpreter extends Interpreter {
   public abstract String getSparkUIUrl();
 
   public abstract boolean isUnsupportedSparkVersion();
+
+  public void setParentSparkInterpreter(SparkInterpreter parentSparkInterpreter) {
+    this.parentSparkInterpreter = parentSparkInterpreter;
+  }
+
+  public SparkInterpreter getParentSparkInterpreter() {
+    return parentSparkInterpreter;
+  }
 }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
@@ -244,7 +244,8 @@ public class NewSparkInterpreter extends AbstractSparkInterpreter {
   }
 
   private DepInterpreter getDepInterpreter() {
-    Interpreter p = getInterpreterInTheSameSessionByClassName(DepInterpreter.class.getName());
+    Interpreter p = getParentSparkInterpreter()
+        .getInterpreterInTheSameSessionByClassName(DepInterpreter.class.getName());
     if (p == null) {
       return null;
     }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
@@ -281,7 +281,8 @@ public class OldSparkInterpreter extends AbstractSparkInterpreter {
   }
 
   private DepInterpreter getDepInterpreter() {
-    Interpreter p = getInterpreterInTheSameSessionByClassName(DepInterpreter.class.getName());
+    Interpreter p = getParentSparkInterpreter()
+        .getInterpreterInTheSameSessionByClassName(DepInterpreter.class.getName());
     if (p == null) {
       return null;
     }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -50,6 +50,7 @@ public class SparkInterpreter extends AbstractSparkInterpreter {
     } else {
       delegation = new OldSparkInterpreter(properties);
     }
+    delegation.setParentSparkInterpreter(this);
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
The bug is due to getInterpreterInTheSameSessionByClassName doesn't find the correct DepInterpreter. This PR fix this issue. The unit test fails due to classpath issue, will enable it later.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3506

### How should this be tested?
* CI pass and manually tested 

### Screenshots (if appropriate)
![screen shot 2018-05-28 at 11 49 33 am](https://user-images.githubusercontent.com/164491/40596424-36e407e2-626d-11e8-8965-05a5833af54c.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
