### PR TITLE
ZEPPELIN-3887. Print INTERPRETER_RUN_COMMAND in interpreter.sh for debugging purpose

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -246,6 +246,7 @@ if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]] && [[ -n "${suid}" || -z "${SPARK_SUB
     INTERPRETER_RUN_COMMAND+="'"
 fi
 
+echo "Interpreter launch command: $INTERPRETER_RUN_COMMAND"
 eval $INTERPRETER_RUN_COMMAND &
 pid=$!
 


### PR DESCRIPTION
### What is this PR for?

This is a minor improvement to print interpreter launch command, just for developer debugging purpose 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3887

### How should this be tested?
Manually tested, there's the log in the log file.

> DEBUG [2019-01-28 14:07:32,508] ({Exec Stream Pumper} RemoteInterpreterManagedProcess.java[processLine]:252) - Interpreter launch command:  /Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///Users/jzhang/github/zeppelin/conf/log4j.properties -Dzeppelin.log.file=/Users/jzhang/github/zeppelin/logs/zeppelin-interpreter-jdbc-shared_process-jzhang-jeffzhangzjfdeMacBook-Pro.local.log -Xms1024m -Xmx1024m -XX:MaxPermSize=512m -cp :/Users/jzhang/github/zeppelin/local-repo/jdbc/*:/Users/jzhang/github/zeppelin/interpreter/jdbc/*:/Users/jzhang/github/zeppelin/zeppelin-interpreter-api/target/*::/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/classes:/Users/jzhang/github/zeppelin/zeppelin-zengine/target/test-classes org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer 30.16.192.30 57928 jdbc-shared_process :

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
