### PR TITLE
ZEPPELIN-3892 Make SecurityUtils as a service

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/AbstractRestApi.java
@@ -18,22 +18,27 @@
 package org.apache.zeppelin.rest;
 
 import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.Set;
+import javax.ws.rs.WebApplicationException;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.service.SimpleServiceCallback;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.apache.zeppelin.utils.SecurityUtils;
-
-import javax.ws.rs.WebApplicationException;
-import java.io.IOException;
-import java.util.Set;
 
 public class AbstractRestApi {
 
+  protected SecurityService securityService;
+
+  protected AbstractRestApi(SecurityService securityService) {
+    this.securityService = securityService;
+  }
+
   protected ServiceContext getServiceContext() {
-    AuthenticationInfo authInfo = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    AuthenticationInfo authInfo = new AuthenticationInfo(securityService.getPrincipal());
     Set<String> userAndRoles = Sets.newHashSet();
-    userAndRoles.add(SecurityUtils.getPrincipal());
-    userAndRoles.addAll(SecurityUtils.getAssociatedRoles());
+    userAndRoles.add(securityService.getPrincipal());
+    userAndRoles.addAll(securityService.getAssociatedRoles());
     return new ServiceContext(authInfo, userAndRoles);
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ConfigurationsRestApi.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.service.ConfigurationService;
+import org.apache.zeppelin.service.SecurityService;
 
 /** Configurations Rest API Endpoint. */
 @Path("/configurations")
@@ -37,7 +38,9 @@ public class ConfigurationsRestApi extends AbstractRestApi {
   private ConfigurationService configurationService;
 
   @Inject
-  public ConfigurationsRestApi(ConfigurationService configurationService) {
+  public ConfigurationsRestApi(
+      SecurityService securityService, ConfigurationService configurationService) {
+    super(securityService);
     this.configurationService = configurationService;
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/CredentialRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/CredentialRestApi.java
@@ -32,10 +32,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.zeppelin.server.JsonResponse;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.user.UserCredentials;
 import org.apache.zeppelin.user.UsernamePassword;
-import org.apache.zeppelin.utils.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,11 +45,13 @@ import org.slf4j.LoggerFactory;
 public class CredentialRestApi {
   Logger logger = LoggerFactory.getLogger(CredentialRestApi.class);
   private Credentials credentials;
+  private SecurityService securityService;
   private Gson gson = new Gson();
 
   @Inject
-  public CredentialRestApi(Credentials credentials) {
+  public CredentialRestApi(Credentials credentials, SecurityService securityService) {
     this.credentials = credentials;
+    this.securityService = securityService;
   }
 
   /**
@@ -74,7 +76,7 @@ public class CredentialRestApi {
       return new JsonResponse(Status.BAD_REQUEST).build();
     }
 
-    String user = SecurityUtils.getPrincipal();
+    String user = securityService.getPrincipal();
     logger.info("Update credentials for user {} entity {}", user, entity);
     UserCredentials uc = credentials.getUserCredentials(user);
     uc.putUsernamePassword(entity, new UsernamePassword(username, password));
@@ -90,7 +92,7 @@ public class CredentialRestApi {
    */
   @GET
   public Response getCredentials() throws IllegalArgumentException {
-    String user = SecurityUtils.getPrincipal();
+    String user = securityService.getPrincipal();
     logger.info("getCredentials credentials for user {} ", user);
     UserCredentials uc = credentials.getUserCredentials(user);
     return new JsonResponse<>(Status.OK, uc).build();
@@ -105,7 +107,7 @@ public class CredentialRestApi {
    */
   @DELETE
   public Response removeCredentials() throws IOException, IllegalArgumentException {
-    String user = SecurityUtils.getPrincipal();
+    String user = securityService.getPrincipal();
     logger.info("removeCredentials credentials for user {} ", user);
     UserCredentials uc = credentials.removeUserCredentials(user);
     if (uc == null) {
@@ -126,7 +128,7 @@ public class CredentialRestApi {
   @Path("{entity}")
   public Response removeCredentialEntity(@PathParam("entity") String entity)
       throws IOException, IllegalArgumentException {
-    String user = SecurityUtils.getPrincipal();
+    String user = securityService.getPrincipal();
     logger.info("removeCredentialEntity for user {} entity {}", user, entity);
     if (!credentials.removeCredentialEntity(user, entity)) {
       return new JsonResponse(Status.NOT_FOUND).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -34,10 +34,10 @@ import org.apache.zeppelin.rest.message.RestartInterpreterRequest;
 import org.apache.zeppelin.rest.message.UpdateInterpreterSettingRequest;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.service.InterpreterService;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.service.SimpleServiceCallback;
 import org.apache.zeppelin.socket.NotebookServer;
-import org.apache.zeppelin.utils.SecurityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.repository.RemoteRepository;
@@ -65,15 +65,18 @@ public class InterpreterRestApi {
 
   private static final Logger logger = LoggerFactory.getLogger(InterpreterRestApi.class);
 
+  private final SecurityService securityService;
   private final InterpreterService interpreterService;
   private final InterpreterSettingManager interpreterSettingManager;
   private final NotebookServer notebookServer;
 
   @Inject
   public InterpreterRestApi(
+      SecurityService securityService,
       InterpreterService interpreterService,
       InterpreterSettingManager interpreterSettingManager,
       NotebookServer notebookWsServer) {
+    this.securityService = securityService;
     this.interpreterService = interpreterService;
     this.interpreterSettingManager = interpreterSettingManager;
     this.notebookServer = notebookWsServer;
@@ -195,7 +198,7 @@ public class InterpreterRestApi {
       if (null == noteId) {
         interpreterSettingManager.close(settingId);
       } else {
-        interpreterSettingManager.restart(settingId, noteId, SecurityUtils.getPrincipal());
+        interpreterSettingManager.restart(settingId, noteId, securityService.getPrincipal());
       }
 
     } catch (InterpreterException e) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonSyntaxException;
 
 import javax.inject.Inject;
 import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,6 @@ import org.apache.zeppelin.rest.message.NotebookRepoSettingsRequest;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.AuthenticationInfo;
-import org.apache.zeppelin.utils.SecurityUtils;
 
 /**
  * NoteRepo rest API endpoint.
@@ -58,11 +58,14 @@ public class NotebookRepoRestApi {
 
   private NotebookRepoSync noteRepos;
   private NotebookServer notebookWsServer;
+  private SecurityService securityService;
 
   @Inject
-  public NotebookRepoRestApi(NotebookRepoSync noteRepos, NotebookServer notebookWsServer) {
+  public NotebookRepoRestApi(NotebookRepoSync noteRepos, NotebookServer notebookWsServer,
+      SecurityService securityService) {
     this.noteRepos = noteRepos;
     this.notebookWsServer = notebookWsServer;
+    this.securityService = securityService;
   }
 
   /**
@@ -71,7 +74,7 @@ public class NotebookRepoRestApi {
   @GET
   @ZeppelinApi
   public Response listRepoSettings() {
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    AuthenticationInfo subject = new AuthenticationInfo(securityService.getPrincipal());
     LOG.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
     List<NotebookRepoWithSettings> settings = noteRepos.getNotebookRepos(subject);
     return new JsonResponse<>(Status.OK, "", settings).build();
@@ -84,7 +87,7 @@ public class NotebookRepoRestApi {
   @Path("reload")
   @ZeppelinApi
   public Response refreshRepo(){
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    AuthenticationInfo subject = new AuthenticationInfo(securityService.getPrincipal());
     LOG.info("Reloading notebook repository for user {}", subject.getUser());
     try {
       notebookWsServer.broadcastReloadedNoteList(null, getServiceContext());
@@ -95,10 +98,10 @@ public class NotebookRepoRestApi {
   }
 
   private ServiceContext getServiceContext() {
-    AuthenticationInfo authInfo = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    AuthenticationInfo authInfo = new AuthenticationInfo(securityService.getPrincipal());
     Set<String> userAndRoles = Sets.newHashSet();
-    userAndRoles.add(SecurityUtils.getPrincipal());
-    userAndRoles.addAll(SecurityUtils.getAssociatedRoles());
+    userAndRoles.add(securityService.getPrincipal());
+    userAndRoles.addAll(securityService.getAssociatedRoles());
     return new ServiceContext(authInfo, userAndRoles);
   }
 
@@ -114,7 +117,7 @@ public class NotebookRepoRestApi {
     if (StringUtils.isBlank(payload)) {
       return new JsonResponse<>(Status.NOT_FOUND, "", Collections.emptyMap()).build();
     }
-    AuthenticationInfo subject = new AuthenticationInfo(SecurityUtils.getPrincipal());
+    AuthenticationInfo subject = new AuthenticationInfo(securityService.getPrincipal());
     NotebookRepoSettingsRequest newSettings;
     try {
       newSettings = NotebookRepoSettingsRequest.fromJson(payload);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.server.JsonResponse;
-import org.apache.zeppelin.service.ShiroSecurityService;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,10 +47,10 @@ public class SecurityRestApi {
   private static final Logger LOG = LoggerFactory.getLogger(SecurityRestApi.class);
   private static final Gson gson = new Gson();
 
-  private final ShiroSecurityService securityService;
+  private final SecurityService securityService;
 
   @Inject
-  public SecurityRestApi(ShiroSecurityService securityService) {
+  public SecurityRestApi(SecurityService securityService) {
     this.securityService = securityService;
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -16,12 +16,8 @@
  */
 package org.apache.zeppelin.server;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
-
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -30,9 +26,10 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.utils.SecurityUtils;
+import org.apache.zeppelin.utils.CorsUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Cors filter.
@@ -47,7 +44,7 @@ public class CorsFilter implements Filter {
     String origin = "";
 
     try {
-      if (SecurityUtils.isValidOrigin(sourceHost, ZeppelinConfiguration.create())) {
+      if (CorsUtils.isValidOrigin(sourceHost, ZeppelinConfiguration.create())) {
         origin = sourceHost;
       }
     } catch (URISyntaxException e) {
@@ -85,5 +82,5 @@ public class CorsFilter implements Filter {
   public void destroy() {}
 
   @Override
-  public void init(FilterConfig filterConfig) throws ServletException {}
+  public void init(FilterConfig filterConfig) {}
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -104,29 +104,6 @@ public class ZeppelinServer extends ResourceConfig {
   @Inject
   public ZeppelinServer(ServiceLocator serviceLocator) throws Exception {
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
-    if (conf.getShiroPath().length() > 0) {
-      try {
-        Collection<Realm> realms =
-            ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils.getSecurityManager())
-                .getRealms();
-        if (realms.size() > 1) {
-          Boolean isIniRealmEnabled = false;
-          for (Object realm : realms) {
-            if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
-              isIniRealmEnabled = true;
-              break;
-            }
-          }
-          if (isIniRealmEnabled) {
-            throw new Exception(
-                "IniRealm/password based auth mechanisms should be exclusive. "
-                    + "Consider removing [users] block from shiro.ini");
-          }
-        }
-      } catch (UnavailableSecurityManagerException e) {
-        LOG.error("Failed to initialise shiro configuraion", e);
-      }
-    }
 
     InterpreterOutput.limit = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT);
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -223,10 +223,10 @@ public class ZeppelinServer extends ResourceConfig {
             bind(NotebookService.class).to(NotebookService.class).in(Immediate.class);
             // TODO(jl): Will make it more beautiful
             if (!StringUtils.isBlank(conf.getShiroPath())) {
-              bind(SecurityService.class).to(ShiroSecurityService.class).in(Singleton.class);
+              bind(ShiroSecurityService.class).to(SecurityService.class).in(Singleton.class);
             } else {
               // TODO(jl): Will be added more type
-              bind(SecurityService.class).to(NoSecurityService.class).in(Singleton.class);
+              bind(NoSecurityService.class).to(SecurityService.class).in(Singleton.class);
             }
           }
         });

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.service;
 
 import com.google.common.collect.Sets;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
@@ -1,0 +1,30 @@
+package org.apache.zeppelin.service;
+
+import com.google.common.collect.Sets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+public class NoSecurityService implements SecurityService {
+  private final String ANONYMOUS = "anonymous";
+
+  @Override
+  public String getPrincipal() {
+    return ANONYMOUS;
+  }
+
+  @Override
+  public Set<String> getAssociatedRoles() {
+    return Sets.newHashSet();
+  }
+
+  @Override
+  public Collection getRealmsList() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    return false;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NoSecurityService.java
@@ -17,9 +17,11 @@
 
 package org.apache.zeppelin.service;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class NoSecurityService implements SecurityService {
@@ -43,5 +45,15 @@ public class NoSecurityService implements SecurityService {
   @Override
   public boolean isAuthenticated() {
     return false;
+  }
+
+  @Override
+  public List<String> getMatchedUsers(String searchText, int numUsersToFetch) {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public List<String> getMatchedRoles() {
+    return Lists.newArrayList();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.service;
 
 import java.util.Collection;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
@@ -1,0 +1,15 @@
+package org.apache.zeppelin.service;
+
+import java.util.Collection;
+import java.util.Set;
+
+public interface SecurityService {
+
+  String getPrincipal();
+
+  Set<String> getAssociatedRoles();
+
+  Collection getRealmsList();
+
+  boolean isAuthenticated();
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SecurityService.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.service;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public interface SecurityService {
@@ -29,4 +30,8 @@ public interface SecurityService {
   Collection getRealmsList();
 
   boolean isAuthenticated();
+
+  List<String> getMatchedUsers(String searchText, int numUsersToFetch);
+
+  List<String> getMatchedRoles();
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroSecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroSecurityService.java
@@ -145,6 +145,7 @@ public class ShiroSecurityService implements SecurityService {
    * @param numUsersToFetch
    * @return
    */
+  @Override
   public List<String> getMatchedUsers(String searchText, int numUsersToFetch) {
     List<String> usersList = new ArrayList<>();
     try {
@@ -178,6 +179,7 @@ public class ShiroSecurityService implements SecurityService {
    *
    * @return
    */
+  @Override
   public List<String> getMatchedRoles() {
     List<String> rolesList = new ArrayList<>();
     try {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroSecurityService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroSecurityService.java
@@ -14,10 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.zeppelin.utils;
+package org.apache.zeppelin.service;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.security.Principal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
+import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.shiro.authz.AuthorizationInfo;
@@ -38,89 +61,36 @@ import org.apache.zeppelin.server.ZeppelinServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
-import javax.naming.ldap.LdapContext;
-import javax.sql.DataSource;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
-import java.security.Principal;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+/** Tools for securing Zeppelin. */
+public class ShiroSecurityService implements SecurityService {
 
-/**
- * Tools for securing Zeppelin.
- */
-public class SecurityUtils {
-  private static final String ANONYMOUS = "anonymous";
-  private static final HashSet<String> EMPTY_HASHSET = Sets.newHashSet();
-  private static boolean isEnabled = false;
-  private static final Logger LOGGER = LoggerFactory.getLogger(SecurityUtils.class);
-  private static Collection<Realm> realms;
-
-
-  public static void setIsEnabled(boolean value) {
-    isEnabled = value;
-  }
-
-  public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)
-      throws UnknownHostException, URISyntaxException {
-
-    String sourceUriHost = "";
-
-    if (sourceHost != null && !sourceHost.isEmpty()) {
-      sourceUriHost = new URI(sourceHost).getHost();
-      sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase();
-    }
-
-    sourceUriHost = sourceUriHost.toLowerCase();
-    String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase();
-
-    return conf.getAllowedOrigins().contains("*") ||
-        currentHost.equals(sourceUriHost) ||
-        "localhost".equals(sourceUriHost) ||
-        conf.getAllowedOrigins().contains(sourceHost);
-  }
+  private final Logger LOGGER = LoggerFactory.getLogger(ShiroSecurityService.class);
 
   /**
    * Return the authenticated user if any otherwise returns "anonymous".
    *
    * @return shiro principal
    */
-  public static String getPrincipal() {
-    if (!isEnabled) {
-      return ANONYMOUS;
-    }
+  @Override
+  public String getPrincipal() {
     Subject subject = org.apache.shiro.SecurityUtils.getSubject();
 
     String principal;
     if (subject.isAuthenticated()) {
       principal = extractPrincipal(subject);
       if (ZeppelinServer.notebook.getConf().isUsernameForceLowerCase()) {
-        LOGGER.debug("Converting principal name " + principal
-            + " to lower case:" + principal.toLowerCase());
+        LOGGER.debug(
+            "Converting principal name " + principal + " to lower case:" + principal.toLowerCase());
         principal = principal.toLowerCase();
       }
     } else {
-      principal = ANONYMOUS;
+      // TODO(jl): Could be better to occur error?
+      principal = "anonymous";
     }
     return principal;
   }
 
-  private static String extractPrincipal(Subject subject) {
+  private String extractPrincipal(Subject subject) {
     String principal;
     Object principalObject = subject.getPrincipal();
     if (principalObject instanceof Principal) {
@@ -131,54 +101,44 @@ public class SecurityUtils {
     return principal;
   }
 
-  public static Collection getRealmsList() {
-    if (!isEnabled) {
-      return Collections.emptyList();
-    }
+  @Override
+  public Collection getRealmsList() {
     DefaultWebSecurityManager defaultWebSecurityManager;
     String key = ThreadContext.SECURITY_MANAGER_KEY;
     defaultWebSecurityManager = (DefaultWebSecurityManager) ThreadContext.get(key);
-    Collection<Realm> realms = defaultWebSecurityManager.getRealms();
-    return realms;
+    return defaultWebSecurityManager.getRealms();
   }
-  
-  /**
-   * Checked if shiro enabled or not.
-   */
-  public static boolean isAuthenticated() {
-    if (!isEnabled) {
-      return false;
-    }
+
+  /** Checked if shiro enabled or not. */
+  @Override
+  public boolean isAuthenticated() {
     return org.apache.shiro.SecurityUtils.getSubject().isAuthenticated();
   }
 
-
   /**
    * Get candidated users based on searchText
+   *
    * @param searchText
    * @param numUsersToFetch
    * @return
    */
-  public static List<String> getMatchedUsers(String searchText, int numUsersToFetch) {
+  public List<String> getMatchedUsers(String searchText, int numUsersToFetch) {
     List<String> usersList = new ArrayList<>();
     try {
-      Collection realmsList = SecurityUtils.getRealmsList();
+      Collection<Realm> realmsList = (Collection<Realm>) getRealmsList();
       if (realmsList != null) {
-        for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
-          Realm realm = iterator.next();
+        for (Realm realm : realmsList) {
           String name = realm.getClass().getName();
           LOGGER.debug("RealmClass.getName: " + name);
           if (name.equals("org.apache.shiro.realm.text.IniRealm")) {
-            usersList.addAll(SecurityUtils.getUserList((IniRealm) realm));
+            usersList.addAll(getUserList((IniRealm) realm));
           } else if (name.equals("org.apache.zeppelin.realm.LdapGroupRealm")) {
-            usersList.addAll(getUserList((JndiLdapRealm) realm, searchText,
-                numUsersToFetch));
+            usersList.addAll(getUserList((JndiLdapRealm) realm, searchText, numUsersToFetch));
           } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
-            usersList.addAll(getUserList((LdapRealm) realm, searchText,
-                numUsersToFetch));
+            usersList.addAll(getUserList((LdapRealm) realm, searchText, numUsersToFetch));
           } else if (name.equals("org.apache.zeppelin.realm.ActiveDirectoryGroupRealm")) {
-            usersList.addAll(getUserList((ActiveDirectoryGroupRealm) realm,
-                searchText, numUsersToFetch));
+            usersList.addAll(
+                getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
           } else if (name.equals("org.apache.shiro.realm.jdbc.JdbcRealm")) {
             usersList.addAll(getUserList((JdbcRealm) realm));
           }
@@ -195,10 +155,10 @@ public class SecurityUtils {
    *
    * @return
    */
-  public static List<String> getMatchedRoles() {
+  public List<String> getMatchedRoles() {
     List<String> rolesList = new ArrayList<>();
     try {
-      Collection realmsList = SecurityUtils.getRealmsList();
+      Collection realmsList = getRealmsList();
       if (realmsList != null) {
         for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
           Realm realm = iterator.next();
@@ -223,16 +183,14 @@ public class SecurityUtils {
    *
    * @return shiro roles
    */
-  public static HashSet<String> getAssociatedRoles() {
-    if (!isEnabled) {
-      return  Sets.newHashSet();
-    }
+  @Override
+  public Set<String> getAssociatedRoles() {
     Subject subject = org.apache.shiro.SecurityUtils.getSubject();
     HashSet<String> roles = new HashSet<>();
     Map allRoles = null;
 
     if (subject.isAuthenticated()) {
-      Collection realmsList = SecurityUtils.getRealmsList();
+      Collection realmsList = getRealmsList();
       for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
         Realm realm = iterator.next();
         String name = realm.getClass().getName();
@@ -241,10 +199,11 @@ public class SecurityUtils {
           break;
         } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
           try {
-            AuthorizationInfo auth = ((LdapRealm) realm).queryForAuthorizationInfo(
-                new SimplePrincipalCollection(subject.getPrincipal(), realm.getName()),
-                ((LdapRealm) realm).getContextFactory()
-            );
+            AuthorizationInfo auth =
+                ((LdapRealm) realm)
+                    .queryForAuthorizationInfo(
+                        new SimplePrincipalCollection(subject.getPrincipal(), realm.getName()),
+                        ((LdapRealm) realm).getContextFactory());
             if (auth != null) {
               roles = new HashSet<>(auth.getRoles());
             }
@@ -270,10 +229,8 @@ public class SecurityUtils {
     return roles;
   }
 
-  /**
-   * Function to extract users from shiro.ini.
-   */
-  private static List<String> getUserList(IniRealm r) {
+  /** Function to extract users from shiro.ini. */
+  private List<String> getUserList(IniRealm r) {
     List<String> userList = new ArrayList<>();
     Map getIniUser = r.getIni().get("users");
     if (getIniUser != null) {
@@ -286,14 +243,13 @@ public class SecurityUtils {
     return userList;
   }
 
-
-  /***
-   * Get user roles from shiro.ini.
+  /**
+   * * Get user roles from shiro.ini.
    *
    * @param r
    * @return
    */
-  private static List<String> getRolesList(IniRealm r) {
+  private List<String> getRolesList(IniRealm r) {
     List<String> roleList = new ArrayList<>();
     Map getIniRoles = r.getIni().get("roles");
     if (getIniRoles != null) {
@@ -306,10 +262,8 @@ public class SecurityUtils {
     return roleList;
   }
 
-  /**
-   * Function to extract users from LDAP.
-   */
-  private static List<String> getUserList(JndiLdapRealm r, String searchText, int numUsersToFetch) {
+  /** Function to extract users from LDAP. */
+  private List<String> getUserList(JndiLdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     String userDnTemplate = r.getUserDnTemplate();
     String userDn[] = userDnTemplate.split(",", 2);
@@ -323,8 +277,8 @@ public class SecurityUtils {
       constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
       String[] attrIDs = {userDnPrefix};
       constraints.setReturningAttributes(attrIDs);
-      NamingEnumeration result = ctx.search(userDnSuffix, "(" + userDnPrefix + "=*" + searchText +
-          "*)", constraints);
+      NamingEnumeration result =
+          ctx.search(userDnSuffix, "(" + userDnPrefix + "=*" + searchText + "*)", constraints);
       while (result.hasMore()) {
         Attributes attrs = ((SearchResult) result.next()).getAttributes();
         if (attrs.get(userDnPrefix) != null) {
@@ -339,10 +293,8 @@ public class SecurityUtils {
     return userList;
   }
 
-  /**
-   * Function to extract users from Zeppelin LdapRealm.
-   */
-  private static List<String> getUserList(LdapRealm r, String searchText, int numUsersToFetch) {
+  /** Function to extract users from Zeppelin LdapRealm. */
+  private List<String> getUserList(LdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     LOGGER.debug("SearchText: " + searchText);
     String userAttribute = r.getUserSearchAttributeName();
@@ -356,9 +308,17 @@ public class SecurityUtils {
       constraints.setCountLimit(numUsersToFetch);
       String[] attrIDs = {userAttribute};
       constraints.setReturningAttributes(attrIDs);
-      NamingEnumeration result = ctx.search(userSearchRealm, "(&(objectclass=" +
-          userObjectClass + ")("
-          + userAttribute + "=*" + searchText + "*))", constraints);
+      NamingEnumeration result =
+          ctx.search(
+              userSearchRealm,
+              "(&(objectclass="
+                  + userObjectClass
+                  + ")("
+                  + userAttribute
+                  + "=*"
+                  + searchText
+                  + "*))",
+              constraints);
       while (result.hasMore()) {
         Attributes attrs = ((SearchResult) result.next()).getAttributes();
         if (attrs.get(userAttribute) != null) {
@@ -380,29 +340,28 @@ public class SecurityUtils {
     return userList;
   }
 
-  /***
-   * Get user roles from shiro.ini for Zeppelin LdapRealm.
+  /**
+   * * Get user roles from shiro.ini for Zeppelin LdapRealm.
    *
    * @param r
    * @return
    */
-  private static List<String> getRolesList(LdapRealm r) {
+  private List<String> getRolesList(LdapRealm r) {
     List<String> roleList = new ArrayList<>();
     Map<String, String> roles = r.getListRoles();
     if (roles != null) {
       Iterator it = roles.entrySet().iterator();
       while (it.hasNext()) {
         Map.Entry pair = (Map.Entry) it.next();
-        LOGGER.debug("RoleKeyValue: " + pair.getKey() +
-            " = " + pair.getValue());
+        LOGGER.debug("RoleKeyValue: " + pair.getKey() + " = " + pair.getValue());
         roleList.add((String) pair.getKey());
       }
     }
     return roleList;
   }
 
-  private static List<String> getUserList(ActiveDirectoryGroupRealm r, String searchText,
-                                   int numUsersToFetch) {
+  private List<String> getUserList(
+      ActiveDirectoryGroupRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     try {
       LdapContext ctx = r.getLdapContextFactory().getSystemLdapContext();
@@ -413,10 +372,8 @@ public class SecurityUtils {
     return userList;
   }
 
-  /**
-   * Function to extract users from JDBCs.
-   */
-  private static List<String> getUserList(JdbcRealm obj) {
+  /** Function to extract users from JDBCs. */
+  private List<String> getUserList(JdbcRealm obj) {
     List<String> userlist = new ArrayList<>();
     Connection con = null;
     PreparedStatement ps = null;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -60,8 +60,8 @@ import org.apache.zeppelin.service.SimpleServiceCallback;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.user.AuthenticationInfo;
+import org.apache.zeppelin.utils.CorsUtils;
 import org.apache.zeppelin.utils.InterpreterBindingUtils;
-import org.apache.zeppelin.utils.SecurityUtils;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
 import org.slf4j.Logger;
@@ -188,7 +188,7 @@ public class NotebookServer extends WebSocketServlet
 
   public boolean checkOrigin(HttpServletRequest request, String origin) {
     try {
-      return SecurityUtils.isValidOrigin(origin, ZeppelinConfiguration.create());
+      return CorsUtils.isValidOrigin(origin, ZeppelinConfiguration.create());
     } catch (UnknownHostException | URISyntaxException e) {
       LOG.error(e.toString(), e);
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
@@ -1,0 +1,28 @@
+package org.apache.zeppelin.utils;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+
+public class CorsUtils {
+  public static Boolean isValidOrigin(String sourceHost, ZeppelinConfiguration conf)
+      throws UnknownHostException, URISyntaxException {
+
+    String sourceUriHost = "";
+
+    if (sourceHost != null && !sourceHost.isEmpty()) {
+      sourceUriHost = new URI(sourceHost).getHost();
+      sourceUriHost = (sourceUriHost == null) ? "" : sourceUriHost.toLowerCase();
+    }
+
+    sourceUriHost = sourceUriHost.toLowerCase();
+    String currentHost = InetAddress.getLocalHost().getHostName().toLowerCase();
+
+    return conf.getAllowedOrigins().contains("*")
+        || currentHost.equals(sourceUriHost)
+        || "localhost".equals(sourceUriHost)
+        || conf.getAllowedOrigins().contains(sourceHost);
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/utils/CorsUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.utils;
 
 import java.net.InetAddress;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/CredentialsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/CredentialsRestApiTest.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.apache.zeppelin.service.NoSecurityService;
+import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.user.UserCredentials;
 import org.junit.Before;
@@ -37,12 +39,14 @@ public class CredentialsRestApiTest {
 
   private CredentialRestApi credentialRestApi;
   private Credentials credentials;
+  private SecurityService securityService;
 
   @Before
   public void setUp() throws IOException {
     credentials =
         new Credentials(false, Files.createTempFile("credentials", "test").toString(), null);
-    credentialRestApi = new CredentialRestApi(credentials);
+    securityService = new NoSecurityService();
+    credentialRestApi = new CredentialRestApi(credentials, securityService);
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroSecurityServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroSecurityServiceTest.java
@@ -48,76 +48,12 @@ public class ShiroSecurityServiceTest {
   org.apache.shiro.subject.Subject subject;
 
   ShiroSecurityService shiroSecurityService;
+  ZeppelinConfiguration zeppelinConfiguration;
 
   @Before
-  public void setup() {
-    shiroSecurityService = new ShiroSecurityService();
-  }
-
-  @Test
-  public void isInvalid() throws URISyntaxException, UnknownHostException {
-    assertFalse(shiroSecurityService.isValidOrigin("http://127.0.1.1", ZeppelinConfiguration.create()));
-  }
-
-  @Test
-  public void isInvalidFromConfig()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertFalse(shiroSecurityService.isValidOrigin("http://otherinvalidhost.com",
-          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-  }
-
-  @Test
-  public void isLocalhost() throws URISyntaxException, UnknownHostException {
-    assertTrue(shiroSecurityService.isValidOrigin("http://localhost", ZeppelinConfiguration.create()));
-  }
-
-  @Test
-  public void isLocalMachine() throws URISyntaxException, UnknownHostException {
-    String origin = "http://" + InetAddress.getLocalHost().getHostName();
-    assertTrue("Origin " + origin + " is not allowed. Please check your hostname.",
-               shiroSecurityService.isValidOrigin(origin, ZeppelinConfiguration.create()));
-  }
-
-  @Test
-  public void isValidFromConfig()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertTrue(shiroSecurityService.isValidOrigin("http://otherhost.com",
-           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-  }
-
-  @Test
-  public void isValidFromStar()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertTrue(shiroSecurityService.isValidOrigin("http://anyhost.com",
-           new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
-  }
-
-  @Test
-  public void nullOrigin()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertFalse(shiroSecurityService.isValidOrigin(null,
-          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-  }
-
-  @Test
-  public void nullOriginWithStar()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertTrue(shiroSecurityService.isValidOrigin(null,
-        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
-  }
-
-  @Test
-  public void emptyOrigin()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertFalse(shiroSecurityService.isValidOrigin("",
-          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
-  }
-
-  @Test
-  public void notAURIOrigin()
-          throws URISyntaxException, UnknownHostException, ConfigurationException {
-    assertFalse(shiroSecurityService.isValidOrigin("test123",
-          new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  public void setup() throws Exception {
+    zeppelinConfiguration = ZeppelinConfiguration.create();
+    shiroSecurityService = new ShiroSecurityService(zeppelinConfiguration);
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/utils/CorsUtilsTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/utils/CorsUtilsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.junit.Test;
+
+public class CorsUtilsTest {
+  @Test
+  public void isInvalid() throws URISyntaxException, UnknownHostException {
+    assertFalse(CorsUtils.isValidOrigin("http://127.0.1.1", ZeppelinConfiguration.create()));
+  }
+
+  @Test
+  public void isInvalidFromConfig()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(CorsUtils.isValidOrigin("http://otherinvalidhost.com",
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+  @Test
+  public void isLocalhost() throws URISyntaxException, UnknownHostException {
+    assertTrue(CorsUtils.isValidOrigin("http://localhost", ZeppelinConfiguration.create()));
+  }
+
+  @Test
+  public void isLocalMachine() throws URISyntaxException, UnknownHostException {
+    String origin = "http://" + InetAddress.getLocalHost().getHostName();
+    assertTrue("Origin " + origin + " is not allowed. Please check your hostname.",
+        CorsUtils.isValidOrigin(origin, ZeppelinConfiguration.create()));
+  }
+
+  @Test
+  public void isValidFromConfig()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(CorsUtils.isValidOrigin("http://otherhost.com",
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+  @Test
+  public void isValidFromStar()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(CorsUtils.isValidOrigin("http://anyhost.com",
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
+  }
+
+  @Test
+  public void nullOrigin()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(CorsUtils.isValidOrigin(null,
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+  @Test
+  public void nullOriginWithStar()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertTrue(CorsUtils.isValidOrigin(null,
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site-star.xml"))));
+  }
+
+  @Test
+  public void emptyOrigin()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(CorsUtils.isValidOrigin("",
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+
+  @Test
+  public void notAURIOrigin()
+      throws URISyntaxException, UnknownHostException, ConfigurationException {
+    assertFalse(CorsUtils.isValidOrigin("test123",
+        new ZeppelinConfiguration(this.getClass().getResource("/zeppelin-site.xml"))));
+  }
+}


### PR DESCRIPTION
### What is this PR for?
Making SecurityService more configurable. Currently, SecurityUtils consists of static methods, and which means it's not extendable and pluggable. It would be better if users could implement new security features easily.

### What type of PR is it?
[Refactoring]

### Todos
* [x] - Introduce `SecurityService` as an interface to support security features
* [x] - Move `SecurityUtils` to `ShiroSecurityService` as an implementation of `SecurityService`

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3892

### How should this be tested?
* This is a refactoring. It should pass all of the current tests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
