### PR TITLE
[ZEPPELIN-4160] Fixed Move this note to trash icon always show

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -123,6 +123,16 @@ abstract public class AbstractZeppelinIT {
     ZeppelinITUtils.sleep(100, false);
   }
 
+  protected void deleteTrashNotebook(final WebDriver driver) {
+    WebDriverWait block = new WebDriverWait(driver, MAX_BROWSER_TIMEOUT_SEC);
+    driver.findElement(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']"))
+        .sendKeys(Keys.ENTER);
+    block.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(".//*[@id='main']//button[@ng-click='removeNote(note.id)']")));
+    driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'This cannot be undone. Are you sure?')]" +
+        "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+    ZeppelinITUtils.sleep(100, false);
+  }
+
   protected void clickAndWait(final By locator) {
     pollingWait(locator, MAX_IMPLICIT_WAIT).click();
     ZeppelinITUtils.sleep(1000, false);

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -323,4 +323,32 @@ public class ZeppelinIT extends AbstractZeppelinIT {
     }
 
   }
+
+  @Test
+  public void deleteTrashNode() throws Exception {
+    try {
+      createNewNote();
+
+      // wait for first paragraph's " READY " status text
+      waitForParagraph(1, "READY");
+
+      String currentUrl = driver.getCurrentUrl();
+      LOG.info("currentUrl = " + currentUrl);
+
+      //delete created notebook to trash
+      deleteTestNotebook(driver);
+      ZeppelinITUtils.sleep(3000, false);
+
+      // reopen trash note
+      driver.get(currentUrl);
+      ZeppelinITUtils.sleep(3000, false);
+
+      // delete note from trash
+      deleteTrashNotebook(driver);
+      ZeppelinITUtils.sleep(2000, false);
+      LOG.info("deleteTrashNode executed");
+    }  catch (Exception e) {
+      handleException("Exception in ZeppelinIT while deleteTrashNode", e);
+    }
+  }
 }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -237,7 +237,8 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   $scope.isTrash = function(note) {
-    return note ? note.name.split('/')[0] === TRASH_FOLDER_ID : false;
+    console.log('note.path = ' + note.path);
+    return note ? note.path.split('/')[1] === TRASH_FOLDER_ID : false;
   };
 
   // Export notebook

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -237,7 +237,6 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   $scope.isTrash = function(note) {
-    console.log('note.path = ' + note.path);
     return note ? note.path.split('/')[1] === TRASH_FOLDER_ID : false;
   };
 

--- a/zeppelin-web/src/components/note-list/note-list.factory.js
+++ b/zeppelin-web/src/components/note-list/note-list.factory.js
@@ -26,7 +26,7 @@ function NoteListFactory(arrayOrderingSrv, TRASH_FOLDER_ID) {
       // a flat list to boost searching
       notes.flatList = _.map(notesList, (note) => {
         note.isTrash = note.path
-          ? note.path.split('/')[0] === TRASH_FOLDER_ID : false;
+          ? note.path.split('/')[1] === TRASH_FOLDER_ID : false;
         return note;
       });
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -92,10 +92,11 @@ public class Note implements JsonSerializable {
    */
   private Map<String, Object> info = new HashMap<>();
 
+  // The front end needs to judge TRASH_FOLDER according to the path
+  private String path;
 
   /********************************** transient fields ******************************************/
   private transient boolean loaded = false;
-  private transient String path;
   private transient InterpreterFactory interpreterFactory;
   private transient InterpreterSettingManager interpreterSettingManager;
   private transient ParagraphJobListener paragraphJobListener;


### PR DESCRIPTION
### What is this PR for?
when the note moved to trash, the note should show 'Remove this note permanently', it does not work correctly after clicked again, more ~Trash folder will be created


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4160

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/532764123)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
