### PR TITLE
[ZEPPELIN-3988] Paragraph Text output includes \r\n is not displayed correctly.

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -24,6 +24,7 @@ import ScatterchartVisualization from '../../../visualization/builtins/visualiza
 import NetworkVisualization from '../../../visualization/builtins/visualization-d3network';
 import {DefaultDisplayType, SpellResult} from '../../../spell';
 import {ParagraphStatus} from '../paragraph.status';
+import Result from './result';
 
 const AnsiUp = require('ansi_up');
 const AnsiUpConverter = new AnsiUp.default; // eslint-disable-line new-parens,new-cap
@@ -488,22 +489,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
   };
 
   const checkAndReplaceCarriageReturn = function(str) {
-    if (/\r/.test(str)) {
-      let newGenerated = '';
-      let strArr = str.split('\n');
-      for (let str of strArr) {
-        if (/\r/.test(str)) {
-          let splitCR = str.split('\r');
-          newGenerated += splitCR[splitCR.length - 1] + '\n';
-        } else {
-          newGenerated += str + '\n';
-        }
-      }
-      // remove last "\n" character
-      return newGenerated.slice(0, -1);
-    } else {
-      return str;
-    }
+    return new Result(str).checkAndReplaceCarriageReturn();
   };
 
   const renderText = function(targetElemId, data, refresh) {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.test.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.test.js
@@ -1,0 +1,41 @@
+describe('Controller: ResultCtrl', function() {
+  beforeEach(angular.mock.module('zeppelinWebApp'));
+
+  let scope;
+  let controller;
+  let resultMock = {
+  };
+  let configMock = {
+  };
+  let paragraphMock = {
+    id: 'p1',
+    results: {
+      msg: [],
+    },
+  };
+  let route = {
+    current: {
+      pathParams: {
+        noteId: 'noteId',
+      },
+    },
+  };
+
+  beforeEach(inject(function($controller, $rootScope) {
+    scope = $rootScope.$new();
+    scope.$parent = $rootScope.$new(true, $rootScope);
+    scope.$parent.paragraph = paragraphMock;
+
+    controller = $controller('ResultCtrl', {
+      $scope: scope,
+      $route: route,
+    });
+
+    scope.init(resultMock, configMock, paragraphMock, 1);
+  }));
+
+  it('scope should be initialized', function() {
+    expect(scope).toBeDefined();
+    expect(controller).toBeDefined();
+  });
+});

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.js
@@ -1,0 +1,9 @@
+export default class Result {
+  constructor(data) {
+    this.data = data;
+  }
+
+  checkAndReplaceCarriageReturn() {
+    return this.data.replace(/(\r\n)/gm, '\n');
+  }
+}

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.js
@@ -4,6 +4,22 @@ export default class Result {
   }
 
   checkAndReplaceCarriageReturn() {
-    return this.data.replace(/(\r\n)/gm, '\n');
+    const str = this.data.replace(/\r\n/g, '\n');
+    if (/\r/.test(str)) {
+      let newGenerated = '';
+      let strArr = str.split('\n');
+      for (let str of strArr) {
+        if (/\r/.test(str)) {
+          let splitCR = str.split('\r');
+          newGenerated += splitCR[splitCR.length - 1] + '\n';
+        } else {
+          newGenerated += str + '\n';
+        }
+      }
+      // remove last "\n" character
+      return newGenerated.slice(0, -1);
+    } else {
+      return str;
+    }
   }
 }

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.test.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.test.js
@@ -5,5 +5,7 @@ describe('result', () => {
     expect(new Result('Hello world').checkAndReplaceCarriageReturn()).toEqual('Hello world');
     expect(new Result('Hello world\n').checkAndReplaceCarriageReturn()).toEqual('Hello world\n');
     expect(new Result('Hello world\r\n').checkAndReplaceCarriageReturn()).toEqual('Hello world\n');
+    expect(new Result('Hello\rworld\n').checkAndReplaceCarriageReturn()).toEqual('world\n');
+    expect(new Result('Hello\rworld\r\n').checkAndReplaceCarriageReturn()).toEqual('world\n');
   });
 });

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.test.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.test.js
@@ -1,0 +1,9 @@
+import Result from './result.js';
+
+describe('result', () => {
+  it('should handle carriage return', () => {
+    expect(new Result('Hello world').checkAndReplaceCarriageReturn()).toEqual('Hello world');
+    expect(new Result('Hello world\n').checkAndReplaceCarriageReturn()).toEqual('Hello world\n');
+    expect(new Result('Hello world\r\n').checkAndReplaceCarriageReturn()).toEqual('Hello world\n');
+  });
+});


### PR DESCRIPTION
### What is this PR for?
When paragraph text output includes `\r\n`, it is not displayed correctly in paragraph result.

Expected result
![image](https://user-images.githubusercontent.com/1540981/52189818-da9e8680-27ef-11e9-8d17-790101677a9b.png)

Current behavior (displays empty result)
![image](https://user-images.githubusercontent.com/1540981/52189831-e8540c00-27ef-11e9-8f35-bc79b21669e3.png)


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-3988

### How should this be tested?
run

```
%python
print("Hello world\r\n")
```

and see if output is displayed correctly.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
