### PR TITLE
[ZEPPELIN-3438] Passing Z variables to BigQuery 

### DIFF
--- a/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
+++ b/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
@@ -289,7 +289,9 @@ public class BigQueryInterpreter extends Interpreter {
   }
 
   @Override
-  public InterpreterResult interpret(String sql, InterpreterContext contextInterpreter) {
+  public InterpreterResult interpret(String originalSql, InterpreterContext contextInterpreter) {
+    String sql = Boolean.parseBoolean(getProperty("zeppelin.bigquery.interpolation")) ?
+            interpolate(originalSql, contextInterpreter.getResourcePool()) : originalSql;
     logger.info("Run SQL command '{}'", sql);
     return executeSql(sql);
   }

--- a/bigquery/src/main/resources/interpreter-setting.json
+++ b/bigquery/src/main/resources/interpreter-setting.json
@@ -31,6 +31,13 @@
         "defaultValue": "",
         "description": "BigQuery SQL dialect (standardSQL or legacySQL). If empty, query prefix like '#standardSQL' can be used.",
         "type": "string"
+      },
+      "zeppelin.bigquery.interpolation": {
+        "envName": null,
+        "propertyName": "zeppelin.bigquery.interpolation",
+        "defaultValue": false,
+        "description": "Enable ZeppelinContext variable interpolation into paragraph text",
+        "type": "checkbox"
       }
     },
     "editor": {

--- a/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationDisabled.java
+++ b/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationDisabled.java
@@ -1,0 +1,109 @@
+/*
+* Copyright 2016 Google Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.zeppelin.bigquery;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.resource.LocalResourcePool;
+import org.apache.zeppelin.resource.ResourcePool;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class BigQueryInterpolationDisabled {
+  protected static class Constants {
+    private String projectId;
+    private String oneQuery;
+    private String wrongQuery;
+
+    public String getProjectId() {
+      return projectId;
+    }
+
+    public String getOne() {
+      return oneQuery;
+    }
+
+    public String getWrong()  {
+      return wrongQuery;
+    }
+  }
+
+  protected static Constants constants = null;
+
+  public BigQueryInterpolationDisabled()
+      throws JsonSyntaxException, JsonIOException, FileNotFoundException {
+    if (constants == null) {
+      InputStream is = this.getClass().getResourceAsStream("/constants.json");
+      constants = (new Gson()).<Constants>fromJson(new InputStreamReader(is), Constants.class);
+    }
+  }
+
+  private InterpreterGroup intpGroup;
+  private BigQueryInterpreter bqInterpreter;
+
+  private InterpreterContext context;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties p = new Properties();
+    p.setProperty("zeppelin.bigquery.project_id", constants.getProjectId());
+    p.setProperty("zeppelin.bigquery.wait_time", "5000");
+    p.setProperty("zeppelin.bigquery.max_no_of_rows", "100");
+    p.setProperty("zeppelin.bigquery.sql_dialect", "");
+
+    intpGroup = new InterpreterGroup();
+
+    bqInterpreter = new BigQueryInterpreter(p);
+    bqInterpreter.setInterpreterGroup(intpGroup);
+    bqInterpreter.open();
+    ResourcePool resourcePool = new LocalResourcePool("BigQueryInterpolationTest");
+    resourcePool.put("one", 1);
+    resourcePool.put("two", 2);
+    context = InterpreterContext.builder().setResourcePool(resourcePool).build();
+  }
+
+  @Test
+  public void testInterpolation() {
+    InterpreterResult ret = bqInterpreter.
+            interpret("SELECT {one} AS col1, {two} AS col2", context);
+    String[] lines = ret.message().get(0).getData().split("\\n");
+    assertEquals(2, lines.length);
+    assertEquals("col1\tcol2", lines[0]);
+    assertEquals("{one}\t{two}", lines[1]);
+  }
+
+  @Test
+  public void testEscaping() {
+    InterpreterResult ret = bqInterpreter.
+        interpret("SELECT {{one}} AS col1, {{two}} AS col2", context);
+    String[] lines = ret.message().get(0).getData().split("\\n");
+    assertEquals(2, lines.length);
+    assertEquals("col1\tcol2", lines[0]);
+    assertEquals("{{one}}\t{{two}}", lines[1]);
+  }
+}

--- a/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationEnabled.java
+++ b/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationEnabled.java
@@ -1,0 +1,111 @@
+/*
+* Copyright 2016 Google Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.zeppelin.bigquery;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.resource.LocalResourcePool;
+import org.apache.zeppelin.resource.ResourcePool;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class BigQueryInterpolationEnabled {
+  protected static class Constants {
+    private String projectId;
+    private String oneQuery;
+    private String wrongQuery;
+
+    public String getProjectId() {
+      return projectId;
+    }
+
+    public String getOne() {
+      return oneQuery;
+    }
+
+    public String getWrong()  {
+      return wrongQuery;
+    }
+  }
+
+  protected static Constants constants = null;
+
+  public BigQueryInterpolationEnabled()
+      throws JsonSyntaxException, JsonIOException, FileNotFoundException {
+    if (constants == null) {
+      InputStream is = this.getClass().getResourceAsStream("/constants.json");
+      constants = (new Gson()).<Constants>fromJson(new InputStreamReader(is), Constants.class);
+    }
+  }
+
+  private InterpreterGroup intpGroup;
+  private BigQueryInterpreter bqInterpreter;
+
+  private InterpreterContext context;
+
+  @Before
+  public void setUp() throws Exception {
+    Properties p = new Properties();
+    p.setProperty("zeppelin.bigquery.project_id", constants.getProjectId());
+    p.setProperty("zeppelin.bigquery.wait_time", "5000");
+    p.setProperty("zeppelin.bigquery.max_no_of_rows", "100");
+    p.setProperty("zeppelin.bigquery.sql_dialect", "");
+
+    p.setProperty("zeppelin.bigquery.interpolation", "true");
+
+    intpGroup = new InterpreterGroup();
+
+    bqInterpreter = new BigQueryInterpreter(p);
+    bqInterpreter.setInterpreterGroup(intpGroup);
+    bqInterpreter.open();
+    ResourcePool resourcePool = new LocalResourcePool("BigQueryInterpolationTest");
+    resourcePool.put("one", 1);
+    resourcePool.put("two", 2);
+    context = InterpreterContext.builder().setResourcePool(resourcePool).build();
+  }
+
+  @Test
+  public void testInterpolation() {
+    InterpreterResult ret = bqInterpreter.
+            interpret("SELECT {one} AS col1, {two} AS col2", context);
+    String[] lines = ret.message().get(0).getData().split("\\n");
+    assertEquals(2, lines.length);
+    assertEquals("col1\tcol2", lines[0]);
+    assertEquals("1\t2", lines[1]);
+  }
+
+  @Test
+  public void testEscaping() {
+    InterpreterResult ret = bqInterpreter.
+        interpret("SELECT {{one}} AS col1, {{two}} AS col2", context);
+    String[] lines = ret.message().get(0).getData().split("\\n");
+    assertEquals(2, lines.length);
+    assertEquals("col1\tcol2", lines[0]);
+    assertEquals("{one}\t{two}", lines[1]);
+  }
+}

--- a/docs/interpreter/bigquery.md
+++ b/docs/interpreter/bigquery.md
@@ -53,6 +53,11 @@ limitations under the License.
     <td></td>
     <td>BigQuery SQL dialect (standardSQL or legacySQL). If empty, [query prefix](https://cloud.google.com/bigquery/docs/reference/standard-sql/enabling-standard-sql#sql-prefix) like '#standardSQL' can be used.</td>
   </tr>
+  <tr>
+    <td>zeppelin.bigquery.interpolation</td>
+    <td></td>
+    <td>Enables ZeppelinContext variable interpolation into paragraph text. Default value is false.</td>
+  </tr>
 </table>
 
 
@@ -118,6 +123,28 @@ ORDER BY
 LIMIT
   40
 ```
+
+## Object Interpolation
+The BigQuery interpreter also supports interpolation of `ZeppelinContext` objects into the paragraph text.
+The following example shows one use of this facility:
+
+####In Scala cell:
+```
+z.put("country_code", "KR")
+    // ...
+```
+
+
+```bash
+%bigquery.sql
+    select * from patents_list where 
+    priority_country = '{country_code}' and filing_date like '2015-%'
+```
+
+Object interpolation is disabled by default, and can be enabled  by 
+setting the value of the property `zeppelin.bigquery.interpolation` to `true` (see _More Properties_ above). 
+More details of this feature can be found in the Spark interpreter documentation under 
+[Object Interpolation](spark.html#object-interpolation)
 
 ## Technical description
 

--- a/docs/interpreter/bigquery.md
+++ b/docs/interpreter/bigquery.md
@@ -55,8 +55,8 @@ limitations under the License.
   </tr>
   <tr>
     <td>zeppelin.bigquery.interpolation</td>
-    <td></td>
-    <td>Enables ZeppelinContext variable interpolation into paragraph text. Default value is false.</td>
+    <td>false</td>
+    <td>Enables ZeppelinContext variable interpolation into paragraph text.</td>
   </tr>
 </table>
 
@@ -143,8 +143,7 @@ z.put("country_code", "KR")
 
 Object interpolation is disabled by default, and can be enabled  by 
 setting the value of the property `zeppelin.bigquery.interpolation` to `true` (see _More Properties_ above). 
-More details of this feature can be found in the Spark interpreter documentation under 
-[Object Interpolation](spark.html#object-interpolation)
+More details of this feature can be found under _Usage_/_Other Features_/[Zeppelin-Context](../usage/other_features/zeppelin_context.html)
 
 ## Technical description
 


### PR DESCRIPTION
### What is this PR for?
This PR enables the interpolation of ZeppelinContext objects into the paragraph text of BigQuery cells. It also introduces a new interpreter-level configuration parameter named `zeppelin.bigquery.interpolation`. This new parameter is `false` by default, and must be set to `true` to enable object interpolation. The default value of `false` guarantees backward compatibility for users who are not aware of the new feature.

The implementation takes the same approach that was followed in PR [2898](https://github.com/apache/zeppelin/pull/2898) and [2903](https://github.com/apache/zeppelin/pull/2903).

### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3438

### How should this be tested?
Two new unit test classes have been added: [BigQueryInterpolationDisabled.java](https://github.com/sanjaydasgupta/zeppelin/blob/572c2aaa7a96eca98cdef4c77044dfc7a359f89f/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationDisabled.java), and [BigQueryInterpolationEnabled.java](https://github.com/sanjaydasgupta/zeppelin/blob/572c2aaa7a96eca98cdef4c77044dfc7a359f89f/bigquery/src/test/java/org/apache/zeppelin/bigquery/BigQueryInterpolationEnabled.java).

Also, the code in this PR merely causes the BigQuery interpreter to "opt-in" to the implementation of z-variable interpolation already existing in the Interpreter base class - described in [PR-2898](https://github.com/apache/zeppelin/pull/2898). The unit tests necessary for testing z-variable interpolation in detail are already present in PR-2898

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?  No
* Is there breaking changes for older versions?  No
* Does this needs documentation?  Yes, documentation changes provided in [bigquery.md](https://github.com/sanjaydasgupta/zeppelin/blob/572c2aaa7a96eca98cdef4c77044dfc7a359f89f/docs/interpreter/bigquery.md)
