### PR TITLE
[ZEPPELIN-4011] Fix note path

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -232,7 +232,7 @@ public class Note implements JsonSerializable {
         this.path = "/" + name;
       }
     } else {
-      int pos = this.path.indexOf("/");
+      int pos = this.path.lastIndexOf("/");
       this.path = this.path.substring(0, pos + 1) + this.name;
     }
   }


### PR DESCRIPTION
### What is this PR for?
Now note may move to the root directory after enabling cron in it. It caused by `Note#setName`

* Bug:
 ![notepath](https://user-images.githubusercontent.com/6136993/52917693-87542a00-32ff-11e9-9fb1-82d21c0942f8.gif)
* Fix:
![notepath_fix](https://user-images.githubusercontent.com/6136993/52917704-abb00680-32ff-11e9-8f50-0e8908e4edc0.gif)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4011
### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
