### PR TITLE
[MINOR] Disable checkstyle for `zeppelin-*` modules

### DIFF
--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -248,14 +248,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
     </plugins>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -445,14 +445,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### What is this PR for?
Disabling `checkstyle` for some modules including `zeppelin-*` as it breaks lambda expressions which are supported by JDK8. We should fix them but, currently, it would be better to disable them only as we are on refactoring now.

### What type of PR is it?
[Refactoring]