### PR TITLE
Update org.eclipse.jetty version to 9.4.11.v20180605 to avoid CVE issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <libthrift.version>0.9.3</libthrift.version>
     <gson.version>2.2</gson.version>
     <gson-extras.version>0.2.1</gson-extras.version>
-    <jetty.version>9.2.15.v20160210</jetty.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.1</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>

--- a/zeppelin-plugins/notebookrepo/zeppelin-hub/pom.xml
+++ b/zeppelin-plugins/notebookrepo/zeppelin-hub/pom.xml
@@ -37,7 +37,6 @@
     <description>NotebookRepo implementation based on Zeppelin Hub</description>
 
     <properties>
-        <jetty.version>9.2.15.v20160210</jetty.version>
         <google.truth.version>0.27</google.truth.version>
         <plugin.name>NotebookRepo/ZeppelinHubRepo</plugin.name>
     </properties>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/configuration/RequestHeaderSizeTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/configuration/RequestHeaderSizeTest.java
@@ -20,9 +20,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang.RandomStringUtils;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,20 +46,20 @@ public class RequestHeaderSizeTest extends AbstractTestRestApi {
   }
 
   @Test
-  public void increased_request_header_size_do_not_cause_413_when_request_size_is_over_8K()
-          throws Exception {
+  public void increased_request_header_size_do_not_cause_431_when_request_size_is_over_8K()
+      throws Exception {
     HttpClient httpClient = new HttpClient();
 
     GetMethod getMethod = new GetMethod(getUrlToTest() + "/version");
     String headerValue = RandomStringUtils.randomAlphanumeric(REQUEST_HEADER_MAX_SIZE - 2000);
     getMethod.setRequestHeader("not_too_large_header", headerValue);
     int httpCode = httpClient.executeMethod(getMethod);
-    assertThat(httpCode, is(HttpStatus.SC_OK));
+    assertThat(httpCode, is(HttpStatus.OK_200));
 
     getMethod = new GetMethod(getUrlToTest() + "/version");
     headerValue = RandomStringUtils.randomAlphanumeric(REQUEST_HEADER_MAX_SIZE + 2000);
     getMethod.setRequestHeader("too_large_header", headerValue);
     httpCode = httpClient.executeMethod(getMethod);
-    assertThat(httpCode, is(HttpStatus.SC_REQUEST_TOO_LONG));
+    assertThat(httpCode, is(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431));
   }
 }


### PR DESCRIPTION
### What is this PR for?
Update org.eclipse.jetty version to 9.4.11.v20180605 to avoid CVE issues.

See https://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00123.html for reported issues.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
* [ZEPPELIN-3686](https://issues.apache.org/jira/browse/ZEPPELIN-3686)

### How should this be tested?
* CI should be green

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
