### PR TITLE
ZEPPELIN-3870. Configuration in spark-defaults.conf doesn't take effect

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.interpreter.remote;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -343,9 +344,7 @@ public class RemoteInterpreterServer extends Thread
     for (Object key : properties.keySet()) {
       if (!RemoteInterpreterUtils.isEnvString((String) key)) {
         String value = properties.getProperty((String) key);
-        if (value == null || value.isEmpty()) {
-          System.clearProperty((String) key);
-        } else {
+        if (!StringUtils.isBlank(value)) {
           System.setProperty((String) key, properties.getProperty((String) key));
         }
       }
@@ -470,7 +469,7 @@ public class RemoteInterpreterServer extends Thread
         context.getGui(),
         context.getNoteGui());
   }
-  
+
   class InterpretJobListener implements JobListener {
 
     @Override


### PR DESCRIPTION
### What is this PR for?

By default, spark.executor.memory is not set in spark's interpreter setting, if I set it in spark-defaults.xml, then it won't take effect. Because spark.executor.memory in spark's interpreter setting will override that value in spark-defaults.xml. This doesn't make sense, we should only override property in spark-default.xml when you have non-empty value.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3870

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
