### PR TITLE
ZEPPELIN-3566. Add imageWidth as paragraph level properties in SparkRInterpreter

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -127,22 +127,8 @@ public class SparkRInterpreter extends Interpreter {
     sparkInterpreter.getSparkContext().setJobGroup(jobGroup, jobDesc, false);
 
     String imageWidth = getProperty("zeppelin.R.image.width", "100%");
-
-    String[] sl = lines.split("\n");
-    if (sl[0].contains("{") && sl[0].contains("}")) {
-      String jsonConfig = sl[0].substring(sl[0].indexOf("{"), sl[0].indexOf("}") + 1);
-      ObjectMapper m = new ObjectMapper();
-      try {
-        JsonNode rootNode = m.readTree(jsonConfig);
-        JsonNode imageWidthNode = rootNode.path("imageWidth");
-        if (!imageWidthNode.isMissingNode()) imageWidth = imageWidthNode.textValue();
-      }
-      catch (Exception e) {
-        logger.warn("Can not parse json config: " + jsonConfig, e);
-      }
-      finally {
-        lines = lines.replace(jsonConfig, "");
-      }
+    if (interpreterContext.getLocalProperties().containsKey("imageWidth")) {
+      imageWidth = interpreterContext.getLocalProperties().get("imageWidth");
     }
 
     String setJobGroup = "";

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkRInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkRInterpreterTest.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.spark;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
@@ -27,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -125,11 +127,14 @@ public class SparkRInterpreterTest {
     }
 
     // plotting
-    result = sparkRInterpreter.interpret("hist(mtcars$mpg)", getInterpreterContext());
+    InterpreterContext context = getInterpreterContext();
+    context.getLocalProperties().put("imageWidth", "100");
+    result = sparkRInterpreter.interpret("hist(mtcars$mpg)", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertEquals(1, result.message().size());
     assertEquals(InterpreterResult.Type.HTML, result.message().get(0).getType());
     assertTrue(result.message().get(0).getData().contains("<img src="));
+    assertTrue(result.message().get(0).getData().contains("width=\"100\""));
 
     result = sparkRInterpreter.interpret("library(ggplot2)\n" +
         "ggplot(diamonds, aes(x=carat, y=price, color=cut)) + geom_point()", getInterpreterContext());
@@ -150,6 +155,8 @@ public class SparkRInterpreterTest {
         .setNoteId("note_1")
         .setParagraphId("paragraph_1")
         .setIntpEventClient(mockRemoteIntpEventClient)
+        .setInterpreterOut(new InterpreterOutput(null))
+        .setLocalProperties(new HashMap<>())
         .build();
     return context;
   }


### PR DESCRIPTION
### What is this PR for?
Update SparkRInterpreter to put imageWidth as paragraph properties.


### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3666

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
