### PR TITLE
[HOTFIX][ZEPPELIN-3526] fix when no shiro.ini exists

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.server;
 
 import java.util.Collection;
 import org.apache.commons.lang.StringUtils;
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.web.env.EnvironmentLoaderListener;
@@ -102,19 +103,25 @@ public class ZeppelinServer extends Application {
 
   public ZeppelinServer() throws Exception {
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-    Collection<Realm> realms = ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils
-        .getSecurityManager()).getRealms();
-    if (realms.size() > 1) {
-      Boolean isIniRealmEnabled = false;
-      for (Object realm : realms) {
-        if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
-          isIniRealmEnabled = true;
-          break;
+    if (conf.getShiroPath().length() > 0) {
+      try {
+        Collection<Realm> realms = ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils
+            .getSecurityManager()).getRealms();
+        if (realms.size() > 1) {
+          Boolean isIniRealmEnabled = false;
+          for (Object realm : realms) {
+            if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
+              isIniRealmEnabled = true;
+              break;
+            }
+          }
+          if (isIniRealmEnabled) {
+            throw new Exception("IniRealm/password based auth mechanisms should be exclusive. "
+                + "Consider removing [users] block from shiro.ini");
+          }
         }
-      }
-      if (isIniRealmEnabled) {
-        throw new Exception("IniRealm/password based auth mechanisms should be exclusive. "
-            + "Consider removing [users] block from shiro.ini");
+      } catch (UnavailableSecurityManagerException e) {
+        LOG.error("Failed to initialise shiro configuraion", e);
       }
     }
 


### PR DESCRIPTION
### What is this PR for?
This is a side effect of ZEPPELIN-3526, occurs when there's no shiro.ini in the classpath.

### What type of PR is it?
[Hot Fix]

### How should this be tested?
* CI should be green


### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
