### PR TITLE
ZEPPELIN-3687. Fix IndexError in spark.pyspark with empty input (branch-0.8)

### DIFF
--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -366,7 +366,7 @@ while True :
       if (nhooks > 0):
         to_run_hooks = code.body[-nhooks:]
       to_run_exec, to_run_single = (code.body[:-(nhooks + 1)],
-                                    [code.body[-(nhooks + 1)]])
+                                    [code.body[-(nhooks + 1)]] if len(code.body) > nhooks else [])
 
       try:
         for node in to_run_exec:


### PR DESCRIPTION
### What is this PR for?
#3115 fix only python interpreter. For master branch is OK because spark.pyspark implements python interpreter, but spark in branch-0.8 has own python.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-3687](https://issues.apache.org/jira/browse/ZEPPELIN-3687)

### How should this be tested?
- CI pass
In #3115 was added test. I think we can not duplicate test.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no 
* Does this needs documentation? no
