### PR TITLE
[ZEPPELIN-4091] Fix concurrent autocomplete and execute for Ipython

### DIFF
--- a/python/src/main/resources/grpc/python/ipython_server.py
+++ b/python/src/main/resources/grpc/python/ipython_server.py
@@ -87,8 +87,8 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
         payload_reply = []
         def execute_worker():
             reply = self._kc.execute_interactive(request.code,
-                                        output_hook=_output_hook,
-                                        timeout=None)
+                                          output_hook=_output_hook,
+                                          timeout=None)
             payload_reply.append(reply)
 
         t = threading.Thread(name="ConsumerThread", target=execute_worker)

--- a/python/src/main/resources/grpc/python/ipython_server.py
+++ b/python/src/main/resources/grpc/python/ipython_server.py
@@ -38,6 +38,10 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
     def __init__(self, server):
         self._status = ipython_pb2.STARTING
         self._server = server
+        # issue with execute_interactive and auto completion: https://github.com/jupyter/jupyter_client/issues/429
+        # in all case because ipython does not support run and auto completion at the same time: https://github.com/jupyter/notebook/issues/3763
+        # For now we will lock to ensure that there is no concurrent bug that can "hang" the kernel
+        self._lock = threading.Lock()
 
     def start(self):
         print("starting...")
@@ -82,10 +86,11 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
 
         payload_reply = []
         def execute_worker():
-            reply = self._kc.execute_interactive(request.code,
+            with self._lock:
+                reply = self._kc.execute_interactive(request.code,
                                             output_hook=_output_hook,
                                             timeout=None)
-            payload_reply.append(reply)
+                payload_reply.append(reply)
 
         t = threading.Thread(name="ConsumerThread", target=execute_worker)
         t.start()
@@ -169,7 +174,8 @@ class IPython(ipython_pb2_grpc.IPythonServicer):
         return ipython_pb2.CancelResponse()
 
     def complete(self, request, context):
-        reply = self._kc.complete(request.code, request.cursor, reply=True, timeout=None)
+        with self._lock:
+            reply = self._kc.complete(request.code, request.cursor, reply=True, timeout=None)
         return ipython_pb2.CompletionResponse(matches=reply['content']['matches'])
 
     def status(self, request, context):

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -301,31 +301,33 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
 
     // The goal of this test is to ensure that concurrent interpret and complete
     // will not make execute hang forever.
-    ExecutorService pool = Executors.newFixedThreadPool(2);
-    FutureTask<InterpreterResult> interpretFuture =
-        new FutureTask(new Callable() {
-          @Override
-          public Object call() throws Exception {
-            return interpreter.interpret(code, getInterpreterContext());
-          }
-        });
-    FutureTask<List<InterpreterCompletion>> completionFuture =
-        new FutureTask(new Callable() {
-          @Override
-          public Object call() throws Exception {
-            return interpreter.completion(base, base.length(), null);
-          }
-        });
+    // ExecutorService pool = Executors.newFixedThreadPool(2);
+    // FutureTask<InterpreterResult> interpretFuture =
+    //    new FutureTask(new Callable() {
+    //      @Override
+    //      public Object call() throws Exception {
+    //        return interpreter.interpret(code, getInterpreterContext());
+    //      }
+    //    });
+    // FutureTask<List<InterpreterCompletion>> completionFuture =
+    //    new FutureTask(new Callable() {
+    //      @Override
+    //      public Object call() throws Exception {
+    //        return interpreter.completion(base, base.length(), null);
+    //      }
+    //    });
 
-    pool.execute(interpretFuture);
+    // pool.execute(interpretFuture);
     // we sleep to ensure that the paragraph is running
-    Thread.sleep(3000);
-    pool.execute(completionFuture);
+    // Thread.sleep(3000);
+    // pool.execute(completionFuture);
 
     // We ensure that running and auto completion are not hanging.
-    InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
-    List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
-    assertTrue(res.code().name().equals("SUCCESS"));
+    // InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
+    // List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
+    InterpreterResult res = interpreter.interpret(code, getInterpreterContext());
+    List<InterpreterCompletion> autoRes = interpreter.completion(base, base.length(), null);
+        assertTrue(res.code().name().equals("SUCCESS"));
     assertTrue(autoRes.size() > 0);
   }
 

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -318,13 +318,11 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
         });
 
     pool.execute(interpretFuture);
-    // we sleep to ensure that the paragraph is running
-    Thread.sleep(3000);
-    pool.execute(completionFuture);
-
-    // We ensure that running and auto completion are not hanging.
+    // Not testing anything just to see the ci behavior
     InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
-    List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
+    pool.execute(completionFuture);
+    List<InterpreterCompletion> autoRes = completionFuture.get(5000, TimeUnit.MILLISECONDS);
+    // We ensure that running and auto completion are not hanging.
     assertTrue(res.code().name().equals("SUCCESS"));
     assertTrue(autoRes.size() > 0);
   }

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -404,7 +404,7 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
     pool.execute(completionFuture);
 
     // We ensure that running and auto completion are not hanging.
-    InterpreterResult res = interpretFuture.get(10000, TimeUnit.MILLISECONDS);
+    InterpreterResult res = interpretFuture.get(15000, TimeUnit.MILLISECONDS);
     List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
     assertTrue(res.code().name().equals("SUCCESS"));
     assertTrue(autoRes.size() > 0);

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -301,33 +301,31 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
 
     // The goal of this test is to ensure that concurrent interpret and complete
     // will not make execute hang forever.
-    // ExecutorService pool = Executors.newFixedThreadPool(2);
-    // FutureTask<InterpreterResult> interpretFuture =
-    //    new FutureTask(new Callable() {
-    //      @Override
-    //      public Object call() throws Exception {
-    //        return interpreter.interpret(code, getInterpreterContext());
-    //      }
-    //    });
-    // FutureTask<List<InterpreterCompletion>> completionFuture =
-    //    new FutureTask(new Callable() {
-    //      @Override
-    //      public Object call() throws Exception {
-    //        return interpreter.completion(base, base.length(), null);
-    //      }
-    //    });
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    FutureTask<InterpreterResult> interpretFuture =
+        new FutureTask(new Callable() {
+          @Override
+          public Object call() throws Exception {
+            return interpreter.interpret(code, getInterpreterContext());
+          }
+        });
+    FutureTask<List<InterpreterCompletion>> completionFuture =
+        new FutureTask(new Callable() {
+          @Override
+          public Object call() throws Exception {
+            return interpreter.completion(base, base.length(), getInterpreterContext());
+          }
+        });
 
-    // pool.execute(interpretFuture);
+    pool.execute(interpretFuture);
     // we sleep to ensure that the paragraph is running
-    // Thread.sleep(3000);
-    // pool.execute(completionFuture);
+    Thread.sleep(3000);
+    pool.execute(completionFuture);
 
     // We ensure that running and auto completion are not hanging.
-    // InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
-    // List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
-    InterpreterResult res = interpreter.interpret(code, getInterpreterContext());
-    List<InterpreterCompletion> autoRes = interpreter.completion(base, base.length(), null);
-        assertTrue(res.code().name().equals("SUCCESS"));
+    InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
+    List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
+    assertTrue(res.code().name().equals("SUCCESS"));
     assertTrue(autoRes.size() > 0);
   }
 

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -412,46 +412,5 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
       assertTrue(exceptionMsg, exceptionMsg.contains("No such file or directory"));
     }
   }
-  @Test
-  public void testIpython_shouldNotHang_whenCallingAutoCompleteAndInterpretConcurrently()
-      throws InterpreterException,
-      InterruptedException, TimeoutException, ExecutionException {
-    Properties properties = initIntpProperties();
-    startInterpreter(properties);
-    final String code = "import time\n"
-        + "print(1)\n"
-        + "time.sleep(5)\n"
-        + "print(2)";
-    final String base = "time.";
-
-    // The goal of this test is to ensure that concurrent interpret and complete
-    // will not make execute hang forever.
-    ExecutorService pool = Executors.newFixedThreadPool(2);
-    FutureTask<InterpreterResult> interpretFuture =
-        new FutureTask(new Callable() {
-          @Override
-          public Object call() throws Exception {
-            return interpreter.interpret(code, getInterpreterContext());
-          }
-        });
-    FutureTask<List<InterpreterCompletion>> completionFuture =
-        new FutureTask(new Callable() {
-          @Override
-          public Object call() throws Exception {
-            return interpreter.completion(base, base.length(), null);
-          }
-        });
-
-    pool.execute(interpretFuture);
-    // we sleep to ensure that the paragraph is running
-    Thread.sleep(2000);
-    pool.execute(completionFuture);
-
-    // We ensure that running and auto completion are not hanging.
-    InterpreterResult res = interpretFuture.get(15000, TimeUnit.MILLISECONDS);
-    List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
-    assertTrue(res.code().name().equals("SUCCESS"));
-    assertTrue(autoRes.size() > 0);
-  }
 
 }

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -373,7 +373,8 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
   public void testIpython_shouldNotHang_whenCallingAutoCompleteAndInterpretConcurrently()
       throws InterpreterException,
       InterruptedException, TimeoutException, ExecutionException {
-    startInterpreter(new Properties());
+    Properties properties = initIntpProperties();
+    startInterpreter(properties);
     final String code = "import time\n"
         + "print(1)\n"
         + "time.sleep(5)\n"

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -318,11 +318,13 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
         });
 
     pool.execute(interpretFuture);
-    // Not testing anything just to see the ci behavior
-    InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
+    // we sleep to ensure that the paragraph is running
+    Thread.sleep(3000);
     pool.execute(completionFuture);
-    List<InterpreterCompletion> autoRes = completionFuture.get(5000, TimeUnit.MILLISECONDS);
+
     // We ensure that running and auto completion are not hanging.
+    InterpreterResult res = interpretFuture.get(20000, TimeUnit.MILLISECONDS);
+    List<InterpreterCompletion> autoRes = completionFuture.get(1000, TimeUnit.MILLISECONDS);
     assertTrue(res.code().name().equals("SUCCESS"));
     assertTrue(autoRes.size() > 0);
   }


### PR DESCRIPTION
### What is this PR for?

The pr is to fix a bug that will make the **ipython** `execute_interactive` hang forever if a auto `complete` call is make at the same time. (see unit test for example that is failing on master).

For now the fix is to synchronize those method : `execute` / `complete`. It will not bring regression because anyway, the kernel does not support concurrent execute and auto complete (see https://github.com/jupyter/notebook/issues/3763)

### What type of PR is it?
Bug Fix

### Todos
* [x] - unit test failing in master / succeed on this branch
* [x] - fix with lock

### What is the Jira issue?
It is one part of the jira issue. Other fix will come soon
https://issues.apache.org/jira/browse/ZEPPELIN-4091

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
