### PR TITLE
ZEPPELIN-3581. Add "type": "textarea" to "default.statementPrecode" in interpreter-setting.json

### DIFF
--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -57,7 +57,8 @@
         "envName": null,
         "propertyName": "default.statementPrecode",
         "defaultValue": "",
-        "description": "Runs before each run of the paragraph, in the same connection"
+        "description": "Runs before each run of the paragraph, in the same connection",
+        "type": "textarea"
       },
       "default.splitQueries": {
         "envName": null,


### PR DESCRIPTION
### What is this PR for?
Fix "interpreter-setting.json" for JDBC interpreter

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3581](https://issues.apache.org/jira/browse/ZEPPELIN-3581)

### How should this be tested?
* Check text area near the "default.statementPrecode" setting.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
