### PR TITLE
[zeppelin-3693] Option to toggle chart settings of paragraph

### DIFF
--- a/docs/quickstart/explore_ui.md
+++ b/docs/quickstart/explore_ui.md
@@ -107,6 +107,7 @@ On the top-right corner of each paragraph there are some commands to:
 * execute the paragraph code
 * hide/show `code section`
 * hide/show `result section`
+* hide/show `chart settings section`
 * configure the paragraph
 
 To configure the paragraph, just click on the gear icon:
@@ -140,6 +141,7 @@ In the middle of the toolbar you can find the command buttons:
 * execute all the paragraphs **sequentially**, in their display order
 * hide/show `code section` of all paragraphs
 * hide/show `result section` of all paragraphs
+* hide/show `chart settings section` of all paragraphs
 * clear the `result section` of all paragraphs
 * clone the current note
 * export the current note to a JSON file. _Please note that the `code section` and `result section` of all paragraphs will be exported. If you have heavy data in the `result section` of some paragraphs, it is recommended to clean them before exporting

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -53,6 +53,14 @@ limitations under the License.
       </button>
       <button type="button"
               class="btn btn-default btn-xs"
+              ng-click="toggleAllChartSettings()"
+              ng-hide="viewOnly"
+              tooltip-placement="bottom" uib-tooltip="Show/hide the chart settings"
+              ng-disabled="revisionView">
+        <i ng-class="chartSettingsToggled ? 'fa icon-pie-chart' : 'fa icon-bar-chart'"></i>
+      </button>
+      <button type="button"
+              class="btn btn-default btn-xs"
               ng-click="clearAllParagraphOutput(note.id)"
               ng-hide="viewOnly"
               ng-class="{'disabled':isNoteRunning()}"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -32,6 +32,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   $scope.disableForms = false;
   $scope.editorToggled = false;
   $scope.tableToggled = false;
+  $scope.chartSettingsToggled = false;
   $scope.viewOnly = false;
   $scope.showSetting = false;
   $scope.showRevisionsComparator = false;
@@ -420,6 +421,15 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
 
   $scope.hideAllTable = function() {
     $scope.$broadcast('closeTable');
+  };
+
+  $scope.toggleAllChartSettings = function() {
+    if ($scope.chartSettingsToggled) {
+      $scope.$broadcast('openChartSettings');
+    } else {
+      $scope.$broadcast('closeChartSettings');
+    }
+    $scope.chartSettingsToggled = !$scope.chartSettingsToggled;
   };
 
   /**

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -72,6 +72,9 @@ limitations under the License.
     <span class="{{paragraph.config.tableHide ? 'icon-notebook' : 'icon-book-open'}}" style="cursor:pointer" tooltip-placement="top"
           uib-tooltip="{{(paragraph.config.tableHide ? 'Show' : 'Hide')}} output (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+O)"
           ng-click="toggleOutput(paragraph)"></span>
+    <span class="{{paragraph.config.chartSettingsHide ? 'icon-pie-chart' : 'icon-bar-chart'}}" style="cursor:pointer" tooltip-placement="top"
+          uib-tooltip="{{(paragraph.config.chartSettingsHide ? 'Show' : 'Hide')}} chart settings (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+S)"
+          ng-click="toggleChartSettings(paragraph)"></span>
     <span class="dropdown navbar-right">
       <span class="icon-settings" style="cursor:pointer"
             data-toggle="dropdown"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -620,6 +620,24 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     commitParagraph(paragraph);
   };
 
+  $scope.toggleChartSettings = function(paragraph) {
+    if (paragraph.config.chartSettingsHide) {
+      $scope.openChartSettings(paragraph);
+    } else {
+      $scope.closeChartSettings(paragraph);
+    }
+  };
+
+  $scope.closeChartSettings = function(paragraph) {
+    paragraph.config.chartSettingsHide = true;
+    commitParagraph(paragraph);
+  };
+
+  $scope.openChartSettings = function(paragraph) {
+    paragraph.config.chartSettingsHide = false;
+    commitParagraph(paragraph);
+  };
+
   let openEditorAndCloseTable = function(paragraph) {
     manageEditorAndTableState(paragraph, false, true);
   };
@@ -1660,6 +1678,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         $scope.insertNew('below');
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 79) { // Ctrl + Alt + o
         $scope.toggleOutput($scope.paragraph);
+      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 83) { // Ctrl + Alt + s
+        $scope.toggleChartSettings($scope.paragraph);
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 82) { // Ctrl + Alt + r
         $scope.toggleEnableDisable($scope.paragraph);
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 69) { // Ctrl + Alt + e
@@ -1770,6 +1790,14 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
   $scope.$on('closeTable', function(event) {
     $scope.closeTable($scope.paragraph);
+  });
+
+  $scope.$on('openChartSettings', function(event) {
+    $scope.openChartSettings($scope.paragraph);
+  });
+
+  $scope.$on('closeChartSettings', function(event) {
+    $scope.closeChartSettings($scope.paragraph);
   });
 
   $scope.$on('resultRendered', function(event, paragraphId) {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.html
@@ -13,7 +13,7 @@ limitations under the License.
 -->
 
 <div>
-  <div ng-include src="'app/notebook/paragraph/result/result-chart-selector.html'"></div>
+  <div ng-show="!paragraph.config.chartSettingsHide" ng-include src="'app/notebook/paragraph/result/result-chart-selector.html'"></div>
   <div
     ng-mouseout="onMouseOut()"
     ng-mouseover="onMouseOver()"
@@ -27,7 +27,7 @@ limitations under the License.
          ng-style="getPointerEvent()">
       <!-- setting -->
       <div class="option lightBold" style="overflow: visible;"
-           ng-show="config.graph.optionOpen && !asIframe && !viewOnly">
+           ng-show="config.graph.optionOpen && !paragraph.config.chartSettingsHide && !asIframe && !viewOnly">
         <div ng-repeat="viz in builtInTableDataVisualizationList track by $index"
              id="trsetting{{id}}_{{viz.id}}"
              ng-show="graphMode == viz.id"></div>

--- a/zeppelin-web/src/app/notebook/shortcut.html
+++ b/zeppelin-web/src/app/notebook/shortcut.html
@@ -182,6 +182,17 @@ limitations under the License.
 
           <tr>
             <td>
+              <div class="col-md-8">Toggle chart settings</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">{{ isMac ? 'Option' : 'Alt'}}</kbd> + <kbd class="kbd-default">S</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
               <div class="col-md-8">Toggle line number</div>
             </td>
             <td>


### PR DESCRIPTION
### What is this PR for?
To add an option to toggle chart settings of paragraph

Reasons:
* Reducing the paragraph width less than 4 breaks UI
* Hiding the chart settings will give dashboard feel
* Chart selector length increases when multiple helium packages are enabled

### What type of PR is it?
Improvement

### Todos
* Add integration test

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3693

### How should this be tested?
* CI Pass
* Yet to add integration test

### Screenshots (if appropriate)
before:
<img width="1438" alt="before_1" src="https://user-images.githubusercontent.com/3000143/43855211-8a83cf1c-9b62-11e8-9105-dcf62002aedd.png">

after:
<img width="1433" alt="after_1" src="https://user-images.githubusercontent.com/3000143/43855231-980e6160-9b62-11e8-8725-a79c3f5d7a7e.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Basic documentation added
