### PR TITLE
ZEPPELIN-3672. spark interpreter: Java output (to the console) is lost

### DIFF
--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/NewSparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/NewSparkInterpreterTest.java
@@ -100,6 +100,11 @@ public class NewSparkInterpreterTest {
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertEquals("hello world", output);
 
+    // java stdout
+    result = interpreter.interpret("System.out.print(a)", getInterpreterContext());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals("hello world", output);
+
     // incomplete
     result = interpreter.interpret("println(a", getInterpreterContext());
     assertEquals(InterpreterResult.Code.INCOMPLETE, result.code());

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -81,8 +81,10 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
 
   def interpret(code: String, context: InterpreterContext): InterpreterResult = {
 
+    val originalOut = System.out
     def _interpret(code: String): scala.tools.nsc.interpreter.Results.Result = {
       Console.withOut(interpreterOutput) {
+        System.setOut(Console.out)
         interpreterOutput.setInterpreterOutput(context.out)
         interpreterOutput.ignoreLeadingNewLinesFromScalaReporter()
         context.out.clear()
@@ -108,6 +110,8 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
         status
       }
     }
+    // reset the java stdout
+    System.setOut(originalOut)
 
     val lastStatus = _interpret(code) match {
       case scala.tools.nsc.interpreter.IR.Success =>


### PR DESCRIPTION
### What is this PR for?
This is to fix the bug of redirecting java stdout to zeppelin frontend


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3672

### How should this be tested?
* Unit test added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
