### PR TITLE
[ZEPPELIN-3095] fix UI when paragraphs run sequential (in v0.8)

### DIFF
--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -236,6 +236,12 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -385,7 +385,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     note.persist(anonymous);
     String noteId = note.getId();
 
-    note.runAll();
+    note.runAll(anonymous, true);
     // wait until job is finished or timeout.
     int timeout = 1;
     while (!paragraph.isTerminated()) {
@@ -441,7 +441,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     note.persist(anonymous);
     String noteId = note.getId();
 
-    note.runAll();
+    note.runAll(anonymous, true);
     // assume that status of the paragraph is running
     GetMethod get = httpGet("/notebook/job/" + noteId);
     assertThat("test get note job: ", get, isAllowed());
@@ -488,7 +488,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     note.persist(anonymous);
     String noteId = note.getId();
 
-    note.runAll();
+    note.runAll(anonymous, true);
 
     // Call Run paragraph REST API
     PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(),

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -232,6 +232,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="removeNote(note.id)"
                 ng-hide="viewOnly"
+                ng-class="{'disabled':isNoteRunning()}"
                 tooltip-placement="bottom" uib-tooltip="Remove this note permanently"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>
@@ -242,6 +243,7 @@ limitations under the License.
                 class="btn btn-default btn-xs"
                 ng-click="moveNoteToTrash(note.id)"
                 ng-hide="viewOnly"
+                ng-class="{'disabled':isNoteRunning()}"
                 tooltip-placement="bottom" uib-tooltip="Move this note to trash"
                 ng-disabled="revisionView">
           <i class="icon-trash"></i>

--- a/zeppelin-web/src/app/notebook/notebook.css
+++ b/zeppelin-web/src/app/notebook/notebook.css
@@ -106,6 +106,11 @@
   display: block;
 }
 
+.new-paragraph-disable{
+  color: lightgray !important;
+  cursor: default !important;
+}
+
 .plus-sign{
   display: none;
   height: 7px;

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -167,7 +167,7 @@ limitations under the License.
          ng-click="insertNew('above')"
          ng-hide="viewOnly || asIframe || revisionView"
          ng-class="{'first-paragraph': $first}">
-      <h4 class="plus-sign">&#43; Add Paragraph</h4>
+      <h4 class="plus-sign" ng-class="{'new-paragraph-disable': isNoteRunning}">&#43; Add Paragraph</h4>
     </div>
     <div id="{{currentParagraph.id}}_paragraphColumn"
          ng-include src="'app/notebook/paragraph/paragraph.html'"
@@ -177,7 +177,7 @@ limitations under the License.
          ng-dblclick="paragraphOnDoubleClick(currentParagraph.id);">
     </div>
     <div class="new-paragraph last-paragraph" ng-click="insertNew('below');" ng-hide="!$last || viewOnly || asIframe || revisionView">
-      <h4 class="plus-sign">&#43; Add Paragraph</h4>
+      <h4 class="plus-sign" ng-class="{'new-paragraph-disable': isNoteRunning}">&#43; Add Paragraph</h4>
     </div>
   </div>
   <div style="clear:both;height:10px"></div>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -47,10 +47,12 @@ limitations under the License.
     <span class="icon-control-play" style="cursor:pointer;color:#3071A9"
           tooltip-placement="top" uib-tooltip="Run this paragraph (Shift+Enter)"
           ng-click="runParagraphFromButton(getEditorValue())"
+          ng-class="{'item-disable' : isNoteRunning}"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING' && paragraph.config.enabled"></span>
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C"
           tooltip-placement="top" uib-tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
           ng-click="cancelParagraph(paragraph)"
+          ng-class="{'item-disable' : isNoteRunning}"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
     <span ng-show="paragraph.runtimeInfos.jobUrl.length == 1">
       <a href="{{paragraph.runtimeInfos.jobUrl[0]}}" target="_blank"><span class="fa fa-tasks"></span> Spark job </a>
@@ -123,25 +125,28 @@ limitations under the License.
           </a>
         </li>
         <li>
-          <a ng-click="moveUp(paragraph)" ng-hide="$first"><span class="icon-arrow-up shortcut-icon"></span>
+          <a ng-click="moveUp(paragraph)" ng-hide="$first" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="icon-arrow-up shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+K</span>
             Move up
           </a>
         </li>
         <li>
-          <a ng-click="moveDown(paragraph)" ng-hide="$last"><span class="icon-arrow-down shortcut-icon"></span>
+          <a ng-click="moveDown(paragraph)" ng-hide="$last" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="icon-arrow-down shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+J</span>
             Move down
           </a>
         </li>
         <li>
-          <a ng-click="insertNew('below')"><span class="icon-plus shortcut-icon"></span>
+          <a ng-click="insertNew('below')" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="icon-plus shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+B</span>
             Insert new
           </a>
         </li>
         <li>
-          <a ng-click="runAllToThis(paragraph)" ng-hide="$first">
+          <a ng-click="runAllToThis(paragraph)" ng-hide="$first" ng-class="{'item-disable' : isNoteRunning}">
             <span class="icon-action-redo shortcut-icon"
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
@@ -150,7 +155,7 @@ limitations under the License.
           </a>
         </li>
         <li>
-          <a ng-click="runAllFromThis(paragraph)" ng-hide="$last">
+          <a ng-click="runAllFromThis(paragraph)" ng-hide="$last" ng-class="{'item-disable' : isNoteRunning}">
             <span class="icon-action-undo shortcut-icon"
                   style="position: relative; transform: rotate(-90deg); left: -4px;">
             </span>
@@ -159,7 +164,8 @@ limitations under the License.
           </a>
         </li>
         <li>
-          <a ng-click="copyParagraph(getEditorValue())"><span class="fa fa-copy shortcut-icon"></span>
+          <a ng-click="copyParagraph(getEditorValue())" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="fa fa-copy shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+Shift+C</span>
             Clone paragraph
           </a>
@@ -190,7 +196,8 @@ limitations under the License.
           </a>
         </li>
         <li>
-          <a ng-click="toggleEnableDisable(paragraph)"><span class="icon-control-play shortcut-icon"></span>
+          <a ng-click="toggleEnableDisable(paragraph)" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="icon-control-play shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+ {{ isMac ? 'Option' : 'Alt'}}+R</span>
             {{paragraph.config.enabled ? "Disable" : "Enable"}} run
           </a>
@@ -202,14 +209,16 @@ limitations under the License.
           </a>
         </li>
         <li>
-          <a ng-click="clearParagraphOutput(paragraph)"><span class="fa fa-eraser shortcut-icon"></span>
+          <a ng-click="clearParagraphOutput(paragraph)" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="fa fa-eraser shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+L</span>
             Clear output
           </a>
         </li>
         <li>
           <!-- remove paragraph -->
-          <a ng-click="removeParagraph(paragraph)" ng-if="note.paragraphs.length > 1"><span class="fa fa-times shortcut-icon"></span>
+          <a ng-click="removeParagraph(paragraph)" ng-if="note.paragraphs.length > 1" ng-class="{'item-disable' : isNoteRunning}">
+            <span class="fa fa-times shortcut-icon"></span>
             <span class="shortcut-keys">Ctrl+{{ isMac ? 'Option' : 'Alt'}}+D</span>
             Remove
           </a>

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -42,6 +42,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   $scope.paragraph.results.msg = [];
   $scope.originalText = '';
   $scope.editor = null;
+  $scope.isNoteRunning = false;
 
   // transactional info for spell execution
   $scope.spellTransaction = {
@@ -144,10 +145,19 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       $scope.paragraph.config = {};
     }
 
+    $scope.isNoteRunning = !!(note && note.hasOwnProperty('info') &&
+      note.info.hasOwnProperty('isRunning')
+      && note.info.isRunning === true);
+
     noteVarShareService.put($scope.paragraph.id + '_paragraphScope', paragraphScope);
 
     initializeDefault($scope.paragraph.config);
   };
+
+  $scope.$on('noteRunningStatus', function(event, status) {
+    $scope.isNoteRunning = status;
+    $scope.editor.setReadOnly(status);
+  });
 
   const initializeDefault = function(config) {
     let forms = $scope.paragraph.settings.forms;
@@ -247,7 +257,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       console.log('editor isnt loaded yet, returning');
       return;
     }
-    if ($scope.revisionView === true) {
+    if ($scope.revisionView === true || $scope.isNoteRunning === true) {
       $scope.editor.setReadOnly(true);
     } else {
       $scope.editor.setReadOnly(false);
@@ -263,6 +273,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.cancelParagraph = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     console.log('Cancel %o', paragraph.id);
     websocketMsgSrv.cancelParagraphRun(paragraph.id);
   };
@@ -427,6 +440,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.toggleEnableDisable = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     paragraph.config.enabled = !paragraph.config.enabled;
     commitParagraph(paragraph);
   };
@@ -469,15 +485,24 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.runParagraphFromButton = function() {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     // we come here from the view, so we don't need to call `$digest()`
     $scope.runParagraph($scope.getEditorValue(), false, false);
   };
 
   $scope.runAllToThis = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     $scope.$emit('runAllAbove', paragraph, true);
   };
 
   $scope.runAllFromThis = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     $scope.$emit('runAllBelowAndCurrent', paragraph, true);
   };
 
@@ -516,18 +541,30 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.moveUp = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     $scope.$emit('moveParagraphUp', paragraph);
   };
 
   $scope.moveDown = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     $scope.$emit('moveParagraphDown', paragraph);
   };
 
   $scope.insertNew = function(position) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     $scope.$emit('insertParagraph', $scope.paragraph.id, position);
   };
 
   $scope.copyPara = function(position) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     let editorValue = $scope.getEditorValue();
     if (editorValue) {
       $scope.copyParagraph(editorValue, position);
@@ -535,6 +572,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.copyParagraph = function(data, position) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     let newIndex = -1;
     for (let i = 0; i < $scope.note.paragraphs.length; i++) {
       if ($scope.note.paragraphs[i].id === $scope.paragraph.id) {
@@ -560,6 +600,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.removeParagraph = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
     if ($scope.note.paragraphs.length === 1) {
       BootstrapDialog.alert({
         closable: true,
@@ -720,7 +763,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
       $scope.editor.setHighlightActiveLine(false);
       $scope.editor.getSession().setUseWrapMode(true);
       $scope.editor.setTheme('ace/theme/chrome');
-      $scope.editor.setReadOnly($scope.isRunning($scope.paragraph));
+      $scope.editor.setReadOnly($scope.isRunning($scope.paragraph) || $scope.isNoteRunning);
       $scope.editor.setHighlightActiveLine($scope.paragraphFocused);
 
       if ($scope.paragraphFocused) {
@@ -1469,7 +1512,8 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     $scope.paragraph.settings = newPara.settings;
     $scope.paragraph.runtimeInfos = newPara.runtimeInfos;
     if ($scope.editor) {
-      $scope.editor.setReadOnly($scope.isRunning(newPara));
+      let isReadOnly = $scope.isRunning(newPara) || $scope.isNoteRunning;
+      $scope.editor.setReadOnly(isReadOnly);
     }
 
     if (!$scope.asIframe) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -212,6 +212,11 @@
   float: left;
 }
 
+.item-disable {
+  color: rgba(128, 128, 128, 0.61) !important;
+  cursor: default !important;
+}
+
 .dropdown-menu .shortcut-keys {
   float: right;
   color: #999;

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -65,6 +65,8 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, ng
       $location.path('/notebook/' + data.note.id);
     } else if (op === 'NOTES_INFO') {
       $rootScope.$broadcast('setNoteMenu', data.notes);
+    } else if (op === 'NOTE_RUNNING_STATUS') {
+      $rootScope.$broadcast('noteRunningStatus', data.status);
     } else if (op === 'LIST_NOTE_JOBS') {
       $rootScope.$emit('jobmanager:set-jobs', data.noteJobs);
     } else if (op === 'LIST_UPDATE_NOTE_JOBS') {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/ParagraphJobListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/ParagraphJobListener.java
@@ -31,4 +31,7 @@ public interface ParagraphJobListener extends JobListener {
   public void onOutputAppend(Paragraph paragraph, int idx, String output);
   public void onOutputUpdate(Paragraph paragraph, int idx, InterpreterResultMessage msg);
   public void onOutputUpdateAll(Paragraph paragraph, List<InterpreterResultMessage> msgs);
+
+  //TODO(savalek) Temporary solution. Need to refactor cron to be able to notify frontend directly.
+  void noteRunningStatusChange(String noteId, boolean newStatus);
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -18,6 +18,10 @@
 package org.apache.zeppelin.notebook.socket;
 
 import com.google.gson.Gson;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.zeppelin.common.JsonSerializable;
 
 import java.util.HashMap;
@@ -186,8 +190,25 @@ public class Message implements JsonSerializable {
     PARAS_INFO,                   // [s-c] paragraph runtime infos
     SAVE_NOTE_FORMS,              // save note forms
     REMOVE_NOTE_FORMS,            // remove note forms
+    NOTE_RUNNING_STATUS,          // [s-c] sequential run status will be change
     NOTICE                        // [s-c] Notice
   }
+
+  // these messages will be ignored during the sequential run of the note
+  private static final Set<OP> disabledForRunningNoteMessages = Collections
+      .unmodifiableSet(new HashSet<>(Arrays.asList(
+          OP.COMMIT_PARAGRAPH,
+          OP.RUN_PARAGRAPH,
+          OP.RUN_PARAGRAPH_USING_SPELL,
+          OP.RUN_ALL_PARAGRAPHS,
+          OP.PARAGRAPH_CLEAR_OUTPUT,
+          OP.PARAGRAPH_CLEAR_ALL_OUTPUT,
+          OP.INSERT_PARAGRAPH,
+          OP.MOVE_PARAGRAPH,
+          OP.COPY_PARAGRAPH,
+          OP.PARAGRAPH_REMOVE,
+          OP.MOVE_NOTE_TO_TRASH,
+          OP.DEL_NOTE)));
 
   private static final Gson gson = new Gson();
   public static final Message EMPTY = new Message(null);
@@ -213,6 +234,10 @@ public class Message implements JsonSerializable {
 
   public <T> T getType(String key) {
     return (T) data.get(key);
+  }
+
+  public static boolean isDisabledForRunningNotes(OP eventType) {
+    return disabledForRunningNoteMessages.contains(eventType);
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -317,6 +317,11 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest implem
       }
 
       @Override
+      public void noteRunningStatusChange(String noteId, boolean newStatus) {
+
+      }
+
+      @Override
       public void onProgressUpdate(Job job, int progress) {
 
       }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -355,7 +355,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     p3.setText("%mock1 p3");
 
     // when
-    note.runAll();
+    note.runAll(anonymous, true);
 
     assertEquals("repl1: p1", p1.getResult().message().get(0).getData());
     assertNull(p2.getResult());
@@ -720,7 +720,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     String simpleText = "hello world";
     p.setText(simpleText);
 
-    note.runAll();
+    note.runAll(anonymous, true);
 
     String exportedNoteJson = notebook.exportNote(note.getId());
 
@@ -754,7 +754,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
 
     final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
-    note.runAll();
+    note.runAll(anonymous, true);
 
     p.setStatus(Status.RUNNING);
     Note cloneNote = notebook.cloneNote(note.getId(), "clone note", anonymous);
@@ -799,7 +799,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
 
     final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
-    note.runAll();
+    note.runAll(anonymous, true);
 
     // Force paragraph to have String type object
     p.setResult("Exception");
@@ -827,7 +827,7 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
     for (InterpreterGroup intpGroup : interpreterSettingManager.getAllInterpreterGroup()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
     }
-    note.runAll();
+    note.runAll(anonymous, true);
 
     assertEquals(2, interpreterSettingManager.getAllResources().size());
 
@@ -1499,6 +1499,11 @@ public class NotebookTest extends AbstractInterpreterTest implements JobListener
 
       @Override
       public void onOutputUpdateAll(Paragraph paragraph, List<InterpreterResultMessage> msgs) {
+
+      }
+
+      @Override
+      public void noteRunningStatusChange(String noteId, boolean newStatus) {
 
       }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -424,6 +424,11 @@ public class NotebookRepoSyncTest implements JobListenerFactory {
       }
 
       @Override
+      public void noteRunningStatusChange(String noteId, boolean newStatus) {
+
+      }
+
+      @Override
       public void onProgressUpdate(Job job, int progress) {
       }
 


### PR DESCRIPTION
### What is this PR for?
This PR fixes the incorrect behavior of UI during the execution of the RunAllParagraphs. 
Including: allows you to copy the note at runtime (before that, the new note was created only after the end of runAllParagraph), blocks some interface elements.
The following items are blocked:

**Paragraphs Control :**
* Move up
* Move down
* Insert new
* Clone paragraph
* Run all above
* Run all below
* Disable run
* Remove

**Note :**
* Insert new paragraph

### What type of PR is it?
Improvement

### What is the Jira issue?
[Zeppelin-3095](https://issues.apache.org/jira/browse/ZEPPELIN-3095)
[ZP-25]

### GIF
![peek 2018-11-12 16-20](https://user-images.githubusercontent.com/30798933/48350794-511c6400-e699-11e8-952a-76a4dcc9e7b0.gif)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
