### PR TITLE
[ZEPPELIN-3869] Close interpreters in multithreaded mode

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -58,6 +58,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_MAX_POOL_SIZE;
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT;
@@ -477,27 +478,20 @@ public class InterpreterSetting {
 
   public void close() {
     LOGGER.info("Close InterpreterSetting: " + name);
-    List<Thread> closeThreads = new LinkedList<>();
-    for (final ManagedInterpreterGroup group : interpreterGroups.values()) {
-      Thread t =
-              new Thread() {
-        public void run() {
-          group.close();
-        }
-      };
-      t.setName(String.format("%s-close", group.getInterpreterSetting().getGroup()));
-      t.start();
-      closeThreads.add(t);
-    }
-
+    List<Thread> closeThreads = interpreterGroups.values().stream()
+            .map(g -> new Thread(g::close, name + "-close"))
+            .peek(Thread::start)
+            .collect(Collectors.toList());
+    interpreterGroups.clear();
     for (Thread t : closeThreads) {
       try {
         t.join();
       } catch (InterruptedException e) {
-        LOGGER.error("Can't close managedInterpreterGroup", e);
+        LOGGER.error("Can't wait InterpreterSetting close threads", e);
+        Thread.currentThread().interrupt();
+        break;
       }
     }
-    interpreterGroups.clear();
   }
 
   public void setProperties(Object object) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -480,6 +480,8 @@ public class InterpreterSetting {
     LOGGER.info("Close InterpreterSetting: " + name);
     List<Thread> closeThreads = interpreterGroups.values().stream()
             .map(g -> new Thread(g::close, name + "-close"))
+            .peek(t -> t.setUncaughtExceptionHandler((th, e) ->
+                    LOGGER.error("InterpreterSetting close error", e)))
             .peek(Thread::start)
             .collect(Collectors.toList());
     interpreterGroups.clear();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -481,10 +481,10 @@ public class InterpreterSetting {
     for (final ManagedInterpreterGroup group : interpreterGroups.values()) {
       Thread t =
               new Thread() {
-                public void run() {
-                  group.close();
-                }
-              };
+        public void run() {
+          group.close();
+        }
+      };
       t.setName(String.format("%s-close", group.getInterpreterSetting().getGroup()));
       t.start();
       closeThreads.add(t);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -852,6 +852,8 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
   public void close() {
     List<Thread> closeThreads = interpreterSettings.values().stream()
             .map(intpSetting-> new Thread(intpSetting::close, intpSetting.getId() + "-close"))
+            .peek(t -> t.setUncaughtExceptionHandler((th, e) ->
+                    LOGGER.error("interpreterGroup close error", e)))
             .peek(Thread::start)
             .collect(Collectors.toList());
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -76,7 +76,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -858,6 +857,7 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
               intpSetting.close();
             }
           };
+      t.setName(String.format("%s-close", intpSetting.getId()));
       t.start();
       closeThreads.add(t);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -86,6 +86,8 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
     LOGGER.info("Close InterpreterGroup: " + id);
     List<Thread> closeThreads = sessions.keySet().stream()
             .map(sessionId -> new Thread(() -> close(sessionId), id + "-close"))
+            .peek(t -> t.setUncaughtExceptionHandler((th, e) ->
+                    LOGGER.error("InterpreterGroup close error", e)))
             .peek(Thread::start)
             .collect(Collectors.toList());
 
@@ -133,6 +135,8 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
             .map(interpreter -> new Thread(() ->
                     closeInterpreter(interpreter),
                     interpreter.getClass().getSimpleName() + "-close"))
+            .peek(t -> t.setUncaughtExceptionHandler((th, e) ->
+                    LOGGER.error("Interpreter close error", e)))
             .peek(Thread::start)
             .collect(Collectors.toList());
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -84,21 +84,8 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
    */
   public void close() {
     LOGGER.info("Close InterpreterGroup: " + id);
-    List<Thread> closeThreads = sessions.keySet().stream()
-            .map(sessionId -> new Thread(() -> close(sessionId), id + "-close"))
-            .peek(t -> t.setUncaughtExceptionHandler((th, e) ->
-                    LOGGER.error("InterpreterGroup close error", e)))
-            .peek(Thread::start)
-            .collect(Collectors.toList());
-
-    for (Thread t : closeThreads) {
-      try {
-        t.join();
-      } catch (InterruptedException e) {
-        LOGGER.error("Can't wait session close threads", e);
-        Thread.currentThread().interrupt();
-        break;
-      }
+    for (String sessionId : sessions.keySet()) {
+      close(sessionId);
     }
   }
 
@@ -166,6 +153,8 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
     } catch (InterpreterException e) {
       LOGGER.warn("Fail to close interpreter " + interpreter.getClassName(), e);
     }
+
+    //TODO(zjffdu) move the close of schedule to Interpreter
     SchedulerFactory.singleton().removeScheduler(scheduler.getName());
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -173,7 +173,9 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
       } catch (Exception e) {
         logger.warn("ignore the exception when shutting down");
       }
-      watchdog.destroyProcess();
+      if (watchdog != null) {
+        watchdog.destroyProcess();
+      }
     }
 
     executor = null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -173,9 +173,7 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
       } catch (Exception e) {
         logger.warn("ignore the exception when shutting down");
       }
-      if (watchdog != null) {
-        watchdog.destroyProcess();
-      }
+      watchdog.destroyProcess();
     }
 
     executor = null;


### PR DESCRIPTION
### What is this PR for?

This PR provides multithreading realization of interpreters closing.

Benchmark based on [JMH](http://openjdk.java.net/projects/code-tools/jmh/) - `ZeppelinServerBenchmarkTest`:
* Creates `InterpreterSettingManager` and `InterpreterFactory`;
* Runs 6 interpreters (`python`, `sh`, `md`, `groovy`, `angular`, `spark`) for each user in isolated mode;
* Measures InterpreterSettingManager closing.

Result with usersCnt - 7, 5, 3, 1 (42, 30, 18, 6 interpreter processes):
```
Benchmark                                                 (usersCnt)  Mode  Cnt   Score   Error  Units
ZeppelinServerBenchmarkTest.testDefaultServerShutdown              7  avgt   10  16,690 ± 0,191   s/op
ZeppelinServerBenchmarkTest.testDefaultServerShutdown              5  avgt   10  11,532 ± 0,064   s/op
ZeppelinServerBenchmarkTest.testDefaultServerShutdown              3  avgt   10   6,942 ± 0,020   s/op
ZeppelinServerBenchmarkTest.testDefaultServerShutdown              1  avgt   10   2,348 ± 0,018   s/op
ZeppelinServerBenchmarkTest.testServerShutdownInParallel           7  avgt   10   3,612 ± 0,317   s/op
ZeppelinServerBenchmarkTest.testServerShutdownInParallel           5  avgt   10   2,635 ± 0,075   s/op
ZeppelinServerBenchmarkTest.testServerShutdownInParallel           3  avgt   10   2,473 ± 0,072   s/op
ZeppelinServerBenchmarkTest.testServerShutdownInParallel           1  avgt   10   2,378 ± 0,029   s/op
```
[benchmark.zip](https://github.com/TinkoffCreditSystems/zeppelin/files/2591694/benchmark.zip) contains: 
* `Benchmark.patch` - patch with `ZeppelinServerBenchmarkTest`;
* `benchmark.csv` - benchmark result;
![jmh-benchmark](https://user-images.githubusercontent.com/6136993/48660410-06706280-ea72-11e8-805f-fe5379f03131.png)
* `benchmark-result.json` - results (you could visualize it using [JMH Visualizer](http://jmh.morethan.io/))
![zp-36](https://user-images.githubusercontent.com/6136993/48660111-5b5daa00-ea6d-11e8-8f13-0df27d5a767d.png)

### How to run benchmark 
1. Apply patch from `benchmark.zip`
2. Add [IntelliJ IDEA JMH Plugin](https://plugins.jetbrains.com/plugin/7529-jmh-plugin)
3. Build Zeppelin 
4. Run ZeppelinServerBenchmarkTest in IntelliJ IDEA

### What type of PR is it?
Refactoring

### What is the Jira issue?
[[ZEPPELIN-3869]](https://issues.apache.org/jira/browse/ZEPPELIN-3869)

### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
