### PR TITLE
[ZEPPELIN-3528] Ordering by interpreter name in same interpreter group

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -917,7 +917,7 @@ public class InterpreterSettingManager {
         } else if (i > j) {
           return 1;
         } else {
-          return 0;
+          return o1.getName().compareTo(o2.getName());
         }
       }
     });


### PR DESCRIPTION
### What is this PR for?
In 'Create new note' diagram, 'Default Interpreter' is ordered by only interpreter groups.

But interpreter is not ordered in same interpreter group.
(It seems to be ordered by hashcode of 'InterpreterSetting')

When there are many interpreter in same group and this group is first,
user cannot predict what interpreter is showed first.

So I think that interpreter need to be ordered by name.


### What type of PR is it?
[Improvement]

### Todos
* [x] - Modify Code

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3528

### How should this be tested?
* Click 'create new note'

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No
