### PR TITLE
[zeppelin-3639] Add Ipython interpreter prerequisite check for protobuf

### DIFF
--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -258,8 +258,9 @@ IPython is more powerful than the default python interpreter with extra function
    
     - Jupyter `pip install jupyter`
     - grpcio `pip install grpcio`
+    - protobuf `pip install protobuf`
 
-If you already install anaconda, then you just need to install `grpcio` as Jupyter is already included in anaconda.
+If you already install anaconda, then you just need to install `grpcio` as Jupyter is already included in anaconda. For grpcio version >= 1.12.0 you'll also need to install protobuf separately.
 
 In addition to all basic functions of the python interpreter, you can use all the IPython advanced features as you use it in Jupyter Notebook.
 

--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -186,6 +186,9 @@ public class IPythonInterpreter extends Interpreter implements ExecuteResultHand
       if (!freezeOutput.contains("grpcio=")) {
         return "grpcio is not installed";
       }
+      if (!freezeOutput.contains("protobuf=")) {
+        return "protobuf is not installed";
+      }
       LOGGER.info("IPython prerequisite is met");
     } catch (Exception e) {
       LOGGER.warn("Fail to checkIPythonPrerequisite", e);


### PR DESCRIPTION
### What is this PR for?
This is to protobuf prerequisite check when starting ipython kernel. This is required since from grpcio 1.12.0 it's  independent from protobuf


### What type of PR is it?
[ Improvement ]

### Todos
* [x] - add protobuf prerequisite check
* [x] - add to ipython docs

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3639

### How should this be tested?
1. remove grpcio and protobuf 
2. install latest grpcio and try to run ipython interpreter - should fail
3. then install protobuf and try again - should work

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
