### PR TITLE
[WIP][ZEPPELIN-3713] Remove paragraph text and title from NotebookService.runParagraph

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -776,7 +776,7 @@ public class NotebookRestApi {
           RunParagraphWithParametersRequest.fromJson(message);
       params = request.getParams();
     }
-    notebookService.runParagraph(noteId, paragraphId, "", "", params,
+    notebookService.runParagraph(noteId, paragraphId, params,
         new HashMap<String, Object>(), false, getServiceContext(), new RestServiceCallback<>());
     return new JsonResponse<>(Status.OK).build();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -215,8 +215,6 @@ public class NotebookService {
 
   public boolean runParagraph(String noteId,
                               String paragraphId,
-                              String title,
-                              String text,
                               Map<String, Object> params,
                               Map<String, Object> config,
                               boolean isRunAll,
@@ -243,16 +241,12 @@ public class NotebookService {
       }
       return false;
     }
-    p.setText(text);
-    p.setTitle(title);
     p.setAuthenticationInfo(context.getAutheInfo());
     p.settings.setParams(params);
     p.setConfig(config);
 
     if (note.isPersonalizedMode()) {
       p = note.getParagraph(paragraphId);
-      p.setText(text);
-      p.setTitle(title);
       p.setAuthenticationInfo(context.getAutheInfo());
       p.settings.setParams(params);
       p.setConfig(config);
@@ -292,12 +286,10 @@ public class NotebookService {
       if (paragraphId == null) {
         continue;
       }
-      String text = (String) raw.get("paragraph");
-      String title = (String) raw.get("title");
       Map<String, Object> params = (Map<String, Object>) raw.get("params");
       Map<String, Object> config = (Map<String, Object>) raw.get("config");
 
-      if (runParagraph(noteId, paragraphId, title, text, params, config, true, context, callback)) {
+      if (runParagraph(noteId, paragraphId, params, config, true, context, callback)) {
         // stop execution when one paragraph fails.
         break;
       }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1726,13 +1726,10 @@ public class NotebookServer extends WebSocketServlet
       //TODO(zjffdu) it is possible ?
       return;
     }
-
     String noteId = getOpenNoteId(conn);
-    String text = (String) fromMessage.get("paragraph");
-    String title = (String) fromMessage.get("title");
     Map<String, Object> params = (Map<String, Object>) fromMessage.get("params");
     Map<String, Object> config = (Map<String, Object>) fromMessage.get("config");
-    getNotebookService().runParagraph(noteId, paragraphId, title, text, params, config, false,
+    getNotebookService().runParagraph(noteId, paragraphId, params, config, false,
         getServiceContext(fromMessage),
         new WebSocketServiceCallback<Paragraph>(conn) {
           @Override


### PR DESCRIPTION
### What is this PR for?

NotebookService.runParagraph has paragraph text and title as args, it seems to be unnecessary, because paragraphs extracted from the note already contains them. Also it might cause new bugs related to incorrect text/title passing.

For example, bug in NotebookRestApi.runParagraph():

```
@POST
@Path("job/{noteId}/{paragraphId}")
@ZeppelinApi
public Response runParagraph(@PathParam("noteId") String noteId,
@PathParam("paragraphId") String paragraphId, String message)
throws IOException, IllegalArgumentException {

...

notebookService.runParagraph(
    noteId, paragraphId, "", "", params,
    new HashMap<String, Object>(), false, getServiceContext(), new RestServiceCallback<>());
return new JsonResponse<>(Status.OK).build();
}

```
All paragraphs processing as blank, because text string is empty

### What type of PR is it?
Bug Fix & Refactoring

### What is the Jira issue?
* issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3713

### How should this be tested?
* Tested manually
* [CI in progress](https://travis-ci.org/TinkoffCreditSystems/zeppelin/builds/416018134) 

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
