### PR TITLE
Zeppelin 3879: create "maxRows" and "rowsFetchSize" values in interpreter/jdbc/interpreter-setting.json

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -136,12 +136,14 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private static final String CONCURRENT_EXECUTION_COUNT =
           "zeppelin.jdbc.concurrent.max_connection";
   private static final String DBCP_STRING = "jdbc:apache:commons:dbcp:";
+  private static final String MAX_ROWS_KEY = "zeppelin.jdbc.maxRows";
 
   private final HashMap<String, Properties> basePropretiesMap;
   private final HashMap<String, JDBCUserConfigurations> jdbcUserConfigurationsMap;
   private final HashMap<String, SqlCompleter> sqlCompletersMap;
 
   private int maxLineResults;
+  private int maxRows;
 
   public JDBCInterpreter(Properties property) {
     super(property);
@@ -209,6 +211,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     logger.debug("JDBC PropretiesMap: {}", basePropretiesMap);
 
     setMaxLineResults();
+    setMaxRows();
   }
 
   protected boolean isKerboseEnabled() {
@@ -226,6 +229,14 @@ public class JDBCInterpreter extends KerberosInterpreter {
         basePropretiesMap.get(COMMON_KEY).containsKey(MAX_LINE_KEY)) {
       maxLineResults = Integer.valueOf(basePropretiesMap.get(COMMON_KEY).getProperty(MAX_LINE_KEY));
     }
+  }
+
+  /**
+   * Fetch MAX_ROWS_KEYS value from property file and set it to
+   * "maxRows" value.
+   */
+  private void setMaxRows() {
+    maxRows = Integer.valueOf(getProperty(MAX_ROWS_KEY, "1000"));
   }
 
   private SqlCompleter createOrUpdateSqlCompleter(SqlCompleter sqlCompleter,
@@ -705,7 +716,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)
         statement.setFetchSize(getMaxResult());
-        statement.setMaxRows(getMaxResult() + 1);
+        statement.setMaxRows(maxRows);
 
         if (statement == null) {
           return new InterpreterResult(Code.ERROR, "Prefix not found.");

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -122,6 +122,13 @@
         "defaultValue": "-1",
         "description": "Maximum of connection lifetime in milliseconds. A value of zero or less means the connection has an infinite lifetime.",
         "type": "number"
+      },
+      "zeppelin.jdbc.maxRows": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.maxRows",
+        "defaultValue": "1000",
+        "description": "Maximum number of rows fetched from the query.",
+        "type": "number"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
This PR introduces code to configure manually the "maxRows" and "rowsFetchSize" Statement settings directly from the interpreter/jdbc/interpreter-setting.json file. The default value for these two settings is 1000 which can slow down a Zeppelin instance quite a lot if a SQL query returns a big chunk of data. See [1] and [2] for more info about these function calls.

[1]: https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setFetchSize-int-
[2]: https://docs.oracle.com/javase/8/docs/api/java/sql/Statement.html#setMaxRows-int-

### What type of PR is it?
Improvement.

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3879

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. For the time being, I'd like the Zeppelin authors input whether such a change makes sense.

Thanks!