### PR TITLE
[ZEPPELIN-4152]. Use spark 2.2 as the default profile

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -196,9 +196,6 @@
                 <protobuf.version>2.5.0</protobuf.version>
                 <py4j.version>0.10.7</py4j.version>
             </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
         </profile>
 
         <profile>
@@ -212,6 +209,9 @@
 
         <profile>
             <id>spark-2.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <spark.version>2.2.1</spark.version>
                 <py4j.version>0.10.4</py4j.version>


### PR DESCRIPTION
### What is this PR for?
Trivial PR to use spark 2.2 as the default profile so that the default build command can pass

```
mvn clean package -DskipTests
```


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4152

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
