### PR TITLE
ZEPPELIN-3871. Spark interpreter doesn't work with KryoSerializer

### DIFF
--- a/zeppelin-interpreter-api/pom.xml
+++ b/zeppelin-interpreter-api/pom.xml
@@ -66,6 +66,8 @@
               <exclude>commons-logging:commons-logging</exclude>
               <!-- Leave log4j unshaded so downstream users can configure logging. -->
               <exclude>log4j:log4j</exclude>
+              <exclude>com.esotericsoftware:kryo</exclude>
+              <exclude>com.esotericsoftware:reflectasm</exclude>
             </excludes>
           </artifactSet>
           <filters>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -162,12 +162,6 @@
       </plugins>
     </pluginManagement>
 
-    <plugins>
-
-
-
-
-    </plugins>
   </build>
 
 </project>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinSparkClusterTest.java
@@ -118,7 +118,8 @@ public class ZeppelinSparkClusterTest extends AbstractTestRestApi {
             new InterpreterProperty("zeppelin.spark.useNew", "true"));
     sparkProperties.put("zeppelin.spark.test",
             new InterpreterProperty("zeppelin.spark.test", "true"));
-
+    sparkProperties.put("spark.serializer",
+            new InterpreterProperty("spark.serializer", "org.apache.spark.serializer.KryoSerializer"));
     ZeppelinServer.notebook.getInterpreterSettingManager().restart(sparkIntpSetting.getId());
   }
 


### PR DESCRIPTION
### What is this PR for?

This is due to another version of kryo in zeppelin-interpreter-api, this PR just exclude this and also add test to avoid regression.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3871

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
