### PR TITLE
ZEPPELIN-4153. Move zeppelin-interpreter-api jar out of interpreter jar

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -69,7 +69,8 @@ fi
 
 . "${bin}/common.sh"
 
-ZEPPELIN_INTP_CLASSPATH="${CLASSPATH}"
+ZEPPELIN_INTERPRETER_API_JAR=$(find "${ZEPPELIN_HOME}/interpreter" -name 'zeppelin-interpreter-api-*.jar')
+ZEPPELIN_INTP_CLASSPATH="${CLASSPATH}:${ZEPPELIN_INTERPRETER_API_JAR}"
 
 # construct classpath
 if [[ -d "${ZEPPELIN_HOME}/zeppelin-interpreter/target/classes" ]]; then

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -58,7 +58,13 @@
             <groupId>org.apache.zeppelin</groupId>
             <artifactId>zeppelin-interpreter</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -58,7 +58,7 @@
             <groupId>org.apache.zeppelin</groupId>
             <artifactId>zeppelin-interpreter</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -190,6 +190,11 @@
               <resource>reference.conf</resource>
             </transformer>
           </transformers>
+          <artifactSet>
+            <excludes>
+              <exclude>org.apache.zeppelin:zeppelin-interpreter-api</exclude>
+            </excludes>
+          </artifactSet>
           <outputFile>${project.build.directory}/../../interpreter/python/${interpreter.jar.name}-${project.version}.jar</outputFile>
         </configuration>
         <executions>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -157,124 +157,7 @@
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
-    
-    <!-- Aether :: maven dependency resolution -->
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>${maven.plugin.api.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-inject-plexus</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-model</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-      <version>${maven.aeither.provider.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.aether</groupId>
-          <artifactId>aether-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.aether</groupId>
-          <artifactId>aether-spi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.aether</groupId>
-          <artifactId>aether-util</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.aether</groupId>
-          <artifactId>aether-impl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-connector-file</artifactId>
-      <version>${aether.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-connector-wagon</artifactId>
-      <version>${aether.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.maven.wagon</groupId>
-          <artifactId>wagon-provider-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-provider-api</artifactId>
-      <version>${wagon.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>${wagon.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.maven.wagon</groupId>
-          <artifactId>wagon-http-shared</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http</artifactId>
-      <version>${wagon.version}</version>
-      <exclusions>
-      </exclusions>
-    </dependency>
-
+      
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
@@ -497,6 +380,7 @@
               <exclude>org.scala-lang:scala-reflect</exclude>
               <exclude>commons-lang:commons-lang</exclude>
               <exclude>org.apache.commons:commons-compress</exclude>
+              <exclude>org.apache.zeppelin:zeppelin-interpreter-api</exclude>
             </excludes>
           </artifactSet>
 

--- a/zeppelin-interpreter-api/pom.xml
+++ b/zeppelin-interpreter-api/pom.xml
@@ -139,7 +139,6 @@
               <shadedPattern>${shaded.dependency.prefix}.io</shadedPattern>
             </relocation>
           </relocations>
-          <outputFile>${project.basedir}/../interpreter/${project.artifactId}-${project.version}.jar</outputFile>
         </configuration>
         <executions>
           <execution>
@@ -147,6 +146,26 @@
             <goals>
               <goal>shade</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <executions>
+          <execution>
+            <id>copy-to-interpreter</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <echo>ANT TASK - copying files....</echo>
+                <copy todir="${project.basedir}/../interpreter" overwrite="true" flatten="true">
+                  <fileset dir="${project.build.directory}" includes="zeppelin-interpreter-api-*.jar" >
+                  </fileset>
+                </copy>
+              </target>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeppelin-interpreter-api/pom.xml
+++ b/zeppelin-interpreter-api/pom.xml
@@ -139,6 +139,7 @@
               <shadedPattern>${shaded.dependency.prefix}.io</shadedPattern>
             </relocation>
           </relocations>
+          <outputFile>${project.basedir}/../interpreter/${project.artifactId}-${project.version}.jar</outputFile>
         </configuration>
         <executions>
           <execution>

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -597,7 +597,6 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       Paragraph p0 = note.addNewParagraph(anonymous);
       p0.setText("%dep z.load(\"com.databricks:spark-csv_2.11:1.2.0\")");
       note.run(p0.getId(), true);
-      LOGGER.info(p0.getReturn().toString());
       assertEquals(Status.FINISHED, p0.getStatus());
 
       // write test csv file

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -597,6 +597,7 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       Paragraph p0 = note.addNewParagraph(anonymous);
       p0.setText("%dep z.load(\"com.databricks:spark-csv_2.11:1.2.0\")");
       note.run(p0.getId(), true);
+      LOGGER.info(p0.getReturn().toString());
       assertEquals(Status.FINISHED, p0.getStatus());
 
       // write test csv file

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -100,6 +100,7 @@
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>
+                  <exclude>org.apache.zeppelin:zeppelin-interpreter-api</exclude>
                 </excludes>
               </filter>
             </filters>
@@ -109,6 +110,11 @@
                 <resource>reference.conf</resource>
               </transformer>
             </transformers>
+            <artifactSet>
+              <excludes>
+                <exclude>org.apache.zeppelin:zeppelin-interpreter-api</exclude>
+              </excludes>
+            </artifactSet>
             <outputFile>${project.basedir}/../interpreter/${interpreter.name}/${project.artifactId}-${project.version}.jar</outputFile>
           </configuration>
           <executions>


### PR DESCRIPTION
### What is this PR for?
This PR is to move zeppelin-interpreter-api jar out of interpreter jar, and put it under folder ${ZEPPELIN_HOME}/interpreter which is shared between all interpreters.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4153

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
