### PR TITLE
ZEPPELIN-3745. Disable CRC check of hadoop FileSystem

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FileSystemStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/FileSystemStorage.java
@@ -62,6 +62,8 @@ public class FileSystemStorage {
     this.hadoopConf = new Configuration();
     // disable checksum for local file system. because interpreter.json may be updated by
     // non-hadoop filesystem api
+    // disable caching for file:// scheme to avoid getting LocalFS which does CRC checks
+    this.hadoopConf.setBoolean("fs.file.impl.disable.cache", true);
     this.hadoopConf.set("fs.file.impl", RawLocalFileSystem.class.getName());
     this.isSecurityEnabled = UserGroupInformation.isSecurityEnabled();
 


### PR DESCRIPTION
### What is this PR for?
Trivial PR to disable CRC check of hadoop FileSystem, otherwise we may get error if we manually change the file content of interpreter-setting.json


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3745

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
