### PR TITLE
[ZEPPELIN-3701].Missing first several '0' and losing digital accuracy in result table

### DIFF
--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -36,6 +36,7 @@ export default class TableData extends Dataset {
     let textRows = paragraphResult.msg.split('\n');
     let comment = '';
     let commentRow = false;
+    const float64MaxDigits = 16;
 
     for (let i = 0; i < textRows.length; i++) {
       let textRow = textRows[i];
@@ -60,7 +61,7 @@ export default class TableData extends Dataset {
           columnNames.push({name: col, index: j, aggr: 'sum'});
         } else {
           let valueOfCol;
-          if (!(col[0] === '0' || col.length >= 7)) {
+          if (!(col[0] === '0' || col.length > float64MaxDigits)) {
             if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
               col = valueOfCol;
             }

--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -60,8 +60,10 @@ export default class TableData extends Dataset {
           columnNames.push({name: col, index: j, aggr: 'sum'});
         } else {
           let valueOfCol;
-          if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
-            col = valueOfCol;
+          if (!(col[0] === '0' || col.length >= 7)) {
+            if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
+              col = valueOfCol;
+            }
           }
           cols.push(col);
           cols2.push({key: (columnNames[i]) ? columnNames[i].name : undefined, value: col});

--- a/zeppelin-web/src/app/tabledata/tabledata.js
+++ b/zeppelin-web/src/app/tabledata/tabledata.js
@@ -61,7 +61,7 @@ export default class TableData extends Dataset {
           columnNames.push({name: col, index: j, aggr: 'sum'});
         } else {
           let valueOfCol;
-          if (!(col[0] === '0' || col.length > float64MaxDigits)) {
+          if (!(col[0] === '0' || col[0] === '+' || col.length > float64MaxDigits)) {
             if (!isNaN(valueOfCol = parseFloat(col)) && isFinite(col)) {
               col = valueOfCol;
             }


### PR DESCRIPTION
### What is this PR for?

Improvements:
-Datas like '00058806' will be displayed correctly instead of '58806'.
-Datas like '5880658806' will be displayed correctly instead of '5.880659E9'.

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3701

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

Author: heguozi <zyzzxycj@gmail.com>