### PR TITLE
[ZEPPELIN-3526] Zeppelin auth mechanisms (LDAP or password based) should be mutually exclusive

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -104,6 +104,9 @@ To learn more about Apache Shiro Realm, please check [this documentation](http:/
 
 We also provide community custom Realms.
 
+**Note**: When using any of the below realms the default 
+      password-based (IniRealm) authentication needs to be disabled.
+
 ### Active Directory
 
 ```
@@ -267,6 +270,7 @@ If you want to grant this permission to other users, you can change **roles[ ]**
 
 ### Apply multiple roles in Shiro configuration
 By default, Shiro will allow access to a URL if only user is part of "**all the roles**" defined like this:
+
 ```
 [urls]
 
@@ -274,6 +278,7 @@ By default, Shiro will allow access to a URL if only user is part of "**all the 
 ```
 
 If there is a need that user with "**any of the defined roles**" should be allowed, then following Shiro configuration can be used:
+
 ```
 [main]
 anyofroles = org.apache.zeppelin.utils.AnyOfRolesAuthorizationFilter


### PR DESCRIPTION
### What is this PR for?
Problem:
When any external authentication (like LDAP/AD) is enabled for Zeppelin, the default password-based authentication could still be configured in addition to that. This makes space for backdoor in Zeppelin where the user can still get in using the local username/password.

Proposed Solution:
Zeppelin shouldn't allow specifying [users] section in shiro.ini when it is configured to authenticate with LDAP/AD.


### What type of PR is it?
[Bug Fix | Feature ]

### Todos
* [x] - Add documentation 

### What is the Jira issue?
* [ZEPPELIN-3526](https://issues.apache.org/jira/browse/ZEPPELIN-3526)

### How should this be tested?
If both [users] and [main] for example activeDirectoryRealm section enabled in shiro, Zeppelin server should not start.
