### PR TITLE
[ZEPPELIN-3618] ZeppelinContext methods z.run and z.runNote fall after passing wrong argument

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -234,9 +234,8 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
     appListener.onStatusChange(event.noteId, event.paragraphId, event.appId, event.status);
   }
 
-
   @Override
-  public void runParagraphs(RunParagraphsEvent event) {
+  public void runParagraphs(RunParagraphsEvent event) throws TException {
     try {
       listener.runParagraphs(event.getNoteId(), event.getParagraphIndices(),
           event.getParagraphIds(), event.getCurParagraphId());
@@ -247,7 +246,7 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
         LOGGER.info("complete runParagraphs." + event);
       }
     } catch (IOException e) {
-      throw new RuntimeException(e.getMessage());
+      throw new TException(e);
     }
   }
 


### PR DESCRIPTION

### What is this PR for?
Passing wrong argument to z.run() or z.runNote() causes error:
* Zeppelin log:
```
ERROR [2018-07-12 18:19:05,110] ({pool-5-thread-1} TThreadPoolServer.java[run]:297) - Error occurred during processing of message.
java.lang.RuntimeException: Not existed noteId: WrongNoteId
at org.apache.zeppelin.interpreter.RemoteInterpreterEventServer.runParagraphs(RemoteInterpreterEventServer.java:250)
... 
```
* Interpreter log:
```
WARN [2018-07-12 18:19:05,113] ({pool-2-thread-5} RemoteInterpreterEventClient.java[runParagraphs]:259) - Fail to runParagraphs: RunParagraphsEvent(noteId:broadcast, paragraphIds:[], paragraphIndices:[], curParagraphId:20180709-113817_1103600568)
org.apache.thrift.transport.TTransportException
...
INFO [2018-07-12 18:19:05,223] ({pool-2-thread-5} SchedulerFactory.java[jobFinished]:115) - Job 20180709-113817_1103600568 finished by scheduler interpreter_434750169
WARN [2018-07-12 18:20:10,756] ({pool-1-thread-1} RemoteInterpreterEventClient.java[onInterpreterOutputUpdateAll]:234) - Fail to updateAllOutput
org.apache.thrift.transport.TTransportException
...
```
After that user couldn't use z.run() and z.runNote() until interpreter restart.
### What type of PR is it?
Bug Fix

### What is the Jira issue?
Issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3618

### How should this be tested?
* CI pass
* Zeppelin log for `z.run("WrongParagraphId")` and `z.runNote("WrongNoteId")`:
```
ERROR [2018-07-12 19:32:49,125] ({pool-5-thread-1} RemoteInterpreterEventServer.java[runParagraphs]:250) - Not existed paragraphId: WrongParagraphId
ERROR [2018-07-12 19:31:45,746] ({pool-5-thread-1} RemoteInterpreterEventServer.java[runParagraphs]:250) - Not existed noteId: WrongNoteId
```
* No error messages in interpreter log

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
