### PR TITLE
ZEPPELIN-3907. Add code statement into Spark JobGroup Id for SparkInterpreter

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -78,7 +78,6 @@ public class SparkSqlInterpreter extends Interpreter {
       Method method = sqlc.getClass().getMethod("sql", String.class);
       String msg = sparkInterpreter.getZeppelinContext().showData(
           method.invoke(sqlc, effectiveSQL));
-      sc.clearJobGroup();
       return new InterpreterResult(Code.SUCCESS, msg);
     } catch (Exception e) {
       if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace"))) {
@@ -88,6 +87,8 @@ public class SparkSqlInterpreter extends Interpreter {
       String msg = e.getMessage()
               + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
       return new InterpreterResult(Code.ERROR, msg);
+    } finally {
+      sc.clearJobGroup();
     }
   }
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/Utils.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/Utils.java
@@ -103,7 +103,7 @@ class Utils {
   static boolean isScala2_11() {
     return !isScala2_10();
   }
-  
+
   static boolean isCompilerAboveScala2_11_7() {
     if (isScala2_10() || SCALA_COMPILER_VERSION == null) {
       return false;
@@ -147,9 +147,11 @@ class Utils {
       return false;
     }
   }
-  
+
   public static String buildJobGroupId(InterpreterContext context) {
-    return "zeppelin-" + context.getNoteId() + "-" + context.getParagraphId();
+    return "zeppelin-" + context.getNoteId() + "-" + context.getParagraphId() + "\n" +
+            context.getParagraphText().substring(0,
+                    context.getParagraphText().length() > 200 ? 200 : context.getParagraphText().length());
   }
 
   public static String buildJobDesc(InterpreterContext context) {


### PR DESCRIPTION

### What is this PR for?
Straightforward change to add code statement into Spark JobGroupId, so that we can find the associated spark job in spark ui easier. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3907

### How should this be tested?
* Manually tested.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/49925345-92e83680-fef3-11e8-949c-1b97ea55724b.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
