### PR TITLE
[ZEPPELIN-4063] Don't include noteId for constructing Interpreter GroupId when under isolated per user mode

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOption.java
@@ -149,7 +149,7 @@ public class InterpreterOption {
     return ISOLATED.equals(perNote);
   }
 
-  public boolean isProcess() {
+  public boolean isIsolated() {
     return perUserIsolated() || perNoteIsolated();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.internal.StringMap;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.dep.DependencyResolver;
@@ -378,17 +379,22 @@ public class InterpreterSetting {
   }
 
   private String getInterpreterGroupId(String user, String noteId) {
-    String key;
+    List<String> keys = new ArrayList<>();
     if (option.isExistingProcess) {
-      key = Constants.EXISTING_PROCESS;
-    } else if (getOption().isProcess()) {
-      key = (option.perUserIsolated() ? user : "") + "-" + (option.perNoteIsolated() ? noteId : "");
+      keys.add(Constants.EXISTING_PROCESS);
+    } else if (getOption().isIsolated()) {
+      if (option.perUserIsolated()) {
+        keys.add(user);
+      }
+      if (option.perNoteIsolated()) {
+        keys.add(noteId);
+      }
     } else {
-      key = SHARED_PROCESS;
+      keys.add(SHARED_PROCESS);
     }
 
     //TODO(zjffdu) we encode interpreter setting id into groupId, this is not a good design
-    return id + "-" + key;
+    return id + "-" + StringUtils.join(keys, "-");
   }
 
   private String getInterpreterSessionId(String user, String noteId) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingTest.java
@@ -82,8 +82,9 @@ public class InterpreterSettingTest {
         .create();
 
     // create default interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-shared_process", interpreter.getInterpreterGroup().getId());
 
     // create default interpreter for user2 and note1
     interpreterSetting.getDefaultInterpreter("user2", "note1");
@@ -120,9 +121,10 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-shared_process", interpreter.getInterpreterGroup().getId());
 
     // create interpreter for user2 and note1
     interpreterSetting.getDefaultInterpreter("user2", "note1");
@@ -158,9 +160,10 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-shared_process", interpreter.getInterpreterGroup().getId());
 
     // create interpreter for user1 and note2
     interpreterSetting.getDefaultInterpreter("user1", "note2");
@@ -196,13 +199,15 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-user1", interpreter1.getInterpreterGroup().getId());
 
     // create interpreter for user2 and note1
-    interpreterSetting.getDefaultInterpreter("user2", "note1");
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note1");
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-user2", interpreter2.getInterpreterGroup().getId());
 
     // Each user own one InterpreterGroup and one session per InterpreterGroup
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
@@ -234,13 +239,16 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-note1", interpreter1.getInterpreterGroup().getId());
 
     // create interpreter for user2 and note2
-    interpreterSetting.getDefaultInterpreter("user1", "note2");
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user1", "note2");
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-note2", interpreter2.getInterpreterGroup().getId());
+
     // Each user own one InterpreterGroup and one session per InterpreterGroup
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(1).getSessionNum());
@@ -272,17 +280,19 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-user1", interpreter1.getInterpreterGroup().getId());
 
     interpreterSetting.getDefaultInterpreter("user1", "note2");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
 
     // create interpreter for user2 and note1
-    interpreterSetting.getDefaultInterpreter("user2", "note1");
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note1");
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-user2", interpreter2.getInterpreterGroup().getId());
 
     // group1 for user1 has 2 sessions, and group2 for user2 has 1 session
     assertEquals(interpreterSetting.getInterpreterGroup("user1", "note1"), interpreterSetting.getInterpreterGroup("user1", "note2"));
@@ -325,20 +335,23 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-user1-note1", interpreter1.getInterpreterGroup().getId());
 
     // create interpreter for user1 and note2
-    interpreterSetting.getDefaultInterpreter("user1", "note2");
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user1", "note2");
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-user1-note2", interpreter2.getInterpreterGroup().getId());
 
     // create interpreter for user2 and note1
-    interpreterSetting.getDefaultInterpreter("user2", "note1");
-    assertEquals(3, interpreterSetting.getAllInterpreterGroups().size());
+    Interpreter interpreter3 = interpreterSetting.getDefaultInterpreter("user2", "note1");
+    assertEquals("test-user2-note1", interpreter3.getInterpreterGroup().getId());
 
     // create interpreter for user2 and note2
-    interpreterSetting.getDefaultInterpreter("user2", "note2");
+    Interpreter interpreter4 = interpreterSetting.getDefaultInterpreter("user2", "note2");
     assertEquals(4, interpreterSetting.getAllInterpreterGroups().size());
+    assertEquals("test-user2-note2", interpreter4.getInterpreterGroup().getId());
 
     for (InterpreterGroup interpreterGroup : interpreterSetting.getAllInterpreterGroups()) {
       // each InterpreterGroup has one session
@@ -383,9 +396,10 @@ public class InterpreterSettingTest {
         .create();
 
     // create interpreter for user1 and note1
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
+    assertEquals("test-shared_process", interpreter1.getInterpreterGroup().getId());
 
     // create interpreter for user1 and note2
     interpreterSetting.getDefaultInterpreter("user1", "note2");


### PR DESCRIPTION
### What is this PR for?
It is a straightforward fix to correct the groupId in different isolated mode.  


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4063

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
