### PR TITLE
[Zeppelin 3792]  Zeppelin SPNEGO support 

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -222,7 +222,7 @@ zeppelinHubRealm.zeppelinhubUrl = https://www.zeppelinhub.com
 securityManager.realms = $zeppelinHubRealm
 ```
 
-> Note: ZeppelinHub is not releated to Apache Zeppelin project.
+> Note: ZeppelinHub is not related to Apache Zeppelin project.
 
 ### Knox SSO
 [KnoxSSO](https://knox.apache.org/books/knox-0-13-0/dev-guide.html#KnoxSSO+Integration) provides an abstraction for integrating any number of authentication systems and SSO solutions and enables participating web applications to scale to those solutions more easily. Without the token exchange capabilities offered by KnoxSSO each component UI would need to integrate with each desired solution on its own.
@@ -247,6 +247,52 @@ knoxJwtRealm.principalMapping = principal.mapping
 authc = org.apache.zeppelin.realm.jwt.KnoxAuthenticationFilter
 ```
 
+### HTTP SPNEGO Authentication
+HTTP SPNEGO (Simple and Protected GSS-API NEGOtiation) is the standard way to support Kerberos Ticket based user authentication for Web Services. Based on [Apache Hadoop Auth](https://hadoop.apache.org/docs/current/hadoop-auth/index.html), Zeppelin supports ability to authenticate users by accepting and validating their Kerberos Ticket.
+
+When HTTP SPNEGO Authentication is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine group membership of user who is tyring to log in. Role-based access permission can be set based on groups as seen by Hadoop.
+
+To enable this, apply the following change in `conf/shiro.ini` under `[main]` section.
+
+```
+krbRealm = org.apache.zeppelin.realm.kerberos.KerberosRealm
+krbRealm.principal=HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+krbRealm.keytab=/etc/security/keytabs/spnego.service.keytab
+krbRealm.nameRules=DEFAULT
+krbRealm.signatureSecretFile=/etc/security/http_secret
+krbRealm.tokenValidity=36000
+krbRealm.cookieDomain=domain.com
+krbRealm.cookiePath=/
+authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
+```
+For above configuration to work, user need to do some more configurations outside Zeppelin.
+
+1). A valid SPNEGO keytab should be available on the Zeppelin node and should be readable by 'zeppelin' user. If there is a SPNEGO keytab already available (because of other Hadoop service), it can be reused here and no need to generate a new keytab. An example of working SPNEGO keytab could be:
+```
+$ klist -kt /etc/security/keytabs/spnego.service.keytab
+Keytab name: FILE:/etc/security/keytabs/spnego.service.keytab
+KVNO Timestamp           Principal
+---- ------------------- ------------------------------------------------------
+   2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+   2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+   2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+   2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+```
+and the keytab permission should be: (VERY IMPORTANT to not to set this to 777 or readable by all !!!):
+```
+$ ls -l /etc/security/keytabs/spnego.service.keytab
+-r--r-----. 1 root hadoop 346 Nov 26 16:58 /etc/security/keytabs/spnego.service.keytab
+```
+Above 'zeppelin' user happens to be member of 'hadoop' group.
+
+2). A secret signature file must be present on Zeppelin node (readable to 'zeppelin' user). This file contains the random binary numbers which is used to sign 'hadoop.auth' cookie, generated during SPNEGO exchange. If such a file is already generated and available on the Zeppelin node, it should be used rather than generating a new file.
+
+Commands to generate a secret signature file (if required):
+```
+dd if=/dev/urandom of=/etc/security/http_secret bs=1024 count=1
+chown hdfs:hadoop /etc/security/http_secret
+chmod 440 /etc/security/http_secret
+```
 
 ## Secure Cookie for Zeppelin Sessions (optional)
 Zeppelin can be configured to set `HttpOnly` flag in the session cookie. With this configuration, Zeppelin cookies can 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.realm.kerberos;
+
+import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
+import org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter;
+import org.apache.zeppelin.utils.SecurityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import java.io.IOException;
+
+/**
+ * Created for org.apache.zeppelin.server
+ */
+public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KerberosAuthenticationFilter.class);
+
+  /**
+   * <p>Initializes the authentication filter and signer secret provider.</p>
+   * It instantiates and initializes the specified {@link
+   * AuthenticationHandler}. Currently, Zeppelin supports only Kerberos type
+   * AuthenticationHandler.
+   *
+   * @throws ServletException thrown if the filter or the authentication handler
+   *                          could not be initialized properly.
+   */
+  @Override
+  protected void onFilterConfigSet() throws Exception {
+    super.onFilterConfigSet();
+    LOG.info("VR46 - inside onFilterConfigSet()");
+  }
+
+  @Override
+  protected void saveRequestAndRedirectToLogin(ServletRequest request, ServletResponse response) {
+    // We don't want to redirect request to loginUrl here
+  }
+
+  /**
+   * If the request has a valid authentication token it allows the request to continue to
+   * the target resource,
+   * otherwise it triggers an authentication sequence using the configured
+   * {@link AuthenticationHandler}.
+   *
+   * @param request     the request object.
+   * @param response    the response object.
+   * @param filterChain the filter chain object.
+   * @throws IOException      thrown if an IO error occurred.
+   * @throws ServletException thrown if a processing error occurred.
+   */
+  @Override
+  public void doFilterInternal(ServletRequest request,
+                               ServletResponse response,
+                               FilterChain filterChain)
+      throws IOException, ServletException {
+    KerberosRealm kerberosRealm = null;
+    for (Object realm : SecurityUtils.getRealmsList()) {
+      if (realm instanceof KerberosRealm) {
+        kerberosRealm = (KerberosRealm) realm;
+        break;
+      }
+    }
+    if (kerberosRealm != null) {
+      kerberosRealm.doKerberosAuth(request, response, filterChain);
+    } else {
+      LOG.error("Looks like this filter is enabled without enabling KerberosRealm, please refer"
+          + " to https://zeppelin.apache.org/docs/latest/security/shiroauthentication.html"
+          + "#kerberos-auth");
+    }
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
@@ -17,13 +17,16 @@
 package org.apache.zeppelin.realm.kerberos;
 
 import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.util.ThreadContext;
 import org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter;
-import org.apache.zeppelin.utils.SecurityUtils;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.*;
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * Created for org.apache.zeppelin.server
@@ -31,21 +34,6 @@ import java.io.IOException;
 public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(KerberosAuthenticationFilter.class);
-
-  /**
-   * <p>Initializes the authentication filter and signer secret provider.</p>
-   * It instantiates and initializes the specified {@link
-   * AuthenticationHandler}. Currently, Zeppelin supports only Kerberos type
-   * AuthenticationHandler.
-   *
-   * @throws ServletException thrown if the filter or the authentication handler
-   *                          could not be initialized properly.
-   */
-  @Override
-  protected void onFilterConfigSet() throws Exception {
-    super.onFilterConfigSet();
-    LOG.info("VR46 - inside onFilterConfigSet()");
-  }
 
   @Override
   protected void saveRequestAndRedirectToLogin(ServletRequest request, ServletResponse response) {
@@ -70,7 +58,11 @@ public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
                                FilterChain filterChain)
       throws IOException, ServletException {
     KerberosRealm kerberosRealm = null;
-    for (Object realm : SecurityUtils.getRealmsList()) {
+    DefaultWebSecurityManager defaultWebSecurityManager;
+    String key = ThreadContext.SECURITY_MANAGER_KEY;
+    defaultWebSecurityManager = (DefaultWebSecurityManager) ThreadContext.get(key);
+    Collection<Realm> realms = defaultWebSecurityManager.getRealms();
+    for (Object realm : realms) {
       if (realm instanceof KerberosRealm) {
         kerberosRealm = (KerberosRealm) realm;
         break;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -1,0 +1,996 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.realm.kerberos;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.Groups;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
+import org.apache.hadoop.security.authentication.client.KerberosAuthenticator;
+import org.apache.hadoop.security.authentication.server.AuthenticationHandler;
+import org.apache.hadoop.security.authentication.server.AuthenticationToken;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.security.authentication.util.*;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.SimpleAccount;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.authz.AuthorizationException;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.cache.CacheManager;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.Oid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.kerberos.KeyTab;
+import javax.servlet.*;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * The {@link KerberosRealm} implements the Kerberos SPNEGO
+ * authentication mechanism for HTTP.
+ * <p>
+ * The supported configuration properties are:
+ * <ul>
+ * <li>kerberos.principal: the Kerberos principal to used by the server. As
+ * stated by the Kerberos SPNEGO specification, it should be
+ * <code>HTTP/${HOSTNAME}@{REALM}</code>. The realm can be omitted from the
+ * principal as the JDK GSS libraries will use the realm name of the configured
+ * default realm.
+ * It does not have a default value.</li>
+ * <li>kerberos.keytab: the keytab file containing the credentials for the
+ * Kerberos principal.
+ * It does not have a default value.</li>
+ * <li>kerberos.name.rules: kerberos names rules to resolve principal names, see
+ * {@link KerberosName#setRules(String)}</li>
+ * </ul>
+ */
+public class KerberosRealm extends AuthorizingRealm {
+  public static final Logger LOG = LoggerFactory.getLogger(KerberosRealm.class);
+
+  /**
+   * Constant for the property that specifies the configuration prefix.
+   */
+  private static final String CONFIG_PREFIX = "config.prefix";
+
+  /**
+   * Constant for the property that specifies the authentication handler to use.
+   */
+  private static final String AUTH_TYPE = "type";
+
+  /**
+   * Constant for the property that specifies the secret to use for signing the HTTP Cookies.
+   */
+  private static final String SIGNATURE_SECRET = "signature.secret";
+
+  private static final String SIGNATURE_SECRET_FILE = SIGNATURE_SECRET + ".file";
+
+  /**
+   * Constant for the configuration property
+   * that indicates the max inactive interval of the generated token.
+   */
+  private static final String AUTH_TOKEN_MAX_INACTIVE_INTERVAL = "token.max-inactive-interval";
+
+  /**
+   * Constant for the configuration property that indicates the tokenValidity of the generated
+   * token.
+   */
+  private static final String AUTH_TOKEN_VALIDITY = "token.tokenValidity";
+
+  /**
+   * Constant for the configuration property that indicates the domain to use in the HTTP cookie.
+   */
+  private static final String COOKIE_DOMAIN = "cookie.domain";
+
+  /**
+   * Constant for the configuration property that indicates the path to use in the HTTP cookie.
+   */
+  private static final String COOKIE_PATH = "cookie.path";
+
+  /**
+   * Constant for the configuration property
+   * that indicates the persistence of the HTTP cookie.
+   */
+  private static final String COOKIE_PERSISTENT = "cookie.persistent";
+
+  /**
+   * Constant for the configuration property that indicates the name of the
+   * SignerSecretProvider class to use.
+   * Possible values are: "file"
+   * We are NOT supporting "random", "zookeeper", or a classname, at the moment
+   * If not specified, the "file" implementation will be used with
+   * SIGNATURE_SECRET_FILE; and if that's not specified, the "random"
+   * implementation will be used.
+   */
+  private static final String SIGNER_SECRET_PROVIDER = "signer.secret.provider";
+
+  private static Signer signer = null;
+  private SignerSecretProvider secretProvider = null;
+  private boolean destroySecretProvider = true;
+
+  // Configs to set in shiro.ini
+  private String signatureSecretFile = null;
+  private long tokenMaxInactiveInterval = -1;
+  private long tokenValidity = 36000; // 10 hours
+  private String cookieDomain = null;
+  private String cookiePath = "/";
+  private boolean isCookiePersistent = false;
+  private String principal = null;
+  private String keytab = null;
+  private String nameRules = "DEFAULT";
+
+  /**
+   * Constant that identifies the authentication mechanism.
+   */
+  public static final String TYPE = "kerberos";
+
+  /**
+   * Constant for the configuration property that indicates the kerberos
+   * principal.
+   */
+  public static final String PRINCIPAL = TYPE + ".principal";
+
+  /**
+   * Constant for the configuration property that indicates the keytab
+   * file path.
+   */
+  public static final String KEYTAB = TYPE + ".keytab";
+
+  /**
+   * Constant for the configuration property that indicates the Kerberos name
+   * rules for the Kerberos principals.
+   */
+  public static final String NAME_RULES = TYPE + ".name.rules";
+
+  private static final String type = TYPE;
+  private String rules;
+  private GSSManager gssManager;
+  private Subject serverSubject = new Subject();
+  private Properties config = null;
+
+  /**
+   * Configuration object needed by for hadoop classes
+   */
+  private Configuration hadoopConfig;
+
+  /**
+   * Hadoop Groups implementation.
+   */
+  private Groups hadoopGroups;
+
+  @Override
+  public boolean supports(org.apache.shiro.authc.AuthenticationToken token) {
+    return token instanceof KerberosToken;
+  }
+
+  /**
+   * Initializes the KerberosRealm by 'kinit'ing using principal and keytab.
+   * <p>
+   * It creates a Kerberos context using the principal and keytab specified in
+   * the Shiro configuration.
+   * <p>
+   * This method should be called only once; is invoked in {@link KerberosAuthenticationFilter}
+   *
+   * @throws RuntimeException thrown if the handler could not be initialized.
+   */
+  @Override
+  protected void onInit() {
+    LOG.info("VR46 - inside onInit()");
+    super.onInit();
+    config = getConfiguration();
+    try {
+      if (principal == null || principal.trim().length() == 0) {
+        throw new RuntimeException("Principal not defined in configuration");
+      }
+
+      if (keytab == null || keytab.trim().length() == 0) {
+        throw new RuntimeException("Keytab not defined in configuration");
+      }
+
+      File keytabFile = new File(keytab);
+      if (!keytabFile.exists()) {
+        throw new RuntimeException("Keytab file does not exist: " + keytab);
+      }
+
+      // use all SPNEGO principals in the keytab if a principal isn't
+      // specifically configured
+      final String[] spnegoPrincipals;
+      if (principal.equals("*")) {
+        spnegoPrincipals = KerberosUtil.getPrincipalNames(
+            keytab, Pattern.compile("HTTP/.*"));
+        if (spnegoPrincipals.length == 0) {
+          throw new RuntimeException("Principals do not exist in the keytab");
+        }
+      } else {
+        spnegoPrincipals = new String[]{principal};
+      }
+      KeyTab keytabInstance = KeyTab.getInstance(keytabFile);
+      serverSubject.getPrivateCredentials().add(keytabInstance);
+      for (String spnegoPrincipal : spnegoPrincipals) {
+        Principal krbPrincipal = new KerberosPrincipal(spnegoPrincipal);
+        LOG.info("Using keytab {}, for principal {}",
+            keytab, krbPrincipal);
+        serverSubject.getPrincipals().add(krbPrincipal);
+      }
+
+      if (rules == null || rules.trim().length() == 0) {
+        LOG.warn("No auth_to_local rules defined, DEFAULT will be used.");
+        rules = "DEFAULT";
+      }
+
+      KerberosName.setRules(rules);
+
+      try {
+        gssManager = Subject.doAs(serverSubject,
+            new PrivilegedExceptionAction<GSSManager>() {
+              @Override
+              public GSSManager run(){
+                return GSSManager.getInstance();
+              }
+            });
+      } catch (PrivilegedActionException ex) {
+        throw ex.getException();
+      }
+
+      initializeSecretProvider();
+
+      hadoopConfig = new Configuration();
+      hadoopGroups = new Groups(hadoopConfig);
+
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+    LOG.info("VR46 - exit onInit()");
+  }
+
+  protected void initializeSecretProvider() throws ServletException {
+    try {
+      secretProvider = constructSecretProvider(false);
+      destroySecretProvider = true;
+      signer = new Signer(secretProvider);
+    } catch (Exception ex) {
+      throw new ServletException(ex);
+    }
+  }
+
+  public SignerSecretProvider constructSecretProvider(
+      boolean disallowFallbackToRandomSecretProvider) throws Exception {
+    // Default Signature provider type is file
+    String name = "file";
+    if (!disallowFallbackToRandomSecretProvider
+        && config.getProperty(SIGNATURE_SECRET_FILE) == null) {
+      name = "random";
+    }
+
+    SignerSecretProvider provider;
+    if ("file".equals(name)) {
+      provider = new FileSignerSecretProvider();
+      try {
+        provider.init(config, null, tokenValidity);
+      } catch (Exception e) {
+        if (!disallowFallbackToRandomSecretProvider) {
+          LOG.info("Unable to initialize FileSignerSecretProvider, " +
+              "falling back to use random secrets.");
+          provider = new RandomSignerSecretProvider();
+          provider.init(config, null, tokenValidity);
+        } else {
+          throw e;
+        }
+      }
+    } else if ("random".equals(name)) {
+      provider = new RandomSignerSecretProvider();
+      provider.init(config, null, tokenValidity);
+    } else {
+      throw new RuntimeException("Custom Signer not implemented yet. Use 'file' or 'random'.");
+    }
+    return provider;
+  }
+
+  /**
+   * This is an empty implementation, it always returns <code>TRUE</code>.
+   *
+   * @param token the authentication token if any, otherwise <code>NULL</code>.
+   * @param request the HTTP client request.
+   * @param response the HTTP client response.
+   *
+   * @return <code>TRUE</code>
+   * @throws IOException it is never thrown.
+   * @throws AuthenticationException it is never thrown.
+   */
+  public boolean managementOperation(AuthenticationToken token,
+                                     HttpServletRequest request,
+                                     HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    return true;
+  }
+
+  @Override
+  public AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals)
+      throws AuthorizationException {
+    Set<String> roles = mapGroupPrincipals(principals.toString());
+    return new SimpleAuthorizationInfo(roles);
+  }
+
+  /**
+   * Query the Hadoop implementation of {@link Groups} to retrieve groups for
+   * provided user.
+   */
+  public Set<String> mapGroupPrincipals(final String mappedPrincipalName)
+      throws AuthorizationException {
+    /* return the groups as seen by Hadoop */
+    Set<String> groups = null;
+    try {
+      hadoopGroups.refresh();
+      final List<String> groupList = hadoopGroups.getGroups(mappedPrincipalName);
+
+      LOG.debug(String.format("group found %s, %s",
+            mappedPrincipalName, groupList.toString()));
+
+      groups = new HashSet<>(groupList);
+
+    } catch (final IOException e) {
+      if (e.toString().contains("No groups found for user")) {
+        /* no groups found move on */
+        LOG.info(String.format("No groups found for user %s", mappedPrincipalName));
+      } else {
+        /* Log the error and return empty group */
+        LOG.info(String.format("errorGettingUserGroups for %s", mappedPrincipalName));
+        throw new AuthorizationException(e);
+      }
+      groups = new HashSet();
+    }
+    return groups;
+  }
+
+  @Override
+  protected AuthenticationInfo doGetAuthenticationInfo(
+      org.apache.shiro.authc.AuthenticationToken authenticationToken)
+      throws org.apache.shiro.authc.AuthenticationException {
+    LOG.debug("VR46 - inside doGetAuthenticationInfo()");
+    if (null != authenticationToken) {
+      KerberosToken kerberosToken = (KerberosToken) authenticationToken;
+      //  try {
+      SimpleAccount account = new SimpleAccount(kerberosToken.getPrincipal(),
+          kerberosToken.getCredentials(), kerberosToken.getClass().getName());
+      //account.addRole(mapGroupPrincipals(getName(upToken)));
+      return account;
+      // } catch (ParseException e) {
+      //   LOG.error("ParseException in doGetAuthenticationInfo", e);
+      // }
+    }
+    return null;
+  }
+
+  /**
+   * If the request has a valid authentication token it allows the request to continue to
+   * the target resource,
+   * otherwise it triggers a GSS-API sequence for authentication
+   *
+   * @param request     the request object.
+   * @param response    the response object.
+   * @param filterChain the filter chain object.
+   * @throws IOException      thrown if an IO error occurred.
+   * @throws ServletException thrown if a processing error occurred.
+   */
+  public void doKerberosAuth(ServletRequest request,
+                             ServletResponse response,
+                             FilterChain filterChain)
+      throws IOException, ServletException {
+    boolean unauthorizedResponse = true;
+    int errCode = HttpServletResponse.SC_UNAUTHORIZED;
+    AuthenticationException authenticationEx = null;
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+    boolean isHttps = "https".equals(httpRequest.getScheme());
+    try {
+      boolean newToken = false;
+      AuthenticationToken token;
+      try {
+        token = getToken(httpRequest);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Got token {} from httpRequest {}", token,
+              getRequestURL(httpRequest));
+        }
+      } catch (AuthenticationException ex) {
+        LOG.warn("AuthenticationToken ignored: " + ex.getMessage());
+        if (!ex.getMessage().equals("Empty token")) {
+          // will be sent back in a 401 unless filter authenticates
+          authenticationEx = ex;
+        }
+        token = null;
+      }
+      if (managementOperation(token, httpRequest, httpResponse)) {
+        if (token == null) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Request [{}] triggering authentication. handler: {}",
+                getRequestURL(httpRequest), this.getClass());
+          }
+          token = authenticate(httpRequest, httpResponse);
+          if (token != null && token != AuthenticationToken.ANONYMOUS) {
+//            if (token.getMaxInactives() > 0) {
+//              token.setMaxInactives(System.currentTimeMillis()
+//                  + getTokenMaxInactiveInterval() * 1000);
+//            }
+            if (token.getExpires() != 0) {
+              token.setExpires(System.currentTimeMillis()
+                  + getTokenValidity() * 1000);
+            }
+          }
+          newToken = true;
+        }
+        if (token != null) {
+          unauthorizedResponse = false;
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Request [{}] user [{}] authenticated",
+                getRequestURL(httpRequest), token.getUserName());
+          }
+          final AuthenticationToken authToken = token;
+          httpRequest = new HttpServletRequestWrapper(httpRequest) {
+
+            @Override
+            public String getAuthType() {
+              return authToken.getType();
+            }
+
+            @Override
+            public String getRemoteUser() {
+              return authToken.getUserName();
+            }
+
+            @Override
+            public Principal getUserPrincipal() {
+              return (authToken != AuthenticationToken.ANONYMOUS) ?
+                  authToken : null;
+            }
+          };
+
+          // If cookie persistence is configured to false,
+          // it means the cookie will be a session cookie.
+          // If the token is an old one, renew the its tokenMaxInactiveInterval.
+          if (!newToken && !isCookiePersistent()
+              && getTokenMaxInactiveInterval() > 0) {
+//            token.setMaxInactives(System.currentTimeMillis()
+//                + getTokenMaxInactiveInterval() * 1000);
+            token.setExpires(token.getExpires());
+            newToken = true;
+          }
+          if (newToken && !token.isExpired()
+              && token != AuthenticationToken.ANONYMOUS) {
+            String signedToken = signer.sign(token.toString());
+            createAuthCookie(httpResponse, signedToken, getCookieDomain(),
+                getCookiePath(), token.getExpires(),
+                isCookiePersistent(), isHttps);
+            KerberosToken kerberosToken = new KerberosToken(token.getUserName(), token.toString());
+            SecurityUtils.getSubject().login(kerberosToken);
+          }
+          doFilter(filterChain, httpRequest, httpResponse);
+        }
+      } else {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("managementOperation returned false for request {}."
+              + " token: {}", getRequestURL(httpRequest), token);
+        }
+        unauthorizedResponse = false;
+      }
+    } catch (AuthenticationException ex) {
+      // exception from the filter itself is fatal
+      errCode = HttpServletResponse.SC_FORBIDDEN;
+      authenticationEx = ex;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Authentication exception: " + ex.getMessage(), ex);
+      } else {
+        LOG.warn("Authentication exception: " + ex.getMessage());
+      }
+    }
+    if (unauthorizedResponse) {
+      if (!httpResponse.isCommitted()) {
+        createAuthCookie(httpResponse, "", getCookieDomain(),
+            getCookiePath(), 0, isCookiePersistent(), isHttps);
+        // If response code is 401. Then WWW-Authenticate Header should be
+        // present.. reset to 403 if not found..
+        if ((errCode == HttpServletResponse.SC_UNAUTHORIZED)
+            && (!httpResponse.containsHeader(KerberosAuthenticator.WWW_AUTHENTICATE))) {
+          errCode = HttpServletResponse.SC_FORBIDDEN;
+        }
+        if (authenticationEx == null) {
+          httpResponse.sendError(errCode, "Authentication required");
+        } else {
+          httpResponse.sendError(errCode, authenticationEx.getMessage());
+        }
+      }
+    }
+  }
+
+  /**
+   * It enforces the the Kerberos SPNEGO authentication sequence returning an
+   * {@link AuthenticationToken} only after the Kerberos SPNEGO sequence has
+   * completed successfully.
+   *
+   * @param request  the HTTP client request.
+   * @param response the HTTP client response.
+   * @return an authentication token if the Kerberos SPNEGO sequence is complete
+   * and valid, <code>null</code> if it is in progress (in this case the handler
+   * handles the response to the client).
+   * @throws IOException             thrown if an IO error occurred.
+   * @throws AuthenticationException thrown if Kerberos SPNEGO sequence failed.
+   */
+  public AuthenticationToken authenticate(HttpServletRequest request,
+                                          final HttpServletResponse response)
+      throws IOException, AuthenticationException {
+    AuthenticationToken token = null;
+    String authorization = request.getHeader(
+        KerberosAuthenticator.AUTHORIZATION);
+
+    if (authorization == null
+        || !authorization.startsWith(KerberosAuthenticator.NEGOTIATE)) {
+      response.setHeader(KerberosAuthenticator.WWW_AUTHENTICATE, KerberosAuthenticator.NEGOTIATE);
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      if (authorization == null) {
+        LOG.trace("SPNEGO starting for url: {}", request.getRequestURL());
+      } else {
+        LOG.warn("'" + KerberosAuthenticator.AUTHORIZATION +
+            "' does not start with '" +
+            KerberosAuthenticator.NEGOTIATE + "' :  {}", authorization);
+      }
+    } else {
+      authorization = authorization.substring(
+          KerberosAuthenticator.NEGOTIATE.length()).trim();
+      final Base64 base64 = new Base64(0);
+      final byte[] clientToken = base64.decode(authorization);
+      try {
+        final String serverPrincipal =
+            KerberosUtil.getTokenServerName(clientToken);
+        if (!serverPrincipal.startsWith("HTTP/")) {
+          throw new IllegalArgumentException(
+              "Invalid server principal " + serverPrincipal +
+                  "decoded from client request");
+        }
+        token = Subject.doAs(serverSubject,
+            new PrivilegedExceptionAction<AuthenticationToken>() {
+              @Override
+              public AuthenticationToken run() throws Exception {
+                return runWithPrincipal(serverPrincipal, clientToken,
+                    base64, response);
+              }
+            });
+      } catch (PrivilegedActionException ex) {
+        if (ex.getException() instanceof IOException) {
+          throw (IOException) ex.getException();
+        } else {
+          throw new AuthenticationException(ex.getException());
+        }
+      } catch (Exception ex) {
+        throw new AuthenticationException(ex);
+      }
+    }
+    return token;
+  }
+
+  private AuthenticationToken runWithPrincipal(String serverPrincipal,
+                                               byte[] clientToken, Base64 base64,
+                                               HttpServletResponse response)
+      throws IOException, GSSException {
+    GSSContext gssContext = null;
+    GSSCredential gssCreds = null;
+    AuthenticationToken token = null;
+    try {
+      LOG.trace("SPNEGO initiated with server principal [{}]", serverPrincipal);
+      gssCreds = this.gssManager.createCredential(
+          this.gssManager.createName(serverPrincipal,
+              KerberosUtil.NT_GSS_KRB5_PRINCIPAL_OID),
+          GSSCredential.INDEFINITE_LIFETIME,
+          new Oid[]{KerberosUtil.GSS_SPNEGO_MECH_OID, KerberosUtil.GSS_KRB5_MECH_OID},
+          GSSCredential.ACCEPT_ONLY);
+      gssContext = this.gssManager.createContext(gssCreds);
+      byte[] serverToken = gssContext.acceptSecContext(clientToken, 0,
+          clientToken.length);
+      if (serverToken != null && serverToken.length > 0) {
+        String authenticate = base64.encodeToString(serverToken);
+        response.setHeader(KerberosAuthenticator.WWW_AUTHENTICATE,
+            KerberosAuthenticator.NEGOTIATE + " " +
+                authenticate);
+      }
+      if (!gssContext.isEstablished()) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        LOG.trace("SPNEGO in progress");
+      } else {
+        String clientPrincipal = gssContext.getSrcName().toString();
+        KerberosName kerberosName = new KerberosName(clientPrincipal);
+        String userName = kerberosName.getShortName();
+        token = new AuthenticationToken(userName, clientPrincipal, getType());
+        response.setStatus(HttpServletResponse.SC_OK);
+        LOG.trace("SPNEGO completed for client principal [{}]",
+            clientPrincipal);
+      }
+    } finally {
+      if (gssContext != null) {
+        gssContext.dispose();
+      }
+      if (gssCreds != null) {
+        gssCreds.dispose();
+      }
+    }
+    return token;
+  }
+
+  /**
+   * Returns the full URL of the request including the query string.
+   * <p>
+   * Used as a convenience method for logging purposes.
+   *
+   * @param request the request object.
+   * @return the full URL of the request including the query string.
+   */
+  protected String getRequestURL(HttpServletRequest request) {
+    StringBuffer sb = request.getRequestURL();
+    if (request.getQueryString() != null) {
+      sb.append("?").append(request.getQueryString());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Returns the {@link AuthenticationToken} for the request.
+   * <p>
+   * It looks at the received HTTP cookies and extracts the value of the
+   * {@link AuthenticatedURL#AUTH_COOKIE}
+   * if present. It verifies the signature and if correct it creates the
+   * {@link AuthenticationToken} and returns
+   * it.
+   * <p>
+   * If this method returns <code>null</code> the filter will invoke the configured
+   * {@link AuthenticationHandler}
+   * to perform user authentication.
+   *
+   * @param request request object.
+   * @return the Authentication token if the request is authenticated, <code>null</code> otherwise.
+   * @throws IOException             thrown if an IO error occurred.
+   * @throws AuthenticationException thrown if the token is invalid or if it has expired.
+   */
+  protected AuthenticationToken getToken(HttpServletRequest request)
+      throws AuthenticationException {
+    AuthenticationToken token;
+    Cookie[] cookies = request.getCookies();
+    token = getTokenFromCookies(cookies);
+    return token;
+  }
+
+  public static AuthenticationToken getTokenFromCookies(Cookie[] cookies)
+      throws AuthenticationException {
+    AuthenticationToken token = null;
+    String tokenStr = null;
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals(AuthenticatedURL.AUTH_COOKIE)) {
+          tokenStr = cookie.getValue();
+          if (tokenStr.isEmpty()) {
+            throw new AuthenticationException("Empty token");
+          }
+          try {
+            tokenStr = signer.verifyAndExtract(tokenStr);
+          } catch (SignerException ex) {
+            throw new AuthenticationException(ex);
+          }
+          break;
+        }
+      }
+    }
+    if (tokenStr != null) {
+      token = AuthenticationToken.parse(tokenStr);
+      boolean match = verifyTokenType(token);
+      if (!match) {
+        throw new AuthenticationException("Invalid AuthenticationToken type");
+      }
+      if (token.isExpired()) {
+        throw new AuthenticationException("AuthenticationToken expired");
+      }
+    }
+    return token;
+  }
+
+  public static KerberosToken getKerberosTokenFromCookies(
+      Map<String, javax.ws.rs.core.Cookie> cookies)
+      throws org.apache.shiro.authc.AuthenticationException {
+    KerberosToken kerberosToken = null;
+    String tokenStr = null;
+    if (cookies != null) {
+      for (javax.ws.rs.core.Cookie cookie : cookies.values()) {
+        if (cookie.getName().equals(KerberosAuthenticator.AUTHORIZATION)) {
+          tokenStr = cookie.getValue();
+          if (tokenStr.isEmpty()) {
+            throw new org.apache.shiro.authc.AuthenticationException("Empty token");
+          }
+          try {
+            tokenStr = tokenStr.substring(KerberosAuthenticator.NEGOTIATE.length()).trim();
+          } catch (Exception ex) {
+            throw new org.apache.shiro.authc.AuthenticationException(ex);
+          }
+          break;
+        }
+      }
+    }
+    if (tokenStr != null) {
+      try {
+        AuthenticationToken authToken = AuthenticationToken.parse(tokenStr);
+        boolean match = verifyTokenType(authToken);
+        if (!match) {
+          throw new
+              org.apache.shiro.authc.AuthenticationException("Invalid AuthenticationToken type");
+        }
+        if (authToken.isExpired()) {
+          throw new org.apache.shiro.authc.AuthenticationException("AuthenticationToken expired");
+        }
+        kerberosToken = new KerberosToken(authToken.getUserName(), tokenStr);
+      } catch (AuthenticationException ex) {
+        throw new org.apache.shiro.authc.AuthenticationException(ex);
+      }
+    }
+    return kerberosToken;
+  }
+
+  /**
+   * This method verifies if the specified token type matches one of the the
+   * token types supported by our Authentication provider : {@link KerberosRealm}
+   *
+   * @param token The token whose type needs to be verified.
+   * @return true   If the token type matches one of the supported token types
+   * false  Otherwise
+   */
+  protected static boolean verifyTokenType(AuthenticationToken token) {
+    return getType().equals(token.getType());
+  }
+
+  /**
+   * Delegates call to the servlet filter chain. Sub-classes my override this
+   * method to perform pre and post tasks.
+   *
+   * @param filterChain the filter chain object.
+   * @param request     the request object.
+   * @param response    the response object.
+   * @throws IOException      thrown if an IO error occurred.
+   * @throws ServletException thrown if a processing error occurred.
+   */
+  protected void doFilter(FilterChain filterChain, HttpServletRequest request,
+                          HttpServletResponse response) throws IOException, ServletException {
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * Creates the Hadoop authentication HTTP cookie.
+   *
+   * @param resp               the response object.
+   * @param token              authentication token for the cookie.
+   * @param domain             the cookie domain.
+   * @param path               the cookie path.
+   * @param expires            UNIX timestamp that indicates the expire date of the
+   *                           cookie. It has no effect if its value &lt; 0.
+   * @param isSecure           is the cookie secure?
+   * @param isCookiePersistent whether the cookie is persistent or not.
+   *                           <p>
+   *                           XXX the following code duplicate some logic in Jetty / Servlet API,
+   *                           because of the fact that Hadoop is stuck at servlet 2.5 and jetty 6
+   *                           right now.
+   */
+  public static void createAuthCookie(HttpServletResponse resp, String token,
+                                      String domain, String path, long expires,
+                                      boolean isCookiePersistent,
+                                      boolean isSecure) {
+    StringBuilder sb = new StringBuilder(AuthenticatedURL.AUTH_COOKIE)
+        .append("=");
+    if (token != null && token.length() > 0) {
+      sb.append("\"").append(token).append("\"");
+    }
+
+    if (path != null) {
+      sb.append("; Path=").append(path);
+    }
+
+    if (domain != null) {
+      sb.append("; Domain=").append(domain);
+    }
+
+    if (expires >= 0 && isCookiePersistent) {
+      Date date = new Date(expires);
+      SimpleDateFormat df = new SimpleDateFormat("EEE, " +
+          "dd-MMM-yyyy HH:mm:ss zzz");
+      df.setTimeZone(TimeZone.getTimeZone("GMT"));
+      sb.append("; Expires=").append(df.format(date));
+    }
+
+    if (isSecure) {
+      sb.append("; Secure");
+    }
+
+    sb.append("; HttpOnly");
+    resp.addHeader("Set-Cookie", sb.toString());
+  }
+
+  protected Properties getConfiguration() {
+    Properties props = new Properties();
+    props.put(COOKIE_DOMAIN, cookieDomain);
+    props.put(COOKIE_PATH, cookiePath);
+    props.put(COOKIE_PERSISTENT, isCookiePersistent);
+    props.put(SIGNER_SECRET_PROVIDER, "file");
+    props.put(SIGNATURE_SECRET_FILE, signatureSecretFile);
+    props.put(AUTH_TYPE, type);
+    props.put(AUTH_TOKEN_VALIDITY, tokenValidity);
+    props.put(AUTH_TOKEN_MAX_INACTIVE_INTERVAL, tokenMaxInactiveInterval);
+    props.put(PRINCIPAL, principal);
+    props.put(KEYTAB, keytab);
+    props.put(NAME_RULES, nameRules);
+    return props;
+  }
+
+  /**
+   * Returns the max inactive interval time of the generated tokens.
+   *
+   * @return the max inactive interval time of the generated tokens in seconds.
+   */
+  protected long getTokenMaxInactiveInterval() {
+    return tokenMaxInactiveInterval / 1000;
+  }
+
+  /**
+   * Returns the tokenValidity time of the generated tokens.
+   *
+   * @return the tokenValidity time of the generated tokens, in seconds.
+   */
+  protected long getTokenValidity() {
+    return tokenValidity / 1000;
+  }
+
+  /**
+   * Returns the cookie domain to use for the HTTP cookie.
+   *
+   * @return the cookie domain to use for the HTTP cookie.
+   */
+  protected String getCookieDomain() {
+    return cookieDomain;
+  }
+
+  /**
+   * Returns the cookie path to use for the HTTP cookie.
+   *
+   * @return the cookie path to use for the HTTP cookie.
+   */
+  protected String getCookiePath() {
+    return cookiePath;
+  }
+
+  /**
+   * Returns the cookie persistence to use for the HTTP cookie.
+   *
+   * @return the cookie persistence to use for the HTTP cookie.
+   */
+  public boolean isCookiePersistent() {
+    return isCookiePersistent;
+  }
+
+  public void setTokenMaxInactiveInterval(long tokenMaxInactiveInterval) {
+    this.tokenMaxInactiveInterval = tokenMaxInactiveInterval * 1000;
+  }
+
+  public void setTokenValidity(long tokenValidity) {
+    this.tokenValidity = tokenValidity * 1000;
+  }
+
+  public void setCookieDomain(String cookieDomain) {
+    this.cookieDomain = cookieDomain;
+  }
+
+  public void setCookiePath(String cookiePath) {
+    this.cookiePath = cookiePath;
+  }
+
+  public void setCookiePersistent(boolean cookiePersistent) {
+    isCookiePersistent = cookiePersistent;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public void setPrincipal(String principal) {
+    this.principal = principal;
+  }
+
+  public void setKeytab(String keytab) {
+    this.keytab = keytab;
+  }
+
+  public String getNameRules() {
+    return nameRules;
+  }
+
+  public void setNameRules(String nameRules) {
+    this.nameRules = nameRules;
+  }
+
+  public String getSignatureSecretFile() {
+    return signatureSecretFile;
+  }
+
+  public void setSignatureSecretFile(String signatureSecretFile) {
+    this.signatureSecretFile = signatureSecretFile;
+  }
+
+  /**
+   * Releases any resources initialized by the authentication handler.
+   * <p>
+   * It destroys the Kerberos context.
+   */
+  public void destroy() {
+    keytab = null;
+    serverSubject = null;
+
+    if (secretProvider != null && destroySecretProvider) {
+      secretProvider.destroy();
+      secretProvider = null;
+    }
+  }
+
+  /**
+   * Returns the authentication type of the authentication handler, 'kerberos'.
+   * <p>
+   *
+   * @return the authentication type of the authentication handler, 'kerberos'.
+   */
+  public static String getType() {
+    return type;
+  }
+
+  /**
+   * Returns the Kerberos principals used by the authentication handler.
+   *
+   * @return the Kerberos principals used by the authentication handler.
+   */
+  protected Set<KerberosPrincipal> getPrincipals() {
+    return serverSubject.getPrincipals(KerberosPrincipal.class);
+  }
+
+  /**
+   * Returns the keytab used by the authentication handler.
+   *
+   * @return the keytab used by the authentication handler.
+   */
+  protected String getKeytab() {
+    return keytab;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosToken.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosToken.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.realm.kerberos;
+
+import org.apache.shiro.authc.AuthenticationToken;
+
+/**
+ * Created for org.apache.zeppelin.server
+ */
+public class KerberosToken implements AuthenticationToken {
+  private Object userId;
+  private String token;
+
+  public KerberosToken(Object userId, String token) {
+    this.userId = userId;
+    this.token = token;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return getUserId();
+  }
+
+  @Override
+  public Object getCredentials() {
+    return getToken();
+  }
+
+  public Object getUserId() {
+    return userId;
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.realm.kerberos;
 
 import static org.apache.hadoop.util.PlatformName.IBM_JAVA;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
@@ -31,7 +31,10 @@ import javax.security.auth.kerberos.KerberosTicket;
 import javax.security.auth.kerberos.KeyTab;
 
 /**
- * Created by prabhjyot.singh on 03/12/18.
+ * Created for {@link KerberosRealm}, from
+ * org.apache.hadoop.security.authentication.util.KerberosUtil
+ *
+ * TODO(vr): This should be removed once we move to Apache Hadoop 2.8+
  */
 public class KerberosUtil {
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosUtil.java
@@ -1,0 +1,447 @@
+package org.apache.zeppelin.realm.kerberos;
+
+import static org.apache.hadoop.util.PlatformName.IBM_JAVA;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.charset.IllegalCharsetNameException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.directory.server.kerberos.shared.keytab.Keytab;
+import org.apache.directory.server.kerberos.shared.keytab.KeytabEntry;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.Oid;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosTicket;
+import javax.security.auth.kerberos.KeyTab;
+
+/**
+ * Created by prabhjyot.singh on 03/12/18.
+ */
+public class KerberosUtil {
+
+  /* Return the Kerberos login module name */
+  public static String getKrb5LoginModuleName() {
+    return System.getProperty("java.vendor").contains("IBM")
+      ? "com.ibm.security.auth.module.Krb5LoginModule"
+      : "com.sun.security.auth.module.Krb5LoginModule";
+  }
+
+  public static final Oid GSS_SPNEGO_MECH_OID =
+    getNumericOidInstance("1.3.6.1.5.5.2");
+  public static final Oid GSS_KRB5_MECH_OID =
+    getNumericOidInstance("1.2.840.113554.1.2.2");
+  public static final Oid NT_GSS_KRB5_PRINCIPAL_OID =
+    getNumericOidInstance("1.2.840.113554.1.2.2.1");
+
+  // numeric oids will never generate a GSSException for a malformed oid.
+  // use to initialize statics.
+  private static Oid getNumericOidInstance(String oidName) {
+    try {
+      return new Oid(oidName);
+    } catch (GSSException ex) {
+      throw new IllegalArgumentException(ex);
+    }
+  }
+
+  public static Oid getOidInstance(String oidName)
+    throws ClassNotFoundException, GSSException, NoSuchFieldException,
+    IllegalAccessException {
+    Class<?> oidClass;
+    if (IBM_JAVA) {
+      if ("NT_GSS_KRB5_PRINCIPAL".equals(oidName)) {
+        // IBM JDK GSSUtil class does not have field for krb5 principal oid
+        return new Oid("1.2.840.113554.1.2.2.1");
+      }
+      oidClass = Class.forName("com.ibm.security.jgss.GSSUtil");
+    } else {
+      oidClass = Class.forName("sun.security.jgss.GSSUtil");
+    }
+    Field oidField = oidClass.getDeclaredField(oidName);
+    return (Oid)oidField.get(oidClass);
+  }
+
+  public static String getDefaultRealm()
+    throws ClassNotFoundException, NoSuchMethodException,
+    IllegalArgumentException, IllegalAccessException,
+    InvocationTargetException {
+    Object kerbConf;
+    Class<?> classRef;
+    Method getInstanceMethod;
+    Method getDefaultRealmMethod;
+    if (System.getProperty("java.vendor").contains("IBM")) {
+      classRef = Class.forName("com.ibm.security.krb5.internal.Config");
+    } else {
+      classRef = Class.forName("sun.security.krb5.Config");
+    }
+    getInstanceMethod = classRef.getMethod("getInstance", new Class[0]);
+    kerbConf = getInstanceMethod.invoke(classRef, new Object[0]);
+    getDefaultRealmMethod = classRef.getDeclaredMethod("getDefaultRealm",
+      new Class[0]);
+    return (String)getDefaultRealmMethod.invoke(kerbConf, new Object[0]);
+  }
+
+  public static String getDefaultRealmProtected() {
+    String realmString = null;
+    try {
+      realmString = getDefaultRealm();
+    } catch (RuntimeException rte) {
+      //silently catch everything
+    } catch (Exception e) {
+      //silently return null
+    }
+    return realmString;
+  }
+
+  /*
+   * For a Service Host Principal specification, map the host's domain
+   * to kerberos realm, as specified by krb5.conf [domain_realm] mappings.
+   * Unfortunately the mapping routines are private to the security.krb5
+   * package, so have to construct a PrincipalName instance to derive the realm.
+   *
+   * Many things can go wrong with Kerberos configuration, and this is not
+   * the place to be throwing exceptions to help debug them.  Nor do we choose
+   * to make potentially voluminous logs on every call to a communications API.
+   * So we simply swallow all exceptions from the underlying libraries and
+   * return null if we can't get a good value for the realmString.
+   *
+   * @param shortprinc A service principal name with host fqdn as instance, e.g.
+   *     "HTTP/myhost.mydomain"
+   * @return String value of Kerberos realm, mapped from host fqdn
+   *     May be default realm, or may be null.
+   */
+  public static String getDomainRealm(String shortprinc) {
+    Class<?> classRef;
+    Object principalName; //of type sun.security.krb5.PrincipalName or IBM equiv
+    String realmString = null;
+    try {
+      if (System.getProperty("java.vendor").contains("IBM")) {
+        classRef = Class.forName("com.ibm.security.krb5.PrincipalName");
+      } else {
+        classRef = Class.forName("sun.security.krb5.PrincipalName");
+      }
+      int tKrbNtSrvHst = classRef.getField("KRB_NT_SRV_HST").getInt(null);
+      principalName = classRef.getConstructor(String.class, int.class).
+        newInstance(shortprinc, tKrbNtSrvHst);
+      realmString = (String)classRef.getMethod("getRealmString", new Class[0]).
+        invoke(principalName, new Object[0]);
+    } catch (RuntimeException rte) {
+      //silently catch everything
+    } catch (Exception e) {
+      //silently return default realm (which may itself be null)
+    }
+    if (null == realmString || realmString.equals("")) {
+      return getDefaultRealmProtected();
+    } else {
+      return realmString;
+    }
+  }
+
+  /* Return fqdn of the current host */
+  static String getLocalHostName() throws UnknownHostException {
+    return InetAddress.getLocalHost().getCanonicalHostName();
+  }
+
+  /**
+   * Create Kerberos principal for a given service and hostname,
+   * inferring realm from the fqdn of the hostname. It converts
+   * hostname to lower case. If hostname is null or "0.0.0.0", it uses
+   * dynamically looked-up fqdn of the current host instead.
+   * If domain_realm mappings are inadequately specified, it will
+   * use default_realm, per usual Kerberos behavior.
+   * If default_realm also gives a null value, then a principal
+   * without realm will be returned, which by Kerberos definitions is
+   * just another way to specify default realm.
+   *
+   * @param service
+   *          Service for which you want to generate the principal.
+   * @param hostname
+   *          Fully-qualified domain name.
+   * @return Converted Kerberos principal name.
+   * @throws UnknownHostException
+   *           If no IP address for the local host could be found.
+   */
+  public static final String getServicePrincipal(String service,
+    String hostname)
+    throws UnknownHostException {
+    String fqdn = hostname;
+    String shortprinc = null;
+    String realmString = null;
+    if (null == fqdn || fqdn.equals("") || fqdn.equals("0.0.0.0")) {
+      fqdn = getLocalHostName();
+    }
+    // convert hostname to lowercase as kerberos does not work with hostnames
+    // with uppercase characters.
+    fqdn = fqdn.toLowerCase(Locale.ENGLISH);
+    shortprinc = service + "/" + fqdn;
+    // Obtain the realm name inferred from the domain of the host
+    realmString = getDomainRealm(shortprinc);
+    if (null == realmString || realmString.equals("")) {
+      return shortprinc;
+    } else {
+      return shortprinc + "@" + realmString;
+    }
+  }
+
+  /**
+   * Get all the unique principals present in the keytabfile.
+   *
+   * @param keytabFileName
+   *          Name of the keytab file to be read.
+   * @return list of unique principals in the keytab.
+   * @throws IOException
+   *          If keytab entries cannot be read from the file.
+   */
+  static final String[] getPrincipalNames(String keytabFileName) throws IOException {
+    Keytab keytab = Keytab.read(new File(keytabFileName));
+    Set<String> principals = new HashSet<String>();
+    List<KeytabEntry> entries = keytab.getEntries();
+    for (KeytabEntry entry: entries){
+      principals.add(entry.getPrincipalName().replace("\\", "/"));
+    }
+    return principals.toArray(new String[0]);
+  }
+
+  /**
+   * Get all the unique principals from keytabfile which matches a pattern.
+   *
+   * @param keytab Name of the keytab file to be read.
+   * @param pattern pattern to be matched.
+   * @return list of unique principals which matches the pattern.
+   * @throws IOException if cannot get the principal name
+   */
+  public static final String[] getPrincipalNames(String keytab,
+    Pattern pattern) throws IOException {
+    String[] principals = getPrincipalNames(keytab);
+    if (principals.length != 0) {
+      List<String> matchingPrincipals = new ArrayList<String>();
+      for (String principal : principals) {
+        if (pattern.matcher(principal).matches()) {
+          matchingPrincipals.add(principal);
+        }
+      }
+      principals = matchingPrincipals.toArray(new String[0]);
+    }
+    return principals;
+  }
+
+  /**
+   * Check if the subject contains Kerberos keytab related objects.
+   * The Kerberos keytab object attached in subject has been changed
+   * from KerberosKey (JDK 7) to KeyTab (JDK 8)
+   *
+   *
+   * @param subject subject to be checked
+   * @return true if the subject contains Kerberos keytab
+   */
+  public static boolean hasKerberosKeyTab(Subject subject) {
+    return !subject.getPrivateCredentials(KeyTab.class).isEmpty();
+  }
+
+  /**
+   * Check if the subject contains Kerberos ticket.
+   *
+   *
+   * @param subject subject to be checked
+   * @return true if the subject contains Kerberos ticket
+   */
+  public static boolean hasKerberosTicket(Subject subject) {
+    return !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
+  }
+
+  /**
+   * Extract the TGS server principal from the given gssapi kerberos or spnego
+   * wrapped token.
+   * @param rawToken bytes of the gss token
+   * @return String of server principal
+   * @throws IllegalArgumentException if token is undecodable
+   */
+  public static String getTokenServerName(byte[] rawToken) {
+    // subsequent comments include only relevant portions of the kerberos
+    // DER encoding that will be extracted.
+    DER token = new DER(rawToken);
+    // InitialContextToken ::= [APPLICATION 0] IMPLICIT SEQUENCE {
+    //     mech   OID
+    //     mech-token  (NegotiationToken or InnerContextToken)
+    // }
+    DER oid = token.next();
+    if (oid.equals(DER.SPNEGO_MECH_OID)) {
+      // NegotiationToken ::= CHOICE {
+      //     neg-token-init[0] NegTokenInit
+      // }
+      // NegTokenInit ::= SEQUENCE {
+      //     mech-token[2]     InitialContextToken
+      // }
+      token = token.next().get(0xa0, 0x30, 0xa2, 0x04).next();
+      oid = token.next();
+    }
+    if (!oid.equals(DER.KRB5_MECH_OID)) {
+      throw new IllegalArgumentException("Malformed gss token");
+    }
+    // InnerContextToken ::= {
+    //     token-id[1]
+    //     AP-REQ
+    // }
+    if (token.next().getTag() != 1) {
+      throw new IllegalArgumentException("Not an AP-REQ token");
+    }
+    // AP-REQ ::= [APPLICATION 14] SEQUENCE {
+    //     ticket[3]      Ticket
+    // }
+    DER ticket = token.next().get(0x6e, 0x30, 0xa3, 0x61, 0x30);
+    // Ticket ::= [APPLICATION 1] SEQUENCE {
+    //     realm[1]       String
+    //     sname[2]       PrincipalName
+    // }
+    // PrincipalName ::= SEQUENCE {
+    //     name-string[1] SEQUENCE OF String
+    // }
+    String realm = ticket.get(0xa1, 0x1b).getAsString();
+    DER names = ticket.get(0xa2, 0x30, 0xa1, 0x30);
+    StringBuilder sb = new StringBuilder();
+    while (names.hasNext()) {
+      if (sb.length() > 0) {
+        sb.append('/');
+      }
+      sb.append(names.next().getAsString());
+    }
+    return sb.append('@').append(realm).toString();
+  }
+
+  // basic ASN.1 DER decoder to traverse encoded byte arrays.
+  private static class DER implements Iterator<DER> {
+    static final DER SPNEGO_MECH_OID = getDER(GSS_SPNEGO_MECH_OID);
+    static final DER KRB5_MECH_OID = getDER(GSS_KRB5_MECH_OID);
+
+    private static DER getDER(Oid oid) {
+      try {
+        return new DER(oid.getDER());
+      } catch (GSSException ex) {
+        // won't happen.  a proper OID is encodable.
+        throw new IllegalArgumentException(ex);
+      }
+    }
+
+    private final int tag;
+    private final ByteBuffer bb;
+
+    DER(byte[] buf) {
+      this(ByteBuffer.wrap(buf));
+    }
+
+    DER(ByteBuffer srcbb) {
+      tag = srcbb.get() & 0xff;
+      int length = readLength(srcbb);
+      bb = srcbb.slice();
+      bb.limit(length);
+      srcbb.position(srcbb.position() + length);
+    }
+
+    int getTag() {
+      return tag;
+    }
+
+    // standard ASN.1 encoding.
+    private static int readLength(ByteBuffer bb) {
+      int length = bb.get();
+      if ((length & (byte)0x80) != 0) {
+        int varlength = length & 0x7f;
+        length = 0;
+        for (int i=0; i < varlength; i++) {
+          length = (length << 8) | (bb.get() & 0xff);
+        }
+      }
+      return length;
+    }
+
+    DER choose(int subtag) {
+      while (hasNext()) {
+        DER der = next();
+        if (der.getTag() == subtag) {
+          return der;
+        }
+      }
+      return null;
+    }
+
+    DER get(int... tags) {
+      DER der = this;
+      for (int i=0; i < tags.length; i++) {
+        int expectedTag = tags[i];
+        // lookup for exact match, else scan if it's sequenced.
+        if (der.getTag() != expectedTag) {
+          der = der.hasNext() ? der.choose(expectedTag) : null;
+        }
+        if (der == null) {
+          StringBuilder sb = new StringBuilder("Tag not found:");
+          for (int ii=0; ii <= i; ii++) {
+            sb.append(" 0x").append(Integer.toHexString(tags[ii]));
+          }
+          throw new IllegalStateException(sb.toString());
+        }
+      }
+      return der;
+    }
+
+    String getAsString() {
+      try {
+        return new String(bb.array(), bb.arrayOffset() + bb.position(),
+          bb.remaining(), "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        throw new IllegalCharsetNameException("UTF-8"); // won't happen.
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * tag + bb.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return (o instanceof DER) &&
+        tag == ((DER)o).tag && bb.equals(((DER)o).bb);
+    }
+
+    @Override
+    public boolean hasNext() {
+      // it's a sequence or an embedded octet.
+      return ((tag & 0x30) != 0 || tag == 0x04) && bb.hasRemaining();
+    }
+
+    @Override
+    public DER next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      return new DER(bb);
+    }
+
+    @Override
+    public String toString() {
+      return "[tag=0x"+Integer.toHexString(tag)+" bb="+bb+"]";
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
@@ -45,6 +46,8 @@ import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.realm.jwt.JWTAuthenticationToken;
 import org.apache.zeppelin.realm.jwt.KnoxJwtRealm;
+import org.apache.zeppelin.realm.kerberos.KerberosRealm;
+import org.apache.zeppelin.realm.kerberos.KerberosToken;
 import org.apache.zeppelin.server.JsonResponse;
 import org.apache.zeppelin.service.SecurityService;
 import org.apache.zeppelin.ticket.TicketContainer;
@@ -72,7 +75,6 @@ public class LoginRestApi {
   @GET
   @ZeppelinApi
   public Response getLogin(@Context HttpHeaders headers) {
-    LOG.info("VR46: inside getLogin()");
     JsonResponse response = null;
     if (isKnoxSSOEnabled()) {
       KnoxJwtRealm knoxJwtRealm = getJTWRealm();
@@ -110,9 +112,7 @@ public class LoginRestApi {
           }
           if (null == response) {
             LOG.warn("No Kerberos token received");
-            Map<String, String> data = new HashMap<>();
-            data.put(KerberosAuthenticator.WWW_AUTHENTICATE, KerberosAuthenticator.NEGOTIATE);
-            response = new JsonResponse(Status.UNAUTHORIZED, "", data);
+            response = new JsonResponse(Status.UNAUTHORIZED, "", null);
           }
           return response.build();
         } catch (AuthenticationException e){
@@ -124,7 +124,7 @@ public class LoginRestApi {
   }
 
   private KerberosRealm getKerberosRealm() {
-    Collection realmsList = SecurityUtils.getRealmsList();
+    Collection realmsList = securityService.getRealmsList();
     if (realmsList != null) {
       for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
         Realm realm = iterator.next();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -72,6 +72,7 @@ public class LoginRestApi {
   @GET
   @ZeppelinApi
   public Response getLogin(@Context HttpHeaders headers) {
+    LOG.info("VR46: inside getLogin()");
     JsonResponse response = null;
     if (isKnoxSSOEnabled()) {
       KnoxJwtRealm knoxJwtRealm = getJTWRealm();
@@ -94,8 +95,49 @@ public class LoginRestApi {
         response = new JsonResponse(Status.OK, "", data);
       }
       return response.build();
+    } else {
+      KerberosRealm kerberosRealm = getKerberosRealm();
+      if (null != kerberosRealm) {
+        try {
+          Map<String, Cookie> cookies = headers.getCookies();
+          KerberosToken kerberosToken = KerberosRealm.getKerberosTokenFromCookies(cookies);
+          if (null != kerberosToken) {
+            Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
+            String name = (String) kerberosToken.getPrincipal();
+            if (!currentUser.isAuthenticated() || !currentUser.getPrincipal().equals(name)) {
+              response = proceedToLogin(currentUser, kerberosToken);
+            }
+          }
+          if (null == response) {
+            LOG.warn("No Kerberos token received");
+            Map<String, String> data = new HashMap<>();
+            data.put(KerberosAuthenticator.WWW_AUTHENTICATE, KerberosAuthenticator.NEGOTIATE);
+            response = new JsonResponse(Status.UNAUTHORIZED, "", data);
+          }
+          return response.build();
+        } catch (AuthenticationException e){
+          LOG.error("Error in Login: " + e);
+        }
+      }
     }
     return new JsonResponse(Status.METHOD_NOT_ALLOWED).build();
+  }
+
+  private KerberosRealm getKerberosRealm() {
+    Collection realmsList = SecurityUtils.getRealmsList();
+    if (realmsList != null) {
+      for (Iterator<Realm> iterator = realmsList.iterator(); iterator.hasNext(); ) {
+        Realm realm = iterator.next();
+        String name = realm.getClass().getName();
+
+        LOG.debug("RealmClass.getName: " + name);
+
+        if (name.equals("org.apache.zeppelin.realm.kerberos.KerberosRealm")) {
+          return (KerberosRealm) realm;
+        }
+      }
+    }
+    return null;
   }
 
   private KnoxJwtRealm getJTWRealm() {
@@ -135,6 +177,7 @@ public class LoginRestApi {
     try {
       logoutCurrentUser();
       currentUser.getSession(true);
+      LOG.info("Try to login");
       currentUser.login(token);
 
       Set<String> roles = securityService.getAssociatedRoles();
@@ -178,12 +221,14 @@ public class LoginRestApi {
   @ZeppelinApi
   public Response postLogin(@FormParam("userName") String userName,
       @FormParam("password") String password) {
+    LOG.info("userName:" + userName);
     JsonResponse response = null;
     // ticket set to anonymous for anonymous user. Simplify testing.
     Subject currentUser = org.apache.shiro.SecurityUtils.getSubject();
     if (currentUser.isAuthenticated()) {
       currentUser.logout();
     }
+    LOG.info("currentUser: " + currentUser);
     if (!currentUser.isAuthenticated()) {
 
       UsernamePasswordToken token = new UsernamePasswordToken(userName, password);


### PR DESCRIPTION
### What is this PR for?
HTTP SPNEGO (Simple and Protected GSS-API NEGOtiation) is the standard way to support Kerberos Ticket based user authentication for Web Services. With this PR, Zeppelin supports ability to authenticate users by accepting and validating their Kerberos Ticket based on Apache Hadoop Auth framework.

### What type of PR is it?
[Feature | Documentation]

### What is the Jira issue?
* [Zeppelin 3792](https://issues.apache.org/jira/browse/ZEPPELIN-3792)

### How should this be tested?
* Manual Testing
* To enable this, apply the following change in `conf/shiro.ini` under `[main]` section.
```
krbRealm = org.apache.zeppelin.realm.kerberos.KerberosRealm
krbRealm.principal=HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
krbRealm.keytab=/etc/security/keytabs/spnego.service.keytab
krbRealm.nameRules=DEFAULT
krbRealm.signatureSecretFile=/etc/security/http_secret
krbRealm.tokenValidity=36000
krbRealm.cookieDomain=domain.com
krbRealm.cookiePath=/
authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
