### PR TITLE
[ZEPPELIN-3671] Add info about running interpreters to API and JMX

### DIFF
--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -507,6 +507,130 @@ The role of registered interpreters, settings and interpreters group are describ
   </table>
 
 <br/>
+### List of running interpreters
+
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method returns all the running interpreters available on the server.</td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/running```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td>Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td>Sample JSON response</td>
+      <td>
+        <pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": [
+   {
+     "port": "37395",
+     "name": "python-shared_process",
+     "host": "192.168.88.13",
+     "group": "python"
+   },
+   {
+     "port": "45105",
+     "name": "spark-shared_process",
+     "host":"192.168.88.13",
+     "group":"spark"
+   },
+   {
+     "port": "41281",
+     "name":"sh-shared_process",
+     "host":"192.168.88.13",
+     "group":"sh"
+   },
+   { "port": "40873",
+     "name": "md-shared_process",
+     "host": "192.168.88.13",
+     "group":"md"
+   }
+  ]
+}
+        </pre>
+      </td>
+    </tr>
+  </table>
+
+<br/>
+###  Get paragraph info of running interpreters
+  <table class="table-configuration">
+    <col width="200">
+    <tr>
+      <td>Description</td>
+      <td>This ```GET``` method lists the running paragraphs grouped by interpreters.
+          The body field of the returned JSON contain information about paragraphs.
+      </td>
+    </tr>
+    <tr>
+      <td>URL</td>
+      <td>```http://[zeppelin-server]:[zeppelin-port]/api/interpreter/running/jobs```</td>
+    </tr>
+    <tr>
+      <td>Success code</td>
+      <td>200</td>
+    </tr>
+    <tr>
+      <td> Fail code</td>
+      <td> 500 </td>
+    </tr>
+    <tr>
+      <td> sample JSON response (python is configured with isolated per Note setting) </td>
+      <td><pre>
+{
+  "status": "OK",
+  "message": "",
+  "body": {
+    "lastResponseUnixTime": 1544653922027,
+    "runningInterpreters": {
+      "python--2DX6CWH35": {
+        "port": "37799",
+        "host": "192.168.88.13",
+        "paragraphs": [
+          {
+            "interpreterText": "python",
+            "noteName": "Processes",
+            "noteId": "2DX6CWH35",
+            "id": "paragraph_1544653814070_1471435369",
+            "user": "anonymous"
+          }
+        ],
+        "group": "python"
+      },
+      "sh-shared_process": {
+        "port": "33857",
+        "host": "192.168.88.13",
+        "paragraphs": [
+          {
+            "interpreterText": "sh",
+            "noteName": "Processes",
+            "noteId": "2DX6CWH35",
+            "id": "paragraph_1544653826296_1659478713",
+            "user":"anonymous"
+          }
+        ],
+        "group":"sh"
+      }
+    }
+   }
+}</pre></td>
+    </tr>
+  </table>
+
+<br/>
 ### Add a new repository for dependency resolving
 
   <table class="table-configuration">

--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -595,37 +595,42 @@ The role of registered interpreters, settings and interpreters group are describ
   "message": "",
   "body": {
     "lastResponseUnixTime": 1544653922027,
-    "runningInterpreters": {
-      "python--2DX6CWH35": {
-        "port": "37799",
-        "host": "192.168.88.13",
-        "paragraphs": [
-          {
-            "interpreterText": "python",
-            "noteName": "Processes",
-            "noteId": "2DX6CWH35",
-            "id": "paragraph_1544653814070_1471435369",
-            "user": "anonymous"
-          }
-        ],
-        "group": "python"
+    "runningInterpreters": [
+      {
+        "name": "python--2DX6CWH35",
+        "group": "python",
+        "host": "172.30.13.213",
+        "port": "33757",
+        "interpreterText": "python",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653814070_1471435369",
+        "user": "anonymous"
       },
-      "sh-shared_process": {
-        "port": "33857",
-        "host": "192.168.88.13",
-        "paragraphs": [
-          {
-            "interpreterText": "sh",
-            "noteName": "Processes",
-            "noteId": "2DX6CWH35",
-            "id": "paragraph_1544653826296_1659478713",
-            "user":"anonymous"
-          }
-        ],
-        "group":"sh"
+      {
+        "name": "spark-shared_process",
+        "group": "spark",
+        "host": "172.30.13.213",
+        "port": "42861",
+        "interpreterText": "spark.pyspark",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653819987_-1635354679",
+        "user":"anonymous"
+      },
+      {
+        "name": "sh-shared_process",
+        "group": "sh",
+        "host": "172.30.13.213",
+        "port": "38089",
+        "interpreterText": "sh",
+        "noteName": "Processes",
+        "noteId": "2DX6CWH35",
+        "id": "paragraph_1544653826296_1659478713",
+        "user":"anonymous"
       }
-    }
-   }
+    ]
+  }
 }</pre></td>
     </tr>
   </table>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -18,6 +18,7 @@
 package org.apache.zeppelin.rest;
 
 import com.google.common.collect.Maps;
+import java.util.HashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -333,5 +334,35 @@ public class InterpreterRestApi {
     }
 
     return new JsonResponse<>(Status.OK).build();
+  }
+
+  /**
+   * Get all running interpreters.
+   */
+  @GET
+  @Path("running")
+  @ZeppelinApi
+  public Response listRunningInterpreters() {
+    return new JsonResponse<>(
+        Status.OK,
+        "",
+        interpreterSettingManager.getRunningInterpreters()
+    ).build();
+  }
+
+  /**
+   * Get info about the running paragraphs grouped by their interpreters.
+   *
+   * @return JSON with status.OK
+   */
+  @GET
+  @Path("running/jobs")
+  @ZeppelinApi
+  public Response getRunning() {
+    Map<String, Object> response = new HashMap<>();
+    response.put("lastResponseUnixTime", System.currentTimeMillis());
+    response.put("runningInterpreters", notebookServer.getRunningInterpretersParagraphInfo());
+
+    return new JsonResponse<>(Status.OK, "", response).build();
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -346,7 +346,7 @@ public class InterpreterRestApi {
     return new JsonResponse<>(
         Status.OK,
         "",
-        interpreterSettingManager.getRunningInterpreters()
+        interpreterSettingManager.getRunningInterpretersInfo()
     ).build();
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -469,6 +469,54 @@ public class NotebookServerTest extends AbstractTestRestApi {
     notebook.removeNote(note.getId(), anonymous);
   }
 
+  @Test
+  public void testRuntimeInfos() {
+    // mock note
+    String msg = "{\"op\":\"IMPORT_NOTE\",\"data\":" +
+        "{\"note\":{\"paragraphs\": [{\"text\": \"Test " +
+        "paragraphs import\"," + "\"progressUpdateIntervalMs\":500," +
+        "\"config\":{},\"settings\":{}}]," +
+        "\"name\": \"Test Zeppelin notebook import\",\"config\": " +
+        "{}}}}";
+    Message messageReceived = notebookServer.deserializeMessage(msg);
+    Note note = null;
+    try {
+      note = notebookServer.importNote(null, messageReceived);
+    } catch (NullPointerException e) {
+      //broadcastNoteList(); failed nothing to worry.
+      LOG.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
+          "worry ", e);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    assertNotEquals(null, notebook.getNote(note.getId()));
+    assertNotEquals(null, note.getParagraph(0));
+
+    String nodeId = note.getId();
+    String paragraphId = note.getParagraph(0).getId();
+
+    // update RuntimeInfos
+    Map<String, String> infos = new java.util.HashMap<>();
+    infos.put("jobUrl", "jobUrl_value");
+    infos.put("jobLabel", "jobLabel_value");
+    infos.put("label", "SPARK JOB");
+    infos.put("tooltip", "View in Spark web UI");
+    infos.put("noteId", nodeId);
+    infos.put("paraId", paragraphId);
+
+    notebookServer.onParaInfosReceived(nodeId, paragraphId, "spark", infos);
+    Paragraph paragraph = note.getParagraph(paragraphId);
+
+    // check RuntimeInfos
+    assertTrue(paragraph.getRuntimeInfos().containsKey("jobUrl"));
+    List<Map<String, String>> list = paragraph.getRuntimeInfos().get("jobUrl").getValue();
+    assertEquals(1, list.size());
+    assertEquals(2, list.get(0).size());
+    assertEquals(list.get(0).get("jobUrl"), "jobUrl_value");
+    assertEquals(list.get(0).get("jobLabel"), "jobLabel_value");
+  }
+
   private NotebookSocket createWebSocket() {
     NotebookSocket sock = mock(NotebookSocket.class);
     when(sock.getRequest()).thenReturn(mockRequest);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -446,7 +446,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     interpreterInfo.put("port", "1111");
     fakeRunningInterpreterList.add(interpreterInfo);
 
-    when(intpSettingManager.getRunningInterpreters()).thenReturn(fakeRunningInterpreterList);
+    when(intpSettingManager.getRunningInterpretersInfo()).thenReturn(fakeRunningInterpreterList);
 
     final Note note = ZeppelinServer.notebook.createNote("testNote", anonymous);
     final Paragraph fakeParagraph = spy(new Paragraph(note, mock(ParagraphJobListener.class)));
@@ -464,17 +464,19 @@ public class NotebookServerTest extends AbstractTestRestApi {
     when(bindedInterpreter.getInterpreterGroup()).thenReturn(fakeMIG);
     when(fakeParagraph.getBindedInterpreter()).thenReturn(bindedInterpreter);
     when(fakeParagraph.isRunning()).thenReturn(true);
+    when(fakeParagraph.getUser()).thenReturn(String.valueOf(anonymous));
+    when(fakeParagraph.getIntpText()).thenReturn("fake");
 
-    Map<String, Object> result = notebookServer.getRunningInterpretersParagraphInfo();
+    List<Map<String, String>> result = notebookServer.getRunningInterpretersParagraphInfo();
     LOG.info("Running interpreters paragraph info is {}", result);
-    Map<String, Object> resultInterpreterInfo = (Map<String, Object>) result.get("fake");
+
+    assertTrue(!result.isEmpty());
+    assertEquals(1, result.size());
+    Map<String, String> resultInterpreterInfo = result.get(0);
     assertEquals("1111", resultInterpreterInfo.get("port"));
     assertEquals("1.1.1.1", resultInterpreterInfo.get("host"));
-
-    Map<String, String> paragraphInfo =
-        ((List<Map<String, String>>) resultInterpreterInfo.get("paragraphs")).get(0);
-    assertEquals(fakeParagraph.getNote().getName(), paragraphInfo.get("noteName"));
-    assertEquals(fakeParagraph.getUser(), paragraphInfo.get("user"));
+    assertEquals(fakeParagraph.getNote().getName(), resultInterpreterInfo.get("noteName"));
+    assertEquals(fakeParagraph.getUser(), resultInterpreterInfo.get("user"));
 
     // clean
     ZeppelinServer.notebook.removeNote(note.getId(), anonymous);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -894,12 +894,17 @@ public class InterpreterSettingManager implements NoteEventListener {
   }
 
   @ManagedAttribute
-  public Set<String> getRunningInterpreters() {
-    Set<String> runningInterpreters = Sets.newHashSet();
+  public List<Map<String, String>> getRunningInterpreters() {
+    List<Map<String, String>> runningInterpreters = new ArrayList<>();
     for (Map.Entry<String, InterpreterSetting> entry : interpreterSettings.entrySet()) {
       for (ManagedInterpreterGroup mig : entry.getValue().getAllInterpreterGroups()) {
-        if (null != mig.getRemoteInterpreterProcess()) {
-          runningInterpreters.add(entry.getKey());
+        if (mig.getRemoteInterpreterProcess() != null) {
+          Map<String, String> interpreterInfo = new HashMap<>();
+          interpreterInfo.put("name", mig.getId());
+          interpreterInfo.put("group", mig.getInterpreterSetting().getGroup());
+          interpreterInfo.put("host", mig.getInterpreterProcess().getHost());
+          interpreterInfo.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
+          runningInterpreters.add(interpreterInfo);
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -25,7 +25,9 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
@@ -79,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -894,21 +897,18 @@ public class InterpreterSettingManager implements NoteEventListener {
   }
 
   @ManagedAttribute
-  public List<Map<String, String>> getRunningInterpreters() {
-    List<Map<String, String>> runningInterpreters = new ArrayList<>();
-    for (Map.Entry<String, InterpreterSetting> entry : interpreterSettings.entrySet()) {
-      for (ManagedInterpreterGroup mig : entry.getValue().getAllInterpreterGroups()) {
-        if (mig.getRemoteInterpreterProcess() != null) {
-          Map<String, String> interpreterInfo = new HashMap<>();
-          interpreterInfo.put("name", mig.getId());
-          interpreterInfo.put("group", mig.getInterpreterSetting().getGroup());
-          interpreterInfo.put("host", mig.getInterpreterProcess().getHost());
-          interpreterInfo.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
-          runningInterpreters.add(interpreterInfo);
-        }
-      }
-    }
-    return runningInterpreters;
+  public List<Map<String, String>> getRunningInterpretersInfo() {
+    return interpreterSettings.values().stream()
+        .map(InterpreterSetting::getAllInterpreterGroups)
+        .flatMap(Collection::stream)
+        .filter(mig -> mig.getInterpreterProcess() != null)
+        .map(mig -> ImmutableMap.<String, String>builder()
+            .put("name", mig.getId())
+            .put("group", mig.getInterpreterSetting().getGroup())
+            .put("host", mig.getInterpreterProcess().getHost())
+            .put("port", String.valueOf(mig.getInterpreterProcess().getPort()))
+            .build())
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -81,10 +81,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 
 /**
@@ -896,18 +894,22 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
   }
 
+  public Map<String, String> extractProcessInfo(ManagedInterpreterGroup mig) {
+    HashMap<String, String> info = new HashMap<>();
+    info.put("name", mig.getId());
+    info.put("group", mig.getInterpreterSetting().getGroup());
+    info.put("host", mig.getInterpreterProcess().getHost());
+    info.put("port", String.valueOf(mig.getInterpreterProcess().getPort()));
+    return info;
+  }
+
   @ManagedAttribute
   public List<Map<String, String>> getRunningInterpretersInfo() {
     return interpreterSettings.values().stream()
         .map(InterpreterSetting::getAllInterpreterGroups)
         .flatMap(Collection::stream)
         .filter(mig -> mig.getInterpreterProcess() != null)
-        .map(mig -> ImmutableMap.<String, String>builder()
-            .put("name", mig.getId())
-            .put("group", mig.getInterpreterSetting().getGroup())
-            .put("host", mig.getInterpreterProcess().getHost())
-            .put("port", String.valueOf(mig.getInterpreterProcess().getPort()))
-            .build())
+        .map(this::extractProcessInfo)
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### What is this PR for?
It would be nice if we could get PID of running interpreter, and info about paragraph that running under that interpreter, using API and JMX.

Using this feature it will be easy to check CPU and memory load, etc.

This PR adds:
* API method to get info about running interpreters (/api/interpreter/running) - interpreter `host`, `port`, `group`, `name`;
* API method to get info about running paragraphs grouped by interpreters (/api/notebook/running/jobs) -`user`, `noteId`, `paragraphId`, `noteName`, `interpreterText`;
* Few JMX methods which do the same as API;
* Documentation for mentioned methods.

[Here](https://gist.github.com/egorklimov/3c6d00b2afa49c26474192c23687beb3) is the template for simple running paragraphs analysis using API. 

### What type of PR is it?
Feature

### What is the Jira issue?
* [ZEPPELIN-3671](https://issues.apache.org/jira/browse/ZEPPELIN-3671)

### How should this be tested?
* CI pass.
* You may use [template](https://gist.github.com/egorklimov/3c6d00b2afa49c26474192c23687beb3) mentioned above.

### Screenshots
* REST API
![zp-91](https://user-images.githubusercontent.com/6136993/50045157-45a8c800-009f-11e9-901d-d253054ca405.gif)
* JMX (viewed in `jconsole`)
  * Basic info ![jmx_example1](https://user-images.githubusercontent.com/6136993/50548846-99510f00-0c64-11e9-8305-f41aeeb6524c.png)
  * With paragraph info ![jmx_example2](https://user-images.githubusercontent.com/6136993/50548847-99e9a580-0c64-11e9-8564-c92eda149fda.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, API info updated
