### PR TITLE
[ZEPPELIN-3667] [Improvement] Large CVS download.

### DIFF
--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -41,7 +41,8 @@ function saveAsService(browserDetectService) {
       content = 'data:image/svg;charset=utf-8,' + BOM + encodeURIComponent(content);
       angular.element('body').append('<a id="SaveAsId"></a>');
       var saveAsElement = angular.element('body > a#SaveAsId');
-      saveAsElement.attr('href', content);
+      var url = window.URL.createObjectURL(new Blob([content], {type: 'image/svg;charset=utf-8'}));
+      saveAsElement.attr('href', url);
       saveAsElement.attr('download', filename + '.' + extension);
       saveAsElement.attr('target', '_blank');
       saveAsElement[0].click();

--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -38,7 +38,6 @@ function saveAsService(browserDetectService) {
       }
       angular.element('body > iframe#SaveAsId').remove();
     } else {
-      content = 'data:image/svg;charset=utf-8,' + BOM + encodeURIComponent(content);
       angular.element('body').append('<a id="SaveAsId"></a>');
       var saveAsElement = angular.element('body > a#SaveAsId');
       var url = window.URL.createObjectURL(new Blob([content], {type: 'image/svg;charset=utf-8'}));

--- a/zeppelin-web/src/components/saveAs/saveAs.service.js
+++ b/zeppelin-web/src/components/saveAs/saveAs.service.js
@@ -40,7 +40,7 @@ function saveAsService(browserDetectService) {
     } else {
       angular.element('body').append('<a id="SaveAsId"></a>');
       var saveAsElement = angular.element('body > a#SaveAsId');
-      var url = window.URL.createObjectURL(new Blob([content], {type: 'image/svg;charset=utf-8'}));
+      var url = window.URL.createObjectURL(new Blob([content], {type: 'charset=utf-8'}));
       saveAsElement.attr('href', url);
       saveAsElement.attr('download', filename + '.' + extension);
       saveAsElement.attr('target', '_blank');


### PR DESCRIPTION
### What is this PR for?
The download CSV feature from the table views fails when the total data accumulated is greater than 2MB on the chrome browser.  

encodeURIComponent call has a maxs out for larger sizes of csv, using blob extends csv download size limitations.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
[ZEPPELIN-3667](https://issues.apache.org/jira/browse/ZEPPELIN-3667)

### How should this be tested?
set env variable ZEPPELIN_INTERPRETER_OUTPUT_LIMIT to greater than 2 MB. 
Test downloading a small to moderate CSV from the table segment on chrome, safari, opera and firefox.
Test downloading a large CSV(2MB or greater) from the table segment on chrome, safari, opera and firefox.
All downloads should pass.



