### PR TITLE
[ZEPPELIN-3701]. Missing first several '0' and losing digital accuracy in result table

### DIFF
--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -60,8 +60,10 @@ export default class TableData extends Dataset {
           columnNames.push({name: col, index: j, aggr: 'sum'});
         } else {
           let valueOfCol;
-          if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
-            col = valueOfCol;
+          if (!(col[0] === '0' || col.length >= 7)) {
+            if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
+              col = valueOfCol;
+            }
           }
           cols.push(col);
           cols2.push({key: (columnNames[i]) ? columnNames[i].name : undefined, value: col});


### PR DESCRIPTION
### What is this PR for?
Improvements:
- Datas like '00058806' will be displayed correctly instead of '58806'.
- Datas like '5880658806' will be displayed correctly instead of '5.880659E9'.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-3701](https://issues.apache.org/jira/browse/ZEPPELIN-3701)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this need documentation? No

Author: heguozi <zyzzxycj@gmail.com>

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?

Author: heguozi <zyzzxycj@gmail.com>