### PR TITLE
[ZEPPELIN-3690] display all column with the same name in ui-grid

### DIFF
--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -32,7 +32,6 @@ export default class TableData extends Dataset {
 
     let columnNames = [];
     let rows = [];
-    let array = [];
     let textRows = paragraphResult.msg.split('\n');
     let comment = '';
     let commentRow = false;
@@ -54,7 +53,6 @@ export default class TableData extends Dataset {
       }
       let textCols = textRow.split('\t');
       let cols = [];
-      let cols2 = [];
       for (let j = 0; j < textCols.length; j++) {
         let col = textCols[j];
         if (i === 0) {
@@ -67,12 +65,10 @@ export default class TableData extends Dataset {
             }
           }
           cols.push(col);
-          cols2.push({key: (columnNames[i]) ? columnNames[i].name : undefined, value: col});
         }
       }
       if (i !== 0) {
         rows.push(cols);
-        array.push(cols2);
       }
     }
     this.comment = comment;

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -92,7 +92,7 @@ export default class TableVisualization extends Visualization {
 
     const gridData = rows.map((r) => {
       return columnNames.reduce((acc, colName, index) => {
-        acc[colName] = r[index];
+        acc[colName + index] = r[index];
         return acc;
       }, {});
     });
@@ -108,11 +108,11 @@ export default class TableVisualization extends Visualization {
       treeRowHeaderAlwaysVisible: false,
       exporterExcelFilename: 'myFile.xlsx',
 
-      columnDefs: columnNames.map((colName) => {
+      columnDefs: columnNames.map((colName, index) => {
         const self = this;
         return {
           displayName: colName,
-          name: colName,
+          name: colName + index,
           type: DefaultTableColumnType,
           cellTemplate: `
             <div ng-if="!grid.getCellValue(row, col).startsWith('%html')"


### PR DESCRIPTION
### Description
This PR allows you to correctly display tables with the same column names.
Also removes a little unnecessary code.

### Info
PR type:   `Bug Fix`
Jira issue [`ZEPPELIN-3690`](https://issues.apache.org/jira/browse/ZEPPELIN-3690)
paragraph's text : [`paragraph-text.txt`](https://github.com/apache/zeppelin/files/2270553/paragraph-text.txt)

### Screenshots
<p align="center">Before PR</p>

![before](https://user-images.githubusercontent.com/30798933/43842410-f7128bb2-9b2d-11e8-8fb3-62ae01ca649c.png)

<p align="center">After PR</p>

![after](https://user-images.githubusercontent.com/30798933/43842418-fbd5ac60-9b2d-11e8-92f8-bfeb9d6bdc97.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no