### PR TITLE
[ZEPPELIN-4054] Fix LdapGroupRealm path in shiro doc

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -83,7 +83,7 @@ activeDirectoryRealm.groupRolesMap = "CN=aGroupName,OU=groups,DC=SOME_GROUP,DC=C
 activeDirectoryRealm.authorizationCachingEnabled = false
 activeDirectoryRealm.principalSuffix = @corp.company.net
 
-ldapRealm = org.apache.zeppelin.server.LdapGroupRealm
+ldapRealm = org.apache.zeppelin.realm.LdapGroupRealm
 # search base for ldap groups (only relevant for LdapGroupRealm):
 ldapRealm.contextFactory.environment[ldap.searchBase] = dc=COMPANY,dc=COM
 ldapRealm.contextFactory.url = ldap://ldap.test.com:389


### PR DESCRIPTION
LdapGroupRealm has moved to org.apache.zeppelin.realm

### What is this PR for?
Fix doc


### What type of PR is it?
Documentation 

### Todos
[ ] - Fix LdapGroupRealm path in shiro doc

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4054

### How should this be tested?
no need

### Screenshots (if appropriate)
no need

### Questions:
