### PR TITLE
[ZEPPELIN-3761] Aliasing is not working with JDBC interperter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -542,7 +542,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
       if (i > 1) {
         msg.append(TAB);
       }
-      msg.append(replaceReservedChars(md.getColumnName(i)));
+      if (StringUtils.isNotEmpty(md.getColumnLabel(i))) {
+        msg.append(replaceReservedChars(md.getColumnLabel(i)));
+      } else {
+        msg.append(replaceReservedChars(md.getColumnName(i)));
+      }
     }
     msg.append(NEWLINE);
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -191,6 +191,27 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
+  public void testColumnAliasQuery() throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "select NAME as SOME_OTHER_NAME from test_table limit 1";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResult.message().get(0).getType());
+    assertEquals("SOME_OTHER_NAME\na_name\n", interpreterResult.message().get(0).getData());
+  }
+
+  @Test
   public void testSplitSqlQuery() throws SQLException, IOException {
     String sqlQuery = "insert into test_table(id, name) values ('a', ';\"');" +
         "select * from test_table;" +


### PR DESCRIPTION
### What is this PR for?
Using aliasing to rename the column name is not really working. For instance, a SELECT like this renames "aircraft" column in output to "something" in MySQL terminal, but not in Zeppelin:

SELECT aircraft AS something FROM birdstrikes LIMIT 5;

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-3761](https://jira.apache.org/jira/browse/ZEPPELIN-3761)

### How should this be tested?
* Running SQL query with or without alisa should result with the expected column name.

### Questions:
* Does the licenses files need an update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
