### PR TITLE
[ZEPPELIN-3715] Fix text & titile passing in NotebookRestApi.runParagraph

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -751,14 +751,20 @@ public class NotebookRestApi extends AbstractRestApi {
       throws IOException, IllegalArgumentException {
     LOG.info("run paragraph job asynchronously {} {} {}", noteId, paragraphId, message);
 
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    Paragraph paragraph = note.getParagraph(paragraphId);
+    checkIfParagraphIsNotNull(paragraph);
+
     Map<String, Object> params = new HashMap<>();
     if (!StringUtils.isEmpty(message)) {
       RunParagraphWithParametersRequest request =
           RunParagraphWithParametersRequest.fromJson(message);
       params = request.getParams();
     }
-    notebookService.runParagraph(noteId, paragraphId, "", "", params,
-        new HashMap<>(), false, false, getServiceContext(), new RestServiceCallback<>());
+    notebookService.runParagraph(noteId, paragraphId, paragraph.getTitle(),
+            paragraph.getText(), params, new HashMap<>(),
+            false, false, getServiceContext(), new RestServiceCallback<>());
     return new JsonResponse<>(Status.OK).build();
   }
 


### PR DESCRIPTION
### What is this PR for?

All paragraphs processing as blank, because text string is empty.
```
@POST
@Path("job/{noteId}/{paragraphId}")
@ZeppelinApi
public Response runParagraph(@PathParam("noteId") String noteId,
@PathParam("paragraphId") String paragraphId, String message)
throws IOException, IllegalArgumentException {

...

notebookService.runParagraph(
    noteId, paragraphId, "", "", params,
    new HashMap<String, Object>(), false, getServiceContext(), new RestServiceCallback<>());
return new JsonResponse<>(Status.OK).build();
}
```

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* [issue](https://issues.apache.org/jira/browse/ZEPPELIN-3715)

### How should this be tested?
* [CI pass](https://travis-ci.org/TinkoffCreditSystems/zeppelin/builds/416706975)
* Test updated

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
