### PR TITLE
[ZEPPELIN-3701]. Missing first several '0' and losing digital accuracy in result table

### DIFF
--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -60,8 +60,10 @@ export default class TableData extends Dataset {
           columnNames.push({name: col, index: j, aggr: 'sum'});
         } else {
           let valueOfCol;
-          if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
-            col = valueOfCol;
+          if (!(col[0] === '0' || col.length >= 7)) {
+            if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
+              col = valueOfCol;
+            }
           }
           cols.push(col);
           cols2.push({key: (columnNames[i]) ? columnNames[i].name : undefined, value: col});


### PR DESCRIPTION
What is this PR for?
Improvements:
-Datas like '00058806' will be displayed correctly instead of '58806'.
-Datas like '5880658806' will be displayed correctly instead of '5.880659E9'.

What type of PR is it?
Improvement

What is the Jira issue?
[ZEPPELIN-3701](https://issues.apache.org/jira/browse/ZEPPELIN-3701)

Questions:
Does the licenses files need update? No
Is there breaking changes for older versions? No
Does this need documentation? No

Author: <heguozi zyzzxycj@gmail.com>