### PR TITLE
[ZEPPELIN-3712] Add `maxConnLifetime` parameter to JDBC Interpreter

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -201,6 +201,10 @@ There are more JDBC interpreter properties you can specify like below.
     <td>zeppelin.jdbc.interpolation</td>
     <td>Enables ZeppelinContext variable interpolation into paragraph text. Default value is false.</td>
   </tr>
+  <tr>
+    <td>zeppelin.jdbc.maxConnLifetime</td>
+    <td>Maximum of connection lifetime in milliseconds. A value of zero or less means the connection has an infinite lifetime.</td>
+  </tr>
 </table>
 
 You can also add more properties by using this [method](http://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection%28java.lang.String,%20java.util.Properties%29).

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -389,6 +389,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
     PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(
             connectionFactory, null);
+    final String maxConnectionLifetime =
+        StringUtils.defaultIfEmpty(getProperty("zeppelin.jdbc.maxConnLifetime"), "-1");
+    poolableConnectionFactory.setMaxConnLifetimeMillis(Long.parseLong(maxConnectionLifetime));
+
     ObjectPool connectionPool = new GenericObjectPool(poolableConnectionFactory);
 
     poolableConnectionFactory.setPool(connectionPool);

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -115,6 +115,13 @@
         "defaultValue": false,
         "description": "Enable ZeppelinContext variable interpolation into paragraph text",
         "type": "checkbox"
+      },
+      "zeppelin.jdbc.maxConnLifetime": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.maxConnLifetime",
+        "defaultValue": "-1",
+        "description": "Maximum of connection lifetime in milliseconds. A value of zero or less means the connection has an infinite lifetime.",
+        "type": "number"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
This parameter is necessary in that case:
1) Zeppelin open connection and keep it in pool;
2) Database close this connection after some time of inactivity;
3) User get an error and necessity to restart interpreter when he runs a paragraph.
 
The default value of this parameter is `-1` which means the connection has an infinite lifetime.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-3712](https://issues.apache.org/jira/browse/ZEPPELIN-3712)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No