### PR TITLE
[ZEPPELIN-3684] Remove cron job in ZeppelinRestApiTest.testCronDisable

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -582,6 +582,12 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     postCron.releaseConnection();
     Thread.sleep(1000);
 
+    // remove cron job.
+    DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
+    assertThat("", deleteCron, isAllowed());
+    deleteCron.releaseConnection();
+    Thread.sleep(1000);
+
     System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName());
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
   }


### PR DESCRIPTION
### What is this PR for?
`testCronDisable` in `ZeppelinRestApiTest` produces error:
```
09:15:51,001 ERROR org.quartz.core.ErrorLogger:2425 - Job (note.2DPJCQJGP threw an exception.
org.quartz.SchedulerException: Job threw an unhandled exception. [See nested exception: java.lang.NullPointerException]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:213)
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
Caused by: java.lang.NullPointerException
	at org.apache.zeppelin.notebook.Notebook$CronJob.execute(Notebook.java:925)
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
	... 1 more
```
Because cron job is not removed

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3684

### How should this be tested?
* Tested manually
* [CI pass](https://travis-ci.org/TinkoffCreditSystems/zeppelin/builds/412604637)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
