### PR TITLE
ZEPPELIN-3520. Use the first one as the default value of dynamic form dropdown list

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkZeppelinContext.java
@@ -177,7 +177,7 @@ public class SparkZeppelinContext extends BaseZeppelinContext {
 
   @ZeppelinApi
   public Object select(String name, scala.collection.Iterable<Tuple2<Object, String>> options) {
-    return select(name, "", options);
+    return select(name, null, options);
   }
 
   @ZeppelinApi

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -571,7 +571,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Output text should not display any of the options in select form",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
-              CoreMatchers.equalTo("Howdy "));
+              CoreMatchers.equalTo("Howdy 1"));
 
       Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[1]"))));
 
@@ -649,13 +649,13 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Output text should not display any of the options in select form",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
-              CoreMatchers.equalTo("Howdy \nHowdy "));
+              CoreMatchers.equalTo("Howdy 1\nHowdy 1"));
 
       Select dropDownMenu = new Select(driver.findElement(By.xpath("(" + (getParagraphXPath(1) + "//select)[1]"))));
       dropDownMenu.selectByVisibleText("Apple");
       collector.checkThat("After selection in drop down menu, output should display the new option we selected",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
-              CoreMatchers.equalTo("Howdy 1\nHowdy "));
+              CoreMatchers.equalTo("Howdy 1\nHowdy 1"));
 
       driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
       clickAndWait(By.xpath(getParagraphXPath(1) + "//ul/li/form/input[contains(@ng-checked, 'true')]"));
@@ -665,7 +665,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       waitForParagraph(1, "FINISHED");
       collector.checkThat("After 'Run on selection change' checkbox is unchecked, the paragraph should not run if selecting a different option",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),
-              CoreMatchers.equalTo("Howdy 1\nHowdy "));
+              CoreMatchers.equalTo("Howdy 1\nHowdy 1"));
 
       deleteTestNotebook(driver);
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
@@ -91,11 +91,15 @@ public class GUI implements Serializable {
   }
 
   public Object select(String id, Object defaultValue, ParamOption[] options) {
+    if (defaultValue == null && options != null && options.length > 0) {
+      defaultValue = options[0].getValue();
+    }
+    forms.put(id, new Select(id, defaultValue, options));
     Object value = params.get(id);
     if (value == null) {
       value = defaultValue;
+      params.put(id, value);
     }
-    forms.put(id, new Select(id, defaultValue, options));
     return value;
   }
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
@@ -47,6 +47,22 @@ public class GUITest {
   }
 
   @Test
+  public void testSelect() {
+    GUI gui = new GUI();
+    Object selected = gui.select("list_1", null, options);
+    // use the first one as the default value
+    assertEquals("1", selected);
+
+    gui = new GUI();
+    selected = gui.select("list_1", "2", options);
+    assertEquals("2", selected);
+    // "2" is selected by above statement, so even this default value is "1", the selected value is
+    // still "2"
+    selected = gui.select("list_1", "1", options);
+    assertEquals("2", selected);
+  }
+
+  @Test
   public void testGson() {
     GUI gui = new GUI();
     gui.textbox("textbox_1", "default_text_1");


### PR DESCRIPTION
### What is this PR for?
This PR would use the first one as the default value of dynamic form dropdown list. Otherwise user will get error when the return value of null. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3520
### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
