### PR TITLE
[ZEPPELIN-3839] Replace | to , in the filename

### DIFF
--- a/notebook/Zeppelin Tutorial/Matplotlib (Python, PySpark)_2C2AUG798.zpln
+++ b/notebook/Zeppelin Tutorial/Matplotlib (Python, PySpark)_2C2AUG798.zpln
@@ -751,7 +751,7 @@
       "progressUpdateIntervalMs": 500
     }
   ],
-  "name": "Matplotlib (Python | PySpark)",
+  "name": "Matplotlib (Python, PySpark)",
   "id": "2C2AUG798",
   "angularObjects": {
     "2C6WUGPNH:shared_process": [],


### PR DESCRIPTION
### What is this PR for?
A tutorial notebook filename, which includes `|`, is not compatible with windows filesystem.
This PR replace `|` with `,`.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3839

### How should this be tested?
CI pass

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
