### PR TITLE
[ZEPPELIN-3687] Fix IndexError in python interpreter with empty input

### DIFF
--- a/python/src/main/resources/python/zeppelin_python.py
+++ b/python/src/main/resources/python/zeppelin_python.py
@@ -145,7 +145,7 @@ while True :
       if (nhooks > 0):
         to_run_hooks = code.body[-nhooks:]
       to_run_exec, to_run_single = (code.body[:-(nhooks + 1)],
-                                    [code.body[-(nhooks + 1)]])
+                                   [code.body[-(nhooks + 1)]] if len(code.body) > nhooks else [])
       try:
         for node in to_run_exec:
           mod = ast.Module([node])

--- a/python/src/test/java/org/apache/zeppelin/python/BasePythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/BasePythonInterpreterTest.java
@@ -185,6 +185,22 @@ public abstract class BasePythonInterpreterTest {
     interpreterResultMessages = context.out.toInterpreterResultMessage();
     assertEquals(1, interpreterResultMessages.size());
     assertEquals("there is no Error: ok\n", interpreterResultMessages.get(0).getData());
+
+    // ZEPPELIN-3687
+    context = getInterpreterContext();
+    result = interpreter.interpret("# print('Hello')", context);
+    Thread.sleep(100);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    interpreterResultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(0, interpreterResultMessages.size());
+
+    context = getInterpreterContext();
+    result = interpreter.interpret(
+        "# print('Hello')\n# print('How are u?')\n# time.sleep(1)", context);
+    Thread.sleep(100);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    interpreterResultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(0, interpreterResultMessages.size());
   }
 
   @Test

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -26,7 +26,6 @@ import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -105,15 +104,5 @@ public class PythonInterpreterTest extends BasePythonInterpreterTest {
     assertTrue(t.isAlive());
     t.join(2000);
     assertFalse(t.isAlive());
-  }
-
-  @Test
-  public void testOnlyCommentsJob() throws InterpreterException {
-    final String code = "# print('hello')";
-    InterpreterResult ret = interpreter.interpret(code, getInterpreterContext());
-
-    assertNotNull(ret);
-    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
-    assertEquals(Collections.emptyList(), ret.message());
   }
 }

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterTest.java
@@ -26,6 +26,7 @@ import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -104,5 +105,15 @@ public class PythonInterpreterTest extends BasePythonInterpreterTest {
     assertTrue(t.isAlive());
     t.join(2000);
     assertFalse(t.isAlive());
+  }
+
+  @Test
+  public void testOnlyCommentsJob() throws InterpreterException {
+    final String code = "# print('hello')";
+    InterpreterResult ret = interpreter.interpret(code, getInterpreterContext());
+
+    assertNotNull(ret);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(Collections.emptyList(), ret.message());
   }
 }


### PR DESCRIPTION
### What is this PR for?
If input of python or pyspark interpreter is empty (contains only comments), it will fail with `IndexError` from `zeppelin_python.py`.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3687](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3687)

### Screenshots
## Before:
![screen-shot-2018-08-05-at-23 29 34](https://user-images.githubusercontent.com/16215034/43775282-d1274caa-9a54-11e8-9c6c-3b882f96cf7e.jpg)
![screen-shot-2018-08-07-at-11 48 10](https://user-images.githubusercontent.com/16215034/43775285-d385ad2a-9a54-11e8-9a14-aa0080cc5824.jpg)

## After:
![screen-shot-2018-08-07-at-15 11 452](https://user-images.githubusercontent.com/16215034/43775306-e17acf28-9a54-11e8-8378-9b6a8b1c817c.jpg)
![screen-shot-2018-08-07-at-15 11 45](https://user-images.githubusercontent.com/16215034/43775313-e51f81c8-9a54-11e8-829f-d2aba1cc9613.jpg)


### Questions:
* Does the licenses files need update? No 
* Is there breaking changes for older versions? No
* Does this needs documentation? No