### PR TITLE
ZEPPELIN-3422 Add JMX support

### DIFF
--- a/bin/common.cmd
+++ b/bin/common.cmd
@@ -71,6 +71,14 @@ if not defined ZEPPELIN_JAVA_OPTS (
     set ZEPPELIN_JAVA_OPTS=%ZEPPELIN_JAVA_OPTS% -Dfile.encoding=%ZEPPELIN_ENCODING% %ZEPPELIN_MEM%
 )
 
+if defined ZEPPELIN_JMX_ENABLE (
+  if not defined ZEPPELIN_JMX_PORT (
+    set ZEPPELIN_JMX_PORT="9996"
+  }
+  set JMX_JAVA_OPTS=" -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${ZEPPELIN_JMX_PORT} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+  set ZEPPELIN_JAVA_OPTS=%JMX_JAVA_OPTS% %ZEPPELIN_JAVA_OPTS
+)
+
 if not defined JAVA_OPTS (
     set JAVA_OPTS=%ZEPPELIN_JAVA_OPTS%
 ) else (

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -121,19 +121,15 @@ JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPEL
 JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
 export JAVA_OPTS
 
-if [[ -n "${ZEPPELIN_JMX_ENABLE}" ]]; then
-  if [[ -n "${ZEPPELIN_JMX_OVERRIDE}" ]]; then
-    JAVA_OPTS="${ZEPPELIN_JMX_OVERRIDE} ${JAVA_OPTS}"
-  else
-    if [[ -z "${ZEPPELIN_JMX_PORT}" ]]; then
-      ZEPPELIN_JMX_PORT="9996"
-    fi
-    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote"
-    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.port=${ZEPPELIN_JMX_PORT}"
-    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.authenticate=false"
-    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.ssl=false"
-    JAVA_OPTS="${JMX_JAVA_OPTS} ${JAVA_OPTS}"
+if [[ x"${ZEPPELIN_JMX_ENABLE}" == x"true" ]]; then
+  if [[ -z "${ZEPPELIN_JMX_PORT}" ]]; then
+    ZEPPELIN_JMX_PORT="9996"
   fi
+  JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote"
+  JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.port=${ZEPPELIN_JMX_PORT}"
+  JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.authenticate=false"
+  JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.ssl=false"
+  JAVA_OPTS="${JMX_JAVA_OPTS} ${JAVA_OPTS}"
 fi
 export JAVA_OPTS
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -121,6 +121,22 @@ JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPEL
 JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
 export JAVA_OPTS
 
+if [[ -n "${ZEPPELIN_JMX_ENABLE}" ]]; then
+  if [[ -n "${ZEPPELIN_JMX_OVERRIDE}" ]]; then
+    JAVA_OPTS="${ZEPPELIN_JMX_OVERRIDE} ${JAVA_OPTS}"
+  else
+    if [[ -z "${ZEPPELIN_JMX_PORT}" ]]; then
+      ZEPPELIN_JMX_PORT="9996"
+    fi
+    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote"
+    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.port=${ZEPPELIN_JMX_PORT}"
+    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.authenticate=false"
+    JMX_JAVA_OPTS+=" -Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_OPTS="${JMX_JAVA_OPTS} ${JAVA_OPTS}"
+  fi
+fi
+export JAVA_OPTS
+
 JAVA_INTP_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
 if [[ -z "${ZEPPELIN_SPARK_YARN_CLUSTER}" ]]; then
     JAVA_INTP_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"

--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -24,7 +24,6 @@ REM set ZEPPELIN_INTP_MEM       		REM zeppelin interpreter process jvm mem optio
 REM set ZEPPELIN_INTP_JAVA_OPTS 		REM zeppelin interpreter process jvm options.
 REM set ZEPPELIN_JMX_ENABLE     		REM Enable JMX feature by defining it like "true"
 REM set ZEPPELIN_JMX_PORT       		REM Port number which JMX uses. Default: "9996"
-REM set ZEPPELIN_JMX_OVERRIDE   		REM Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 REM set ZEPPELIN_LOG_DIR        		REM Where log files are stored.  PWD by default.
 REM set ZEPPELIN_PID_DIR        		REM The pid files are stored. /tmp by default.

--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -22,9 +22,9 @@ REM set ZEPPELIN_JAVA_OPTS      		REM Additional jvm options. for example, set Z
 REM set ZEPPELIN_MEM            		REM Zeppelin jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 REM set ZEPPELIN_INTP_MEM       		REM zeppelin interpreter process jvm mem options. Default -Xmx1024m -Xms1024m -XX:MaxPermSize=512m
 REM set ZEPPELIN_INTP_JAVA_OPTS 		REM zeppelin interpreter process jvm options.
-REM set ZEPPELIN_JMX_ENABLE         REM Enable JMX feature by defining it like "true"
-REM set ZEPPELIN_JMX_PORT           REM Port number which JMX uses. Default: "9996"
-REM set ZEPPELIN_JMX_OVERRIDE       REM Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
+REM set ZEPPELIN_JMX_ENABLE     		REM Enable JMX feature by defining it like "true"
+REM set ZEPPELIN_JMX_PORT       		REM Port number which JMX uses. Default: "9996"
+REM set ZEPPELIN_JMX_OVERRIDE   		REM Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 REM set ZEPPELIN_LOG_DIR        		REM Where log files are stored.  PWD by default.
 REM set ZEPPELIN_PID_DIR        		REM The pid files are stored. /tmp by default.

--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -22,6 +22,9 @@ REM set ZEPPELIN_JAVA_OPTS      		REM Additional jvm options. for example, set Z
 REM set ZEPPELIN_MEM            		REM Zeppelin jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 REM set ZEPPELIN_INTP_MEM       		REM zeppelin interpreter process jvm mem options. Default -Xmx1024m -Xms1024m -XX:MaxPermSize=512m
 REM set ZEPPELIN_INTP_JAVA_OPTS 		REM zeppelin interpreter process jvm options.
+REM set ZEPPELIN_JMX_ENABLE         REM Enable JMX feature by defining it like "true"
+REM set ZEPPELIN_JMX_PORT           REM Port number which JMX uses. Default: "9996"
+REM set ZEPPELIN_JMX_OVERRIDE       REM Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 REM set ZEPPELIN_LOG_DIR        		REM Where log files are stored.  PWD by default.
 REM set ZEPPELIN_PID_DIR        		REM The pid files are stored. /tmp by default.

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -23,6 +23,9 @@
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options.
 # export ZEPPELIN_SSL_PORT       		# ssl port (used when ssl environment variable is set to true)
+# export ZEPPELIN_JMX_ENABLE        # Enable JMX feature by defining it like "true"
+# export ZEPPELIN_JMX_PORT          # Port number which JMX uses. Default: "9996"
+# export ZEPPELIN_JMX_OVERRIDE      # Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -23,9 +23,8 @@
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options.
 # export ZEPPELIN_SSL_PORT       		# ssl port (used when ssl environment variable is set to true)
-# export ZEPPELIN_JMX_ENABLE    		# Enable JMX feature by defining it like "true"
+# export ZEPPELIN_JMX_ENABLE    		# Enable JMX feature by defining "true"
 # export ZEPPELIN_JMX_PORT      		# Port number which JMX uses. Default: "9996"
-# export ZEPPELIN_JMX_OVERRIDE  		# Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -23,9 +23,9 @@
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options.
 # export ZEPPELIN_SSL_PORT       		# ssl port (used when ssl environment variable is set to true)
-# export ZEPPELIN_JMX_ENABLE      	# Enable JMX feature by defining it like "true"
-# export ZEPPELIN_JMX_PORT        	# Port number which JMX uses. Default: "9996"
-# export ZEPPELIN_JMX_OVERRIDE    	# Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
+# export ZEPPELIN_JMX_ENABLE    		# Enable JMX feature by defining it like "true"
+# export ZEPPELIN_JMX_PORT      		# Port number which JMX uses. Default: "9996"
+# export ZEPPELIN_JMX_OVERRIDE  		# Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -23,9 +23,9 @@
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options.
 # export ZEPPELIN_SSL_PORT       		# ssl port (used when ssl environment variable is set to true)
-# export ZEPPELIN_JMX_ENABLE        # Enable JMX feature by defining it like "true"
-# export ZEPPELIN_JMX_PORT          # Port number which JMX uses. Default: "9996"
-# export ZEPPELIN_JMX_OVERRIDE      # Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
+# export ZEPPELIN_JMX_ENABLE      	# Enable JMX feature by defining it like "true"
+# export ZEPPELIN_JMX_PORT        	# Port number which JMX uses. Default: "9996"
+# export ZEPPELIN_JMX_OVERRIDE    	# Override all of JMX options. This will replace any default setting including ZEPPELIN_JMX_PORT
 
 # export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR        		# The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -202,7 +202,7 @@ public class ZeppelinServer extends Application {
     this.interpreterService = new InterpreterService(conf, interpreterSettingManager);
 
     // Register MBean
-    if (null != System.getenv("ZEPPELIN_ENABLE_JMX")) {
+    if ("true".equals(System.getenv("ZEPPELIN_ENABLE_JMX"))) {
       MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
       try {
         mBeanServer.registerMBean(

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -202,19 +202,22 @@ public class ZeppelinServer extends Application {
     this.interpreterService = new InterpreterService(conf, interpreterSettingManager);
 
     // Register MBean
-    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    try {
-      mBeanServer.registerMBean(
-          notebookWsServer,
-          new ObjectName("org.apache.zeppelin:type=" + NotebookServer.class.getSimpleName()));
-      mBeanServer.registerMBean(
-          interpreterSettingManager,
-          new ObjectName(
-              "org.apache.zeppelin:type=" + InterpreterSettingManager.class.getSimpleName()));
-    } catch (InstanceAlreadyExistsException | MBeanRegistrationException
-        | MalformedObjectNameException
-        | NotCompliantMBeanException e) {
-      e.printStackTrace();
+    if (null != System.getenv("ZEPPELIN_ENABLE_JMX")) {
+      MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+      try {
+        mBeanServer.registerMBean(
+            notebookWsServer,
+            new ObjectName("org.apache.zeppelin:type=" + NotebookServer.class.getSimpleName()));
+        mBeanServer.registerMBean(
+            interpreterSettingManager,
+            new ObjectName(
+                "org.apache.zeppelin:type=" + InterpreterSettingManager.class.getSimpleName()));
+      } catch (InstanceAlreadyExistsException
+          | MBeanRegistrationException
+          | MalformedObjectNameException
+          | NotCompliantMBeanException e) {
+        LOG.error("Failed to register MBeans", e);
+      }
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -16,7 +16,14 @@
  */
 package org.apache.zeppelin.server;
 
+import java.lang.management.ManagementFactory;
 import java.util.Collection;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.realm.Realm;
@@ -193,6 +200,22 @@ public class ZeppelinServer extends Application {
     notebook.addNotebookEventListener(heliumApplicationFactory);
     notebook.addNotebookEventListener(notebookWsServer.getNotebookInformationListener());
     this.interpreterService = new InterpreterService(conf, interpreterSettingManager);
+
+    // Register MBean
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    try {
+      mBeanServer.registerMBean(
+          notebookWsServer,
+          new ObjectName("org.apache.zeppelin:type=" + NotebookServer.class.getSimpleName()));
+      mBeanServer.registerMBean(
+          interpreterSettingManager,
+          new ObjectName(
+              "org.apache.zeppelin:type=" + InterpreterSettingManager.class.getSimpleName()));
+    } catch (InstanceAlreadyExistsException | MBeanRegistrationException
+        | MalformedObjectNameException
+        | NotCompliantMBeanException e) {
+      e.printStackTrace();
+    }
   }
 
   public static void main(String[] args) throws InterruptedException {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -100,13 +100,14 @@ import org.apache.zeppelin.utils.InterpreterBindingUtils;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 
-
-/**
- * Zeppelin websocket service.
- */
+/** Zeppelin websocket service. */
 public class NotebookServer extends WebSocketServlet
-    implements NotebookSocketListener, JobListenerFactory, AngularObjectRegistryListener,
-    RemoteInterpreterProcessListener, ApplicationEventListener {
+    implements NotebookSocketListener,
+        JobListenerFactory,
+        AngularObjectRegistryListener,
+        RemoteInterpreterProcessListener,
+        ApplicationEventListener,
+        NotebookServerMBean {
 
   /**
    * Job manager service type.
@@ -2705,5 +2706,21 @@ public class NotebookServer extends WebSocketServlet
       note.persist(subject);
       broadcastNoteForms(note);
     }
+  }
+
+  @Override
+  public Set<String> getConnectedUsers() {
+    Set<String> connectionList = Sets.newHashSet();
+    for (NotebookSocket notebookSocket : connectedSockets) {
+      connectionList.add(notebookSocket.getUser());
+    }
+    return connectionList;
+  }
+
+  @Override
+  public void sendMessage(String message) {
+    Message m = new Message(OP.NOTICE);
+    m.data.put("notice", message);
+    broadcast(m);
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServerMBean.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServerMBean.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.socket;
 
 import java.util.Set;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServerMBean.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServerMBean.java
@@ -1,0 +1,9 @@
+package org.apache.zeppelin.socket;
+
+import java.util.Set;
+
+public interface NotebookServerMBean {
+  Set<String> getConnectedUsers();
+
+  void sendMessage(String message);
+}

--- a/zeppelin-web/package-lock.json
+++ b/zeppelin-web/package-lock.json
@@ -154,21 +154,23 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
-    "angular": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.11.tgz",
-      "integrity": "sha1-jFunOG8VllyazzQp9ogVU6raMNY="
-    },
     "angular-ui-grid": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/angular-ui-grid/-/angular-ui-grid-4.0.11.tgz",
-      "integrity": "sha1-lqp1KkH2CiVMGeBSV2iehMZhhiY=",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/angular-ui-grid/-/angular-ui-grid-4.4.6.tgz",
+      "integrity": "sha512-0d14HDY4XeqFHI508thxeufiR0AlFoZQ8ihk0x8TRCQc+b9CCk1/F63W2zihirxF0cdOAqBCY2pVSM7vfZvXBQ==",
       "requires": {
-        "angular": "1.5.11"
+        "angular": "1.6.10"
+      },
+      "dependencies": {
+        "angular": {
+          "version": "1.6.10",
+          "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.10.tgz",
+          "integrity": "sha512-PCZ5/hVdvPQiYyH0VwsPjrErPHRcITnaXxhksceOXgtJeesKHLA7KDu4X/yvcAi+1zdGgGF+9pDxkJvghXI9Wg=="
+        }
       }
     },
     "angular-viewport-watch": {
-      "version": "github:shahata/angular-viewport-watch#182923b3934e63817b6fc7b640ecb5c4a011f74c"
+      "version": "github:wix/angular-viewport-watch#182923b3934e63817b6fc7b640ecb5c4a011f74c"
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -2384,6 +2386,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
       "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
       "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg="
     },
     "doctrine": {
       "version": "2.0.2",

--- a/zeppelin-web/package-lock.json
+++ b/zeppelin-web/package-lock.json
@@ -154,23 +154,21 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "angular": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.11.tgz",
+      "integrity": "sha1-jFunOG8VllyazzQp9ogVU6raMNY="
+    },
     "angular-ui-grid": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/angular-ui-grid/-/angular-ui-grid-4.4.6.tgz",
-      "integrity": "sha512-0d14HDY4XeqFHI508thxeufiR0AlFoZQ8ihk0x8TRCQc+b9CCk1/F63W2zihirxF0cdOAqBCY2pVSM7vfZvXBQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/angular-ui-grid/-/angular-ui-grid-4.0.11.tgz",
+      "integrity": "sha1-lqp1KkH2CiVMGeBSV2iehMZhhiY=",
       "requires": {
-        "angular": "1.6.10"
-      },
-      "dependencies": {
-        "angular": {
-          "version": "1.6.10",
-          "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.10.tgz",
-          "integrity": "sha512-PCZ5/hVdvPQiYyH0VwsPjrErPHRcITnaXxhksceOXgtJeesKHLA7KDu4X/yvcAi+1zdGgGF+9pDxkJvghXI9Wg=="
-        }
+        "angular": "1.5.11"
       }
     },
     "angular-viewport-watch": {
-      "version": "github:wix/angular-viewport-watch#182923b3934e63817b6fc7b640ecb5c4a011f74c"
+      "version": "github:shahata/angular-viewport-watch#182923b3934e63817b6fc7b640ecb5c4a011f74c"
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -2386,11 +2384,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
       "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
       "dev": true
-    },
-    "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg="
     },
     "doctrine": {
       "version": "2.0.2",

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -185,6 +185,8 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, ng
       ngToast.info(data.message);
     } else if (op === 'INTERPRETER_INSTALL_RESULT') {
       ngToast.info(data.message);
+    } else if (op === 'NOTICE') {
+      ngToast.info(data.notice);
     } else {
       console.error(`unknown websocket op: ${op}`);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -81,7 +81,7 @@ import java.util.Map;
  * Besides that InterpreterSettingManager also manage the interpreter setting binding.
  * TODO(zjffdu) We could move it into another separated component.
  */
-public class InterpreterSettingManager {
+public class InterpreterSettingManager implements InterpreterSettingManagerMBean {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterSettingManager.class);
   private static final Map<String, Object> DEFAULT_EDITOR = ImmutableMap.of(
@@ -957,5 +957,18 @@ public class InterpreterSettingManager {
         LOGGER.error("Can't close interpreterGroup", e);
       }
     }
+  }
+
+  @Override
+  public Set<String> getRunningInterpreters() {
+    Set<String> runningInterpreters = Sets.newHashSet();
+    for (Map.Entry<String, InterpreterSetting> entry : interpreterSettings.entrySet()) {
+      for (ManagedInterpreterGroup mig : entry.getValue().getAllInterpreterGroups()) {
+        if (null != mig.getRemoteInterpreterProcess()) {
+          runningInterpreters.add(entry.getKey());
+        }
+      }
+    }
+    return runningInterpreters;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerMBean.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerMBean.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.interpreter;
 
 import java.util.Set;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerMBean.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerMBean.java
@@ -1,0 +1,7 @@
+package org.apache.zeppelin.interpreter;
+
+import java.util.Set;
+
+public interface InterpreterSettingManagerMBean {
+  Set<String> getRunningInterpreters();
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -190,7 +190,8 @@ public class Message implements JsonSerializable {
     INTERPRETER_INSTALL_STARTED,  // [s-c] start to download an interpreter
     INTERPRETER_INSTALL_RESULT,   // [s-c] Status of an interpreter installation
     COLLABORATIVE_MODE_STATUS,    // [s-c] collaborative mode status
-    PATCH_PARAGRAPH               // [c-s][s-c] patch editor text
+    PATCH_PARAGRAPH,              // [c-s][s-c] patch editor text
+    NOTICE                        // [s-c] Notice
   }
 
   private static final Gson gson = new Gson();


### PR DESCRIPTION
### What is this PR for?
Providing JMX support optionally and add some MBeans for checking a basic status


### What type of PR is it?
[Improvement]

### Todos
* [x] - Add JMX options to `JAVA_OPTS`
* [x] - Add Mbeans

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3422

### How should this be tested?
* You can connect JMX with the port # of 9996 by defining `ZEPPELIN_JMX_ENABLE`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
