### PR TITLE
[ZEPPELIN-2605] Import notebook has 1MB size limit but bigger notebooks can be saved without error or warning

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -220,9 +220,29 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   // Export notebook
+  let limit = 0;
+
+  websocketMsgSrv.listConfigurations();
+  $scope.$on('configurationsInfo', function(scope, event) {
+    limit = event.configurations['zeppelin.websocket.max.text.message.size'];
+  });
+
   $scope.exportNote = function() {
     let jsonContent = JSON.stringify($scope.note);
-    saveAsService.saveAs(jsonContent, $scope.note.name, 'json');
+    if (jsonContent.length > limit) {
+      BootstrapDialog.confirm({
+        closable: true,
+        title: 'Note size exceeds importable limit (' + limit + ')',
+        message: 'Do you still want to export this note?',
+        callback: function(result) {
+          if (result) {
+            saveAsService.saveAs(jsonContent, $scope.note.name, 'json');
+          }
+        },
+      });
+    } else {
+      saveAsService.saveAs(jsonContent, $scope.note.name, 'json');
+    }
   };
 
   // Clone note


### PR DESCRIPTION
### What is this PR for?
Notebooks of any size can be exported and saved, but the import facility only accepts notebooks up to 1Mb in size. Allowing notebooks bigger than 1Mb to be saved silently (without any warning or error notification) is therefore a dangerous trap for users.

It has been argued that notebooks bigger than 1Mb are rare and unusual, but a saved notebook also contains the displayed output - and can contain large volumes of tabular data, and even images from matplotlib output. Large notebooks can be common when zeppelin is used for presentation of visual analysis.

This PR adds a popup dialog which is displayed when the user attempts to export a notebook that has a size exceeding 1Mb. A screenshot of the popup is shown below.

![popup-dialog](https://user-images.githubusercontent.com/477015/41522941-cb2c5c7c-72f5-11e8-83e6-b3f6f29ee834.png)

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2605

### How should this be tested?
CI pass
Manual testing. A notebook that is small when outputs are cleared, but becomes bigger than the limit when all cells are run is included (big-output-tester.json).

[big-output-tester.json.zip](https://github.com/apache/zeppelin/files/2110281/big-output-tester.json.zip)

### Screenshots (if appropriate)
See above.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
