### PR TITLE
ZEPPELIN-3570. Fix for doing user search for LDAPRealm

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -238,12 +238,14 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     return new SimpleAuthorizationInfo(roleNames);
   }
 
-  public List<String> searchForUserName(String containString, LdapContext ldapContext)
+  public List<String> searchForUserName(String containString, LdapContext ldapContext,
+      int numUsersToFetch)
           throws NamingException {
     List<String> userNameList = new ArrayList<>();
 
     SearchControls searchCtls = new SearchControls();
     searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+    searchCtls.setCountLimit(numUsersToFetch);
 
     String searchFilter = "(&(objectClass=*)(userPrincipalName=*" + containString + "*))";
     Object[] searchArguments = new Object[]{containString};

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/GetUserList.java
@@ -91,7 +91,7 @@ public class GetUserList {
   /**
    * Function to extract users from LDAP.
    */
-  public List<String> getUserList(JndiLdapRealm r, String searchText) {
+  public List<String> getUserList(JndiLdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     String userDnTemplate = r.getUserDnTemplate();
     String userDn[] = userDnTemplate.split(",", 2);
@@ -101,6 +101,7 @@ public class GetUserList {
     try {
       LdapContext ctx = cf.getSystemLdapContext();
       SearchControls constraints = new SearchControls();
+      constraints.setCountLimit(numUsersToFetch);
       constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
       String[] attrIDs = {userDnPrefix};
       constraints.setReturningAttributes(attrIDs);
@@ -123,7 +124,7 @@ public class GetUserList {
   /**
    * Function to extract users from Zeppelin LdapRealm.
    */
-  public List<String> getUserList(LdapRealm r, String searchText) {
+  public List<String> getUserList(LdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     if (LOG.isDebugEnabled()) {
       LOG.debug("SearchText: " + searchText);
@@ -136,11 +137,12 @@ public class GetUserList {
       LdapContext ctx = cf.getSystemLdapContext();
       SearchControls constraints = new SearchControls();
       constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
+      constraints.setCountLimit(numUsersToFetch);
       String[] attrIDs = {userAttribute};
       constraints.setReturningAttributes(attrIDs);
       NamingEnumeration result = ctx.search(userSearchRealm, "(&(objectclass=" + 
             userObjectClass + ")(" 
-            + userAttribute + "=" + searchText + "))", constraints);
+            + userAttribute + "=*" + searchText + "*))", constraints);
       while (result.hasMore()) {
         Attributes attrs = ((SearchResult) result.next()).getAttributes();
         if (attrs.get(userAttribute) != null) {
@@ -187,11 +189,12 @@ public class GetUserList {
     return roleList;
   }
 
-  public List<String> getUserList(ActiveDirectoryGroupRealm r, String searchText) {
+  public List<String> getUserList(ActiveDirectoryGroupRealm r, String searchText,
+      int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     try {
       LdapContext ctx = r.getLdapContextFactory().getSystemLdapContext();
-      userList = r.searchForUserName(searchText, ctx);
+      userList = r.searchForUserName(searchText, ctx, numUsersToFetch);
     } catch (Exception e) {
       LOG.error("Error retrieving User list from ActiveDirectory Realm", e);
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
@@ -109,6 +109,8 @@ public class SecurityRestApi {
   @GET
   @Path("userlist/{searchText}")
   public Response getUserList(@PathParam("searchText") final String searchText) {
+
+    final int numUsersToFetch = 5;
     List<String> usersList = new ArrayList<>();
     List<String> rolesList = new ArrayList<>();
     try {
@@ -125,13 +127,15 @@ public class SecurityRestApi {
             usersList.addAll(getUserListObj.getUserList((IniRealm) realm));
             rolesList.addAll(getUserListObj.getRolesList((IniRealm) realm));
           } else if (name.equals("org.apache.zeppelin.realm.LdapGroupRealm")) {
-            usersList.addAll(getUserListObj.getUserList((JndiLdapRealm) realm, searchText));
+            usersList.addAll(getUserListObj.getUserList((JndiLdapRealm) realm, searchText,
+                numUsersToFetch));
           } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
-            usersList.addAll(getUserListObj.getUserList((LdapRealm) realm, searchText));
+            usersList.addAll(getUserListObj.getUserList((LdapRealm) realm, searchText,
+                numUsersToFetch));
             rolesList.addAll(getUserListObj.getRolesList((LdapRealm) realm));
           } else if (name.equals("org.apache.zeppelin.realm.ActiveDirectoryGroupRealm")) {
             usersList.addAll(getUserListObj.getUserList((ActiveDirectoryGroupRealm) realm,
-                searchText));
+                searchText, numUsersToFetch));
           } else if (name.equals("org.apache.shiro.realm.jdbc.JdbcRealm")) {
             usersList.addAll(getUserListObj.getUserList((JdbcRealm) realm));
           }
@@ -161,7 +165,7 @@ public class SecurityRestApi {
         autoSuggestUserList.add(user);
         maxLength++;
       }
-      if (maxLength == 5) {
+      if (maxLength == numUsersToFetch) {
         break;
       }
     }


### PR DESCRIPTION
### What is this PR for?
To enable user search for LdapRealm.

### What type of PR is it?
Bug Fix 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3570

### How should this be tested?
For the below config 
```
[main]
ldapRealm = org.apache.zeppelin.realm.LdapRealm
ldapRealm.userDnTemplate = cn={0},ou=Users,dc=company,dc=com
ldapRealm.contextFactory.url = ldap://<ldap-server-host>:389
ldapRealm.contextFactory.authenticationMechanism = SIMPLE
ldapRealm.searchBase = dc=company,dc=com
ldapRealm.userSearchBase = dc=company,dc=com
ldapRealm.groupSearchBase = dc=company,dc=com
ldapRealm.userSearchAttributeName = uid

sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
securityManager.sessionManager = $sessionManager
securityManager.sessionManager.globalSessionTimeout = 86400000
shiro.loginUrl = /api/login
[urls]
/api/version = anon
/** = authc
```
user search in notebook/interpreter should work for partial string.

