### PR TITLE
[ZEPPELIN-2444] Better error message on shell timeout being reached.

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -132,7 +132,7 @@ public class ShellInterpreter extends KerberosInterpreter {
       String message = outStream.toString();
       if (exitValue == 143) {
         code = Code.INCOMPLETE;
-        message += "Paragraph received a SIGTERM\n";
+        message += "Timeout of " + getProperty(TIMEOUT_PROPERTY) + " ms to run reached.\n";
         LOGGER.info("The paragraph " + contextInterpreter.getParagraphId()
             + " stopped executing: " + message);
       }

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -85,6 +85,6 @@ public class ShellInterpreterTest {
     }
 
     assertEquals(Code.INCOMPLETE, result.code());
-    assertTrue(result.message().get(0).getData().contains("Paragraph received a SIGTERM"));
+    assertTrue(result.message().get(0).getData().contains("Timeout of 2000 ms to run reached"));
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
@@ -7,9 +7,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
 /**
@@ -30,29 +32,30 @@ public class TimeoutLifecycleManager implements LifecycleManager {
   private long checkInterval;
   private long timeoutThreshold;
 
-  private Timer checkTimer;
+  private ScheduledExecutorService checkScheduler;
 
   public TimeoutLifecycleManager(ZeppelinConfiguration zConf) {
     this.checkInterval = zConf.getLong(ZeppelinConfiguration.ConfVars
             .ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_CHECK_INTERVAL);
     this.timeoutThreshold = zConf.getLong(
         ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_TIMEOUT_THRESHOLD);
-    this.checkTimer = new Timer(true);
-    this.checkTimer.scheduleAtFixedRate(new TimerTask() {
-      @Override
-      public void run() {
-        long now = System.currentTimeMillis();
-        for (Map.Entry<ManagedInterpreterGroup, Long> entry : interpreterGroups.entrySet()) {
-          ManagedInterpreterGroup interpreterGroup = entry.getKey();
-          Long lastTimeUsing = entry.getValue();
-          if ((now - lastTimeUsing) > timeoutThreshold )  {
-            LOGGER.info("InterpreterGroup {} is timeout.", interpreterGroup.getId());
+    this.checkScheduler = Executors.newScheduledThreadPool(1);
+    this.checkScheduler.scheduleAtFixedRate(() -> {
+      long now = System.currentTimeMillis();
+      for (Map.Entry<ManagedInterpreterGroup, Long> entry : interpreterGroups.entrySet()) {
+        ManagedInterpreterGroup interpreterGroup = entry.getKey();
+        Long lastTimeUsing = entry.getValue();
+        if ((now - lastTimeUsing) > timeoutThreshold) {
+          LOGGER.info("InterpreterGroup {} is timeout.", interpreterGroup.getId());
+          try {
             interpreterGroup.close();
-            interpreterGroups.remove(entry.getKey());
+          } catch (Exception e) {
+            LOGGER.warn("Fail to close interpreterGroup: " + interpreterGroup.getId(), e);
           }
+          interpreterGroups.remove(entry.getKey());
         }
       }
-    }, checkInterval, checkInterval);
+    }, checkInterval, checkInterval, MILLISECONDS);
     LOGGER.info("TimeoutLifecycleManager is started with checkinterval: " + checkInterval
         + ", timeoutThreshold: " + timeoutThreshold);
   }


### PR DESCRIPTION
### What is this PR for?
Cue the user what the error they are getting is due to.  I would get spurious timeouts, and I had no idea it was a timeout, and that I had the option of extending the timeout.  Same issue as the reporter of ZEPPELIN-2444.  


### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-2444

### How should this be tested?
Run sleep 61 and verify you get a nice error message.  Unit test was updated.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No.
