### PR TITLE
[ZEPPELIN-4072] Fix CreateNote() throws Note existed exception interrupt travis-ci

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -151,82 +151,98 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
   @Test
   public void scalaOutputTest() throws IOException, InterruptedException {
-    // create new note
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark import java.util.Date\n" +
-        "import java.net.URL\n" +
-        "println(\"hello\")\n"
-    );
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals("hello\n" +
-        "import java.util.Date\n" +
-        "import java.net.URL\n",
-        p.getReturn().message().get(0).getData());
+    Note note = null;
+    try {
+      // create new note
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark import java.util.Date\n" +
+          "import java.net.URL\n" +
+          "println(\"hello\")\n"
+      );
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals("hello\n" +
+          "import java.util.Date\n" +
+          "import java.net.URL\n",
+          p.getReturn().message().get(0).getData());
 
-    p.setText("%spark invalid_code");
-    note.run(p.getId(), true);
-    assertEquals(Status.ERROR, p.getStatus());
-    assertTrue(p.getReturn().message().get(0).getData().contains("error: "));
+      p.setText("%spark invalid_code");
+      note.run(p.getId(), true);
+      assertEquals(Status.ERROR, p.getStatus());
+      assertTrue(p.getReturn().message().get(0).getData().contains("error: "));
 
-    // test local properties
-    p.setText("%spark(p1=v1,p2=v2) print(z.getInterpreterContext().getLocalProperties().size())");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals("2", p.getReturn().message().get(0).getData());
+      // test local properties
+      p.setText("%spark(p1=v1,p2=v2) print(z.getInterpreterContext().getLocalProperties().size())");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals("2", p.getReturn().message().get(0).getData());
 
-    // test code completion
-    List<InterpreterCompletion> completions = note.completion(p.getId(), "sc.", 2, AuthenticationInfo.ANONYMOUS);
-    assertTrue(completions.size() > 0);
+      // test code completion
+      List<InterpreterCompletion> completions = note.completion(p.getId(), "sc.", 2, AuthenticationInfo.ANONYMOUS);
+      assertTrue(completions.size() > 0);
 
-    // test cancel
-    p.setText("%spark sc.range(1,10).map(e=>{Thread.sleep(1000); e}).collect()");
-    note.run(p.getId(), false);
-    waitForRunning(p);
-    p.abort();
-    waitForFinish(p);
-    assertEquals(Status.ABORT, p.getStatus());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // test cancel
+      p.setText("%spark sc.range(1,10).map(e=>{Thread.sleep(1000); e}).collect()");
+      note.run(p.getId(), false);
+      waitForRunning(p);
+      p.abort();
+      waitForFinish(p);
+      assertEquals(Status.ABORT, p.getStatus());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void basicRDDTransformationAndActionTest() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark print(sc.parallelize(1 to 10).reduce(_ + _))");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals("55", p.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark print(sc.parallelize(1 to 10).reduce(_ + _))");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals("55", p.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void sparkReadJSONTest() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    File tmpJsonFile = File.createTempFile("test", ".json");
-    FileWriter jsonFileWriter = new FileWriter(tmpJsonFile);
-    IOUtils.copy(new StringReader("{\"metadata\": { \"key\": 84896, \"value\": 54 }}\n"),
-            jsonFileWriter);
-    jsonFileWriter.close();
-    if (isSpark2()) {
-      p.setText("%spark spark.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
-    } else {
-      p.setText("%spark sqlContext.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      File tmpJsonFile = File.createTempFile("test", ".json");
+      FileWriter jsonFileWriter = new FileWriter(tmpJsonFile);
+      IOUtils.copy(new StringReader("{\"metadata\": { \"key\": 84896, \"value\": 54 }}\n"),
+              jsonFileWriter);
+      jsonFileWriter.close();
+      if (isSpark2()) {
+        p.setText("%spark spark.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
+      } else {
+        p.setText("%spark sqlContext.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
+      }
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      if (isSpark2()) {
+        assertTrue(p.getReturn().message().get(0).getData().contains(
+                "org.apache.spark.sql.DataFrame = [metadata: struct<key: bigint, value: bigint>]"));
+      } else {
+        assertTrue(p.getReturn().message().get(0).getData().contains(
+                "org.apache.spark.sql.DataFrame = [metadata: struct<key:bigint,value:bigint>]"));
+      }
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
     }
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    if (isSpark2()) {
-      assertTrue(p.getReturn().message().get(0).getData().contains(
-              "org.apache.spark.sql.DataFrame = [metadata: struct<key: bigint, value: bigint>]"));
-    } else {
-      assertTrue(p.getReturn().message().get(0).getData().contains(
-              "org.apache.spark.sql.DataFrame = [metadata: struct<key:bigint,value:bigint>]"));
-    }
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   @Test
@@ -235,340 +251,393 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       // csv if not supported in spark 1.x natively
       return;
     }
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    File tmpCSVFile = File.createTempFile("test", ".csv");
-    FileWriter csvFileWriter = new FileWriter(tmpCSVFile);
-    IOUtils.copy(new StringReader("84896,54"), csvFileWriter);
-    csvFileWriter.close();
-    p.setText("%spark spark.read.csv(\"file://" + tmpCSVFile.getAbsolutePath() + "\")");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertTrue(p.getReturn().message().get(0).getData().contains(
-            "org.apache.spark.sql.DataFrame = [_c0: string, _c1: string]\n"));
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      File tmpCSVFile = File.createTempFile("test", ".csv");
+      FileWriter csvFileWriter = new FileWriter(tmpCSVFile);
+      IOUtils.copy(new StringReader("84896,54"), csvFileWriter);
+      csvFileWriter.close();
+      p.setText("%spark spark.read.csv(\"file://" + tmpCSVFile.getAbsolutePath() + "\")");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertTrue(p.getReturn().message().get(0).getData().contains(
+              "org.apache.spark.sql.DataFrame = [_c0: string, _c1: string]\n"));
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void sparkSQLTest() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    // test basic dataframe api
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))\n" +
-            "df.collect()");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertTrue(p.getReturn().message().get(0).getData().contains(
-            "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      // test basic dataframe api
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))\n" +
+              "df.collect()");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertTrue(p.getReturn().message().get(0).getData().contains(
+              "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
 
-    // test display DataFrame
-    p = note.addNewParagraph(anonymous);
-    p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))\n" +
-        "z.show(df)");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-    assertEquals("_1\t_2\nhello\t20\n", p.getReturn().message().get(0).getData());
-
-    // test display DataSet
-    if (isSpark2()) {
+      // test display DataFrame
       p = note.addNewParagraph(anonymous);
-      p.setText("%spark val ds=spark.createDataset(Seq((\"hello\",20)))\n" +
-          "z.show(ds)");
+      p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))\n" +
+          "z.show(df)");
       note.run(p.getId(), true);
       assertEquals(Status.FINISHED, p.getStatus());
       assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
       assertEquals("_1\t_2\nhello\t20\n", p.getReturn().message().get(0).getData());
-    }
 
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // test display DataSet
+      if (isSpark2()) {
+        p = note.addNewParagraph(anonymous);
+        p.setText("%spark val ds=spark.createDataset(Seq((\"hello\",20)))\n" +
+            "z.show(ds)");
+        note.run(p.getId(), true);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+        assertEquals("_1\t_2\nhello\t20\n", p.getReturn().message().get(0).getData());
+      }
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void sparkRTest() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
 
-    String sqlContextName = "sqlContext";
-    if (isSpark2()) {
-      sqlContextName = "spark";
+      String sqlContextName = "sqlContext";
+      if (isSpark2()) {
+        sqlContextName = "spark";
+      }
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
+          "df <- createDataFrame(" + sqlContextName + ", localDF)\n" +
+          "count(df)"
+      );
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals("[1] 3", p.getReturn().message().get(0).getData().trim());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
     }
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
-        "df <- createDataFrame(" + sqlContextName + ", localDF)\n" +
-        "count(df)"
-    );
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals("[1] 3", p.getReturn().message().get(0).getData().trim());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   // @Test
   public void pySparkTest() throws IOException {
     // create new note
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
 
-    // run markdown paragraph, again
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark.pyspark sc.parallelize(range(1, 11)).reduce(lambda a, b: a + b)");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals("55\n", p.getReturn().message().get(0).getData());
-    if (!isSpark2()) {
-      // run sqlContext test
-      p = note.addNewParagraph(anonymous);
-      p.setText("%pyspark from pyspark.sql import Row\n" +
-          "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-          "df.collect()");
+      // run markdown paragraph, again
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark.pyspark sc.parallelize(range(1, 11)).reduce(lambda a, b: a + b)");
       note.run(p.getId(), true);
       assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
+      assertEquals("55\n", p.getReturn().message().get(0).getData());
+      if (!isSpark2()) {
+        // run sqlContext test
+        p = note.addNewParagraph(anonymous);
+        p.setText("%pyspark from pyspark.sql import Row\n" +
+            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+            "df.collect()");
+        note.run(p.getId(), true);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
 
-      // test display Dataframe
-      p = note.addNewParagraph(anonymous);
-      p.setText("%pyspark from pyspark.sql import Row\n" +
-          "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-          "z.show(df)");
-      note.run(p.getId(), true);
-      waitForFinish(p);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      // TODO(zjffdu), one more \n is appended, need to investigate why.
-      assertEquals("age\tid\n20\t1\n", p.getReturn().message().get(0).getData());
+        // test display Dataframe
+        p = note.addNewParagraph(anonymous);
+        p.setText("%pyspark from pyspark.sql import Row\n" +
+            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+            "z.show(df)");
+        note.run(p.getId(), true);
+        waitForFinish(p);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+        // TODO(zjffdu), one more \n is appended, need to investigate why.
+        assertEquals("age\tid\n20\t1\n", p.getReturn().message().get(0).getData());
 
-      // test udf
-      p = note.addNewParagraph(anonymous);
-      p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
-          "sqlContext.sql(\"select f1(\\\"abc\\\") as len\").collect()");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
-          "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
+        // test udf
+        p = note.addNewParagraph(anonymous);
+        p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
+            "sqlContext.sql(\"select f1(\\\"abc\\\") as len\").collect()");
+        note.run(p.getId(), true);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
+            "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
 
-      // test exception
-      p = note.addNewParagraph(anonymous);
-      /*
-       %pyspark
-       a=1
+        // test exception
+        p = note.addNewParagraph(anonymous);
+        /*
+         %pyspark
+         a=1
 
-       print(a2)
-       */
-      p.setText("%pyspark a=1\n\nprint(a2)");
-      note.run(p.getId(), true);
-      assertEquals(Status.ERROR, p.getStatus());
-      assertTrue(p.getReturn().message().get(0).getData()
-          .contains("Fail to execute line 3: print(a2)"));
-      assertTrue(p.getReturn().message().get(0).getData()
-          .contains("name 'a2' is not defined"));
-    } else {
-      // run SparkSession test
-      p = note.addNewParagraph(anonymous);
-      p.setText("%pyspark from pyspark.sql import Row\n" +
-          "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-          "df.collect()");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
+         print(a2)
+         */
+        p.setText("%pyspark a=1\n\nprint(a2)");
+        note.run(p.getId(), true);
+        assertEquals(Status.ERROR, p.getStatus());
+        assertTrue(p.getReturn().message().get(0).getData()
+            .contains("Fail to execute line 3: print(a2)"));
+        assertTrue(p.getReturn().message().get(0).getData()
+            .contains("name 'a2' is not defined"));
+      } else {
+        // run SparkSession test
+        p = note.addNewParagraph(anonymous);
+        p.setText("%pyspark from pyspark.sql import Row\n" +
+            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+            "df.collect()");
+        note.run(p.getId(), true);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
 
-      // test udf
-      p = note.addNewParagraph(anonymous);
-      // use SQLContext to register UDF but use this UDF through SparkSession
-      p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
-          "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
-          "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
+        // test udf
+        p = note.addNewParagraph(anonymous);
+        // use SQLContext to register UDF but use this UDF through SparkSession
+        p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
+            "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
+        note.run(p.getId(), true);
+        assertEquals(Status.FINISHED, p.getStatus());
+        assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
+            "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
+      }
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
     }
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   @Test
   public void zRunTest() throws IOException {
-    // create new note
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p0 = note.addNewParagraph(anonymous);
-    // z.run(paragraphIndex)
-    p0.setText("%spark z.run(1)");
-    Paragraph p1 = note.addNewParagraph(anonymous);
-    p1.setText("%spark val a=10");
-    Paragraph p2 = note.addNewParagraph(anonymous);
-    p2.setText("%spark print(a)");
+    Note note = null;
+    Note note2 = null;
+    try {
+      // create new note
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p0 = note.addNewParagraph(anonymous);
+      // z.run(paragraphIndex)
+      p0.setText("%spark z.run(1)");
+      Paragraph p1 = note.addNewParagraph(anonymous);
+      p1.setText("%spark val a=10");
+      Paragraph p2 = note.addNewParagraph(anonymous);
+      p2.setText("%spark print(a)");
 
-    note.run(p0.getId(), true);
-    assertEquals(Status.FINISHED, p0.getStatus());
+      note.run(p0.getId(), true);
+      assertEquals(Status.FINISHED, p0.getStatus());
 
-    // z.run is not blocking call. So p1 may not be finished when p0 is done.
-    waitForFinish(p1);
-    assertEquals(Status.FINISHED, p1.getStatus());
-    note.run(p2.getId(), true);
-    assertEquals(Status.FINISHED, p2.getStatus());
-    assertEquals("10", p2.getReturn().message().get(0).getData());
+      // z.run is not blocking call. So p1 may not be finished when p0 is done.
+      waitForFinish(p1);
+      assertEquals(Status.FINISHED, p1.getStatus());
+      note.run(p2.getId(), true);
+      assertEquals(Status.FINISHED, p2.getStatus());
+      assertEquals("10", p2.getReturn().message().get(0).getData());
 
-    Paragraph p3 = note.addNewParagraph(anonymous);
-    p3.setText("%spark println(new java.util.Date())");
+      Paragraph p3 = note.addNewParagraph(anonymous);
+      p3.setText("%spark println(new java.util.Date())");
 
-    // run current Node, z.runNote(noteId)
-    p0.setText(String.format("%%spark z.runNote(\"%s\")", note.getId()));
-    note.run(p0.getId());
-    waitForFinish(p0);
-    waitForFinish(p1);
-    waitForFinish(p2);
-    waitForFinish(p3);
+      // run current Node, z.runNote(noteId)
+      p0.setText(String.format("%%spark z.runNote(\"%s\")", note.getId()));
+      note.run(p0.getId());
+      waitForFinish(p0);
+      waitForFinish(p1);
+      waitForFinish(p2);
+      waitForFinish(p3);
 
-    assertEquals(Status.FINISHED, p3.getStatus());
-    String p3result = p3.getReturn().message().get(0).getData();
-    assertTrue(p3result.length() > 0);
+      assertEquals(Status.FINISHED, p3.getStatus());
+      String p3result = p3.getReturn().message().get(0).getData();
+      assertTrue(p3result.length() > 0);
 
-    // z.run(noteId, paragraphId)
-    p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note.getId(), p3.getId()));
-    p3.setText("%spark println(\"END\")");
+      // z.run(noteId, paragraphId)
+      p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note.getId(), p3.getId()));
+      p3.setText("%spark println(\"END\")");
 
-    note.run(p0.getId(), true);
-    waitForFinish(p3);
-    assertEquals(Status.FINISHED, p3.getStatus());
-    assertEquals("END\n", p3.getReturn().message().get(0).getData());
+      note.run(p0.getId(), true);
+      waitForFinish(p3);
+      assertEquals(Status.FINISHED, p3.getStatus());
+      assertEquals("END\n", p3.getReturn().message().get(0).getData());
 
-    // run paragraph in note2 via paragraph in note1
-    Note note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
-    Paragraph p20 = note2.addNewParagraph(anonymous);
-    p20.setText("%spark val a = 1");
-    Paragraph p21 = note2.addNewParagraph(anonymous);
-    p21.setText("%spark print(a)");
+      // run paragraph in note2 via paragraph in note1
+      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
+      Paragraph p20 = note2.addNewParagraph(anonymous);
+      p20.setText("%spark val a = 1");
+      Paragraph p21 = note2.addNewParagraph(anonymous);
+      p21.setText("%spark print(a)");
 
-    // run p20 of note2 via paragraph in note1
-    p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note2.getId(), p20.getId()));
-    note.run(p0.getId(), true);
-    waitForFinish(p20);
-    assertEquals(Status.FINISHED, p20.getStatus());
-    assertEquals(Status.READY, p21.getStatus());
+      // run p20 of note2 via paragraph in note1
+      p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note2.getId(), p20.getId()));
+      note.run(p0.getId(), true);
+      waitForFinish(p20);
+      assertEquals(Status.FINISHED, p20.getStatus());
+      assertEquals(Status.READY, p21.getStatus());
 
-    p0.setText(String.format("%%spark z.runNote(\"%s\")", note2.getId()));
-    note.run(p0.getId(), true);
-    waitForFinish(p20);
-    waitForFinish(p21);
-    assertEquals(Status.FINISHED, p20.getStatus());
-    assertEquals(Status.FINISHED, p21.getStatus());
-    assertEquals("1", p21.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
-    TestUtils.getInstance(Notebook.class).removeNote(note2.getId(), anonymous);
+      p0.setText(String.format("%%spark z.runNote(\"%s\")", note2.getId()));
+      note.run(p0.getId(), true);
+      waitForFinish(p20);
+      waitForFinish(p21);
+      assertEquals(Status.FINISHED, p20.getStatus());
+      assertEquals(Status.FINISHED, p21.getStatus());
+      assertEquals("1", p21.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+      if (null != note2) {
+        TestUtils.getInstance(Notebook.class).removeNote(note2.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testZeppelinContextResource() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
 
-    Paragraph p1 = note.addNewParagraph(anonymous);
-    p1.setText("%spark z.put(\"var_1\", \"hello world\")");
+      Paragraph p1 = note.addNewParagraph(anonymous);
+      p1.setText("%spark z.put(\"var_1\", \"hello world\")");
 
-    Paragraph p2 = note.addNewParagraph(anonymous);
-    p2.setText("%spark println(z.get(\"var_1\"))");
+      Paragraph p2 = note.addNewParagraph(anonymous);
+      p2.setText("%spark println(z.get(\"var_1\"))");
 
-    Paragraph p3 = note.addNewParagraph(anonymous);
-    p3.setText("%spark.pyspark print(z.get(\"var_1\"))");
+      Paragraph p3 = note.addNewParagraph(anonymous);
+      p3.setText("%spark.pyspark print(z.get(\"var_1\"))");
 
-    // resources across interpreter processes (via DistributedResourcePool)
-    Paragraph p4 = note.addNewParagraph(anonymous);
-    p4.setText("%python print(z.get('var_1'))");
+      // resources across interpreter processes (via DistributedResourcePool)
+      Paragraph p4 = note.addNewParagraph(anonymous);
+      p4.setText("%python print(z.get('var_1'))");
 
-    note.run(p1.getId(), true);
-    note.run(p2.getId(), true);
-    note.run(p3.getId(), true);
-    note.run(p4.getId(), true);
+      note.run(p1.getId(), true);
+      note.run(p2.getId(), true);
+      note.run(p3.getId(), true);
+      note.run(p4.getId(), true);
 
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertEquals(Status.FINISHED, p2.getStatus());
-    assertEquals("hello world\n", p2.getReturn().message().get(0).getData());
-    assertEquals(Status.FINISHED, p3.getStatus());
-    assertEquals("hello world\n", p3.getReturn().message().get(0).getData());
-    assertEquals(Status.FINISHED, p4.getStatus());
-    assertEquals("hello world\n", p4.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      assertEquals(Status.FINISHED, p1.getStatus());
+      assertEquals(Status.FINISHED, p2.getStatus());
+      assertEquals("hello world\n", p2.getReturn().message().get(0).getData());
+      assertEquals(Status.FINISHED, p3.getStatus());
+      assertEquals("hello world\n", p3.getReturn().message().get(0).getData());
+      assertEquals(Status.FINISHED, p4.getStatus());
+      assertEquals("hello world\n", p4.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testZeppelinContextHook() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+    Note note = null;
+    Note note2 = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
 
-    // register global hook & note1 hook
-    Paragraph p1 = note.addNewParagraph(anonymous);
-    p1.setText("%python from __future__ import print_function\n" +
-        "z.registerHook('pre_exec', 'print(1)')\n" +
-        "z.registerHook('post_exec', 'print(2)')\n" +
-        "z.registerNoteHook('pre_exec', 'print(3)', '" + note.getId() + "')\n" +
-        "z.registerNoteHook('post_exec', 'print(4)', '" + note.getId() + "')\n");
+      // register global hook & note1 hook
+      Paragraph p1 = note.addNewParagraph(anonymous);
+      p1.setText("%python from __future__ import print_function\n" +
+          "z.registerHook('pre_exec', 'print(1)')\n" +
+          "z.registerHook('post_exec', 'print(2)')\n" +
+          "z.registerNoteHook('pre_exec', 'print(3)', '" + note.getId() + "')\n" +
+          "z.registerNoteHook('post_exec', 'print(4)', '" + note.getId() + "')\n");
 
-    Paragraph p2 = note.addNewParagraph(anonymous);
-    p2.setText("%python print(5)");
+      Paragraph p2 = note.addNewParagraph(anonymous);
+      p2.setText("%python print(5)");
 
-    note.run(p1.getId(), true);
-    note.run(p2.getId(), true);
+      note.run(p1.getId(), true);
+      note.run(p2.getId(), true);
 
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertEquals(Status.FINISHED, p2.getStatus());
-    assertEquals("1\n3\n5\n4\n2\n", p2.getReturn().message().get(0).getData());
+      assertEquals(Status.FINISHED, p1.getStatus());
+      assertEquals(Status.FINISHED, p2.getStatus());
+      assertEquals("1\n3\n5\n4\n2\n", p2.getReturn().message().get(0).getData());
 
-    Note note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
-    Paragraph p3 = note2.addNewParagraph(anonymous);
-    p3.setText("%python print(6)");
-    note2.run(p3.getId(), true);
-    assertEquals("1\n6\n2\n", p3.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
-    TestUtils.getInstance(Notebook.class).removeNote(note2.getId(), anonymous);
+      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
+      Paragraph p3 = note2.addNewParagraph(anonymous);
+      p3.setText("%python print(6)");
+      note2.run(p3.getId(), true);
+      assertEquals("1\n6\n2\n", p3.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+      if (null != note2) {
+        TestUtils.getInstance(Notebook.class).removeNote(note2.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void pySparkDepLoaderTest() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
 
-    // restart spark interpreter to make dep loader work
-    TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
+      // restart spark interpreter to make dep loader work
+      TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
 
-    // load dep
-    Paragraph p0 = note.addNewParagraph(anonymous);
-    p0.setText("%dep z.load(\"com.databricks:spark-csv_2.11:1.2.0\")");
-    note.run(p0.getId(), true);
-    assertEquals(Status.FINISHED, p0.getStatus());
+      // load dep
+      Paragraph p0 = note.addNewParagraph(anonymous);
+      p0.setText("%dep z.load(\"com.databricks:spark-csv_2.11:1.2.0\")");
+      note.run(p0.getId(), true);
+      assertEquals(Status.FINISHED, p0.getStatus());
 
-    // write test csv file
-    File tmpFile = File.createTempFile("test", "csv");
-    FileUtils.write(tmpFile, "a,b\n1,2");
+      // write test csv file
+      File tmpFile = File.createTempFile("test", "csv");
+      FileUtils.write(tmpFile, "a,b\n1,2");
 
-    // load data using libraries from dep loader
-    Paragraph p1 = note.addNewParagraph(anonymous);
+      // load data using libraries from dep loader
+      Paragraph p1 = note.addNewParagraph(anonymous);
 
-    String sqlContextName = "sqlContext";
-    if (isSpark2()) {
-      sqlContextName = "spark";
+      String sqlContextName = "sqlContext";
+      if (isSpark2()) {
+        sqlContextName = "spark";
+      }
+      p1.setText("%pyspark\n" +
+          "from pyspark.sql import SQLContext\n" +
+          "print(" + sqlContextName + ".read.format('com.databricks.spark.csv')" +
+          ".load('file://" + tmpFile.getAbsolutePath() + "').count())");
+      note.run(p1.getId(), true);
+
+      assertEquals(Status.FINISHED, p1.getStatus());
+      assertEquals("2\n", p1.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
     }
-    p1.setText("%pyspark\n" +
-        "from pyspark.sql import SQLContext\n" +
-        "print(" + sqlContextName + ".read.format('com.databricks.spark.csv')" +
-        ".load('file://" + tmpFile.getAbsolutePath() + "').count())");
-    note.run(p1.getId(), true);
-
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertEquals("2\n", p1.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   private void verifySparkVersionNumber() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
 
-    p.setText("%spark print(sc.version)");
-    note.run(p.getId());
-    waitForFinish(p);
-    assertEquals(Status.FINISHED, p.getStatus());
-    assertEquals(sparkVersion, p.getReturn().message().get(0).getData());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      p.setText("%spark print(sc.version)");
+      note.run(p.getId());
+      waitForFinish(p);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals(sparkVersion, p.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   private int toIntSparkVersion(String sparkVersion) {
@@ -583,131 +652,153 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
   @Test
   public void testSparkZeppelinContextDynamicForms() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    String code = "%spark.spark println(z.textbox(\"my_input\", \"default_name\"))\n" +
-        "println(z.password(\"my_pwd\"))\n" +
-        "println(z.select(\"my_select\", \"1\"," +
-        "Seq((\"1\", \"select_1\"), (\"2\", \"select_2\"))))\n" +
-        "val items=z.checkbox(\"my_checkbox\", Seq(\"2\"), " +
-        "Seq((\"1\", \"check_1\"), (\"2\", \"check_2\")))\n" +
-        "println(items(0))";
-    p.setText(code);
-    note.run(p.getId());
-    waitForFinish(p);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      String code = "%spark.spark println(z.textbox(\"my_input\", \"default_name\"))\n" +
+          "println(z.password(\"my_pwd\"))\n" +
+          "println(z.select(\"my_select\", \"1\"," +
+          "Seq((\"1\", \"select_1\"), (\"2\", \"select_2\"))))\n" +
+          "val items=z.checkbox(\"my_checkbox\", Seq(\"2\"), " +
+          "Seq((\"1\", \"check_1\"), (\"2\", \"check_2\")))\n" +
+          "println(items(0))";
+      p.setText(code);
+      note.run(p.getId());
+      waitForFinish(p);
 
-    assertEquals(Status.FINISHED, p.getStatus());
-    Iterator<String> formIter = p.settings.getForms().keySet().iterator();
-    assertEquals("my_input", formIter.next());
-    assertEquals("my_pwd", formIter.next());
-    assertEquals("my_select", formIter.next());
-    assertEquals("my_checkbox", formIter.next());
+      assertEquals(Status.FINISHED, p.getStatus());
+      Iterator<String> formIter = p.settings.getForms().keySet().iterator();
+      assertEquals("my_input", formIter.next());
+      assertEquals("my_pwd", formIter.next());
+      assertEquals("my_select", formIter.next());
+      assertEquals("my_checkbox", formIter.next());
 
-    // check dynamic forms values
-    String[] result = p.getReturn().message().get(0).getData().split("\n");
-    assertEquals(5, result.length);
-    assertEquals("default_name", result[0]);
-    assertEquals("null", result[1]);
-    assertEquals("1", result[2]);
-    assertEquals("2", result[3]);
-    assertEquals("items: Seq[Any] = Buffer(2)", result[4]);
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // check dynamic forms values
+      String[] result = p.getReturn().message().get(0).getData().split("\n");
+      assertEquals(5, result.length);
+      assertEquals("default_name", result[0]);
+      assertEquals("null", result[1]);
+      assertEquals("1", result[2]);
+      assertEquals("2", result[3]);
+      assertEquals("items: Seq[Any] = Buffer(2)", result[4]);
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testPySparkZeppelinContextDynamicForms() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    String code = "%spark.pyspark print(z.input('my_input', 'default_name'))\n" +
-        "print(z.password('my_pwd'))\n" +
-        "print(z.select('my_select', " +
-        "[('1', 'select_1'), ('2', 'select_2')], defaultValue='1'))\n" +
-        "items=z.checkbox('my_checkbox', " +
-        "[('1', 'check_1'), ('2', 'check_2')], defaultChecked=['2'])\n" +
-        "print(items[0])";
-    p.setText(code);
-    note.run(p.getId(), true);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      String code = "%spark.pyspark print(z.input('my_input', 'default_name'))\n" +
+          "print(z.password('my_pwd'))\n" +
+          "print(z.select('my_select', " +
+          "[('1', 'select_1'), ('2', 'select_2')], defaultValue='1'))\n" +
+          "items=z.checkbox('my_checkbox', " +
+          "[('1', 'check_1'), ('2', 'check_2')], defaultChecked=['2'])\n" +
+          "print(items[0])";
+      p.setText(code);
+      note.run(p.getId(), true);
 
-    assertEquals(Status.FINISHED, p.getStatus());
-    Iterator<String> formIter = p.settings.getForms().keySet().iterator();
-    assertEquals("my_input", formIter.next());
-    assertEquals("my_pwd", formIter.next());
-    assertEquals("my_select", formIter.next());
-    assertEquals("my_checkbox", formIter.next());
+      assertEquals(Status.FINISHED, p.getStatus());
+      Iterator<String> formIter = p.settings.getForms().keySet().iterator();
+      assertEquals("my_input", formIter.next());
+      assertEquals("my_pwd", formIter.next());
+      assertEquals("my_select", formIter.next());
+      assertEquals("my_checkbox", formIter.next());
 
-    // check dynamic forms values
-    String[] result = p.getReturn().message().get(0).getData().split("\n");
-    assertEquals(4, result.length);
-    assertEquals("default_name", result[0]);
-    assertEquals("None", result[1]);
-    assertEquals("1", result[2]);
-    assertEquals("2", result[3]);
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // check dynamic forms values
+      String[] result = p.getReturn().message().get(0).getData().split("\n");
+      assertEquals(4, result.length);
+      assertEquals("default_name", result[0]);
+      assertEquals("None", result[1]);
+      assertEquals("1", result[2]);
+      assertEquals("2", result[3]);
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testAngularObjects() throws IOException, InterpreterNotFoundException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p1 = note.addNewParagraph(anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p1 = note.addNewParagraph(anonymous);
 
-    // add local angular object
-    p1.setText("%spark z.angularBind(\"name\", \"world\")");
-    note.run(p1.getId(), true);
-    assertEquals(Status.FINISHED, p1.getStatus());
-    List<AngularObject> angularObjects = p1.getBindedInterpreter().getInterpreterGroup()
-            .getAngularObjectRegistry().getAll(note.getId(), null);
-    assertEquals(1, angularObjects.size());
-    assertEquals("name", angularObjects.get(0).getName());
-    assertEquals("world", angularObjects.get(0).get());
+      // add local angular object
+      p1.setText("%spark z.angularBind(\"name\", \"world\")");
+      note.run(p1.getId(), true);
+      assertEquals(Status.FINISHED, p1.getStatus());
+      List<AngularObject> angularObjects = p1.getBindedInterpreter().getInterpreterGroup()
+              .getAngularObjectRegistry().getAll(note.getId(), null);
+      assertEquals(1, angularObjects.size());
+      assertEquals("name", angularObjects.get(0).getName());
+      assertEquals("world", angularObjects.get(0).get());
 
-    // remove local angular object
-    Paragraph p2 = note.addNewParagraph(anonymous);
-    p2.setText("%spark z.angularUnbind(\"name\")");
-    note.run(p2.getId(), true);
-    assertEquals(Status.FINISHED, p2.getStatus());
-    angularObjects = p1.getBindedInterpreter().getInterpreterGroup().getAngularObjectRegistry()
-            .getAll(note.getId(), null);
-    assertEquals(0, angularObjects.size());
+      // remove local angular object
+      Paragraph p2 = note.addNewParagraph(anonymous);
+      p2.setText("%spark z.angularUnbind(\"name\")");
+      note.run(p2.getId(), true);
+      assertEquals(Status.FINISHED, p2.getStatus());
+      angularObjects = p1.getBindedInterpreter().getInterpreterGroup().getAngularObjectRegistry()
+              .getAll(note.getId(), null);
+      assertEquals(0, angularObjects.size());
 
-    // add global angular object
-    Paragraph p3 = note.addNewParagraph(anonymous);
-    p3.setText("%spark z.angularBindGlobal(\"name2\", \"world2\")");
-    note.run(p3.getId(), true);
-    assertEquals(Status.FINISHED, p3.getStatus());
-    List<AngularObject> globalAngularObjects = p3.getBindedInterpreter().getInterpreterGroup()
-            .getAngularObjectRegistry().getAll(null, null);
-    assertEquals(1, globalAngularObjects.size());
-    assertEquals("name2", globalAngularObjects.get(0).getName());
-    assertEquals("world2", globalAngularObjects.get(0).get());
+      // add global angular object
+      Paragraph p3 = note.addNewParagraph(anonymous);
+      p3.setText("%spark z.angularBindGlobal(\"name2\", \"world2\")");
+      note.run(p3.getId(), true);
+      assertEquals(Status.FINISHED, p3.getStatus());
+      List<AngularObject> globalAngularObjects = p3.getBindedInterpreter().getInterpreterGroup()
+              .getAngularObjectRegistry().getAll(null, null);
+      assertEquals(1, globalAngularObjects.size());
+      assertEquals("name2", globalAngularObjects.get(0).getName());
+      assertEquals("world2", globalAngularObjects.get(0).get());
 
-    // remove global angular object
-    Paragraph p4 = note.addNewParagraph(anonymous);
-    p4.setText("%spark z.angularUnbindGlobal(\"name2\")");
-    note.run(p4.getId(), true);
-    assertEquals(Status.FINISHED, p4.getStatus());
-    globalAngularObjects = p4.getBindedInterpreter().getInterpreterGroup()
-            .getAngularObjectRegistry().getAll(note.getId(), null);
-    assertEquals(0, globalAngularObjects.size());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // remove global angular object
+      Paragraph p4 = note.addNewParagraph(anonymous);
+      p4.setText("%spark z.angularUnbindGlobal(\"name2\")");
+      note.run(p4.getId(), true);
+      assertEquals(Status.FINISHED, p4.getStatus());
+      globalAngularObjects = p4.getBindedInterpreter().getInterpreterGroup()
+              .getAngularObjectRegistry().getAll(note.getId(), null);
+      assertEquals(0, globalAngularObjects.size());
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testConfInterpreter() throws IOException {
-    TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(anonymous);
-    p.setText("%spark.conf spark.jars.packages\tcom.databricks:spark-csv_2.11:1.2.0");
-    note.run(p.getId(), true);
-    assertEquals(Status.FINISHED, p.getStatus());
+    Note note = null;
+    try {
+      TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p = note.addNewParagraph(anonymous);
+      p.setText("%spark.conf spark.jars.packages\tcom.databricks:spark-csv_2.11:1.2.0");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
 
-    Paragraph p1 = note.addNewParagraph(anonymous);
-    p1.setText("%spark\nimport com.databricks.spark.csv._");
-    note.run(p1.getId(), true);
-    assertEquals(Status.FINISHED, p1.getStatus());
+      Paragraph p1 = note.addNewParagraph(anonymous);
+      p1.setText("%spark\nimport com.databricks.spark.csv._");
+      note.run(p1.getId(), true);
+      assertEquals(Status.FINISHED, p1.getStatus());
 
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/recovery/RecoveryTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/recovery/RecoveryTest.java
@@ -49,6 +49,8 @@ public class RecoveryTest extends AbstractTestRestApi {
 
   private Notebook notebook;
 
+  private AuthenticationInfo anonymous = new AuthenticationInfo("anonymous");
+
   @BeforeClass
   public static void init() throws Exception {
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_RECOVERY_STORAGE_CLASS.getVarName(),
@@ -73,101 +75,122 @@ public class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   public void testRecovery() throws Exception {
-    Note note1 = notebook.createNote("note1", AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = notebook.createNote("note1", anonymous);
 
-    // run python interpreter and create new variable `user`
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python user='abc'");
-    PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    TestUtils.getInstance(Notebook.class).saveNote(note1, AuthenticationInfo.ANONYMOUS);
+      // run python interpreter and create new variable `user`
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python user='abc'");
+      PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      TestUtils.getInstance(Notebook.class).saveNote(note1, anonymous);
 
-    // shutdown zeppelin and restart it
-    shutDown();
-    startUp(RecoveryTest.class.getSimpleName(), false);
+      // shutdown zeppelin and restart it
+      shutDown();
+      startUp(RecoveryTest.class.getSimpleName(), false);
 
-    // run the paragraph again, but change the text to print variable `user`
-    note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
-    p1 = note1.getParagraph(p1.getId());
-    p1.setText("%python print(user)");
-    post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    assertEquals("abc\n", p1.getReturn().message().get(0).getData());
+      // run the paragraph again, but change the text to print variable `user`
+      note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
+      p1 = note1.getParagraph(p1.getId());
+      p1.setText("%python print(user)");
+      post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      assertEquals("abc\n", p1.getReturn().message().get(0).getData());
+    } finally {
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRecovery_2() throws Exception {
-    Note note1 = notebook.createNote("note2", AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = notebook.createNote("note2", AuthenticationInfo.ANONYMOUS);
 
-    // run python interpreter and create new variable `user`
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python user='abc'");
-    PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    TestUtils.getInstance(Notebook.class).saveNote(note1, AuthenticationInfo.ANONYMOUS);
-    // restart the python interpreter
-    TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().restart(
-        ((ManagedInterpreterGroup) p1.getBindedInterpreter().getInterpreterGroup())
-            .getInterpreterSetting().getId()
-    );
+      // run python interpreter and create new variable `user`
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python user='abc'");
+      PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      TestUtils.getInstance(Notebook.class).saveNote(note1, AuthenticationInfo.ANONYMOUS);
+      // restart the python interpreter
+      TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().restart(
+          ((ManagedInterpreterGroup) p1.getBindedInterpreter().getInterpreterGroup())
+              .getInterpreterSetting().getId()
+      );
 
-    // shutdown zeppelin and restart it
-    shutDown();
-    startUp(RecoveryTest.class.getSimpleName(), false);
+      // shutdown zeppelin and restart it
+      shutDown();
+      startUp(RecoveryTest.class.getSimpleName(), false);
 
-    // run the paragraph again, but change the text to print variable `user`.
-    // can not recover the python interpreter, because it has been shutdown.
-    note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
-    p1 = note1.getParagraph(p1.getId());
-    p1.setText("%python print(user)");
-    post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.ERROR, p1.getStatus());
+      // run the paragraph again, but change the text to print variable `user`.
+      // can not recover the python interpreter, because it has been shutdown.
+      note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
+      p1 = note1.getParagraph(p1.getId());
+      p1.setText("%python print(user)");
+      post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.ERROR, p1.getStatus());
+    } finally {
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRecovery_3() throws Exception {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note3", AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note3", AuthenticationInfo.ANONYMOUS);
 
-    // run python interpreter and create new variable `user`
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python user='abc'");
-    PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    TestUtils.getInstance(Notebook.class).saveNote(note1, AuthenticationInfo.ANONYMOUS);
+      // run python interpreter and create new variable `user`
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python user='abc'");
+      PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      TestUtils.getInstance(Notebook.class).saveNote(note1, AuthenticationInfo.ANONYMOUS);
 
-    // shutdown zeppelin and restart it
-    shutDown();
-    StopInterpreter.main(new String[]{});
+      // shutdown zeppelin and restart it
+      shutDown();
+      StopInterpreter.main(new String[]{});
 
-    startUp(RecoveryTest.class.getSimpleName(), false);
+      startUp(RecoveryTest.class.getSimpleName(), false);
 
-    // run the paragraph again, but change the text to print variable `user`.
-    // can not recover the python interpreter, because it has been shutdown.
-    note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
-    p1 = note1.getParagraph(p1.getId());
-    p1.setText("%python print(user)");
-    post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(Job.Status.ERROR, p1.getStatus());
+      // run the paragraph again, but change the text to print variable `user`.
+      // can not recover the python interpreter, because it has been shutdown.
+      note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
+      p1 = note1.getParagraph(p1.getId());
+      p1.setText("%python print(user)");
+      post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(Job.Status.ERROR, p1.getStatus());
+    } finally {
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -74,309 +74,363 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testGetNoteParagraphJobStatus() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    String paragraphId = note1.getLastParagraph().getId();
+      String paragraphId = note1.getLastParagraph().getId();
 
-    GetMethod get = httpGet("/notebook/job/" + note1.getId() + "/" + paragraphId);
-    assertThat(get, isAllowed());
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    Map<String, Set<String>> paragraphStatus = (Map<String, Set<String>>) resp.get("body");
+      GetMethod get = httpGet("/notebook/job/" + note1.getId() + "/" + paragraphId);
+      assertThat(get, isAllowed());
+      Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Set<String>> paragraphStatus = (Map<String, Set<String>>) resp.get("body");
 
-    // Check id and status have proper value
-    assertEquals(paragraphStatus.get("id"), paragraphId);
-    assertEquals(paragraphStatus.get("status"), "READY");
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      // Check id and status have proper value
+      assertEquals(paragraphStatus.get("id"), paragraphId);
+      assertEquals(paragraphStatus.get("status"), "READY");
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRunParagraphJob() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    // run blank paragraph
-    PostMethod post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertEquals(p.getStatus(), Job.Status.FINISHED);
+      // run blank paragraph
+      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertEquals(p.getStatus(), Job.Status.FINISHED);
 
-    // run non-blank paragraph
-    p.setText("test");
-    post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
-    assertThat(post, isAllowed());
-    resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertNotEquals(p.getStatus(), Job.Status.READY);
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      // run non-blank paragraph
+      p.setText("test");
+      post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
+      assertThat(post, isAllowed());
+      resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertNotEquals(p.getStatus(), Job.Status.READY);
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRunParagraphSynchronously() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    // run non-blank paragraph
-    String title = "title";
-    String text = "%sh\n sleep 1";
-    p.setTitle(title);
-    p.setText(text);
+      // run non-blank paragraph
+      String title = "title";
+      String text = "%sh\n sleep 1";
+      p.setTitle(title);
+      p.setText(text);
 
-    PostMethod post = httpPost("/notebook/run/" + note1.getId() + "/" + p.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-        new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
-    assertNotEquals(p.getStatus(), Job.Status.READY);
+      PostMethod post = httpPost("/notebook/run/" + note1.getId() + "/" + p.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+          new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
+      assertNotEquals(p.getStatus(), Job.Status.READY);
 
-    // Check if the paragraph is emptied
-    assertEquals(title, p.getTitle());
-    assertEquals(text, p.getText());
-
-    // cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      // Check if the paragraph is emptied
+      assertEquals(title, p.getTitle());
+      assertEquals(text, p.getText());
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRunAllParagraph_AllSuccess() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    // 2 paragraphs
-    // P1:
-    //    %python
-    //    import time
-    //    time.sleep(1)
-    //    user='abc'
-    // P2:
-    //    %python
-    //    from __future__ import print_function
-    //    print(user)
-    //
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python import time\ntime.sleep(1)\nuser='abc'");
-    p2.setText("%python from __future__ import print_function\nprint(user)");
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      // 2 paragraphs
+      // P1:
+      //    %python
+      //    import time
+      //    time.sleep(1)
+      //    user='abc'
+      // P2:
+      //    %python
+      //    from __future__ import print_function
+      //    print(user)
+      //
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python import time\ntime.sleep(1)\nuser='abc'");
+      p2.setText("%python from __future__ import print_function\nprint(user)");
 
-    PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
+      PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
 
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    assertEquals(Job.Status.FINISHED, p2.getStatus());
-    assertEquals("abc\n", p2.getReturn().message().get(0).getData());
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      assertEquals(Job.Status.FINISHED, p2.getStatus());
+      assertEquals("abc\n", p2.getReturn().message().get(0).getData());
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRunAllParagraph_FirstFailed() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    // 2 paragraphs
-    // P1:
-    //    %python
-    //    import time
-    //    time.sleep(1)
-    //    from __future__ import print_function
-    //    print(user)
-    // P2:
-    //    %python
-    //    user='abc'
-    //
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python import time\ntime.sleep(1)\nfrom __future__ import print_function\nprint(user2)");
-    p2.setText("%python user2='abc'\nprint(user2)");
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      // 2 paragraphs
+      // P1:
+      //    %python
+      //    import time
+      //    time.sleep(1)
+      //    from __future__ import print_function
+      //    print(user)
+      // P2:
+      //    %python
+      //    user='abc'
+      //
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python import time\ntime.sleep(1)\nfrom __future__ import print_function\nprint(user2)");
+      p2.setText("%python user2='abc'\nprint(user2)");
 
-    PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post.releaseConnection();
+      PostMethod post = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post.releaseConnection();
 
-    assertEquals(Job.Status.ERROR, p1.getStatus());
-    // p2 will be skipped because p1 is failed.
-    assertEquals(Job.Status.READY, p2.getStatus());
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      assertEquals(Job.Status.ERROR, p1.getStatus());
+      // p2 will be skipped because p1 is failed.
+      assertEquals(Job.Status.READY, p2.getStatus());
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testCloneNote() throws IOException {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    PostMethod post = httpPost("/notebook/" + note1.getId(), "");
-    LOG.info("testCloneNote response\n" + post.getResponseBodyAsString());
-    assertThat(post, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    String clonedNoteId = (String) resp.get("body");
-    post.releaseConnection();
+    Note note1 = null;
+    String clonedNoteId = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      PostMethod post = httpPost("/notebook/" + note1.getId(), "");
+      LOG.info("testCloneNote response\n" + post.getResponseBodyAsString());
+      assertThat(post, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      clonedNoteId = (String) resp.get("body");
+      post.releaseConnection();
 
-    GetMethod get = httpGet("/notebook/" + clonedNoteId);
-    assertThat(get, isAllowed());
-    Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
+      GetMethod get = httpGet("/notebook/" + clonedNoteId);
+      assertThat(get, isAllowed());
+      Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
 
-    //    assertEquals(resp2Body.get("name"), "Note " + clonedNoteId);
-    get.releaseConnection();
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
-    TestUtils.getInstance(Notebook.class).removeNote(clonedNoteId, anonymous);
+      //    assertEquals(resp2Body.get("name"), "Note " + clonedNoteId);
+      get.releaseConnection();
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+      if (null != clonedNoteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(clonedNoteId, anonymous);
+      }
+    }
   }
 
   @Test
   public void testRenameNote() throws IOException {
-    String oldName = "old_name";
-    Note note = TestUtils.getInstance(Notebook.class).createNote(oldName, anonymous);
-    assertEquals(note.getName(), oldName);
-    String noteId = note.getId();
+    Note note = null;
+    try {
+      String oldName = "old_name";
+      note = TestUtils.getInstance(Notebook.class).createNote(oldName, anonymous);
+      assertEquals(note.getName(), oldName);
+      String noteId = note.getId();
 
-    final String newName = "testName";
-    String jsonRequest = "{\"name\": " + newName + "}";
+      final String newName = "testName";
+      String jsonRequest = "{\"name\": " + newName + "}";
 
-    PutMethod put = httpPut("/notebook/" + noteId + "/rename/", jsonRequest);
-    assertThat("test testRenameNote:", put, isAllowed());
-    put.releaseConnection();
+      PutMethod put = httpPut("/notebook/" + noteId + "/rename/", jsonRequest);
+      assertThat("test testRenameNote:", put, isAllowed());
+      put.releaseConnection();
 
-    assertEquals(note.getName(), newName);
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
+      assertEquals(note.getName(), newName);
+    } finally {
+      // cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testUpdateParagraphConfig() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    String noteId = note.getId();
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    assertNull(p.getConfig().get("colWidth"));
-    String paragraphId = p.getId();
-    String jsonRequest = "{\"colWidth\": 6.0}";
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      String noteId = note.getId();
+      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      assertNull(p.getConfig().get("colWidth"));
+      String paragraphId = p.getId();
+      String jsonRequest = "{\"colWidth\": 6.0}";
 
-    PutMethod put = httpPut("/notebook/" + noteId + "/paragraph/" + paragraphId + "/config",
-            jsonRequest);
-    assertThat("test testUpdateParagraphConfig:", put, isAllowed());
+      PutMethod put = httpPut("/notebook/" + noteId + "/paragraph/" + paragraphId + "/config",
+              jsonRequest);
+      assertThat("test testUpdateParagraphConfig:", put, isAllowed());
 
-    Map<String, Object> resp = gson.fromJson(put.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    Map<String, Object> respBody = (Map<String, Object>) resp.get("body");
-    Map<String, Object> config = (Map<String, Object>) respBody.get("config");
-    put.releaseConnection();
+      Map<String, Object> resp = gson.fromJson(put.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> respBody = (Map<String, Object>) resp.get("body");
+      Map<String, Object> config = (Map<String, Object>) respBody.get("config");
+      put.releaseConnection();
 
-    assertEquals(config.get("colWidth"), 6.0);
-    note = TestUtils.getInstance(Notebook.class).getNote(noteId);
-    assertEquals(note.getParagraph(paragraphId).getConfig().get("colWidth"), 6.0);
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
+      assertEquals(config.get("colWidth"), 6.0);
+      note = TestUtils.getInstance(Notebook.class).getNote(noteId);
+      assertEquals(note.getParagraph(paragraphId).getConfig().get("colWidth"), 6.0);
+    } finally {
+      // cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testClearAllParagraphOutput() throws IOException {
-    // Create note and set result explicitly
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS,
-            InterpreterResult.Type.TEXT, "result");
-    p1.setResult(result);
+    Note note = null;
+    try {
+      // Create note and set result explicitly
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      InterpreterResult result = new InterpreterResult(InterpreterResult.Code.SUCCESS,
+              InterpreterResult.Type.TEXT, "result");
+      p1.setResult(result);
 
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p2.setReturn(result, new Throwable());
+      Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p2.setReturn(result, new Throwable());
 
-    // clear paragraph result
-    PutMethod put = httpPut("/notebook/" + note.getId() + "/clear", "");
-    LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
-    assertThat(put, isAllowed());
-    put.releaseConnection();
+      // clear paragraph result
+      PutMethod put = httpPut("/notebook/" + note.getId() + "/clear", "");
+      LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
+      assertThat(put, isAllowed());
+      put.releaseConnection();
 
-    // check if paragraph results are cleared
-    GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p1.getId());
-    assertThat(get, isAllowed());
-    Map<String, Object> resp1 = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    Map<String, Object> resp1Body = (Map<String, Object>) resp1.get("body");
-    assertNull(resp1Body.get("result"));
+      // check if paragraph results are cleared
+      GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p1.getId());
+      assertThat(get, isAllowed());
+      Map<String, Object> resp1 = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp1Body = (Map<String, Object>) resp1.get("body");
+      assertNull(resp1Body.get("result"));
 
-    get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p2.getId());
-    assertThat(get, isAllowed());
-    Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
-    assertNull(resp2Body.get("result"));
-    get.releaseConnection();
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p2.getId());
+      assertThat(get, isAllowed());
+      Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
+      assertNull(resp2Body.get("result"));
+      get.releaseConnection();
+    } finally {
+      // cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRunWithServerRestart() throws Exception {
-    Note note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    // 2 paragraphs
-    // P1:
-    //    %python
-    //    import time
-    //    time.sleep(1)
-    //    from __future__ import print_function
-    //    print(user)
-    // P2:
-    //    %python
-    //    user='abc'
-    //
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%python import time\ntime.sleep(1)\nuser='abc'");
-    p2.setText("%python from __future__ import print_function\nprint(user)");
+    Note note1 = null;
+    try {
+      note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      // 2 paragraphs
+      // P1:
+      //    %python
+      //    import time
+      //    time.sleep(1)
+      //    from __future__ import print_function
+      //    print(user)
+      // P2:
+      //    %python
+      //    user='abc'
+      //
+      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p2 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p1.setText("%python import time\ntime.sleep(1)\nuser='abc'");
+      p2.setText("%python from __future__ import print_function\nprint(user)");
 
-    PostMethod post1 = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post1, isAllowed());
-    post1.releaseConnection();
-    PutMethod put = httpPut("/notebook/" + note1.getId() + "/clear", "");
-    LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
-    assertThat(put, isAllowed());
-    put.releaseConnection();
+      PostMethod post1 = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post1, isAllowed());
+      post1.releaseConnection();
+      PutMethod put = httpPut("/notebook/" + note1.getId() + "/clear", "");
+      LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
+      assertThat(put, isAllowed());
+      put.releaseConnection();
 
-    // restart server (while keeping interpreter configuration)
-    AbstractTestRestApi.shutDown(false);
-    startUp(NotebookRestApiTest.class.getSimpleName(), false);
+      // restart server (while keeping interpreter configuration)
+      AbstractTestRestApi.shutDown(false);
+      startUp(NotebookRestApiTest.class.getSimpleName(), false);
 
-    note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
-    p1 = note1.getParagraph(p1.getId());
-    p2 = note1.getParagraph(p2.getId());
+      note1 = TestUtils.getInstance(Notebook.class).getNote(note1.getId());
+      p1 = note1.getParagraph(p1.getId());
+      p2 = note1.getParagraph(p2.getId());
 
-    PostMethod post2 = httpPost("/notebook/job/" + note1.getId(), "");
-    assertThat(post2, isAllowed());
-    Map<String, Object> resp = gson.fromJson(post2.getResponseBodyAsString(),
-        new TypeToken<Map<String, Object>>() {}.getType());
-    assertEquals(resp.get("status"), "OK");
-    post2.releaseConnection();
+      PostMethod post2 = httpPost("/notebook/job/" + note1.getId(), "");
+      assertThat(post2, isAllowed());
+      Map<String, Object> resp = gson.fromJson(post2.getResponseBodyAsString(),
+          new TypeToken<Map<String, Object>>() {}.getType());
+      assertEquals(resp.get("status"), "OK");
+      post2.releaseConnection();
 
-    assertEquals(Job.Status.FINISHED, p1.getStatus());
-    assertEquals(Job.Status.FINISHED, p2.getStatus());
-    assertNotNull(p2.getReturn());
-    assertEquals("abc\n", p2.getReturn().message().get(0).getData());
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      assertEquals(Job.Status.FINISHED, p1.getStatus());
+      assertEquals(Job.Status.FINISHED, p2.getStatus());
+      assertNotNull(p2.getReturn());
+      assertEquals("abc\n", p2.getReturn().message().get(0).getData());
+    } finally {
+      // cleanup
+      if (null != note1) {
+        TestUtils.getInstance(Notebook.class).removeNote(note1.getId(), anonymous);
+      }
+    }
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -91,36 +91,41 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testGetNoteInfo() throws IOException {
     LOG.info("testGetNoteInfo");
-    // Create note to get info
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("note");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
-    String paragraphText = "%md This is my new paragraph in my new note";
-    paragraph.setText(paragraphText);
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+    Note note = null;
+    try {
+      // Create note to get info
+      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("note");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
+      String paragraphText = "%md This is my new paragraph in my new note";
+      paragraph.setText(paragraphText);
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
 
-    String sourceNoteId = note.getId();
-    GetMethod get = httpGet("/notebook/" + sourceNoteId);
-    LOG.info("testGetNoteInfo \n" + get.getResponseBodyAsString());
-    assertThat("test note get method:", get, isAllowed());
+      String sourceNoteId = note.getId();
+      GetMethod get = httpGet("/notebook/" + sourceNoteId);
+      LOG.info("testGetNoteInfo \n" + get.getResponseBodyAsString());
+      assertThat("test note get method:", get, isAllowed());
 
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
 
-    assertNotNull(resp);
-    assertEquals("OK", resp.get("status"));
+      assertNotNull(resp);
+      assertEquals("OK", resp.get("status"));
 
-    Map<String, Object> body = (Map<String, Object>) resp.get("body");
-    List<Map<String, Object>> paragraphs = (List<Map<String, Object>>) body.get("paragraphs");
+      Map<String, Object> body = (Map<String, Object>) resp.get("body");
+      List<Map<String, Object>> paragraphs = (List<Map<String, Object>>) body.get("paragraphs");
 
-    assertTrue(paragraphs.size() > 0);
-    assertEquals(paragraphText, paragraphs.get(0).get("text"));
-    //
-    TestUtils.getInstance(Notebook.class).removeNote(sourceNoteId, anonymous);
+      assertTrue(paragraphs.size() > 0);
+      assertEquals(paragraphText, paragraphs.get(0).get("text"));
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
@@ -213,10 +218,18 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testDeleteNote() throws IOException {
     LOG.info("testDeleteNote");
-    //Create note and get ID
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeletedNote", anonymous);
-    String noteId = note.getId();
-    testDeleteNote(noteId);
+
+    Note note = null;
+    try {
+      //Create note and get ID
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeletedNote", anonymous);
+      String noteId = note.getId();
+      testDeleteNote(noteId);
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
@@ -228,68 +241,93 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testExportNote() throws IOException {
     LOG.info("testExportNote");
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testExportNote", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("source note for export");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
-    paragraph.setText("%md This is my new paragraph in my new note");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String sourceNoteId = note.getId();
-    // Call export Note REST API
-    GetMethod get = httpGet("/notebook/export/" + sourceNoteId);
-    LOG.info("testNoteExport \n" + get.getResponseBodyAsString());
-    assertThat("test note export method:", get, isAllowed());
 
-    Map<String, Object> resp =
-        gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testExportNote", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("source note for export");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
+      paragraph.setText("%md This is my new paragraph in my new note");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String sourceNoteId = note.getId();
+      // Call export Note REST API
+      GetMethod get = httpGet("/notebook/export/" + sourceNoteId);
+      LOG.info("testNoteExport \n" + get.getResponseBodyAsString());
+      assertThat("test note export method:", get, isAllowed());
 
-    String exportJSON = (String) resp.get("body");
-    assertNotNull("Can not find new notejson", exportJSON);
-    LOG.info("export JSON:=" + exportJSON);
-    TestUtils.getInstance(Notebook.class).removeNote(sourceNoteId, anonymous);
-    get.releaseConnection();
+      Map<String, Object> resp =
+          gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+
+      String exportJSON = (String) resp.get("body");
+      assertNotNull("Can not find new notejson", exportJSON);
+      LOG.info("export JSON:=" + exportJSON);
+      TestUtils.getInstance(Notebook.class).removeNote(sourceNoteId, anonymous);
+      get.releaseConnection();
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testImportNotebook() throws IOException {
+    Note note = null;
     Map<String, Object> resp;
-    String noteName = "source note for import";
-    LOG.info("testImportNote");
-    // create test note
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testImportNotebook", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName(noteName);
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
-    paragraph.setText("%md This is my new paragraph in my new note");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String sourceNoteId = note.getId();
-    // get note content as JSON
-    String oldJson = getNoteContent(sourceNoteId);
-    // delete it first then import it
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
-    // call note post
-    PostMethod importPost = httpPost("/notebook/import/", oldJson);
-    assertThat(importPost, isAllowed());
-    resp =
-        gson.fromJson(importPost.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    String importId = (String) resp.get("body");
+    String oldJson;
+    String noteName;
+    try {
+      noteName = "source note for import";
+      LOG.info("testImportNote");
+      // create test note
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testImportNotebook", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName(noteName);
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
+      paragraph.setText("%md This is my new paragraph in my new note");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String sourceNoteId = note.getId();
+      // get note content as JSON
+      oldJson = getNoteContent(sourceNoteId);
+      // delete it first then import it
+      TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
 
-    assertNotNull("Did not get back a note id in body", importId);
-    Note newNote = TestUtils.getInstance(Notebook.class).getNote(importId);
-    assertEquals("Compare note names", noteName, newNote.getName());
-    assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs()
-        .size());
-    // cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(newNote.getId(), anonymous);
-    importPost.releaseConnection();
+    Note newNote = null;
+    try {
+      // call note post
+      PostMethod importPost = httpPost("/notebook/import/", oldJson);
+      assertThat(importPost, isAllowed());
+      resp =
+          gson.fromJson(importPost.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      String importId = (String) resp.get("body");
+
+      assertNotNull("Did not get back a note id in body", importId);
+      newNote = TestUtils.getInstance(Notebook.class).getNote(importId);
+      assertEquals("Compare note names", noteName, newNote.getName());
+      assertEquals("Compare paragraphs count", note.getParagraphs().size(), newNote.getParagraphs()
+          .size());
+      // cleanup
+      TestUtils.getInstance(Notebook.class).removeNote(newNote.getId(), anonymous);
+      importPost.releaseConnection();
+    } finally {
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   private String getNoteContent(String id) throws IOException {
@@ -328,39 +366,47 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testCloneNote() throws IOException, IllegalArgumentException {
     LOG.info("testCloneNote");
-    // Create note to clone
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testCloneNote", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("source note for clone");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
-    paragraph.setText("%md This is my new paragraph in my new note");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String sourceNoteId = note.getId();
+    Note note = null, newNote = null;
+    try {
+      // Create note to clone
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testCloneNote", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("source note for clone");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
+      paragraph.setText("%md This is my new paragraph in my new note");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String sourceNoteId = note.getId();
 
-    String noteName = "clone Note Name";
-    // Call Clone Note REST API
-    String jsonRequest = "{\"name\":\"" + noteName + "\"}";
-    PostMethod post = httpPost("/notebook/" + sourceNoteId, jsonRequest);
-    LOG.info("testNoteClone \n" + post.getResponseBodyAsString());
-    assertThat("test note clone method:", post, isAllowed());
+      String noteName = "clone Note Name";
+      // Call Clone Note REST API
+      String jsonRequest = "{\"name\":\"" + noteName + "\"}";
+      PostMethod post = httpPost("/notebook/" + sourceNoteId, jsonRequest);
+      LOG.info("testNoteClone \n" + post.getResponseBodyAsString());
+      assertThat("test note clone method:", post, isAllowed());
 
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
 
-    String newNoteId =  (String) resp.get("body");
-    LOG.info("newNoteId:=" + newNoteId);
-    Note newNote = TestUtils.getInstance(Notebook.class).getNote(newNoteId);
-    assertNotNull("Can not find new note by id", newNote);
-    assertEquals("Compare note names", noteName, newNote.getName());
-    assertEquals("Compare paragraphs count", note.getParagraphs().size(),
-            newNote.getParagraphs().size());
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
-    TestUtils.getInstance(Notebook.class).removeNote(newNote.getId(), anonymous);
-    post.releaseConnection();
+      String newNoteId =  (String) resp.get("body");
+      LOG.info("newNoteId:=" + newNoteId);
+      newNote = TestUtils.getInstance(Notebook.class).getNote(newNoteId);
+      assertNotNull("Can not find new note by id", newNote);
+      assertEquals("Compare note names", noteName, newNote.getName());
+      assertEquals("Compare paragraphs count", note.getParagraphs().size(),
+              newNote.getParagraphs().size());
+      post.releaseConnection();
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+      if (null != newNote) {
+        TestUtils.getInstance(Notebook.class).removeNote(newNote.getId(), anonymous);
+      }
+    }
   }
 
   @Test
@@ -381,457 +427,533 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
   @Test
   public void testNoteJobs() throws IOException, InterruptedException {
     LOG.info("testNoteJobs");
-    // Create note to run test.
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testNoteJobs", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
+    Note note = null;
+    try {
+      // Create note to run test.
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testNoteJobs", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    paragraph.setText("%md This is test paragraph.");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String noteId = note.getId();
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
 
-    note.runAll(anonymous, true);
-    // wait until job is finished or timeout.
-    int timeout = 1;
-    while (!paragraph.isTerminated()) {
+      paragraph.setText("%md This is test paragraph.");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String noteId = note.getId();
+
+      note.runAll(anonymous, true);
+      // wait until job is finished or timeout.
+      int timeout = 1;
+      while (!paragraph.isTerminated()) {
+        Thread.sleep(1000);
+        if (timeout++ > 10) {
+          LOG.info("testNoteJobs timeout job.");
+          break;
+        }
+      }
+
+      // Call Run note jobs REST API
+      PostMethod postNoteJobs = httpPost("/notebook/job/" + noteId, "");
+      assertThat("test note jobs run:", postNoteJobs, isAllowed());
+      postNoteJobs.releaseConnection();
+
+      // Call Stop note jobs REST API
+      DeleteMethod deleteNoteJobs = httpDelete("/notebook/job/" + noteId);
+      assertThat("test note stop:", deleteNoteJobs, isAllowed());
+      deleteNoteJobs.releaseConnection();
       Thread.sleep(1000);
-      if (timeout++ > 10) {
-        LOG.info("testNoteJobs timeout job.");
-        break;
+
+      // Call Run paragraph REST API
+      PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(), "");
+      assertThat("test paragraph run:", postParagraph, isAllowed());
+      postParagraph.releaseConnection();
+      Thread.sleep(1000);
+
+      // Call Stop paragraph REST API
+      DeleteMethod deleteParagraph = httpDelete("/notebook/job/" + noteId + "/" + paragraph.getId());
+      assertThat("test paragraph stop:", deleteParagraph, isAllowed());
+      deleteParagraph.releaseConnection();
+      Thread.sleep(1000);
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
       }
     }
-
-    // Call Run note jobs REST API
-    PostMethod postNoteJobs = httpPost("/notebook/job/" + noteId, "");
-    assertThat("test note jobs run:", postNoteJobs, isAllowed());
-    postNoteJobs.releaseConnection();
-
-    // Call Stop note jobs REST API
-    DeleteMethod deleteNoteJobs = httpDelete("/notebook/job/" + noteId);
-    assertThat("test note stop:", deleteNoteJobs, isAllowed());
-    deleteNoteJobs.releaseConnection();
-    Thread.sleep(1000);
-
-    // Call Run paragraph REST API
-    PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(), "");
-    assertThat("test paragraph run:", postParagraph, isAllowed());
-    postParagraph.releaseConnection();
-    Thread.sleep(1000);
-
-    // Call Stop paragraph REST API
-    DeleteMethod deleteParagraph = httpDelete("/notebook/job/" + noteId + "/" + paragraph.getId());
-    assertThat("test paragraph stop:", deleteParagraph, isAllowed());
-    deleteParagraph.releaseConnection();
-    Thread.sleep(1000);
-
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   @Test
   public void testGetNoteJob() throws IOException, InterruptedException {
     LOG.info("testGetNoteJob");
-    // Create note to run test.
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testGetNoteJob", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
+    Note note = null;
+    try {
+      // Create note to run test.
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testGetNoteJob", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    paragraph.setText("%sh sleep 1");
-    paragraph.setAuthenticationInfo(anonymous);
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String noteId = note.getId();
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
 
-    note.runAll(anonymous, true);
-    // assume that status of the paragraph is running
-    GetMethod get = httpGet("/notebook/job/" + noteId);
-    assertThat("test get note job: ", get, isAllowed());
-    String responseBody = get.getResponseBodyAsString();
-    get.releaseConnection();
+      paragraph.setText("%sh sleep 1");
+      paragraph.setAuthenticationInfo(anonymous);
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String noteId = note.getId();
 
-    LOG.info("test get note job: \n" + responseBody);
-    Map<String, Object> resp = gson.fromJson(responseBody,
-            new TypeToken<Map<String, Object>>() {}.getType());
+      note.runAll(anonymous, true);
+      // assume that status of the paragraph is running
+      GetMethod get = httpGet("/notebook/job/" + noteId);
+      assertThat("test get note job: ", get, isAllowed());
+      String responseBody = get.getResponseBodyAsString();
+      get.releaseConnection();
 
-    List<Map<String, Object>> paragraphs = (List<Map<String, Object>>) resp.get("body");
-    assertEquals(1, paragraphs.size());
-    assertTrue(paragraphs.get(0).containsKey("progress"));
-    int progress = Integer.parseInt((String) paragraphs.get(0).get("progress"));
-    assertTrue(progress >= 0 && progress <= 100);
+      LOG.info("test get note job: \n" + responseBody);
+      Map<String, Object> resp = gson.fromJson(responseBody,
+              new TypeToken<Map<String, Object>>() {}.getType());
 
-    // wait until job is finished or timeout.
-    int timeout = 1;
-    while (!paragraph.isTerminated()) {
-      Thread.sleep(100);
-      if (timeout++ > 10) {
-        LOG.info("testGetNoteJob timeout job.");
-        break;
+      List<Map<String, Object>> paragraphs = (List<Map<String, Object>>) resp.get("body");
+      assertEquals(1, paragraphs.size());
+      assertTrue(paragraphs.get(0).containsKey("progress"));
+      int progress = Integer.parseInt((String) paragraphs.get(0).get("progress"));
+      assertTrue(progress >= 0 && progress <= 100);
+
+      // wait until job is finished or timeout.
+      int timeout = 1;
+      while (!paragraph.isTerminated()) {
+        Thread.sleep(100);
+        if (timeout++ > 10) {
+          LOG.info("testGetNoteJob timeout job.");
+          break;
+        }
+      }
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
       }
     }
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 
   @Test
   public void testRunParagraphWithParams() throws IOException, InterruptedException {
     LOG.info("testRunParagraphWithParams");
-    // Create note to run test.
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testRunParagraphWithParams", anonymous);
-    assertNotNull("can't create new note", note);
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
+    Note note = null;
+    try {
+      // Create note to run test.
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testRunParagraphWithParams", anonymous);
+      assertNotNull("can't create new note", note);
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
-    String noteId = note.getId();
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
 
-    note.runAll(anonymous, true);
+      paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      String noteId = note.getId();
 
-    // Call Run paragraph REST API
-    PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(),
-        "{\"params\": {\"param\": \"hello\", \"param2\": \"world\"}}");
-    assertThat("test paragraph run:", postParagraph, isAllowed());
-    postParagraph.releaseConnection();
-    Thread.sleep(1000);
+      note.runAll(anonymous, true);
 
-    Note retrNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
-    Paragraph retrParagraph = retrNote.getParagraph(paragraph.getId());
-    Map<String, Object> params = retrParagraph.settings.getParams();
-    assertEquals("hello", params.get("param"));
-    assertEquals("world", params.get("param2"));
+      // Call Run paragraph REST API
+      PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(),
+          "{\"params\": {\"param\": \"hello\", \"param2\": \"world\"}}");
+      assertThat("test paragraph run:", postParagraph, isAllowed());
+      postParagraph.releaseConnection();
+      Thread.sleep(1000);
 
-    //cleanup
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      Note retrNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
+      Paragraph retrParagraph = retrNote.getParagraph(paragraph.getId());
+      Map<String, Object> params = retrParagraph.settings.getParams();
+      assertEquals("hello", params.get("param"));
+      assertEquals("world", params.get("param2"));
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testJobs() throws InterruptedException, IOException{
     // create a note and a paragraph
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testJobs", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testJobs", anonymous);
 
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    paragraph.setText("%md This is test paragraph.");
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      paragraph.setText("%md This is test paragraph.");
 
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
 
-    note.runAll(AuthenticationInfo.ANONYMOUS, false);
+      note.runAll(AuthenticationInfo.ANONYMOUS, false);
 
-    String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
-    // right cron expression but not exist note.
-    PostMethod postCron = httpPost("/notebook/cron/notexistnote", jsonRequest);
-    assertThat("", postCron, isNotFound());
-    postCron.releaseConnection();
+      String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
+      // right cron expression but not exist note.
+      PostMethod postCron = httpPost("/notebook/cron/notexistnote", jsonRequest);
+      assertThat("", postCron, isNotFound());
+      postCron.releaseConnection();
 
-    // right cron expression.
-    postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
-    assertThat("", postCron, isAllowed());
-    postCron.releaseConnection();
-    Thread.sleep(1000);
+      // right cron expression.
+      postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
+      assertThat("", postCron, isAllowed());
+      postCron.releaseConnection();
+      Thread.sleep(1000);
 
-    // wrong cron expression.
-    jsonRequest = "{\"cron\":\"a * * * * ?\" }";
-    postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
-    assertThat("", postCron, isBadRequest());
-    postCron.releaseConnection();
-    Thread.sleep(1000);
+      // wrong cron expression.
+      jsonRequest = "{\"cron\":\"a * * * * ?\" }";
+      postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
+      assertThat("", postCron, isBadRequest());
+      postCron.releaseConnection();
+      Thread.sleep(1000);
 
-    // remove cron job.
-    DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
-    assertThat("", deleteCron, isAllowed());
-    deleteCron.releaseConnection();
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      // remove cron job.
+      DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
+      assertThat("", deleteCron, isAllowed());
+      deleteCron.releaseConnection();
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testCronDisable() throws InterruptedException, IOException{
-    // create a note and a paragraph
-    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "false");
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testCronDisable", anonymous);
+    Note note = null;
+    try {
+      // create a note and a paragraph
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "false");
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testCronDisable", anonymous);
 
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    paragraph.setText("%md This is test paragraph.");
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      paragraph.setText("%md This is test paragraph.");
 
-    Map config = paragraph.getConfig();
-    config.put("enabled", true);
-    paragraph.setConfig(config);
+      Map config = paragraph.getConfig();
+      config.put("enabled", true);
+      paragraph.setConfig(config);
 
-    note.runAll(AuthenticationInfo.ANONYMOUS, false);
+      note.runAll(AuthenticationInfo.ANONYMOUS, false);
 
-    String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
-    // right cron expression.
-    PostMethod postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
-    assertThat("", postCron, isForbidden());
-    postCron.releaseConnection();
+      String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
+      // right cron expression.
+      PostMethod postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
+      assertThat("", postCron, isForbidden());
+      postCron.releaseConnection();
 
-    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
-    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "System/*");
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "System/*");
 
-    note.setName("System/test2");
-    note.runAll(AuthenticationInfo.ANONYMOUS, false);
-    postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
-    assertThat("", postCron, isAllowed());
-    postCron.releaseConnection();
-    Thread.sleep(1000);
+      note.setName("System/test2");
+      note.runAll(AuthenticationInfo.ANONYMOUS, false);
+      postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
+      assertThat("", postCron, isAllowed());
+      postCron.releaseConnection();
+      Thread.sleep(1000);
 
-    // remove cron job.
-    DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
-    assertThat("", deleteCron, isAllowed());
-    deleteCron.releaseConnection();
-    Thread.sleep(1000);
+      // remove cron job.
+      DeleteMethod deleteCron = httpDelete("/notebook/cron/" + note.getId());
+      assertThat("", deleteCron, isAllowed());
+      deleteCron.releaseConnection();
+      Thread.sleep(1000);
 
-    System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName());
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName());
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testRegressionZEPPELIN_527() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testRegressionZEPPELIN_527", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testRegressionZEPPELIN_527", anonymous);
 
-    note.setName("note for run test");
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
+      note.setName("note for run test");
+      Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      paragraph.setText("%spark\nval param = z.input(\"param\").toString\nprintln(param)");
 
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
 
-    GetMethod getNoteJobs = httpGet("/notebook/job/" + note.getId());
-    assertThat("test note jobs run:", getNoteJobs, isAllowed());
-    Map<String, Object> resp = gson.fromJson(getNoteJobs.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    List<Map<String, String>> body = (List<Map<String, String>>) resp.get("body");
-    assertFalse(body.get(0).containsKey("started"));
-    assertFalse(body.get(0).containsKey("finished"));
-    getNoteJobs.releaseConnection();
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      GetMethod getNoteJobs = httpGet("/notebook/job/" + note.getId());
+      assertThat("test note jobs run:", getNoteJobs, isAllowed());
+      Map<String, Object> resp = gson.fromJson(getNoteJobs.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      List<Map<String, String>> body = (List<Map<String, String>>) resp.get("body");
+      assertFalse(body.get(0).containsKey("started"));
+      assertFalse(body.get(0).containsKey("finished"));
+      getNoteJobs.releaseConnection();
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testInsertParagraph() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testInsertParagraph", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testInsertParagraph", anonymous);
 
-    String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
-    PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
-    LOG.info("testInsertParagraph response\n" + post.getResponseBodyAsString());
-    assertThat("Test insert method:", post, isAllowed());
-    post.releaseConnection();
+      String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
+      PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
+      LOG.info("testInsertParagraph response\n" + post.getResponseBodyAsString());
+      assertThat("Test insert method:", post, isAllowed());
+      post.releaseConnection();
 
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
 
-    String newParagraphId = (String) resp.get("body");
-    LOG.info("newParagraphId:=" + newParagraphId);
+      String newParagraphId = (String) resp.get("body");
+      LOG.info("newParagraphId:=" + newParagraphId);
 
-    Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
-    Paragraph newParagraph = retrNote.getParagraph(newParagraphId);
-    assertNotNull("Can not find new paragraph by id", newParagraph);
+      Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
+      Paragraph newParagraph = retrNote.getParagraph(newParagraphId);
+      assertNotNull("Can not find new paragraph by id", newParagraph);
 
-    assertEquals("title1", newParagraph.getTitle());
-    assertEquals("text1", newParagraph.getText());
+      assertEquals("title1", newParagraph.getTitle());
+      assertEquals("text1", newParagraph.getText());
 
-    Paragraph lastParagraph = note.getLastParagraph();
-    assertEquals(newParagraph.getId(), lastParagraph.getId());
+      Paragraph lastParagraph = note.getLastParagraph();
+      assertEquals(newParagraph.getId(), lastParagraph.getId());
 
-    // insert to index 0
-    String jsonRequest2 = "{\"index\": 0, \"title\": \"title2\", \"text\": \"text2\"}";
-    PostMethod post2 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest2);
-    LOG.info("testInsertParagraph response2\n" + post2.getResponseBodyAsString());
-    assertThat("Test insert method:", post2, isAllowed());
-    post2.releaseConnection();
+      // insert to index 0
+      String jsonRequest2 = "{\"index\": 0, \"title\": \"title2\", \"text\": \"text2\"}";
+      PostMethod post2 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest2);
+      LOG.info("testInsertParagraph response2\n" + post2.getResponseBodyAsString());
+      assertThat("Test insert method:", post2, isAllowed());
+      post2.releaseConnection();
 
-    Paragraph paragraphAtIdx0 = note.getParagraphs().get(0);
-    assertEquals("title2", paragraphAtIdx0.getTitle());
-    assertEquals("text2", paragraphAtIdx0.getText());
+      Paragraph paragraphAtIdx0 = note.getParagraphs().get(0);
+      assertEquals("title2", paragraphAtIdx0.getTitle());
+      assertEquals("text2", paragraphAtIdx0.getText());
 
-    //append paragraph providing graph
-    String jsonRequest3 = "{\"title\": \"title3\", \"text\": \"text3\", " +
-                          "\"config\": {\"colWidth\": 9.0, \"title\": true, " +
-                          "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
-    PostMethod post3 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest3);
-    LOG.info("testInsertParagraph response4\n" + post3.getResponseBodyAsString());
-    assertThat("Test insert method:", post3, isAllowed());
-    post3.releaseConnection();
+      //append paragraph providing graph
+      String jsonRequest3 = "{\"title\": \"title3\", \"text\": \"text3\", " +
+                            "\"config\": {\"colWidth\": 9.0, \"title\": true, " +
+                            "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
+      PostMethod post3 = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest3);
+      LOG.info("testInsertParagraph response4\n" + post3.getResponseBodyAsString());
+      assertThat("Test insert method:", post3, isAllowed());
+      post3.releaseConnection();
 
-    Paragraph p = note.getLastParagraph();
-    assertEquals("title3", p.getTitle());
-    assertEquals("text3", p.getText());
-    Map result = ((List<Map>) p.getConfig().get("results")).get(0);
-    String mode = ((Map) result.get("graph")).get("mode").toString();
-    assertEquals("pieChart", mode);
-    assertEquals(9.0, p.getConfig().get("colWidth"));
-    assertTrue(((boolean) p.getConfig().get("title")));
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      Paragraph p = note.getLastParagraph();
+      assertEquals("title3", p.getTitle());
+      assertEquals("text3", p.getText());
+      Map result = ((List<Map>) p.getConfig().get("results")).get(0);
+      String mode = ((Map) result.get("graph")).get("mode").toString();
+      assertEquals("pieChart", mode);
+      assertEquals(9.0, p.getConfig().get("colWidth"));
+      assertTrue(((boolean) p.getConfig().get("title")));
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testUpdateParagraph() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testUpdateParagraph", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testUpdateParagraph", anonymous);
 
-    String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
-    PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
-    Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
-    post.releaseConnection();
+      String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
+      PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
+      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
+      post.releaseConnection();
 
-    String newParagraphId = (String) resp.get("body");
-    Paragraph newParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
-            .getParagraph(newParagraphId);
+      String newParagraphId = (String) resp.get("body");
+      Paragraph newParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
+              .getParagraph(newParagraphId);
 
-    assertEquals("title1", newParagraph.getTitle());
-    assertEquals("text1", newParagraph.getText());
+      assertEquals("title1", newParagraph.getTitle());
+      assertEquals("text1", newParagraph.getText());
 
-    String updateRequest = "{\"text\": \"updated text\"}";
-    PutMethod put = httpPut("/notebook/" + note.getId() + "/paragraph/" + newParagraphId,
-            updateRequest);
-    assertThat("Test update method:", put, isAllowed());
-    put.releaseConnection();
+      String updateRequest = "{\"text\": \"updated text\"}";
+      PutMethod put = httpPut("/notebook/" + note.getId() + "/paragraph/" + newParagraphId,
+              updateRequest);
+      assertThat("Test update method:", put, isAllowed());
+      put.releaseConnection();
 
-    Paragraph updatedParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
-            .getParagraph(newParagraphId);
+      Paragraph updatedParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
+              .getParagraph(newParagraphId);
 
-    assertEquals("title1", updatedParagraph.getTitle());
-    assertEquals("updated text", updatedParagraph.getText());
+      assertEquals("title1", updatedParagraph.getTitle());
+      assertEquals("updated text", updatedParagraph.getText());
 
-    String updateBothRequest = "{\"title\": \"updated title\", \"text\" : \"updated text 2\" }";
-    PutMethod updatePut = httpPut("/notebook/" + note.getId() + "/paragraph/" + newParagraphId,
-            updateBothRequest);
-    updatePut.releaseConnection();
+      String updateBothRequest = "{\"title\": \"updated title\", \"text\" : \"updated text 2\" }";
+      PutMethod updatePut = httpPut("/notebook/" + note.getId() + "/paragraph/" + newParagraphId,
+              updateBothRequest);
+      updatePut.releaseConnection();
 
-    Paragraph updatedBothParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
-            .getParagraph(newParagraphId);
+      Paragraph updatedBothParagraph = TestUtils.getInstance(Notebook.class).getNote(note.getId())
+              .getParagraph(newParagraphId);
 
-    assertEquals("updated title", updatedBothParagraph.getTitle());
-    assertEquals("updated text 2", updatedBothParagraph.getText());
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      assertEquals("updated title", updatedBothParagraph.getTitle());
+      assertEquals("updated text 2", updatedBothParagraph.getText());
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testGetParagraph() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testGetParagraph", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testGetParagraph", anonymous);
 
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p.setTitle("hello");
-    p.setText("world");
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p.setTitle("hello");
+      p.setText("world");
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
 
-    GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p.getId());
-    LOG.info("testGetParagraph response\n" + get.getResponseBodyAsString());
-    assertThat("Test get method: ", get, isAllowed());
-    get.releaseConnection();
+      GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p.getId());
+      LOG.info("testGetParagraph response\n" + get.getResponseBodyAsString());
+      assertThat("Test get method: ", get, isAllowed());
+      get.releaseConnection();
 
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
-            new TypeToken<Map<String, Object>>() {}.getType());
+      Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+              new TypeToken<Map<String, Object>>() {}.getType());
 
-    assertNotNull(resp);
-    assertEquals("OK", resp.get("status"));
+      assertNotNull(resp);
+      assertEquals("OK", resp.get("status"));
 
-    Map<String, Object> body = (Map<String, Object>) resp.get("body");
+      Map<String, Object> body = (Map<String, Object>) resp.get("body");
 
-    assertEquals(p.getId(), body.get("id"));
-    assertEquals("hello", body.get("title"));
-    assertEquals("world", body.get("text"));
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      assertEquals(p.getId(), body.get("id"));
+      assertEquals("hello", body.get("title"));
+      assertEquals("world", body.get("text"));
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testMoveParagraph() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testMoveParagraph", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testMoveParagraph", anonymous);
 
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p.setTitle("title1");
-    p.setText("text1");
+      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p.setTitle("title1");
+      p.setText("text1");
 
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p2.setTitle("title2");
-    p2.setText("text2");
+      Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p2.setTitle("title2");
+      p2.setText("text2");
 
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
 
-    PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph/" + p2.getId() +
-            "/move/" + 0, "");
-    assertThat("Test post method: ", post, isAllowed());
-    post.releaseConnection();
+      PostMethod post = httpPost("/notebook/" + note.getId() + "/paragraph/" + p2.getId() +
+              "/move/" + 0, "");
+      assertThat("Test post method: ", post, isAllowed());
+      post.releaseConnection();
 
-    Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
-    Paragraph paragraphAtIdx0 = retrNote.getParagraphs().get(0);
+      Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
+      Paragraph paragraphAtIdx0 = retrNote.getParagraphs().get(0);
 
-    assertEquals(p2.getId(), paragraphAtIdx0.getId());
-    assertEquals(p2.getTitle(), paragraphAtIdx0.getTitle());
-    assertEquals(p2.getText(), paragraphAtIdx0.getText());
+      assertEquals(p2.getId(), paragraphAtIdx0.getId());
+      assertEquals(p2.getTitle(), paragraphAtIdx0.getTitle());
+      assertEquals(p2.getText(), paragraphAtIdx0.getText());
 
-    PostMethod post2 = httpPost("/notebook/" + note.getId() + "/paragraph/" + p2.getId() +
-            "/move/" + 10, "");
-    assertThat("Test post method: ", post2, isBadRequest());
-    post.releaseConnection();
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      PostMethod post2 = httpPost("/notebook/" + note.getId() + "/paragraph/" + p2.getId() +
+              "/move/" + 10, "");
+      assertThat("Test post method: ", post2, isBadRequest());
+      post.releaseConnection();
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testDeleteParagraph() throws IOException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeleteParagraph", anonymous);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testDeleteParagraph", anonymous);
 
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p.setTitle("title1");
-    p.setText("text1");
+      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      p.setTitle("title1");
+      p.setText("text1");
 
-    TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
+      TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
 
-    DeleteMethod delete = httpDelete("/notebook/" + note.getId() + "/paragraph/" + p.getId());
-    assertThat("Test delete method: ", delete, isAllowed());
-    delete.releaseConnection();
+      DeleteMethod delete = httpDelete("/notebook/" + note.getId() + "/paragraph/" + p.getId());
+      assertThat("Test delete method: ", delete, isAllowed());
+      delete.releaseConnection();
 
-    Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
-    Paragraph retrParagrah = retrNote.getParagraph(p.getId());
-    assertNull("paragraph should be deleted", retrParagrah);
-
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      Note retrNote = TestUtils.getInstance(Notebook.class).getNote(note.getId());
+      Paragraph retrParagrah = retrNote.getParagraph(p.getId());
+      assertNull("paragraph should be deleted", retrParagrah);
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
+      }
+    }
   }
 
   @Test
   public void testTitleSearch() throws IOException, InterruptedException {
-    Note note = TestUtils.getInstance(Notebook.class).createNote("note1_testTitleSearch", anonymous);
-    String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", " +
-            "\"text\": \"ThisIsToTestSearchMethodWithTitle \"}";
-    PostMethod postNoteText = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
-    postNoteText.releaseConnection();
-    Thread.sleep(1000);
+    Note note = null;
+    try {
+      note = TestUtils.getInstance(Notebook.class).createNote("note1_testTitleSearch", anonymous);
+      String jsonRequest = "{\"title\": \"testTitleSearchOfParagraph\", " +
+              "\"text\": \"ThisIsToTestSearchMethodWithTitle \"}";
+      PostMethod postNoteText = httpPost("/notebook/" + note.getId() + "/paragraph", jsonRequest);
+      postNoteText.releaseConnection();
+      Thread.sleep(1000);
 
-    GetMethod searchNote = httpGet("/notebook/search?q='testTitleSearchOfParagraph'");
-    searchNote.addRequestHeader("Origin", "http://localhost");
-    Map<String, Object> respSearchResult = gson.fromJson(searchNote.getResponseBodyAsString(),
-        new TypeToken<Map<String, Object>>() {
-        }.getType());
-    ArrayList searchBody = (ArrayList) respSearchResult.get("body");
+      GetMethod searchNote = httpGet("/notebook/search?q='testTitleSearchOfParagraph'");
+      searchNote.addRequestHeader("Origin", "http://localhost");
+      Map<String, Object> respSearchResult = gson.fromJson(searchNote.getResponseBodyAsString(),
+          new TypeToken<Map<String, Object>>() {
+          }.getType());
+      ArrayList searchBody = (ArrayList) respSearchResult.get("body");
 
-    int numberOfTitleHits = 0;
-    for (int i = 0; i < searchBody.size(); i++) {
-      Map<String, String> searchResult = (Map<String, String>) searchBody.get(i);
-      if (searchResult.get("header").contains("testTitleSearchOfParagraph")) {
-        numberOfTitleHits++;
+      int numberOfTitleHits = 0;
+      for (int i = 0; i < searchBody.size(); i++) {
+        Map<String, String> searchResult = (Map<String, String>) searchBody.get(i);
+        if (searchResult.get("header").contains("testTitleSearchOfParagraph")) {
+          numberOfTitleHits++;
+        }
+      }
+      assertEquals("Paragraph title hits must be at-least one", true, numberOfTitleHits >= 1);
+      searchNote.releaseConnection();
+    } finally {
+      //cleanup
+      if (null != note) {
+        TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
       }
     }
-    assertEquals("Paragraph title hits must be at-least one", true, numberOfTitleHits >= 1);
-    searchNote.releaseConnection();
-    TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -136,7 +136,7 @@ public class NotebookServiceTest {
     assertNull(note2);
     ArgumentCaptor<Exception> exception = ArgumentCaptor.forClass(Exception.class);
     verify(callback).onFailure(exception.capture(), any(ServiceContext.class));
-    assertTrue(exception.getValue().getCause().getMessage().equals("Note /folder_1/note1 existed"));
+    assertTrue(exception.getValue().getMessage().equals("Note '/folder_1/note1' existed"));
 
     // list note
     reset(callback);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -251,8 +251,10 @@ public class Notebook {
   public void removeNote(String noteId, AuthenticationInfo subject) throws IOException {
     LOGGER.info("Remove note " + noteId);
     Note note = getNote(noteId);
-    noteManager.removeNote(noteId, subject);
-    fireNoteRemoveEvent(note, subject);
+    if (null != note) {
+      noteManager.removeNote(noteId, subject);
+      fireNoteRemoveEvent(note, subject);
+    }
   }
 
   public Note getNote(String id) {


### PR DESCRIPTION
### What is this PR for?
Fix CreateNote() function throw Note existed IOException caused travis to fail.
When using trivis-ci, The exception will be triggered randomly.

#### **Cause Analysis:**
1. Recently, Notebook added a new one in createNote() to determine if the note name already exists. If it exists, an exception is thrown.
2. In the test case, the code
TestUtils.getInstance(Notebook.class) creates a global single instance object.

3. Program processing flow
    + TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
    + After executing some test code, eg: spark, python, etc
    + TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
    + Delete this note.
    + If the spark, python exception is thrown before removeNote, then the note still exists. Causes other test cases to be abnormal.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4072

### How should this be tested?
* travis pass

### Screenshots (if appropriate)
<img width="1013" alt="WechatIMG1" src="https://user-images.githubusercontent.com/3677382/54428195-ab1c5b80-4757-11e9-9c8a-232847d8b2b3.png">
<img width="1223" alt="WechatIMG2" src="https://user-images.githubusercontent.com/3677382/54428213-b7a0b400-4757-11e9-982c-0fbd85dd84bb.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
