### PR TITLE
[HOTFIX] ZEPPELIN-2221's dependency issue

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -102,6 +102,10 @@
           <groupId>net.sf.py4j</groupId>
           <artifactId>py4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -102,10 +102,6 @@
           <groupId>net.sf.py4j</groupId>
           <artifactId>py4j</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
@@ -134,6 +130,18 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>2.6.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.2.0</version>
+      <version>2.6.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -49,14 +49,8 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.6.5</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
 
     <!--
-      Those two are for ZEPPELIN-2221 using VersionInfo for check the version of Yarn.
+      This is for ZEPPELIN-2221 using VersionInfo for check the version of Yarn.
       It's checked that VersionInfo is compatible at least 2.2.0 to the latest one.
     -->
     <dependency>
@@ -51,6 +51,12 @@
       <artifactId>hadoop-common</artifactId>
       <version>2.6.5</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -52,13 +52,6 @@
       <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>2.2.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
 
     <!--
-      This is for ZEPPELIN-2221 using VersionInfo for check the version of Yarn.
+      Those two are for ZEPPELIN-2221 using VersionInfo for check the version of Yarn.
       It's checked that VersionInfo is compatible at least 2.2.0 to the latest one.
     -->
     <dependency>
@@ -51,6 +51,13 @@
       <artifactId>hadoop-common</artifactId>
       <version>2.2.0</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.2.0</version>
+      <version>2.6.5</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### What is this PR for?
Fixing some CI by changing `hadoop-client` version of ₩spark_core` and `guava` version of `zeppelin-python`. We basically remove `zeppelin-python` dependency from `zeppelin-spark` interpreter in a near future.

### What type of PR is it?
[Hot Fix]

### Todos
* [x] - Fix dependency problem between hadoop-client and guava

### What is the Jira issue?
N/A

### How should this be tested?
* It should pass CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
