### PR TITLE
[ZEPPELIN-3741] Do not clear "Authorization" header if Z-server is running behind proxy

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -486,6 +486,14 @@
 
 <!--
 <property>
+    <name>zeppelin.server.clear.authorization.header</name>
+    <value>true</value>
+    <description>Authorization header to be cleared if server is running as authcBasic</description>
+</property>
+-->
+
+<!--
+<property>
   <name>zeppelin.server.xframe.options</name>
   <value>SAMEORIGIN</value>
   <description>The X-Frame-Options HTTP response header can be used to indicate whether or not a browser should be allowed to render a page in a frame/iframe/object.</description>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -486,7 +486,7 @@
 
 <!--
 <property>
-    <name>zeppelin.server.clear.authorization.header</name>
+    <name>zeppelin.server.authorization.header.clear</name>
     <value>true</value>
     <description>Authorization header to be cleared if server is running as authcBasic</description>
 </property>

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -307,6 +307,12 @@ anyofrolesuser = org.apache.zeppelin.utils.AnyOfRolesUserAuthorizationFilter
 > **NOTE :** All of the above configurations are defined in the `conf/shiro.ini` file.
 
 
+## FAQ
+
+Zeppelin sever is configured as form-based authentication but is behind proxy configured as basic-authentication for example [NGINX](./authentication_nginx.html#http-basic-authentication-using-nginx) and don't want Zeppelin-Server to clear authentication headers. 
+
+> Set `zeppelin.server.authorization.header.clear` to `false` in zeppelin-site.xml
+
 ## Other authentication methods
 
 - [HTTP Basic Authentication using NGINX](./authentication_nginx.html)

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -571,6 +571,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getInt(ConfVars.ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE);
   }
 
+  public Boolean isClearAuthorizationHeader() {
+    return getBoolean(ConfVars.ZEPPELIN_SERVER_CLEAR_AUTHORIZATION_HEADER);
+  }
+
 
   public String getXFrameOptions() {
     return getString(ConfVars.ZEPPELIN_SERVER_XFRAME_OPTIONS);
@@ -759,6 +763,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE("zeppelin.server.jetty.request.header.size", 8192),
+    ZEPPELIN_SERVER_CLEAR_AUTHORIZATION_HEADER("zeppelin.server.clear.authorization.header", true),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -571,8 +571,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getInt(ConfVars.ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE);
   }
 
-  public Boolean isClearAuthorizationHeader() {
-    return getBoolean(ConfVars.ZEPPELIN_SERVER_CLEAR_AUTHORIZATION_HEADER);
+  public Boolean isAuthorizationHeaderClear() {
+    return getBoolean(ConfVars.ZEPPELIN_SERVER_AUTHORIZATION_HEADER_CLEAR);
   }
 
 
@@ -763,7 +763,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_XFRAME_OPTIONS("zeppelin.server.xframe.options", "SAMEORIGIN"),
     ZEPPELIN_SERVER_JETTY_NAME("zeppelin.server.jetty.name", null),
     ZEPPELIN_SERVER_JETTY_REQUEST_HEADER_SIZE("zeppelin.server.jetty.request.header.size", 8192),
-    ZEPPELIN_SERVER_CLEAR_AUTHORIZATION_HEADER("zeppelin.server.clear.authorization.header", true),
+    ZEPPELIN_SERVER_AUTHORIZATION_HEADER_CLEAR("zeppelin.server.authorization.header.clear", true),
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -216,7 +216,7 @@ public class LoginRestApi {
     logoutCurrentUser();
     Status status = null;
     Map<String, String> data = new HashMap<>();
-    if (zConf.isClearAuthorizationHeader()) {
+    if (zConf.isAuthorizationHeaderClear()) {
       status = Status.UNAUTHORIZED;
       data.put("clearAuthorizationHeader", "true");
     } else {


### PR DESCRIPTION
### What is this PR for?
There can be a case where Zeppelin-Sever is running as Form-Based-Authentication, however, it can be running behind a proxy which may be requiring Authorization header.
The idea of this PR is to not clear that header when it behind a proxy and control it with config.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Add documentaion


### What is the Jira issue?
* [ZEPPELIN-3741](https://issues.apache.org/jira/browse/ZEPPELIN-3741)

### How should this be tested?
* Configure Nginx to run with `auth_basic` option
* Start Zeppelin server behind a proxy server like Nginx 
* Make sure that `shiro.ini` is configured to run with `/** = authc`
* In `zeppelin-site.xml` configure `zeppelin.server.authorization.header.clear` as `false`
Now on logout from Zeppelin-Server should not clear *Authorization* header of Nginx


### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? Yes
