### PR TITLE
ZEPPELIN-4193 Upgrade Bouncy Castle bcpkix-jdk15on to 1.60

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -275,7 +275,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) headroom.js 0.9.3 (https://github.com/WickyNilliams/headroom.js) - https://github.com/WickyNilliams/headroom.js/blob/master/LICENSE
     (The MIT License) angular-viewport-watch 0.135 (https://github.com/wix/angular-viewport-watch) - https://github.com/wix/angular-viewport-watch/blob/master/LICENSE
     (The MIT License) ansi-up 2.0.2 (https://github.com/drudru/ansi_up) - https://github.com/drudru/ansi_up#license
-    (The MIT License) bcpkix-jdk15on 1.52 (org.bouncycastle:bcpkix-jdk15on:1.52 https://github.com/bcgit/bc-java) - https://github.com/bcgit/bc-java/blob/master/LICENSE.html
+    (The MIT License) bcpkix-jdk15on 1.60 (org.bouncycastle:bcpkix-jdk15on:1.60 https://github.com/bcgit/bc-java) - https://github.com/bcgit/bc-java/blob/master/LICENSE.html
 
 ========================================================================
 BSD-style licenses

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.52</version>
+      <version>1.60</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
Upgrade Bouncy Castle bcpkix-jdk15on to 1.60

### What type of PR is it?
Improvement

### Todos
--

### What is the Jira issue?
[ZEPPELIN-4193](https://issues.apache.org/jira/browse/ZEPPELIN-4193)

### How should this be tested?
Should pass CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? No
