### PR TITLE
ZEPPELIN-3794. NPE when running paragraph without interpreter specified

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -195,6 +195,10 @@ public class Note implements JsonSerializable {
   }
 
   public String getDefaultInterpreterGroup() {
+    if (defaultInterpreterGroup == null) {
+      defaultInterpreterGroup = ZeppelinConfiguration.create()
+          .getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT);
+    }
     return defaultInterpreterGroup;
   }
 


### PR DESCRIPTION
### What is this PR for?
This issue happens for the old note where no defaultInterpreterGroup is specified in note.json. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3794

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
