### PR TITLE
[ZEPPELIN-3529] Add uName into jobGroupId for checking user

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/Utils.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/Utils.java
@@ -149,7 +149,11 @@ class Utils {
   }
   
   public static String buildJobGroupId(InterpreterContext context) {
-    return "zeppelin-" + context.getNoteId() + "-" + context.getParagraphId();
+    String uName = "anonymous";
+    if (context.getAuthenticationInfo() != null) {
+      uName = getUserName(context.getAuthenticationInfo());
+    }
+    return "zeppelin-" + uName + "-" + context.getNoteId() + "-" + context.getParagraphId();
   }
 
   public static String buildJobDesc(InterpreterContext context) {


### PR DESCRIPTION
### What is this PR for?
Need to check user in jobGroupId
because when some paragraph is running,
who run paragraph cannot be found in spark application web UI.

I just add to userId.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Modify Code

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3529

### How should this be tested?
* Check jobGroupId in Spark Application Web UI of Zeppelin Spark Interpreter

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No
