### PR TITLE
ZEPPELIN-3804. Separate log file for each interpreter process

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -93,7 +93,7 @@ ZEPPELIN_SERVER=org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer
 
 INTERPRETER_ID=$(basename "${INTERPRETER_DIR}")
 ZEPPELIN_PID="${ZEPPELIN_PID_DIR}/zeppelin-interpreter-${INTERPRETER_ID}-${ZEPPELIN_IDENT_STRING}-${HOSTNAME}-${PORT}.pid"
-ZEPPELIN_LOGFILE="${ZEPPELIN_LOG_DIR}/zeppelin-interpreter-${INTERPRETER_SETTING_NAME}-"
+ZEPPELIN_LOGFILE="${ZEPPELIN_LOG_DIR}/zeppelin-interpreter-${INTERPRETER_GROUP_ID}-"
 
 if [[ -z "$ZEPPELIN_IMPERSONATE_CMD" ]]; then
     if [[ "${INTERPRETER_ID}" != "spark" || "$ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER" == "false" ]]; then

--- a/zeppelin-plugins/launcher/standard/src/main/java/org/apache/zeppelin/interpreter/launcher/StandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/standard/src/main/java/org/apache/zeppelin/interpreter/launcher/StandardInterpreterLauncher.java
@@ -101,6 +101,7 @@ public class StandardInterpreterLauncher extends InterpreterLauncher {
         env.put("FLINK_LIB_DIR", flinkHome + "/lib");
       }
     }
+    env.put("INTERPRETER_GROUP_ID", context.getInterpreterGroupId());
     return env;
   }
 }

--- a/zeppelin-plugins/launcher/standard/src/test/java/org/apache/zeppelin/interpreter/launcher/StandardInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/standard/src/test/java/org/apache/zeppelin/interpreter/launcher/StandardInterpreterLauncherTest.java
@@ -56,7 +56,7 @@ public class StandardInterpreterLauncherTest {
     assertEquals(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getIntValue(),
         interpreterProcess.getConnectTimeout());
     assertEquals(zConf.getInterpreterRemoteRunnerPath(), interpreterProcess.getInterpreterRunner());
-    assertEquals(1, interpreterProcess.getEnv().size());
+    assertEquals(2, interpreterProcess.getEnv().size());
     assertEquals("VALUE_1", interpreterProcess.getEnv().get("ENV_1"));
     assertEquals(true, interpreterProcess.isUserImpersonated());
   }
@@ -79,7 +79,7 @@ public class StandardInterpreterLauncherTest {
     assertEquals(".//local-repo/groupId", interpreterProcess.getLocalRepoDir());
     assertEquals(10000, interpreterProcess.getConnectTimeout());
     assertEquals(zConf.getInterpreterRemoteRunnerPath(), interpreterProcess.getInterpreterRunner());
-    assertEquals(0, interpreterProcess.getEnv().size());
+    assertEquals(1, interpreterProcess.getEnv().size());
     assertEquals(true, interpreterProcess.isUserImpersonated());
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -381,13 +381,13 @@ public class InterpreterSetting {
     if (option.isExistingProcess) {
       key = Constants.EXISTING_PROCESS;
     } else if (getOption().isProcess()) {
-      key = (option.perUserIsolated() ? user : "") + ":" + (option.perNoteIsolated() ? noteId : "");
+      key = (option.perUserIsolated() ? user : "") + "-" + (option.perNoteIsolated() ? noteId : "");
     } else {
       key = SHARED_PROCESS;
     }
 
     //TODO(zjffdu) we encode interpreter setting id into groupId, this is not a good design
-    return id + ":" + key;
+    return id + "-" + key;
   }
 
   private String getInterpreterSessionId(String user, String noteId) {


### PR DESCRIPTION
### What is this PR for?
This PR just separate log file for each interpreter process instead of putting them all in one log file.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3804

### How should this be tested?
* set shell interpreter as isolated per note
* run shell interpreter in 2 note, and then check log files
* 2 log files are generated
** zeppelin-interpreter-sh--2D8U1YTJU-jzhang-HW12527.log
** zeppelin-interpreter-sh--2D9VN6VWT-jzhang-HW12527.log

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
