### PR TITLE
[ZEPPELIN-3898] Adding repo in testDelRepo so test can run by itself

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
@@ -66,6 +66,7 @@ public class DependencyResolverTest {
 
   @Test
   public void testDelRepo() {
+    resolver.addRepo("securecentral", "https://repo1.maven.org/maven2", false);
     int reposCnt = resolver.getRepos().size();
     resolver.delRepo("securecentral");
     resolver.delRepo("badId");


### PR DESCRIPTION
### What is this PR for?
Test DependencyResolverTest.testDelRepo fails when run on its own. The test needs a repo to already be added so it can delete it. If the test is run on its own, the repo is not added to start and so the test fails. The proposed PR fixes this issue by having the test add the repo at the beginning.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3898