### PR TITLE
[ZEPPELIN-4144] After refresh the revision tools are sometimes hidden

### DIFF
--- a/zeppelin-web/e2e/revisionControls.spec.js
+++ b/zeppelin-web/e2e/revisionControls.spec.js
@@ -1,0 +1,45 @@
+describe('Revision controls e2e Test', function() {
+  /*Common methods for interact with elements*/
+  let clickOn = function (elem) {
+    browser.actions().mouseMove(elem).click().perform()
+  }
+
+  let clickAndWait = function(elem) {
+    clickOn(elem)
+    browser.sleep(60);
+  }
+
+  let waitVisibility = function(elem) {
+    browser.wait(protractor.ExpectedConditions.visibilityOf(elem))
+  }
+
+  beforeEach(function() {
+    browser.get('http://localhost:8080')
+    clickOn(element(by.linkText('Create new note')))
+    waitVisibility(element(by.id('noteCreateModal')))
+    clickAndWait(element(by.id('createNoteButton')))
+  })
+
+  afterEach(function() {
+    clickOn(element(by.xpath('//*[@id="main"]//button[@ng-click="moveNoteToTrash(note.id)"]')))
+    let moveToTrashDialogPath =
+      '//div[@class="modal-dialog"][contains(.,"This note will be moved to trash")]'
+    waitVisibility(element(by.xpath(moveToTrashDialogPath)))
+    let okButton = element(
+      by.xpath(moveToTrashDialogPath + '//div[@class="modal-footer"]//button[contains(.,"OK")]'))
+    clickOn(okButton)
+  })
+
+  //tests
+  it('should have revision controls even after refresh', function() {
+    waitVisibility(element(by.xpath('//button[@id="versionControlDropdown"]')))
+
+    // revision controls should be visible after refresh as well
+    browser.refresh()
+    waitVisibility(element(by.xpath('//button[@id="versionControlDropdown"]')))
+    browser.refresh()
+    waitVisibility(element(by.xpath('//button[@id="versionControlDropdown"]')))
+    browser.refresh()
+    waitVisibility(element(by.xpath('//button[@id="versionControlDropdown"]')))
+  })
+})

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -56,6 +56,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     });
 
     getZeppelinVersion();
+    listConfigurations();
     loadNotes();
   }
 

--- a/zeppelin-web/src/components/navbar/navbar.controller.test.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.test.js
@@ -1,18 +1,48 @@
 describe('Controller: NavCtrl', function() {
   // load the controller's module
   beforeEach(angular.mock.module('zeppelinWebApp'));
+
   let NavCtrl;
   let scope;
+
+  let websocketMsgSrvMock = {
+    isConnected: function() {},
+    getNoteList: function() {},
+    getHomeNote: function() {},
+    listConfigurations: function() {},
+  };
+
+  let ticketMock = {};
+
   // Initialize the controller and a mock scope
   beforeEach(inject(function($controller, $rootScope) {
     scope = $rootScope.$new();
+
+    // spy on listConfigurations before creating the controller to catch calls during init
+    spyOn(websocketMsgSrvMock, 'listConfigurations');
+
     NavCtrl = $controller('NavCtrl', {
       $scope: scope,
-    });
-
-    it('NavCtrl to toBeDefined', function() {
-      expect(NavCtrl).toBeDefined();
-      expect(NavCtrl.loadNotes).toBeDefined();
+      websocketMsgSrv: websocketMsgSrvMock,
     });
   }));
+
+  it('should be defined', function() {
+    expect(NavCtrl).toBeDefined();
+  });
+
+  it('should call listConfigurations on init to get revision support config', function() {
+    // listConfigurations was called once during init
+    expect(websocketMsgSrvMock.listConfigurations.calls.count()).toEqual(1);
+  });
+
+  it('should call listConfigurations on login success to get revision support config', function() {
+    // mock root scope ticket for the loginSuccess event
+    scope.$root.ticket = ticketMock;
+
+    scope.$broadcast('loginSuccess');
+
+    // listConfigurations was called twice - once during init and then again after loginSuccess
+    expect(websocketMsgSrvMock.listConfigurations.calls.count()).toEqual(2);
+  });
 });


### PR DESCRIPTION
### What is this PR for?
Fixes issue where after refreshing a note's page the revision controls in the navigation bar are hidden since listConfigurations is only requested in the navbar controller after a loginSuccess broadcast.
This currently works sometimes because another controller (note-import) sends a listConfigurations request when it is loaded and navbar controller is sometimes loaded by the time the response arrives, but I can reproduce it easily using Firefox (gif attached to Jira issue).


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[https://issues.apache.org/jira/browse/ZEPPELIN-4144](https://issues.apache.org/jira/browse/ZEPPELIN-4144)

### How should this be tested?
Added unit and e2e tests to make sure listConfigurations is called and controls are visible.
Seems to me like the issue is easier to reproduce using Firefox. Was able to do so using the official 0.8.1 docker image.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
