### PR TITLE
[ZEPPELIN-3835] Update website for 0.8.0 release

### DIFF
--- a/whats_new.md
+++ b/whats_new.md
@@ -16,88 +16,56 @@ limitations under the License.
 <div class="new">
   <div class="container">
     <h2>What's new in</h2>
-    <span class="newZeppelin center-block">Apache Zeppelin 0.7</span>
+    <span class="newZeppelin center-block">Apache Zeppelin 0.8</span>
     <div class="border row">
       <div class="border col-md-4 col-sm-4">
-        <h4>Pluggable Visualization <br/> via Helium</h4>
-        <div class="viz">
+        <h4>Python, improved</h4>
+        <div>
           <p>
-            Load/unload Javascript 
-            <a href="https://www.npmjs.com/" target="_blank">npm packages</a>
-            like Zeppelin built-in chart using Helium framework.
-            <a class="thumbnail" href="#thumb">
-              See more in DEMO <span><img src="./assets/themes/zeppelin/img/helium.gif" /></span>
-            </a>
-            and
-            <a href="./docs/0.7.0/development/writingzeppelinvisualization.html#how-it-works" target="_blank">Zeppelin Visualization: How it works?</a>
+            IPython interpreter provides comparable user experience like Jupyter Notebook. For the details, click <a href="./docs/0.8.0/interpreter/python.html#ipython-support">here</a>.
           </p>
         </div>
       </div>
       <div class="border col-md-4 col-sm-4">
-        <h4>Multi-user Support Improvement</h4>
-        <div class="multi">
+        <h4>Note improvements</h4>
         <p>
-          Separate interpreter running scope 
-          <span style="font-weight: 900; font-style: initial;">Per user</span> or 
-          <span style="font-weight: 900; font-style: initial;">Per Note</span>.
-          <a class="thumbnail text-center" href="#thumb">
-            See more in DEMO.
-            <span><img src="./assets/themes/zeppelin/img/scope.gif" style="max-width: 55vw" /></span>
-          </a> <br/>
-          Also running Zeppelin interpreter process as web front end user is available now. 
-          <a class="thumbnail text-center" href="#thumb">
-            See more in DEMO
-            <span style="top: 230px;"><img src="./assets/themes/zeppelin/img/user-impersonation.gif" style="max-width: 55vw;" /></span>
-          </a>
-          and 
-          <a href="./docs/0.7.0/manual/userimpersonation.html" target="_blank">Interpreter User Impersonation</a>.
+          This release includes <a href="./docs/0.8.0/usage/dynamic_form/intro.html#using-form-templates-scope-note">Note level dynamic form</a>, note revision comparator and ability to run paragraph sequentially, instead of simultaneous paragraph execution in previous releases.
         </p>
-        </div>
       </div>
       <div class="border col-md-4 col-sm-4">
-        <h4>New Note Mode - <br/> Personal Mode</h4>
+        <h4>Inline configuration</h4>
         <div class="personal">
         <p>
-          Personalize your analysis result by switching the note to Personal Mode. 
-          (Collaboration Mode is default.) 
-          <a class="thumbnail text-center personal" href="#thumb">
-            See more in DEMO.
-            <span><img src="./assets/themes/zeppelin/img/personalize.gif" /></span>
-          </a>
+          Generic <a href="./docs/0.8.0/usage/interpreter/overview.html#generic-confinterpreter">ConfInterpreter</a> provide a way configure interpreter inside each note.
         </p>
         </div>
       </div>
     </div>
     <div class="border row">
       <div class="border col-md-4 col-sm-4">
-        <h4>Support Spark 2.1</h4>
+        <h4>Tab-key completion</h4>
         <p>
-          The latest version of <a href="http://spark.apache.org/releases/spark-release-2-1-0.html" target="_blank">Apache Spark 2.1.0</a> is now available in Zeppelin.
+          Press `Tab` for code completion. (previous key combination `Ctrl+.` works as well)
         </p>
       </div>
       <div class="border col-md-4 col-sm-4">
-        <h4>Improvement in Python</h4>
+        <h4>Interpreter lifecycle</h4>
+        <div>
         <p>
-          Integrated
-          <a href="./docs/latest/interpreter/python.html#matplotlib-integration" target="_blank">Matplotlib</a>
-          with Python & Pyspark interpreter. And 
-          <a href="./docs/latest/interpreter/python.html#conda" target="_blank">Conda</a>
-          is now available in Zeppelin. 
+          Interpreter lifecycle manager automatically terminate interpreter process on idle timeout. So resources are released when they're not in use. See <a href="./docs/0.8.0/usage/interpreter/overview.html#interpreter-lifecycle-management">here</a> for more details.
         </p>
+        </div>
       </div>
       <div class="border col-md-4 col-sm-4">
-        <h4>New Interpreters</h4>
+        <h4>Helium online registry</h4>
         <p>
-        You can use
-        <a href="https://beam.apache.org/" target="_blank">Apache Beam</a>, 
-        <a href="https://github.com/spotify/scio" target="_blank">Scio</a>, and
-        <a href="https://pig.apache.org/" target="_blank">Apache Pig</a> as backend interpreters from this release.
+          This release includes online registry for Helium that can add custom visualization and more. <a href="./docs/0.8.0/development/helium/overview.html">learn more</a> about it.
         </p>
       </div>
     </div>
     <div class="col-md-12 col-sm-12 col-xs-12 text-center">
       <p style="text-align:center; margin-top: 32px; font-size: 14px; color: gray; font-weight: 200; font-style: italic; padding-bottom: 0;">See more details in 
-        <a href="./releases/zeppelin-release-0.7.0.html">0.7 Release Note</a>
+        <a href="./releases/zeppelin-release-0.8.0.html">0.8 Release Note</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
### What is this PR for?
0.8.0 has released in last June, but what's new section in website still have information of 0.7.x.
This PR update information for the latest release.

I compiled contents based on https://medium.com/@zjffdu/zeppelin-0-8-0-new-features-ea53e8810235

### What type of PR is it?
Website update

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3835

### How should this be tested?
* [Run website locally](https://github.com/apache/zeppelin/tree/gh-pages#run-website)

### Screenshots (if appropriate)
Before
![image](https://user-images.githubusercontent.com/1540981/47679890-8b0e4600-db82-11e8-9390-5a28a5954be0.png)


After
![image](https://user-images.githubusercontent.com/1540981/47679872-834ea180-db82-11e8-9bec-6a8b5ff50359.png)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
