### PR TITLE
[ZEPPELIN-3522] String "defaultValue" instead of boolean in some "interpreter-settings.json" files

### DIFF
--- a/cassandra/src/main/resources/interpreter-setting.json
+++ b/cassandra/src/main/resources/interpreter-setting.json
@@ -224,7 +224,7 @@
       "cassandra.ssl.enabled": {
         "envName": null,
         "propertyName": "cassandra.ssl.enabled",
-        "defaultValue": "false",
+        "defaultValue": false,
         "description": "Cassandra SSL",
         "type": "checkbox"
       },

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -111,13 +111,13 @@
       },
       "zeppelin.livy.displayAppInfo": {
         "propertyName": "zeppelin.livy.displayAppInfo",
-        "defaultValue": "true",
+        "defaultValue": true,
         "description": "Whether display app info",
         "type": "checkbox"
       },
       "zeppelin.livy.restart_dead_session": {
         "propertyName": "zeppelin.livy.restart_dead_session",
-        "defaultValue": "false",
+        "defaultValue": false,
         "description": "Whether restart a dead session",
         "type": "checkbox"
       }


### PR DESCRIPTION
### What is this PR for?
The _interpreter-settings.json_ file for each interpreter has details of each configurable parameter for that interpreter. Each parameter also has a _defaultValue_ setting. For boolean-typed parameters the _defaultValue_ must be set to _true_ or _false_.

But in some _interpreter-settings.json_ files, the _defaultValue_ has been set to the string values _"true"_ or _"false"_ (the quote marks are included in the value provided). 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3522

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
