### PR TITLE
[ZEPPELIN-4102] fix "getJSONObject()" to "optJSONObject()" to avoid crash

### DIFF
--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/HttpBasedClient.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/HttpBasedClient.java
@@ -74,7 +74,7 @@ public class HttpBasedClient implements ElasticsearchClient {
   private JSONObject getParentField(JSONObject parent, String[] fields) {
     JSONObject obj = parent;
     for (int i = 0; i < fields.length - 1; i++) {
-      obj = obj.getJSONObject(fields[i]);
+      obj = obj.optJSONObject(fields[i]);
     }
     return obj;
   }


### PR DESCRIPTION
### What is this PR for?
Fix [#ZEPPELIN-4102](https://issues.apache.org/jira/browse/ZEPPELIN-4102), which changes "getJSONObject()" to "optJSONObject()" to avoid program crash.

### What type of PR is it?
[Bug Fix]