### PR TITLE
[ZEPPELIN-4012] Save paragraphs after clone

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -244,6 +244,7 @@ public class Notebook {
     for (Paragraph p : paragraphs) {
       newNote.addCloneParagraph(p, subject);
     }
+    saveNote(newNote, subject);
     return newNote;
   }
 


### PR DESCRIPTION
### What is this PR for?
Paragraphs in cloned note disappear after zeppelin restart if they weren't executed
* Bug:
![clone_bug](https://user-images.githubusercontent.com/6136993/52918382-5ed02e00-3307-11e9-888e-5eb4dce756f1.gif)
* Fix:
![clone_fix](https://user-images.githubusercontent.com/6136993/52918383-6263b500-3307-11e9-83e3-e851f65c34b8.gif)

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4012

### How should this be tested?
* CI pass

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
