### PR TITLE
[ZEPPELIN-4040]. Changed links in documentation to use Gitbox

### DIFF
--- a/docs/development/contribution/how_to_contribute_code.md
+++ b/docs/development/contribution/how_to_contribute_code.md
@@ -45,20 +45,20 @@ To build the code, install
   * Apache Maven
 
 ## Getting the source code
-First of all, you need Zeppelin source code. The official location of Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
+First of all, you need Zeppelin source code. The official location of Zeppelin is [https://gitbox.apache.org/repos/asf/zeppelin.git](https://gitbox.apache.org/repos/asf/zeppelin.git).
 
 ### git access
 
 Get the source code on your development machine using git.
 
 ```bash
-git clone git://git.apache.org/zeppelin.git zeppelin
+git clone git://gitbox.apache.org/repos/asf/zeppelin.git zeppelin
 ```
 
 You may also want to develop against a specific branch. For example, for branch-0.5.6
 
 ```bash
-git clone -b branch-0.5.6 git://git.apache.org/zeppelin.git zeppelin
+git clone -b branch-0.5.6 git://gitbox.apache.org/repos/asf/zeppelin.git zeppelin
 ```
 
 Apache Zeppelin follows [Fork & Pull](https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Development-workflow-with-Git:-Fork,-Branching,-Commits,-and-Pull-Request) as a source control workflow.

--- a/docs/development/contribution/how_to_contribute_website.md
+++ b/docs/development/contribution/how_to_contribute_website.md
@@ -31,16 +31,16 @@ The online documentation at [zeppelin.apache.org](https://zeppelin.apache.org/do
 Any contributions to Zeppelin (Source code, Documents, Image, Website) means you agree with license all your contributions as Apache2 License.
 
 ## Getting the source code
-First of all, you need Zeppelin source code. The official location of Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
+First of all, you need Zeppelin source code. The official location of Zeppelin is [https://gitbox.apache.org/repos/asf/zeppelin.git](https://gitbox.apache.org/repos/asf/zeppelin.git).
 Documentation website is hosted in 'master' branch under `/docs/` dir.
 
 ### git access
 
-First of all, you need the website source code. The official location of mirror for Zeppelin is [http://git.apache.org/zeppelin.git](http://git.apache.org/zeppelin.git).
+First of all, you need the website source code. The official location of mirror for Zeppelin is [https://gitbox.apache.org/repos/asf/zeppelin.git](https://gitbox.apache.org/repos/asf/zeppelin.git).
 Get the source code on your development machine using git.
 
 ```bash
-git clone git://git.apache.org/zeppelin.git
+git clone git://gitbox.apache.org/repos/asf/zeppelin.git
 cd docs
 ```
 Apache Zeppelin follows [Fork & Pull](https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Development-workflow-with-Git:-Fork,-Branching,-Commits,-and-Pull-Request) as a source control workflow.


### PR DESCRIPTION
### What is this PR for?

Changed the broken Git links to use Gitbox

### What type of PR is it?

Documentation

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4040

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
