### PR TITLE
Adding CSP header

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -494,6 +494,14 @@
 
 <!--
 <property>
+  <name>zeppelin.server.csp.frame</name>
+  <value>frame-ancestors 'none'</value>
+  <description>The Content-Security-Policy HTTP response header can be used to mitigate the risk of content-injection attacks and can be used in conjunction with X-Frame-Options to provide better security for browsers that don't support ALLOWED-FROM.</description>
+</property>
+-->
+
+<!--
+<property>
   <name>zeppelin.server.strict.transport</name>
   <value>max-age=631138519</value>
   <description>The HTTP Strict-Transport-Security response header is a security feature that lets a web site tell browsers that it should only be communicated with using HTTPS, instead of using HTTP. Enable this when Zeppelin is running on HTTPS. Value is in Seconds, the default value is equivalent to 20 years.</description>

--- a/docs/setup/security/http_security_headers.md
+++ b/docs/setup/security/http_security_headers.md
@@ -111,7 +111,7 @@ You can choose from an appropriate value below:
 
 * `frame-ancestors 'none'`
 * `frame-ancestors 'self'`
-* `frame-ancestors 'https://example.com:8443' 'http://example.com'`
+* `frame-ancestors https://example.com:8443 http://example.com`
 
 Additional documentation can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
 

--- a/docs/setup/security/http_security_headers.md
+++ b/docs/setup/security/http_security_headers.md
@@ -87,11 +87,33 @@ The following property needs to be updated in the zeppelin-site.xml in order to 
 ```
 
 
-You can choose appropriate value from below.
+You can choose from an appropriate value from below.
 
 * `DENY`
 * `SAMEORIGIN`
 * `ALLOW-FROM uri`
+
+## Setting up Content-Security-Policy Header
+
+The Content-Security-Policy HTTP response header can indicate browser to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites in a `<frame>`,`<iframe>` or `<object>`.
+
+The following property needs to be updated in the zeppelin-site.xml in order to set Content-Security-Policy header.
+
+```xml
+<property>
+  <name>zeppelin.server.csp.frame</name>
+  <value>frame-ancestors 'none'</value>
+  <description>The Content-Security-Policy HTTP response header can be used to mitigate the risk of content-injection attacks and can be used in conjunction with X-Frame-Options to provide better security for browsers that don't support ALLOWED-FROM.</description>
+</property>
+```
+
+You can choose from an appropriate value below:
+
+* `frame-ancestors 'none'`
+* `frame-ancestors 'self'`
+* `frame-ancestors 'https://example.com:8443' 'http://example.com'`
+
+Additional documentation can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors).
 
 ## Setting up Server Header
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -574,6 +574,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_SERVER_XFRAME_OPTIONS);
   }
 
+  public String getCSPFrame() {
+    return getString(ConfVars.ZEPPELIN_SERVER_CSP_FRAME);
+  }
+
   public String getXxssProtection() {
     return getString(ConfVars.ZEPPELIN_SERVER_X_XSS_PROTECTION);
   }
@@ -763,6 +767,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE("zeppelin.websocket.max.text.message.size", "1024000"),
     ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED("zeppelin.server.default.dir.allowed", false),
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
+    ZEPPELIN_SERVER_CSP_FRAME("zeppelin.server.csp.frame", "frame-ancestors 'none'"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE("zeppelin.server.jetty.request.header.size", 8192),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -75,6 +75,8 @@ public class CorsFilter implements Filter {
 
     ZeppelinConfiguration zeppelinConfiguration = ZeppelinConfiguration.create();
     response.setHeader("X-FRAME-OPTIONS", zeppelinConfiguration.getXFrameOptions());
+    response.setHeader("Content-Security-Policy", zeppelinConfiguration.getCSPFrame());
+
     if (zeppelinConfiguration.useSsl()) {
       response.setHeader("Strict-Transport-Security", zeppelinConfiguration.getStrictTransport());
     }


### PR DESCRIPTION
### What is this PR for?
Exposing CSP headers in Zeppelin. Sometimes enterprises might not want to set `X-Frame-Options` due to security concerns and chrome not supporting `ALLOWED-FROM` directive. Using CSP solves both problems.


### What type of PR is it?
* Improvement
* Documentation

### Todos
* None

### What is the Jira issue?
* ZEPPELIN-3714

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* No license change is required
* No breaking change for older versions
* Docs have already been updated
