### PR TITLE
[ZEPPELIN-3722] Zeppelin UI shows "configured HomePage is not existed" with default config

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.service;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
@@ -65,7 +66,7 @@ public class NotebookService {
                           ServiceCallback<Note> callback) throws IOException {
     String noteId = notebook.getConf().getString(ZEPPELIN_NOTEBOOK_HOMESCREEN);
     Note note = null;
-    if (noteId != null) {
+    if (!StringUtils.isBlank(noteId)) {
       note = notebook.getNote(noteId);
       if (note != null) {
         if (!checkPermission(noteId, Permission.READER, Message.OP.GET_HOME_NOTE, context,
@@ -73,7 +74,7 @@ public class NotebookService {
           return null;
         }
       } else {
-        callback.onFailure(new Exception("configured HomePage is not existed"), context);
+        callback.onFailure(new Exception("The configured home screen does not exist."), context);
       }
     }
     callback.onSuccess(note, context);


### PR DESCRIPTION
### What is this PR for?
With default `zeppelin-site.xml` config i.e. "zeppelin.notebook.homescreen" set to empty string Zeppelin home page shows "configured HomePage is not existed".


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3722](https://issues.apache.org/jira/browse/ZEPPELIN-3722)

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
