### PR TITLE
[ZEPPELIN-4155] Unable get available HostAddress in multi-NIC environment

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
@@ -106,7 +106,9 @@ public class RemoteInterpreterUtils {
     Enumeration<?> netInterfaces = NetworkInterface.getNetworkInterfaces();
     while (netInterfaces.hasMoreElements()) {
       NetworkInterface networkInterface = (NetworkInterface)netInterfaces.nextElement();
-      LOGGER.info("networkInterface = " + networkInterface.toString());
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("networkInterface = " + networkInterface.toString());
+      }
       if (networkInterface.isLoopback()) {
         // Filter lo network card
         continue;
@@ -124,7 +126,9 @@ public class RemoteInterpreterUtils {
 
       while (enumInetAddress.hasMoreElements()) {
         InetAddress ip = (InetAddress) enumInetAddress.nextElement();
-        LOGGER.info("ip = " + ip.toString());
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("ip = " + ip.toString());
+        }
         if (!ip.isLoopbackAddress() && !ip.isLinkLocalAddress()) {
           if (ip.getHostAddress().equalsIgnoreCase("127.0.0.1")){
             continue;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
@@ -125,7 +125,7 @@ public class RemoteInterpreterUtils {
       while (enumInetAddress.hasMoreElements()) {
         InetAddress ip = (InetAddress) enumInetAddress.nextElement();
         LOGGER.info("ip = " + ip.toString());
-        if (!ip.isLoopbackAddress()) {
+        if (!ip.isLoopbackAddress() && !ip.isLinkLocalAddress()) {
           if (ip.getHostAddress().equalsIgnoreCase("127.0.0.1")){
             continue;
           }


### PR DESCRIPTION
### What is this PR for?
1. Multiple NetworkCard will be configured on some servers.
2. In the docker container environment, A container will also generate multiple virtual NetworkCard.

`RemoteInterpreterUtils#findAvailableHostAddress()` sometimes can't get the correct network card information.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4155

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/532212106)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
