### PR TITLE
ZEPPELIN-3846. Code Completion is broken

### DIFF
--- a/zeppelin-interpreter-api/pom.xml
+++ b/zeppelin-interpreter-api/pom.xml
@@ -125,22 +125,8 @@
               </excludes>
             </relocation>
             <relocation>
-              <pattern>com</pattern>
-              <shadedPattern>${shaded.dependency.prefix}.com</shadedPattern>
-              <excludes>
-                <exclude>**/pom.xml</exclude>
-                <!-- Not the com/ packages that are a part of particular jdk implementations -->
-                <exclude>com/sun/tools/*</exclude>
-                <exclude>com/sun/javadoc/*</exclude>
-                <exclude>com/sun/security/*</exclude>
-                <exclude>com/sun/jndi/*</exclude>
-                <exclude>com/sun/management/*</exclude>
-                <exclude>com/sun/tools/**/*</exclude>
-                <exclude>com/sun/javadoc/**/*</exclude>
-                <exclude>com/sun/security/**/*</exclude>
-                <exclude>com/sun/jndi/**/*</exclude>
-                <exclude>com/sun/management/**/*</exclude>
-              </excludes>
+              <pattern>com.google</pattern>
+              <shadedPattern>${shaded.dependency.prefix}.com.google</shadedPattern>
             </relocation>
             <relocation>
               <pattern>io</pattern>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -64,7 +65,7 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
   //ci timeout.
   //TODO(zjffdu) remove this after we upgrade it to junit 4.13 (ZEPPELIN-3341)
   private static Set<String> verifiedSparkVersions = new HashSet<>();
-  
+
 
   private String sparkVersion;
   private AuthenticationInfo anonymous = new AuthenticationInfo("anonymous");
@@ -170,6 +171,9 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     assertEquals(Status.FINISHED, p.getStatus());
     assertEquals("2", p.getReturn().message().get(0).getData());
 
+    // test code completion
+    List<InterpreterCompletion> completions = note.completion(p.getId(), "sc.", 2);
+    assertTrue(completions.size() > 0);
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);
   }
 


### PR DESCRIPTION
### What is this PR for?
Code completion is broken due to the shaded jar in zeppelin-interpreter-api, this PR fix this issue and also add unit test for it.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3846

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
