### PR TITLE
[MINOR][ZEPPELIN-1919] Reduce font size in markdown output

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -520,7 +520,7 @@ table.table-striped {
 }
 
 /*
-  Overwrite github-markdown-css for Markdown interpreter
+  Override github-markdown-css for Markdown interpreter
 */
 
 .markdown-body h1,
@@ -529,24 +529,24 @@ table.table-striped {
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  margin-top: 16px;
-  margin-bottom: 16px;
+  margin-top: 16px !important;
+  margin-bottom: 16px !important;
 }
 
 .markdown-body {
-  font-size: 14px;
+  font-size: 14px !important;
 }
 
 .markdown-body h2 {
-  font-size: 26px;
+  font-size: 26px !important;
 }
 
 .markdown-body h3 {
-  font-size: 20px;
+  font-size: 20px !important;
 }
 
 .markdown-body h4 {
-  font-size: 16px;
+  font-size: 16px !important;
 }
 
 .network-labels {


### PR DESCRIPTION
### What is this PR for?
This PR fixes the CSS such that the original intent of PR #1867 is properly implemented.

The relative inclusion order of `github-markdown.css` (via WebPack) vs `paragraph.css` (via `<link>` tag) cannot be relied upon for the intended override behavior.  This fix adds the `!important` qualifier to the style overrides to address this problem.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-1919](https://issues.apache.org/jira/browse/ZEPPELIN-1919)

### How should this be tested?
* Compare font size in markdown interpreter before and after fix

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? **No**
* Is there breaking changes for older versions? **No**
* Does this needs documentation? **No**
