### PR TITLE
ZEPPELIN-4033. Remove spark dependency from zeppelin-zengine

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -594,20 +594,6 @@
             </exclusion>
           </exclusions>
         </dependency>
-
-        <dependency>
-          <groupId>org.apache.zeppelin</groupId>
-          <artifactId>spark-interpreter</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-          <exclusions>
-            <!-- It is fine to exclude zeppelin-python, because it is only used at runtime when launching interpreter -->
-            <exclusion>
-              <groupId>org.apache.zeppelin</groupId>
-              <artifactId>zeppelin-python</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
       </dependencies>
     </profile>
 


### PR DESCRIPTION
### What is this PR for?
Straightforward fix to remove  spark dependency from zeppelin-zengine as we have move spark integration test to zeppelin-interpreter-integration.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4033

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
