### PR TITLE
[ZEPPELIN-3665] fix notebook name

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -184,7 +184,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  direction: ltr;
+  direction: rtl;
+  unicode-bidi: plaintext;
   text-align: left;
   font-size: 29px;
   padding-top: 7px;

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -184,7 +184,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  direction: rtl;
+  direction: ltr;
   text-align: left;
   font-size: 29px;
   padding-top: 7px;


### PR DESCRIPTION
### What is this PR for?
Name of notebook incorrectly displayed due to text direction.

Bug Fix

### What is the Jira issue?
[ZEPPELIN-3665](https://issues.apache.org/jira/browse/ZEPPELIN-3665)

### example:
Path: `2_Folder/NoteName`
#### Before
![before](https://user-images.githubusercontent.com/30798933/43382664-2caf8c6a-93e1-11e8-9bef-be271573a858.png)

#### After
![after](https://user-images.githubusercontent.com/30798933/43382674-3323e1b8-93e1-11e8-9ab9-fbfc88671042.png)



### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no