### PR TITLE
[ZEPPELIN-3772] Allow definition of http proxy for default interpreter repository

### DIFF
--- a/conf/zeppelin-env.cmd.template
+++ b/conf/zeppelin-env.cmd.template
@@ -41,6 +41,9 @@ REM set ZEPPELIN_IDENT_STRING   		REM A string representing this instance of zep
 REM set ZEPPELIN_NICENESS       		REM The scheduling priority for daemons. Defaults to 0.
 REM set ZEPPELIN_INTERPRETER_LOCALREPO         REM Local repository for interpreter's additional dependency loading
 REM set ZEPPELIN_INTERPRETER_DEP_MVNREPO       REM Maven principal repository for interpreter's additional dependency loading
+REM set ZEPPELIN_INTERPRETER_DEP_MVN_PROXYHOST REM Host of proxy for remote principal repository
+REM set ZEPPELIN_INTERPRETER_DEP_MVN_PROXYPORT REM Port of proxy for remote principal repository
+REM set ZEPPELIN_INTERPRETER_DEP_MVN_PROXYTYPE REM Proxy type for remote principal repository
 REM set ZEPPELIN_HELIUM_NODE_INSTALLER_URL     REM Remote Node installer url for Helium dependency loader
 REM set ZEPPELIN_HELIUM_NPM_INSTALLER_URL      REM Remote Npm installer url for Helium dependency loader
 REM set ZEPPELIN_HELIUM_YARNPKG_INSTALLER_URL  REM Remote Yarn package installer url for Helium dependency loader

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -52,6 +52,9 @@
 # export ZEPPELIN_NICENESS       		# The scheduling priority for daemons. Defaults to 0.
 # export ZEPPELIN_INTERPRETER_LOCALREPO         # Local repository for interpreter's additional dependency loading
 # export ZEPPELIN_INTERPRETER_DEP_MVNREPO       # Remote principal repository for interpreter's additional dependency loading
+# export ZEPPELIN_INTERPRETER_DEP_MVN_PROXYHOST # Host of proxy for remote principal repository
+# export ZEPPELIN_INTERPRETER_DEP_MVN_PROXYPORT # Port of proxy for remote principal repository
+# export ZEPPELIN_INTERPRETER_DEP_MVN_PROXYTYPE # Proxy type for remote principal repository
 # export ZEPPELIN_HELIUM_NODE_INSTALLER_URL     # Remote Node installer url for Helium dependency loader
 # export ZEPPELIN_HELIUM_NPM_INSTALLER_URL      # Remote Npm installer url for Helium dependency loader
 # export ZEPPELIN_HELIUM_YARNPKG_INSTALLER_URL  # Remote Yarn package installer url for Helium dependency loader

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -305,6 +305,25 @@
   <description>Remote principal repository for interpreter's additional dependency loading</description>
 </property>
 
+<!--
+<property>
+  <name>zeppelin.interpreter.dep.mvnRepo.proxyHost</name>
+  <value>proxy.host</value>
+  <description>Host of proxy for remote principal repository</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.dep.mvnRepo.proxyPort</name>
+  <value>1111</value>
+  <description>Port of proxy for remote principal repository</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.dep.mvnRepo.proxyType</name>
+  <value>http</value>
+  <description>Proxy type for remote principal repository</description>
+</property>
+-->
 <property>
   <name>zeppelin.dep.localrepo</name>
   <value>local-repo</value>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -494,6 +494,18 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_DEP_MVNREPO);
   }
 
+  public String getInterpreterMvnRepoProxyHost() {
+    return getString(ConfVars.ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYHOST);
+  }
+
+  public int getInterpreterMvnRepoProxyPort() {
+    return getInt(ConfVars.ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYHOST);
+  }
+
+  public String getInterpreterMvnRepoProxyType(){
+    return getString(ConfVars.ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYHOST);
+  }
+
   public String getRelativeDir(ConfVars c) {
     return getRelativeDir(getString(c));
   }
@@ -697,6 +709,12 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_LOCALREPO("zeppelin.interpreter.localRepo", "local-repo"),
     ZEPPELIN_INTERPRETER_DEP_MVNREPO("zeppelin.interpreter.dep.mvnRepo",
         "http://repo1.maven.org/maven2/"),
+    ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYHOST("zeppelin.interpreter.dep.mvnRepo.proxyHost",
+            null),
+    ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYPORT("zeppelin.interpreter.dep.mvnRepo.proxyPort",
+            null),
+    ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYTYPE("zeppelin.interpreter.dep.mvnRepo.proxyType",
+            "http"),
     ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 60000),
     ZEPPELIN_INTERPRETER_MAX_POOL_SIZE("zeppelin.interpreter.max.poolsize", 10),
     ZEPPELIN_INTERPRETER_GROUP_DEFAULT("zeppelin.interpreter.group.default", "spark"),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -26,7 +26,6 @@ import org.sonatype.aether.RepositorySystemSession;
 import org.sonatype.aether.repository.LocalRepository;
 import org.sonatype.aether.repository.Proxy;
 import org.sonatype.aether.repository.RemoteRepository;
-
 import java.nio.file.Paths;
 import java.util.Optional;
 
@@ -74,13 +73,14 @@ public class Booter {
   }
 
   /**
-   * Check for environment variable and java property with precedence of the environment variable
+   * Check for environment variable and java property with precedence of the environment variable.
+   *
    * @param environmentVariableName
    * @param javaPropertyName
    * @return
    * The environment variable, if not set the system property, or null
    */
-  private static String getEnvironmentVariable(
+  private static String getEnviromentVariableOrProperty(
           String environmentVariableName,
           String javaPropertyName) {
     String propertyValue = System.getenv(environmentVariableName);
@@ -89,7 +89,7 @@ public class Booter {
 
   public static RemoteRepository newCentralRepository() {
 
-    String mvnRepo = getEnvironmentVariable(
+    String mvnRepo = getEnviromentVariableOrProperty(
             "ZEPPELIN_INTERPRETER_DEP_MVNREPO",
             "zeppelin.interpreter.dep.mvnRepo");
     if (mvnRepo == null) {
@@ -97,15 +97,16 @@ public class Booter {
     }
     RemoteRepository remoteRepository = new RemoteRepository("central", "default", mvnRepo);
 
-    String proxyHost = getEnvironmentVariable(
+    String proxyHost = getEnviromentVariableOrProperty(
             "ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYHOST",
             "zeppelin.interpreter.dep.mvnRepo.proxyHost");
-    String proxyPort = getEnvironmentVariable(
-            "ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYPORT",
-            "zeppelin.interpreter.dep.mvnRepo.proxyPort");
 
-    if (proxyHost != null && proxyPort != null) {
-      String proxyType = Optional.ofNullable(getEnvironmentVariable(
+    if (proxyHost != null) {
+      String proxyPort = Optional.ofNullable(getEnviromentVariableOrProperty(
+              "ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYPORT",
+              "zeppelin.interpreter.dep.mvnRepo.proxyPort")).orElse("8080");
+
+      String proxyType = Optional.ofNullable(getEnviromentVariableOrProperty(
               "ZEPPELIN_INTERPRETER_DEP_MVNREPO_PROXYTYPE",
               "zeppelin.interpreter.dep.mvnRepo.proxyType")).orElse(Proxy.TYPE_HTTP);
 


### PR DESCRIPTION
### What is this PR for?
When running zeppelin behind a firewall the default maven central _without_ proxy is always checked first, which makes dependency downloading unusable - for every pom, jar the timeout of the request against maven central adds up to the total time of downloading the dependencies, even if a repository with proxy is added (made possible in ZEPPELIN-1376)

This commit adds additional properties / environment variables that set the proxy on the default repository  

### What type of PR is it?
Improvement
### Todos
* [ ] - Is the modification of org.apache.zeppelin.conf.ZeppelinConfiguration really necessary? The properties are never referenced anywhere and not used in Booter 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3772

### How should this be tested?
* In a proxy environment

### Questions:
* Does the licenses files need update? 
  no
* Is there breaking changes for older versions? 
  no
* Does this needs documentation?
  Currently the default repository is not documented somewhere. Maybe this should be changed? Besides this, the environment template and site file have comments
