### PR TITLE
[ZEPPELIN-3875] Groups are not derived when using ActiveDirectory

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -291,11 +291,11 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     SearchControls searchCtls = new SearchControls();
     searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
     String userPrincipalName = username;
-    if (this.principalSuffix != null && userPrincipalName.indexOf('@') < 0) {
-      userPrincipalName += principalSuffix;
+    if (this.principalSuffix != null && userPrincipalName.indexOf('@') > 1) {
+      userPrincipalName = userPrincipalName.split("@")[0];
     }
 
-    String searchFilter = "(&(objectClass=*)(userPrincipalName=" + userPrincipalName + "))";
+    String searchFilter = "(&(objectClass=*)(sAMAccountName=" + userPrincipalName + "))";
     Object[] searchArguments = new Object[]{userPrincipalName};
 
     NamingEnumeration answer = ldapContext.search(searchBase, searchFilter, searchArguments,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -66,7 +66,19 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
   private static final String ROLE_NAMES_DELIMETER = ",";
 
   final String keystorePass = "activeDirectoryRealm.systemPassword";
+
+  private String userSearchAttributeName = "sAMAccountName";
+
   private String hadoopSecurityCredentialPath;
+
+  public String getUserSearchAttributeName() {
+    return userSearchAttributeName;
+  }
+
+  public void setUserSearchAttributeName(String userSearchAttributeName) {
+    this.userSearchAttributeName = userSearchAttributeName;
+  }
+
 
   public void setHadoopSecurityCredentialPath(String hadoopSecurityCredentialPath) {
     this.hadoopSecurityCredentialPath = hadoopSecurityCredentialPath;
@@ -247,7 +259,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     searchCtls.setSearchScope(SearchControls.SUBTREE_SCOPE);
     searchCtls.setCountLimit(numUsersToFetch);
 
-    String searchFilter = "(&(objectClass=*)(userPrincipalName=*" + containString + "*))";
+    String searchFilter = String.format("(&(objectClass=*)(%s=*%s*))", this.getUserSearchAttributeName(), containString);
+
     Object[] searchArguments = new Object[]{containString};
 
     NamingEnumeration answer = ldapContext.search(searchBase, searchFilter, searchArguments,
@@ -265,7 +278,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
         NamingEnumeration ae = attrs.getAll();
         while (ae.hasMore()) {
           Attribute attr = (Attribute) ae.next();
-          if (attr.getID().toLowerCase().equals("cn")) {
+          if (attr.getID().toLowerCase().equals(this.getUserSearchAttributeName().toLowerCase())) {
             userNameList.addAll(LdapUtils.getAllAttributeValues(attr));
           }
         }
@@ -295,7 +308,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
       userPrincipalName = userPrincipalName.split("@")[0];
     }
 
-    String searchFilter = "(&(objectClass=*)(sAMAccountName=" + userPrincipalName + "))";
+    String searchFilter = String.format("(&(objectClass=*)(%s=%s))", this.getUserSearchAttributeName(), userPrincipalName);
     Object[] searchArguments = new Object[]{userPrincipalName};
 
     NamingEnumeration answer = ldapContext.search(searchBase, searchFilter, searchArguments,


### PR DESCRIPTION
### What is this PR for?
ActiveDirectoryGroupRealm is using UserPrincipalName for finding user and deriving groups that he belongs to. However this is not mandatory nor always corresponds to the REALM that user belongs to.
This PR changed userPrincipalName to sAMAccountName when deriving groups user belongs to


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-3875](https://issues.apache.org/jira/browse/ZEPPELIN-3875)

### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
