### PR TITLE
ZEPPELIN-3679. Provide option to allow hide spark ui in frontend

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
@@ -120,7 +120,7 @@ public class NewSparkInterpreter extends AbstractSparkInterpreter {
       if (!StringUtils.isBlank(sparkUrlProp)) {
         sparkUrl = sparkUrlProp;
       }
-      sparkShims = SparkShims.getInstance(sc.version());
+      sparkShims = SparkShims.getInstance(sc.version(), getProperties());
       sparkShims.setupSparkListener(sc.master(), sparkUrl, InterpreterContext.get());
 
       z = new SparkZeppelinContext(sc, sparkShims, hooks,

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/OldSparkInterpreter.java
@@ -707,7 +707,7 @@ public class OldSparkInterpreter extends AbstractSparkInterpreter {
       dep = getDependencyResolver();
       hooks = getInterpreterGroup().getInterpreterHookRegistry();
       sparkUrl = getSparkUIUrl();
-      sparkShims = SparkShims.getInstance(sc.version());
+      sparkShims = SparkShims.getInstance(sc.version(), getProperties());
       sparkShims.setupSparkListener(sc.master(), sparkUrl, InterpreterContext.get());
       numReferenceOfSparkContext.incrementAndGet();
 

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -81,6 +81,13 @@
         "defaultValue": true,
         "description": "Whether use new spark interpreter implementation",
         "type": "checkbox"
+      },
+      "zeppelin.spark.ui.hidden": {
+        "envName": null,
+        "propertyName": "zeppelin.spark.ui.hidden",
+        "defaultValue": false,
+        "description": "Whether to hide spark ui in zeppelin ui",
+        "type": "checkbox"
       }
     },
     "editor": {

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -89,7 +89,7 @@ public class SparkShimsTest {
     @Test
     public void checkYarnVersionTest() {
       SparkShims sparkShims =
-          new SparkShims() {
+          new SparkShims(new Properties()) {
             @Override
             public void setupSparkListener(String master,
                                            String sparkWebUrl,
@@ -121,9 +121,9 @@ public class SparkShimsTest {
       when(mockContext.getIntpEventClient()).thenReturn(mockIntpEventClient);
       doNothing().when(mockIntpEventClient).onParaInfosReceived(argumentCaptor.capture());
       try {
-        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString());
+        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_2_0_0.toString(), new Properties());
       } catch (Throwable ignore) {
-        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString());
+        sparkShims = SparkShims.getInstance(SparkVersion.SPARK_1_6_0.toString(), new Properties());
       }
     }
 

--- a/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
+++ b/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.spark;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.util.VersionInfo;
 import org.apache.hadoop.util.VersionUtil;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -48,7 +49,14 @@ public abstract class SparkShims {
 
   private static SparkShims sparkShims;
 
-  private static SparkShims loadShims(String sparkVersion) throws ReflectiveOperationException {
+  protected Properties properties;
+
+  public SparkShims(Properties properties) {
+    this.properties = properties;
+  }
+
+  private static SparkShims loadShims(String sparkVersion, Properties properties)
+      throws ReflectiveOperationException {
     Class<?> sparkShimsClass;
     if ("2".equals(sparkVersion)) {
       LOGGER.info("Initializing shims for Spark 2.x");
@@ -58,15 +66,15 @@ public abstract class SparkShims {
       sparkShimsClass = Class.forName("org.apache.zeppelin.spark.Spark1Shims");
     }
 
-    Constructor c = sparkShimsClass.getConstructor();
-    return (SparkShims) c.newInstance();
+    Constructor c = sparkShimsClass.getConstructor(Properties.class);
+    return (SparkShims) c.newInstance(properties);
   }
 
-  public static SparkShims getInstance(String sparkVersion) {
+  public static SparkShims getInstance(String sparkVersion, Properties properties) {
     if (sparkShims == null) {
       String sparkMajorVersion = getSparkMajorVersion(sparkVersion);
       try {
-        sparkShims = loadShims(sparkMajorVersion);
+        sparkShims = loadShims(sparkMajorVersion, properties);
       } catch (ReflectiveOperationException e) {
         throw new RuntimeException(e);
       }
@@ -136,5 +144,10 @@ public abstract class SparkShims {
             && VersionUtil.compareVersions(HADOOP_VERSION_3_0_0, version) > 0)
         || (VersionUtil.compareVersions(HADOOP_VERSION_3_0_0_ALPHA4, version) <= 0)
         || (VersionUtil.compareVersions(HADOOP_VERSION_3_0_0, version) <= 0);
+  }
+
+  @VisibleForTesting
+  public static void reset() {
+    sparkShims = null;
   }
 }

--- a/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
+++ b/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
@@ -28,8 +28,13 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.ResultMessages;
 
 import java.util.List;
+import java.util.Properties;
 
 public class Spark1Shims extends SparkShims {
+
+  public Spark1Shims(Properties properties) {
+    super(properties);
+  }
 
   public void setupSparkListener(final String master,
                                  final String sparkWebUrl,
@@ -38,7 +43,8 @@ public class Spark1Shims extends SparkShims {
     sc.addSparkListener(new JobProgressListener(sc.getConf()) {
       @Override
       public void onJobStart(SparkListenerJobStart jobStart) {
-        if (sc.getConf().getBoolean("spark.ui.enabled", true)) {
+        if (sc.getConf().getBoolean("spark.ui.enabled", true) &&
+            !Boolean.parseBoolean(properties.getProperty("zeppelin.spark.ui.hidden", "false"))) {
           buildSparkJobUrl(master, sparkWebUrl, jobStart.jobId(), context);
         }
       }
@@ -59,7 +65,7 @@ public class Spark1Shims extends SparkShims {
       for (Row row : rows) {
         for (int i = 0; i < row.size(); ++i) {
           msg.append(row.get(i));
-          if (i != row.size() -1) {
+          if (i != row.size() - 1) {
             msg.append("\t");
           }
         }

--- a/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
+++ b/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
@@ -24,13 +24,17 @@ import org.apache.spark.scheduler.SparkListener;
 import org.apache.spark.scheduler.SparkListenerJobStart;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.ResultMessages;
 
 import java.util.List;
+import java.util.Properties;
 
 public class Spark2Shims extends SparkShims {
+
+  public Spark2Shims(Properties properties) {
+    super(properties);
+  }
 
   public void setupSparkListener(final String master,
                                  final String sparkWebUrl,
@@ -39,7 +43,9 @@ public class Spark2Shims extends SparkShims {
     sc.addSparkListener(new SparkListener() {
       @Override
       public void onJobStart(SparkListenerJobStart jobStart) {
-        if (sc.getConf().getBoolean("spark.ui.enabled", true)) {
+
+        if (sc.getConf().getBoolean("spark.ui.enabled", true) &&
+            !Boolean.parseBoolean(properties.getProperty("zeppelin.spark.ui.hidden", "false"))) {
           buildSparkJobUrl(master, sparkWebUrl, jobStart.jobId(), context);
         }
       }


### PR DESCRIPTION
### What is this PR for?
Introducing new property `zeppelin.spark.ui.hidden` to control whether hide spark ui in frontend. By default it is false.


### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3679

### How should this be tested?
* Unit test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
