### PR TITLE
ZEPPELIN-3606. Reduce verbose InterpreterNotFoundException for getEditorSetting

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -2518,12 +2518,14 @@ public class NotebookServer extends WebSocketServlet
 
     try {
       interpreter = notebook().getInterpreterFactory().getInterpreter(user, noteId, replName);
+      LOG.debug("getEditorSetting for interpreter: {} for paragraph {}", replName, paragraphId);
+      resp.put("editor", notebook().getInterpreterSettingManager().
+          getEditorSetting(interpreter, user, noteId, replName));
+      conn.send(serializeMessage(resp));
     } catch (InterpreterNotFoundException e) {
-      throw new IOException("Fail to get interpreter: " + replName, e);
+      LOG.warn("Fail to get interpreter: " + replName);
+      return;
     }
-    resp.put("editor", notebook().getInterpreterSettingManager().
-        getEditorSetting(interpreter, user, noteId, replName));
-    conn.send(serializeMessage(resp));
   }
 
   private void getInterpreterSettings(NotebookSocket conn, AuthenticationInfo subject)


### PR DESCRIPTION

### What is this PR for?

Simple PR to reduce the verbose exception for getEditorSetting. 


### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3606

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
