### PR TITLE
Zeppelin build fails with "Could not complete Mojo execution.."

### DIFF
--- a/notebook/Zeppelin Tutorial/Matplotlib (Python | PySpark)_2C2AUG798.zpln
+++ b/notebook/Zeppelin Tutorial/Matplotlib (Python | PySpark)_2C2AUG798.zpln
@@ -751,7 +751,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Matplotlib (Python • PySpark)",
+  "name": "Matplotlib (Python | PySpark)",
   "id": "2C2AUG798",
   "angularObjects": {
     "2C6WUGPNH:shared_process": [],


### PR DESCRIPTION
### What is this PR for?
Maven build fails due to invalid file name character, this PR fix it by renaming the note file name.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3788

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
