### PR TITLE
ZEPPELIN-3699. Remove the logic of converting single result to multiple results

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/Job.java
@@ -38,7 +38,6 @@ import java.util.Map;
  * Changing/adding/deleting non transitive field name need consideration of that.
  */
 public abstract class Job<T> {
-
   private static Logger LOGGER = LoggerFactory.getLogger(Job.class);
   private static SimpleDateFormat JOB_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd-HHmmss");
 

--- a/zeppelin-plugins/notebookrepo/git/src/test/resources/2A94M5J1Z/note.json
+++ b/zeppelin-plugins/notebookrepo/git/src/test/resources/2A94M5J1Z/note.json
@@ -21,10 +21,14 @@
       },
       "jobName": "paragraph_1423836981412_-1007008116",
       "id": "20150213-231621_168813393",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:16:21 PM",
       "dateStarted": "Apr 1, 2015 9:11:09 PM",
@@ -54,10 +58,14 @@
       },
       "jobName": "paragraph_1423500779206_-1502780787",
       "id": "20150210-015259_1403135953",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TEXT",
-        "msg": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[32] at parallelize at \u003cconsole\u003e:65\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string, marital: string, education: string, balance: int]\n"
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[32] at parallelize at \u003cconsole\u003e:65\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string, marital: string, education: string, balance: int]\n"
+          }
+        ]
       },
       "dateCreated": "Feb 10, 2015 1:52:59 AM",
       "dateStarted": "Jul 3, 2015 1:43:40 PM",
@@ -108,10 +116,14 @@
       },
       "jobName": "paragraph_1423500782552_-1439281894",
       "id": "20150210-015302_1492795503",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+          }
+        ]
       },
       "dateCreated": "Feb 10, 2015 1:53:02 AM",
       "dateStarted": "Jul 3, 2015 1:43:17 PM",
@@ -170,10 +182,14 @@
       },
       "jobName": "paragraph_1423720444030_-1424110477",
       "id": "20150212-145404_867439529",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+          }
+        ]
       },
       "dateCreated": "Feb 12, 2015 2:54:04 PM",
       "dateStarted": "Jul 3, 2015 1:43:28 PM",
@@ -243,10 +259,14 @@
       },
       "jobName": "paragraph_1423836262027_-210588283",
       "id": "20150213-230422_1600658137",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:22 PM",
       "dateStarted": "Jul 3, 2015 1:43:33 PM",
@@ -275,10 +295,14 @@
       },
       "jobName": "paragraph_1423836268492_216498320",
       "id": "20150213-230428_1231780373",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:28 PM",
       "dateStarted": "Apr 1, 2015 9:12:18 PM",
@@ -307,10 +331,14 @@
       },
       "jobName": "paragraph_1427420818407_872443482",
       "id": "20150326-214658_12335843",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Mar 26, 2015 9:46:58 PM",
       "dateStarted": "Jul 3, 2015 1:44:56 PM",

--- a/zeppelin-plugins/notebookrepo/git/src/test/resources/2A94M5J2Z/note.json
+++ b/zeppelin-plugins/notebookrepo/git/src/test/resources/2A94M5J2Z/note.json
@@ -21,10 +21,14 @@
       },
       "jobName": "paragraph_1423836268492_216498320",
       "id": "20150213-230428_1231780373",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:28 PM",
       "dateStarted": "Apr 1, 2015 9:12:18 PM",
@@ -53,10 +57,14 @@
       },
       "jobName": "paragraph_1427420818407_872443482",
       "id": "20150326-214658_12335843",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Mar 26, 2015 9:46:58 PM",
       "dateStarted": "Jul 3, 2015 1:44:56 PM",

--- a/zeppelin-plugins/notebookrepo/github/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/github/src/test/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepoTest.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/zeppelin-plugins/notebookrepo/github/src/test/resources/2A94M5J1Z/note.json
+++ b/zeppelin-plugins/notebookrepo/github/src/test/resources/2A94M5J1Z/note.json
@@ -21,10 +21,14 @@
       },
       "jobName": "paragraph_1423836981412_-1007008116",
       "id": "20150213-231621_168813393",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eWelcome to Zeppelin.\u003c/h2\u003e\n\u003ch5\u003eThis is a live tutorial, you can run the code yourself. (Shift-Enter to Run)\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:16:21 PM",
       "dateStarted": "Apr 1, 2015 9:11:09 PM",
@@ -54,10 +58,14 @@
       },
       "jobName": "paragraph_1423500779206_-1502780787",
       "id": "20150210-015259_1403135953",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TEXT",
-        "msg": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[32] at parallelize at \u003cconsole\u003e:65\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string, marital: string, education: string, balance: int]\n"
+        "msg": [
+          {
+            "type": "TEXT",
+            "data": "import org.apache.commons.io.IOUtils\nimport java.net.URL\nimport java.nio.charset.Charset\nbankText: org.apache.spark.rdd.RDD[String] \u003d ParallelCollectionRDD[32] at parallelize at \u003cconsole\u003e:65\ndefined class Bank\nbank: org.apache.spark.sql.DataFrame \u003d [age: int, job: string, marital: string, education: string, balance: int]\n"
+          }
+        ]
       },
       "dateCreated": "Feb 10, 2015 1:52:59 AM",
       "dateStarted": "Jul 3, 2015 1:43:40 PM",
@@ -108,10 +116,14 @@
       },
       "jobName": "paragraph_1423500782552_-1439281894",
       "id": "20150210-015302_1492795503",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+          }
+        ]
       },
       "dateCreated": "Feb 10, 2015 1:53:02 AM",
       "dateStarted": "Jul 3, 2015 1:43:17 PM",
@@ -170,10 +182,14 @@
       },
       "jobName": "paragraph_1423720444030_-1424110477",
       "id": "20150212-145404_867439529",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n30\t150\n31\t199\n32\t224\n33\t186\n34\t231\n"
+          }
+        ]
       },
       "dateCreated": "Feb 12, 2015 2:54:04 PM",
       "dateStarted": "Jul 3, 2015 1:43:28 PM",
@@ -243,10 +259,14 @@
       },
       "jobName": "paragraph_1423836262027_-210588283",
       "id": "20150213-230422_1600658137",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "TABLE",
-        "msg": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+        "msg": [
+          {
+            "type": "TABLE",
+            "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t17\n24\t13\n25\t33\n26\t56\n27\t64\n28\t78\n29\t56\n30\t92\n31\t86\n32\t105\n33\t61\n34\t75\n35\t46\n36\t50\n37\t43\n38\t44\n39\t30\n40\t25\n41\t19\n42\t23\n43\t21\n44\t20\n45\t15\n46\t14\n47\t12\n48\t12\n49\t11\n50\t8\n51\t6\n52\t9\n53\t4\n55\t3\n56\t3\n57\t2\n58\t7\n59\t2\n60\t5\n66\t2\n69\t1\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:22 PM",
       "dateStarted": "Jul 3, 2015 1:43:33 PM",
@@ -275,10 +295,14 @@
       },
       "jobName": "paragraph_1423836268492_216498320",
       "id": "20150213-230428_1231780373",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:28 PM",
       "dateStarted": "Apr 1, 2015 9:12:18 PM",
@@ -307,10 +331,14 @@
       },
       "jobName": "paragraph_1427420818407_872443482",
       "id": "20150326-214658_12335843",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Mar 26, 2015 9:46:58 PM",
       "dateStarted": "Jul 3, 2015 1:44:56 PM",

--- a/zeppelin-plugins/notebookrepo/github/src/test/resources/2A94M5J2Z/note.json
+++ b/zeppelin-plugins/notebookrepo/github/src/test/resources/2A94M5J2Z/note.json
@@ -21,10 +21,14 @@
       },
       "jobName": "paragraph_1423836268492_216498320",
       "id": "20150213-230428_1231780373",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003ch2\u003eCongratulations, it\u0027s done.\u003c/h2\u003e\n\u003ch5\u003eYou can create your own notebook in \u0027Notebook\u0027 menu. Good luck!\u003c/h5\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Feb 13, 2015 11:04:28 PM",
       "dateStarted": "Apr 1, 2015 9:12:18 PM",
@@ -53,10 +57,14 @@
       },
       "jobName": "paragraph_1427420818407_872443482",
       "id": "20150326-214658_12335843",
-      "result": {
+      "results": {
         "code": "SUCCESS",
-        "type": "HTML",
-        "msg": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+        "msg": [
+          {
+            "type": "HTML",
+            "data": "\u003cp\u003eAbout bank data\u003c/p\u003e\n\u003cpre\u003e\u003ccode\u003eCitation Request:\n  This dataset is public available for research. The details are described in [Moro et al., 2011]. \n  Please include this citation if you plan to use this database:\n\n  [Moro et al., 2011] S. Moro, R. Laureano and P. Cortez. Using Data Mining for Bank Direct Marketing: An Application of the CRISP-DM Methodology. \n  In P. Novais et al. (Eds.), Proceedings of the European Simulation and Modelling Conference - ESM\u00272011, pp. 117-121, Guimarães, Portugal, October, 2011. EUROSIS.\n\n  Available at: [pdf] http://hdl.handle.net/1822/14838\n                [bib] http://www3.dsi.uminho.pt/pcortez/bib/2011-esm-1.txt\n\u003c/code\u003e\u003c/pre\u003e\n"
+          }
+        ]
       },
       "dateCreated": "Mar 26, 2015 9:46:58 PM",
       "dateStarted": "Jul 3, 2015 1:44:56 PM",

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1660,7 +1660,7 @@ public class NotebookServer extends WebSocketServlet
     final Note note = notebook.getNote(noteId);
     Paragraph p = setParagraphUsingMessage(note, fromMessage, paragraphId,
         text, title, params, config);
-    p.setResult(fromMessage.get("results"));
+    p.setResult((InterpreterResult) fromMessage.get("results"));
     p.setErrorMessage((String) fromMessage.get("errorMessage"));
     p.setStatusWithoutNotification(status);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NoteTest.java
@@ -242,7 +242,7 @@ public class NoteTest {
     String pText = "%spark sc.version";
     Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText(pText);
-    p.setResult("1.6.2");
+    p.setResult(new InterpreterResult(InterpreterResult.Code.SUCCESS, "1.6.2"));
     p.settings.getForms().put("textbox_1", new TextBox("name", "default_name"));
     p.settings.getParams().put("textbox_1", "my_name");
     note.getAngularObjects().put("ao_1", Lists.newArrayList(new AngularObject("name_1", "value_1", note.getId(), p.getId(), null)));

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -835,30 +835,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     notebook.removeNote(note.getId(), anonymous);
     notebook.removeNote(cloneNote.getId(), anonymous);
   }
-
-  @Test
-  public void testCloneNoteWithExceptionResult() throws IOException, CloneNotSupportedException,
-      InterruptedException {
-    Note note = notebook.createNote(anonymous);
-
-    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p.setText("hello world");
-    note.runAll();
-
-    // Force paragraph to have String type object
-    p.setResult("Exception");
-
-    Note cloneNote = notebook.cloneNote(note.getId(), "clone note with Exception result", anonymous);
-    Paragraph cp = cloneNote.paragraphs.get(0);
-
-    // Keep same ParagraphId
-    assertEquals(cp.getId(), p.getId());
-    assertEquals(cp.getText(), p.getText());
-    assertNull(cp.getResult());
-    notebook.removeNote(note.getId(), anonymous);
-    notebook.removeNote(cloneNote.getId(), anonymous);
-  }
-
+  
   @Test
   public void testResourceRemovealOnParagraphNoteRemove() throws IOException {
     Note note = notebook.createNote(anonymous);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -241,11 +241,11 @@ public class ParagraphTest extends AbstractInterpreterTest {
   @Test
   public void returnDefaultParagraphWithNewUser() {
     Paragraph p = new Paragraph("para_1", null, null, null);
-    Object defaultValue = "Default Value";
-    p.setResult(defaultValue);
+    String defaultValue = "Default Value";
+    p.setResult(new InterpreterResult(Code.SUCCESS, defaultValue));
     Paragraph newUserParagraph = p.getUserParagraph("new_user");
     assertNotNull(newUserParagraph);
-    assertEquals(defaultValue, newUserParagraph.getReturn());
+    assertEquals(defaultValue, newUserParagraph.getReturn().message().get(0).getData());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?
It is a refactoring PR. Zeppelin introduce multiple interpreter result in 0.7, and also introduce logic of converting single result to multiple results. I think it it good time to remove that for 0.9, as I believe no one is using zeppelin before 0.7 for now.


### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3699

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
