### PR TITLE
[ZEPPELIN-3985]. Move note permission from notebook-authorization.json to note file

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -44,7 +44,7 @@ import org.apache.shiro.subject.Subject;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.realm.jwt.JWTAuthenticationToken;
 import org.apache.zeppelin.realm.jwt.KnoxJwtRealm;
 import org.apache.zeppelin.realm.kerberos.KerberosRealm;
@@ -65,13 +65,17 @@ public class LoginRestApi {
   private static final Logger LOG = LoggerFactory.getLogger(LoginRestApi.class);
   private static final Gson gson = new Gson();
   private ZeppelinConfiguration zConf;
+
   private AuthenticationService authenticationService;
+  private AuthorizationService authorizationService;
 
   @Inject
   public LoginRestApi(Notebook notebook,
-      AuthenticationService authenticationService) {
+                      AuthenticationService authenticationService,
+                      AuthorizationService authorizationService) {
     this.zConf = notebook.getConf();
     this.authenticationService = authenticationService;
+    this.authorizationService = authorizationService;
   }
 
   @GET
@@ -199,7 +203,7 @@ public class LoginRestApi {
       // if no exception, that's it, we're done!
 
       // set roles for user in NotebookAuthorization module
-      NotebookAuthorization.getInstance().setRoles(principal, roles);
+      authorizationService.setRoles(principal, roles);
     } catch (AuthenticationException uae) {
       // username wasn't in the system, show them an error message?
       // password didn't match, try again?

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -44,7 +44,7 @@ import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.notebook.NoteEventListener;
 import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.rest.exception.WebApplicationExceptionMapper;
@@ -118,7 +118,6 @@ public class ZeppelinServer extends ResourceConfig {
         new AbstractBinder() {
           @Override
           protected void configure() {
-            NotebookAuthorization notebookAuthorization = NotebookAuthorization.getInstance();
             Credentials credentials =
                 new Credentials(
                     conf.credentialsPersist(),
@@ -136,7 +135,7 @@ public class ZeppelinServer extends ResourceConfig {
             bindAsContract(GsonProvider.class).in(Singleton.class);
             bindAsContract(WebApplicationExceptionMapper.class).in(Singleton.class);
             bindAsContract(AdminService.class).in(Singleton.class);
-            bind(notebookAuthorization).to(NotebookAuthorization.class);
+            bindAsContract(AuthorizationService.class).to(Singleton.class);
             // TODO(jl): Will make it more beautiful
             if (!StringUtils.isBlank(conf.getShiroPath())) {
               bind(ShiroAuthenticationService.class).to(AuthenticationService.class).in(Singleton.class);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -29,7 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import javax.inject.Inject;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
@@ -44,8 +43,8 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.NoteManager;
 import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.rest.exception.BadRequestException;
@@ -53,7 +52,6 @@ import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.rest.exception.NoteNotFoundException;
 import org.apache.zeppelin.rest.exception.ParagraphNotFoundException;
 import org.apache.zeppelin.scheduler.Job;
-import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 import org.joda.time.DateTime;
@@ -80,15 +78,15 @@ public class NotebookService {
 
   private ZeppelinConfiguration zConf;
   private Notebook notebook;
-  private NotebookAuthorization notebookAuthorization;
+  private AuthorizationService authorizationService;
 
   @Inject
   public NotebookService(
       Notebook notebook,
-      NotebookAuthorization notebookAuthorization,
+      AuthorizationService authorizationService,
       ZeppelinConfiguration zeppelinConfiguration) {
     this.notebook = notebook;
-    this.notebookAuthorization = notebookAuthorization;
+    this.authorizationService = authorizationService;
     this.zConf = zeppelinConfiguration;
   }
 
@@ -177,10 +175,10 @@ public class NotebookService {
   public void removeNote(String noteId,
                          ServiceContext context,
                          ServiceCallback<String> callback) throws IOException {
-    if (!checkPermission(noteId, Permission.OWNER, Message.OP.DEL_NOTE, context, callback)) {
-      return;
-    }
     if (notebook.getNote(noteId) != null) {
+      if (!checkPermission(noteId, Permission.OWNER, Message.OP.DEL_NOTE, context, callback)) {
+        return;
+      }
       notebook.removeNote(noteId, context.getAutheInfo());
       callback.onSuccess("Delete note successfully", context);
     } else {
@@ -199,7 +197,8 @@ public class NotebookService {
         LOGGER.error("Fail to reload notes from repository", e);
       }
     }
-    List<NoteInfo> notesInfo = notebook.getNotesInfo(context.getUserAndRoles());
+    List<NoteInfo> notesInfo = notebook.getNotesInfo(
+            noteId -> authorizationService.isReader(noteId, context.getUserAndRoles()));
     callback.onSuccess(notesInfo, context);
     return notesInfo;
   }
@@ -929,7 +928,8 @@ public class NotebookService {
                            ServiceCallback<List<NoteInfo>> callback) throws IOException {
     try {
       notebook.removeFolder(folderPath, context.getAutheInfo());
-      List<NoteInfo> notesInfo = notebook.getNotesInfo(context.getUserAndRoles());
+      List<NoteInfo> notesInfo = notebook.getNotesInfo(
+              noteId -> authorizationService.isReader(noteId, context.getUserAndRoles()));
       callback.onSuccess(notesInfo, context);
       return notesInfo;
     } catch (IOException e) {
@@ -946,7 +946,8 @@ public class NotebookService {
 
     try {
       notebook.moveFolder(folderPath, newFolderPath, context.getAutheInfo());
-      List<NoteInfo> notesInfo = notebook.getNotesInfo(context.getUserAndRoles());
+      List<NoteInfo> notesInfo = notebook.getNotesInfo(
+              noteId -> authorizationService.isReader(noteId, context.getUserAndRoles()));
       callback.onSuccess(notesInfo, context);
       return notesInfo;
     } catch (IOException e) {
@@ -1166,20 +1167,20 @@ public class NotebookService {
     Set<String> allowed = null;
     switch (permission) {
       case READER:
-        isAllowed = notebookAuthorization.isReader(noteId, context.getUserAndRoles());
-        allowed = notebookAuthorization.getReaders(noteId);
+        isAllowed = authorizationService.isReader(noteId, context.getUserAndRoles());
+        allowed = authorizationService.getReaders(noteId);
         break;
       case WRITER:
-        isAllowed = notebookAuthorization.isWriter(noteId, context.getUserAndRoles());
-        allowed = notebookAuthorization.getWriters(noteId);
+        isAllowed = authorizationService.isWriter(noteId, context.getUserAndRoles());
+        allowed = authorizationService.getWriters(noteId);
         break;
       case RUNNER:
-        isAllowed = notebookAuthorization.isRunner(noteId, context.getUserAndRoles());
-        allowed = notebookAuthorization.getRunners(noteId);
+        isAllowed = authorizationService.isRunner(noteId, context.getUserAndRoles());
+        allowed = authorizationService.getRunners(noteId);
         break;
       case OWNER:
-        isAllowed = notebookAuthorization.isOwner(noteId, context.getUserAndRoles());
-        allowed = notebookAuthorization.getOwners(noteId);
+        isAllowed = authorizationService.isOwner(noteId, context.getUserAndRoles());
+        allowed = authorizationService.getOwners(noteId);
         break;
     }
     if (isAllowed) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
@@ -31,6 +31,7 @@ import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.NotebookImportDeserializer;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.WatcherMessage;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -83,6 +84,13 @@ public class ConnectionManager {
       .create()
       .isZeppelinNotebookCollaborativeModeEnable();
 
+
+  private AuthorizationService authorizationService;
+
+  public void setAuthorizationService(
+          AuthorizationService authorizationService) {
+    this.authorizationService = authorizationService;
+  }
 
   public void addConnection(NotebookSocket conn) {
     connectedSockets.add(conn);
@@ -354,13 +362,12 @@ public class ConnectionManager {
   public void broadcastNoteListExcept(List<NoteInfo> notesInfo,
                                       AuthenticationInfo subject) {
     Set<String> userAndRoles;
-    NotebookAuthorization authInfo = NotebookAuthorization.getInstance();
     for (String user : userSocketMap.keySet()) {
       if (subject.getUser().equals(user)) {
         continue;
       }
       //reloaded already above; parameter - false
-      userAndRoles = authInfo.getRoles(user);
+      userAndRoles = authorizationService.getRoles(user);
       userAndRoles.add(user);
       // TODO(zjffdu) is it ok for comment the following line ?
       // notesInfo = generateNotesInfo(false, new AuthenticationInfo(user), userAndRoles);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -32,7 +32,9 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.service.AuthenticationService;
 import org.apache.zeppelin.utils.TestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -419,7 +421,9 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     List<Map<String, String>> body = (List<Map<String, String>>) resp.get("body");
     //TODO(khalid): anonymous or specific user notes?
     HashSet<String> anonymous = Sets.newHashSet("anonymous");
-    assertEquals("List notes are equal", TestUtils.getInstance(Notebook.class).getAllNotes(anonymous)
+    AuthorizationService authorizationService = TestUtils.getInstance(AuthorizationService.class);
+    assertEquals("List notes are equal", TestUtils.getInstance(Notebook.class)
+            .getAllNotes(note -> authorizationService.isReader(note.getId(), anonymous))
             .size(), body.size());
     get.releaseConnection();
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -51,11 +51,8 @@ import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
-import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
-import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.*;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.repo.InMemoryNotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.search.LuceneSearch;
@@ -97,7 +94,7 @@ public class NotebookServiceTest {
     when(mockInterpreterSetting.isUserAuthorized(any())).thenReturn(true);
     when(mockInterpreterGroup.getInterpreterSetting()).thenReturn(mockInterpreterSetting);
     SearchService searchService = new LuceneSearch(zeppelinConfiguration);
-    NotebookAuthorization notebookAuthorization = NotebookAuthorization.getInstance();
+
     Credentials credentials = new Credentials(false, null, null);
     Notebook notebook =
         new Notebook(
@@ -106,10 +103,10 @@ public class NotebookServiceTest {
             mockInterpreterFactory,
             mockInterpreterSettingManager,
             searchService,
-            notebookAuthorization,
             credentials,
             null);
-    notebookService = new NotebookService(notebook, notebookAuthorization, zeppelinConfiguration);
+    AuthorizationService authorizationService = new AuthorizationService(notebook, notebook.getConf());
+    notebookService = new NotebookService(notebook, authorizationService, zeppelinConfiguration);
 
     String interpreterName = "test";
     when(mockInterpreterSetting.getName()).thenReturn(interpreterName);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class is responsible for maintain notes authorization info. And provide api for
+ * setting and querying note authorization info.
+ */
+public class AuthorizationService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationService.class);
+  private static final Set<String> EMPTY_SET = new HashSet<>();
+
+  private ZeppelinConfiguration conf;
+  private Notebook notebook;
+  /*
+   * contains roles for each user
+   */
+  private Map<String, Set<String>> userRoles = new HashMap<>();
+
+  @Inject
+  public AuthorizationService(Notebook notebook, ZeppelinConfiguration conf) {
+    this.notebook = notebook;
+    this.conf = conf;
+  }
+
+  private Set<String> validateUser(Set<String> users) {
+    Set<String> returnUser = new HashSet<>();
+    for (String user : users) {
+      if (!user.trim().isEmpty()) {
+        returnUser.add(user.trim());
+      }
+    }
+    return returnUser;
+  }
+
+  public void setOwners(String noteId, Set<String> entities) {
+    entities = validateUser(entities);
+    notebook.getNote(noteId).setOwners(entities);
+  }
+
+  public void setReaders(String noteId, Set<String> entities) {
+    entities = validateUser(entities);
+    notebook.getNote(noteId).setReaders(entities);
+  }
+
+  public void setRunners(String noteId, Set<String> entities) {
+    entities = validateUser(entities);
+    notebook.getNote(noteId).setRunners(entities);
+  }
+
+  public void setWriters(String noteId, Set<String> entities) {
+    entities = validateUser(entities);
+    notebook.getNote(noteId).setWriters(entities);
+  }
+
+  public Set<String> getOwners(String noteId) {
+    Set<String> entities = notebook.getNote(noteId).getOwners();
+    if (entities != null) {
+      return entities;
+    } else {
+      return EMPTY_SET ;
+    }
+  }
+
+  public Set<String> getReaders(String noteId) {
+    Set<String> entities = notebook.getNote(noteId).getReaders();
+    if (entities != null) {
+      return entities;
+    } else {
+      return EMPTY_SET ;
+    }
+  }
+
+  public Set<String> getRunners(String noteId) {
+    Set<String> entities = notebook.getNote(noteId).getRunners();
+    if (entities != null) {
+      return entities;
+    } else {
+      return EMPTY_SET ;
+    }
+  }
+
+  public Set<String> getWriters(String noteId) {
+    Set<String> entities = notebook.getNote(noteId).getWriters();
+    if (entities != null) {
+      return entities;
+    } else {
+      return EMPTY_SET ;
+    }
+  }
+
+  public boolean isOwner(String noteId, Set<String> entities) {
+    return isMember(entities, notebook.getNote(noteId).getOwners()) || isAdmin(entities);
+  }
+
+  public boolean isWriter(String noteId, Set<String> entities) {
+    return isMember(entities, notebook.getNote(noteId).getWriters()) ||
+            isMember(entities, notebook.getNote(noteId).getOwners()) ||
+            isAdmin(entities);
+  }
+
+  public boolean isReader(String noteId, Set<String> entities) {
+    return isMember(entities, notebook.getNote(noteId).getReaders()) ||
+            isMember(entities, notebook.getNote(noteId).getOwners()) ||
+            isMember(entities, notebook.getNote(noteId).getWriters()) ||
+            isMember(entities, notebook.getNote(noteId).getRunners()) ||
+            isAdmin(entities);
+  }
+
+  public boolean isRunner(String noteId, Set<String> entities) {
+    return isMember(entities, notebook.getNote(noteId).getRunners()) ||
+            isMember(entities, notebook.getNote(noteId).getWriters()) ||
+            isMember(entities, notebook.getNote(noteId).getOwners()) ||
+            isAdmin(entities);
+  }
+
+  private boolean isAdmin(Set<String> entities) {
+    String adminRole = conf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_OWNER_ROLE);
+    if (StringUtils.isBlank(adminRole)) {
+      return false;
+    }
+    return entities.contains(adminRole);
+  }
+
+  // return true if b is empty or if (a intersection b) is non-empty
+  private boolean isMember(Set<String> a, Set<String> b) {
+    Set<String> intersection = new HashSet<>(b);
+    intersection.retainAll(a);
+    return (b.isEmpty() || (intersection.size() > 0));
+  }
+
+  public boolean isOwner(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOGGER.debug("Zeppelin runs in anonymous mode, everybody is owner");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isOwner(noteId, userAndRoles);
+  }
+
+  //TODO(zjffdu) merge this hasWritePermission with isWriter ?
+  public boolean hasWritePermission(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOGGER.debug("Zeppelin runs in anonymous mode, everybody is writer");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isWriter(noteId, userAndRoles);
+  }
+
+  public boolean hasReadPermission(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOGGER.debug("Zeppelin runs in anonymous mode, everybody is reader");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isReader(noteId, userAndRoles);
+  }
+
+  public boolean hasRunPermission(Set<String> userAndRoles, String noteId) {
+    if (conf.isAnonymousAllowed()) {
+      LOGGER.debug("Zeppelin runs in anonymous mode, everybody is reader");
+      return true;
+    }
+    if (userAndRoles == null) {
+      return false;
+    }
+    return isReader(noteId, userAndRoles);
+  }
+
+  public boolean isPublic() {
+    return conf.isNotebookPublic();
+  }
+
+  public void setRoles(String user, Set<String> roles) {
+    if (StringUtils.isBlank(user)) {
+      LOGGER.warn("Setting roles for empty user");
+      return;
+    }
+    roles = validateUser(roles);
+    userRoles.put(user, roles);
+  }
+
+  public Set<String> getRoles(String user) {
+    Set<String> roles = Sets.newHashSet();
+    if (userRoles.containsKey(user)) {
+      roles.addAll(userRoles.get(user));
+    }
+    return roles;
+  }
+
+  public List<NoteInfo> filterByUser(List<NoteInfo> notes, AuthenticationInfo subject) {
+    final Set<String> entities = Sets.newHashSet();
+    if (subject != null) {
+      entities.add(subject.getUser());
+    }
+    return FluentIterable.from(notes).filter(new Predicate<NoteInfo>() {
+      @Override
+      public boolean apply(NoteInfo input) {
+        return input != null && isReader(input.getId(), entities);
+      }
+    }).toList();
+  }
+
+  public void clearPermission(String noteId) {
+    notebook.getNote(noteId).setReaders(Sets.newHashSet());
+    notebook.getNote(noteId).setRunners(Sets.newHashSet());
+    notebook.getNote(noteId).setWriters(Sets.newHashSet());
+    notebook.getNote(noteId).setOwners(Sets.newHashSet());
+  }
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinClient.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Future;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.model.UserTokenContainer;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.security.Authentication;
 import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.listener.WatcherWebsocket;
@@ -81,7 +81,7 @@ public class ZeppelinClient {
       "RUN_PARAGRAPH",
       "CANCEL_PARAGRAPH"));
 
-  public static ZeppelinClient initialize(String zeppelinUrl, String token, 
+  public static ZeppelinClient initialize(String zeppelinUrl, String token,
       ZeppelinConfiguration conf) {
     if (instance == null) {
       instance = new ZeppelinClient(zeppelinUrl, token, conf);
@@ -192,7 +192,7 @@ public class ZeppelinClient {
       return null;
     }
   }
-  
+
   private Session openWatcherSession() {
     ClientUpgradeRequest request = new ClientUpgradeRequest();
     request.setHeader(WatcherSecurityKey.HTTP_HEADER, WatcherSecurityKey.getKey());
@@ -218,7 +218,7 @@ public class ZeppelinClient {
     }
     noteSession.getRemote().sendStringByFuture(serialize(msg));
   }
-  
+
   public Session getZeppelinConnection(String noteId, String principal, String ticket) {
     if (StringUtils.isBlank(noteId)) {
       LOG.warn("Cannot get Websocket session with blanck noteId");
@@ -226,7 +226,7 @@ public class ZeppelinClient {
     }
     return getNoteSession(noteId, principal, ticket);
   }
-  
+
 /*
   private Message zeppelinGetNoteMsg(String noteId) {
     Message getNoteMsg = new Message(Message.OP.GET_NOTE);
@@ -247,7 +247,7 @@ public class ZeppelinClient {
     }
     return session;
   }
-  
+
   private Session openNoteSession(String noteId, String principal, String ticket) {
     ClientUpgradeRequest request = new ClientUpgradeRequest();
     request.setHeader(ORIGIN, "*");
@@ -272,7 +272,7 @@ public class ZeppelinClient {
     }
     return session;
   }
-  
+
   private boolean isSessionOpen(Session session) {
     return (session != null) && (session.isOpen());
   }
@@ -299,7 +299,7 @@ public class ZeppelinClient {
     if (!isActionable(zeppelinMsg.op)) {
       return;
     }
-    
+
     token = UserTokenContainer.getInstance().getUserToken(zeppelinMsg.principal);
     Client client = Client.getInstance();
     if (client == null) {
@@ -319,7 +319,7 @@ public class ZeppelinClient {
     if (StringUtils.isBlank(noteId)) {
       return;
     }
-    NotebookAuthorization noteAuth = NotebookAuthorization.getInstance();
+    AuthorizationService noteAuth = null; // AuthorizationService.get();
     Map<String, String> userTokens = UserTokenContainer.getInstance().getAllUserTokens();
     Client client = Client.getInstance();
     Set<String> userAndRoles;
@@ -341,7 +341,7 @@ public class ZeppelinClient {
     }
     return actionable.contains(action.name());
   }
-  
+
   public void removeNoteConnection(String noteId) {
     if (StringUtils.isBlank(noteId)) {
       LOG.error("Cannot remove session for empty noteId");
@@ -356,7 +356,7 @@ public class ZeppelinClient {
     }
     LOG.info("Removed note websocket connection for note {}", noteId);
   }
-  
+
   private void removeAllConnections() {
     if (watcherSession != null && watcherSession.isOpen()) {
       watcherSession.close();
@@ -379,7 +379,7 @@ public class ZeppelinClient {
     }
     watcherSession.getRemote().sendStringByFuture(serialize(new Message(OP.PING)));
   }
-  
+
   /**
    * Only used in test.
    */

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -29,7 +29,6 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.search.SearchService;
@@ -57,16 +56,14 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
 
     SearchService search = mock(SearchService.class);
     notebookRepo = mock(NotebookRepo.class);
-    NotebookAuthorization notebookAuthorization = NotebookAuthorization.init(conf);
-    /*notebook =
+    notebook =
         new Notebook(
             conf,
             notebookRepo,
             interpreterFactory,
             interpreterSettingManager,
             search,
-            notebookAuthorization,
-            new Credentials(false, null, null));*/
+            new Credentials(false, null, null));
 
     heliumAppFactory = new HeliumApplicationFactory(notebook, null);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -31,7 +31,6 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
-import org.apache.zeppelin.notebook.NotebookAuthorization;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -57,7 +56,7 @@ public class LuceneSearchTest {
     when(interpreterSettingManager.getDefaultInterpreterSetting()).thenReturn(defaultInterpreterSetting);
     notebook = new Notebook(ZeppelinConfiguration.create(), mock(NotebookRepo.class),
         mock(InterpreterFactory.class), interpreterSettingManager,
-        noteSearchService, mock(NotebookAuthorization.class),
+        noteSearchService,
         mock(Credentials.class), null);
   }
 


### PR DESCRIPTION
### What is this PR for?

This PR move note permission from `notebook-authorization.json` to note json file. `AuthorizationService` is responsible for authorization operations, including setting permission and querying permissions. I keep `NoteAuthorization` and will create another PR to upgrade notes.

### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-3985

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
