### PR TITLE
[ZEPPELIN-4043]. Create shell script for moving note permission info from notebook-authorization.json to note file

### DIFF
--- a/docs/setup/operation/upgrading.md
+++ b/docs/setup/operation/upgrading.md
@@ -37,7 +37,7 @@ So, copying `notebook` and `conf` directory should be enough.
 
 ### Upgrading from Zeppelin 0.8 to 0.9
 
- - From 0.9, we change the notes file name structure ([ZEPPELIN-2619](https://issues.apache.org/jira/browse/ZEPPELIN-2619)). So when you upgrading zeppelin to 0.9, you need to upgrade note file. Here's steps you need to follow:
+ - From 0.9, we change the notes file name structure ([ZEPPELIN-2619](https://issues.apache.org/jira/browse/ZEPPELIN-2619)) and move permissions info from `notebook-authorization.json` into note file itself [ZEPPELIN-3985](https://issues.apache.org/jira/browse/ZEPPELIN-3985). So when you upgrading zeppelin to 0.9, you need to upgrade note file. Here's steps you need to follow:
    1. Backup your notes file in case the upgrade fails
    2. Call `bin/upgrade-note.sh -d` to upgrade note, `-d` option means to delete the old note file, missing this option will keep the old file.  
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/UpgradeNoteFileTool.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/UpgradeNoteFileTool.java
@@ -40,5 +40,6 @@ public class UpgradeNoteFileTool {
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
     NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
     notebookRepoSync.convertNoteFiles(conf, cmd.hasOption("d"));
+    notebookRepoSync.mergeAuthorizationInfo();
   }
 }


### PR DESCRIPTION
### What is this PR for?
This PR is followup of ZEPPELIN-3985. It will help user to do the note upgrade (moving permission info from notebook-authorization.json to note file)

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4043

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
