### PR TITLE
ZEPPELIN-3575. Add 'Copy Column Name' button in visualization table

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -256,6 +256,15 @@ export default class TableVisualization extends Visualization {
             return this.context.col.colDef.type === TableColumnType.DATE;
           },
         },
+        {
+          title: 'Copy Column Name',
+          action: function() {
+            self.copyStringToClipboard(this.context.col.displayName);
+          },
+          active: function() {
+            self.copyStringToClipboard(this.context.col.displayName);
+          },
+        },
       ];
     });
   }
@@ -514,5 +523,15 @@ export default class TableVisualization extends Visualization {
         },
       },
     };
+  }
+
+  copyStringToClipboard(copyString) {
+    const strToClipboard = document.createElement('textarea');
+    strToClipboard.value = copyString;
+    document.body.appendChild(strToClipboard);
+    strToClipboard.select();
+    document.execCommand('copy');
+    document.body.removeChild(strToClipboard);
+    return;
   }
 }


### PR DESCRIPTION
### What is this PR for?
Add button to drop-down list in visualization table to copy column name.
I know that column name could be obtained in a different way, for example, by auto-complete.
Nevertheless I think this feature is comfortable.

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-3575](https://issues.apache.org/jira/browse/ZEPPELIN-3575)

### How should this be tested?
* Manually

### Screenshots (if appropriate)
![zeppelin-3575](https://user-images.githubusercontent.com/9324163/42883801-4b910db0-8aa5-11e8-881c-3f9b750ea6d8.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no 


