### PR TITLE
ZEPPELIN-3521 Dynamic note form overlaps with paragraph content in iframe page ("Link this paragraph")

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1498,7 +1498,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   });
 
   $scope.isShowNoteForms = function() {
-    if ($scope.note && !angular.equals({}, $scope.note.noteForms)) {
+    if ($scope.note && !_.isEmpty($scope.note.noteForms) && !$scope.paragraphUrl) {
       return true;
     }
     return false;


### PR DESCRIPTION
### What is this PR for?
Dynamic note form overlaps with paragraph content in iframe page ("Link this paragraph")

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3521

### How should this be tested?
Click on "Link this paragraph" from the paragraph menu to get paragraph in iframe mode

### Screenshots (if appropriate)
***Before***
<img width="755" alt="before" src="https://user-images.githubusercontent.com/2031306/40834926-c3783e22-65af-11e8-9ff1-39cb0ece60ff.png">
***After***
<img width="881" alt="after" src="https://user-images.githubusercontent.com/2031306/40834928-c4c43a1a-65af-11e8-947d-093cfcde38ef.png">


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
