### PR TITLE
Upgrade Jetty version to the latest version - 9.4.14.v20181114

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <libthrift.version>0.9.3</libthrift.version>
     <gson.version>2.2</gson.version>
     <gson-extras.version>0.2.1</gson-extras.version>
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>9.4.14.v20181114</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.1</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>


### PR DESCRIPTION
### What is this PR for?
Our service frequently failed because of exception from the websocket.

Upgrade to the latest Jetty version to fix the hang issue if the websocket endpoint is invalid.

9.4.14.v20181114

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.14.v20181114

9.4.13.v20181111

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.13.v20181111
+ 2875 Fix WebSocketClient.connect() hang when attempting to connect at an
invalid websocket endpoint
 
### What type of PR is it?
Bug Fix & Improvement 

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3902
Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-3902]

### How should this be tested?
Tested in the dev server and production

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
