### PR TITLE
ZEPPELIN-3815. No interpreter group name in spark interpreter log file

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/Util.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/Util.java
@@ -39,7 +39,7 @@ public class Util {
     try {
       projectProperties.load(Util.class.getResourceAsStream("/project.properties"));
       gitProperties.load(Util.class.getResourceAsStream("/git.properties"));
-    } catch (IOException e) {
+    } catch (Exception e) {
       //Fail to read project.properties
     }
   }

--- a/zeppelin-plugins/launcher/spark/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/spark/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -47,7 +47,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
 
   @Override
   protected Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context) {
-    Map<String, String> env = new HashMap<String, String>();
+    Map<String, String> env = super.buildEnvFromProperties(context);
     Properties sparkProperties = new Properties();
     String sparkMaster = getSparkMaster(properties);
     for (String key : properties.stringPropertyNames()) {


### PR DESCRIPTION
### What is this PR for?
Trivial PR for fixing group name missing in spark interpreter log file


### What type of PR is it?
[ Hot Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3815

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? NO
* Does this needs documentation? No
