### PR TITLE
[ZEPPELIN-3893] Bug Fix that clear paragraphs when executing the Paragraph API asynchronously

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -798,6 +798,11 @@ public class NotebookRestApi extends AbstractRestApi {
       throws IOException, IllegalArgumentException {
     LOG.info("run paragraph synchronously {} {} {}", noteId, paragraphId, message);
 
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    Paragraph paragraph = note.getParagraph(paragraphId);
+    checkIfParagraphIsNotNull(paragraph);
+
     Map<String, Object> params = new HashMap<>();
     if (!StringUtils.isEmpty(message)) {
       RunParagraphWithParametersRequest request =
@@ -805,9 +810,10 @@ public class NotebookRestApi extends AbstractRestApi {
       params = request.getParams();
     }
 
-    if (notebookService.runParagraph(noteId, paragraphId, params,
+    if (notebookService.runParagraph(noteId, paragraphId, paragraph.getTitle(),
+        paragraph.getText(), params,
         new HashMap<>(), false, true, getServiceContext(), new RestServiceCallback<>())) {
-      Note note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
+      note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
       Paragraph p = note.getParagraph(paragraphId);
       InterpreterResult result = p.getReturn();
       if (result.code() == InterpreterResult.Code.SUCCESS) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -798,15 +798,22 @@ public class NotebookRestApi extends AbstractRestApi {
       throws IOException, IllegalArgumentException {
     LOG.info("run paragraph synchronously {} {} {}", noteId, paragraphId, message);
 
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    Paragraph paragraph = note.getParagraph(paragraphId);
+    checkIfParagraphIsNotNull(paragraph);
+
     Map<String, Object> params = new HashMap<>();
     if (!StringUtils.isEmpty(message)) {
       RunParagraphWithParametersRequest request =
           RunParagraphWithParametersRequest.fromJson(message);
       params = request.getParams();
     }
-    if (notebookService.runParagraph(noteId, paragraphId, "", "", params,
+
+    if (notebookService.runParagraph(noteId, paragraphId, paragraph.getTitle(),
+        paragraph.getText(), params,
         new HashMap<>(), false, true, getServiceContext(), new RestServiceCallback<>())) {
-      Note note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
+      note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
       Paragraph p = note.getParagraph(paragraphId);
       InterpreterResult result = p.getReturn();
       if (result.code() == InterpreterResult.Code.SUCCESS) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -798,11 +798,6 @@ public class NotebookRestApi extends AbstractRestApi {
       throws IOException, IllegalArgumentException {
     LOG.info("run paragraph synchronously {} {} {}", noteId, paragraphId, message);
 
-    Note note = notebook.getNote(noteId);
-    checkIfNoteIsNotNull(note);
-    Paragraph paragraph = note.getParagraph(paragraphId);
-    checkIfParagraphIsNotNull(paragraph);
-
     Map<String, Object> params = new HashMap<>();
     if (!StringUtils.isEmpty(message)) {
       RunParagraphWithParametersRequest request =
@@ -810,10 +805,9 @@ public class NotebookRestApi extends AbstractRestApi {
       params = request.getParams();
     }
 
-    if (notebookService.runParagraph(noteId, paragraphId, paragraph.getTitle(),
-        paragraph.getText(), params,
+    if (notebookService.runParagraph(noteId, paragraphId, params,
         new HashMap<>(), false, true, getServiceContext(), new RestServiceCallback<>())) {
-      note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
+      Note note = notebookService.getNote(noteId, getServiceContext(), new RestServiceCallback<>());
       Paragraph p = note.getParagraph(paragraphId);
       InterpreterResult result = p.getReturn();
       if (result.code() == InterpreterResult.Code.SUCCESS) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -314,6 +314,26 @@ public class NotebookService {
   }
 
   public boolean runParagraph(String noteId,
+                               String paragraphId,
+                               Map<String, Object> params,
+                               Map<String, Object> config,
+                               boolean failIfDisabled,
+                               boolean blocking,
+                               ServiceContext context,
+                               ServiceCallback<Paragraph> callback) throws IOException {
+    return runParagraph(noteId,
+        paragraphId,
+        null,
+        null,
+        params,
+        config,
+        failIfDisabled,
+        blocking,
+        context,
+        callback);
+  }
+
+  public boolean runParagraph(String noteId,
                               String paragraphId,
                               String title,
                               String text,
@@ -342,20 +362,15 @@ public class NotebookService {
       callback.onFailure(new IOException("paragraph is disabled."), context);
       return false;
     }
-    p.setText(text);
-    p.setTitle(title);
+    if (text != null) {
+      p.setText(text);
+    }
+    if (title != null) {
+      p.setTitle(title);
+    }
     p.setAuthenticationInfo(context.getAutheInfo());
     p.settings.setParams(params);
     p.setConfig(config);
-
-    if (note.isPersonalizedMode()) {
-      p = note.getParagraph(paragraphId);
-      p.setText(text);
-      p.setTitle(title);
-      p.setAuthenticationInfo(context.getAutheInfo());
-      p.settings.setParams(params);
-      p.setConfig(config);
-    }
 
     try {
       notebook.saveNote(note, context.getAutheInfo());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -314,26 +314,6 @@ public class NotebookService {
   }
 
   public boolean runParagraph(String noteId,
-                               String paragraphId,
-                               Map<String, Object> params,
-                               Map<String, Object> config,
-                               boolean failIfDisabled,
-                               boolean blocking,
-                               ServiceContext context,
-                               ServiceCallback<Paragraph> callback) throws IOException {
-    return runParagraph(noteId,
-        paragraphId,
-        null,
-        null,
-        params,
-        config,
-        failIfDisabled,
-        blocking,
-        context,
-        callback);
-  }
-
-  public boolean runParagraph(String noteId,
                               String paragraphId,
                               String title,
                               String text,
@@ -362,15 +342,20 @@ public class NotebookService {
       callback.onFailure(new IOException("paragraph is disabled."), context);
       return false;
     }
-    if (text != null) {
-      p.setText(text);
-    }
-    if (title != null) {
-      p.setTitle(title);
-    }
+    p.setText(text);
+    p.setTitle(title);
     p.setAuthenticationInfo(context.getAutheInfo());
     p.settings.setParams(params);
     p.setConfig(config);
+
+    if (note.isPersonalizedMode()) {
+      p = note.getParagraph(paragraphId);
+      p.setText(text);
+      p.setTitle(title);
+      p.setAuthenticationInfo(context.getAutheInfo());
+      p.settings.setParams(params);
+      p.setConfig(config);
+    }
 
     try {
       notebook.saveNote(note, context.getAutheInfo());


### PR DESCRIPTION
### What is this PR for?

When calling the asynchronous execution of the paragraph API, 

```
http://[zeppelin-server]:[zeppelin-port]/api/notebook/run/[noteId]/[paragraphId]
```

The title and text of the paragraph will be cleared.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3893

### How should this be tested?
[CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/462203315)

### Screenshots (if appropriate)
No

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No