### PR TITLE
ZEPPELIN-3858. Code completion doesn't work for spark interpreter when cursor is in the middle of code

### DIFF
--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/NewSparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/NewSparkInterpreterTest.java
@@ -290,6 +290,10 @@ public class NewSparkInterpreterTest {
     assertEquals(1, completions.size());
     assertEquals("range", completions.get(0).name);
 
+    // cursor in middle of code
+    completions = interpreter.completion("sc.ra\n1+1", 5, getInterpreterContext());
+    assertEquals(1, completions.size());
+    assertEquals("range", completions.get(0).name);
 
     // Zeppelin-Display
     result = interpreter.interpret("import org.apache.zeppelin.display.angular.notebookscope._\n" +

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -138,7 +138,7 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
   protected def completion(buf: String,
                            cursor: Int,
                            context: InterpreterContext): java.util.List[InterpreterCompletion] = {
-    val completions = scalaCompleter.complete(buf, cursor).candidates
+    val completions = scalaCompleter.complete(buf.substring(0, cursor), cursor).candidates
       .map(e => new InterpreterCompletion(e, e, null))
     scala.collection.JavaConversions.seqAsJavaList(completions)
   }


### PR DESCRIPTION
### What is this PR for?
It is a trivial fix for the code completion of spark interpreter when the cursor is in the middle of code.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3858

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
