### PR TITLE
[ZEPPELIN-3882] Neo4jInterpreter - Support Point and Date Types

### DIFF
--- a/docs/interpreter/neo4j.md
+++ b/docs/interpreter/neo4j.md
@@ -26,6 +26,9 @@ limitations under the License.
 ## Overview
 [Neo4j](https://neo4j.com/product/) is a native graph database, designed to store and process graphs from bottom to top.
 
+### Supported Version
+
+The Neo4j Interpreter supports all Neo4j versions since v3 via the official [Neo4j Java Driver](https://github.com/neo4j/neo4j-java-driver)
 
 ![Neo4j - Interpreter - Video]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/neo4j-interpreter-video.gif)
 

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -33,9 +33,9 @@
   <name>Zeppelin: Neo4j interpreter</name>
   
   <properties>
-  	<neo4j.driver.version>1.4.3</neo4j.driver.version>
-  	<test.neo4j.kernel.version>3.2.3</test.neo4j.kernel.version>
-  	<neo4j.version>3.2.3</neo4j.version>
+  	<neo4j.driver.version>1.7.1</neo4j.driver.version>
+  	<test.neo4j.kernel.version>3.4.10</test.neo4j.kernel.version>
+  	<neo4j.version>3.4.10</neo4j.version>
   	<jackson.version>2.8.9</jackson.version>
     <interpreter.name>neo4j</interpreter.name>
   </properties>

--- a/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
+++ b/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
@@ -55,9 +55,9 @@ public class Neo4jCypherInterpreterTest {
   private static final String REL_KNOWS = "KNOWS";
 
   private static final String CYPHER_FOREACH =
-          "FOREACH (x in range(1,1000) | CREATE (:%s{name: \"name\" + x, age: %s}))";
-  private static final String CHPHER_UNWIND = "UNWIND range(1,1000) as x "
-        + "MATCH (n), (m) WHERE id(n) = x AND id(m) = toInt(rand() * 1000) "
+          "FOREACH (x in range(1,100) | CREATE (:%s{name: \"name\" + x, age: %s, address: point({ longitude: 56.7, latitude: 12.78, height: 8 }), birth: date('1984-04-04')}))";
+  private static final String CHPHER_UNWIND = "UNWIND range(1,100) as x "
+        + "MATCH (n), (m) WHERE id(n) = x AND id(m) = toInt(rand() * 100) "
         + "CREATE (n)-[:%s]->(m)";
 
   @BeforeClass

--- a/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
+++ b/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
@@ -55,7 +55,9 @@ public class Neo4jCypherInterpreterTest {
   private static final String REL_KNOWS = "KNOWS";
 
   private static final String CYPHER_FOREACH =
-          "FOREACH (x in range(1,100) | CREATE (:%s{name: \"name\" + x, age: %s, address: point({ longitude: 56.7, latitude: 12.78, height: 8 }), birth: date('1984-04-04')}))";
+          "FOREACH (x in range(1,100) | CREATE (:%s{name: \"name\" + x, age: %s, " +
+                  "address: point({ longitude: 56.7, latitude: 12.78, height: 8 }), " +
+                  "birth: date('1984-04-04')}))";
   private static final String CHPHER_UNWIND = "UNWIND range(1,100) as x "
         + "MATCH (n), (m) WHERE id(n) = x AND id(m) = toInt(rand() * 100) "
         + "CREATE (n)-[:%s]->(m)";
@@ -73,7 +75,7 @@ public class Neo4jCypherInterpreterTest {
   public static void tearDownNeo4jServer() throws Exception {
     server.close();
   }
-  
+
   @Before
   public void setUpZeppelin() {
     Properties p = new Properties();
@@ -83,7 +85,7 @@ public class Neo4jCypherInterpreterTest {
     interpreter = new Neo4jCypherInterpreter(p);
     context = InterpreterContext.builder()
         .setInterpreterOut(new InterpreterOutput(null))
-        .build();;
+        .build();
   }
 
   @After
@@ -99,7 +101,7 @@ public class Neo4jCypherInterpreterTest {
     assertEquals(Code.SUCCESS, result.code());
     final String tableResult = "colA\tcolB\tcolC\n\"a\"\t\"b\"\t[1,2,3]\n";
     assertEquals(tableResult, result.toString().replace("%table ", StringUtils.EMPTY));
-    
+
     result = interpreter.interpret(
             "return 'a' as colA, 'b' as colB, [{key: \"value\"}, {key: 1}] as colC", context);
     assertEquals(Code.SUCCESS, result.code());
@@ -191,7 +193,7 @@ public class Neo4jCypherInterpreterTest {
     assertEquals(row.get(header.indexOf(objectKey)), "value2");
     assertEquals(row.get(header.indexOf(objectListKey)),
             "[{\"inner\":\"Map1\"},{\"inner\":\"Map2\"}]");
-    
+
     final String jsonListWithoutListKeyQuery = "WITH [{key: \"value\"},"
             + "{key: \"value2\", listKey: [{inner: \"Map1\"}, {inner: \"Map2\"}]}] "
             + "AS array UNWIND array AS object RETURN object";


### PR DESCRIPTION
### What is this PR for?
Add the support for Point and Date data types introduced since Neo4j 3.4

### What type of PR is it?
[Improvement] In order to allow users to use the Neo4j Interpreter with the last introduced Data types

### Todos
* [x] - Bumped Neo4j dependecies version
* [x] - Added new data types to test

### What is the Jira issue?
* Put link here, and add [ZEPPELIN-3882](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3882)

### How should this be tested?
* Execute the unit tests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
