### PR TITLE
[ZEPPELIN-3738] Fix enabling JMX in ZeppelinServer

### DIFF
--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -54,6 +54,18 @@ If both are defined, then the **environment variables** will take priority.
     <td>Zeppelin Server ssl port (used when ssl environment/property is set to true)</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_JMX_ENABLE</h6></td>
+    <td><h6 class="properties">N/A</h6></td>
+    <td></td>
+    <td>Enable JMX by defining "true"</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_JMX_PORT</h6></td>
+    <td><h6 class="properties">N/A</h6></td>
+    <td>9996</td>
+    <td>Port number which JMX uses</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_MEM</h6></td>
     <td>N/A</td>
     <td>-Xmx1024m -XX:MaxPermSize=512m</td>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -202,7 +202,7 @@ public class ZeppelinServer extends ResourceConfig {
     this.interpreterService = new InterpreterService(conf, interpreterSettingManager);
 
     // Register MBean
-    if ("true".equals(System.getenv("ZEPPELIN_ENABLE_JMX"))) {
+    if ("true".equals(System.getenv("ZEPPELIN_JMX_ENABLE"))) {
       MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
       try {
         mBeanServer.registerMBean(


### PR DESCRIPTION
### What is this PR for?

There is a typo in the system variable name `ZEPPELIN_JMX_ENABLE`:
```
    // Register MBean
    if ("true".equals(System.getenv("ZEPPELIN_ENABLE_JMX"))) {
```
Variable defined in zeppelin-env.sh.template ([[ZEPPELIN-3422]](https://issues.apache.org/jira/browse/ZEPPELIN-3422)):
```
# export ZEPPELIN_JMX_ENABLE    		# Enable JMX feature by defining "true"
```
Also ZEPPELIN_JMX_ENABLE not mentioned in docs.
### What type of PR is it?
Bug Fix

### What is the Jira issue?
* [issue](https://issues.apache.org/jira/browse/ZEPPELIN-3738)

### How should this be tested?
* CI pass
* Tested manually during [[ZEPPELIN-3671]](https://github.com/apache/zeppelin/pull/3110)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Docs updated
