### PR TITLE
ZEPPELIN-3776. Add zeppelin-interpreter as provided dependency of zeppelin-interpreter-parent

### DIFF
--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -67,15 +67,9 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zeppelin-interpreter-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -44,7 +44,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What is this PR for?

Trivial PR to add zeppelin-interpreter as provided dependency of zeppelin-interpreter-parent. The purpose it to make intellij work with zeppelin project. Because intellij can not recognize shaded jar so interpreter modules can not recognize zeppelin-interpreter-api. provided dependency won't have effect on the final shaded interpreter jar. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3776

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? NO
* Does this needs documentation? No
