### PR TITLE
[ZEPPELIN-3567] fix InterpreterContext convert(...) method

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -758,6 +758,8 @@ public class RemoteInterpreterServer extends Thread
         .setLocalProperties(ric.getLocalProperties())
         .setAuthenticationInfo(AuthenticationInfo.fromJson(ric.getAuthenticationInfo()))
         .setGUI(GUI.fromJson(ric.getGui()))
+        .setConfig(gson.fromJson(ric.getConfig(),
+                   new TypeToken<Map<String, Object>>() {}.getType()))
         .setNoteGUI(GUI.fromJson(ric.getNoteGui()))
         .setAngularObjectRegistry(interpreterGroup.getAngularObjectRegistry())
         .setResourcePool(interpreterGroup.getResourcePool())


### PR DESCRIPTION
### What is this PR for?
After commit [7af861...](https://github.com/apache/zeppelin/commit/7af86168254e0ad08234c57043e18179fca8d04c) will be lost convert of `config`.
This PR returning it back.
Because of this, the status of the autocomplete was lost after the run of the paragraph.

![tab_complition_fix](https://user-images.githubusercontent.com/30798933/42382820-17e4ea92-813e-11e8-994c-4791ccbfe16f.png)

### What type of PR is it?
Bug Fix

JIRA: [ZEPPELIN-3567](https://issues.apache.org/jira/browse/ZEPPELIN-3567)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
