### PR TITLE
[ZEPPELIN-4136] -Use a match expression to determine SparkR Security

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -50,8 +50,7 @@ public class IPySparkInterpreter extends IPythonInterpreter {
         getInterpreterInTheSameSessionByClassName(PySparkInterpreter.class, false);
     setProperty("zeppelin.python", pySparkInterpreter.getPythonExec());
     sparkInterpreter = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class);
-    setProperty("zeppelin.py4j.useAuth",
-        sparkInterpreter.getSparkVersion().isSecretSocketSupported() + "");
+    setProperty("zeppelin.py4j.useAuth", isSecretSupported() + "");
     SparkConf conf = sparkInterpreter.getSparkContext().getConf();
     // only set PYTHONPATH in embedded, local or yarn-client mode.
     // yarn-cluster will setup PYTHONPATH automatically.
@@ -140,5 +139,16 @@ public class IPySparkInterpreter extends IPythonInterpreter {
 
   public Object getSparkSession() {
     return sparkInterpreter.getSparkSession();
+  }
+
+  private Boolean isSecretSupported() {
+    try {
+      // Check to see if the available py4j version supports authTokens
+      py4j.GatewayServer.GatewayServerBuilder.class.getMethod("authToken", String.class);
+      return true;
+    } catch (NoSuchMethodException e)
+    {
+      return false;
+    }
   }
 }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -88,7 +88,7 @@ public class SparkRInterpreter extends Interpreter {
     SparkVersion sparkVersion = new SparkVersion(sc.version());
     synchronized (SparkRBackend.backend()) {
       if (!SparkRBackend.isStarted()) {
-        SparkRBackend.init(sparkVersion);
+        SparkRBackend.init();
         SparkRBackend.start();
       }
     }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -89,13 +89,6 @@ public class SparkVersion {
     return this.newerThanEquals(SPARK_2_0_0);
   }
 
-  public boolean isSecretSocketSupported() {
-    return this.newerThanEquals(SparkVersion.SPARK_2_4_0) ||
-            this.newerThanEqualsPatchVersion(SPARK_2_3_1) ||
-            this.newerThanEqualsPatchVersion(SparkVersion.fromVersionString("2.2.2")) ||
-            this.newerThanEqualsPatchVersion(SparkVersion.fromVersionString("2.1.3"));
-  }
-
   public boolean equals(Object versionToCompare) {
     return version == ((SparkVersion) versionToCompare).version;
   }


### PR DESCRIPTION

### What is this PR for?
Previously the code dependend on hard coded Spark Versions, this made
some distributions of Spark incompatible because they included security
backports not listed in the official distribution versions. This instead
checks the class itself to determine whether or not the new Secret
method should be utilized


### What type of PR is it?
[Bug Fix | Refactoring]

### Todos
Change from version check to Match

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4136

### How should this be tested?
Gonna try out CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Nope
* Is there breaking changes for older versions? Nope
* Does this needs documentation? Nope
