### PR TITLE
[ZEPPELIN-3549] Add to shiro.ini authorization for notebook-repositories

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -114,6 +114,7 @@ admin = *
 # Comment out the following line if you would like to authorize only admin users to restart interpreters.
 /api/interpreter/setting/restart/** = authc
 /api/interpreter/** = authc, roles[admin]
+/api/notebook-repositories/** = authc, roles[admin]
 /api/configurations/** = authc, roles[admin]
 /api/credential/** = authc, roles[admin]
 #/** = anon


### PR DESCRIPTION
### What is this PR for?
Small improvement that users cannot change notebook repositories by default.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-3549](https://issues.apache.org/jira/browse/ZEPPELIN-3549)

### How should this be tested?
- Check correct ulr for `/api/notebook-repositories/**`

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
