### PR TITLE
Minor fix "ipykernel" package name shown in logs when ipython prerequisite isn't met

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -186,7 +186,7 @@ public class IPythonInterpreter extends Interpreter implements ExecuteResultHand
       if (!freezeOutput.contains("grpcio=")) {
         return "grpcio is not installed";
       }
-      LOGGER.info("IPython prerequisite is meet");
+      LOGGER.info("IPython prerequisite is met");
     } catch (Exception e) {
       LOGGER.warn("Fail to checkIPythonPrerequisite", e);
       return "Fail to checkIPythonPrerequisite: " + ExceptionUtils.getStackTrace(e);

--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -178,7 +178,7 @@ public class IPythonInterpreter extends Interpreter implements ExecuteResultHand
         return "jupyter-client is not installed.";
       }
       if (!freezeOutput.contains("ipykernel=")) {
-        return "ipkernel is not installed";
+        return "ipykernel is not installed";
       }
       if (!freezeOutput.contains("ipython=")) {
         return "ipython is not installed";


### PR DESCRIPTION
### What is this PR for?
minor fix to show correct package name `ipykernel` in logs when prerequisite for ipython interpreter isn't met.

### What type of PR is it?
[ Improvement ]

### Todos
* [x] - fix naming

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
if `ipykernel` isn't installed then it would show correct message in logs when running ipython interpreter

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
