### PR TITLE
[ZEPPELIN-3919] Paragraph config default value can be customized

### DIFF
--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -118,6 +118,12 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
       "language": "your-syntax-highlight-language",
       "editOnDblClick": false,
       "completionKey": "TAB"
+    },
+    "config": {
+      "fontSize": 9,
+      "colWidth": 12,
+      "runOnSelectionChange": true/false,
+      "title": true/false
     }
   },
   {
@@ -183,6 +189,25 @@ Currently `TAB` is only available option.
 }
 ```
 
+### Notebook paragraph display title (Optional)
+The notebook paragraph does not display the title by default.
+You can have the title of the notebook display the title by `config.title=true`.
+
+```json
+"config": {
+  "title": true  # default: false
+}
+```
+
+### Notebook run on selection change (Optional)
+The dynamic form in the notebook triggers execution when the selection is modified.
+You can make the dynamic form in the notebook not trigger execution after selecting the modification by setting `config.runOnSelectionChange=false`.
+
+```json
+"config": {
+  "runOnSelectionChange": false # default: true
+}
+```
 
 ## Install your interpreter binary
 

--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -120,8 +120,6 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
       "completionKey": "TAB"
     },
     "config": {
-      "fontSize": 9,
-      "colWidth": 12,
       "runOnSelectionChange": true/false,
       "title": true/false
     }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -549,6 +549,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
               CoreMatchers.equalTo("Hello world"));
 
       runParagraph(1);
+      ZeppelinITUtils.sleep(1000, false);
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Only after running the paragraph, we can see the newly updated output",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/Interpreter.java
@@ -419,6 +419,7 @@ public abstract class Interpreter {
     private boolean defaultInterpreter;
     private Map<String, DefaultInterpreterProperty> properties;
     private Map<String, Object> editor;
+    private Map<String, Object> config;
     private String path;
     private InterpreterOption option;
     private InterpreterRunner runner;
@@ -485,6 +486,14 @@ public abstract class Interpreter {
 
     public InterpreterRunner getRunner() {
       return runner;
+    }
+
+    public Map<String, Object> getConfig() {
+      return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+      this.config = config;
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
@@ -33,11 +33,12 @@ public class InterpreterInfo {
   private Map<String, Object> config;
 
   public InterpreterInfo(String className, String name, boolean defaultInterpreter,
-      Map<String, Object> editor) {
+                         Map<String, Object> editor, Map<String, Object> config) {
     this.className = className;
     this.name = name;
     this.defaultInterpreter = defaultInterpreter;
     this.editor = editor;
+    this.config = config;
   }
 
   public String getName() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterInfo.java
@@ -30,6 +30,7 @@ public class InterpreterInfo {
   @SerializedName("class") private String className;
   private boolean defaultInterpreter = false;
   private Map<String, Object> editor;
+  private Map<String, Object> config;
 
   public InterpreterInfo(String className, String name, boolean defaultInterpreter,
       Map<String, Object> editor) {
@@ -78,5 +79,13 @@ public class InterpreterInfo {
     boolean sameIsDefaultInterpreter = defaultInterpreter == other.isDefaultInterpreter();
 
     return sameName && sameClassName && sameIsDefaultInterpreter;
+  }
+
+  public Map<String, Object> getConfig() {
+    return config;
+  }
+
+  public void setConfig(Map<String, Object> config) {
+    this.config = config;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -400,7 +400,8 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
       //TODO(zjffdu) merge RegisteredInterpreter & InterpreterInfo
       InterpreterInfo interpreterInfo =
           new InterpreterInfo(registeredInterpreter.getClassName(), registeredInterpreter.getName(),
-              registeredInterpreter.isDefaultInterpreter(), registeredInterpreter.getEditor());
+              registeredInterpreter.isDefaultInterpreter(), registeredInterpreter.getEditor(),
+              registeredInterpreter.getConfig());
       interpreterInfo.setConfig(registeredInterpreter.getConfig());
       group = registeredInterpreter.getGroup();
       runner = registeredInterpreter.getRunner();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -495,20 +495,22 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
     return editor;
   }
 
+  // Get configuration parameters from `interpreter-setting.json`
+  // based on the interpreter group ID
   public Map<String, Object> getConfigSetting(String interpreterGroupId) {
     InterpreterSetting interpreterSetting = get(interpreterGroupId);
     if (null != interpreterSetting) {
       List<InterpreterInfo> interpreterInfos = interpreterSetting.getInterpreterInfos();
+      int infoSize = interpreterInfos.size();
       for (InterpreterInfo intpInfo : interpreterInfos) {
-        if (intpInfo.isDefaultInterpreter() || (interpreterInfos.size() == 1)) {
-          if (intpInfo.getConfig() != null) {
-            return intpInfo.getConfig();
-          }
+        if ((intpInfo.isDefaultInterpreter() || (infoSize == 1))
+            && (intpInfo.getConfig() != null)) {
+          return intpInfo.getConfig();
         }
       }
     }
 
-    return new HashMap<String, Object>();
+    return new HashMap<>();
   }
 
   public List<ManagedInterpreterGroup> getAllInterpreterGroup() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -401,6 +401,7 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
       InterpreterInfo interpreterInfo =
           new InterpreterInfo(registeredInterpreter.getClassName(), registeredInterpreter.getName(),
               registeredInterpreter.isDefaultInterpreter(), registeredInterpreter.getEditor());
+      interpreterInfo.setConfig(registeredInterpreter.getConfig());
       group = registeredInterpreter.getGroup();
       runner = registeredInterpreter.getRunner();
       // use defaultOption if it is not specified in interpreter-setting.json
@@ -492,6 +493,22 @@ public class InterpreterSettingManager implements InterpreterSettingManagerMBean
       LOGGER.debug("Couldn't get interpreter editor setting");
     }
     return editor;
+  }
+
+  public Map<String, Object> getConfigSetting(String interpreterGroupId) {
+    InterpreterSetting interpreterSetting = get(interpreterGroupId);
+    if (null != interpreterSetting) {
+      List<InterpreterInfo> interpreterInfos = interpreterSetting.getInterpreterInfos();
+      for (InterpreterInfo intpInfo : interpreterInfos) {
+        if (intpInfo.isDefaultInterpreter() || (interpreterInfos.size() == 1)) {
+          if (intpInfo.getConfig() != null) {
+            return intpInfo.getConfig();
+          }
+        }
+      }
+    }
+
+    return new HashMap<String, Object>();
   }
 
   public List<ManagedInterpreterGroup> getAllInterpreterGroup() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -248,6 +248,10 @@ public class Note implements JsonSerializable {
     this.interpreterSettingManager = interpreterSettingManager;
   }
 
+  InterpreterSettingManager getInterpreterSettingManager() {
+    return this.interpreterSettingManager;
+  }
+
   void setParagraphJobListener(ParagraphJobListener paragraphJobListener) {
     this.paragraphJobListener = paragraphJobListener;
   }
@@ -366,6 +370,8 @@ public class Note implements JsonSerializable {
   public Paragraph insertNewParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph paragraph = new Paragraph(this, paragraphJobListener);
     if (null != interpreterSettingManager) {
+      // Set the default parameter configuration for the paragraph
+      // based on `interpreter-setting.json` config
       Map<String, Object> config =
           interpreterSettingManager.getConfigSetting(defaultInterpreterGroup);
       paragraph.setConfig(config);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -365,6 +365,11 @@ public class Note implements JsonSerializable {
    */
   public Paragraph insertNewParagraph(int index, AuthenticationInfo authenticationInfo) {
     Paragraph paragraph = new Paragraph(this, paragraphJobListener);
+    if (null != interpreterSettingManager) {
+      Map<String, Object> config =
+          interpreterSettingManager.getConfigSetting(defaultInterpreterGroup);
+      paragraph.setConfig(config);
+    }
     paragraph.setAuthenticationInfo(authenticationInfo);
     setParagraphMagic(paragraph, index);
     insertParagraph(paragraph, index);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -43,10 +43,8 @@ import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.Interpreter.FormType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
-import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
-import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterOutputListener;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -61,7 +59,6 @@ import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.JobListener;
 import org.apache.zeppelin.scheduler.JobWithProgressPoller;
-import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.apache.zeppelin.user.UserCredentials;
@@ -106,6 +103,14 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   private transient Map<String, String> localProperties = new HashMap<>();
   private transient Map<String, ParagraphRuntimeInfo> runtimeInfos = new HashMap<>();
 
+  private static String  PARAGRAPH_CONFIG_FONTSIZE = "fontSize";
+  private static int     PARAGRAPH_CONFIG_FONTSIZE_DEFAULT = 9;
+  private static String  PARAGRAPH_CONFIG_COLWIDTH = "colWidth";
+  private static int     PARAGRAPH_CONFIG_COLWIDTH_DEFAULT = 12;
+  private static String  PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE = "runOnSelectionChange";
+  private static boolean PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE_DEFAULT = true;
+  private static String  PARAGRAPH_CONFIG_TITLE = "title";
+  private static boolean PARAGRAPH_CONFIG_TITLE_DEFAULT = false;
 
   @VisibleForTesting
   Paragraph() {
@@ -603,8 +608,9 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
       newConfig = getDefaultConfigSetting();
     }
 
-    List<String> keysToRemove = Arrays.asList("fontSize", "colWidth",
-        "runOnSelectionChange", "title");
+    List<String> keysToRemove = Arrays.asList(PARAGRAPH_CONFIG_FONTSIZE,
+        PARAGRAPH_CONFIG_COLWIDTH, PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE,
+        PARAGRAPH_CONFIG_TITLE);
     for (String removeKey : keysToRemove) {
       if ((false == newConfig.containsKey(removeKey))
           && (true == config.containsKey(removeKey))) {
@@ -618,10 +624,10 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   // default parameters of the interpreter
   private Map<String, Object> getDefaultConfigSetting() {
     Map<String, Object> config = new HashMap<>();
-    config.put("fontSize", 9);
-    config.put("colWidth", 12);
-    config.put("runOnSelectionChange", true);
-    config.put("title", false);
+    config.put(PARAGRAPH_CONFIG_FONTSIZE, PARAGRAPH_CONFIG_FONTSIZE_DEFAULT);
+    config.put(PARAGRAPH_CONFIG_COLWIDTH, PARAGRAPH_CONFIG_COLWIDTH_DEFAULT);
+    config.put(PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE, PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE_DEFAULT);
+    config.put(PARAGRAPH_CONFIG_TITLE, PARAGRAPH_CONFIG_TITLE_DEFAULT);
 
     return config;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -46,7 +46,7 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
 
   @Test
   public void testInitInterpreterSettingManager() throws IOException, RepositoryException {
-    assertEquals(5, interpreterSettingManager.get().size());
+    assertEquals(6, interpreterSettingManager.get().size());
     InterpreterSetting interpreterSetting = interpreterSettingManager.getByName("test");
     assertEquals("test", interpreterSetting.getName());
     assertEquals("test", interpreterSetting.getGroup());
@@ -76,7 +76,7 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     // Load it again
     InterpreterSettingManager interpreterSettingManager2 = new InterpreterSettingManager(conf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));
-    assertEquals(5, interpreterSettingManager2.get().size());
+    assertEquals(6, interpreterSettingManager2.get().size());
     interpreterSetting = interpreterSettingManager2.getByName("test");
     assertEquals("test", interpreterSetting.getName());
     assertEquals("test", interpreterSetting.getGroup());
@@ -112,7 +112,7 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     }
 
     interpreterSettingManager.createNewSetting("test3", "test", new ArrayList<Dependency>(), option, properties);
-    assertEquals(6, interpreterSettingManager.get().size());
+    assertEquals(7, interpreterSettingManager.get().size());
     InterpreterSetting interpreterSetting = interpreterSettingManager.getByName("test3");
     assertEquals("test3", interpreterSetting.getName());
     assertEquals("test", interpreterSetting.getGroup());
@@ -134,7 +134,7 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     // load it again, it should be saved in interpreter-setting.json. So we can restore it properly
     InterpreterSettingManager interpreterSettingManager2 = new InterpreterSettingManager(conf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));
-    assertEquals(6, interpreterSettingManager2.get().size());
+    assertEquals(7, interpreterSettingManager2.get().size());
     interpreterSetting = interpreterSettingManager2.getByName("test3");
     assertEquals("test3", interpreterSetting.getName());
     assertEquals("test", interpreterSetting.getGroup());
@@ -181,12 +181,12 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
 
     // remove interpreter setting
     interpreterSettingManager.remove(interpreterSetting.getId());
-    assertEquals(5, interpreterSettingManager.get().size());
+    assertEquals(6, interpreterSettingManager.get().size());
 
     // load it again
     InterpreterSettingManager interpreterSettingManager3 = new InterpreterSettingManager(new ZeppelinConfiguration(),
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));
-    assertEquals(5, interpreterSettingManager3.get().size());
+    assertEquals(6, interpreterSettingManager3.get().size());
 
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingTest.java
@@ -32,8 +32,11 @@ public class InterpreterSettingTest {
   public void testCreateInterpreters() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.SHARED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(),
+        new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -63,8 +66,10 @@ public class InterpreterSettingTest {
   public void testSharedMode() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.SHARED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -99,8 +104,10 @@ public class InterpreterSettingTest {
   public void testPerUserScopedMode() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.SCOPED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -135,8 +142,10 @@ public class InterpreterSettingTest {
   public void testPerNoteScopedMode() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerNote(InterpreterOption.SCOPED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -171,8 +180,10 @@ public class InterpreterSettingTest {
   public void testPerUserIsolatedMode() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.ISOLATED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -207,8 +218,10 @@ public class InterpreterSettingTest {
   public void testPerNoteIsolatedMode() {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerNote(InterpreterOption.ISOLATED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -243,8 +256,10 @@ public class InterpreterSettingTest {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.ISOLATED);
     interpreterOption.setPerNote(InterpreterOption.SCOPED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -294,8 +309,10 @@ public class InterpreterSettingTest {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.ISOLATED);
     interpreterOption.setPerNote(InterpreterOption.ISOLATED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);
@@ -350,8 +367,10 @@ public class InterpreterSettingTest {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.SCOPED);
     interpreterOption.setPerNote(InterpreterOption.SCOPED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroupTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroupTest.java
@@ -41,8 +41,10 @@ public class ManagedInterpreterGroupTest {
   public void setUp() throws IOException, RepositoryException {
     InterpreterOption interpreterOption = new InterpreterOption();
     interpreterOption.setPerUser(InterpreterOption.SCOPED);
-    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(), "echo", true, new HashMap<String, Object>());
-    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(), "double_echo", false, new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo1 = new InterpreterInfo(EchoInterpreter.class.getName(),
+        "echo", true, new HashMap<String, Object>(), new HashMap<String, Object>());
+    InterpreterInfo interpreterInfo2 = new InterpreterInfo(DoubleEchoInterpreter.class.getName(),
+        "double_echo", false, new HashMap<String, Object>(), new HashMap<String, Object>());
     List<InterpreterInfo> interpreterInfos = new ArrayList<>();
     interpreterInfos.add(interpreterInfo1);
     interpreterInfos.add(interpreterInfo2);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1084,22 +1084,47 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   }
 
   @Test
-  public void testInterpreterSettingConfig() throws InterruptedException,
-      IOException, InterpreterException {
+  public void testInterpreterSettingConfig() {
+    LOGGER.info("testInterpreterSettingConfig >>> ");
     Note note = new Note("testInterpreterSettingConfig", "config_test",
-        interpreterFactory, interpreterSettingManager, null, null, new ArrayList<>());
+        interpreterFactory, interpreterSettingManager, this, credentials, new ArrayList<>());
 
-    // create three paragraphs
+    // create paragraphs
     Paragraph p1 = note.addNewParagraph(anonymous);
     Map<String, Object> config = p1.getConfig();
-    assertTrue(config.containsKey("fontSize"));
-    assertTrue(config.containsKey("colWidth"));
     assertTrue(config.containsKey("runOnSelectionChange"));
     assertTrue(config.containsKey("title"));
-    assertEquals(config.get("fontSize"), 9.0);
-    assertEquals(config.get("colWidth"), 12.0);
     assertEquals(config.get("runOnSelectionChange"), false);
     assertEquals(config.get("title"), true);
+
+    // The config_test interpreter sets the default parameters
+    // in interpreter/config_test/interpreter-setting.json
+    //    "config": {
+    //      "runOnSelectionChange": false,
+    //      "title": true
+    //    },
+    p1.setText("%config_test sleep 1000");
+    note.runAll(AuthenticationInfo.ANONYMOUS, false);
+
+    // wait until first paragraph finishes and second paragraph starts
+    while (p1.getStatus() != Status.FINISHED) Thread.yield();
+
+    // Check if the config_test interpreter default parameter takes effect
+    LOGGER.info("p1.getConfig() =  " + p1.getConfig());
+    assertEquals(config.get("runOnSelectionChange"), false);
+    assertEquals(config.get("title"), true);
+
+    // The mock1 interpreter does not set default parameters
+    p1.setText("%mock1 sleep 1000");
+    note.runAll(AuthenticationInfo.ANONYMOUS, false);
+
+    // wait until first paragraph finishes and second paragraph starts
+    while (p1.getStatus() != Status.FINISHED) Thread.yield();
+
+    // Check if the mock1 interpreter parameter is updated
+    LOGGER.info("changed intp p1.getConfig() =  " + p1.getConfig());
+    assertEquals(config.get("runOnSelectionChange"), true);
+    assertEquals(config.get("title"), false);
   }
 
   @Test

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -52,6 +52,7 @@ import org.sonatype.aether.RepositoryException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -1080,6 +1081,25 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     List<Note> user2Notes = notebook.getAllNotes(user2AndRoles);
     assertEquals(user2Notes.size(), 1);
     assertEquals(user2Notes.get(0).getId(), note.getId());
+  }
+
+  @Test
+  public void testInterpreterSettingConfig() throws InterruptedException,
+      IOException, InterpreterException {
+    Note note = new Note("testInterpreterSettingConfig", "config_test",
+        interpreterFactory, interpreterSettingManager, null, null, new ArrayList<>());
+
+    // create three paragraphs
+    Paragraph p1 = note.addNewParagraph(anonymous);
+    Map<String, Object> config = p1.getConfig();
+    assertTrue(config.containsKey("fontSize"));
+    assertTrue(config.containsKey("colWidth"));
+    assertTrue(config.containsKey("runOnSelectionChange"));
+    assertTrue(config.containsKey("title"));
+    assertEquals(config.get("fontSize"), 9.0);
+    assertEquals(config.get("colWidth"), 12.0);
+    assertEquals(config.get("runOnSelectionChange"), false);
+    assertEquals(config.get("title"), true);
   }
 
   @Test

--- a/zeppelin-zengine/src/test/resources/conf/interpreter.json
+++ b/zeppelin-zengine/src/test/resources/conf/interpreter.json
@@ -120,6 +120,30 @@
         "users": [],
         "isUserImpersonate": false
       }
+    },
+
+    "2C5EERVGA" : {
+      "group": "config_test",
+      "name": "config_test",
+      "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter1",
+      "properties": {
+      },
+      "config": {
+        "fontSize": 9,
+        "colWidth": 12,
+        "runOnSelectionChange": false,
+        "title": true
+      },
+      "option": {
+        "remote": true,
+        "port": -1,
+        "perNote": "shared",
+        "perUser": "shared",
+        "isExistingProcess": false,
+        "setPermission": false,
+        "users": [],
+        "isUserImpersonate": false
+      }
     }
   },
   "interpreterBindings": {

--- a/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
@@ -1,0 +1,26 @@
+[
+  {
+    "group": "config_test",
+    "name": "config_test",
+    "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter1",
+    "defaultInterpreter": true,
+    "properties": {
+    },
+    "config": {
+      "fontSize": 9,
+      "colWidth": 12,
+      "runOnSelectionChange": false,
+      "title": true
+    },
+    "option": {
+      "remote": true,
+      "port": -1,
+      "perNote": "shared",
+      "perUser": "shared",
+      "isExistingProcess": false,
+      "setPermission": false,
+      "users": [],
+      "isUserImpersonate": false
+    }
+  }
+]

--- a/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
@@ -7,8 +7,6 @@
     "properties": {
     },
     "config": {
-      "fontSize": 9,
-      "colWidth": 12,
       "runOnSelectionChange": false,
       "title": true
     },


### PR DESCRIPTION
### What is this PR for?

The title of the paragraph is not displayed by default, and the runOnSelectionChange check option is `ON` by default.
For added flexibility, Add the config configuration section in the interpreter-setting.json file of the interpreter. You can modify the default values with the following four options.

```
"config": {
  "fontSize": 9,
  "colWidth": 12,
  "runOnSelectionChange": false,
  "title": true
}
```

In the `hadoop submarine interpreter`, each paragraph of a notebook represents a complete module of a machine learning algorithm. The name of the algorithm name needs to be filled in through the title of the paragraph. 

**Notebook paragraph display title (Optional)**
The notebook paragraph does not display the title by default.
You can display the title by default with `config.title = true`.

**Notebook run on selection change (Optional)**
The dynamic form in the notebook triggers execution when the selection is change.
You can make the dynamic form in the notebook not trigger execution after selecting the modification by setting `config.runOnSelectionChange=false`.

### What type of PR is it?
[Improvement]

### Todos
* [x] Add paragraph config default configuration in interpreter-setting.json

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3919

### How should this be tested?
[CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/470852962)

### Screenshots (if appropriate)

![alt text](https://github.com/liuxunorg/images/blob/master/zeppelin/config-setting.gif?raw=true "config-setting")

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes