### PR TITLE
ZEPPELIN-3664: ActiveDirectoryGroupRealm returns "cn" instead of "userPrincipalName" for note permission auto completion

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -265,7 +265,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
         NamingEnumeration ae = attrs.getAll();
         while (ae.hasMore()) {
           Attribute attr = (Attribute) ae.next();
-          if (attr.getID().toLowerCase().equals("cn")) {
+          if (attr.getID().toLowerCase().equals("userprincipalname")) {
             userNameList.addAll(LdapUtils.getAllAttributeValues(attr));
           }
         }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealmTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealmTest.java
@@ -1,0 +1,50 @@
+package org.apache.zeppelin.realm;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
+
+import org.junit.Test;
+
+public class ActiveDirectoryGroupRealmTest {
+	
+	@Test
+	public void testSearchForUserName() throws NamingException {
+		final ActiveDirectoryGroupRealm activeDirectoryGroupRealm = new ActiveDirectoryGroupRealm();
+		final LdapContext ldapContext = mock(LdapContext.class);
+		final NamingEnumeration namingEnumeration = mock(NamingEnumeration.class);
+		
+		final Attributes attributes_1 = new BasicAttributes(true);
+		attributes_1.put("userprincipalname", "bob@testcompany.com");
+		attributes_1.put("cn", "Bob | Test Company");
+		
+		final Attributes attributes_2 = new BasicAttributes(true);
+		attributes_2.put("userprincipalname", "peter@testcompany.com");
+		attributes_2.put("cn", "Peter | Test Company");
+		
+		final SearchResult searchResult_1 = new SearchResult("bob@testcompany.com", null, attributes_1);
+		final SearchResult searchResult_2 = new SearchResult("peter@testcompany.com", null, attributes_2);
+		
+		when(ldapContext.search(anyString(), anyString(), any(Object[].class), any(SearchControls.class))).thenReturn(namingEnumeration);
+		when(namingEnumeration.hasMoreElements()).thenReturn(Boolean.TRUE).thenReturn(Boolean.TRUE).thenReturn(Boolean.FALSE);
+		when(namingEnumeration.next()).thenReturn(searchResult_1).thenReturn(searchResult_2);
+		
+		final List<String> result = activeDirectoryGroupRealm.searchForUserName("bob", ldapContext, 3);
+		
+		assertEquals(2, result.size());
+		assertEquals("bob@testcompany.com", result.get(0));
+		assertEquals("peter@testcompany.com", result.get(1));
+	}
+}


### PR DESCRIPTION
* Return "userPrincipalName" from ActiveDirectoryGroupRealm when searching for users.
* Added unit test for search functionality.

### What is this PR for?
Fix for https://issues.apache.org/jira/browse/ZEPPELIN-3664
Return the "userPrincipalName" instead of the "cn" (common name) from ActiveDirectoryGroupRealm when searching users to set note permissions.

### What type of PR is it?
[Bug Fix]

### Todos
* -

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3664

### How should this be tested?
Steps to reproduce
1. Configure connection to AD with org.apache.zeppelin.realm.ActiveDirectoryGroupRealm
2. Login to Zeppelin
3. Create new notebook
4. Edit the permissions and start typing the name of a AD user to one of the permission fields
5. Select one of the suggestions and save
6. Check the content of "notebook-authorization.json"

Expected result
* The "userPrincipalName" of the user is shown in the suggestion box and written to "notebook-authorization.json" (see screenshot attached).

Actual result
* The "cn" (common name) of the user is shown in the suggestion box and written to "notebook-authorization.json".

### Screenshots
![notepermission](https://user-images.githubusercontent.com/41739962/43268484-13c09516-90f1-11e8-9967-4513c668b4e5.png)

### Questions:
* Does the licenses files need update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
