### PR TITLE
[ZEPPELIN-3836] update website url rewrite rule for 0.8.0 release

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RewriteRule ^/?docs/0.6.0-(?!SNAPSHOT).*/(.*) /docs/0.6.0/$2  [R=301,L,NE]
 RewriteRule ^/?docs/(0.5.[056])(?!-incubating).*/(.*) /docs/$1-incubating/$3  [R=301,L,NE]
 
 # rewrite docs/latest to latest stable release
-RewriteRule ^/?docs/latest/(.*) /docs/0.7.3/$1  [PT]
+RewriteRule ^/?docs/latest/(.*) /docs/0.8.0/$1  [PT]
 
 # rewrite docs/snapshot to latest snapshot version
-RewriteRule ^/?docs/snapshot/(.*) /docs/0.8.0-SNAPSHOT/$1  [PT]
+RewriteRule ^/?docs/snapshot/(.*) /docs/0.9.0-SNAPSHOT/$1  [PT]


### PR DESCRIPTION
### What is this PR for?
`https://zeppelin.apache.org/docs/latest` supposed to point latest release version documentation. But it currently points 0.7.3 version doc, instead of 0.8.0.


### What type of PR is it?
Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3836


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
