### PR TITLE
[ZEPPELIN-3847] Duplicate results in notebooks due to WS interruption

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1361,13 +1361,6 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     $scope.$broadcast('focusParagraph', paragraph.id, row + 1, col);
   };
 
-  $scope.$on('setConnectedStatus', function(event, param) {
-    if (connectedOnce && param) {
-      initNotebook();
-    }
-    connectedOnce = true;
-  });
-
   $scope.$on('moveParagraphUp', function(event, paragraph) {
     let newIndex = -1;
     for (let i = 0; i < $scope.note.paragraphs.length; i++) {


### PR DESCRIPTION
### What is this PR for?
Duplicate results in notebooks after ws reconnect.
The problem occurs via duplicated 'setConnectedStatus' event handler in notebook.controller.js.
The same function exists at https://github.com/Leemoonsoo/zeppelin/blob/dbbf0436490941d117fd4c06b9da5b6cb47697ff/zeppelin-web/src/app/notebook/notebook.controller.js#L99-L104.



### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3847

### How should this be tested?
Disconnect and reconnect websocket connection to browser, and check if result is duplicated.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
