### PR TITLE
ZEPPELIN-3703. Introduce ConfigurationService

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.apache.commons.configuration.tree.ConfigurationNode;
@@ -634,43 +636,35 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getRelativeDir(ConfVars.ZEPPELIN_SEARCH_TEMP_PATH);
   }
 
-  public Map<String, String> dumpConfigurations(ZeppelinConfiguration conf,
-                                                ConfigurationKeyPredicate predicate) {
-    Map<String, String> configurations = new HashMap<>();
+  public Map<String, String> dumpConfigurations(Predicate<String> predicate) {
+    Map<String, String> properties = new HashMap<>();
 
     for (ConfVars v : ConfVars.values()) {
       String key = v.getVarName();
 
-      if (!predicate.apply(key)) {
+      if (!predicate.test(key)) {
         continue;
       }
 
       ConfVars.VarType type = v.getType();
       Object value = null;
       if (type == ConfVars.VarType.BOOLEAN) {
-        value = conf.getBoolean(v);
+        value = getBoolean(v);
       } else if (type == ConfVars.VarType.LONG) {
-        value = conf.getLong(v);
+        value = getLong(v);
       } else if (type == ConfVars.VarType.INT) {
-        value = conf.getInt(v);
+        value = getInt(v);
       } else if (type == ConfVars.VarType.FLOAT) {
-        value = conf.getFloat(v);
+        value = getFloat(v);
       } else if (type == ConfVars.VarType.STRING) {
-        value = conf.getString(v);
+        value = getString(v);
       }
 
       if (value != null) {
-        configurations.put(key, value.toString());
+        properties.put(key, value.toString());
       }
     }
-    return configurations;
-  }
-
-  /**
-   * Predication whether key/value pair should be included or not
-   */
-  public interface ConfigurationKeyPredicate {
-    boolean apply(String key);
+    return properties;
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest;
+
+import com.google.common.collect.Sets;
+import org.apache.zeppelin.service.ServiceContext;
+import org.apache.zeppelin.service.SimpleServiceCallback;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.utils.SecurityUtils;
+
+import javax.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.util.Set;
+
+public class AbstractRestApi {
+
+  protected ServiceContext getServiceContext() {
+    AuthenticationInfo authInfo = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    Set<String> userAndRoles = Sets.newHashSet();
+    userAndRoles.add(SecurityUtils.getPrincipal());
+    userAndRoles.addAll(SecurityUtils.getAssociatedRoles());
+    return new ServiceContext(authInfo, userAndRoles);
+  }
+
+  public static class RestServiceCallback<T> extends SimpleServiceCallback<T> {
+
+    @Override
+    public void onFailure(Exception ex, ServiceContext context) throws IOException {
+      super.onFailure(ex, context);
+      if (ex instanceof WebApplicationException) {
+        throw (WebApplicationException) ex;
+      } else {
+        throw new IOException(ex);
+      }
+    }
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -42,7 +42,6 @@ import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
-import org.apache.zeppelin.service.SimpleServiceCallback;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.utils.SecurityUtils;
@@ -58,7 +57,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
@@ -74,7 +72,7 @@ import java.util.Set;
  */
 @Path("/notebook")
 @Produces("application/json")
-public class NotebookRestApi {
+public class NotebookRestApi extends AbstractRestApi {
   private static final Logger LOG = LoggerFactory.getLogger(NotebookRestApi.class);
   private static Gson gson = new Gson();
 
@@ -1032,26 +1030,5 @@ public class NotebookRestApi {
     }
 
     p.setConfig(origConfig);
-  }
-
-  private ServiceContext getServiceContext() {
-    AuthenticationInfo authInfo = new AuthenticationInfo(SecurityUtils.getPrincipal());
-    Set<String> userAndRoles = Sets.newHashSet();
-    userAndRoles.add(SecurityUtils.getPrincipal());
-    userAndRoles.addAll(SecurityUtils.getAssociatedRoles());
-    return new ServiceContext(authInfo, userAndRoles);
-  }
-
-  private static class RestServiceCallback<T> extends SimpleServiceCallback<T> {
-
-    @Override
-    public void onFailure(Exception ex, ServiceContext context) throws IOException {
-      super.onFailure(ex, context);
-      if (ex instanceof WebApplicationException) {
-        throw (WebApplicationException) ex;
-      } else {
-        throw new IOException(ex);
-      }
-    }
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -34,6 +34,7 @@ import org.apache.shiro.web.servlet.ShiroFilter;
 import org.apache.zeppelin.rest.AdminRestApi;
 import org.apache.zeppelin.rest.exception.WebApplicationExceptionMapper;
 import org.apache.zeppelin.service.AdminService;
+import org.apache.zeppelin.service.ConfigurationService;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -471,7 +472,8 @@ public class ZeppelinServer extends Application {
     LoginRestApi loginRestApi = new LoginRestApi();
     singletons.add(loginRestApi);
 
-    ConfigurationsRestApi settingsApi = new ConfigurationsRestApi(notebook);
+    ConfigurationsRestApi settingsApi = new ConfigurationsRestApi(
+        new ConfigurationService(notebook.getConf()));
     singletons.add(settingsApi);
 
     AdminService adminService = new AdminService();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ConfigurationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ConfigurationService.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zeppelin.service;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ConfigurationService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationService.class);
+
+  private ZeppelinConfiguration zConf;
+
+  public ConfigurationService(ZeppelinConfiguration zConf) {
+    this.zConf = zConf;
+  }
+
+  public Map<String, String> getAllProperties(ServiceContext context,
+                                              ServiceCallback<Map<String, String>> callback)
+      throws IOException {
+    Map<String, String> properties = zConf.dumpConfigurations(key ->
+        !key.contains("password") &&
+            !key.equals(ZeppelinConfiguration.ConfVars
+                .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING.getVarName()));
+    callback.onSuccess(properties, context);
+    return properties;
+  }
+
+  public Map<String, String> getPropertiesWithPrefix(String prefix,
+                                                     ServiceContext context,
+                                                     ServiceCallback<Map<String, String>> callback)
+      throws IOException {
+    Map<String, String> properties = zConf.dumpConfigurations(key ->
+        !key.contains("password") &&
+            !key.equals(ZeppelinConfiguration.ConfVars
+                    .ZEPPELIN_NOTEBOOK_AZURE_CONNECTION_STRING
+                    .getVarName()) &&
+            key.startsWith(prefix));
+    callback.onSuccess(properties, context);
+    return properties;
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ConfigurationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ConfigurationServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zeppelin.service;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.apache.zeppelin.server.ZeppelinServer;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+public class ConfigurationServiceTest extends AbstractTestRestApi {
+
+  private static ConfigurationService configurationService;
+
+  private ServiceContext context =
+      new ServiceContext(AuthenticationInfo.ANONYMOUS, new HashSet<>());
+
+  private ServiceCallback callback = mock(ServiceCallback.class);
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HELIUM_REGISTRY.getVarName(),
+        "helium");
+    AbstractTestRestApi.startUp(ConfigurationServiceTest.class.getSimpleName());
+    configurationService = ZeppelinServer.notebookWsServer.getConfigurationService();
+  }
+
+  @AfterClass
+  public static void destroy() throws Exception {
+    AbstractTestRestApi.shutDown();
+  }
+
+  @Test
+  public void testFetchConfiguration() throws IOException {
+    Map<String, String> properties = configurationService.getAllProperties(context, callback);
+    verify(callback).onSuccess(properties, context);
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      assertFalse(entry.getKey().contains("password"));
+    }
+
+    reset(callback);
+    properties = configurationService.getPropertiesWithPrefix("zeppelin.server", context, callback);
+    verify(callback).onSuccess(properties, context);
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      assertFalse(entry.getKey().contains("password"));
+      assertTrue(entry.getKey().startsWith("zeppelin.server"));
+    }
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This is sub task of ZEPPELIN-3288.

* Code refactoring of ZeppelinConfiguration, use Java 8 lambda function`Predicate` instead of ConfigurationKeyPredicate
* Introduce `AbstractRestApi` which has the common functions

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3703


### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
