### PR TITLE
ZEPPELIN-3617. Allow to specify saving resourceName as paragraph property

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -559,6 +559,8 @@ public class PythonInterpreter extends Interpreter {
           InterpreterContext.get());
       if (result.code() != Code.SUCCESS) {
         throw new IOException("Fail to run bootstrap script: " + resourceName + "\n" + result);
+      } else {
+        LOGGER.debug("Bootstrap python successfully.");
       }
     } catch (InterpreterException e) {
       throw new IOException(e);

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -98,6 +98,7 @@ public class PySparkInterpreter extends PythonInterpreter {
       try {
         bootstrapInterpreter("python/zeppelin_pyspark.py");
       } catch (IOException e) {
+        LOGGER.error("Fail to bootstrap pyspark", e);
         throw new InterpreterException("Fail to bootstrap pyspark", e);
       }
     }

--- a/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
+++ b/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
@@ -66,6 +66,12 @@ z.put <- function(name, object) {
 z.get <- function(name) {
   SparkR:::callJMethod(.zeppelinContext, "get", name)
 }
+
+z.getAsDataFrame <- function(name) {
+  stringValue <- z.get(name)
+  read.table(text=stringValue, header=TRUE, sep="\t")
+}
+
 z.angular <- function(name, noteId=NULL, paragraphId=NULL) {
   SparkR:::callJMethod(.zeppelinContext, "angular", name, noteId, paragraphId)
 }

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -99,6 +99,11 @@ public class SparkShimsTest {
             public String showDataFrame(Object obj, int maxResult) {
               return null;
             }
+
+            @Override
+            public Object getAsDataFrame(String value) {
+              return null;
+            }
           };
       assertEquals(expected, sparkShims.supportYarn6615(version));
     }
@@ -121,9 +126,9 @@ public class SparkShimsTest {
       when(mockContext.getIntpEventClient()).thenReturn(mockIntpEventClient);
       doNothing().when(mockIntpEventClient).onParaInfosReceived(argumentCaptor.capture());
       try {
-        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString(), new Properties());
+        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString(), new Properties(), null);
       } catch (Throwable ignore) {
-        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString(), new Properties());
+        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString(), new Properties(), null);
       }
     }
 

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -303,7 +303,13 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
   }
 
   protected def createZeppelinContext(): Unit = {
-    val sparkShims = SparkShims.getInstance(sc.version, properties)
+
+    var sparkShims: SparkShims = null
+    if (isSparkSessionPresent()) {
+      sparkShims = SparkShims.getInstance(sc.version, properties, sparkSession)
+    } else {
+      sparkShims = SparkShims.getInstance(sc.version, properties, sc)
+    }
     var webUiUrl = properties.getProperty("zeppelin.spark.uiWebUrl");
     if (StringUtils.isBlank(webUiUrl)) {
       webUiUrl = sparkUrl;

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/SparkZeppelinContext.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/SparkZeppelinContext.scala
@@ -20,6 +20,7 @@ package org.apache.zeppelin.spark
 import java.util
 
 import org.apache.spark.SparkContext
+import org.apache.spark.sql.DataFrame
 import org.apache.zeppelin.annotation.ZeppelinApi
 import org.apache.zeppelin.display.AngularObjectWatcher
 import org.apache.zeppelin.display.ui.OptionInput.ParamOption
@@ -145,5 +146,9 @@ class SparkZeppelinContext(val sc: SparkContext,
       }
     }
     angularWatch(name, noteId, w)
+  }
+
+  def getAsDataFrame(name: String): Object = {
+    sparkShims.getAsDataFrame(get(name).toString)
   }
 }

--- a/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
+++ b/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
@@ -54,7 +54,7 @@ public abstract class SparkShims {
     this.properties = properties;
   }
 
-  private static SparkShims loadShims(String sparkVersion, Properties properties)
+  private static SparkShims loadShims(String sparkVersion, Properties properties, Object entryPoint)
       throws ReflectiveOperationException {
     Class<?> sparkShimsClass;
     if ("2".equals(sparkVersion)) {
@@ -65,15 +65,22 @@ public abstract class SparkShims {
       sparkShimsClass = Class.forName("org.apache.zeppelin.spark.Spark1Shims");
     }
 
-    Constructor c = sparkShimsClass.getConstructor(Properties.class);
-    return (SparkShims) c.newInstance(properties);
+    Constructor c = sparkShimsClass.getConstructor(Properties.class, Object.class);
+    return (SparkShims) c.newInstance(properties, entryPoint);
   }
 
-  public static SparkShims getInstance(String sparkVersion, Properties properties) {
+  /**
+   *
+   * @param sparkVersion
+   * @param properties
+   * @param entryPoint  entryPoint is SparkContext for Spark 1.x SparkSession for Spark 2.x
+   * @return
+   */
+  public static SparkShims getInstance(String sparkVersion, Properties properties, Object entryPoint) {
     if (sparkShims == null) {
       String sparkMajorVersion = getSparkMajorVersion(sparkVersion);
       try {
-        sparkShims = loadShims(sparkMajorVersion, properties);
+        sparkShims = loadShims(sparkMajorVersion, properties, entryPoint);
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(e);
       }
@@ -95,6 +102,7 @@ public abstract class SparkShims {
 
   public abstract String showDataFrame(Object obj, int maxResult);
 
+  public abstract Object getAsDataFrame(String value);
 
   protected void buildSparkJobUrl(String master,
                                   String sparkWebUrl,

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/BaseZeppelinContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/BaseZeppelinContext.java
@@ -853,6 +853,25 @@ public abstract class BaseZeppelinContext {
   }
 
   /**
+   * Get object from resource pool
+   * Search local process first and then the other processes
+   *
+   * @param name
+   * @param clazz  The class of the returned value
+   * @return null if resource not found
+   */
+  @ZeppelinApi
+  public <T> T get(String name, Class<T> clazz) {
+    ResourcePool resourcePool = interpreterContext.getResourcePool();
+    Resource resource = resourcePool.get(name);
+    if (resource != null) {
+      return resource.get(clazz);
+    } else {
+      return null;
+    }
+  }
+
+  /**
    * Remove object from resourcePool
    *
    * @param name

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -69,7 +69,6 @@ import org.apache.zeppelin.resource.DistributedResourcePool;
 import org.apache.zeppelin.resource.Resource;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.resource.ResourceSet;
-import org.apache.zeppelin.resource.WellKnownResourceName;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.scheduler.JobListener;
@@ -88,6 +87,7 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -679,24 +679,35 @@ public class RemoteInterpreterServer extends Thread
         // data from context.out is prepended to InterpreterResult if both defined
         context.out.flush();
         List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
-        resultMessages.addAll(result.message());
 
+        for (InterpreterResultMessage resultMessage : result.message()) {
+          // only add non-empty InterpreterResultMessage
+          if (!StringUtils.isBlank(resultMessage.getData())) {
+            resultMessages.add(resultMessage);
+          }
+        }
+
+        List<String> stringResult = new ArrayList<>();
         for (InterpreterResultMessage msg : resultMessages) {
           if (msg.getType() == InterpreterResult.Type.IMG) {
             logger.debug("InterpreterResultMessage: IMAGE_DATA");
           } else {
             logger.debug("InterpreterResultMessage: " + msg.toString());
           }
+          stringResult.add(msg.getData());
         }
         // put result into resource pool
-        if (resultMessages.size() > 0) {
-          int lastMessageIndex = resultMessages.size() - 1;
-          if (resultMessages.get(lastMessageIndex).getType() == InterpreterResult.Type.TABLE) {
+        if (context.getLocalProperties().containsKey("saveAs")) {
+          if (stringResult.size() == 1) {
+            logger.info("Saving result into ResourcePool as single string: " +
+                    context.getLocalProperties().get("saveAs"));
             context.getResourcePool().put(
-                    context.getNoteId(),
-                    context.getParagraphId(),
-                    WellKnownResourceName.ZeppelinTableResult.toString(),
-                    resultMessages.get(lastMessageIndex));
+                    context.getLocalProperties().get("saveAs"), stringResult.get(0));
+          } else {
+            logger.info("Saving result into ResourcePool as string list: " +
+                    context.getLocalProperties().get("saveAs"));
+            context.getResourcePool().put(
+                    context.getLocalProperties().get("saveAs"), stringResult);
           }
         }
         return new InterpreterResult(result.code(), resultMessages);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/DistributedResourcePool.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/DistributedResourcePool.java
@@ -56,6 +56,8 @@ public class DistributedResourcePool extends LocalResourcePool {
       if (resources.isEmpty()) {
         return null;
       } else {
+        // TODO(zjffdu) just assume there's no dupicated resources with the same name, but
+        // this assumption is false
         return resources.get(0);
       }
     } else {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
@@ -17,10 +17,10 @@
 package org.apache.zeppelin.resource;
 
 import com.google.gson.Gson;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import com.google.gson.internal.Primitives;
 import org.apache.zeppelin.common.JsonSerializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,6 +92,10 @@ public class Resource implements JsonSerializable, Serializable {
     } else {
       return null;
     }
+  }
+
+  public <T> T get(Class<T> clazz) {
+    return Primitives.wrap(clazz).cast(r);
   }
 
   public boolean isSerializable() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourceId.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/ResourceId.java
@@ -26,6 +26,7 @@ import org.apache.zeppelin.common.JsonSerializable;
 public class ResourceId implements JsonSerializable, Serializable {
   private static final Gson gson = new Gson();
 
+  // resourcePoolId is the interpreterGroupId which is unique across one Zeppelin instance
   private final String resourcePoolId;
   private final String name;
   private final String noteId;


### PR DESCRIPTION
### What is this PR for?
This is allow user to specify resourceName when they want to save the paragraph result into ResourcePool. Before this PR, user don't have control on what name of the saving resource name. It is associated with noteId and paragraphId, but this is not a good solution. Because when you clone the note, noteId will be changed, and you have to change the noteId in code as well. This PR is trying to allow user to set resource Name for the saving paragraph result. 


### What type of PR is it?
[ Feature |g]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3617

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![screen shot 2018-07-12 at 2 45 54 pm](https://user-images.githubusercontent.com/164491/42616882-5ee2fa3a-85e2-11e8-80d5-3ba45c84114b.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
