### PR TITLE
docs [master]: REST API JSON response status fix

### DIFF
--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -315,7 +315,7 @@ The role of registered interpreters, settings and interpreters group are describ
       <td>
         <pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": {
     "id": "2AYW25ANY",

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -132,7 +132,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> sample JSON response </td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": "2AZPHY918"
 }</pre></td>
@@ -344,7 +344,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> sample JSON response </td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": "2AZPHY918"
 }</pre></td>
@@ -491,7 +491,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td>sample JSON response</td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": "2AZPHY918"
 }</pre></td>
@@ -672,7 +672,7 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> sample JSON response </td>
       <td><pre>
 {
-  "status": "CREATED",
+  "status": "OK",
   "message": "",
   "body": "20151218-100330\_1754029574"
 }</pre></td>


### PR DESCRIPTION
### What is this PR for?
Since v0.8.0, REST API JSON response `status` attribute has changed from `CREATED` to `OK`.

Related source code:
* https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
* https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java

### What type of PR is it?
Documentation

### Questions:
* Shall I add tests to check the returned `status` in:
   * https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
   * https://github.com/apache/zeppelin/blob/master/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java