### PR TITLE
Fix Date Sorting issue

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-nvd3chart.js
@@ -164,6 +164,18 @@ export default class Nvd3ChartVisualization extends Visualization {
     let rowIndexValue = {};
 
     for (let k in rows) {
+    let rowKeys = Object.keys(rows);
+    let isNumberKey = false;
+
+    rowKeys.sort(function(a, b) {
+      if (!isNaN(a) && !isNaN(b) && typeof Number(a) === 'number' && typeof Number(b) === 'number') {
+        isNumberKey = true;
+        return a-b;
+      }
+    });
+    rowKeys = isNumberKey ? rowKeys : Object.keys(rows);
+    for (let i=0; i<rowKeys.length; i++) {
+      let k = rowKeys[i];
       if (rows.hasOwnProperty(k)) {
         traverse(sKey, schema[sKey], k, rows[k], function(rowName, rowValue, colName, value) {
           // console.log("RowName=%o, row=%o, col=%o, value=%o", rowName, rowValue, colName, value);


### PR DESCRIPTION
### What is this PR for?
When plotting a histogram, Zeppelin does not order the x variable correctly, making the plot incorrect.

I have attached screenshots of both histograms below.

It seems that Zeppelin is putting numbers with no decimal places to the left (as if the were smaller) than numbers with decimal places. I tried casting the x axis value to a float but the problem persists.ns.html


### What type of PR is it?
[Bug Fix]

### Todos
N/A

### What is the Jira issue?
[ZEPPELIN-3908]
https://issues.apache.org/jira/browse/ZEPPELIN-3908

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
It is in the Jira

### Questions:
* Does the licenses files need update? n/a
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
