### PR TITLE
[ZEPPELIN-3949] Add HADOOP_CLASSPATH in ZEPPELIN_CLASSPATH when starting Zeppelin

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -77,6 +77,10 @@ if [[ -n "${HADOOP_CONF_DIR}" ]] && [[ -d "${HADOOP_CONF_DIR}" ]]; then
   ZEPPELIN_CLASSPATH+=":${HADOOP_CONF_DIR}"
 fi
 
+if [[ -n "${HADOOP_CLASSPATH}" ]] && [[ -d "${HADOOP_CLASSPATH}" ]]; then
+  ZEPPELIN_CLASSPATH+=":${HADOOP_CLASSPATH}"
+fi
+
 if [[ ! -d "${ZEPPELIN_LOG_DIR}" ]]; then
   echo "Log dir doesn't exist, create ${ZEPPELIN_LOG_DIR}"
   $(mkdir -p "${ZEPPELIN_LOG_DIR}")


### PR DESCRIPTION
### What is this PR for?
Add `HADOOP_CLASSPATH` to `ZEPPELIN_CLASSPATH` when starting Zeppelin. This adds some important deps that Zeppelin may need. For instance when storing the notebooks in [Swift](https://wiki.openstack.org/wiki/Swift) (an Hadoop-compatible storage system) Zeppelin need to use a driver that is generally included in `HADOOP_CLASSPATH`, but not in `HADOOP_CONF_DIR`.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3949

### How should this be tested?
The Travis build should run just fine.

### Questions:
* Does the licenses files need update?
Nope.

* Is there breaking changes for older versions?
Nope.

* Does this needs documentation?
Nope. Adding the HADOOP_CLASSPATH would be the expected behaviour.