### PR TITLE
[ZEPPELIN-3946] Fixed zeppelin hive interpreter broken pipe issue

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -409,7 +409,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     final String maxConnectionLifetime =
         StringUtils.defaultIfEmpty(getProperty("zeppelin.jdbc.maxConnLifetime"), "-1");
     poolableConnectionFactory.setMaxConnLifetimeMillis(Long.parseLong(maxConnectionLifetime));
-
+    poolableConnectionFactory.setValidationQuery("show databases");
     ObjectPool connectionPool = new GenericObjectPool(poolableConnectionFactory);
 
     poolableConnectionFactory.setPool(connectionPool);


### PR DESCRIPTION
### What is this PR for?
Upon raising the concern (ZEPPELIN-3860), we were suggested to upgrade the zeppelin service from 0.7.3 to 0.8.0 version. With the current zeppelin version i.e 0.8.0 the frequency of broken pipe error has gone up.

When connecting to a database through a database connection pool, If there is no sql operation for a long time, The database connection pool will actively close this connection. The connection between the client and the database is broken.

So by increasing
```
poolableConnectionFactory.setValidationQuery("show databases");
```
Periodically call the `show databases` statement, Keep the connection to the database.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3946

### How should this be tested?
The user passed the actual test, Verification solves this problem.
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/539529259)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions?  no
* Does this needs documentation? no
