### PR TITLE
[WIP] [ZEPPELIN-3694] Dynamically change cron scheduler thread pool size using REST API 

### DIFF
--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -58,3 +58,11 @@ Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/co
 ### Run cron selectively on folders
 
 In `$ZEPPELIN_HOME/conf/zeppelin-site.xml` make sure the property **zeppelin.notebook.cron.enable** is set to **true**, and then set property **zeppelin.notebook.cron.folders** to the desired folder as comma-separated values, e.g. `*yst*, Sys?em, System`. This property accepts wildcard and joker.
+
+### Enable dynamic pool size for Quartz
+By default the number of threads available for concurrent execution of jobs is set to 10.
+
+In order to change it dynamically using REST API or `Notebook.setSchedulerThreadPoolSize()` you need to set **org.quartz.threadPool.class** property to **org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool** in `quartz.properties` file. 
+Notice, that **org.quartz.threadPool.threadPriority** and **org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread** are not implemented in **ExecutorServiceThreadPool**
+
+*In case you didn't configure quartz.properties: create file `quartz.properties` from default properties located in `org.quartz`, delete org.quartz.threadPool.threadPriority and org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread options and add it to `conf` directory.*

--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -110,6 +110,7 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+
 ### List of registered interpreter settings
 
   <table class="table-configuration">
@@ -193,6 +194,7 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
   
 <br/>
+
 ### Get a registered interpreter setting by the setting id 
 
   <table class="table-configuration">
@@ -256,6 +258,7 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+
 ### Create a new interpreter setting  
 
   <table class="table-configuration">
@@ -349,6 +352,7 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+
 ### Update an interpreter setting
   <table class="table-configuration">
     <col width="200">
@@ -438,6 +442,7 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+
 ### Delete an interpreter setting
 
   <table class="table-configuration">

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -1270,9 +1270,128 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
   </table>
 
+### Get scheduler settings
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets scheduler settings.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/settings```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+          400 if scheduler settings do not exist <br/>
+          500 for any other errors
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td>
+      <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": 
+    {
+      "storeClass": "org.quartz.simpl.RAMJobStore",
+      "poolSize": "10",
+      "name": "DefaultQuartzScheduler",
+      "poolClass": "org.quartz.simpl.SimpleThreadPool",
+      "id": "NON_CLUSTERED"
+    }
+}</pre>
+      </td>
+    </tr>
+  </table>
+
+### Get scheduler setting by the setting id
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method gets scheduler setting by it's id.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/settings/[setting ID]```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+          400 if such scheduler setting id does not exist <br/>
+          500 for any other errors
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td>
+      <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": "org.quartz.simpl.RAMJobStore"
+}      </pre>
+      </td>
+    </tr>
+  </table>
+
+### Change quartz thread pool size
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>
+      This ```PUT``` method update scheduler pool size. 
+      Available only if scheduler configured with dynamic thread pool.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/notebook/cron/settings/update/poolSize```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+          400 if new pool size is not valid or dynamic thread pool is not configured <br/>
+          500 for any other errors
+    </tr>
+    <tr>
+      <td> sample JSON input</td>
+      <td>
+      <pre>
+{
+  "poolSize": "10"
+}</pre>
+      </td>
+    </tr>
+    <tr>
+      <td> sample JSON response </td>
+      <td>
+      <pre>
+{
+  "status": "OK"
+}</pre>
+      </td>
+    </tr>
+      </td>
+    </tr>
+  </table>
+
+
 ## Permission
-
-
 
 ### Get a note permission information
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import javax.inject.Inject;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -40,6 +41,8 @@ import org.apache.zeppelin.rest.message.NewParagraphRequest;
 import org.apache.zeppelin.rest.message.RenameNoteRequest;
 import org.apache.zeppelin.rest.message.RunParagraphWithParametersRequest;
 import org.apache.zeppelin.rest.message.UpdateParagraphRequest;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPool;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPoolRepository;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.service.JobManagerService;
@@ -49,6 +52,7 @@ import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.utils.SecurityUtils;
 import org.quartz.CronExpression;
+import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -425,7 +429,7 @@ public class NotebookRestApi extends AbstractRestApi {
   }
 
   /**
-   * Rename note REST API
+   * Rename note REST API.
    *
    * @param message - JSON containing new name
    * @return JSON with status.OK
@@ -870,6 +874,83 @@ public class NotebookRestApi extends AbstractRestApi {
     notebook.refreshCron(note.getId());
 
     return new JsonResponse<>(Status.OK).build();
+  }
+
+  /**
+   * Change quartz thread pool size REST API.
+   *
+   * @param message - JSON with poolSize value.
+   * @return JSON with status.OK
+   * @throws IllegalArgumentException
+   * @throws SchedulerException
+   */
+  @PUT
+  @Path("cron/settings/update/poolSize")
+  @ZeppelinApi
+  public Response changeCronJob(String message)
+      throws IllegalArgumentException, SchedulerException {
+    CronRequest request = CronRequest.fromJson(message);
+
+    LOG.info("Change cron pool size with msg={}", message);
+    DynamicThreadPool threadPool =
+        DynamicThreadPoolRepository.getInstance().lookup(notebook.getSchedulerName());
+    if (threadPool == null) {
+      throw new BadRequestException("Thread pool size is constant.");
+    }
+    if (request.getPoolSize() < 1) {
+      throw new BadRequestException("Wrong pool size.");
+    }
+    threadPool.doResize(request.getPoolSize());
+    return new JsonResponse<>(Status.OK).build();
+  }
+
+  /**
+   * Get scheduler settings REST API.
+   *
+   * @return JSON with status.OK
+   */
+  @GET
+  @Path("cron/settings")
+  @ZeppelinApi
+  public Response getCronJobInfo() {
+    try {
+      Map<String, String> settings = notebook.getSchedulerInfo();
+      if (settings == null) {
+        return new JsonResponse<>(Status.NOT_FOUND).build();
+      } else {
+        return new JsonResponse<>(Status.OK, "", settings).build();
+      }
+    } catch (SchedulerException | NullPointerException e) {
+      LOG.error("Exception in NotebookRestApi while creating ", e);
+      return new JsonResponse<>(
+              Status.INTERNAL_SERVER_ERROR, e.getMessage(), ExceptionUtils.getStackTrace(e))
+          .build();
+    }
+  }
+
+  /**
+   * Get scheduler setting by the setting id REST API.
+   *
+   * @return JSON with status.OK
+   */
+  @GET
+  @Path("cron/settings/{settingId}")
+  @ZeppelinApi
+  public Response getQuartzSetting(@PathParam("settingId") String settingId) {
+    try {
+      Map<String, String> settings = notebook.getSchedulerInfo();
+      String setting = settings.get(settingId);
+      if (setting == null) {
+        return new JsonResponse<>(Status.NOT_FOUND).build();
+      } else {
+        return new JsonResponse<>(Status.OK, "", setting).build();
+      }
+    } catch (SchedulerException | NullPointerException e) {
+      LOG.error("Exception in NotebookRestApi while creating ", e);
+      return new JsonResponse<>(
+              Status.INTERNAL_SERVER_ERROR, e.getMessage(), ExceptionUtils.getStackTrace(e))
+          .build();
+    }
   }
 
   /**

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -170,11 +170,17 @@ public abstract class AbstractTestRestApi {
   private static void start(boolean withAuth,
                             String testClassName,
                             boolean withKnox,
+                            boolean withDynamicPool,
                             boolean cleanData)
           throws Exception {
-    LOG.info("Starting ZeppelinServer withAuth: {}, testClassName: {}, withKnox: {}",
-        withAuth, testClassName, withKnox);
-    
+    LOG.info(
+        "Starting ZeppelinServer withAuth: {}, testClassName: {},"
+            + " withKnox: {}, withDynamicPool: {}",
+        withAuth,
+        testClassName,
+        withKnox,
+        withDynamicPool);
+
     if (!WAS_RUNNING) {
       // copy the resources files to a temp folder
       zeppelinHome = new File("..");
@@ -206,6 +212,10 @@ public abstract class AbstractTestRestApi {
 
       LOG.info("Staring test Zeppelin up...");
       ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+
+      if (withDynamicPool) {
+        System.setProperty("org.quartz.properties", "./quartz.properties");
+      }
 
       if (withAuth) {
         isRunningWithAuth = true;
@@ -250,20 +260,24 @@ public abstract class AbstractTestRestApi {
     }
   }
 
+  protected static void startUpWithDynamicPoolEnable(String testClassName) throws Exception {
+    start(false, testClassName, false, true, true);
+  }
+
   protected static void startUpWithKnoxEnable(String testClassName) throws Exception {
-    start(true, testClassName, true, true);
+    start(true, testClassName, true, false, true);
   }
-  
+
   protected static void startUpWithAuthenticationEnable(String testClassName) throws Exception {
-    start(true, testClassName, false, true);
-  }
-  
-  protected static void startUp(String testClassName) throws Exception {
-    start(false, testClassName, false, true);
+    start(true, testClassName, false, false, true);
   }
 
   protected static void startUp(String testClassName, boolean cleanData) throws Exception {
-    start(false, testClassName, false, cleanData);
+    start(false, testClassName, false, false, cleanData);
+  }
+
+  protected static void startUp(String testClassName) throws Exception {
+    start(false, testClassName, false, false, true);
   }
 
   private static String getHostname() {
@@ -311,7 +325,7 @@ public abstract class AbstractTestRestApi {
       }
 
       LOG.info("Test Zeppelin terminated.");
-      
+
       if (isRunningWithAuth) {
         isRunningWithAuth = false;
         System
@@ -348,7 +362,7 @@ public abstract class AbstractTestRestApi {
   protected static GetMethod httpGet(String path) throws IOException {
     return httpGet(path, StringUtils.EMPTY, StringUtils.EMPTY);
   }
-  
+
   protected static GetMethod httpGet(String path, String user, String pwd) throws IOException {
     return httpGet(path, user, pwd, StringUtils.EMPTY);
   }
@@ -458,7 +472,7 @@ public abstract class AbstractTestRestApi {
     }
     return true;
   }
-  
+
   protected Matcher<HttpMethodBase> responsesWith(final int expectedStatusCode) {
     return new TypeSafeMatcher<HttpMethodBase>() {
       WeakReference<HttpMethodBase> method;

--- a/zeppelin-server/src/test/resources/quartz.properties
+++ b/zeppelin-server/src/test/resources/quartz.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.quartz.scheduler.instanceName: QuartzSchedulerWithDynamicThreadPool
+org.quartz.scheduler.rmi.export: false
+org.quartz.scheduler.rmi.proxy: false
+org.quartz.scheduler.wrapJobExecutionInUserTransaction: false
+
+org.quartz.threadPool.class = org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool
+org.quartz.threadPool.threadCount: 10
+
+org.quartz.jobStore.misfireThreshold: 60000
+
+org.quartz.jobStore.class: org.quartz.simpl.RAMJobStore
+

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPool.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPool.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.scheduler.dynamic_pool;
+
+public interface DynamicThreadPool {
+
+  void doResize(Integer threadPoolSize);
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPoolRepository.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPoolRepository.java
@@ -14,45 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.rest.message;
+package org.apache.zeppelin.scheduler.dynamic_pool;
 
-import com.google.gson.Gson;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.zeppelin.common.JsonSerializable;
+public class DynamicThreadPoolRepository {
 
-/**
- *  CronRequest rest api request message.
- */
-public class CronRequest implements JsonSerializable {
-  private static final Gson gson = new Gson();
+  private static final Map<String, DynamicThreadPool> INSTANCES = new ConcurrentHashMap<>();
 
-  private String cron;
-  private Boolean releaseResource;
-  private Integer poolSize;
+  private static DynamicThreadPoolRepository instance = new DynamicThreadPoolRepository();
 
-  public CronRequest (){
+  public static DynamicThreadPoolRepository getInstance() {
+    return instance;
   }
 
-  public String getCronString() {
-    return cron;
+  public void bind(String schedulerName, DynamicThreadPool threadPool) {
+    INSTANCES.put(schedulerName, threadPool);
   }
 
-  public Integer getPoolSize() {
-    return poolSize;
-  }
-
-  public Boolean getReleaseResource() {
-    if (releaseResource == null) {
-      return Boolean.FALSE;
-    }
-    return releaseResource;
-  }
-
-  public String toJson() {
-    return gson.toJson(this);
-  }
-
-  public static CronRequest fromJson(String json) {
-    return gson.fromJson(json, CronRequest.class);
+  public DynamicThreadPool lookup(String schedulerName) {
+    return INSTANCES.get(schedulerName);
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/impl/ExecutorServiceThreadPool.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/dynamic_pool/impl/ExecutorServiceThreadPool.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.scheduler.dynamic_pool.impl;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPool;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPoolRepository;
+import org.quartz.SchedulerConfigException;
+import org.quartz.spi.ThreadPool;
+
+public class ExecutorServiceThreadPool implements ThreadPool, DynamicThreadPool {
+  private final ExecutorService executor = Executors.newFixedThreadPool(1);
+  private int threadCount;
+  private String instanceId;
+  private String instanceName;
+
+  @Override
+  public boolean runInThread(Runnable runnable) {
+    if (runnable == null) {
+      return false;
+    }
+    executor.submit(runnable);
+    return true;
+  }
+
+  @Override
+  public int blockForAvailableThreads() {
+    ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
+    return threadPoolExecutor.getCorePoolSize() - threadPoolExecutor.getActiveCount();
+  }
+
+  @Override
+  public void initialize() throws SchedulerConfigException {
+    if (threadCount <= 0) {
+      throw new SchedulerConfigException("Thread count must be > 0");
+    }
+  }
+
+  public int getThreadCount() {
+    return threadCount;
+  }
+
+  public void setThreadCount(int threadCount) {
+    doResize(threadCount);
+  }
+
+  @Override
+  public void shutdown(boolean b) {
+    if (b) {
+      executor.shutdown();
+    } else {
+      executor.shutdownNow();
+    }
+  }
+
+  @Override
+  public int getPoolSize() {
+    return getThreadCount();
+  }
+
+  @Override
+  public void setInstanceId(String s) {
+    this.instanceId = s;
+  }
+
+  @Override
+  public void setInstanceName(String s) {
+    this.instanceName = s;
+    DynamicThreadPoolRepository.getInstance().bind(this.instanceName, this);
+  }
+
+  @Override
+  public void doResize(Integer threadPoolSize) {
+    this.threadCount = threadPoolSize;
+    ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executor;
+    threadPoolExecutor.setCorePoolSize(threadCount);
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -85,6 +85,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   @Before
   public void setUp() throws Exception {
+    System.setProperty("org.quartz.properties", "./quartz.properties");
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
     super.setUp();
@@ -305,6 +306,27 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       fail("Should throw InterpreterNotFoundException");
     } catch (InterpreterNotFoundException e) {
 
+    }
+  }
+
+  @Test
+  public void testChangeThreadPoolSize() throws SchedulerException {
+    try {
+      Integer newPoolSize = notebook.getSchedulerPoolSize() + 1;
+      notebook.setSchedulerThreadPoolSize(newPoolSize);
+      assertEquals(newPoolSize, notebook.getSchedulerPoolSize());
+      assertEquals(
+          "org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool",
+          notebook.getSchedulerThreadPoolClass());
+      notebook.setSchedulerThreadPoolSize(newPoolSize - 1);
+    } catch (SchedulerException e) {
+      assertFalse(
+          notebook
+              .getSchedulerThreadPoolClass()
+              .equals(
+                  "org.apache.zeppelin.scheduler."
+                      + "dynamic_pool.impl.ExecutorServiceThreadPool"));
+      assertEquals("Thread pool size is constant.", e.getMessage());
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.zeppelin.scheduler;
 
 import org.apache.zeppelin.interpreter.AbstractInterpreterTest;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPoolRegisterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/DynamicThreadPoolRegisterTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.scheduler.dynamic_pool;
+
+import org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DynamicThreadPoolRegisterTest {
+  private static final String SCHED_NAME = "SchedTest";
+
+  @Test
+  public void testBind() {
+    bind();
+  }
+
+  private void bind() {
+    DynamicThreadPoolRepository.getInstance().bind(SCHED_NAME, new ExecutorServiceThreadPool());
+  }
+
+  @Test
+  public void testLookupThreadPool() {
+    bind();
+
+    DynamicThreadPool threadPool = DynamicThreadPoolRepository.getInstance().lookup(SCHED_NAME);
+    Assert.assertNotNull(threadPool);
+  }
+
+  @Test
+  public void testLookupWrongThreadPool() {
+    DynamicThreadPool threadPool =
+        DynamicThreadPoolRepository.getInstance().lookup("WrongSchedTest");
+    Assert.assertNull(threadPool);
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/impl/ExecutorServiceThreadPoolTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/impl/ExecutorServiceThreadPoolTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.scheduler.dynamic_pool.impl;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPool;
+import org.apache.zeppelin.scheduler.dynamic_pool.DynamicThreadPoolRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.impl.StdSchedulerFactory;
+
+@RunWith(JUnit4.class)
+public class ExecutorServiceThreadPoolTest {
+
+  private static final String QUARTZ_SCHEDULER = "QuartzScheduler";
+  private static final int POOL_SIZE = 5;
+  private static final int DECREASE_POOL_SIZE = 2;
+
+  private Scheduler scheduler;
+  private AtomicInteger jobSequence = new AtomicInteger(1);
+
+  /**
+   * Setup {@link ExecutorServiceThreadPool}.
+   *
+   * @throws SchedulerException
+   */
+  @Before
+  public void beforeTests() throws SchedulerException {
+    Properties properties = new Properties();
+    properties.setProperty(
+        StdSchedulerFactory.PROP_THREAD_POOL_CLASS, ExecutorServiceThreadPool.class.getName());
+    properties.setProperty("org.quartz.threadPool.threadCount", String.valueOf(POOL_SIZE));
+
+    scheduler = new StdSchedulerFactory(properties).getScheduler();
+    scheduler.start();
+  }
+
+  /**
+   * Close and wait for finish.
+   *
+   * @throws SchedulerException
+   */
+  @After
+  public void afterTests() throws SchedulerException {
+    scheduler.shutdown(true);
+  }
+
+
+  @Test
+  public void changeThreadPoolSize() throws SchedulerException {
+    DynamicThreadPool threadPool =
+        DynamicThreadPoolRepository.getInstance().lookup(QUARTZ_SCHEDULER);
+    threadPool.doResize(DECREASE_POOL_SIZE);
+
+    Assert.assertEquals(DECREASE_POOL_SIZE, scheduler.getMetaData().getThreadPoolSize());
+    threadPool.doResize(POOL_SIZE);
+    Assert.assertEquals(POOL_SIZE, scheduler.getMetaData().getThreadPoolSize());
+  }
+}

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/job/DummyJob.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/dynamic_pool/job/DummyJob.java
@@ -14,45 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.rest.message;
+package org.apache.zeppelin.scheduler.dynamic_pool.job;
 
-import com.google.gson.Gson;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 
-import org.apache.zeppelin.common.JsonSerializable;
-
-/**
- *  CronRequest rest api request message.
- */
-public class CronRequest implements JsonSerializable {
-  private static final Gson gson = new Gson();
-
-  private String cron;
-  private Boolean releaseResource;
-  private Integer poolSize;
-
-  public CronRequest (){
-  }
-
-  public String getCronString() {
-    return cron;
-  }
-
-  public Integer getPoolSize() {
-    return poolSize;
-  }
-
-  public Boolean getReleaseResource() {
-    if (releaseResource == null) {
-      return Boolean.FALSE;
+public class DummyJob implements Job {
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    try {
+      Thread.sleep(200L);
+    } catch (InterruptedException e) {
+      throw new JobExecutionException(e);
     }
-    return releaseResource;
-  }
-
-  public String toJson() {
-    return gson.toJson(this);
-  }
-
-  public static CronRequest fromJson(String json) {
-    return gson.fromJson(json, CronRequest.class);
   }
 }

--- a/zeppelin-zengine/src/test/resources/quartz.properties
+++ b/zeppelin-zengine/src/test/resources/quartz.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.quartz.scheduler.instanceName: QuartzSchedulerWithDynamicThreadPool
+org.quartz.scheduler.rmi.export: false
+org.quartz.scheduler.rmi.proxy: false
+org.quartz.scheduler.wrapJobExecutionInUserTransaction: false
+
+org.quartz.threadPool.class = org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool
+org.quartz.threadPool.threadCount: 10
+
+org.quartz.jobStore.misfireThreshold: 60000
+
+org.quartz.jobStore.class: org.quartz.simpl.RAMJobStore
+


### PR DESCRIPTION
### What is this PR for?
This PR is reopening of https://github.com/apache/zeppelin/pull/3121 
It would be nice if we could change thread pool size for scheduler dynamically.

### Using this feature:
1. Create file `quartz.properties` from default file located in `org.quartz` and add them to `conf` directory
2. Notice, that **org.quartz.threadPool.threadPriority** and **org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread** are not implemented in **ExecutorServiceThreadPool** so these options should be deleted from the file
3. In `quartz.properties` set `org.quartz.threadPool.class` to `org.apache.zeppelin.scheduler.dynamic_pool.impl.ExecutorServiceThreadPool`

Otherwise you will get message "Thread pool size is constant."

### What type of PR is it?
Improvement

### What is the Jira issue?
* issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-3694

### How should this be tested?
* Tests added
* Tested manually
* [CI pass](https://travis-ci.org/TinkoffCreditSystems/zeppelin/builds/441237953)

### Screenshots
Firstly, when thread pool size equals `1` notes wait for each other, but when scheduler thread pool size changed to `2` they start to work in parallel.

![cron mp4](https://user-images.githubusercontent.com/6136993/43912629-77707ad4-9c0b-11e8-9d6c-62cbc67568a8.gif)



### Questions:
* Does the licenses files need update?  No
I added sources of [quartz-dynamic-pool](https://github.com/epiresdasilva/quartz-dynamic-pool) developed by @epiresdasilva, because this repo isn't included in http://mvnrepository.com
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, REST API docs updated
