### PR TITLE
[ZEPPELIN-4173] Fixed open note have wrong repl name throws NullPointerException

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -652,7 +652,10 @@ public class NotebookServer extends WebSocketServlet
       try {
         interpreterGroup = findInterpreterGroupForParagraph(note, paragraph.getId());
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.error(e.getMessage(), e);
+      }
+      if (null == interpreterGroup) {
+        return;
       }
       RemoteAngularObjectRegistry registry = (RemoteAngularObjectRegistry)
           interpreterGroup.getAngularObjectRegistry();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -652,7 +652,7 @@ public class NotebookServer extends WebSocketServlet
       try {
         interpreterGroup = findInterpreterGroupForParagraph(note, paragraph.getId());
       } catch (Exception e) {
-        LOG.error(e.getMessage(), e);
+        LOG.warn(e.getMessage(), e);
       }
       if (null == interpreterGroup) {
         return;


### PR DESCRIPTION
### What is this PR for?
When you open a paragraph with an wrong interpreter name, Will trigger a NullPointerException.

```
java.lang.NullPointerException
at org.apache.zeppelin.socket.NotebookServer.updateAngularObjectRegistry(NotebookServer.java:658)
at org.apache.zeppelin.socket.NotebookServer.access$200(NotebookServer.java:101)
at org.apache.zeppelin.socket.NotebookServer$5.onSuccess(NotebookServer.java:640)
at org.apache.zeppelin.socket.NotebookServer$5.onSuccess(NotebookServer.java:635)
at org.apache.zeppelin.service.NotebookService.getNote(NotebookService.java:130)
at org.apache.zeppelin.socket.NotebookServer.getNote(NotebookServer.java:634)
at org.apache.zeppelin.socket.NotebookServer.onMessage(NotebookServer.java:296)
at org.apache.zeppelin.socket.NotebookSocket.onWebSocketText(NotebookSocket.java:58)
at org.eclipse.jetty.websocket.common.events.JettyListenerEventDriver.onTextMessage(JettyListenerEventDriver.java:189)
at org.eclipse.jetty.websocket.common.message.SimpleTextMessage.messageComplete(SimpleTextMessage.java:69)
at org.eclipse.jetty.websocket.common.events.AbstractEventDriver.appendMessage(AbstractEventDriver.java:66)
```

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4173

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/538540857)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
