### PR TITLE
[ZEPPELIN-3555] Zeppelin auth fails if `activeDirectoryRealm.groupRolesMap` is not specified.

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -83,10 +83,6 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     this.groupRolesMap.putAll(groupRolesMap);
   }
 
-  public Map getGroupRolesMap() {
-    return groupRolesMap;
-  }
-
   LdapContextFactory ldapContextFactory;
 
   protected void onInit() {
@@ -278,7 +274,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   public Map<String, String> getListRoles() {
     Map<String, String> roles = new HashMap<>();
-    Iterator it = getGroupRolesMap().entrySet().iterator();
+    Iterator it = this.groupRolesMap.entrySet().iterator();
     while (it.hasNext()) {
       Map.Entry pair = (Map.Entry) it.next();
       roles.put((String) pair.getValue(), "*");

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -16,6 +16,7 @@
  */
 package org.apache.zeppelin.realm;
 
+import java.util.LinkedHashMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
@@ -76,10 +77,14 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
    * group names (e.g. CN=Group,OU=Company,DC=MyDomain,DC=local)
    * as returned by the active directory LDAP server to role names.
    */
-  private Map<String, String> groupRolesMap;
+  private Map<String, String> groupRolesMap = new LinkedHashMap<>();
 
   public void setGroupRolesMap(Map<String, String> groupRolesMap) {
-    this.groupRolesMap = groupRolesMap;
+    this.groupRolesMap.putAll(groupRolesMap);
+  }
+
+  public Map getGroupRolesMap() {
+    return groupRolesMap;
   }
 
   LdapContextFactory ldapContextFactory;
@@ -273,7 +278,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   public Map<String, String> getListRoles() {
     Map<String, String> roles = new HashMap<>();
-    Iterator it = this.groupRolesMap.entrySet().iterator();
+    Iterator it = getGroupRolesMap().entrySet().iterator();
     while (it.hasNext()) {
       Map.Entry pair = (Map.Entry) it.next();
       roles.put((String) pair.getValue(), "*");


### PR DESCRIPTION
### What is this PR for?
Zeppelin auth fails if `activeDirectoryRealm.groupRolesMap` is not specified.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3555](https://issues.apache.org/jira/browse/ZEPPELIN-3555)

### How should this be tested?
Zeppelin auth fails if `groupRolesMap` is not specified in `ActiveDirectoryGroupRealm`, with this PR following config should work;
```
activeDirectoryRealm = org.apache.zeppelin.realm.ActiveDirectoryGroupRealm
activeDirectoryRealm.systemUsername = userNameA
activeDirectoryRealm.systemPassword = passwordA
activeDirectoryRealm.searchBase = CN=Users,DC=SOME_GROUP,DC=COMPANY,DC=COM
activeDirectoryRealm.url = ldap://ldap.test.com:389
#activeDirectoryRealm.groupRolesMap = "CN=admin,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"admin","CN=finance,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"finance","CN=hr,OU=groups,DC=SOME_GROUP,DC=COMPANY,DC=COM":"hr"
activeDirectoryRealm.authorizationCachingEnabled = false
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
