### PR TITLE
[ZEPPELIN-4171] Configuration paragraph is empty to execute

### DIFF
--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -210,7 +210,7 @@ You can make the dynamic form in the notebook not trigger execution after select
 
 
 ### Check if the paragraph is empty before running (Optional)
-The notebook's paragraph defaults will not run if it is empty.
+The notebook's paragraph default will not run if it is empty.
 You can set `config.checkEmpty=false`, to run even when the paragraph of the notebook is empty.
 
 ```json

--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -211,7 +211,7 @@ You can make the dynamic form in the notebook not trigger execution after select
 
 ### Check if the paragraph is empty before running (Optional)
 The notebook's paragraph defaults will not run if it is empty.
-You can set `config.checkEmpty=false`, Run when the paragraph of the notebook is empty.
+You can set `config.checkEmpty=false`, to run even when the paragraph of the notebook is empty.
 
 ```json
 "config": {

--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -121,7 +121,8 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
     },
     "config": {
       "runOnSelectionChange": true/false,
-      "title": true/false
+      "title": true/false,
+      "checkEmpty": true/false
     }
   },
   {
@@ -204,6 +205,17 @@ You can make the dynamic form in the notebook not trigger execution after select
 ```json
 "config": {
   "runOnSelectionChange": false # default: true
+}
+```
+
+
+### Check if the paragraph is empty before running (Optional)
+The notebook's paragraph defaults will not run if it is empty.
+You can set `config.checkEmpty=false`, Run when the paragraph of the notebook is empty.
+
+```json
+"config": {
+  "checkEmpty": false # default: true
 }
 ```
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -453,7 +453,7 @@ public class NotebookService {
       throw new NoteNotFoundException(noteId);
     }
     Paragraph newPara = note.insertNewParagraph(index, context.getAutheInfo());
-    newPara.applyConfigSetting(config);
+    newPara.mergeConfig(config);
     notebook.saveNote(note, context.getAutheInfo());
     callback.onSuccess(newPara, context);
     return newPara;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -453,7 +453,7 @@ public class NotebookService {
       throw new NoteNotFoundException(noteId);
     }
     Paragraph newPara = note.insertNewParagraph(index, context.getAutheInfo());
-    newPara.setConfig(config);
+    newPara.applyConfigSetting(config);
     notebook.saveNote(note, context.getAutheInfo());
     callback.onSuccess(newPara, context);
     return newPara;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -345,7 +345,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
     return null;
   }
 
-  public boolean isBlankParagraph() {
+  public boolean shouldSkipRunParagraph() {
     // check interpreter-setting.json `config.checkEmpty` is equal false
     Object configCheckEmpty = this.config.get(PARAGRAPH_CONFIG_CHECK_EMTPY);
     if (null != configCheckEmpty) {
@@ -368,7 +368,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   public boolean execute(boolean blocking) {
-    if (isBlankParagraph()) {
+    if (shouldSkipRunParagraph()) {
       LOGGER.info("Skip to run blank paragraph. {}", getId());
       setStatus(Job.Status.FINISHED);
       return true;
@@ -498,7 +498,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
               String name = ((ManagedInterpreterGroup) intpGroup).getInterpreterSetting().getName();
               Map<String, Object> config
                       = intpSettingManager.getConfigSetting(name);
-              applyConfigSetting(config);
+              mergeConfig(config);
             }
           }
         }
@@ -622,7 +622,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   // NOTE: function setConfig(...) will overwrite all configuration
-  // Merge configuration, you need to use function applyConfigSetting(...)
+  // Merge configuration, you need to use function mergeConfig(...)
   public void setConfig(Map<String, Object> config) {
     this.config = config;
   }
@@ -638,7 +638,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   // 2. The user manually modified the  interpreter types of this paragraph.
   //    Need to delete the existing configuration of this paragraph,
   //    update with the specified interpreter configuration
-  public void applyConfigSetting(Map<String, Object> newConfig) {
+  public void mergeConfig(Map<String, Object> newConfig) {
     if (null == newConfig || 0 == newConfig.size()) {
       newConfig = getDefaultConfigSetting();
     }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1094,16 +1094,19 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     // create paragraphs
     Paragraph p1 = note.addNewParagraph(anonymous);
     Map<String, Object> config = p1.getConfig();
-    assertTrue(config.containsKey("runOnSelectionChange"));
-    assertTrue(config.containsKey("title"));
-    assertEquals(config.get("runOnSelectionChange"), false);
-    assertEquals(config.get("title"), true);
+    assertTrue(config.containsKey(Paragraph.PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE));
+    assertTrue(config.containsKey(Paragraph.PARAGRAPH_CONFIG_TITLE));
+    assertTrue(config.containsKey(Paragraph.PARAGRAPH_CONFIG_CHECK_EMTPY));
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE), false);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_TITLE), true);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_CHECK_EMTPY), false);
 
     // The config_test interpreter sets the default parameters
     // in interpreter/config_test/interpreter-setting.json
     //    "config": {
     //      "runOnSelectionChange": false,
-    //      "title": true
+    //      "title": true,
+    //      "checkEmpty": true
     //    },
     p1.setText("%config_test sleep 1000");
     note.runAll(AuthenticationInfo.ANONYMOUS, false);
@@ -1113,8 +1116,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     // Check if the config_test interpreter default parameter takes effect
     LOGGER.info("p1.getConfig() =  " + p1.getConfig());
-    assertEquals(config.get("runOnSelectionChange"), false);
-    assertEquals(config.get("title"), true);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE), false);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_TITLE), true);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_CHECK_EMTPY), false);
 
     // The mock1 interpreter does not set default parameters
     p1.setText("%mock1 sleep 1000");
@@ -1125,8 +1129,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     // Check if the mock1 interpreter parameter is updated
     LOGGER.info("changed intp p1.getConfig() =  " + p1.getConfig());
-    assertEquals(config.get("runOnSelectionChange"), true);
-    assertEquals(config.get("title"), false);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_RUNONSELECTIONCHANGE), true);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_TITLE), false);
+    assertEquals(config.get(Paragraph.PARAGRAPH_CONFIG_CHECK_EMTPY), true);
   }
 
   @Test

--- a/zeppelin-zengine/src/test/resources/conf/interpreter.json
+++ b/zeppelin-zengine/src/test/resources/conf/interpreter.json
@@ -132,7 +132,8 @@
         "fontSize": 9,
         "colWidth": 12,
         "runOnSelectionChange": false,
-        "title": true
+        "title": true,
+        "checkEmpty": false
       },
       "option": {
         "remote": true,

--- a/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/config_test/interpreter-setting.json
@@ -8,7 +8,8 @@
     },
     "config": {
       "runOnSelectionChange": false,
-      "title": true
+      "title": true,
+      "checkEmpty": false
     },
     "option": {
       "remote": true,


### PR DESCRIPTION
### What is this PR for?
In some cases,
For example: `%sh.terminal` interpreter
The paragraph is empty and can be executed

Add the config configuration section in the `interpreter-setting.json` file of the interpreter.

```
"config": {
   "checkEmpty": true
}
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4171

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/537325588)

### Screenshots (if appropriate)
![checkEmpty](https://user-images.githubusercontent.com/3677382/58377742-cad2ca00-7fb9-11e9-98ce-ffc8743cfe4c.gif)



### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
