### PR TITLE
[ZEPPELIN-3553] Fix URLs on "Multi-user Support" page

### DIFF
--- a/docs/setup/basics/multi_user_support.md
+++ b/docs/setup/basics/multi_user_support.md
@@ -25,8 +25,8 @@ limitations under the License.
 
 This page describes about multi-user support.
 
-- multiple users login / logout using [Shiro Authentication](../setup/security/shiro_authentication.html)
-- managing [Notebook Permission](../setup/security/notebook_authorization.html)
+- multiple users login / logout using [Shiro Authentication](../security/shiro_authentication.html)
+- managing [Notebook Permission](../security/notebook_authorization.html)
 - how to setup [impersonation for interpreters](../../usage/interpreter/user_impersonation.html)
 - different contexts per user / note using [Interpreter Binding Mode](../../usage/interpreter/interpreter_binding_mode.html)
 - a paragraph in a notebook can be [Personalized](../../usage/other_features/personalized_mode.html) 


### PR DESCRIPTION
### What is this PR for?
On page Setup > Multi-user Support http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/setup/basics/multi_user_support.html
there are two urls:
* Shiro Authentication - http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/setup/setup/security/shiro_authentication.html
* Notebook Permission - http://zeppelin.apache.org/docs/0.8.0-SNAPSHOT/setup/setup/security/notebook_authorization.html

Need to remove one of the "setup"

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3553](https://issues.apache.org/jira/browse/ZEPPELIN-3553)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? no 
