### PR TITLE
ZEPPELIN-3796. Polluted output for spark interpreter

### DIFF
--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -102,6 +102,7 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
               errorMsg.contains("value toDS is not a member of org.apache.spark.rdd.RDD")) {
               // prepend "import sqlContext.implicits._" due to
               // https://issues.scala-lang.org/browse/SI-6649
+              context.out.clear()
               scalaInterpret("import sqlContext.implicits._\n" + code)
             } else {
               scala.tools.nsc.interpreter.IR.Error


### PR DESCRIPTION
### What is this PR for?
This PR is to clear polluted spark interpreter output. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3796

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
Before
![screen shot 2018-09-27 at 12 41 47 pm](https://user-images.githubusercontent.com/164491/46123777-dadfb180-c252-11e8-9c08-1abbd44be1ca.png)

After
![screen shot 2018-09-27 at 12 41 41 pm](https://user-images.githubusercontent.com/164491/46123774-d87d5780-c252-11e8-84a0-26578b8a5eee.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
