### PR TITLE
[ZEPPELIN-3849] display note name correctly.

### DIFF
--- a/zeppelin-web/src/components/array-ordering/array-ordering.service.js
+++ b/zeppelin-web/src/components/array-ordering/array-ordering.service.js
@@ -27,10 +27,10 @@ function ArrayOrderingService(TRASH_FOLDER_ID) {
   };
 
   this.getNoteName = function(note) {
-    if (note.path === undefined || note.path.trim() === '') {
+    if (note.name === undefined || note.name.trim() === '') {
       return 'Note ' + note.id;
     } else {
-      return note.path;
+      return note.name;
     }
   };
 


### PR DESCRIPTION
### What is this PR for?
Master branch displays note id instead of note name.
I think it's side effect after change https://github.com/apache/zeppelin/pull/3163.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3849

### How should this be tested?
See if note name is displayed instead of note id

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
