### PR TITLE
[ZEPPELIN-4186] Bump up version of org.jsoup:jsoup

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <interpreter.name>spark</interpreter.name>
     <!--library versions-->
-    <jsoup.version>1.8.2</jsoup.version>
+    <jsoup.version>1.12.1</jsoup.version>
     <commons.exec.version>1.3</commons.exec.version>
     <commons.compress.version>1.9</commons.compress.version>
     <maven.plugin.api.version>3.0</maven.plugin.api.version>

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -269,7 +269,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) Spire Macros 0.7.4 (org.spire-math:spire-macros:0.7.4 - https://github.com/non/spire)
     (The MIT License) Java String Similarity 0.12 (info.debatty:java-string-similarity:0.12 - https://github.com/tdebatty/java-string-similarity)
     (The MIT License) Java LSH 0.10 (info.debatty:java-lsh:0.10 - https://github.com/tdebatty/java-LSH)
-    (The MIT License) JSoup 1.6.1 (org.jsoup:jsoup:1.6.1 - https://github.com/jhy/jsoup/)
+    (The MIT License) JSoup 1.12.1 (org.jsoup:jsoup:1.12.1 - https://github.com/jhy/jsoup/)
     (The MIT License) Unirest 1.4.9 (com.mashape.unirest:unirest-java:1.4.9 - https://github.com/Mashape/unirest-java)
     (The MIT License) ngclipboard v1.1.1 (https://github.com/sachinchoolur/ngclipboard) - https://github.com/sachinchoolur/ngclipboard/blob/1.1.1/LICENSE
     (The MIT License) headroom.js 0.9.3 (https://github.com/WickyNilliams/headroom.js) - https://github.com/WickyNilliams/headroom.js/blob/master/LICENSE


### PR DESCRIPTION
### What is this PR for?
This is to bump up version of org.jsoup:jsoup.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* [ZEPPELIN-4186](https://jira.apache.org/jira/browse/ZEPPELIN-4186)

### How should this be tested?
* CI should be green

### Questions:
* Does the licenses files need update? yes
* Is there breaking changes for older versions? n/a
* Does this needs documentation? n/a
