### PR TITLE
ZEPPELIN-4161. Add travis job for default build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,12 @@ matrix:
       dist: trusty
       env: SCALA_VER="2.11" PROFILE="-Prat" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
+    # Default build command, no tests
+    - sudo: required
+      jdk: "oraclejdk8"
+      dist: trusty
+      env: BUILD_FLAG="clean package -DskipTests" TEST_FLAG="test -DskipTests"
+
     # Run e2e tests (in zeppelin-web)
     # chrome dropped the support for precise (ubuntu 12.04), so need to use trusty
     # also, can't use JDK 7 in trusty: https://github.com/travis-ci/travis-ci/issues/7884


### PR DESCRIPTION
### What is this PR for?
This PR add one travis job to build zeppelin by default command:
```
mvn clean package -DskipTests
```


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4161

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
