### PR TITLE
[ZEPPELIN-3878] Browser IE 11  not loading Note

### DIFF
--- a/zeppelin-web/karma.conf.js
+++ b/zeppelin-web/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // for polyfill
-      'node_modules/babel-polyfill/dist/polyfill.js',
+      //'node_modules/babel-polyfill/dist/polyfill.js',
 
       // bower:js
       'bower_components/jquery/dist/jquery.js',

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import "babel-polyfill";
+import "core-js/modules/es7.promise.finally";
 import 'headroom.js';
 import 'headroom.js/dist/angular.headroom';
 

--- a/zeppelin-web/src/app/app.js
+++ b/zeppelin-web/src/app/app.js
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import "babel-polyfill";
-import "core-js/modules/es7.promise.finally";
+import 'babel-polyfill';
+import 'core-js/modules/es7.promise.finally';
 import 'headroom.js';
 import 'headroom.js/dist/angular.headroom';
 


### PR DESCRIPTION
### What is this PR for?
Previous version of the zeppelin supports IE 11 when  we updated to zeppelin 0.8.0, Zeppelin web was not loading properly saying the error promise undefined .


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - 

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-3878


### How should this be tested?
click on any of the existing note in IE 11 browser. 
Observation  : Note not loading or not reponsive
you can check the error in the console
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No
