### PR TITLE
[ZEPPELIN-3628] HTML anchor links on paragraph don't work in Google Chrome

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -234,7 +234,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) bootstrap3-dialog v1.34.7 (https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7) - https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7
     (The MIT License) Angular Websocket v1.0.13 (http://angularclass.github.io/angular-websocket/) - https://github.com/AngularClass/angular-websocket/blob/v1.0.13/LICENSE
     (The MIT License) UI.Ace v0.1.1 (http://angularclass.github.io/angular-websocket/) - https://github.com/angular-ui/ui-ace/blob/master/LICENSE
-    (The MIT License) jquery.scrollTo v2.1.2 (https://github.com/flesler/jquery.scrollTo) - https://github.com/flesler/jquery.scrollTo/blob/master/LICENSE
+    (The MIT License) jquery.scrollTo v2.1.2 (https://github.com/flesler/jquery.scrollTo) - https://github.com/flesler/jquery.scrollTo/blob/2.1.2/LICENSE
     (The MIT License) angular-dragdrop v1.0.8 (http://codef0rmer.github.io/angular-dragdrop/#/) - https://github.com/codef0rmer/angular-dragdrop/blob/v1.0.8/LICENSE
     (The MIT License) perfect-scrollbar v0.5.4 (http://noraesae.github.io/perfect-scrollbar/) - https://github.com/noraesae/perfect-scrollbar/tree/0.5.4
     (The MIT License) ng-sortable v1.3.6 (https://github.com/a5hik/ng-sortable) - https://github.com/a5hik/ng-sortable/blob/1.3.6/LICENSE

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -234,7 +234,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) bootstrap3-dialog v1.34.7 (https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7) - https://github.com/nakupanda/bootstrap3-dialog/tree/v1.34.7
     (The MIT License) Angular Websocket v1.0.13 (http://angularclass.github.io/angular-websocket/) - https://github.com/AngularClass/angular-websocket/blob/v1.0.13/LICENSE
     (The MIT License) UI.Ace v0.1.1 (http://angularclass.github.io/angular-websocket/) - https://github.com/angular-ui/ui-ace/blob/master/LICENSE
-    (The MIT License) jquery.scrollTo v1.4.13 (https://github.com/flesler/jquery.scrollTo) - https://github.com/flesler/jquery.scrollTo/blob/1.4.13/LICENSE
+    (The MIT License) jquery.scrollTo v2.1.2 (https://github.com/flesler/jquery.scrollTo) - https://github.com/flesler/jquery.scrollTo/blob/master/LICENSE
     (The MIT License) angular-dragdrop v1.0.8 (http://codef0rmer.github.io/angular-dragdrop/#/) - https://github.com/codef0rmer/angular-dragdrop/blob/v1.0.8/LICENSE
     (The MIT License) perfect-scrollbar v0.5.4 (http://noraesae.github.io/perfect-scrollbar/) - https://github.com/noraesae/perfect-scrollbar/tree/0.5.4
     (The MIT License) ng-sortable v1.3.6 (https://github.com/a5hik/ng-sortable) - https://github.com/a5hik/ng-sortable/blob/1.3.6/LICENSE

--- a/zeppelin-distribution/src/bin_license/licenses/LICENSE-jquery.scrollTo-2.1.2
+++ b/zeppelin-distribution/src/bin_license/licenses/LICENSE-jquery.scrollTo-2.1.2
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2007-2014 Ariel Flesler <aflesler@gmail.com>
+Copyright (c) 2007-2015 Ariel Flesler <aflesler@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/zeppelin-web/bower.json
+++ b/zeppelin-web/bower.json
@@ -16,7 +16,7 @@
     "angular-websocket": "~1.0.13",
     "ace-builds": "1.3.2",
     "angular-ui-ace": "0.1.3",
-    "jquery.scrollTo": "~1.4.13",
+    "jquery.scrollTo": "~2.1.2",
     "nvd3": "~1.8.5",
     "angular-dragdrop": "~1.0.8",
     "perfect-scrollbar": "~0.5.4",
@@ -71,6 +71,7 @@
   },
   "resolutions": {
     "ace-builds": "1.3.2",
-    "angular": ">=1.5.0 <1.6"
+    "angular": ">=1.5.0 <1.6",
+    "jquery.scrollTo": "~2.1.2"
   }
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1199,7 +1199,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     bodyEl.finish();
 
     // scroll to scrollTargetPos
-    bodyEl.scrollTo(scrollTargetPos, {axis: 'y', interrupt: true, duration: 100});
+    if (scrollTargetPos) {
+      bodyEl.scrollTo(scrollTargetPos, {axis: 'y', interrupt: true, duration: 100});
+    }
   };
 
   $scope.getEditorValue = function() {


### PR DESCRIPTION
### What is this PR for?
Links like [1] work well in Firefox, but don't work in Chrome.
1. http://zeppelin/#/notebook/NOTEID?paragraph=PARAGRAPHID

### What type of PR is it?
Improvement

### What is the Jira issue?
issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3628

### How should this be tested?
* Manual checking (see screenshot below)

### Screenshots (if appropriate)
* #### Before
Chrome (v67.0.3396.99):

![chrome](https://user-images.githubusercontent.com/6136993/42819776-31f951e6-89dd-11e8-9618-710f61ea550f.gif)
Firefox (v61.0.1):

![firefox](https://user-images.githubusercontent.com/6136993/42819794-39c5562c-89dd-11e8-8059-4e8f85855471.gif)
* #### After
Chrome (v67.0.3396.99)

![fixed](https://user-images.githubusercontent.com/6136993/42819862-63095cd6-89dd-11e8-80a0-843e613ca867.gif)

### Questions:
* Does the licenses files need update? 
Yes, JQuery.scrollTo changed from 1.4.14 to 2.1.2 
* Is there breaking changes for older versions? No
* Does this needs documentation? No
