### PR TITLE
[ZEPPELIN-3596] Saving resources from pool to SQL

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -121,7 +121,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private static final char TAB = '\t';
   private static final String TABLE_MAGIC_TAG = "%table ";
   private static final String EXPLAIN_PREDICATE = "EXPLAIN ";
-  private static final String POOL_REQ_PREFIX = "{ResourcePool";
+  static final String POOL_REQ_PREFIX = "{ResourcePool";
 
   static final String COMMON_MAX_LINE = COMMON_KEY + DOT + MAX_LINE_KEY;
 
@@ -579,6 +579,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   inspired from https://github.com/postgres/pgadmin3/blob/794527d97e2e3b01399954f3b79c8e2585b908dd/
     pgadmin/dlg/dlgProperty.cpp#L999-L1045
    */
+
   protected ArrayList<String> splitSqlQueries(String sql) {
     ArrayList<String> queries = new ArrayList<>();
     StringBuilder query = new StringBuilder();
@@ -699,10 +700,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
         statement = connection.createStatement();
 
         final String stringType = getProperty(DEFAULT_STRING_TYPE);
-        while (sqlToExecute.contains(POOL_REQ_PREFIX)) {
-          sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
+        sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
               interpreterContext, stringType);
-        }
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -698,8 +698,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
 
+        final String stringType = getProperty(DEFAULT_STRING_TYPE);
         while (sqlToExecute.contains(POOL_REQ_PREFIX)) {
-          final String stringType = getProperty(DEFAULT_STRING_TYPE);
           sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
               interpreterContext, stringType);
         }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -104,6 +104,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String USER_KEY = "user";
   static final String PASSWORD_KEY = "password";
   static final String PRECODE_KEY = "precode";
+  static final String STRING_TYPE = "stringType";
   static final String STATEMENT_PRECODE_KEY = "statementPrecode";
   static final String COMPLETER_SCHEMA_FILTERS_KEY = "completer.schemaFilters";
   static final String COMPLETER_TTL_KEY = "completer.ttlInSeconds";
@@ -120,6 +121,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private static final char TAB = '\t';
   private static final String TABLE_MAGIC_TAG = "%table ";
   private static final String EXPLAIN_PREDICATE = "EXPLAIN ";
+  private static final String POOL_REQ_PREFIX = "{ResourcePool";
 
   static final String COMMON_MAX_LINE = COMMON_KEY + DOT + MAX_LINE_KEY;
 
@@ -129,6 +131,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String DEFAULT_PASSWORD = DEFAULT_KEY + DOT + PASSWORD_KEY;
   static final String DEFAULT_PRECODE = DEFAULT_KEY + DOT + PRECODE_KEY;
   static final String DEFAULT_STATEMENT_PRECODE = DEFAULT_KEY + DOT + STATEMENT_PRECODE_KEY;
+  static final String DEFAULT_STRING_TYPE = DEFAULT_KEY + DOT + STRING_TYPE;
 
   static final String EMPTY_COLUMN_VALUE = "";
 
@@ -695,9 +698,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
 
-        if (sqlToExecute.contains("{ResourcePool")) {
+        while (sqlToExecute.contains(POOL_REQ_PREFIX)) {
+          final String stringType = getProperty(DEFAULT_STRING_TYPE);
           sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
-              interpreterContext);
+              interpreterContext, stringType);
         }
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -97,6 +97,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String COMMON_KEY = "common";
   static final String MAX_LINE_KEY = "max_count";
   static final int MAX_LINE_DEFAULT = 1000;
+  static final int RESOURCE_POOL_INSERT_ROW_NUMBER_DEFAULT = 10000;
 
   static final String DEFAULT_KEY = "default";
   static final String DRIVER_KEY = "driver";
@@ -701,10 +702,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
         statement = connection.createStatement();
 
         final String stringType = getProperty(DEFAULT_STRING_TYPE);
-        final Integer insertRowNumber =
-            Integer.parseInt(getProperty(RESOURCE_POOL_INSERT_ROW_NUMBER));
+        final String insertRowNumber = getProperty(RESOURCE_POOL_INSERT_ROW_NUMBER);
+
         sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
-              interpreterContext, stringType, insertRowNumber);
+              interpreterContext, stringType, insertRowNumber == null ?
+                RESOURCE_POOL_INSERT_ROW_NUMBER_DEFAULT : Integer.parseInt(insertRowNumber));
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -114,6 +114,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String JDBC_JCEKS_CREDENTIAL_KEY = "jceks.credentialKey";
   static final String PRECODE_KEY_TEMPLATE = "%s.precode";
   static final String STATEMENT_PRECODE_KEY_TEMPLATE = "%s.statementPrecode";
+  static final String RESOURCE_POOL_INSERT_ROW_NUMBER = "resourcePoolInsertRowNumber";
   static final String DOT = ".";
 
   private static final char WHITESPACE = ' ';
@@ -700,8 +701,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
         statement = connection.createStatement();
 
         final String stringType = getProperty(DEFAULT_STRING_TYPE);
+        final Integer insertRowNumber =
+            Integer.parseInt(getProperty(RESOURCE_POOL_INSERT_ROW_NUMBER));
         sqlToExecute = JDBCPoolManager.preparePoolData(sqlToExecute, statement,
-              interpreterContext, stringType);
+              interpreterContext, stringType, insertRowNumber);
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -645,7 +645,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
         if (parser == null) {
           parser = new SqlParser(sql);
         }
-        List <String> poolReqs = parser.recourcePoolReqs();
+        List <String> poolReqs = parser.resourcePoolReqs();
 
         if (!poolReqs.isEmpty()) {
           final String stringType = getProperty(DEFAULT_STRING_TYPE);

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -32,6 +32,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.alias.CredentialProvider;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.resource.ResourcePool;
+import org.apache.zeppelin.resource.WellKnownResourceName;
+import org.apache.zeppelin.tabledata.ColumnDef;
+import org.apache.zeppelin.tabledata.InterpreterResultTableData;
+import org.apache.zeppelin.tabledata.Row;
+import org.apache.zeppelin.tabledata.TableData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -54,6 +62,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
@@ -695,6 +704,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();
 
+        if (sqlToExecute.contains("{ResourcePool")) {
+          sqlToExecute = preparePoolData(sqlToExecute, statement, interpreterContext);
+        }
+
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());
         statement.setMaxRows(getMaxResult() + 1);
@@ -771,6 +784,66 @@ public class JDBCInterpreter extends KerberosInterpreter {
       getJDBCConfiguration(user).removeStatement(paragraphId);
     }
     return interpreterResult;
+  }
+
+  private String preparePoolData(String sqlReq, Statement statement, InterpreterContext context) {
+    // todo: smart parsing
+    final int poolReqBegIndex = sqlReq.indexOf("{ResourcePool");
+    final int poolReqEndIndex = sqlReq.indexOf("}", poolReqBegIndex);
+    final String poolReq = sqlReq.substring(poolReqBegIndex, poolReqEndIndex + 1);
+
+    final String paragraphIdKey = "paragraph_id=";
+    final String nodeIdKey = "note_id=";
+
+    final int pIdIndex = poolReq.indexOf(paragraphIdKey);
+    final String paragraphId = poolReq.substring(pIdIndex + paragraphIdKey.length(),
+        poolReq.length() - 1);
+    // '-' is not allowed in sql table names
+    // the table name must begin with a letter
+    final String paragraphIdSql = "p" + paragraphId.replaceAll("-", "");
+
+    final int nIdBegIndex = poolReq.indexOf(nodeIdKey);
+    final int nIdEndIndex = poolReq.indexOf(".", nIdBegIndex);
+    final String noteId = poolReq.substring(nIdBegIndex + nodeIdKey.length(), nIdEndIndex);
+
+    ResourcePool resourcePool = context.getResourcePool();
+    final String str = "" + resourcePool.get(noteId, paragraphId,
+        WellKnownResourceName.ZeppelinTableResult.toString()).get();
+
+    InterpreterResultMessage msg = new InterpreterResultMessage(InterpreterResult.Type.TABLE, str);
+    TableData tableData = new InterpreterResultTableData(msg);
+
+    final ColumnDef[] columns = tableData.columns();
+    List<String> columDefs = new ArrayList<>();
+    for (final ColumnDef column : columns) {
+      columDefs.add(column.name().replace("%table", "") + " varchar(100)");
+    }
+
+    try {
+      statement.addBatch("DROP TABLE IF EXISTS " + paragraphIdSql);
+
+      final String sqlCreateTable = "CREATE TABLE " + paragraphIdSql + " ("
+                                    + StringUtils.join(columDefs, ", ") + ");";
+      logger.info("POOL: " + sqlCreateTable);
+      statement.addBatch(sqlCreateTable);
+      for (Iterator<Row> iterator = tableData.rows(); iterator.hasNext(); ) {
+        Row row = iterator.next();
+        final String sqlInsert = "INSERT INTO " + paragraphIdSql + " VALUES ("
+            + StringUtils.join(
+                Arrays.stream(row.get())
+                .map(x -> "'" + x + "'")
+                .collect(Collectors.toList()),
+            ", ")
+            + ");";
+        logger.info("POOL: " + sqlInsert);
+        statement.addBatch(sqlInsert);
+      }
+      statement.executeBatch();
+    } catch (SQLException e)  {
+      logger.error("POOL: SQL Exception" + e.getMessage());
+    }
+
+    return sqlReq.replace(poolReq, paragraphIdSql);
   }
 
   /**

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
@@ -183,7 +183,8 @@ public class JDBCPoolManager {
 
 
   static String preparePoolData(String sqlReq, Statement statement,
-                                       InterpreterContext context, String stringType) {
+                                InterpreterContext context, String stringType,
+                                Integer insertRowNumber) {
     final List<String> poolReqs = recourcePoolReqs(sqlReq);
     final Set<String> handledTables = new HashSet<>();
     String newSqlReq = sqlReq;
@@ -211,8 +212,14 @@ public class JDBCPoolManager {
           statement.addBatch(sqlCreate);
 
           final List<String> sqlInserts = getSqlInsertReqs(tableData, sqlTableName);
+          int counter = 0;
           for (final String sqlInsert : sqlInserts) {
+            if (counter > insertRowNumber) {
+              statement.executeBatch();
+              counter = 0;
+            }
             statement.addBatch(sqlInsert);
+            counter++;
           }
 
           statement.executeBatch();

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zeppelin.jdbc;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.apache.zeppelin.interpreter.InterpreterResultMessage;
+import org.apache.zeppelin.resource.ResourcePool;
+import org.apache.zeppelin.resource.WellKnownResourceName;
+import org.apache.zeppelin.tabledata.ColumnDef;
+import org.apache.zeppelin.tabledata.InterpreterResultTableData;
+import org.apache.zeppelin.tabledata.Row;
+import org.apache.zeppelin.tabledata.TableData;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JDBCPoolManager {
+  private static final String paragraphIdKey = "paragraph_id=";
+  private static final String noteIdKey = "note_id=";
+
+  // todo: smarter parser
+  private static String getPoolExpression(String sqlReq) {
+    final int poolReqBegIndex = sqlReq.indexOf("{ResourcePool");
+    final int poolReqEndIndex = sqlReq.indexOf("}", poolReqBegIndex);
+    return sqlReq.substring(poolReqBegIndex, poolReqEndIndex + 1);
+  }
+
+  private static String getParagraphId(String poolExp) {
+    final int pIdIndex = poolExp.indexOf(paragraphIdKey);
+    return poolExp.substring(pIdIndex + paragraphIdKey.length(), poolExp.length() - 1);
+  }
+
+  private static String getNoteId(String poolExp) {
+    final int nIdBegIndex = poolExp.indexOf(noteIdKey);
+    final int nIdEndIndex = poolExp.indexOf(".", nIdBegIndex);
+    return poolExp.substring(nIdBegIndex + noteIdKey.length(), nIdEndIndex);
+  }
+
+  private static TableData getTableDataFromResourcePool(ResourcePool resourcePool,
+                                                        String noteId, String paragraphId) {
+    final String str = "" + resourcePool.get(noteId, paragraphId,
+        WellKnownResourceName.ZeppelinTableResult.toString()).get();
+    InterpreterResultMessage msg = getMsgFromString(str);
+    return new InterpreterResultTableData(msg);
+  }
+
+  private static List<String> getColumnNamesWithTypes(TableData tableData) {
+    final ColumnDef[] columns = tableData.columns();
+    List<String> columDefs = new LinkedList<>();
+    for (final ColumnDef column : columns) {
+      // todo: get type from properties
+      columDefs.add(column.name() + " varchar(100)");
+    }
+    return columDefs;
+  }
+
+  private static String getSqlDropTableReq(String tableName) {
+    return "DROP TABLE IF EXISTS " + tableName + ";";
+  }
+
+  private static String getSqlCreateTableReq(List<String> columDefs, String tableName) {
+    return "CREATE TABLE " + tableName + " (" + StringUtils.join(columDefs, ", ") + ");";
+  }
+
+  private static List<String> getSqlInsertReqs(TableData tableData, String tableName) {
+    List<String> reqs = new LinkedList<>();
+    for (Iterator<Row> iterator = tableData.rows(); iterator.hasNext(); ) {
+      Row row = iterator.next();
+      reqs.add("INSERT INTO " + tableName + " VALUES ("
+          + StringUtils.join(
+          Arrays.stream(row.get())
+              .map(x -> "'" + x + "'")
+              .collect(Collectors.toList()),
+          ", ")
+          + ");");
+    }
+    return reqs;
+  }
+
+  private static InterpreterResultMessage getMsgFromString (String msg) {
+    InterpreterOutput out = new InterpreterOutput(null);
+    InterpreterResultMessage interpreterResultMessage = null;
+    try {
+      out.write(msg);
+      out.flush();
+      interpreterResultMessage = out.toInterpreterResultMessage().get(0);
+      out.close();
+    } catch (IOException e) { /*ignored*/ }
+    return interpreterResultMessage;
+  }
+
+
+  public static String preparePoolData(String sqlReq, Statement statement,
+                                       InterpreterContext context) {
+    final String poolExp = getPoolExpression(sqlReq);
+    final String paragraphId = getParagraphId(poolExp);
+    final String noteId = getNoteId(poolExp);
+
+    ResourcePool resourcePool = context.getResourcePool();
+    TableData tableData = getTableDataFromResourcePool(resourcePool, noteId, paragraphId);
+
+    List<String> columDefs = getColumnNamesWithTypes(tableData);
+    // '-' is not allowed in sql table names, the table name must begin with a letter
+    final String pIdSqlName = "p" + paragraphId.replace("-", "");
+
+    try {
+      final String sqlDrop = getSqlDropTableReq(pIdSqlName);
+      statement.addBatch(sqlDrop);
+
+      final String sqlCreate = getSqlCreateTableReq(columDefs, pIdSqlName);
+      statement.addBatch(sqlCreate);
+
+      final List<String> sqlInserts = getSqlInsertReqs(tableData, pIdSqlName);
+      for (final String sqlInsert : sqlInserts) {
+        statement.addBatch(sqlInsert);
+      }
+
+      statement.executeBatch();
+    } catch (SQLException e) { /*ignored*/ }
+
+    // replace resource pool expression with real table
+    return sqlReq.replace(poolExp, pIdSqlName);
+  }
+}

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCPoolManager.java
@@ -45,14 +45,14 @@ public class JDBCPoolManager {
 
   private static final String PARAGRAPH_ID_KEY = "paragraph_id=";
   private static final String NOTE_ID_KEY = "note_id=";
-  private static final Pattern PARAGRAPH_ID_PATTERT = Pattern.compile("(\\d|_|-)+");
-  private static final Pattern NOTE_ID_PATTERT = Pattern.compile("(\\d|_|-|[a-zA-Z])+");
+  private static final Pattern PARAGRAPH_ID_PATTERN = Pattern.compile("(\\d|_|-)+");
+  private static final Pattern NOTE_ID_PATTERN = Pattern.compile("(\\d|_|-|[a-zA-Z])+");
   // the table name must begin with a letter
   private static final String SQL_NAME_PREFIX = "p";
 
   static String getParagraphId(String poolReq) {
     final int pIdIndex = poolReq.indexOf(PARAGRAPH_ID_KEY);
-    Matcher m = PARAGRAPH_ID_PATTERT.matcher(
+    Matcher m = PARAGRAPH_ID_PATTERN.matcher(
         poolReq.substring(pIdIndex + PARAGRAPH_ID_KEY.length()));
     if (!m.find()) {
       logger.error("Can't eject paragraph_id from pool request {}", poolReq);
@@ -63,7 +63,7 @@ public class JDBCPoolManager {
   static String getNoteId(String poolReq, InterpreterContext context) {
     if (poolReq.contains(NOTE_ID_KEY)) {
       final int nIdIndex = poolReq.indexOf(NOTE_ID_KEY);
-      Matcher m = NOTE_ID_PATTERT.matcher(
+      Matcher m = NOTE_ID_PATTERN.matcher(
           poolReq.substring(nIdIndex + NOTE_ID_KEY.length()));
       if (!m.find()) {
         logger.error("Can't eject note_id from pool request {}", poolReq);

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zeppelin.jdbc;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+
+public class SqlParser {
+  private ArrayList<String> res;
+  private StringBuilder builder;
+
+  private Boolean multiLineComment;
+  private Boolean singleLineComment;
+  private Boolean quoteString;
+  private Boolean doubleQuoteString;
+  private final String sql;
+  private int currIndex;
+  private char currChar;
+
+  public SqlParser(String sql) {
+    this.sql = sql;
+  }
+
+  private void initialize() {
+    res = new ArrayList<>();
+    builder = new StringBuilder();
+    multiLineComment = false;
+    singleLineComment = false;
+    quoteString = false;
+    doubleQuoteString = false;
+    currIndex = 0;
+  }
+
+  private void checkCommentsAndQuetes() {
+    if (singleLineComment && (currChar == '\n' || currIndex == sql.length() - 1)) {
+      singleLineComment = false;
+    }
+
+    if (multiLineComment && currChar == '/' && sql.charAt(currIndex - 1) == '*') {
+      multiLineComment = false;
+    }
+
+    if (currChar == '\'') {
+      if (quoteString) {
+        quoteString = false;
+      } else if (!doubleQuoteString) {
+        quoteString = true;
+      }
+    }
+
+    if (currChar == '"') {
+      if (doubleQuoteString && currIndex > 0) {
+        doubleQuoteString = false;
+      } else if (!quoteString) {
+        doubleQuoteString = true;
+      }
+    }
+
+    if (!quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment
+        && sql.length() > currIndex + 1) {
+      if (currChar == '-' && sql.charAt(currIndex + 1) == '-') {
+        singleLineComment = true;
+      } else if (currChar == '/' && sql.charAt(currIndex + 1) == '*') {
+        multiLineComment = true;
+      }
+    }
+  }
+
+  public ArrayList<String> splitSqlQueries() {
+    initialize();
+
+    for (currIndex = 0; currIndex < sql.length(); currIndex++) {
+      currChar = sql.charAt(currIndex);
+      checkCommentsAndQuetes();
+
+      if (currChar == ';' && !quoteString && !doubleQuoteString && !multiLineComment
+          && !singleLineComment) {
+        res.add(StringUtils.trim(builder.toString()));
+        builder = new StringBuilder();
+      } else if (currIndex == sql.length() - 1) {
+        builder.append(currChar);
+        res.add(StringUtils.trim(builder.toString()));
+      } else {
+        builder.append(currChar);
+      }
+    }
+
+    return res;
+  }
+
+  public ArrayList<String> recourcePoolReqs() {
+    initialize();
+    Boolean formingReq = false;
+
+    for (currIndex = 0; currIndex < sql.length(); currIndex++) {
+      currChar = sql.charAt(currIndex);
+      checkCommentsAndQuetes();
+
+      if (currChar == '{' && sql.indexOf(JDBCInterpreter.POOL_REQ_PREFIX, currIndex) == currIndex &&
+          !quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
+        formingReq = true;
+      }
+
+      if (formingReq) {
+        builder.append(currChar);
+      }
+
+      if (currChar == '}' && formingReq && !quoteString && !doubleQuoteString && !multiLineComment
+          && !singleLineComment) {
+        formingReq = false;
+        res.add(builder.toString());
+        builder = new StringBuilder();
+      }
+    }
+
+    return res;
+  }
+
+}

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
@@ -101,7 +101,7 @@ public class SqlParser {
     return res;
   }
 
-  public ArrayList<String> recourcePoolReqs() {
+  public ArrayList<String> resourcePoolReqs() {
     initialize();
     Boolean formingReq = false;
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlParser.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.ArrayList;
 
 public class SqlParser {
-  private ArrayList<String> res;
+  private ArrayList<String> statement;
   private StringBuilder builder;
 
   private Boolean multiLineComment;
@@ -35,7 +35,7 @@ public class SqlParser {
   }
 
   private void initialize() {
-    res = new ArrayList<>();
+    statement = new ArrayList<>();
     builder = new StringBuilder();
     multiLineComment = false;
     singleLineComment = false;
@@ -44,7 +44,7 @@ public class SqlParser {
     currIndex = 0;
   }
 
-  private void checkCommentsAndQuetes() {
+  private void checkCommentsAndQuotes() {
     if (singleLineComment && (currChar == '\n' || currIndex == sql.length() - 1)) {
       singleLineComment = false;
     }
@@ -84,21 +84,21 @@ public class SqlParser {
 
     for (currIndex = 0; currIndex < sql.length(); currIndex++) {
       currChar = sql.charAt(currIndex);
-      checkCommentsAndQuetes();
+      checkCommentsAndQuotes();
 
       if (currChar == ';' && !quoteString && !doubleQuoteString && !multiLineComment
           && !singleLineComment) {
-        res.add(StringUtils.trim(builder.toString()));
+        statement.add(StringUtils.trim(builder.toString()));
         builder = new StringBuilder();
       } else if (currIndex == sql.length() - 1) {
         builder.append(currChar);
-        res.add(StringUtils.trim(builder.toString()));
+        statement.add(StringUtils.trim(builder.toString()));
       } else {
         builder.append(currChar);
       }
     }
 
-    return res;
+    return statement;
   }
 
   public ArrayList<String> resourcePoolReqs() {
@@ -107,7 +107,7 @@ public class SqlParser {
 
     for (currIndex = 0; currIndex < sql.length(); currIndex++) {
       currChar = sql.charAt(currIndex);
-      checkCommentsAndQuetes();
+      checkCommentsAndQuotes();
 
       if (currChar == '{' && sql.indexOf(JDBCInterpreter.POOL_REQ_PREFIX, currIndex) == currIndex &&
           !quoteString && !doubleQuoteString && !multiLineComment && !singleLineComment) {
@@ -121,12 +121,12 @@ public class SqlParser {
       if (currChar == '}' && formingReq && !quoteString && !doubleQuoteString && !multiLineComment
           && !singleLineComment) {
         formingReq = false;
-        res.add(builder.toString());
+        statement.add(builder.toString());
         builder = new StringBuilder();
       }
     }
 
-    return res;
+    return statement;
   }
 
 }

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCAbstractTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCAbstractTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zeppelin.jdbc;
+
+import static java.lang.String.format;
+
+import org.apache.zeppelin.resource.LocalResourcePool;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Properties;
+
+import com.mockrunner.jdbc.BasicJDBCTestCaseAdapter;
+
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.user.AuthenticationInfo;
+
+/**
+ * JDBC interpreter unit tests.
+ */
+public class JDBCAbstractTest extends BasicJDBCTestCaseAdapter {
+  static String jdbcConnection;
+  InterpreterContext interpreterContext;
+  final String NOTE_ID = "SOMENOTEID";
+
+  protected static String getJdbcConnection() throws IOException {
+    if (null == jdbcConnection) {
+      Path tmpDir = Files.createTempDirectory("h2-test-");
+      tmpDir.toFile().deleteOnExit();
+      jdbcConnection = format("jdbc:h2:%s", tmpDir);
+    }
+    return jdbcConnection;
+  }
+
+  public static Properties getJDBCTestProperties() {
+    Properties p = new Properties();
+    p.setProperty("default.driver", "org.postgresql.Driver");
+    p.setProperty("default.url", "jdbc:postgresql://localhost:5432/");
+    p.setProperty("default.user", "gpadmin");
+    p.setProperty("default.password", "");
+    p.setProperty("common.max_count", "1000");
+
+    return p;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    Class.forName("org.h2.Driver");
+    Connection connection = DriverManager.getConnection(getJdbcConnection());
+    Statement statement = connection.createStatement();
+    statement.execute(
+        "DROP TABLE IF EXISTS test_table; " +
+            "CREATE TABLE test_table(id varchar(255), name varchar(255));");
+
+    PreparedStatement insertStatement = connection.prepareStatement(
+        "insert into test_table(id, name) values ('a', 'a_name'),('b', 'b_name'),('c', ?);");
+    insertStatement.setString(1, null);
+    insertStatement.execute();
+    interpreterContext = InterpreterContext.builder()
+        .setAuthenticationInfo(new AuthenticationInfo("testUser"))
+        .setResourcePool(new LocalResourcePool("pool1"))
+        .setNoteId(NOTE_ID)
+        .build();
+  }
+
+}

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -154,7 +154,7 @@ public class JDBCInterpreterTest extends JDBCAbstractTest {
     Properties properties = new Properties();
     JDBCInterpreter t = new JDBCInterpreter(properties);
     t.open();
-    List<String> multipleSqlArray = t.splitSqlQueries(sqlQuery);
+    List<String> multipleSqlArray = new SqlParser(sqlQuery).splitSqlQueries();
     assertEquals(10, multipleSqlArray.size());
     assertEquals("insert into test_table(id, name) values ('a', ';\"')", multipleSqlArray.get(0));
     assertEquals("select * from test_table", multipleSqlArray.get(1));

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -19,8 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import static java.lang.String.format;
-
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.COMMON_MAX_LINE;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_DRIVER;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_PASSWORD;
@@ -30,25 +28,16 @@ import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_URL;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_PRECODE;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.PRECODE_KEY_TEMPLATE;
 
-import org.junit.Before;
 import org.junit.Test;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.STATEMENT_PRECODE_KEY_TEMPLATE;
 
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
-import com.mockrunner.jdbc.BasicJDBCTestCaseAdapter;
 
 import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -65,49 +54,7 @@ import org.apache.zeppelin.user.UsernamePassword;
 /**
  * JDBC interpreter unit tests.
  */
-public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
-  static String jdbcConnection;
-  InterpreterContext interpreterContext;
-
-  private static String getJdbcConnection() throws IOException {
-    if (null == jdbcConnection) {
-      Path tmpDir = Files.createTempDirectory("h2-test-");
-      tmpDir.toFile().deleteOnExit();
-      jdbcConnection = format("jdbc:h2:%s", tmpDir);
-    }
-    return jdbcConnection;
-  }
-
-  public static Properties getJDBCTestProperties() {
-    Properties p = new Properties();
-    p.setProperty("default.driver", "org.postgresql.Driver");
-    p.setProperty("default.url", "jdbc:postgresql://localhost:5432/");
-    p.setProperty("default.user", "gpadmin");
-    p.setProperty("default.password", "");
-    p.setProperty("common.max_count", "1000");
-
-    return p;
-  }
-
-  @Before
-  public void setUp() throws Exception {
-    Class.forName("org.h2.Driver");
-    Connection connection = DriverManager.getConnection(getJdbcConnection());
-    Statement statement = connection.createStatement();
-    statement.execute(
-        "DROP TABLE IF EXISTS test_table; " +
-        "CREATE TABLE test_table(id varchar(255), name varchar(255));");
-
-    PreparedStatement insertStatement = connection.prepareStatement(
-            "insert into test_table(id, name) values ('a', 'a_name'),('b', 'b_name'),('c', ?);");
-    insertStatement.setString(1, null);
-    insertStatement.execute();
-    interpreterContext = InterpreterContext.builder()
-        .setAuthenticationInfo(new AuthenticationInfo("testUser"))
-        .build();
-  }
-
-
+public class JDBCInterpreterTest extends JDBCAbstractTest {
   @Test
   public void testForParsePropertyKey() {
     JDBCInterpreter t = new JDBCInterpreter(new Properties());

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.zeppelin.jdbc;
+
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.resource.WellKnownResourceName;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class JDBCPoolManagerTest extends JDBCAbstractTest{
+  private final String POOL_STR_HEADER = "%table id\tlogin\tname\treg_date\n";
+  private final String RESP_STR_HEADER = "ID\tLOGIN\tNAME\tREG_DATE\n";
+  private final String STR_DATA = "1\talex\tAlexander\t2018-07-06\n" +
+                          "2\tvasyan\tVasiliy\t2018-07-04\n" +
+                          "3\trusick\tRuslan\t2018-05-28\n";
+  private final String POOL_STR = POOL_STR_HEADER + STR_DATA;
+  private final String RESP_STR = RESP_STR_HEADER + STR_DATA;
+  private final String PARAGRAPH_ID = "20180711-115912_974030005";
+
+  @Before
+  public void fillResourcePool() {
+    interpreterContext.getResourcePool().put(
+        NOTE_ID,
+        PARAGRAPH_ID,
+        WellKnownResourceName.ZeppelinTableResult.toString(),
+        POOL_STR
+    );
+  }
+
+  @Test
+  public void testSelectQueryFromResourcePool() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    properties.setProperty("default.stringType", "varchar(100)");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    final String sqlQuery = String.format(
+        "select * from {ResourcePool.note_id=%s.paragraph_id=%s}", NOTE_ID, PARAGRAPH_ID);
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+    assertEquals(RESP_STR, interpreterResult.message().get(0).getData());
+  }
+
+  @Test
+  public void testSelectQueryFromResourcePoolWithoutNoteId() throws SQLException, IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    properties.setProperty("default.stringType", "varchar(100)");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    final String sqlQuery = String.format("select * from {ResourcePool.paragraph_id=%s}",
+        PARAGRAPH_ID);
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+    assertEquals(RESP_STR, interpreterResult.message().get(0).getData());
+  }
+}

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
@@ -95,7 +95,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
   public void testResourcePoolReqs() {
     final String sql =
         "SELECT * FROM {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID};";
-    List <String> reqs = JDBCPoolManager.recourcePoolReqs(sql);
+    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
     assertEquals(Collections.singletonList(
         "{ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID}"), reqs);
   }
@@ -106,7 +106,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
     final String sql =
         "SELECT * FROM some_table " +
             "'{ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID}';";
-    List <String> reqs = JDBCPoolManager.recourcePoolReqs(sql);
+    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 
@@ -115,7 +115,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
     final String sql =
         "SELECT * FROM {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID " +
             "oops someone miss close figure bracket;";
-    List <String> reqs = JDBCPoolManager.recourcePoolReqs(sql);
+    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 
@@ -125,7 +125,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
         "SELECT * FROM some_table " +
             "/* {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID} */; and  " +
             "\n-- {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID} ";
-    List <String> reqs = JDBCPoolManager.recourcePoolReqs(sql);
+    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCPoolManagerTest.java
@@ -95,7 +95,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
   public void testResourcePoolReqs() {
     final String sql =
         "SELECT * FROM {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID};";
-    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
+    List <String> reqs = new SqlParser(sql).resourcePoolReqs();
     assertEquals(Collections.singletonList(
         "{ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID}"), reqs);
   }
@@ -106,7 +106,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
     final String sql =
         "SELECT * FROM some_table " +
             "'{ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID}';";
-    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
+    List <String> reqs = new SqlParser(sql).resourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 
@@ -115,7 +115,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
     final String sql =
         "SELECT * FROM {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID " +
             "oops someone miss close figure bracket;";
-    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
+    List <String> reqs = new SqlParser(sql).resourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 
@@ -125,7 +125,7 @@ public class JDBCPoolManagerTest extends JDBCAbstractTest{
         "SELECT * FROM some_table " +
             "/* {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID} */; and  " +
             "\n-- {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID} ";
-    List <String> reqs = new SqlParser(sql).recourcePoolReqs();
+    List <String> reqs = new SqlParser(sql).resourcePoolReqs();
     assertEquals(Collections.emptyList(), reqs);
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
@@ -84,17 +84,20 @@ public class InterpreterResult implements Serializable, JsonSerializable {
    * Automatically detect %[display_system] directives
    * @param msg
    */
-  public void add(String msg) {
+  public static List<InterpreterResultMessage> getMsgsFromString(String msg) {
     InterpreterOutput out = new InterpreterOutput(null);
+    List<InterpreterResultMessage> interpreterResultMessages = null;
     try {
       out.write(msg);
       out.flush();
-      this.msg.addAll(out.toInterpreterResultMessage());
+      interpreterResultMessages = out.toInterpreterResultMessage();
       out.close();
-    } catch (IOException e) {
-      logger.error(e.getMessage(), e);
-    }
+    } catch (IOException e) { /*ignored*/ }
+    return interpreterResultMessages;
+  }
 
+  public void add(String msg) {
+    this.msg.addAll(getMsgsFromString(msg));
   }
 
   public void add(Type type, String data) {


### PR DESCRIPTION
### What is this PR for?
> It's information in resourcePool, but it is only available for viewing. It would be nice if we can save this data to SQL via JDBC Driver.

Now you can access to `ResourcePool` data from SQL query. For example, if you write `SELECT * FROM {ResourcePool.note_id=SOME_NOTE_ID.paragraph_id=SOME_PARAGRAPH_ID};` and it will be correct SQL query.
How it works:
1. Creates and fills a table named like a `PARAGRAPH_ID`;
2. Expression `{*}` replaces with actual table name;
3. Updated SQL query is running.

Also, you can not specify the note_id, then the note_id of the current notebook will be used. For example, `SELECT * FROM {ResourcePool.paragraph_id=SOME_PARAGRAPH_ID};`.

### What type of PR is it?
Improvement

### What is the Jira issue?
[Zeppelin 3596](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3596?filter=allopenissues)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
