### PR TITLE
[ZEPPELIN-3582] Add type data to result of query from SQL

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.tabledata.ColumnDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -777,7 +778,12 @@ public class JDBCInterpreter extends KerberosInterpreter {
               String results = getResults(resultSet, isTable, isComplete);
               List<ColumnDef.TYPE> columnTypes = getResultColumnTypes(resultSet);
 
-              interpreterResult.add(results);
+              final InterpreterResultMessage interpreterResMsg = new InterpreterResultMessage(
+                  isTable ? InterpreterResult.Type.TABLE : InterpreterResult.Type.TEXT,
+                  results,
+                  columnTypes
+              );
+              interpreterResult.add(interpreterResMsg);
               if (!isComplete.booleanValue()) {
                 interpreterResult.add(ResultMessages.getExceedsLimitRowsMessage(getMaxResult(),
                     String.format("%s.%s", COMMON_KEY, MAX_LINE_KEY)));

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -606,7 +606,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
       case REAL:
       case TINYINT:
       case SMALLINT:
-        return ColumnDef.TYPE.LONG;
+        return ColumnDef.TYPE.NUMBER;
       default:
         return ColumnDef.TYPE.STRING;
     }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -540,15 +540,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
     return null;
   }
 
-  private String getResults(ResultSet resultSet, boolean isTableType, MutableBoolean isComplete)
+  private String getResults(ResultSet resultSet, MutableBoolean isComplete)
       throws SQLException {
     ResultSetMetaData md = resultSet.getMetaData();
     StringBuilder msg;
-    if (isTableType) {
-      msg = new StringBuilder(TABLE_MAGIC_TAG);
-    } else {
-      msg = new StringBuilder();
-    }
+    msg = new StringBuilder();
 
     for (int i = 1; i < md.getColumnCount() + 1; i++) {
       if (i > 1) {
@@ -774,10 +770,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
                   "Query executed successfully.");
             } else {
               MutableBoolean isComplete = new MutableBoolean(true);
-              final Boolean isTable = !containsIgnoreCase(sqlToExecute, EXPLAIN_PREDICATE);
-              String results = getResults(resultSet, isTable, isComplete);
+
+              String results = getResults(resultSet, isComplete);
               List<ColumnDef.TYPE> columnTypes = getResultColumnTypes(resultSet);
 
+              final Boolean isTable = !containsIgnoreCase(sqlToExecute, EXPLAIN_PREDICATE);
               final InterpreterResultMessage interpreterResMsg = new InterpreterResultMessage(
                   isTable ? InterpreterResult.Type.TABLE : InterpreterResult.Type.TEXT,
                   results,

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -134,7 +134,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private static final char WHITESPACE = ' ';
   private static final char NEWLINE = '\n';
   private static final char TAB = '\t';
-  private static final String TABLE_MAGIC_TAG = "%table ";
   private static final String EXPLAIN_PREDICATE = "EXPLAIN ";
 
   static final String COMMON_MAX_LINE = COMMON_KEY + DOT + MAX_LINE_KEY;

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUtils.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.jdbc;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.mutable.MutableBoolean;
+import org.apache.zeppelin.tabledata.ColumnDef;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.sql.Types.BIGINT;
+import static java.sql.Types.DATE;
+import static java.sql.Types.DECIMAL;
+import static java.sql.Types.DOUBLE;
+import static java.sql.Types.FLOAT;
+import static java.sql.Types.INTEGER;
+import static java.sql.Types.NUMERIC;
+import static java.sql.Types.REAL;
+import static java.sql.Types.SMALLINT;
+import static java.sql.Types.TIME;
+import static java.sql.Types.TIMESTAMP;
+import static java.sql.Types.TIMESTAMP_WITH_TIMEZONE;
+import static java.sql.Types.TIME_WITH_TIMEZONE;
+import static java.sql.Types.TINYINT;
+
+public class JDBCUtils {
+  private static final String EMPTY_COLUMN_VALUE = "";
+  private static final char WHITESPACE = ' ';
+  private static final char NEWLINE = '\n';
+  private static final char TAB = '\t';
+  /**
+   * For %table response replace Tab and Newline characters from the content.
+   */
+  public static String replaceReservedChars(String str) {
+    if (str == null) {
+      return EMPTY_COLUMN_VALUE;
+    }
+    return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
+  }
+
+
+  public static String getResults(ResultSet resultSet, MutableBoolean isComplete, int maxResult)
+      throws SQLException {
+    ResultSetMetaData md = resultSet.getMetaData();
+    StringBuilder msg;
+    msg = new StringBuilder();
+
+    for (int i = 1; i < md.getColumnCount() + 1; i++) {
+      if (i > 1) {
+        msg.append(TAB);
+      }
+      msg.append(replaceReservedChars(md.getColumnName(i)));
+    }
+    msg.append(NEWLINE);
+
+    int displayRowCount = 0;
+    while (resultSet.next()) {
+      if (displayRowCount >= maxResult) {
+        isComplete.setValue(false);
+        break;
+      }
+      for (int i = 1; i < md.getColumnCount() + 1; i++) {
+        Object resultObject;
+        String resultValue;
+        resultObject = resultSet.getObject(i);
+        if (resultObject == null) {
+          resultValue = "null";
+        } else {
+          resultValue = resultSet.getString(i);
+        }
+        msg.append(replaceReservedChars(resultValue));
+        if (i != md.getColumnCount()) {
+          msg.append(TAB);
+        }
+      }
+      msg.append(NEWLINE);
+      displayRowCount++;
+    }
+    return msg.toString();
+  }
+
+  public static List<ColumnDef.TYPE> getResultColumnTypes(ResultSet resultSet) throws SQLException {
+    List<ColumnDef.TYPE> columnTypes = new ArrayList<>();
+    ResultSetMetaData md = resultSet.getMetaData();
+    for (int i = 1; i < md.getColumnCount() + 1; i++) {
+      final ColumnDef.TYPE columnType = castSqlTypeToColumnType(md.getColumnType(i));
+      columnTypes.add(columnType);
+    }
+    return columnTypes;
+  }
+
+  public static ColumnDef.TYPE castSqlTypeToColumnType(int t) {
+    switch(t) {
+      case DATE:
+      case TIME:
+      case TIME_WITH_TIMEZONE:
+      case TIMESTAMP:
+      case TIMESTAMP_WITH_TIMEZONE:
+        return ColumnDef.TYPE.DATE;
+      case BIGINT:
+      case DECIMAL:
+      case DOUBLE:
+      case FLOAT:
+      case INTEGER:
+      case NUMERIC:
+      case REAL:
+      case TINYINT:
+      case SMALLINT:
+        return ColumnDef.TYPE.NUMBER;
+      default:
+        return ColumnDef.TYPE.STRING;
+    }
+  }
+
+  /*
+  inspired from https://github.com/postgres/pgadmin3/blob/794527d97e2e3b01399954f3b79c8e2585b908dd/
+  pgadmin/dlg/dlgProperty.cpp#L999-L1045
+ */
+  public static ArrayList<String> splitSqlQueries(String sql) {
+    ArrayList<String> queries = new ArrayList<>();
+    StringBuilder query = new StringBuilder();
+    char character;
+
+    Boolean multiLineComment = false;
+    Boolean singleLineComment = false;
+    Boolean quoteString = false;
+    Boolean doubleQuoteString = false;
+
+    for (int item = 0; item < sql.length(); item++) {
+      character = sql.charAt(item);
+
+      if (singleLineComment && (character == '\n' || item == sql.length() - 1)) {
+        singleLineComment = false;
+      }
+
+      if (multiLineComment && character == '/' && sql.charAt(item - 1) == '*') {
+        multiLineComment = false;
+      }
+
+      if (character == '\'') {
+        if (quoteString) {
+          quoteString = false;
+        } else if (!doubleQuoteString) {
+          quoteString = true;
+        }
+      }
+
+      if (character == '"') {
+        if (doubleQuoteString && item > 0) {
+          doubleQuoteString = false;
+        } else if (!quoteString) {
+          doubleQuoteString = true;
+        }
+      }
+
+      if (!quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment
+          && sql.length() > item + 1) {
+        if (character == '-' && sql.charAt(item + 1) == '-') {
+          singleLineComment = true;
+        } else if (character == '/' && sql.charAt(item + 1) == '*') {
+          multiLineComment = true;
+        }
+      }
+
+      if (character == ';' && !quoteString && !doubleQuoteString && !multiLineComment
+          && !singleLineComment) {
+        queries.add(StringUtils.trim(query.toString()));
+        query = new StringBuilder();
+      } else if (item == sql.length() - 1) {
+        query.append(character);
+        queries.add(StringUtils.trim(query.toString()));
+      } else {
+        query.append(character);
+      }
+    }
+
+    return queries;
+  }
+
+  public static boolean isDDLCommand(int updatedCount, int columnCount) throws SQLException {
+    return updatedCount < 0 && columnCount <= 0;
+  }
+
+}

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -57,7 +57,8 @@
         "envName": null,
         "propertyName": "default.statementPrecode",
         "defaultValue": "",
-        "description": "Runs before each run of the paragraph, in the same connection"
+        "description": "Runs before each run of the paragraph, in the same connection",
+        "type": "textarea"
       },
       "default.splitQueries": {
         "envName": null,

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -652,7 +652,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -673,6 +673,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(Arrays.asList(ColumnDef.TYPE.NUMBER, ColumnDef.TYPE.STRING, ColumnDef.TYPE.DATE),
-        interpreterResult.message().get(0).getListOfColumnTypes());
+        interpreterResult.message().get(0).getColumnTypes());
   }
 }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -30,6 +30,7 @@ import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_URL;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_PRECODE;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.PRECODE_KEY_TEMPLATE;
 
+import org.apache.zeppelin.tabledata.ColumnDef;
 import org.junit.Before;
 import org.junit.Test;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.STATEMENT_PRECODE_KEY_TEMPLATE;
@@ -43,6 +44,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,6 +158,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     // if prefix not found return ERROR and Prefix not found.
     assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
     assertEquals("Prefix not found.", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.emptyList(),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -188,6 +192,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -250,6 +256,14 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("'Atext;B'\nAtext;B\n", interpreterResult.message().get(1).getData());
     assertEquals("'\\'\t';'\n\\\t;\n", interpreterResult.message().get(2).getData());
     assertEquals("''''\t';'\n'\t;\n", interpreterResult.message().get(3).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(1).getColumnTypes());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(2).getColumnTypes());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(3).getColumnTypes());
   }
 
   @Test
@@ -273,10 +287,14 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
-            interpreterResult.message().get(0).getData());
+        interpreterResult.message().get(0).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
 
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
     assertEquals("ID\tNAME\n", interpreterResult.message().get(1).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(1).getColumnTypes());
   }
 
   @Test
@@ -300,6 +318,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
             interpreterResult.message().get(0).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -321,6 +341,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\nc\tnull\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
 
@@ -343,8 +365,12 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
     assertEquals(InterpreterResult.Type.HTML, interpreterResult.message().get(1).getType());
     assertTrue(interpreterResult.message().get(1).getData().contains("alert-warning"));
+    assertEquals(Collections.emptyList(),
+        interpreterResult.message().get(1).getColumnTypes());
   }
 
   @Test
@@ -511,6 +537,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n1\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.LONG),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -561,6 +589,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n2\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.LONG),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -581,6 +611,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatement\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test
@@ -628,6 +660,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatementAnotherPrefix\n", interpreterResult.message().get(0).getData());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getColumnTypes());
   }
 
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -197,37 +197,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
-  public void testSplitSqlQuery() throws SQLException, IOException {
-    String sqlQuery = "insert into test_table(id, name) values ('a', ';\"');" +
-        "select * from test_table;" +
-        "select * from test_table WHERE ID = \";'\";" +
-        "select * from test_table WHERE ID = ';';" +
-        "select '\n', ';';" +
-        "select replace('A\\;B', '\\', 'text');" +
-        "select '\\', ';';" +
-        "select '''', ';';" +
-        "select /*+ scan */ * from test_table;" +
-        "--singleLineComment\nselect * from test_table";
-
-
-    Properties properties = new Properties();
-    JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
-    List<String> multipleSqlArray = t.splitSqlQueries(sqlQuery);
-    assertEquals(10, multipleSqlArray.size());
-    assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray.get(0));
-    assertEquals("select * from test_table", multipleSqlArray.get(1));
-    assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray.get(2));
-    assertEquals("select * from test_table WHERE ID = ';'", multipleSqlArray.get(3));
-    assertEquals("select '\n', ';'", multipleSqlArray.get(4));
-    assertEquals("select replace('A\\;B', '\\', 'text')", multipleSqlArray.get(5));
-    assertEquals("select '\\', ';'", multipleSqlArray.get(6));
-    assertEquals("select '''', ';'", multipleSqlArray.get(7));
-    assertEquals("select /*+ scan */ * from test_table", multipleSqlArray.get(8));
-    assertEquals("--singleLineComment\nselect * from test_table", multipleSqlArray.get(9));
-  }
-
-  @Test
   public void testQueryWithEscapedCharacters() throws SQLException, IOException {
     String sqlQuery = "select '\\n', ';';" +
         "select replace('A\\;B', '\\', 'text');" +

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -44,6 +44,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -98,7 +99,10 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     Statement statement = connection.createStatement();
     statement.execute(
         "DROP TABLE IF EXISTS test_table; " +
-        "CREATE TABLE test_table(id varchar(255), name varchar(255));");
+        "CREATE TABLE test_table(id varchar(255), name varchar(255));" +
+        "DROP TABLE IF EXISTS test_table_types;" +
+        "CREATE TABLE test_table_types(id integer, name varchar(255), test_date date);"
+    );
 
     PreparedStatement insertStatement = connection.prepareStatement(
             "insert into test_table(id, name) values ('a', 'a_name'),('b', 'b_name'),('c', ?);");
@@ -158,8 +162,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     // if prefix not found return ERROR and Prefix not found.
     assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
     assertEquals("Prefix not found.", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.emptyList(),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -192,8 +194,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -225,14 +225,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("'Atext;B'\nAtext;B\n", interpreterResult.message().get(1).getData());
     assertEquals("'\\'\t';'\n\\\t;\n", interpreterResult.message().get(2).getData());
     assertEquals("''''\t';'\n'\t;\n", interpreterResult.message().get(3).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(1).getListOfColumnTypes());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(2).getListOfColumnTypes());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(3).getListOfColumnTypes());
   }
 
   @Test
@@ -257,13 +249,9 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
         interpreterResult.message().get(0).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
 
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
     assertEquals("ID\tNAME\n", interpreterResult.message().get(1).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(1).getListOfColumnTypes());
   }
 
   @Test
@@ -287,8 +275,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
             interpreterResult.message().get(0).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -310,8 +296,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\nc\tnull\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
 
@@ -334,12 +318,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
     assertEquals(InterpreterResult.Type.HTML, interpreterResult.message().get(1).getType());
     assertTrue(interpreterResult.message().get(1).getData().contains("alert-warning"));
-    assertEquals(Collections.emptyList(),
-        interpreterResult.message().get(1).getListOfColumnTypes());
   }
 
   @Test
@@ -506,8 +486,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n1\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.NUMBER),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -558,8 +536,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n2\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.NUMBER),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -580,8 +556,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatement\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -629,8 +603,6 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatementAnotherPrefix\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -660,5 +632,47 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(3, interpreterResult.message().size());
+  }
+
+  @Test
+  public void testSelectQueryTypes() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "select * from test_table";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+        interpreterResult.message().get(0).getListOfColumnTypes());
+  }
+
+  @Test
+  public void testSelectQueryWithAllTypes() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "select * from test_table_types";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(Arrays.asList(ColumnDef.TYPE.NUMBER, ColumnDef.TYPE.STRING, ColumnDef.TYPE.DATE),
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -159,7 +159,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
     assertEquals("Prefix not found.", interpreterResult.message().get(0).getData());
     assertEquals(Collections.emptyList(),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -257,13 +257,13 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("'\\'\t';'\n\\\t;\n", interpreterResult.message().get(2).getData());
     assertEquals("''''\t';'\n'\t;\n", interpreterResult.message().get(3).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
     assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(1).getColumnTypes());
+        interpreterResult.message().get(1).getListOfColumnTypes());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(2).getColumnTypes());
+        interpreterResult.message().get(2).getListOfColumnTypes());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(3).getColumnTypes());
+        interpreterResult.message().get(3).getListOfColumnTypes());
   }
 
   @Test
@@ -289,12 +289,12 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
         interpreterResult.message().get(0).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
 
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
     assertEquals("ID\tNAME\n", interpreterResult.message().get(1).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(1).getColumnTypes());
+        interpreterResult.message().get(1).getListOfColumnTypes());
   }
 
   @Test
@@ -319,7 +319,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
             interpreterResult.message().get(0).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -342,7 +342,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\nc\tnull\n", interpreterResult.message().get(0).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
 
@@ -366,11 +366,11 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\n", interpreterResult.message().get(0).getData());
     assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
     assertEquals(InterpreterResult.Type.HTML, interpreterResult.message().get(1).getType());
     assertTrue(interpreterResult.message().get(1).getData().contains("alert-warning"));
     assertEquals(Collections.emptyList(),
-        interpreterResult.message().get(1).getColumnTypes());
+        interpreterResult.message().get(1).getListOfColumnTypes());
   }
 
   @Test
@@ -537,8 +537,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n1\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.LONG),
-        interpreterResult.message().get(0).getColumnTypes());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.NUMBER),
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -589,8 +589,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("ID\n2\n", interpreterResult.message().get(0).getData());
-    assertEquals(Collections.singletonList(ColumnDef.TYPE.LONG),
-        interpreterResult.message().get(0).getColumnTypes());
+    assertEquals(Collections.singletonList(ColumnDef.TYPE.NUMBER),
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -612,7 +612,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatement\n", interpreterResult.message().get(0).getData());
     assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test
@@ -661,7 +661,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
     assertEquals("@V\nstatementAnotherPrefix\n", interpreterResult.message().get(0).getData());
     assertEquals(Collections.singletonList(ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+        interpreterResult.message().get(0).getListOfColumnTypes());
   }
 
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -198,7 +198,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
       assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
       assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-      assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
+      assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n",
+          interpreterResult.message().get(0).getData());
     } finally {
       t.close();
     }
@@ -390,7 +391,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
       List<InterpreterCompletion> completionList = jdbcInterpreter.completion("sel", 3,
           interpreterContext);
 
-      InterpreterCompletion correctCompletionKeyword = new InterpreterCompletion("select", "select",
+      InterpreterCompletion correctCompletionKeyword =
+          new InterpreterCompletion("select", "select",
           CompletionType.keyword.name());
 
       assertEquals(1, completionList.size());

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -148,20 +148,24 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    String sqlQuery = "select * from test_table";
-    Map<String, String> localProperties = new HashMap<>();
-    localProperties.put("db", "fake");
-    InterpreterContext context = InterpreterContext.builder()
-        .setAuthenticationInfo(new AuthenticationInfo("testUser"))
-        .setLocalProperties(localProperties)
-        .build();
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, context);
+      String sqlQuery = "select * from test_table";
+      Map<String, String> localProperties = new HashMap<>();
+      localProperties.put("db", "fake");
+      InterpreterContext context = InterpreterContext.builder()
+          .setAuthenticationInfo(new AuthenticationInfo("testUser"))
+          .setLocalProperties(localProperties)
+          .build();
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, context);
 
-    // if prefix not found return ERROR and Prefix not found.
-    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
-    assertEquals("Prefix not found.", interpreterResult.message().get(0).getData());
+      // if prefix not found return ERROR and Prefix not found.
+      assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+      assertEquals("Prefix not found.", interpreterResult.message().get(0).getData());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -185,15 +189,19 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    String sqlQuery = "select * from test_table WHERE ID in ('a', 'b')";
+      String sqlQuery = "select * from test_table WHERE ID in ('a', 'b')";
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\tNAME\na\ta_name\nb\tb_name\n", interpreterResult.message().get(0).getData());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -212,19 +220,23 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.password", "");
     properties.setProperty("default.splitQueries", "true");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(2).getType());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(3).getType());
-    assertEquals("'\\n'\t';'\n\\n\t;\n", interpreterResult.message().get(0).getData());
-    assertEquals("'Atext;B'\nAtext;B\n", interpreterResult.message().get(1).getData());
-    assertEquals("'\\'\t';'\n\\\t;\n", interpreterResult.message().get(2).getData());
-    assertEquals("''''\t';'\n'\t;\n", interpreterResult.message().get(3).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(2).getType());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(3).getType());
+      assertEquals("'\\n'\t';'\n\\n\t;\n", interpreterResult.message().get(0).getData());
+      assertEquals("'Atext;B'\nAtext;B\n", interpreterResult.message().get(1).getData());
+      assertEquals("'\\'\t';'\n\\\t;\n", interpreterResult.message().get(2).getData());
+      assertEquals("''''\t';'\n'\t;\n", interpreterResult.message().get(3).getData());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -238,20 +250,24 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.password", "");
     properties.setProperty("default.splitQueries", "true");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    String sqlQuery = "select * from test_table;" +
-        "select * from test_table WHERE ID = ';';";
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(2, interpreterResult.message().size());
+      String sqlQuery = "select * from test_table;" +
+          "select * from test_table WHERE ID = ';';";
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(2, interpreterResult.message().size());
 
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
-        interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
+          interpreterResult.message().get(0).getData());
 
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
-    assertEquals("ID\tNAME\n", interpreterResult.message().get(1).getData());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(1).getType());
+      assertEquals("ID\tNAME\n", interpreterResult.message().get(1).getData());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -264,17 +280,21 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    String sqlQuery = "select * from test_table;" +
-        "select * from test_table WHERE ID = ';';";
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(1, interpreterResult.message().size());
+      String sqlQuery = "select * from test_table;" +
+          "select * from test_table WHERE ID = ';';";
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(1, interpreterResult.message().size());
 
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
-            interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
+          interpreterResult.message().get(0).getData());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -287,15 +307,19 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
 
-    String sqlQuery = "select * from test_table WHERE ID = 'c'";
+      String sqlQuery = "select * from test_table WHERE ID = 'c'";
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\tNAME\nc\tnull\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\tNAME\nc\tnull\n", interpreterResult.message().get(0).getData());
+    } finally {
+      t.close();
+    }
   }
 
 
@@ -309,17 +333,20 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
+      String sqlQuery = "select * from test_table";
 
-    String sqlQuery = "select * from test_table";
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\tNAME\na\ta_name\n", interpreterResult.message().get(0).getData());
-    assertEquals(InterpreterResult.Type.HTML, interpreterResult.message().get(1).getType());
-    assertTrue(interpreterResult.message().get(1).getData().contains("alert-warning"));
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\tNAME\na\ta_name\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Type.HTML, interpreterResult.message().get(1).getType());
+      assertTrue(interpreterResult.message().get(1).getData().contains("alert-warning"));
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -355,18 +382,22 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
+    try {
+      jdbcInterpreter.open();
 
-    jdbcInterpreter.interpret("", interpreterContext);
+      jdbcInterpreter.interpret("", interpreterContext);
 
-    List<InterpreterCompletion> completionList = jdbcInterpreter.completion("sel", 3,
-            interpreterContext);
+      List<InterpreterCompletion> completionList = jdbcInterpreter.completion("sel", 3,
+          interpreterContext);
 
-    InterpreterCompletion correctCompletionKeyword = new InterpreterCompletion("select", "select",
-            CompletionType.keyword.name());
+      InterpreterCompletion correctCompletionKeyword = new InterpreterCompletion("select", "select",
+          CompletionType.keyword.name());
 
-    assertEquals(1, completionList.size());
-    assertEquals(true, completionList.contains(correctCompletionKeyword));
+      assertEquals(1, completionList.size());
+      assertTrue(completionList.contains(correctCompletionKeyword));
+    } finally {
+      jdbcInterpreter.open();
+    }
   }
 
   private Properties getDBProperty(String dbUser, String dbPassowrd) throws IOException {
@@ -414,56 +445,68 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.jdbc2", "user2Id", "user2Pw");
 
     // user1 runs jdbc1
-    jdbc1.open();
-    InterpreterContext ctx1 = InterpreterContext.builder()
-        .setAuthenticationInfo(user1Credential)
-        .setReplName("jdbc1")
-        .build();
-    jdbc1.interpret("", ctx1);
+    try {
+      jdbc1.open();
+      InterpreterContext ctx1 = InterpreterContext.builder()
+          .setAuthenticationInfo(user1Credential)
+          .setReplName("jdbc1")
+          .build();
+      jdbc1.interpret("", ctx1);
 
-    JDBCUserConfigurations user1JDBC1Conf = jdbc1.getJDBCConfiguration("user1");
-    assertEquals("dbuser", user1JDBC1Conf.getPropertyMap("default").get("user"));
-    assertEquals("dbpassword", user1JDBC1Conf.getPropertyMap("default").get("password"));
-    jdbc1.close();
+      JDBCUserConfigurations user1JDBC1Conf = jdbc1.getJDBCConfiguration("user1");
+      assertEquals("dbuser", user1JDBC1Conf.getPropertyMap("default").get("user"));
+      assertEquals("dbpassword", user1JDBC1Conf.getPropertyMap("default").get("password"));
+    } finally {
+      jdbc1.close();
+    }
 
     // user1 runs jdbc2
-    jdbc2.open();
-    InterpreterContext ctx2 = InterpreterContext.builder()
-        .setAuthenticationInfo(user1Credential)
-        .setReplName("jdbc2")
-        .build();
-    jdbc2.interpret("", ctx2);
+    try {
+      jdbc2.open();
+      InterpreterContext ctx2 = InterpreterContext.builder()
+          .setAuthenticationInfo(user1Credential)
+          .setReplName("jdbc2")
+          .build();
+      jdbc2.interpret("", ctx2);
 
-    JDBCUserConfigurations user1JDBC2Conf = jdbc2.getJDBCConfiguration("user1");
-    assertNull(user1JDBC2Conf.getPropertyMap("default").get("user"));
-    assertNull(user1JDBC2Conf.getPropertyMap("default").get("password"));
-    jdbc2.close();
+      JDBCUserConfigurations user1JDBC2Conf = jdbc2.getJDBCConfiguration("user1");
+      assertNull(user1JDBC2Conf.getPropertyMap("default").get("user"));
+      assertNull(user1JDBC2Conf.getPropertyMap("default").get("password"));
+    } finally {
+      jdbc2.close();
+    }
 
     // user2 runs jdbc1
-    jdbc1.open();
-    InterpreterContext ctx3 = InterpreterContext.builder()
-        .setAuthenticationInfo(user2Credential)
-        .setReplName("jdbc1")
-        .build();
-    jdbc1.interpret("", ctx3);
+    try {
+      jdbc1.open();
+      InterpreterContext ctx3 = InterpreterContext.builder()
+          .setAuthenticationInfo(user2Credential)
+          .setReplName("jdbc1")
+          .build();
+      jdbc1.interpret("", ctx3);
 
-    JDBCUserConfigurations user2JDBC1Conf = jdbc1.getJDBCConfiguration("user2");
-    assertEquals("dbuser", user2JDBC1Conf.getPropertyMap("default").get("user"));
-    assertEquals("dbpassword", user2JDBC1Conf.getPropertyMap("default").get("password"));
-    jdbc1.close();
+      JDBCUserConfigurations user2JDBC1Conf = jdbc1.getJDBCConfiguration("user2");
+      assertEquals("dbuser", user2JDBC1Conf.getPropertyMap("default").get("user"));
+      assertEquals("dbpassword", user2JDBC1Conf.getPropertyMap("default").get("password"));
+    } finally {
+      jdbc1.close();
+    }
 
     // user2 runs jdbc2
-    jdbc2.open();
-    InterpreterContext ctx4 = InterpreterContext.builder()
-        .setAuthenticationInfo(user2Credential)
-        .setReplName("jdbc2")
-        .build();
-    jdbc2.interpret("", ctx4);
+    try {
+      jdbc2.open();
+      InterpreterContext ctx4 = InterpreterContext.builder()
+          .setAuthenticationInfo(user2Credential)
+          .setReplName("jdbc2")
+          .build();
+      jdbc2.interpret("", ctx4);
 
-    JDBCUserConfigurations user2JDBC2Conf = jdbc2.getJDBCConfiguration("user2");
-    assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("default").get("user"));
-    assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("default").get("password"));
-    jdbc2.close();
+      JDBCUserConfigurations user2JDBC2Conf = jdbc2.getJDBCConfiguration("user2");
+      assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("default").get("user"));
+      assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("default").get("password"));
+    } finally {
+      jdbc2.close();
+    }
   }
 
   @Test
@@ -476,16 +519,20 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty(DEFAULT_PRECODE,
             "create table test_precode (id int); insert into test_precode values (1);");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
-    jdbcInterpreter.executePrecode(interpreterContext);
+    try {
+      jdbcInterpreter.open();
+      jdbcInterpreter.executePrecode(interpreterContext);
 
-    String sqlQuery = "select *from test_precode";
+      String sqlQuery = "select *from test_precode";
 
-    InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
+      InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\n1\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\n1\n", interpreterResult.message().get(0).getData());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -502,11 +549,15 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("incorrect.password", "");
     properties.setProperty(String.format(PRECODE_KEY_TEMPLATE, "incorrect"), "incorrect command");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
-    InterpreterResult interpreterResult = jdbcInterpreter.executePrecode(interpreterContext);
+    try {
+      jdbcInterpreter.open();
+      InterpreterResult interpreterResult = jdbcInterpreter.executePrecode(interpreterContext);
 
-    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TEXT, interpreterResult.message().get(0).getType());
+      assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TEXT, interpreterResult.message().get(0).getType());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -519,23 +570,27 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty(String.format(PRECODE_KEY_TEMPLATE, "anotherPrefix"),
             "create table test_precode_2 (id int); insert into test_precode_2 values (2);");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
+    try {
+      jdbcInterpreter.open();
 
-    Map<String, String> localProperties = new HashMap<>();
-    localProperties.put("db", "anotherPrefix");
-    InterpreterContext context = InterpreterContext.builder()
-        .setAuthenticationInfo(new AuthenticationInfo("testUser"))
-        .setLocalProperties(localProperties)
-        .build();
-    jdbcInterpreter.executePrecode(context);
+      Map<String, String> localProperties = new HashMap<>();
+      localProperties.put("db", "anotherPrefix");
+      InterpreterContext context = InterpreterContext.builder()
+          .setAuthenticationInfo(new AuthenticationInfo("testUser"))
+          .setLocalProperties(localProperties)
+          .build();
+      jdbcInterpreter.executePrecode(context);
 
-    String sqlQuery = "select * from test_precode_2";
+      String sqlQuery = "select * from test_precode_2";
 
-    InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, context);
+      InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, context);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("ID\n2\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("ID\n2\n", interpreterResult.message().get(0).getData());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -547,15 +602,18 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.password", "");
     properties.setProperty(DEFAULT_STATEMENT_PRECODE, "set @v='statement'");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
+    try {
+      jdbcInterpreter.open();
+      String sqlQuery = "select @v";
 
-    String sqlQuery = "select @v";
+      InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
 
-    InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
-
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("@V\nstatement\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("@V\nstatement\n", interpreterResult.message().get(0).getData());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -567,14 +625,17 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.password", "");
     properties.setProperty(DEFAULT_STATEMENT_PRECODE, "set incorrect");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
+    try {
+      jdbcInterpreter.open();
+      String sqlQuery = "select 1";
 
-    String sqlQuery = "select 1";
+      InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
 
-    InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, interpreterContext);
-
-    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TEXT, interpreterResult.message().get(0).getType());
+      assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TEXT, interpreterResult.message().get(0).getType());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -587,22 +648,26 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty(String.format(STATEMENT_PRECODE_KEY_TEMPLATE, "anotherPrefix"),
             "set @v='statementAnotherPrefix'");
     JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
-    jdbcInterpreter.open();
+    try {
+      jdbcInterpreter.open();
 
-    Map<String, String> localProperties = new HashMap<>();
-    localProperties.put("db", "anotherPrefix");
-    InterpreterContext context = InterpreterContext.builder()
-        .setAuthenticationInfo(new AuthenticationInfo("testUser"))
-        .setLocalProperties(localProperties)
-        .build();
+      Map<String, String> localProperties = new HashMap<>();
+      localProperties.put("db", "anotherPrefix");
+      InterpreterContext context = InterpreterContext.builder()
+          .setAuthenticationInfo(new AuthenticationInfo("testUser"))
+          .setLocalProperties(localProperties)
+          .build();
 
-    String sqlQuery = "select @v";
+      String sqlQuery = "select @v";
 
-    InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, context);
+      InterpreterResult interpreterResult = jdbcInterpreter.interpret(sqlQuery, context);
 
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
-    assertEquals("@V\nstatementAnotherPrefix\n", interpreterResult.message().get(0).getData());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+      assertEquals("@V\nstatementAnotherPrefix\n", interpreterResult.message().get(0).getData());
+    } finally {
+      jdbcInterpreter.close();
+    }
   }
 
   @Test
@@ -616,22 +681,25 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.password", "");
     properties.setProperty("default.splitQueries", "true");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
+      String sqlQuery = "/* ; */\n" +
+          "-- /* comment\n" +
+          "--select * from test_table\n" +
+          "select * from test_table; /* some comment ; */\n" +
+          "/*\n" +
+          "select * from test_table;\n" +
+          "*/\n" +
+          "-- a ; b\n" +
+          "select * from test_table WHERE ID = ';--';\n" +
+          "select * from test_table WHERE ID = '/*' -- test";
 
-    String sqlQuery = "/* ; */\n" +
-        "-- /* comment\n" +
-        "--select * from test_table\n" +
-        "select * from test_table; /* some comment ; */\n" +
-        "/*\n" +
-        "select * from test_table;\n" +
-        "*/\n" +
-        "-- a ; b\n" +
-        "select * from test_table WHERE ID = ';--';\n" +
-        "select * from test_table WHERE ID = '/*' -- test";
-
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(3, interpreterResult.message().size());
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(3, interpreterResult.message().size());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -644,15 +712,18 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
+      String sqlQuery = "select * from test_table";
 
-    String sqlQuery = "select * from test_table";
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
-        interpreterResult.message().get(0).getColumnTypes());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(Collections.nCopies(2, ColumnDef.TYPE.STRING),
+          interpreterResult.message().get(0).getColumnTypes());
+    } finally {
+      t.close();
+    }
   }
 
   @Test
@@ -665,14 +736,17 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     properties.setProperty("default.user", "");
     properties.setProperty("default.password", "");
     JDBCInterpreter t = new JDBCInterpreter(properties);
-    t.open();
+    try {
+      t.open();
+      String sqlQuery = "select * from test_table_types";
 
-    String sqlQuery = "select * from test_table_types";
+      InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
-    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
-
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
-    assertEquals(Arrays.asList(ColumnDef.TYPE.NUMBER, ColumnDef.TYPE.STRING, ColumnDef.TYPE.DATE),
-        interpreterResult.message().get(0).getColumnTypes());
+      assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+      assertEquals(Arrays.asList(ColumnDef.TYPE.NUMBER, ColumnDef.TYPE.STRING, ColumnDef.TYPE.DATE),
+          interpreterResult.message().get(0).getColumnTypes());
+    } finally {
+      t.close();
+    }
   }
 }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCUtilsTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCUtilsTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zeppelin.jdbc;
+
+import static org.apache.zeppelin.jdbc.JDBCUtils.splitSqlQueries;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class JDBCUtilsTest {
+  @Test
+  public void testSplitSqlQuery() {
+    String sqlQuery = "insert into test_table(id, name) values ('a', ';\"');" +
+        "select * from test_table;" +
+        "select * from test_table WHERE ID = \";'\";" +
+        "select * from test_table WHERE ID = ';';" +
+        "select '\n', ';';" +
+        "select replace('A\\;B', '\\', 'text');" +
+        "select '\\', ';';" +
+        "select '''', ';';" +
+        "select /*+ scan */ * from test_table;" +
+        "--singleLineComment\nselect * from test_table";
+
+    List<String> multipleSqlArray = splitSqlQueries(sqlQuery);
+    assertEquals(10, multipleSqlArray.size());
+    assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray.get(0));
+    assertEquals("select * from test_table", multipleSqlArray.get(1));
+    assertEquals("select * from test_table WHERE ID = \";'\"", multipleSqlArray.get(2));
+    assertEquals("select * from test_table WHERE ID = ';'", multipleSqlArray.get(3));
+    assertEquals("select '\n', ';'", multipleSqlArray.get(4));
+    assertEquals("select replace('A\\;B', '\\', 'text')", multipleSqlArray.get(5));
+    assertEquals("select '\\', ';'", multipleSqlArray.get(6));
+    assertEquals("select '''', ';'", multipleSqlArray.get(7));
+    assertEquals("select /*+ scan */ * from test_table", multipleSqlArray.get(8));
+    assertEquals("--singleLineComment\nselect * from test_table", multipleSqlArray.get(9));
+  }
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
@@ -16,7 +16,11 @@
  */
 package org.apache.zeppelin.interpreter;
 
+import org.apache.zeppelin.tabledata.ColumnDef;
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Interpreter result message
@@ -24,10 +28,18 @@ import java.io.Serializable;
 public class InterpreterResultMessage implements Serializable {
   InterpreterResult.Type type;
   String data;
+  List<ColumnDef.TYPE> columnTypes = new ArrayList<>();
 
   public InterpreterResultMessage(InterpreterResult.Type type, String data) {
     this.type = type;
     this.data = data;
+  }
+
+  public InterpreterResultMessage(InterpreterResult.Type type, String data,
+                                  List<ColumnDef.TYPE> columnTypes) {
+    this.type = type;
+    this.data = data;
+    this.columnTypes = columnTypes;
   }
 
   public InterpreterResult.Type getType() {
@@ -36,6 +48,10 @@ public class InterpreterResultMessage implements Serializable {
 
   public String getData() {
     return data;
+  }
+
+  public List<ColumnDef.TYPE> getColumnTypes() {
+    return columnTypes;
   }
 
   public String toString() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.interpreter;
 import org.apache.zeppelin.tabledata.ColumnDef;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,9 +31,7 @@ public class InterpreterResultMessage implements Serializable {
   MessageColumnTypes msgColumnTypes;
 
   public InterpreterResultMessage(InterpreterResult.Type type, String data) {
-    this.type = type;
-    this.data = data;
-    this.msgColumnTypes = new MessageColumnTypes();
+    this(type, data, new ArrayList<>());
   }
 
   public InterpreterResultMessage(InterpreterResult.Type type, String data,

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessage.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class InterpreterResultMessage implements Serializable {
   InterpreterResult.Type type;
   String data;
-  MessageColumnTypes msgColumnTypes;
+  List<ColumnDef.TYPE> columnTypes;
 
   public InterpreterResultMessage(InterpreterResult.Type type, String data) {
     this(type, data, new ArrayList<>());
@@ -38,7 +38,7 @@ public class InterpreterResultMessage implements Serializable {
                                   List<ColumnDef.TYPE> columnTypes) {
     this.type = type;
     this.data = data;
-    this.msgColumnTypes = new MessageColumnTypes(columnTypes);
+    this.columnTypes = columnTypes;
   }
 
   public InterpreterResult.Type getType() {
@@ -49,12 +49,8 @@ public class InterpreterResultMessage implements Serializable {
     return data;
   }
 
-  public List<ColumnDef.TYPE> getListOfColumnTypes() {
-    return msgColumnTypes.getListOfColumnTypes();
-  }
-
-  public MessageColumnTypes getMessageColumnTypes() {
-    return msgColumnTypes;
+  public List<ColumnDef.TYPE> getColumnTypes() {
+    return columnTypes;
   }
 
   public String toString() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
@@ -16,49 +16,37 @@
  */
 package org.apache.zeppelin.interpreter;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.tabledata.ColumnDef;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
- * Interpreter result message
+ * Type of interpreter result message
  */
-public class InterpreterResultMessage implements Serializable {
-  InterpreterResult.Type type;
-  String data;
-  MessageColumnTypes msgColumnTypes;
+public class MessageColumnTypes implements Serializable {
+  List<ColumnDef.TYPE> columnTypes = new ArrayList<>();
 
-  public InterpreterResultMessage(InterpreterResult.Type type, String data) {
-    this.type = type;
-    this.data = data;
-    this.msgColumnTypes = new MessageColumnTypes();
+  public MessageColumnTypes() {
+
   }
 
-  public InterpreterResultMessage(InterpreterResult.Type type, String data,
-                                  List<ColumnDef.TYPE> columnTypes) {
-    this.type = type;
-    this.data = data;
-    this.msgColumnTypes = new MessageColumnTypes(columnTypes);
-  }
-
-  public InterpreterResult.Type getType() {
-    return type;
-  }
-
-  public String getData() {
-    return data;
+  public MessageColumnTypes(Collection<ColumnDef.TYPE> types) {
+    columnTypes.addAll(types);
   }
 
   public List<ColumnDef.TYPE> getListOfColumnTypes() {
-    return msgColumnTypes.getListOfColumnTypes();
-  }
-
-  public MessageColumnTypes getMessageColumnTypes() {
-    return msgColumnTypes;
+    return columnTypes;
   }
 
   public String toString() {
-    return "%" + type.name().toLowerCase() + " " + data;
+    if (columnTypes.isEmpty()) {
+      return "Type is unknown";
+    } else {
+      return StringUtils.join(columnTypes, ", ");
+    }
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
@@ -34,10 +34,6 @@ public class MessageColumnTypes implements Serializable {
     columnTypes.addAll(types);
   }
 
-  public List<ColumnDef.TYPE> getListOfColumnTypes() {
-    return columnTypes;
-  }
-
   public String toString() {
     if (columnTypes.isEmpty()) {
       return "Type is unknown";

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/MessageColumnTypes.java
@@ -30,10 +30,6 @@ import java.util.List;
 public class MessageColumnTypes implements Serializable {
   List<ColumnDef.TYPE> columnTypes = new ArrayList<>();
 
-  public MessageColumnTypes() {
-
-  }
-
   public MessageColumnTypes(Collection<ColumnDef.TYPE> types) {
     columnTypes.addAll(types);
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -657,13 +657,11 @@ public class RemoteInterpreterServer extends Thread
                 context.getParagraphId(),
                 WellKnownResourceName.ZeppelinTableResult.toString(),
                 lastMessage);
-            if (!lastMessage.getColumnTypes().isEmpty()) {
-              context.getResourcePool().put(
-                  context.getNoteId(),
-                  context.getParagraphId(),
-                  WellKnownResourceName.ZeppelinTableType.toString(),
-                  lastMessage.getColumnTypes());
-            }
+            context.getResourcePool().put(
+                context.getNoteId(),
+                context.getParagraphId(),
+                WellKnownResourceName.ZeppelinTableType.toString(),
+                lastMessage.getMessageColumnTypes());
           }
         }
         return new InterpreterResult(result.code(), resultMessages);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -649,13 +649,21 @@ public class RemoteInterpreterServer extends Thread
         }
         // put result into resource pool
         if (resultMessages.size() > 0) {
-          int lastMessageIndex = resultMessages.size() - 1;
-          if (resultMessages.get(lastMessageIndex).getType() == InterpreterResult.Type.TABLE) {
+          final int lastMessageIndex = resultMessages.size() - 1;
+          final InterpreterResultMessage lastMessage = resultMessages.get(lastMessageIndex);
+          if (lastMessage.getType() == InterpreterResult.Type.TABLE) {
             context.getResourcePool().put(
                 context.getNoteId(),
                 context.getParagraphId(),
                 WellKnownResourceName.ZeppelinTableResult.toString(),
-                resultMessages.get(lastMessageIndex));
+                lastMessage);
+            if (!lastMessage.getColumnTypes().isEmpty()) {
+              context.getResourcePool().put(
+                  context.getNoteId(),
+                  context.getParagraphId(),
+                  WellKnownResourceName.ZeppelinTableType.toString(),
+                  lastMessage.getColumnTypes());
+            }
           }
         }
         return new InterpreterResult(result.code(), resultMessages);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -53,6 +53,7 @@ import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
+import org.apache.zeppelin.interpreter.MessageColumnTypes;
 import org.apache.zeppelin.interpreter.RemoteZeppelinServerResource;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.interpreter.thrift.RegisterInfo;
@@ -656,12 +657,14 @@ public class RemoteInterpreterServer extends Thread
                 context.getNoteId(),
                 context.getParagraphId(),
                 WellKnownResourceName.ZeppelinTableResult.toString(),
-                lastMessage);
+                lastMessage
+            );
             context.getResourcePool().put(
                 context.getNoteId(),
                 context.getParagraphId(),
                 WellKnownResourceName.ZeppelinTableType.toString(),
-                lastMessage.getMessageColumnTypes());
+                new MessageColumnTypes(lastMessage.getColumnTypes())
+            );
           }
         }
         return new InterpreterResult(result.code(), resultMessages);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/WellKnownResourceName.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/WellKnownResourceName.java
@@ -21,7 +21,8 @@ package org.apache.zeppelin.resource;
  */
 public enum WellKnownResourceName {
   ZeppelinReplResult("zeppelin.repl.result"),                 // last object of repl
-  ZeppelinTableResult("zeppelin.paragraph.result.table");     // paragraph run result
+  ZeppelinTableResult("zeppelin.paragraph.result.table"),     // paragraph run result
+  ZeppelinTableType("zeppelin.paragraph.result.table.type");  // paragraph run result's type
 
   String name;
   WellKnownResourceName(String name) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/ColumnDef.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/ColumnDef.java
@@ -27,7 +27,7 @@ public class ColumnDef implements Serializable {
    */
   public enum TYPE {
     STRING,
-    LONG,
+    NUMBER,
     DATE
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/ColumnDef.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/ColumnDef.java
@@ -28,7 +28,7 @@ public class ColumnDef implements Serializable {
   public enum TYPE {
     STRING,
     LONG,
-    INT
+    DATE
   }
 
   private String name;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
@@ -40,8 +40,16 @@ public class InterpreterResultTableData implements TableData, Serializable {
     } else {
       String[] headerRow = lines[0].split("\t");
       columnDef = new ColumnDef[headerRow.length];
-      for (int i = 0; i < headerRow.length; i++) {
-        columnDef[i] = new ColumnDef(headerRow[i], ColumnDef.TYPE.STRING);
+
+      List<ColumnDef.TYPE> columnTypes = msg.getColumnTypes();
+      if (columnTypes.isEmpty()) {
+        for (int i = 0; i < headerRow.length; i++) {
+          columnDef[i] = new ColumnDef(headerRow[i], ColumnDef.TYPE.STRING);
+        }
+      } else {
+        for (int i = 0; i < headerRow.length; i++) {
+          columnDef[i] = new ColumnDef(headerRow[i], columnTypes.get(i));
+        }
       }
 
       for (int r = 1; r < lines.length; r++) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
@@ -41,7 +41,7 @@ public class InterpreterResultTableData implements TableData, Serializable {
       String[] headerRow = lines[0].split("\t");
       columnDef = new ColumnDef[headerRow.length];
 
-      List<ColumnDef.TYPE> columnTypes = msg.getColumnTypes();
+      List<ColumnDef.TYPE> columnTypes = msg.getListOfColumnTypes();
       if (columnTypes.isEmpty()) {
         for (int i = 0; i < headerRow.length; i++) {
           columnDef[i] = new ColumnDef(headerRow[i], ColumnDef.TYPE.STRING);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/tabledata/InterpreterResultTableData.java
@@ -41,7 +41,7 @@ public class InterpreterResultTableData implements TableData, Serializable {
       String[] headerRow = lines[0].split("\t");
       columnDef = new ColumnDef[headerRow.length];
 
-      List<ColumnDef.TYPE> columnTypes = msg.getListOfColumnTypes();
+      List<ColumnDef.TYPE> columnTypes = msg.getColumnTypes();
       if (columnTypes.isEmpty()) {
         for (int i = 0; i < headerRow.length; i++) {
           columnDef[i] = new ColumnDef(headerRow[i], ColumnDef.TYPE.STRING);


### PR DESCRIPTION
### What is this PR for?
JDBCInterpreter knows type information for every SQL Query. We could save this info to pool and use it.
There are three types of table column:
- Number;
- String;
- Date.

### What type of PR is it?
Improvement

### What is the Jira issue?
[Zeppelin 3582](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3582)

### Screenshots
![screenshot from 2018-07-06 18-20-29](https://user-images.githubusercontent.com/16215034/42387208-51009482-814a-11e8-9bc9-bff8b2664f39.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No