### PR TITLE
[ZEPPELIN-3698] Zeppelin stops working after a few days of uptime with RemoteEndpoint unavailable, outgoing connection not open

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
@@ -34,6 +34,7 @@ import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.WatcherMessage;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.util.WatcherSecurityKey;
+import org.eclipse.jetty.websocket.api.WebSocketException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,7 +214,7 @@ public class ConnectionManager {
       for (NotebookSocket ns : connectedSockets) {
         try {
           ns.send(serializeMessage(m));
-        } catch (IOException e) {
+        } catch (IOException | WebSocketException e) {
           LOGGER.error("Send error: " + m, e);
         }
       }
@@ -234,7 +235,7 @@ public class ConnectionManager {
     for (NotebookSocket conn : socketsToBroadcast) {
       try {
         conn.send(serializeMessage(m));
-      } catch (IOException e) {
+      } catch (IOException | WebSocketException e) {
         LOGGER.error("socket error", e);
       }
     }
@@ -245,9 +246,12 @@ public class ConnectionManager {
       for (NotebookSocket watcher : watcherSockets) {
         try {
           watcher.send(
-              WatcherMessage.builder(noteId).subject(subject).message(serializeMessage(message))
-                  .build().toJson());
-        } catch (IOException e) {
+              WatcherMessage.builder(noteId)
+                  .subject(subject)
+                  .message(serializeMessage(message))
+                  .build()
+                  .toJson());
+        } catch (IOException | WebSocketException e) {
           LOGGER.error("Cannot broadcast message to watcher", e);
         }
       }
@@ -272,7 +276,7 @@ public class ConnectionManager {
       }
       try {
         conn.send(serializeMessage(m));
-      } catch (IOException e) {
+      } catch (IOException | WebSocketException e) {
         LOGGER.error("socket error", e);
       }
     }
@@ -294,7 +298,7 @@ public class ConnectionManager {
 
         try {
           conn.send(serializedMsg);
-        } catch (IOException e) {
+        } catch (IOException | WebSocketException e) {
           LOGGER.error("Cannot broadcast message to conn", e);
         }
       }
@@ -324,7 +328,7 @@ public class ConnectionManager {
   public void unicast(Message m, NotebookSocket conn) {
     try {
       conn.send(serializeMessage(m));
-    } catch (IOException e) {
+    } catch (IOException | WebSocketException e) {
       LOGGER.error("socket error", e);
     }
     broadcastToWatchers(StringUtils.EMPTY, StringUtils.EMPTY, m);


### PR DESCRIPTION
### What is this PR for?

Notebooks suddenly show up empty (are not loading) and the logfile (apache-zeppelin-dev.log) shows the following error:
```
org.eclipse.jetty.websocket.api.WebSocketException: RemoteEndpoint unavailable, outgoing connection not open 
at org.eclipse.jetty.websocket.common.WebSocketSession.getRemote(WebSocketSession.java:252) 
at org.apache.zeppelin.socket.NotebookSocket.send(NotebookSocket.java:70)
...
```

It seems that checking the `WebSocketException` after `NotebookSocket.send` will solve this problem .

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* issue: https://issues.apache.org/jira/browse/ZEPPELIN-3698

### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
