### PR TITLE
ZEPELIN-3586. Use hadoop 2.7.3 for embedded spark

### DIFF
--- a/spark/spark-dependencies/pom.xml
+++ b/spark/spark-dependencies/pom.xml
@@ -44,7 +44,7 @@
          instead of changing spark.version in this section.
     -->
 
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>2.7.3</hadoop.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <avro.version>1.7.7</avro.version>
     <avro.mapred.classifier/>


### PR DESCRIPTION
### What is this PR for?
Simple PR to use hadoop 2.7.3 for the embedded spark, otherwise user will hit weird issue if they read csv file or parquet file due to low hadoop version api. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3586?filter=-2

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
