### PR TITLE
ZEPPELIN-3822. All interpreter folders (ZEPPELIN_HOME/interpreter) are deleted when maven clean is invoked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,32 +440,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>${plugin.resource.version}</version>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/site</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${basedir}/../_tools/site</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>**/*</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${plugin.jar.version}</version>
         <configuration>
@@ -619,23 +593,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>${plugin.clean.version}</version>
-          <configuration>
-            <filesets>
-              <fileset>
-                <directory>interpreter</directory>
-                <followSymlinks>false</followSymlinks>
-                <excludes>
-                  <exclude>lib/**</exclude>
-                </excludes>
-              </fileset>
-            </filesets>
-          </configuration>
-        </plugin>
-
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
           <version>1.0.1</version>
@@ -747,7 +704,33 @@
             </execution>
           </executions>
         </plugin>
-        
+
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${plugin.resource.version}</version>
+          <executions>
+            <execution>
+              <id>copy-resources</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${basedir}/target/site</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>${basedir}/../_tools/site</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>**/*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
     </pluginManagement>
   </build>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -136,31 +136,36 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${plugin.clean.version}</version>
+          <configuration>
+            <filesets>
+              <fileset>
+                <directory>${project.basedir}/../interpreter/${interpreter.name}</directory>
+                <followSymlinks>false</followSymlinks>
+              </fileset>
+            </filesets>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>${plugin.clean.version}</version>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${project.basedir}/../interpreter/${interpreter.name}</directory>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
+
+
 
     </plugins>
   </build>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -208,6 +208,11 @@
           </filesets>
         </configuration>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${plugin.resource.version}</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### What is this PR for?
This PR is to fix the bug that `ZEPPELIN_HOME`/interpreter folder is always deleted when maven clean is invoked for module `zeppelin`. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3822

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
