### PR TITLE
[ZEPPELIN-3736] Helium page's UI to show loading screen

### DIFF
--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -15,7 +15,7 @@
 import {HeliumType} from './helium-type';
 
 export default function HeliumCtrl($scope, $rootScope, $sce,
-                                   baseUrlSrv, ngToast, heliumService) {
+                                   baseUrlSrv, ngToast, heliumService, loaderSrv) {
   'ngInject';
 
   $scope.pkgSearchResults = {};
@@ -35,6 +35,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
   function init() {
     // get all package info and set config
+    loaderSrv.showLoader();
     heliumService.getAllPackageInfoAndDefaultPackages()
       .then(({pkgSearchResults, defaultPackages}) => {
         // pagination
@@ -44,6 +45,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
 
         $scope.pkgSearchResults = pkgSearchResults;
         $scope.defaultPackages = defaultPackages;
+        loaderSrv.hideLoader();
         classifyPkgType($scope.defaultPackages);
 
         return heliumService.getAllPackageConfigs();


### PR DESCRIPTION
### What is this PR for?
At times Helium page's API takes time to return the result, the idea of this JIRA is to show a loading screen while it takes time.


### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-3736](https://issues.apache.org/jira/browse/ZEPPELIN-3736)

### How should this be tested?
* Refer screen shot

### Screenshots (if appropriate)
Before:
![before](https://user-images.githubusercontent.com/674497/44323377-458d1880-a46f-11e8-8377-22ae340a45c1.gif)


After:
![after](https://user-images.githubusercontent.com/674497/44323376-458d1880-a46f-11e8-9aeb-b7557c3df183.gif)


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
