### PR TITLE
[ZEPPELIN-4004] add a systemd unit file to launch the Zeppelin daemon via systemd commands

### DIFF
--- a/bin/zeppelin-systemd-service.sh
+++ b/bin/zeppelin-systemd-service.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# description: Enable/disable the Zeppelin systemd service.
+#
+
+# Directory in which the systemd unit files sit.
+SYSTEMD_DIR=/etc/systemd/system
+
+function enable_systemd_service()
+{
+    # Where are we in the fs?
+    OLD_PWD=$(pwd)
+
+    # Work out where the script is run from and cd into said directory.
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+
+    # Work out the current directory.
+    MY_PWD=$(readlink -f .)
+
+    # Work out the Zeppelin source directory (go up a directory actually).
+    ZEPPELIN_DIR=$(dirname "${MY_PWD}")
+
+    # Copy the unit file.
+    cp "${ZEPPELIN_DIR}"/scripts/systemd/zeppelin.systemd "${SYSTEMD_DIR}"
+
+    # Swap the template variable with the right directory path.
+    sed -i -e "s#%ZEPPELIN_DIR%#${ZEPPELIN_DIR}#g;" \
+        "${SYSTEMD_DIR}"/zeppelin.systemd
+
+    # Set up the unit file.
+    systemctl daemon-reload
+    systemctl enable zeppelin.service
+
+    # Display a help message.
+    echo "To start Zeppelin using systemd, simply type:
+# systemctl start zeppelin
+
+To check the service health:
+# systemctl status zeppelin"
+
+    # Go back where we came from.
+    cd "${OLD_PWD}"
+}
+
+function disable_systemd_service()
+{
+    # Let's mop up.
+    systemctl stop zeppelin.service
+    systemctl disable zeppelin.service
+    rm "${SYSMTED_DIR}"/zeppelin.systemd
+    systemctl daemon-reload
+    systemctl reset-failed
+
+    # We're done. Explain what's just happened.
+    echo "Zeppelin systemd service has been disabled and removed from your system."
+}
+
+function check_user()
+{
+    # Are we root?
+    if [[ $(id -u) -ne 0 ]]; then
+        echo "Please run this script as root!"
+        exit -1
+    fi
+}
+
+function check_systemctl()
+{
+    # Is the systemctl command available?
+    type -P systemctl > /dev/null
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR! the 'systemctl' command has not been found!
+Please install systemd if you want to use this script."
+        exit -1
+    fi
+}
+
+USAGE="usage: zeppelin-systemd-service.sh {enable|disable}
+
+  enable:    enable Zeppelin systemd service.
+  disable:   disable Zeppelin systemd service.
+"
+
+# Main method starts from here downwards.
+check_user
+check_systemctl
+
+case "${1}" in
+  enable)
+    enable_systemd_service
+    ;;
+  disable)
+    disable_systemd_service
+    ;;
+  *)
+    echo "${USAGE}"
+esac

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ limitations under the License.
 * [Spark with Zeppelin](./quickstart/spark_with_zeppelin.html)
 * [SQL with Zeppelin](./quickstart/sql_with_zeppelin.html)
 * [Python with Zeppelin](./quickstart/python_with_zeppelin.html)
-  
+
 #### Usage 
 * Dynamic Form 
   * [What is Dynamic Form](./usage/dynamic_form/intro.html): a step by step guide for creating dynamic forms
@@ -83,10 +83,11 @@ limitations under the License.
   * [Configuration API](./usage/rest_api/configuration.html)
   * [Credential API](./usage/rest_api/credential.html)
   * [Helium API](./usage/rest_api/helium.html)
-  
+
 #### Setup 
 * Basics 
   * [How to Build Zeppelin](./setup/basics/how_to_build.html)
+  * [Manage Zeppelin with systemd](./setup/basics/systemd.html)
   * [Multi-user Support](./setup/basics/multi_user_support.html)
 * Deployment 
   * [Spark Cluster Mode: Standalone](./setup/deployment/spark_cluster_mode.html#spark-standalone-mode)
@@ -113,7 +114,7 @@ limitations under the License.
   * [Proxy Setting](./setup/operation/proxy_setting.html)
   * [Upgrading](./setup/operation/upgrading.html): a manual procedure of upgrading Apache Zeppelin version
   * [Trouble Shooting](./setup/operation/trouble_shooting.html)
-  
+
 #### Developer Guide
 * Extending Zeppelin
   * [Writing Zeppelin Interpreter](./development/writing_zeppelin_interpreter.html)
@@ -127,7 +128,7 @@ limitations under the License.
   * [Useful Developer Tools](./development/contribution/useful_developer_tools.html)
   * [How to Contribute (code)](./development/contribution/how_to_contribute_code.html)
   * [How to Contribute (website)](./development/contribution/how_to_contribute_website.html)
-  
+
 #### Available Interpreters 
   * [Alluxio](./interpreter/alluxio.html)
   * [Beam](./interpreter/beam.html)
@@ -157,7 +158,7 @@ limitations under the License.
   * [Scio](./interpreter/scio.html)
   * [Shell](./interpreter/shell.html)
   * [Spark](./interpreter/spark.html)
-  
+
 #### External Resources
   * [Mailing List](https://zeppelin.apache.org/community.html)
   * [Apache Zeppelin Wiki](https://cwiki.apache.org/confluence/display/ZEPPELIN/Zeppelin+Home)

--- a/docs/setup/basics/systemd.md
+++ b/docs/setup/basics/systemd.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: "Manage Zeppelin with systemd"
+description: "Zeppelin and systemd"
+group: setup/basics
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+## Zeppelin and systemd
+
+### Unit file installation / deinstallation
+
+This script accepts two parameters: `enable` and `disable` which, as you might have guessed, enable or disable the Zeppelin systemd unit file. Go ahead and type:
+
+```
+# ./bin/zeppelin-systemd-service.sh enable
+```
+
+This command activates the Zeppelin systemd unit file on your system.
+
+If you wish to roll back and remove this unit file from said system, simply type:
+```
+# ./bin/zeppelin-systemd-service.sh disable
+```
+
+### Manage Zeppelin using systemd commands
+
+To start Zeppelin using systemd;
+```
+# systemctl start zeppelin
+```
+
+To stop Zeppelin using systemd:
+```
+# systemctl stop zeppelin
+```
+
+To check the service health:
+```
+# systemctl status zeppelin"
+```

--- a/scripts/systemd/zeppelin.systemd
+++ b/scripts/systemd/zeppelin.systemd
@@ -1,0 +1,12 @@
+[Unit]
+Description=Apache Zeppelin daemon
+After=syslog.target network.target
+
+[Service]
+Type=oneshot
+ExecStart=%ZEPPELIN_DIR%/bin/zeppelin-daemon.sh start
+ExecStop=%ZEPPELIN_DIR%/bin/zeppelin-daemon.sh stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### What is this PR for?

Here's a possible systemd unit file to control the Zeppelin Java process using systemd commands. Typically on a Ubuntu Linux server for instance. I've also written a very short README to get noobs started.

### What type of PR is it?
Feature

### Todos
* Review code.
* Merge.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4015

### How should this be tested?
* Install systemd unit file.
* Test.
* Report back.

### Screenshots (if appropriate)
* None required.

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? Yes. Written in a README file for the time being. Might need to write a lengthy documentation page if contribution is accepted.
