### PR TITLE
[ZEPPELIN-3931] Redisplay angularObjectBind when the note is reopened

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -549,6 +549,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
               CoreMatchers.equalTo("Hello world"));
 
       runParagraph(1);
+      ZeppelinITUtils.sleep(1000, false);
       waitForParagraph(1, "FINISHED");
       collector.checkThat("Only after running the paragraph, we can see the newly updated output",
               driver.findElement(By.xpath(getParagraphXPath(1) + "//div[contains(@class, 'text plainTextContent')]")).getText(),

--- a/zeppelin-server/src/test/resources/2E1YA3X1U/angularObject_2E1YA3X1U.zpln
+++ b/zeppelin-server/src/test/resources/2E1YA3X1U/angularObject_2E1YA3X1U.zpln
@@ -1,0 +1,188 @@
+{
+  "paragraphs": [
+    {
+      "text": "%angular\n\n\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"paragraphId\"\u003eParagraph Id: \u003c/label\u003e\n    \u003cinput type\u003d\"text\" style\u003d\"width:300px\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-model\u003d\"paragraph\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"z.runParagraph(paragraph)\"\u003e Run Paragraph\u003c/button\u003e\n\u003c/form\u003e\n\u003cbr/\u003e\n\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"paragraphId\"\u003eParagraph Id: \u003c/label\u003e\n    \u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-model\u003d\"paragraph2\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n\u003c/form\u003e",
+      "user": "anonymous",
+      "dateUpdated": "2018-12-30 11:11:13.493",
+      "config": {
+        "tableHide": false,
+        "editorSetting": {
+          "language": "sh",
+          "editOnDblClick": false,
+          "completionSupport": false
+        },
+        "colWidth": 12.0,
+        "editorMode": "ace/mode/undefined",
+        "fontSize": 9.0,
+        "editorHide": false,
+        "runOnSelectionChange": false,
+        "title": true,
+        "results": {},
+        "enabled": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "ANGULAR",
+            "data": "\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"paragraphId\"\u003eParagraph Id: \u003c/label\u003e\n    \u003cinput type\u003d\"text\" style\u003d\"width:300px\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-model\u003d\"paragraph\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"z.runParagraph(paragraph)\"\u003e Run Paragraph\u003c/button\u003e\n\u003c/form\u003e\n\u003cbr/\u003e\n\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"paragraphId\"\u003eParagraph Id: \u003c/label\u003e\n    \u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-model\u003d\"paragraph2\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n\u003c/form\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "progressUpdateIntervalMs": 500,
+      "jobName": "paragraph_1545988535211_-832334376",
+      "id": "paragraph_1545878497556_-1717616036",
+      "dateCreated": "2018-12-28 17:15:35.211",
+      "dateStarted": "2018-12-30 11:11:13.678",
+      "dateFinished": "2018-12-30 11:11:13.683",
+      "status": "FINISHED"
+    },
+    {
+      "text": "%angular\n \n\u003ch2\u003ethis : {{COMMAND_TYPE}}\u003c/h2\u003e\n\u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-value\u003d\"{{COMMAND_TYPE}}\"\u003e\u003c/input\u003e\n",
+      "user": "anonymous",
+      "dateUpdated": "2018-12-30 14:47:10.849",
+      "config": {
+        "editorSetting": {
+          "language": "sh",
+          "editOnDblClick": false,
+          "completionSupport": false
+        },
+        "colWidth": 12.0,
+        "editorMode": "ace/mode/undefined",
+        "fontSize": 9.0,
+        "runOnSelectionChange": false,
+        "title": true,
+        "results": {},
+        "enabled": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "ANGULAR",
+            "data": "\u003ch2\u003ethis : {{COMMAND_TYPE}}\u003c/h2\u003e\n\u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"paragraphId\" placeholder\u003d\"Paragraph Id ...\" ng-value\u003d\"{{COMMAND_TYPE}}\"\u003e\u003c/input\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "progressUpdateIntervalMs": 500,
+      "jobName": "paragraph_1545988535212_-2086109774",
+      "id": "paragraph_1545881601069_1553190230",
+      "dateCreated": "2018-12-28 17:15:35.212",
+      "dateStarted": "2018-12-30 14:47:10.895",
+      "dateFinished": "2018-12-30 14:47:11.690",
+      "status": "FINISHED"
+    },
+    {
+      "text": "%angular\n\n\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"superheroId\"\u003eSuper Hero: {{COMMAND_TYPE}}\u003c/label\u003e\n    \u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"superheroId\" placeholder\u003d\"Superhero name ...\" ng-model\u003d\"superhero\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"z.angularBind(\u0027COMMAND_TYPE\u0027,superhero,\u0027paragraph_1545881601069_1553190230\u0027);\"\u003e Bind\u003c/button\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"isUndefinedOrNull\"\u003e run \u003c/button\u003e  \n\u003c/form\u003e\n",
+      "user": "anonymous",
+      "dateUpdated": "2018-12-30 11:11:17.496",
+      "config": {
+        "editorSetting": {
+          "editOnDblClick": false,
+          "completionSupport": false
+        },
+        "colWidth": 12.0,
+        "editorMode": "ace/mode/undefined",
+        "fontSize": 9.0,
+        "runOnSelectionChange": false,
+        "title": false,
+        "results": {},
+        "enabled": true
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "results": {
+        "code": "SUCCESS",
+        "msg": [
+          {
+            "type": "ANGULAR",
+            "data": "\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"superheroId\"\u003eSuper Hero: {{COMMAND_TYPE}}\u003c/label\u003e\n    \u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"superheroId\" placeholder\u003d\"Superhero name ...\" ng-model\u003d\"superhero\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"z.angularBind(\u0027COMMAND_TYPE\u0027,superhero,\u0027paragraph_1545881601069_1553190230\u0027);\"\u003e Bind\u003c/button\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"isUndefinedOrNull\"\u003e run \u003c/button\u003e  \n\u003c/form\u003e"
+          }
+        ]
+      },
+      "apps": [],
+      "progressUpdateIntervalMs": 500,
+      "jobName": "paragraph_1545988535212_711026158",
+      "id": "paragraph_1545881216236_725482559",
+      "dateCreated": "2018-12-28 17:15:35.212",
+      "dateStarted": "2018-12-30 11:11:17.535",
+      "dateFinished": "2018-12-30 11:11:17.539",
+      "status": "FINISHED"
+    },
+    {
+      "text": "%angular\n\u003cform class\u003d\"form-inline\"\u003e\n  \u003cdiv class\u003d\"form-group\"\u003e\n    \u003clabel for\u003d\"superheroId\"\u003eSuper Hero: \u003c/label\u003e\n    \u003cinput type\u003d\"text\" class\u003d\"form-control\" id\u003d\"superheroId\" placeholder\u003d\"Superhero name ...\" ng-model\u003d\"superhero\"\u003e\u003c/input\u003e\n  \u003c/div\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"z.angularBind(\u0027COMMAND_TYPE\u0027,superhero,\u0027paragraph_1545881601069_1553190230\u0027);\n  z.angularBind(\u0027INPUT_PATH\u0027,superhero,\u0027paragraph_1545881601069_1553190230\u0027);z.runParagraph(\u0027paragraph_1545881601069_1553190230\u0027)\"\u003e Bind\u003c/button\u003e\n  \u003cbutton type\u003d\"submit\" class\u003d\"btn btn-primary\" ng-click\u003d\"isUndefinedOrNull\"\u003e run \u003c/button\u003e  \n\u003c/form\u003e",
+      "user": "anonymous",
+      "dateUpdated": "2018-12-28 21:58:58.034",
+      "config": {
+        "colWidth": 12.0,
+        "fontSize": 9.0,
+        "enabled": true,
+        "results": {},
+        "editorSetting": {
+          "editOnDblClick": false,
+          "completionSupport": false
+        },
+        "editorMode": "ace/mode/undefined"
+      },
+      "settings": {
+        "params": {},
+        "forms": {}
+      },
+      "apps": [],
+      "progressUpdateIntervalMs": 500,
+      "jobName": "paragraph_1545988714036_1708666246",
+      "id": "paragraph_1545988714036_1708666246",
+      "dateCreated": "2018-12-28 17:18:34.036",
+      "status": "READY"
+    }
+  ],
+  "name": "angularObject",
+  "id": "2E1YA3X1U",
+  "defaultInterpreterGroup": "angular",
+  "noteParams": {},
+  "noteForms": {},
+  "angularObjects": {
+    "angular-shared_process": [
+      {
+        "name": "COMMAND_TYPE",
+        "object": "333",
+        "noteId": "2E1YA3X1U",
+        "paragraphId": "paragraph_1545881601069_1553190230"
+      },
+      {
+        "name": "COMMAND_TYPE",
+        "object": "333",
+        "noteId": "2E1YA3X1U",
+        "paragraphId": "paragraph_1545881601069_1553190230"
+      },
+      {
+        "name": "COMMAND_TYPE",
+        "object": "4",
+        "noteId": "2E1YA3X1U",
+        "paragraphId": "paragraph_1545881601069_1553190230"
+      },
+      {
+        "name": "COMMAND_TYPE",
+        "object": "111",
+        "noteId": "2E1YA3X1U",
+        "paragraphId": "paragraph_1545881601069_1553190230"
+      }
+    ]
+  },
+  "config": {
+    "isZeppelinNotebookCronEnable": false
+  },
+  "info": {}
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -31,6 +31,7 @@ import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
+import org.apache.zeppelin.interpreter.remote.RemoteAngularObject;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.notebook.utility.IdHashes;
@@ -283,6 +284,87 @@ public class Note implements JsonSerializable {
 
   Map<String, List<AngularObject>> getAngularObjects() {
     return angularObjects;
+  }
+
+  public List<AngularObject> getAngularObjects(String intpGroupId) {
+    if (!angularObjects.containsKey(intpGroupId)) {
+      return new ArrayList<>();
+    }
+    return angularObjects.get(intpGroupId);
+  }
+
+  /**
+   * Add or update the note AngularObject.
+   */
+  public void addOrUpdateAngularObject(String intpGroupId, AngularObject angularObject) {
+    List<AngularObject> angularObjectList;
+    if (!angularObjects.containsKey(intpGroupId)) {
+      angularObjectList = new ArrayList<>();
+      angularObjects.put(intpGroupId, angularObjectList);
+    } else {
+      angularObjectList = angularObjects.get(intpGroupId);
+
+      // Delete existing AngularObject
+      Iterator<AngularObject> iter = angularObjectList.iterator();
+      while(iter.hasNext()){
+        String noteId = "", paragraphId = "", name = "";
+        Object object = iter.next();
+        if (object instanceof AngularObject) {
+          AngularObject ao = (AngularObject)object;
+          noteId = ao.getNoteId();
+          paragraphId = ao.getParagraphId();
+          name = ao.getName();
+        } else if (object instanceof RemoteAngularObject) {
+          RemoteAngularObject rao = (RemoteAngularObject)object;
+          noteId = rao.getNoteId();
+          paragraphId = rao.getParagraphId();
+          name = rao.getName();
+        } else {
+          continue;
+        }
+        if (StringUtils.equals(noteId, angularObject.getNoteId())
+            && StringUtils.equals(paragraphId, angularObject.getParagraphId())
+            && StringUtils.equals(name, angularObject.getName())) {
+          iter.remove();
+        }
+      }
+    }
+
+    angularObjectList.add(angularObject);
+  }
+
+  /**
+   * Delete the note AngularObject.
+   */
+  public void deleteAngularObject(String intpGroupId, AngularObject angularObject) {
+    List<AngularObject> angularObjectList;
+    if (!angularObjects.containsKey(intpGroupId)) {
+      return;
+    } else {
+      angularObjectList = angularObjects.get(intpGroupId);
+
+      // Delete existing AngularObject
+      Iterator<AngularObject> iter = angularObjectList.iterator();
+      while(iter.hasNext()){
+        String noteId = "", paragraphId = "";
+        Object object = iter.next();
+        if (object instanceof AngularObject) {
+          AngularObject ao = (AngularObject)object;
+          noteId = ao.getNoteId();
+          paragraphId = ao.getParagraphId();
+        } else if (object instanceof RemoteAngularObject) {
+          RemoteAngularObject rao = (RemoteAngularObject)object;
+          noteId = rao.getNoteId();
+          paragraphId = rao.getParagraphId();
+        } else {
+          continue;
+        }
+        if (StringUtils.equals(noteId, angularObject.getNoteId())
+            && StringUtils.equals(paragraphId, angularObject.getParagraphId())) {
+          iter.remove();
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
At present, Bind's angularObject in note is only valid in the current operation web page.
When the note is reopened, or the zeppelin service is restarted, the angularObject of Bind in the note cannot be displayed, and the bind operation must be repeated.

The submarine has a lot of startup commands and parameters. In order to provide the best experience for the user, we provide the parameters to the user through the WEB control.

Zeppelin's own dynamic form is more suitable for parameter input in the query, but it does not meet the needs of the submarine interpreter, so the submarine interpreter uses the angular template to generate a richer input interface.
The controls in the interface are saved to the note through Bind's angularObject, so that when the user reopens the note, there is no need to re-enter it.

### What type of PR is it?
[Improvement]

### Todos
* [x] Save angularObject to Note in NotebookServer::angularObjectClientBind(...) function.
* [x] Delete angularObject to Note in NotebookServer::angularObjectClientUnbind(...) function.
* [x] Update angularObject to Note in NotebookServer:: angularObjectUpdated(...) function.
* [x] Load angularObject update to Note in NotebookServer::getNote(...) function.
* [x] Add test case in NotebookServerTest::testAngularObjectSaveToNote(...).
* [x] Add test case in NotebookServerTest::testLoadAngularObjectFromNote(...).

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3931

### How should this be tested?
[CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/473897099)

### Screenshots (if appropriate)

![alt text](https://github.com/liuxunorg/images/blob/master/zeppelin/angularBing-save.gif?raw=true "angularBing-save.gif")

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
