### PR TITLE
[ZEPPELIN-3656] Fix for completion with Livy interpreter

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -248,7 +248,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
       candidates = callCompletion(new CompletionRequest(buf, getSessionKind(), cursor));
     } catch (SessionNotFoundException e) {
       LOGGER.warn("Livy session {} is expired. Will return empty list of candidates.",
-          sessionInfo.id);
+          getSessionInfo().id);
     } catch (LivyException le) {
       logger.error("Failed to call code completions. Will return empty list of candidates", le);
     }
@@ -259,7 +259,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     List<InterpreterCompletion> candidates = new ArrayList<>();
     try {
       CompletionResponse resp = CompletionResponse.fromJson(
-          callRestAPI("/sessions/" + sessionInfo.id + "/completion", "POST", req.toJson()));
+          callRestAPI("/sessions/" + getSessionInfo().id + "/completion", "POST", req.toJson()));
       for (String candidate : resp.candidates) {
         candidates.add(new InterpreterCompletion(candidate, candidate, StringUtils.EMPTY));
       }

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -259,7 +259,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     List<InterpreterCompletion> candidates = new ArrayList<>();
     try {
       CompletionResponse resp = CompletionResponse.fromJson(
-          callRestAPI("/sessions/" + sessionInfo.id + "/completion", "POST", req.toJson()));
+          callRestAPI("/sessions/" + getSessionInfo().id + "/completion", "POST", req.toJson()));
       for (String candidate : resp.candidates) {
         candidates.add(new InterpreterCompletion(candidate, candidate, StringUtils.EMPTY));
       }

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -259,7 +259,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
     List<InterpreterCompletion> candidates = new ArrayList<>();
     try {
       CompletionResponse resp = CompletionResponse.fromJson(
-          callRestAPI("/sessions/" + getSessionInfo().id + "/completion", "POST", req.toJson()));
+          callRestAPI("/sessions/" + sessionInfo.id + "/completion", "POST", req.toJson()));
       for (String candidate : resp.candidates) {
         candidates.add(new InterpreterCompletion(candidate, candidate, StringUtils.EMPTY));
       }

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -29,6 +29,7 @@ import org.apache.zeppelin.interpreter.InterpreterOutputListener;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -812,6 +814,12 @@ public class LivyInterpreterIT {
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
       assertEquals(1, result.message().size());
       assertEquals(InterpreterResult.Type.IMG, result.message().get(0).getType());
+
+      // test code completion
+      List<InterpreterCompletion> completionResult = sparkInterpreter
+          .completion("spark.sparkC", 14, context);
+      assertEquals(completionResult.size(), 1);
+      assertEquals(completionResult.get(0).value, "sparkContext");
 
     } finally {
       sparkInterpreter.close();

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -817,8 +817,9 @@ public class LivyInterpreterIT {
 
       // test code completion
       List<InterpreterCompletion> completionResult = sparkInterpreter
-          .completion("nothing", 7, context);
-      assertEquals(completionResult.size(), 0);
+          .completion("df.sho", 6, context);
+      assertEquals(1, completionResult.size());
+      assertEquals("show", completionResult.get(0).name);
 
     } finally {
       sparkInterpreter.close();

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -817,9 +817,8 @@ public class LivyInterpreterIT {
 
       // test code completion
       List<InterpreterCompletion> completionResult = sparkInterpreter
-          .completion("spark.sparkC", 14, context);
-      assertEquals(completionResult.size(), 1);
-      assertEquals(completionResult.get(0).value, "sparkContext");
+          .completion("nothing", 7, context);
+      assertEquals(completionResult.size(), 0);
 
     } finally {
       sparkInterpreter.close();


### PR DESCRIPTION
### What is this PR for?
Fix for NullPointerException when using code completion in the Livy Interpreter when Shared Interpreter is enabled.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3656](https://issues.apache.org/jira/browse/ZEPPELIN-3656)

### How should this be tested?
Run Livy Interpreter in an environment where Shared Interpreter is enabled and attempt to trigger code completions.

A unit test has been added to test the completion API when using a shared interpreter. Before applying the fix this test was failing with the same NPE.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
