### PR TITLE
ZEPPELIN-3800. Allow to configure scheduler thread pool size

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -780,6 +780,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD(
         "zeppelin.interpreter.lifecyclemanager.timeout.threshold", 3600000L),
 
+    ZEPPELIN_INTERPRETER_SCHEDULER_POOL_SIZE("zeppelin.scheduler.threadpool.size", 100),
+
     ZEPPELIN_OWNER_ROLE("zeppelin.notebook.default.owner.username", ""),
 
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/SchedulerFactory.java
@@ -57,8 +57,10 @@ public class SchedulerFactory {
 
   SchedulerFactory() {
     ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
-    executor = ExecutorFactory.singleton().createOrGet(SCHEDULER_EXECUTOR_NAME,
-        zConf.getInt("zeppelin.scheduler.threadpool.size", 100));
+    int threadPoolSize =
+        zConf.getInt(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_SCHEDULER_POOL_SIZE);
+    LOGGER.info("Scheduler Thread Pool Size: " + threadPoolSize);
+    executor = ExecutorFactory.singleton().createOrGet(SCHEDULER_EXECUTOR_NAME, threadPoolSize);
   }
 
   public void destroy() {


### PR DESCRIPTION
### What is this PR for?
This PR is for master branch. It just introduce new property `zeppelin.scheduler.threadpool.size` and allow user to customize it in zeppelin-site.xml. 


### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3800

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
