### PR TITLE
[ZEPPELIN-3575] Add 'Copy Column Name' to table visualisation-table 

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -256,6 +256,15 @@ export default class TableVisualization extends Visualization {
             return this.context.col.colDef.type === TableColumnType.DATE;
           },
         },
+        {
+          title: 'Copy Column Name',
+          action: function() {
+            self.copyStringToClipboard(this.context.col.displayName);
+          },
+          active: function() {
+            self.copyStringToClipboard(this.context.col.displayName);
+          },
+        },
       ];
     });
   }
@@ -514,5 +523,15 @@ export default class TableVisualization extends Visualization {
         },
       },
     };
+  }
+
+  copyStringToClipboard(copyString) {
+    const strToClipboard = document.createElement('textarea');
+    strToClipboard.value = copyString;
+    document.body.appendChild(strToClipboard);
+    strToClipboard.select();
+    document.execCommand('copy');
+    document.body.removeChild(strToClipboard);
+    return;
   }
 }

--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -230,6 +230,15 @@ export default class TableVisualization extends Visualization {
     gridOptions.columnDefs.map((colDef) => {
       colDef.menuItems = [
         {
+          title: 'Copy Column Name',
+          action: function() {
+            self.copyStringToClipboard(this.context.col.displayName);
+          },
+          active: function() {
+            return false;
+          },
+        },
+        {
           title: 'Type: String',
           action: function() {
             self.updateColDefType(this.context.col.colDef, TableColumnType.STRING);
@@ -254,15 +263,6 @@ export default class TableVisualization extends Visualization {
           },
           active: function() {
             return this.context.col.colDef.type === TableColumnType.DATE;
-          },
-        },
-        {
-          title: 'Copy Column Name',
-          action: function() {
-            self.copyStringToClipboard(this.context.col.displayName);
-          },
-          active: function() {
-            self.copyStringToClipboard(this.context.col.displayName);
           },
         },
       ];


### PR DESCRIPTION
### What is this PR for?
Add button to drop-down list in visualization table to copy column name.
I know that column name could be obtained in a different way, for example, by auto-complete.
Nevertheless I think this feature is comfortable.

### What type of PR is it?
Feature

### What is the Jira issue?
[ZEPPELIN-3575](https://issues.apache.org/jira/browse/ZEPPELIN-3575)

### How should this be tested?
* Manually

### Screenshots (if appropriate)
![zp-20](https://user-images.githubusercontent.com/6136993/48303733-168ebc00-e51f-11e8-8317-008d59a6b55e.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
