### PR TITLE
[ZEPPELIN-4050] Zeppelin on YARN

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -219,39 +219,34 @@ elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
 fi
 
 if [[ "${ZEPPELIN_RUN_MODE}" == "yarn" ]]; then
-  export YARN_BIN="${HADOOP_HOME}/bin/yarn"
+  export SUBMARINE_BIN="${JAVA_HOME}/bin/java -cp ${HADOOP_CONF_DIR}:${HADOOP_SUBMARINE_JAR} org.apache.hadoop.yarn.submarine.client.cli.Cli "
+  export YARN_RUNNER="${SUBMARINE_BIN} job run --name ${YARN_APP_NAME} "
+  YARN_RUNNER="${YARN_RUNNER} --env DOCKER_JAVA_HOME=${DOCKER_JAVA_HOME} "
+  YARN_RUNNER="${YARN_RUNNER} --env DOCKER_HADOOP_HDFS_HOME=${DOCKER_HADOOP_HOME} "
+  YARN_RUNNER="${YARN_RUNNER} --env DOCKER_HADOOP_CONF_DIR=${DOCKER_HADOOP_CONF_DIR} "
+  YARN_RUNNER="${YARN_RUNNER} --env YARN_CONTAINER_RUNTIME_DOCKER_CONTAINER_NETWORK=bridge "
+  YARN_RUNNER="${YARN_RUNNER} --env TZ=\"Etc/UTC\" "
+  YARN_RUNNER="${YARN_RUNNER} --env HADOOP_LOG_DIR=/tmp "
+  YARN_RUNNER="${YARN_RUNNER} ${ZEPPELIN_CONF_DIR_ENV} "
+  YARN_RUNNER="${YARN_RUNNER} ${YARN_LOCALIZATION_ENV} "
+  YARN_RUNNER="${YARN_RUNNER} --docker_image ${ZEPPELIN_YARN_CONTAINER_IMAGE} "
+  YARN_RUNNER="${YARN_RUNNER} --input_path hdfs:/// "
+  YARN_RUNNER="${YARN_RUNNER} --worker_resources ${ZEPPELIN_YARN_CONTAINER_RESOURCE} "
+  YARN_RUNNER="${YARN_RUNNER} --num_workers 1 "
+  YARN_RUNNER="${YARN_RUNNER} --keytab ${SUBMARINE_HADOOP_KEYTAB} "
+  YARN_RUNNER="${YARN_RUNNER} --principal ${SUBMARINE_HADOOP_PRINCIPAL} "
+  YARN_RUNNER="${YARN_RUNNER} --distribute_keytab "
+
   export YARN_DOCKER_JAVA_INTP_OPTS="java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///zeppelin/conf/log4j.properties "
   YARN_DOCKER_JAVA_INTP_OPTS="${YARN_DOCKER_JAVA_INTP_OPTS} -Dzeppelin.log.file=/tmp/zeppelin-interpreter-on-yarn.log"
-  export YARN_INTP_CLASSPATH="/zeppelin/interpreter/${INTERPRETER_SETTING_NAME}/*"
+
+  export YARN_INTP_CLASSPATH=":/zeppelin/interpreter/${INTERPRETER_SETTING_NAME}/*"
   YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:/zeppelin/lib/interpreter/*"
-  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:/usr/lib/jvm/java-8-openjdk-amd64/lib"
-  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib"
-  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar"
+  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:${DOCKER_JAVA_HOME}/lib"
+  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:${DOCKER_JAVA_HOME}/jre/lib"
+  YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:${DOCKER_JAVA_HOME}/jre/lib/charsets.jar"
   if [[ "${INTERPRETER_ID}" == "spark" ]]; then
     YARN_INTP_CLASSPATH="${YARN_INTP_CLASSPATH}:/zeppelin/interpreter/spark/dep/*"
-  fi
-
-  if [[ -n "${HADOOP_YARN_SUBMARINE_JAR}" ]]; then
-    if [[ -f "${HADOOP_YARN_SUBMARINE_JAR}" ]]; then
-      export YARN_RUNNER="${YARN_BIN} jar ${HADOOP_YARN_SUBMARINE_JAR} "
-      YARN_RUNNER="${YARN_RUNNER} job run --name ${YARN_APP_NAME} "
-      YARN_RUNNER="${YARN_RUNNER} --env DOCKER_JAVA_HOME=${DOCKER_JAVA_HOME} "
-      YARN_RUNNER="${YARN_RUNNER} --env DOCKER_HADOOP_HDFS_HOME=${DOCKER_HADOOP_HOME} "
-      YARN_RUNNER="${YARN_RUNNER} --env DOCKER_HADOOP_CONF_DIR=${DOCKER_HADOOP_CONF_DIR} "
-      YARN_RUNNER="${YARN_RUNNER} --env YARN_CONTAINER_RUNTIME_DOCKER_CONTAINER_NETWORK=bridge "
-      YARN_RUNNER="${YARN_RUNNER} --env TZ=\"Etc/UTC\" "
-      YARN_RUNNER="${YARN_RUNNER} --env HADOOP_LOG_DIR=/tmp "
-      YARN_RUNNER="${YARN_RUNNER} --env ZEPPELIN_HOME=/zeppelin "
-      YARN_RUNNER="${YARN_RUNNER} ${ZEPPELIN_CONF_DIR_ENV} "
-      YARN_RUNNER="${YARN_RUNNER} ${YARN_LOCALIZATION_ENV} "
-      YARN_RUNNER="${YARN_RUNNER} --docker_image ${ZEPPELIN_YARN_CONTAINER_IMAGE} "
-      YARN_RUNNER="${YARN_RUNNER} --input_path hdfs:/// "
-      YARN_RUNNER="${YARN_RUNNER} --worker_resources ${ZEPPELIN_YARN_CONTAINER_RESOURCE} "
-      YARN_RUNNER="${YARN_RUNNER} --num_workers 1 "
-      YARN_RUNNER="${YARN_RUNNER} --keytab ${SUBMARINE_HADOOP_KEYTAB} "
-      YARN_RUNNER="${YARN_RUNNER} --principal ${SUBMARINE_HADOOP_PRINCIPAL} "
-      YARN_RUNNER="${YARN_RUNNER} --distribute_keytab "
-    fi
   fi
 fi
 

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -111,8 +111,6 @@
 
 
 #### Standard Interpreter Launcher On Yarn
-# export HADOOP_HOME= # bin/interpreter.sh environment variable
-# export HADOOP_YARN_SUBMARINE_JAR # (require) hadoop 3.1+ submarine support docker container
-# export DOCKER_HADOOP_HOME # Haodop home dir in docker containter
-# export DOCKER_JAVA_HOME # Java home dir in docker containter
-# export UPLOAD_LOCAL_LIB_TO_CONTAINTER=true # Recommended to upload the local zeppelin library to the container
+# export HADOOP_SUBMARINE_JAR # (require) hadoop 3.3 submarine support docker container
+# export DOCKER_HADOOP_HOME=/hadoop-current
+# export DOCKER_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -108,3 +108,11 @@
 #### Zeppelin impersonation configuration
 # export ZEPPELIN_IMPERSONATE_CMD       # Optional, when user want to run interpreter as end web user. eg) 'sudo -H -u ${ZEPPELIN_IMPERSONATE_USER} bash -c '
 # export ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER  #Optional, by default is true; can be set to false if you don't want to use --proxy-user option with Spark interpreter when impersonation enabled
+
+
+#### Standard Interpreter Launcher On Yarn
+# export HADOOP_HOME= # bin/interpreter.sh environment variable
+# export HADOOP_YARN_SUBMARINE_JAR # (require) hadoop 3.1+ submarine support docker container
+# export DOCKER_HADOOP_HOME # Haodop home dir in docker containter
+# export DOCKER_JAVA_HOME # Java home dir in docker containter
+# export UPLOAD_LOCAL_LIB_TO_CONTAINTER=true # Recommended to upload the local zeppelin library to the container

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -610,7 +610,7 @@
 <property>
   <name>zeppelin.run.mode</name>
   <value>auto</value>
-  <description>'auto|local|k8s'</description>
+  <description>'auto|local|k8s|yarn'</description>
 </property>
 
 <property>
@@ -637,4 +637,39 @@
   <description>Kubernetes yaml spec files</description>
 </property>
 
+  <!--Zeppelin On Yarn-->
+  <property>
+    <name>zeppelin.yarn.webapp.address</name>
+    <value></value>
+    <description>zeppelin.yarn.webapp.address</description>
+  </property>
+
+  <property>
+    <name>zeppelin.yarn.container.image</name>
+    <value>apache/zeppelin:0.9.0-SNAPSHOT</value>
+    <description>Docker image for interpreters</description>
+  </property>
+
+  <property>
+    <name>zeppelin.yarn.container.resource</name>
+    <value>memory=8G,vcores=1,gpu=0</value>
+    <description>Docker default resource for interpreters container</description>
+  </property>
+
+  <!-- Set different resources for different interpreters-->
+  <!--name>zeppelin.yarn.container.${INTERPRETER_SETTING_NAME}.resource</name-->
+  <!--
+  <property>
+    <name>zeppelin.yarn.container.python.resource</name>
+    <value>memory=8G,vcores=1,gpu=0</value>
+    <description>Specify the required resources for the interpreter container</description>
+  </property>
+  -->
+  <!--
+  <property>
+    <name>e.g. zeppelin.yarn.container.submarine.resource</name>
+    <value>memory=8G,vcores=1,gpu=0</value>
+    <description>Specify the required resources for the interpreter container</description>
+  </property>
+  -->
 </configuration>

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -26,6 +26,7 @@
                 <li class="title"><span>Getting Started</span></li>
                 <li><a href="{{BASE_PATH}}/quickstart/install.html">Install</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/kubernetes.html">Kubernetes</a></li>
+                <li><a href="{{BASE_PATH}}/quickstart/yarn.html">Yarn</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/explore_ui.html">Explore UI</a></li>
                 <li><a href="{{BASE_PATH}}/quickstart/tutorial.html">Tutorial</a></li>
                 <li role="separator" class="divider"></li>

--- a/docs/quickstart/Yarn.md
+++ b/docs/quickstart/Yarn.md
@@ -1,0 +1,164 @@
+---
+layout: page
+title: "Install"
+description: "This page will help you get started and will guide you through installing Apache Zeppelin and running it in the command line."
+group: quickstart
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
+# Zeppelin on Yarn
+
+Zeppelin can run on [Yarn](https://hadoop.apache.org/submarine). Zeppelin server runs in local host, it creates docker container for individual interpreter. All interpreters run in yarn (The local mode of the spark interpreter also runs on the yarn).
+
+Key benefits are
+
+ - Interpreter scale-out
+ - Docker container environmental isolation
+ - Users can easily install python and R libraries
+
+## Prerequisites
+
+ - YARN 3.2.0+, You can use [Submarine-installer](https://github.com/hadoopsubmarine/submarine-installer), Deploy Docker and runtime environments.
+ - Zeppelin < 0.9.0 docker image, You need to set `UPLOAD_LOCAL_LIB_TO_CONTAINTER = true` in zeppelin-env.sh
+ - Zeppelin >= 0.9.0 docker image, You can set `UPLOAD_LOCAL_LIB_TO_CONTAINTER = true or false` in zeppelin-env.sh, If equal true, When zeppelin starts the interpreter, it uploads the local interpreter lib library to the docker container, which keeps the local zeppelin service exactly the same as the version in the container. The disadvantage is that the container will start slightly slower.
+
+## Spark Interpreter
+
+If you set `zeppelin.run.mode=yarn` in zepplin-site.xml, All interpreters run in yarn (The local mode of the spark interpreter also runs on the yarn)
+
+## Build Zeppelin image manually
+
+To build your own Zeppelin image, first build Zeppelin project with `-Pbuild-distr` flag.
+
+```
+$ mvn package -DskipTests -Pbuild-distr <your flags>
+```
+
+Binary package will be created under `zeppelin-distribution/target` directory. Move created package file under `scripts/docker/zeppelin/bin/` directory.
+
+```
+$ mv zeppelin-distribution/target/zeppelin-*.tar.gz scripts/docker/zeppelin/bin/
+```
+
+`scripts/docker/zeppelin/bin/Dockerfile` downloads package from internet. Modify the file to add package from filesystem.
+
+```
+...
+
+# Find following section and comment out
+#RUN echo "$LOG_TAG Download Zeppelin binary" && \
+#    wget -O /tmp/zeppelin-${Z_VERSION}-bin-all.tgz http://archive.apache.org/dist/zeppelin/zeppelin-${Z_VERSION}/zeppelin-${Z_VERSION}-bin-all.tgz && \
+#    tar -zxvf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
+#    rm -rf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
+#    mv /zeppelin-${Z_VERSION}-bin-all ${Z_HOME}
+
+# Add following lines right after the commented line above
+ADD zeppelin-${Z_VERSION} /
+RUN mv /zeppelin-${Z_VERSION} /zeppelin
+...
+```
+
+Then build docker image.
+
+```
+# change directory
+$ cd scripts/docker/zeppelin/bin/
+
+# build image. Replace <tag>.
+$ docker build -t <tag> .
+```
+
+You can set `UPLOAD_LOCAL_LIB_TO_CONTAINTER = true or false` in zeppelin-env.sh. When zeppelin starts the interpreter, it uploads the local interpreter lib library to the docker container.
+
+## How it works
+
+### Zeppelin on Yarn
+
+When you create a specific interpreter, Zeppelin uses the `yarn job run` command, Create a zeppelin docker container in yarn.
+Send the start command of this interpreter to the container, After the interpreter in the container is started, Connect by using the IP and port of the server where the container is located.
+
+Each interpreter starts a container, There is a completely isolated container environment between different interpreters.
+
+### Spark on Yarn
+
+Because spark originally supports the yarn mode, But there is a problem, You need to install the python and R packages in the nodemanager server of yarn.
+It is difficult to maintain and it is easy to form version conflicts.
+
+So only when the master configures `master=local[*]` in spark, The spark interpreter will be run in the docker container of yarn.
+The purpose of doing this is because enables users of `pyspark` and `sparkR` to install and upgrade python and R libraries themselves in the container.
+
+
+## Persist /notebook and /conf directory
+
+Zeppelin on YARN mode, The zeppelin server still runs in local, so the notebook and conf is still stored in local, It is not stored in the docker container where the interpreter is located.
+
+
+## Future work
+
+ - Ability to create multiple spark containers to form a spark standalone mode to solve large data volume scenarios.
+ - Let the python and spark interpreter embed the shell interpreter, Let the user container maintain the environment through shell commands.
+ - Upgrade the shell interpreter, the current shell function is relatively simple, no ability to explore.
+
+
+## Development
+
+Instead of build Zeppelin distribution package and docker image everytime during development,
+Zeppelin can run locally (such as inside your IDE in debug mode) and able to run Interpreter using [K8sStandardInterpreterLauncher](https://github.com/apache/zeppelin/blob/master/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncher.java) by configuring following environment variables.
+
+### bin/zeppelin-env.sh
+
+| Environment variable | Value | Description |
+| ----- | ----- | ----- |
+| HADOOP_HOME | hadoop home dir | bin/interpreter.sh need this environment variable |
+| HADOOP_YARN_SUBMARINE_JAR | /hadoop-<version>/submarine/hadoop-yarn-submarine-<version>-standalone.jar | Create docker container in the yarn |
+| DOCKER_HADOOP_HOME | /hadoop | Haodop home dir in docker containter |
+| DOCKER_JAVA_HOME | /usr/lib/jvm/java-8-openjdk-amd64 | Java home dir in docker containter |
+| UPLOAD_LOCAL_LIB_TO_CONTAINTER | `true` or `false` | Upload the local zeppelin library to the container, Default equal true |
+
+### conf/zeppelin-site.xml
+
+| Environment variable | Value | Description |
+| ----- | ----- | ----- |
+| zeppelin.run.mode | yarn | Make Zeppelin run interpreter on Yarn |
+| zeppelin.yarn.webapp.address |  | Yarn webapp address, The zeppelin server gets the state of the interpreter container through this webapp  |
+| zeppelin.yarn.container.image | <image>:<version> | Zeppelin interpreter docker image to use |
+| zeppelin.yarn.container.resource | memory=8G,vcores=1,gpu=0 | Docker default resource for interpreters container |
+| zeppelin.yarn.container.${INTERPRETER_SETTING_NAME}.resource | memory=8G,vcores=1,gpu=0 | Set different resources for different interpreters, e.g. zeppelin.yarn.container.`python`.resource |
+
+## Bugs & Contacts
+
++ **Zeppelin on Yarn BUG**
+  If you encounter a bug for this interpreter, please create a sub **JIRA** ticket on [ZEPPELIN-3856](https://issues.apache.org/jira/browse/ZEPPELIN-4050).
++ **Submarine Running problem**
+  If you encounter a problem for Submarine runtime, please create a **ISSUE** on [hadoop-submarine-ecosystem](https://github.com/hadoopsubmarine/hadoop-submarine-ecosystem).
++ **YARN Submarine BUG**
+  If you encounter a bug for Yarn Submarine, please create a **JIRA** ticket on [SUBMARINE](https://issues.apache.org/jira/browse/SUBMARINE).
+
+## Dependency
+
+1. **YARN**
+  Submarine currently need to run on Hadoop 3.3+
+
+  + The hadoop version of the hadoop submarine team git repository is periodically submitted to the code repository of the hadoop.
+  + The version of the git repository for the hadoop submarine team will be faster than the hadoop version release cycle.
+  + You can use the hadoop version of the hadoop submarine team git repository.
+
+2. **Submarine runtime environment**
+  you can use Submarine-installer https://github.com/hadoopsubmarine, Deploy Docker and network environments.
+
+## More
+
+**Hadoop Submarine Project**: https://hadoop.apache.org/submarine

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -369,7 +369,7 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">ZEPPELIN_RUN_MODE</h6></td>
     <td><h6 class="properties">zeppelin.run.mode</h6></td>
     <td>auto</td>
-    <td>Run mode. 'auto|local|k8s'. 'auto' autodetect environment. 'local' runs interpreter as a local process. k8s runs interpreter on Kubernetes cluster</td>
+    <td>Run mode. 'auto|local|k8s|yarn'. 'auto' autodetect environment. 'local' runs interpreter as a local process. 'k8s' runs interpreter on Kubernetes cluster. 'yarn' runs interpreter on Yarn cluster.</td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_K8S_PORTFORWARD</h6></td>
@@ -394,7 +394,31 @@ If both are defined, then the **environment variables** will take priority.
     <td><h6 class="properties">zeppelin.k8s.template.dir</h6></td>
     <td>k8s</td>
     <td>Kubernetes yaml spec files</td>
-  </tr>  
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_YARN_WEBAPP_ADDRESS</h6></td>
+    <td><h6 class="properties">zeppelin.yarn.webapp.address</h6></td>
+    <td></td>
+    <td>Yarn webapp address, The zeppelin server gets the state of the interpreter container through this webapp</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_YARN_CONTAINER_IMAGE</h6></td>
+    <td><h6 class="properties">zeppelin.yarn.container.image</h6></td>
+    <td>apache/zeppelin:{{ site.ZEPPELIN_VERSION }}</td>
+    <td>Docker image for interpreters</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_YARN_CONTAINER_RESOURCE</h6></td>
+    <td><h6 class="properties">zeppelin.yarn.container.resource</h6></td>
+    <td>memory=8G,vcores=1,gpu=0</td>
+    <td>Docker default resource for interpreters container</td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_YARN_CONTAINER_${INTERPRETER_SETTING_NAME}_RESOURCE</h6></td>
+    <td><h6 class="properties">zeppelin.yarn.container.${INTERPRETER_SETTING_NAME}.resource</h6></td>
+    <td>memory=8G,vcores=1,gpu=0</td>
+    <td>Set different resources for different interpreters, e.g. zeppelin.yarn.container.python.resource</td>
+  </tr>
 </table>
 
 

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -104,7 +104,12 @@ RUN echo "$LOG_TAG Download Zeppelin binary" && \
 
 COPY log4j.properties ${Z_HOME}/conf/
 
+# Zeppelin Server port
 EXPOSE 8080
+# Zeppelin interpreter port
+EXPOSE 29914
+# Zeppelin Spark UI port
+EXPOSE 4040
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 WORKDIR ${Z_HOME}

--- a/zeppelin-plugins/launcher/yarn-standard/pom.xml
+++ b/zeppelin-plugins/launcher/yarn-standard/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>zengine-plugins-parent</artifactId>
+        <groupId>org.apache.zeppelin</groupId>
+        <version>0.9.0-SNAPSHOT</version>
+        <relativePath>../../../zeppelin-plugins</relativePath>
+    </parent>
+
+    <groupId>org.apache.zeppelin</groupId>
+    <artifactId>launcher-yarn-standard</artifactId>
+    <packaging>jar</packaging>
+    <version>0.9.0-SNAPSHOT</version>
+    <name>Zeppelin: Plugin Yarn StandardLauncher</name>
+    <description>Launcher implementation to run interpreters on Yarn</description>
+
+    <properties>
+        <plugin.name>Launcher/YarnStandardInterpreterLauncher</plugin.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.zeppelin</groupId>
+            <artifactId>launcher-standard</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnClient.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnClient.java
@@ -1,0 +1,678 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.LoginContext;
+
+import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_KEYTAB;
+import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_PRINCIPAL;
+
+public class YarnClient {
+  private Logger LOGGER = LoggerFactory.getLogger(YarnClient.class);
+
+  private String yarnWebHttpAddr;
+  private String principal = "";
+  private String keytab = "";
+
+  public static final String YARN_REST_APPATTEMPTS = "appAttempts";
+  public static final String YARN_REST_CONTAINER = "container";
+  public static final String YARN_REST_APPATTEMPT = "appAttempt";
+  public static final String YARN_REST_APPATTEMPTID = "appAttemptId";
+
+  public static final String YARN_REST_EXPOSEDPORTS = "EXPOSEDPORTS";
+  public static final String CONTAINER_IP = "CONTAINER_IP";
+  public static final String CONTAINER_PORT = "CONTAINER_PORT";
+  public static final String HOST_IP = "HOST_IP";
+  public static final String HOST_PORT = "HOST_PORT";
+
+  private Configuration hadoopConf;
+  private ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
+  private boolean hadoopSecurityEnabled = false; // simple or kerberos
+
+  public YarnClient() {
+    this.hadoopConf = new Configuration();
+
+    hadoopSecurityEnabled = UserGroupInformation.isSecurityEnabled();
+    if (hadoopSecurityEnabled) {
+      String keytab = zConf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
+      String principal = zConf.getString(ZEPPELIN_SERVER_KERBEROS_PRINCIPAL);
+
+      if (StringUtils.isBlank(keytab) || StringUtils.isBlank(principal)) {
+        throw new RuntimeException("keytab and principal can not be empty, keytab: "
+            + keytab + ", principal: " + principal);
+      }
+      this.principal = principal;
+      this.keytab = keytab;
+      if (LOGGER.isDebugEnabled()) {
+        System.setProperty("sun.security.spnego.debug", "true");
+        System.setProperty("sun.security.krb5.debug", "true");
+      }
+    }
+    yarnWebHttpAddr = zConf.getYarnWebappAddress();
+  }
+
+  private HttpResponse callRest(final String url, HTTP operation) {
+    if (hadoopSecurityEnabled) {
+      return callSecurityRest(url, operation);
+    } else {
+      return callSimpleRest(url, operation);
+    }
+  }
+
+  public HttpResponse callSimpleRest(final String url, HTTP operation) {
+    DefaultHttpClient httpclient = new DefaultHttpClient();
+    HttpResponse response = null;
+    HttpUriRequest request = null;
+
+    switch (operation) {
+      case DELETE:
+        request = new HttpDelete(url);
+        break;
+      case POST:
+        request = new HttpPost(url);
+        break;
+      default:
+        request = new HttpGet(url);
+        break;
+    }
+
+    try {
+      response = httpclient.execute(request);
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    return response;
+  }
+
+  // yarn application name match the pattern [a-z][a-z0-9-]*
+  public static String formatYarnAppName(String interpreterGroupId) {
+    return interpreterGroupId.toLowerCase().replaceAll("_", "-");
+  }
+
+  // http://yarn-web-http-address/app/v1/services/{service_name}
+  public void deleteService(String serviceName) {
+    String appUrl = this.yarnWebHttpAddr + "/app/v1/services/" + serviceName
+        + "?_=" + System.currentTimeMillis();
+
+    InputStream inputStream = null;
+    try {
+      HttpResponse response = callRest(appUrl, HTTP.DELETE);
+      inputStream = response.getEntity().getContent();
+      String result = new BufferedReader(new InputStreamReader(inputStream))
+          .lines().collect(Collectors.joining(System.lineSeparator()));
+      if (response.getStatusLine().getStatusCode() != 200 /*success*/) {
+        LOGGER.warn("Status code " + response.getStatusLine().getStatusCode());
+        LOGGER.warn("message is :" + Arrays.deepToString(response.getAllHeaders()));
+        LOGGER.warn("result：\n" + result);
+      }
+    } catch (Exception exp) {
+      exp.printStackTrace();
+    } finally {
+      try {
+        if (null != inputStream) {
+          inputStream.close();
+        }
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+  }
+
+  // http://yarn-web-http-address/app/v1/services/{appIdOrName}
+  // test/resources/app-v1-services-app_name.json
+  public Map<String, Object> getAppServices(String appIdOrName) {
+    Map<String, Object> mapStatus = new HashMap<>();
+    String appUrl = this.yarnWebHttpAddr + "/app/v1/services/" + appIdOrName
+        + "?_=" + System.currentTimeMillis();
+
+    InputStream inputStream = null;
+    try {
+      HttpResponse response = callRest(appUrl, HTTP.GET);
+      if (null != response) {
+        inputStream = response.getEntity().getContent();
+        String result = new BufferedReader(new InputStreamReader(inputStream))
+            .lines().collect(Collectors.joining(System.lineSeparator()));
+        if (response.getStatusLine().getStatusCode() != 200 /*success*/
+            && response.getStatusLine().getStatusCode() != 404 /*Not found*/) {
+          LOGGER.warn("Status code " + response.getStatusLine().getStatusCode());
+          LOGGER.warn("message is :" + Arrays.deepToString(response.getAllHeaders()));
+          LOGGER.warn("result：\n" + result);
+        }
+
+        // parse app status json
+        mapStatus = parseAppServices(result);
+      }
+    } catch (Exception exp) {
+      exp.printStackTrace();
+    } finally {
+      try {
+        if (null != inputStream) {
+          inputStream.close();
+        }
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+
+    return mapStatus;
+  }
+
+  // http://yarn-web-http-address/ws/v1/cluster/apps/{appId}
+  // test/resources/ws-v1-cluster-apps-application_id-failed.json
+  // test/resources/ws-v1-cluster-apps-application_id-finished.json
+  // test/resources/ws-v1-cluster-apps-application_id-running.json
+  public Map<String, Object> getClusterApps(String appId) {
+    Map<String, Object> appAttempts = new HashMap<>();
+    String appUrl = this.yarnWebHttpAddr + "/ws/v1/cluster/apps/" + appId
+        + "?_=" + System.currentTimeMillis();
+
+    InputStream inputStream = null;
+    try {
+      HttpResponse response = callRest(appUrl, HTTP.GET);
+      inputStream = response.getEntity().getContent();
+      String result = new BufferedReader(new InputStreamReader(inputStream))
+          .lines().collect(Collectors.joining(System.lineSeparator()));
+      if (response.getStatusLine().getStatusCode() != 200 /*success*/) {
+        LOGGER.warn("Status code " + response.getStatusLine().getStatusCode());
+        LOGGER.warn("message is :" + Arrays.deepToString(response.getAllHeaders()));
+        LOGGER.warn("result：\n" + result);
+      }
+      // parse app status json
+      appAttempts = parseClusterApps(result);
+
+      return appAttempts;
+    } catch (Exception exp) {
+      exp.printStackTrace();
+    } finally {
+      try {
+        if (null != inputStream) {
+          inputStream.close();
+        }
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+
+    return appAttempts;
+  }
+
+  public Map<String, Object> parseClusterApps(String jsonContent) {
+    Map<String, Object> appAttempts = new HashMap<>();
+
+    try {
+      JsonParser jsonParser = new JsonParser();
+      JsonObject jsonObject = (JsonObject) jsonParser.parse(jsonContent);
+
+      JsonObject jsonAppAttempts = jsonObject.get("app").getAsJsonObject();
+      if (null == jsonAppAttempts) {
+        return appAttempts;
+      }
+      for (Map.Entry<String, JsonElement> entry : jsonAppAttempts.entrySet()) {
+        String key = entry.getKey();
+        if (null != entry.getValue() && entry.getValue() instanceof JsonPrimitive) {
+          Object value = entry.getValue().getAsString();
+          appAttempts.put(key, value);
+        }
+      }
+    } catch (JsonIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    } catch (JsonSyntaxException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    return appAttempts;
+  }
+
+  // http://yarn-web-http-address/ws/v1/cluster/apps/{appId}/appattempts
+  // test/resources/ws-v1-cluster-apps-application_id-appattempts.json
+  public List<Map<String, Object>> getAppAttempts(String appId) {
+    List<Map<String, Object>> appAttempts = new ArrayList<>();
+    String appUrl = this.yarnWebHttpAddr + "/ws/v1/cluster/apps/" + appId
+        + "/appattempts?_=" + System.currentTimeMillis();
+
+    InputStream inputStream = null;
+    try {
+      HttpResponse response = callRest(appUrl, HTTP.GET);
+      inputStream = response.getEntity().getContent();
+      String result = new BufferedReader(new InputStreamReader(inputStream))
+          .lines().collect(Collectors.joining(System.lineSeparator()));
+      if (response.getStatusLine().getStatusCode() != 200 /*success*/) {
+        LOGGER.warn("Status code " + response.getStatusLine().getStatusCode());
+        LOGGER.warn("message is :" + Arrays.deepToString(response.getAllHeaders()));
+        LOGGER.warn("result：\n" + result);
+      }
+
+      // parse app status json
+      appAttempts = parseAppAttempts(result);
+    } catch (Exception exp) {
+      exp.printStackTrace();
+    } finally {
+      try {
+        if (null != inputStream) {
+          inputStream.close();
+        }
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+
+    return appAttempts;
+  }
+
+  // http://yarn-web-http-address/ws/v1/cluster/apps/{appId}/appattempts/{appAttemptId}/containers
+  // test/resources/ws-v1-cluster-apps-application_id-appattempts-appattempt_id-containers.json
+  public List<Map<String, Object>> getAppAttemptsContainers(String appId, String appAttemptId) {
+    List<Map<String, Object>> appAttemptsContainers = new ArrayList<>();
+    String appUrl = this.yarnWebHttpAddr + "/ws/v1/cluster/apps/" + appId
+        + "/appattempts/" + appAttemptId + "/containers?_=" + System.currentTimeMillis();
+
+    InputStream inputStream = null;
+    try {
+      HttpResponse response = callRest(appUrl, HTTP.GET);
+      inputStream = response.getEntity().getContent();
+      String result = new BufferedReader(new InputStreamReader(inputStream))
+          .lines().collect(Collectors.joining(System.lineSeparator()));
+      if (response.getStatusLine().getStatusCode() != 200 /*success*/) {
+        LOGGER.warn("Status code " + response.getStatusLine().getStatusCode());
+        LOGGER.warn("message is :" + Arrays.deepToString(response.getAllHeaders()));
+        LOGGER.warn("result：\n" + result);
+      }
+
+      // parse app status json
+      appAttemptsContainers = parseAppAttemptsContainers(result);
+    } catch (Exception exp) {
+      exp.printStackTrace();
+    } finally {
+      try {
+        if (null != inputStream) {
+          inputStream.close();
+        }
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+
+    return appAttemptsContainers;
+  }
+
+  public List<Map<String, Object>> getAppAttemptsContainersExportPorts(String appId) {
+    List<Map<String, Object>> listExportPorts = new ArrayList<>();
+
+    // appId -> appAttemptId
+    List<Map<String, Object>> listAppAttempts = getAppAttempts(appId);
+    for (Map<String, Object> mapAppAttempts : listAppAttempts) {
+      if (mapAppAttempts.containsKey(YARN_REST_APPATTEMPTID)) {
+        String appAttemptId = (String) mapAppAttempts.get(YARN_REST_APPATTEMPTID);
+        List<Map<String, Object>> exportPorts = getAppAttemptsContainers(appId, appAttemptId);
+        if (exportPorts.size() > 0) {
+          listExportPorts.addAll(exportPorts);
+        }
+      }
+    }
+
+    return listExportPorts;
+  }
+
+  // Kerberos authentication for simulated curling
+  private static HttpClient buildSpengoHttpClient() {
+    HttpClientBuilder builder = HttpClientBuilder.create();
+    Lookup<AuthSchemeProvider> authSchemeRegistry
+        = RegistryBuilder.<AuthSchemeProvider>create().register(
+        AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true)).build();
+    builder.setDefaultAuthSchemeRegistry(authSchemeRegistry);
+    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(new AuthScope(null, -1, null), new Credentials() {
+      @Override
+      public Principal getUserPrincipal() {
+        return null;
+      }
+
+      @Override
+      public String getPassword() {
+        return null;
+      }
+    });
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+
+    // Avoid output WARN: Cookie rejected
+    RequestConfig globalConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES)
+        .build();
+    builder.setDefaultRequestConfig(globalConfig);
+
+    CloseableHttpClient httpClient = builder.build();
+
+    return httpClient;
+  }
+
+  public HttpResponse callSecurityRest(final String url, HTTP operation) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(String.format("Calling YarnClient %s %s %s",
+          this.principal, this.keytab, url));
+    }
+    javax.security.auth.login.Configuration config = new javax.security.auth.login.Configuration() {
+      @SuppressWarnings("serial")
+      @Override
+      public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+        return new AppConfigurationEntry[]{new AppConfigurationEntry(
+            "com.sun.security.auth.module.Krb5LoginModule",
+            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+            new HashMap<String, Object>() {
+              {
+                put("useTicketCache", "false");
+                put("useKeyTab", "true");
+                put("keyTab", keytab);
+                // Krb5 in GSS API needs to be refreshed so it does not throw the error
+                // Specified version of key is not available
+                put("refreshKrb5Config", "true");
+                put("principal", principal);
+                put("storeKey", "true");
+                put("doNotPrompt", "true");
+                put("isInitiator", "true");
+                if (LOGGER.isDebugEnabled()) {
+                  put("debug", "true");
+                }
+              }
+            })};
+      }
+    };
+
+    Set<Principal> principals = new HashSet<Principal>(1);
+    principals.add(new KerberosPrincipal(this.principal));
+    Subject sub = new Subject(false, principals, new HashSet<Object>(), new HashSet<Object>());
+    try {
+      // Authentication module: Krb5Login
+      LoginContext loginContext = new LoginContext("Krb5Login", sub, null, config);
+      loginContext.login();
+      Subject serviceSubject = loginContext.getSubject();
+      return Subject.doAs(serviceSubject, new PrivilegedAction<HttpResponse>() {
+        HttpResponse httpResponse = null;
+
+        @Override
+        public HttpResponse run() {
+          try {
+            HttpUriRequest request = null;
+            switch (operation) {
+              case DELETE:
+                request = new HttpDelete(url);
+                break;
+              case POST:
+                request = new HttpPost(url);
+                break;
+              default:
+                request = new HttpGet(url);
+                break;
+            }
+
+            HttpClient spengoClient = buildSpengoHttpClient();
+            httpResponse = spengoClient.execute(request);
+            return httpResponse;
+          } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+          }
+          return httpResponse;
+        }
+      });
+    } catch (Exception e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+    return null;
+  }
+
+  private Map<String, Object> parseAppServices(String appJson) {
+    Map<String, Object> mapStatus = new HashMap<>();
+
+    try {
+      JsonParser jsonParser = new JsonParser();
+      JsonObject jsonObject = (JsonObject) jsonParser.parse(appJson);
+
+      JsonElement elementAppId = jsonObject.get("id");
+      JsonElement elementAppState = jsonObject.get("state");
+      JsonElement elementAppName = jsonObject.get("name");
+
+      String appId = (elementAppId == null) ? "" : elementAppId.getAsString();
+      String appState = (elementAppState == null) ? "" : elementAppState.getAsString();
+      String appName = (elementAppName == null) ? "" : elementAppName.getAsString();
+
+      if (!StringUtils.isEmpty(appId)) {
+        mapStatus.put(YarnConstants.YARN_APPLICATION_ID, appId);
+      }
+      if (!StringUtils.isEmpty(appName)) {
+        mapStatus.put(YarnConstants.YARN_APPLICATION_NAME, appName);
+      }
+      if (!StringUtils.isEmpty(appState)) {
+        mapStatus.put(YarnConstants.YARN_APPLICATION_STATUS, appState);
+      }
+    } catch (JsonIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    } catch (JsonSyntaxException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    return mapStatus;
+  }
+
+  // appJson format : submarine/src/test/resources/appAttempts.json
+  public List<Map<String, Object>> parseAppAttempts(String jsonContent) {
+    List<Map<String, Object>> appAttempts = new ArrayList<>();
+
+    try {
+      JsonParser jsonParser = new JsonParser();
+      JsonObject jsonObject = (JsonObject) jsonParser.parse(jsonContent);
+
+      JsonObject jsonAppAttempts = jsonObject.get(YARN_REST_APPATTEMPTS).getAsJsonObject();
+      if (null == jsonAppAttempts) {
+        return appAttempts;
+      }
+      JsonArray jsonAppAttempt = jsonAppAttempts.get(YARN_REST_APPATTEMPT).getAsJsonArray();
+      if (null == jsonAppAttempt) {
+        return appAttempts;
+      }
+      for (int i = 0; i < jsonAppAttempt.size(); i++) {
+        Map<String, Object> mapAppAttempt = new HashMap<>();
+
+        JsonObject jsonParagraph = jsonAppAttempt.get(i).getAsJsonObject();
+
+        JsonElement jsonElement = jsonParagraph.get("id");
+        String id = (jsonElement == null) ? "" : jsonElement.getAsString();
+        mapAppAttempt.put("id", id);
+
+        jsonElement = jsonParagraph.get(YARN_REST_APPATTEMPTID);
+        String appAttemptId = (jsonElement == null) ? "" : jsonElement.getAsString();
+        mapAppAttempt.put(YARN_REST_APPATTEMPTID, appAttemptId);
+
+        appAttempts.add(mapAppAttempt);
+      }
+    } catch (JsonIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    } catch (JsonSyntaxException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    return appAttempts;
+  }
+
+  // appJson format : submarine/src/test/resources/appAttempts.json
+  public List<Map<String, Object>> parseAppAttemptsContainers(String jsonContent) {
+    List<Map<String, Object>> appContainers = new ArrayList<>();
+
+    try {
+      JsonParser jsonParser = new JsonParser();
+      JsonObject jsonObject = (JsonObject) jsonParser.parse(jsonContent);
+
+      JsonArray jsonContainers = jsonObject.get(YARN_REST_CONTAINER).getAsJsonArray();
+      for (int i = 0; i < jsonContainers.size(); i++) {
+        String hostIp = "";
+
+        JsonObject jsonContainer = jsonContainers.get(i).getAsJsonObject();
+
+        JsonElement jsonElement = jsonContainer.get("nodeId");
+        String nodeId = (jsonElement == null) ? "" : jsonElement.getAsString();
+        String[] nodeIdParts = nodeId.split(":");
+        if (nodeIdParts.length == 2) {
+          hostIp = nodeIdParts[0];
+        }
+
+        jsonElement = jsonContainer.get("exposedPorts");
+        String exposedPorts = (jsonElement == null) ? "" : jsonElement.getAsString();
+
+        Gson gson = new Gson();
+        Map<String, List<Map<String, String>>> listExposedPorts = gson.fromJson(exposedPorts,
+            new TypeToken<Map<String, List<Map<String, String>>>>() {
+            }.getType());
+        if (null == listExposedPorts) {
+          continue;
+        }
+        for (Map.Entry<String, List<Map<String, String>>> entry : listExposedPorts.entrySet()) {
+          String containerPort = entry.getKey();
+          String[] containerPortParts = containerPort.split("/");
+          if (containerPortParts.length == 2) {
+            List<Map<String, String>> hostIps = entry.getValue();
+            for (Map<String, String> hostAttrib : hostIps) {
+              Map<String, Object> containerExposedPort = new HashMap<>();
+              String hostPort = hostAttrib.get("HostPort");
+              containerExposedPort.put(HOST_IP, hostIp);
+              containerExposedPort.put(HOST_PORT, hostPort);
+              containerExposedPort.put(CONTAINER_PORT, containerPortParts[0]);
+              appContainers.add(containerExposedPort);
+            }
+          }
+        }
+      }
+    } catch (JsonIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    } catch (JsonSyntaxException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    return appContainers;
+  }
+
+  public List<Map<String, Object>> getAppExportPorts(String name) {
+    // Query the IP and port of the submarine interpreter process through the yarn client
+    Map<String, Object> mapAppStatus = getAppServices(name);
+    if (mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_ID)
+        && mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_NAME)
+        && mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_STATUS)) {
+      String appId = mapAppStatus.get(YarnConstants.YARN_APPLICATION_ID).toString();
+      String appStatus = mapAppStatus.get(YarnConstants.YARN_APPLICATION_STATUS).toString();
+
+      // if (StringUtils.equals(appStatus, SubmarineJob.YarnApplicationState.RUNNING.toString())) {
+      List<Map<String, Object>> mapAppAttempts = getAppAttemptsContainersExportPorts(appId);
+      return mapAppAttempts;
+      //}
+    }
+
+    return new ArrayList<Map<String, Object>>() {
+    };
+  }
+
+  public Map<String, String> getAppExportPorts(String name, String port) {
+    // Query the IP and port of the submarine interpreter process through the yarn client
+    Map<String, Object> mapAppStatus = getAppServices(name);
+    if (mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_ID)
+        && mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_NAME)
+        && mapAppStatus.containsKey(YarnConstants.YARN_APPLICATION_STATUS)) {
+      String appId = mapAppStatus.get(YarnConstants.YARN_APPLICATION_ID).toString();
+      String appStatus = mapAppStatus.get(YarnConstants.YARN_APPLICATION_STATUS).toString();
+
+      List<Map<String, Object>> mapAppAttempts = getAppAttemptsContainersExportPorts(appId);
+      boolean findExistIntpContainer = false;
+      for (Map<String, Object> exportPorts : mapAppAttempts) {
+        if (exportPorts.containsKey(YarnClient.HOST_IP) && exportPorts.containsKey(YarnClient.HOST_PORT)
+            && exportPorts.containsKey(YarnClient.CONTAINER_PORT)) {
+          String intpAppHostIp = (String) exportPorts.get(YarnClient.HOST_IP);
+          String intpAppHostPort = (String) exportPorts.get(YarnClient.HOST_PORT);
+          String intpAppContainerPort = (String) exportPorts.get(YarnClient.CONTAINER_PORT);
+          if (StringUtils.equals(port, intpAppContainerPort)) {
+            LOGGER.info("Detection Submarine interpreter Container hostIp:{}, hostPort:{}, containerPort:{}.",
+                intpAppHostIp, intpAppHostPort, intpAppContainerPort);
+
+            Map<String, String> exportPortsAttr = new HashMap<>();
+            exportPortsAttr.put(HOST_IP, intpAppHostIp);
+            exportPortsAttr.put(HOST_PORT, intpAppHostPort);
+            exportPortsAttr.put(CONTAINER_PORT, intpAppContainerPort);
+
+            return exportPortsAttr;
+          }
+        }
+      }
+    }
+
+    return new HashMap<String, String>();
+  }
+
+  public enum HTTP {
+    GET,
+    POST,
+    DELETE;
+  }
+}

--- a/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnConstants.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnConstants.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+/*
+ * NOTE: use lowercase + "_" for the option name
+ */
+public class YarnConstants {
+  // Docker container Environmental variable at `submarine-job-run-tf.jinja`
+  // and `/bin/interpreter.sh`
+  public static final String DOCKER_HADOOP_HOME       = "DOCKER_HADOOP_HOME";
+  public static final String DOCKER_JAVA_HOME         = "DOCKER_JAVA_HOME";
+  public static final String DOCKER_HADOOP_CONF_DIR   = "DOCKER_HADOOP_CONF_DIR";
+  public static final String DOCKER_CONTAINER_TIME_ZONE = "DOCKER_CONTAINER_TIME_ZONE";
+  public static final String INTERPRETER_LAUNCH_MODE = "INTERPRETER_LAUNCH_MODE";
+
+  // interpreter.sh Environmental variable
+  public static final String SUBMARINE_HADOOP_HOME  = "SUBMARINE_HADOOP_HOME";
+  public static final String HADOOP_YARN_SUBMARINE_JAR  = "HADOOP_YARN_SUBMARINE_JAR";
+  public static final String SUBMARINE_INTERPRETER_DOCKER_IMAGE
+      = "SUBMARINE_INTERPRETER_DOCKER_IMAGE";
+
+  public static final String ZEPPELIN_SUBMARINE_AUTH_TYPE = "zeppelin.submarine.auth.type";
+  public static final String SUBMARINE_HADOOP_CONF_DIR  = "SUBMARINE_HADOOP_CONF_DIR";
+  public static final String SUBMARINE_HADOOP_KEYTAB    = "SUBMARINE_HADOOP_KEYTAB";
+  public static final String SUBMARINE_HADOOP_PRINCIPAL = "SUBMARINE_HADOOP_PRINCIPAL";
+  public static final String SUBMARINE_HADOOP_KRB5_CONF = "submarine.hadoop.krb5.conf";
+
+  public static final String JOB_NAME = "JOB_NAME";
+  public static final String CLEAN_CHECKPOINT = "CLEAN_CHECKPOINT";
+  public static final String INPUT_PATH = "INPUT_PATH";
+  public static final String CHECKPOINT_PATH = "CHECKPOINT_PATH";
+  public static final String PS_LAUNCH_CMD = "PS_LAUNCH_CMD";
+  public static final String WORKER_LAUNCH_CMD = "WORKER_LAUNCH_CMD";
+  public static final String MACHINELEARNING_DISTRIBUTED_ENABLE
+      = "machinelearning.distributed.enable";
+
+  public static final String ZEPPELIN_INTERPRETER_RPC_PORTRANGE
+      = "zeppelin.interpreter.rpc.portRange";
+
+  public static final String DOCKER_CONTAINER_NETWORK   = "docker.container.network";
+  public static final String SUBMARINE_YARN_QUEUE       = "submarine.yarn.queue";
+  public static final String SUBMARINE_CONCURRENT_MAX   = "submarine.concurrent.max";
+
+  public static final String SUBMARINE_ALGORITHM_HDFS_PATH  = "submarine.algorithm.hdfs.path";
+  public static final String SUBMARINE_ALGORITHM_HDFS_FILES = "submarine.algorithm.hdfs.files";
+
+  public static final String TF_PARAMETER_SERVICES_DOCKER_IMAGE
+      = "tf.parameter.services.docker.image";
+  public static final String TF_PARAMETER_SERVICES_NUM = "tf.parameter.services.num";
+  public static final String TF_PARAMETER_SERVICES_GPU = "tf.parameter.services.gpu";
+  public static final String TF_PARAMETER_SERVICES_CPU = "tf.parameter.services.cpu";
+  public static final String TF_PARAMETER_SERVICES_MEMORY = "tf.parameter.services.memory";
+
+  public static final String TF_WORKER_SERVICES_DOCKER_IMAGE = "tf.worker.services.docker.image";
+  public static final String TF_WORKER_SERVICES_NUM = "tf.worker.services.num";
+  public static final String TF_WORKER_SERVICES_GPU = "tf.worker.services.gpu";
+  public static final String TF_WORKER_SERVICES_CPU = "tf.worker.services.cpu";
+  public static final String TF_WORKER_SERVICES_MEMORY = "tf.worker.services.memory";
+
+  public static final String TF_TENSORBOARD_ENABLE  = "tf.tensorboard.enable";
+  public static final String TF_CHECKPOINT_PATH = "tf.checkpoint.path";
+
+  public static final String COMMAND_TYPE     = "COMMAND_TYPE";
+  public static final String OPERATION_TYPE   = "OPERATION_TYPE";
+  public static final String COMMAND_USAGE    = "USAGE";
+  public static final String COMMAND_JOB_LIST = "JOB LIST";
+  public static final String COMMAND_JOB_SHOW = "JOB SHOW";
+  public static final String COMMAND_JOB_RUN  = "JOB RUN";
+  public static final String COMMAND_JOB_STOP = "JOB STOP";
+  public static final String COMMAND_CLEAN    = "CLEAN";
+  public static final String COMMAND_ACTIVE   = "COMMAND_ACTIVE";
+
+  public static final String PARAGRAPH_ID  = "PARAGRAPH_ID";
+
+  public static final String COMMANDLINE_OPTIONS = "COMMANDLINE_OPTIONS";
+
+  // YARN
+  public static final String YARN_WEB_ADDRESS
+      = "yarn.webapp.http.address";
+
+  public static final String YARN_APPLICATION_ID     = "YARN_APPLICATION_ID";
+  public static final String YARN_APPLICATION_NAME   = "YARN_APPLICATION_NAME";
+  public static final String YARN_APPLICATION_URL    = "YARN_APPLICATION_URL";
+  public static final String YARN_APPLICATION_STATUS = "YARN_APPLICATION_STATUS";
+  public static final String YARN_APPLICATION_FINAL_STATUS = "YARN_APPLICATION_FINAL_STATUS";
+  public static final String YARN_TENSORBOARD_URL = "YARN_TENSORBOARD_URL";
+  public static final String TENSORBOARD_URL         = "TENSORBOARD_URL";
+  public static final String YARN_APP_STARTED_TIME   = "YARN_APP_STARTED_TIME";
+  public static final String YARN_APP_LAUNCH_TIME    = "YARN_APP_LAUNCH_TIME";
+  public static final String YARN_APP_FINISHED_TIME  = "YARN_APP_FINISHED_TIME";
+  public static final String YARN_APP_ELAPSED_TIME   = "YARN_APP_ELAPSED_TIME";
+  public static final String YARN_APP_STATE_NAME        = "state";
+  public static final String YARN_APP_FINAL_STATUS_NAME = "finalStatus";
+  public static final String YARN_APP_STARTEDTIME_NAME  = "startedTime";
+  public static final String YARN_APP_LAUNCHTIME_NAME   = "launchTime";
+
+  public static final String YARN_APPLICATION_STATUS_ACCEPT    = "ACCEPT";
+  public static final String YARN_APPLICATION_STATUS_RUNNING   = "RUNNING";
+  public static final String YARN_APPLICATION_STATUS_FINISHED  = "EXECUTE_SUBMARINE_FINISHED";
+  public static final String YARN_APPLICATION_STATUS_FAILED    = "FAILED";
+
+  public static final String JOB_STATUS   = "JOB_STATUS";
+
+
+  // submarine.algorithm.hdfs.path support for replacing ${user.name} with real user name
+  public static final String USERNAME_SYMBOL = "${user.name}";
+
+  public static String unifyKey(String key) {
+    key = key.replace(".", "_").toUpperCase();
+    return key;
+  }
+}

--- a/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcess.java
@@ -1,0 +1,125 @@
+package org.apache.zeppelin.interpreter.launcher;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.Constants;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.ZEPPELIN_INTERPRETER_RPC_PORTRANGE;
+
+public class YarnRemoteInterpreterProcess extends RemoteInterpreterManagedProcess {
+  private static final Logger LOGGER = LoggerFactory.getLogger(YarnRemoteInterpreterProcess.class);
+
+  private YarnClient yarnClient = null;
+  private Properties properties;
+  private String interpreterGroupId;
+
+  public YarnRemoteInterpreterProcess(
+      String intpRunner,
+      int zeppelinServerRPCPort,
+      String zeppelinServerRPCHost,
+      String interpreterPortRange,
+      String intpDir,
+      String localRepoDir,
+      Map<String, String> env,
+      int connectTimeout,
+      String interpreterSettingName,
+      String interpreterGroupId,
+      boolean isUserImpersonated,
+      Properties properties) {
+    super(intpRunner, zeppelinServerRPCPort, zeppelinServerRPCHost,
+        interpreterPortRange, intpDir, localRepoDir,
+        env, connectTimeout, interpreterSettingName,
+        interpreterGroupId, isUserImpersonated);
+
+    // Because need to modify the properties, make a clone
+    this.properties = (Properties) properties.clone();
+    this.interpreterGroupId = interpreterGroupId;
+
+    yarnClient = new YarnClient();
+  }
+
+  @Override
+  public void start(String userName) throws IOException {
+    String intpYarnAppName = YarnClient.formatYarnAppName(interpreterGroupId);
+
+    // Create a submarine interpreter process with hadoop submarine
+    // First delete the submarine interpreter that may already exist in YARN
+    yarnClient.deleteService(intpYarnAppName);
+    try {
+      // wait for delete submarine interpreter service
+      Thread.sleep(3000);
+    } catch (InterruptedException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+
+    super.start(userName);
+  }
+
+  @Override
+  public void stop() {
+    String intpYarnAppName = YarnClient.formatYarnAppName(interpreterGroupId);
+    Map<String, Object> mapAttrib = yarnClient.getAppServices(intpYarnAppName);
+    if (mapAttrib.size() > 0) {
+      yarnClient.deleteService(intpYarnAppName);
+      try {
+        // wait for delete submarine interpreter service
+        Thread.sleep(3000);
+      } catch (InterruptedException e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
+  }
+
+  @Override
+  public void processStarted(int port, String host) {
+    LOGGER.info("Interpreter container internal {}:{}", host, port);
+
+    String intpYarnAppName = YarnClient.formatYarnAppName(interpreterGroupId);
+
+    // setting port range of submarine interpreter container
+    String intpPort = String.valueOf(Constants.ZEPPELIN_INTERPRETER_DEFAUlT_PORT);
+    String intpAppHostIp = "";
+    String intpAppHostPort = "";
+    String intpAppContainerPort = "";
+    boolean findExistIntpContainer = false;
+
+    // The submarine interpreter already exists in the connection yarn
+    // Or create a submarine interpreter
+    // 1. Query the IP and port of the submarine interpreter process through the yarn client
+    Map<String, String> exportPorts = yarnClient.getAppExportPorts(intpYarnAppName, intpPort);
+    if (exportPorts.size() == 0) {
+      // It may take a few seconds to query the docker container export port.
+      try {
+        Thread.sleep(3000);
+        exportPorts = yarnClient.getAppExportPorts(intpYarnAppName, intpPort);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    if (exportPorts.containsKey(YarnClient.HOST_IP) && exportPorts.containsKey(YarnClient.HOST_PORT)
+        && exportPorts.containsKey(YarnClient.CONTAINER_PORT)) {
+      intpAppHostIp = (String) exportPorts.get(YarnClient.HOST_IP);
+      intpAppHostPort = (String) exportPorts.get(YarnClient.HOST_PORT);
+      intpAppContainerPort = (String) exportPorts.get(YarnClient.CONTAINER_PORT);
+      if (StringUtils.equals(intpPort, intpAppContainerPort)) {
+        findExistIntpContainer = true;
+        LOGGER.info("Detection Submarine interpreter Container hostIp:{}, hostPort:{}, containerPort:{}.",
+            intpAppHostIp, intpAppHostPort, intpAppContainerPort);
+      }
+    }
+
+    if (findExistIntpContainer) {
+      LOGGER.info("Interpreter container external {}:{}", intpAppHostIp, intpAppHostPort);
+      super.processStarted(Integer.parseInt(intpAppHostPort), intpAppHostIp);
+    } else {
+      LOGGER.error("Cann't detection Submarine interpreter Container! {}", exportPorts.toString());
+    }
+  }
+}

--- a/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncher.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.Constants;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.apache.zeppelin.interpreter.InterpreterRunner;
+import org.apache.zeppelin.interpreter.recovery.RecoveryStorage;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterRunningProcess;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_KEYTAB;
+import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_PRINCIPAL;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.DOCKER_HADOOP_CONF_DIR;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.DOCKER_HADOOP_HOME;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.DOCKER_JAVA_HOME;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.HADOOP_YARN_SUBMARINE_JAR;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.SUBMARINE_HADOOP_KEYTAB;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.SUBMARINE_HADOOP_PRINCIPAL;
+import static org.apache.zeppelin.interpreter.launcher.YarnConstants.YARN_WEB_ADDRESS;
+
+/**
+ * Yarn specific launcher.
+ */
+public class YarnStandardInterpreterLauncher extends StandardInterpreterLauncher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(YarnStandardInterpreterLauncher.class);
+
+  private YarnClient yarnClient = null;
+
+  // Zeppelin home path in Docker container
+  // Environment variable `SUBMARINE_ZEPPELIN_CONF_DIR_ENV` in /bin/interpreter.sh
+  private static final String CONTAINER_ZEPPELIN_HOME = "/zeppelin";
+
+  // Upload local zeppelin library to container, There are several benefits
+  // Avoid the difference between the zeppelin version and the local in the container
+  // 1). RemoteInterpreterServer::main(String[] args), Different versions of args may be different
+  // 2). bin/interpreter.sh Start command args may be different
+  // 3). In the debugging phase for easy updating, Upload the local library file to container
+  // After the release, Use the zeppelin library file in the container image
+  private boolean uploadLocalLibToContainter = true;
+
+  private static boolean isTest = false;
+
+  public YarnStandardInterpreterLauncher(ZeppelinConfiguration zConf, RecoveryStorage recoveryStorage) {
+    super(zConf, recoveryStorage);
+
+    String uploadLocalLib = System.getenv("UPLOAD_LOCAL_LIB_TO_CONTAINTER");
+    if (null != uploadLocalLib && StringUtils.equals(uploadLocalLib, "false")) {
+      uploadLocalLibToContainter = false;
+    }
+  }
+
+  @Override
+  public InterpreterClient launch(InterpreterLaunchContext context) throws IOException {
+    LOGGER.info("YarnStandardInterpreterLauncher: "
+        + context.getInterpreterSettingGroup());
+
+    // Because need to modify the properties, make a clone
+    this.properties = (Properties) context.getProperties().clone();
+    yarnClient = new YarnClient();
+
+    InterpreterOption option = context.getOption();
+    InterpreterRunner runner = context.getRunner();
+    String groupName = context.getInterpreterSettingGroup();
+    String name = context.getInterpreterSettingName();
+    int connectTimeout = getConnectTimeout();
+    if (connectTimeout < 200000) {
+      // Because yarn need to download docker image,
+      // So need to increase the timeout setting.
+      connectTimeout = 200000;
+    }
+
+    if (option.isExistingProcess()) {
+      LOGGER.info("Connect an existing remote interpreter process.");
+      return new RemoteInterpreterRunningProcess(
+          context.getInterpreterSettingName(),
+          connectTimeout,
+          option.getHost(),
+          option.getPort());
+    } else {
+      // yarn application name match the pattern [a-z][a-z0-9-]*
+      String submarineIntpAppName = YarnClient.formatYarnAppName(
+          context.getInterpreterGroupId());
+
+      // setting port range of interpreter container
+      String intpPort = String.valueOf(Constants.ZEPPELIN_INTERPRETER_DEFAUlT_PORT);
+      String intpPortRange = intpPort + ":" + intpPort;
+
+      String intpAppHostIp = "";
+      String intpAppHostPort = "";
+      String intpAppContainerPort = "";
+      boolean findExistIntpContainer = false;
+
+      // The submarine interpreter already exists in the connection yarn
+      // Or create a submarine interpreter
+      // 1. Query the IP and port of the submarine interpreter process through the yarn client
+      Map<String, String> exportPorts = yarnClient.getAppExportPorts(submarineIntpAppName, intpPort);
+      if (exportPorts.containsKey(YarnClient.HOST_IP) && exportPorts.containsKey(YarnClient.HOST_PORT)
+          && exportPorts.containsKey(YarnClient.CONTAINER_PORT)) {
+        intpAppHostIp = (String) exportPorts.get(YarnClient.HOST_IP);
+        intpAppHostPort = (String) exportPorts.get(YarnClient.HOST_PORT);
+        intpAppContainerPort = (String) exportPorts.get(YarnClient.CONTAINER_PORT);
+        if (StringUtils.equals(intpPort, intpAppContainerPort)) {
+          findExistIntpContainer = true;
+          LOGGER.info("Detection Submarine interpreter Container hostIp:{}, hostPort:{}, containerPort:{}.",
+              intpAppHostIp, intpAppHostPort, intpAppContainerPort);
+        }
+      }
+
+      if (findExistIntpContainer) {
+        return new RemoteInterpreterRunningProcess(
+            context.getInterpreterSettingName(),
+            connectTimeout,
+            intpAppHostIp,
+            Integer.parseInt(intpAppHostPort));
+      } else {
+        String localRepoPath = zConf.getInterpreterLocalRepoPath() + "/"
+            + context.getInterpreterSettingId();
+        return new YarnRemoteInterpreterProcess(
+            runner != null ? runner.getPath() : zConf.getInterpreterRemoteRunnerPath(),
+            context.getZeppelinServerRPCPort(), context.getZeppelinServerHost(), intpPortRange,
+            zConf.getInterpreterDir() + "/" + groupName, localRepoPath,
+            buildEnvFromProperties(context, properties), connectTimeout, name,
+            context.getInterpreterGroupId(), option.isUserImpersonate(), properties);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public static void setTest(Boolean test) {
+    isTest = test;
+  }
+
+  protected Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context, Properties properties)
+      throws IOException {
+    // yarn application name match the pattern [a-z][a-z0-9-]*
+    String intpYarnAppName = YarnClient.formatYarnAppName(context.getInterpreterGroupId());
+    properties.put("YARN_APP_NAME", intpYarnAppName);
+    properties.put("ZEPPELIN_RUN_MODE", "yarn");
+    // upload configure file to submarine interpreter container
+    // keytab file & zeppelin-site.xml & krb5.conf & hadoop-yarn-submarine-X.X.X-SNAPSHOT.jar
+    // The submarine configures the mount file into the container through `localization`
+    StringBuffer sbLocalization = new StringBuffer();
+
+    // 1) zeppelin-site.xml is uploaded to `${CONTAINER_ZEPPELIN_HOME}` directory in the container
+    if (null != zConf.getDocument()) {
+      String zconfFile = zConf.getDocument().getDocumentURI();
+      if (zconfFile.startsWith("file:")) {
+        zconfFile = zconfFile.replace("file:", "");
+      }
+      if (!StringUtils.isEmpty(zconfFile)) {
+        sbLocalization.append("--localization \"");
+        sbLocalization.append(zconfFile + ":" + CONTAINER_ZEPPELIN_HOME + "/zeppelin-site.xml:rw\"");
+        sbLocalization.append(" ");
+      }
+    }
+
+    String zeppelinHome = getZeppelinHome();
+    if (uploadLocalLibToContainter){
+      // 2) ${ZEPPELIN_HOME}/interpreter/submarine is uploaded to `${CONTAINER_ZEPPELIN_HOME}`
+      //    directory in the container
+      String intpPath = "/interpreter/" + context.getInterpreterSettingName();
+      String zeplIntpSubmarinePath = getPathByHome(zeppelinHome, intpPath);
+      sbLocalization.append("--localization \"");
+      sbLocalization.append(zeplIntpSubmarinePath + ":" + CONTAINER_ZEPPELIN_HOME + intpPath + ":rw\"");
+      sbLocalization.append(" ");
+
+      // 3) ${ZEPPELIN_HOME}/lib/interpreter is uploaded to `${CONTAINER_ZEPPELIN_HOME}`
+      //    directory in the container
+      String libIntpPath = "/lib/interpreter";
+      String zeplLibIntpPath = getPathByHome(zeppelinHome, libIntpPath);
+      sbLocalization.append("--localization \"");
+      sbLocalization.append(zeplLibIntpPath + ":" + CONTAINER_ZEPPELIN_HOME + libIntpPath + ":rw\"");
+      sbLocalization.append(" ");
+    }
+
+    // 4) ${ZEPPELIN_HOME}/conf/log4j.properties
+    String log4jPath = "/conf/log4j.properties";
+    String zeplLog4jPath = getPathByHome(zeppelinHome, log4jPath);
+    sbLocalization.append("--localization \"");
+    sbLocalization.append(zeplLog4jPath + ":" + CONTAINER_ZEPPELIN_HOME + log4jPath + ":rw\"");
+    sbLocalization.append(" ");
+
+    // 5) Keytab file upload container, Keep the same directory as local host
+    String keytab = properties.getProperty(SUBMARINE_HADOOP_KEYTAB, "");
+    String principal = properties.getProperty(SUBMARINE_HADOOP_PRINCIPAL, "");
+    if (StringUtils.isBlank(keytab) || StringUtils.isBlank(principal)) {
+      keytab = zConf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
+      principal = zConf.getString(ZEPPELIN_SERVER_KERBEROS_PRINCIPAL);
+    }
+    // set interpreter.sh Evn
+    properties.put(SUBMARINE_HADOOP_KEYTAB, keytab);
+    properties.put(SUBMARINE_HADOOP_PRINCIPAL, principal);
+    if (!StringUtils.isBlank(keytab)) {
+      sbLocalization.append("--localization \"");
+      sbLocalization.append(keytab + ":" + keytab + ":rw\"").append(" ");
+    }
+
+    // 6) hadoop-yarn-submarine-X.X.X-SNAPSHOT.jar file upload container, Keep the same directory as local
+    String submarineJar = System.getenv(HADOOP_YARN_SUBMARINE_JAR);
+    if (submarineJar != null && !StringUtils.isEmpty(submarineJar)) {
+      submarineJar = getPathByHome(null, submarineJar);
+      sbLocalization.append("--localization \"");
+      sbLocalization.append(submarineJar + ":" + submarineJar + ":rw\"").append(" ");
+    }
+
+    if (!isTest) {
+      // 7) hadoop conf directory upload container, Keep the same directory as local
+      File coreSite = findFileOnClassPath("core-site.xml");
+      File hdfsSite = findFileOnClassPath("hdfs-site.xml");
+      File yarnSite = findFileOnClassPath("yarn-site.xml");
+      if (coreSite == null || hdfsSite == null || yarnSite == null) {
+        LOGGER.error("hdfs is being used, however we couldn't locate core-site.xml/"
+            + "hdfs-site.xml / yarn-site.xml from classpath, please double check you classpath"
+            + "setting and make sure they're included.");
+        throw new IOException(
+            "Failed to locate core-site.xml / hdfs-site.xml / yarn-site.xml from class path");
+      }
+      String hadoopConfDir = coreSite.getParent();
+      if (!StringUtils.isEmpty(hadoopConfDir)) {
+        sbLocalization.append("--localization \"");
+        sbLocalization.append(hadoopConfDir + ":" + hadoopConfDir + ":rw\"").append(" ");
+        // Set the HADOOP_CONF_DIR environment variable in `interpreter.sh`
+        properties.put("DOCKER_HADOOP_CONF_DIR", hadoopConfDir);
+      }
+    }
+
+    properties.put("YARN_LOCALIZATION_ENV", sbLocalization.toString());
+    LOGGER.info("YARN_LOCALIZATION_ENV = " + sbLocalization.toString());
+
+    // Set the zepplin configuration file path environment variable in `interpreter.sh`
+    properties.put("ZEPPELIN_CONF_DIR_ENV", "--env ZEPPELIN_CONF_DIR=" + CONTAINER_ZEPPELIN_HOME);
+
+    String intpContainerRes = zConf.getYarnContainerResource(context.getInterpreterSettingName());
+    properties.put("ZEPPELIN_YARN_CONTAINER_RESOURCE", intpContainerRes);
+
+    String yarnContainerImage = zConf.getYarnContainerImage();
+    properties.put("ZEPPELIN_YARN_CONTAINER_IMAGE", yarnContainerImage);
+
+    String yarnWebappAddress = zConf.getYarnWebappAddress();
+    properties.put(YARN_WEB_ADDRESS, yarnWebappAddress);
+
+    Map<String, String> env = new HashMap<>();
+    for (Object key : properties.keySet()) {
+      if (RemoteInterpreterUtils.isEnvString((String) key)) {
+        env.put((String) key, properties.getProperty((String) key));
+      }
+    }
+    env.put("INTERPRETER_GROUP_ID", context.getInterpreterSettingId());
+
+    // Check environment variables
+    String dockerJavaHome = System.getenv(DOCKER_JAVA_HOME);
+    String dockerHadoopHome = System.getenv(DOCKER_HADOOP_HOME);
+    String dockerHadoopConf = env.get(DOCKER_HADOOP_CONF_DIR);
+    if (StringUtils.isBlank(dockerJavaHome)) {
+      LOGGER.warn("DOCKER_JAVA_HOME environment variables not set!");
+    }
+    if (StringUtils.isBlank(dockerHadoopHome)) {
+      LOGGER.warn("DOCKER_HADOOP_HOME environment variables not set!");
+    }
+    if (StringUtils.isBlank(dockerHadoopConf)) {
+      LOGGER.warn("DOCKER_HADOOP_CONF_DIR environment variables not set!");
+    }
+
+    return env;
+  }
+
+  private String getZeppelinHome() {
+    String zeppelinHome = "";
+    if (System.getenv("ZEPPELIN_HOME") != null) {
+      zeppelinHome = System.getenv("ZEPPELIN_HOME");
+    }
+    if (StringUtils.isEmpty(zeppelinHome)) {
+      zeppelinHome = zConf.getString(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME);
+    }
+    if (StringUtils.isEmpty(zeppelinHome)) {
+      // ${ZEPPELIN_HOME}/plugins/Launcher/YarnStandardInterpreterLauncher
+      zeppelinHome = getClassPath(YarnStandardInterpreterLauncher.class);
+      zeppelinHome = zeppelinHome.replace("/plugins/Launcher/YarnStandardInterpreterLauncher", "");
+    }
+
+    // check zeppelinHome is exist
+    File fileZeppelinHome = new File(zeppelinHome);
+    if (fileZeppelinHome.exists() && fileZeppelinHome.isDirectory()) {
+      return zeppelinHome;
+    }
+
+    return "";
+  }
+
+  // ${ZEPPELIN_HOME}/interpreter/submarine
+  // ${ZEPPELIN_HOME}/lib/interpreter
+  private String getPathByHome(String homeDir, String path) throws IOException {
+    File file = null;
+    if (null == homeDir || StringUtils.isEmpty(homeDir)) {
+      file = new File(path);
+    } else {
+      file = new File(homeDir, path);
+    }
+    if (file.exists()) {
+      return file.getAbsolutePath();
+    }
+
+    if (isTest) {
+      LOGGER.error("Can't find directory in " + homeDir + path + "`!");
+      return "";
+    }
+
+    throw new IOException("Can't find directory in " + homeDir + path + "`!");
+  }
+
+  private File findFileOnClassPath(final String fileName) {
+    final String classpath = System.getProperty("java.class.path");
+    final String pathSeparator = System.getProperty("path.separator");
+    final StringTokenizer tokenizer = new StringTokenizer(classpath, pathSeparator);
+
+    while (tokenizer.hasMoreTokens()) {
+      final String pathElement = tokenizer.nextToken();
+      final File directoryOrJar = new File(pathElement);
+      final File absoluteDirectoryOrJar = directoryOrJar.getAbsoluteFile();
+      if (absoluteDirectoryOrJar.isFile()) {
+        final File target = new File(absoluteDirectoryOrJar.getParent(),
+            fileName);
+        if (target.exists()) {
+          return target;
+        }
+      } else{
+        final File target = new File(directoryOrJar, fileName);
+        if (target.exists()) {
+          return target;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * -----------------------------------------------------------------------
+   * getAppPath needs a class attribute parameter of the Java class used
+   * by the current program, which can return the packaged
+   * The system directory name where the Java executable (jar, war) is located
+   * or the directory where the non-packaged Java program is located
+   *
+   * @param cls
+   * @return The return value is the directory where the Java program
+   * where the class is located is running.
+   * -------------------------------------------------------------------------
+   */
+  private String getClassPath(Class cls) {
+    // Check if the parameters passed in by the user are empty
+    if (cls == null) {
+      throw new java.lang.IllegalArgumentException("The parameter cannot be empty!");
+    }
+
+    ClassLoader loader = cls.getClassLoader();
+    // Get the full name of the class, including the package name
+    String clsName = cls.getName() + ".class";
+    // Get the package where the incoming parameters are located
+    Package pack = cls.getPackage();
+    String path = "";
+    // If not an anonymous package, convert the package name to a path
+    if (pack != null) {
+      String packName = pack.getName();
+      // Here is a simple decision to determine whether it is a Java base class library,
+      // preventing users from passing in the JDK built-in class library.
+      if (packName.startsWith("java.") || packName.startsWith("javax.")) {
+        throw new java.lang.IllegalArgumentException("Do not transfer system classes!");
+      }
+
+      // In the name of the class, remove the part of the package name
+      // and get the file name of the class.
+      clsName = clsName.substring(packName.length() + 1);
+      // Determine whether the package name is a simple package name, and if so,
+      // directly convert the package name to a path.
+      if (packName.indexOf(".") < 0) {
+        path = packName + "/";
+      } else {
+        // Otherwise, the package name is converted to a path according
+        // to the component part of the package name.
+        int start = 0, end = 0;
+        end = packName.indexOf(".");
+        while (end != -1) {
+          path = path + packName.substring(start, end) + "/";
+          start = end + 1;
+          end = packName.indexOf(".", start);
+        }
+        path = path + packName.substring(start) + "/";
+      }
+    }
+    // Call the classReloader's getResource method, passing in the
+    // class file name containing the path information.
+    java.net.URL url = loader.getResource(path + clsName);
+    // Get path information from the URL object
+    String realPath = url.getPath();
+    // Remove the protocol name "file:" in the path information.
+    int pos = realPath.indexOf("file:");
+    if (pos > -1) {
+      realPath = realPath.substring(pos + 5);
+    }
+    // Remove the path information and the part that contains the class file information,
+    // and get the path where the class is located.
+    pos = realPath.indexOf(path + clsName);
+    realPath = realPath.substring(0, pos - 1);
+    // If the class file is packaged into a JAR file, etc.,
+    // remove the corresponding JAR and other package file names.
+    if (realPath.endsWith("!")) {
+      realPath = realPath.substring(0, realPath.lastIndexOf("/"));
+    }
+    try {
+      realPath = java.net.URLDecoder.decode(realPath, "utf-8");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return realPath;
+  }
+}

--- a/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncher.java
@@ -45,7 +45,6 @@ import static org.apache.zeppelin.interpreter.launcher.YarnConstants.DOCKER_JAVA
 import static org.apache.zeppelin.interpreter.launcher.YarnConstants.HADOOP_YARN_SUBMARINE_JAR;
 import static org.apache.zeppelin.interpreter.launcher.YarnConstants.SUBMARINE_HADOOP_KEYTAB;
 import static org.apache.zeppelin.interpreter.launcher.YarnConstants.SUBMARINE_HADOOP_PRINCIPAL;
-import static org.apache.zeppelin.interpreter.launcher.YarnConstants.YARN_WEB_ADDRESS;
 
 /**
  * Yarn specific launcher.
@@ -154,20 +153,21 @@ public class YarnStandardInterpreterLauncher extends StandardInterpreterLauncher
     }
   }
 
-  @VisibleForTesting
-  public static void setTest(Boolean test) {
-    isTest = test;
-  }
-
   protected Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context, Properties properties)
       throws IOException {
+    Map<String, String> env = new HashMap<>();
+
     // yarn application name match the pattern [a-z][a-z0-9-]*
     String intpYarnAppName = YarnClient.formatYarnAppName(context.getInterpreterGroupId());
-    properties.put("YARN_APP_NAME", intpYarnAppName);
-    properties.put("ZEPPELIN_RUN_MODE", "yarn");
+    env.put("YARN_APP_NAME", intpYarnAppName);
+    env.put("ZEPPELIN_RUN_MODE", "yarn");
+
     // upload configure file to submarine interpreter container
     // keytab file & zeppelin-site.xml & krb5.conf & hadoop-yarn-submarine-X.X.X-SNAPSHOT.jar
     // The submarine configures the mount file into the container through `localization`
+    // NOTE: The path to the file uploaded to the container,
+    // Can not be repeated, otherwise it will lead to failure.
+    HashMap<String, String> uploaded = new HashMap<>();
     StringBuffer sbLocalization = new StringBuffer();
 
     // 1) zeppelin-site.xml is uploaded to `${CONTAINER_ZEPPELIN_HOME}` directory in the container
@@ -209,19 +209,34 @@ public class YarnStandardInterpreterLauncher extends StandardInterpreterLauncher
     sbLocalization.append(zeplLog4jPath + ":" + CONTAINER_ZEPPELIN_HOME + log4jPath + ":rw\"");
     sbLocalization.append(" ");
 
-    // 5) Keytab file upload container, Keep the same directory as local host
-    String keytab = properties.getProperty(SUBMARINE_HADOOP_KEYTAB, "");
-    String principal = properties.getProperty(SUBMARINE_HADOOP_PRINCIPAL, "");
-    if (StringUtils.isBlank(keytab) || StringUtils.isBlank(principal)) {
-      keytab = zConf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
-      principal = zConf.getString(ZEPPELIN_SERVER_KERBEROS_PRINCIPAL);
+    // 5) Get the keytab file in each interpreter properties
+    // Upload Keytab file to container, Keep the same directory as local host
+    // 5.1) shell interpreter properties keytab file
+    String intpKeytab = properties.getProperty("zeppelin.shell.keytab.location", "");
+    if (StringUtils.isBlank(intpKeytab)) {
+      // 5.2) spark interpreter properties keytab file
+      intpKeytab = properties.getProperty("spark.yarn.keytab", "");
     }
-    // set interpreter.sh Evn
-    properties.put(SUBMARINE_HADOOP_KEYTAB, keytab);
-    properties.put(SUBMARINE_HADOOP_PRINCIPAL, principal);
-    if (!StringUtils.isBlank(keytab)) {
+    if (StringUtils.isBlank(intpKeytab)) {
+      // 5.3) submarine interpreter properties keytab file
+      intpKeytab = properties.getProperty("submarine.hadoop.keytab", "");
+    }
+    if (StringUtils.isBlank(intpKeytab)) {
+      // 5.4) jdbc interpreter properties keytab file
+      intpKeytab = properties.getProperty("zeppelin.jdbc.keytab.location", "");
+    }
+    if (!StringUtils.isBlank(intpKeytab) && !uploaded.containsKey(intpKeytab)) {
+      uploaded.put(intpKeytab, "");
       sbLocalization.append("--localization \"");
-      sbLocalization.append(keytab + ":" + keytab + ":rw\"").append(" ");
+      sbLocalization.append(intpKeytab + ":" + intpKeytab + ":rw\"").append(" ");
+    }
+
+    String zeppelinServerKeytab = zConf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
+    String zeppelinServerPrincipal = zConf.getString(ZEPPELIN_SERVER_KERBEROS_PRINCIPAL);
+    if (!StringUtils.isBlank(zeppelinServerKeytab) && !uploaded.containsKey(zeppelinServerKeytab)) {
+      uploaded.put(zeppelinServerKeytab, "");
+      sbLocalization.append("--localization \"");
+      sbLocalization.append(zeppelinServerKeytab + ":" + zeppelinServerKeytab + ":rw\"").append(" ");
     }
 
     // 6) hadoop-yarn-submarine-X.X.X-SNAPSHOT.jar file upload container, Keep the same directory as local
@@ -249,26 +264,25 @@ public class YarnStandardInterpreterLauncher extends StandardInterpreterLauncher
         sbLocalization.append("--localization \"");
         sbLocalization.append(hadoopConfDir + ":" + hadoopConfDir + ":rw\"").append(" ");
         // Set the HADOOP_CONF_DIR environment variable in `interpreter.sh`
-        properties.put("DOCKER_HADOOP_CONF_DIR", hadoopConfDir);
+        env.put("DOCKER_HADOOP_CONF_DIR", hadoopConfDir);
       }
     }
 
-    properties.put("YARN_LOCALIZATION_ENV", sbLocalization.toString());
+    env.put("YARN_LOCALIZATION_ENV", sbLocalization.toString());
     LOGGER.info("YARN_LOCALIZATION_ENV = " + sbLocalization.toString());
 
+    env.put(SUBMARINE_HADOOP_KEYTAB, zeppelinServerKeytab);
+    env.put(SUBMARINE_HADOOP_PRINCIPAL, zeppelinServerPrincipal);
+
     // Set the zepplin configuration file path environment variable in `interpreter.sh`
-    properties.put("ZEPPELIN_CONF_DIR_ENV", "--env ZEPPELIN_CONF_DIR=" + CONTAINER_ZEPPELIN_HOME);
+    env.put("ZEPPELIN_CONF_DIR_ENV", "--env ZEPPELIN_CONF_DIR=" + CONTAINER_ZEPPELIN_HOME);
 
     String intpContainerRes = zConf.getYarnContainerResource(context.getInterpreterSettingName());
-    properties.put("ZEPPELIN_YARN_CONTAINER_RESOURCE", intpContainerRes);
+    env.put("ZEPPELIN_YARN_CONTAINER_RESOURCE", intpContainerRes);
 
     String yarnContainerImage = zConf.getYarnContainerImage();
-    properties.put("ZEPPELIN_YARN_CONTAINER_IMAGE", yarnContainerImage);
+    env.put("ZEPPELIN_YARN_CONTAINER_IMAGE", yarnContainerImage);
 
-    String yarnWebappAddress = zConf.getYarnWebappAddress();
-    properties.put(YARN_WEB_ADDRESS, yarnWebappAddress);
-
-    Map<String, String> env = new HashMap<>();
     for (Object key : properties.keySet()) {
       if (RemoteInterpreterUtils.isEnvString((String) key)) {
         env.put((String) key, properties.getProperty((String) key));
@@ -316,7 +330,12 @@ public class YarnStandardInterpreterLauncher extends StandardInterpreterLauncher
     return "";
   }
 
-  // ${ZEPPELIN_HOME}/interpreter/submarine
+  @VisibleForTesting
+  public static void setTest(Boolean test) {
+    isTest = test;
+  }
+
+  // ${ZEPPELIN_HOME}/interpreter/${interpreter-name}
   // ${ZEPPELIN_HOME}/lib/interpreter
   private String getPathByHome(String homeDir, String path) throws IOException {
     File file = null;

--- a/zeppelin-plugins/launcher/yarn-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcessTest.java
@@ -1,0 +1,56 @@
+package org.apache.zeppelin.interpreter.launcher;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class YarnRemoteInterpreterProcessTest {
+  @Before
+  public void setUp() {
+    for (final ZeppelinConfiguration.ConfVars confVar : ZeppelinConfiguration.ConfVars.values()) {
+      System.clearProperty(confVar.getVarName());
+    }
+  }
+
+  @Test
+  public void testLauncher() throws IOException {
+    ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
+    zConf.setServerKerberosKeytab("keytab_value");
+    zConf.setServerKerberosPrincipal("Principal_value");
+    zConf.setYarnWebappAddress("http://127.0.0.1");
+
+    YarnStandardInterpreterLauncher.setTest(true);
+    YarnStandardInterpreterLauncher launcher = new YarnStandardInterpreterLauncher(zConf, null);
+    Properties properties = new Properties();
+    InterpreterOption option = new InterpreterOption();
+    option.setUserImpersonate(true);
+    InterpreterLaunchContext context = new InterpreterLaunchContext(properties, option, null, "user1", "intp_Group-Id", "groupId", "groupName", "name", 0, "host");
+    InterpreterClient client = launcher.launch(context);
+    assertTrue( client instanceof YarnRemoteInterpreterProcess);
+    YarnRemoteInterpreterProcess interpreterProcess = (YarnRemoteInterpreterProcess) client;
+    assertEquals("name", interpreterProcess.getInterpreterSettingName());
+    assertEquals(".//interpreter/groupName", interpreterProcess.getInterpreterDir());
+    assertEquals(".//local-repo/groupId", interpreterProcess.getLocalRepoDir());
+    assertTrue(interpreterProcess.getConnectTimeout()>= 200000);
+    assertEquals(zConf.getInterpreterRemoteRunnerPath(), interpreterProcess.getInterpreterRunner());
+    assertEquals(9, interpreterProcess.getEnv().size());
+    assertEquals("yarn", interpreterProcess.getEnv().get("ZEPPELIN_RUN_MODE"));
+    assertEquals("apache/zeppelin:0.9.0-SNAPSHOT", interpreterProcess.getEnv().get("ZEPPELIN_YARN_CONTAINER_IMAGE"));
+    assertEquals("intp-group-id", interpreterProcess.getEnv().get("YARN_APP_NAME"));
+    assertEquals("keytab_value", interpreterProcess.getEnv().get("SUBMARINE_HADOOP_KEYTAB"));
+    assertEquals("Principal_value", interpreterProcess.getEnv().get("SUBMARINE_HADOOP_PRINCIPAL"));
+    assertEquals("groupId", interpreterProcess.getEnv().get("INTERPRETER_GROUP_ID"));
+    assertEquals("--localization \":/zeppelin/interpreter/name:rw\" --localization \":/zeppelin/lib/interpreter:rw\" --localization \":/zeppelin/conf/log4j.properties:rw\" --localization \"keytab_value:keytab_value:rw\" ", interpreterProcess.getEnv().get("YARN_LOCALIZATION_ENV"));
+    assertEquals("--env ZEPPELIN_CONF_DIR=/zeppelin", interpreterProcess.getEnv().get("ZEPPELIN_CONF_DIR_ENV"));
+    assertEquals("memory=8G,vcores=1,gpu=0", interpreterProcess.getEnv().get("ZEPPELIN_YARN_CONTAINER_RESOURCE"));
+    assertEquals(true, interpreterProcess.isUserImpersonated());
+  }
+}

--- a/zeppelin-plugins/launcher/yarn-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/yarn-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/YarnStandardInterpreterLauncherTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.InterpreterOption;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+public class YarnStandardInterpreterLauncherTest {
+  @Before
+  public void setUp() {
+    for (final ZeppelinConfiguration.ConfVars confVar : ZeppelinConfiguration.ConfVars.values()) {
+      System.clearProperty(confVar.getVarName());
+    }
+  }
+
+  @Test
+  public void testYarnLauncher() throws IOException {
+    ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
+    zConf.setServerKerberosKeytab("keytab");
+    zConf.setServerKerberosPrincipal("Principal");
+    zConf.setYarnWebappAddress("http://127.0.0.1");
+
+    YarnStandardInterpreterLauncher.setTest(true);
+    YarnStandardInterpreterLauncher launcher = new YarnStandardInterpreterLauncher(zConf, null);
+    Properties properties = new Properties();
+    properties.setProperty("zeppelin.python.useIPython", "false");
+    properties.setProperty("zeppelin.python.gatewayserver_address", "127.0.0.1");
+    InterpreterOption option = new InterpreterOption();
+    option.setUserImpersonate(true);
+    InterpreterLaunchContext context = new InterpreterLaunchContext(
+        properties,
+        option,
+        null,
+        "user1",
+        "intpGroupId",
+        "groupId",
+        "sh",
+        "name",
+        0,
+        "host");
+
+    // when
+    InterpreterClient client = launcher.launch(context);
+
+    // then
+    assertTrue(client instanceof YarnRemoteInterpreterProcess);
+  }
+}

--- a/zeppelin-plugins/pom.xml
+++ b/zeppelin-plugins/pom.xml
@@ -49,6 +49,7 @@
         <module>launcher/standard</module>
         <module>launcher/k8s-standard</module>
         <module>launcher/spark</module>
+        <module>launcher/yarn-standard</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
### What is this PR for?
Let Zeppelin all interpreter process running on YARN.

 - Run Zeppelin server on local host.
 - Run Standard interpreters as YARN (Docker) container.
 - Spark on Yarn only support local mode, yarn-client and yarn-cluster mode unchanged.


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4050

### How should this be tested?
https://travis-ci.org/liuxunorg/zeppelin/builds/523999069

### Screenshots (if appropriate)
#### python, shell, ... on yarn
![ZeppelinOnYarn](https://user-images.githubusercontent.com/3677382/56704695-bb552c80-6740-11e9-824e-eab8267394a1.gif)

#### Spark on Yarn (only local mode)
![sparkIntpOnYarn](https://user-images.githubusercontent.com/3677382/56704700-c14b0d80-6740-11e9-91b9-3c2a6609481b.gif)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation? YES
