### PR TITLE
[ZEPPELIN-4035]. mvn dependency:tree is ignored for interpreter module

### DIFF
--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -152,13 +152,20 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
+          <executions>
+            <execution>
+              <id>copy-dependencies</id>
+              <phase>process-test-resources</phase>
+              <goals>
+                <goal>copy-dependencies</goal>
+              </goals>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
-
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
### What is this PR for?
Before this PR, `mvn dependency:tree` can not be executed correctly for interpreter module because the whole plugin `maven-dependency-plugin` is skipped. This PR fix it by just skipping `copy-dependencies`

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4035

### How should this be tested?

Executing the following command:
```
mvn dependency:tree -pl zeppelin-interpreter-parent,shell -am
```

Before this PR.

```
[INFO] -----------------< org.apache.zeppelin:zeppelin-shell >-----------------
[INFO] Building Zeppelin: Shell interpreter 0.9.0-SNAPSHOT                [5/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ zeppelin-shell ---
[INFO] Skipping plugin execution
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
```

After this PR
```
[INFO] -----------------< org.apache.zeppelin:zeppelin-shell >-----------------
[INFO] Building Zeppelin: Shell interpreter 0.9.0-SNAPSHOT                [5/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ zeppelin-shell ---
[INFO] org.apache.zeppelin:zeppelin-shell:jar:0.9.0-SNAPSHOT
[INFO] +- org.apache.commons:commons-exec:jar:1.3:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.4:compile
[INFO] +- org.apache.zeppelin:zeppelin-interpreter-api:jar:0.9.0-SNAPSHOT:compile
[INFO] +- org.apache.zeppelin:zeppelin-interpreter:jar:0.9.0-SNAPSHOT:provided
[INFO] |  +- io.atomix:atomix:jar:3.0.0-rc4:provided
[INFO] |  |  +- io.atomix:atomix-cluster:jar:3.0.0-rc4:provided
[INFO] |  |  |  +- io.netty:netty-transport:jar:4.1.27.Final:provided
[INFO] |  |  |  |  +- io.netty:netty-buffer:jar:4.1.27.Final:provided
...
```
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
