### PR TITLE
[ZEPPELIN-4195] Fixed deleted note does not take effect in the file system

### DIFF
--- a/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
@@ -91,12 +91,16 @@ public class FileSystemNotebookRepo implements NotebookRepo {
                    AuthenticationInfo subject) throws IOException {
     Path src = new Path(notebookDir, buildNoteFileName(noteId, notePath));
     Path dest = new Path(notebookDir, buildNoteFileName(noteId, newNotePath));
+    // [ZEPPELIN-4195] newNotePath parent path maybe not exist
+    this.fs.tryMkDir(new Path(notebookDir, newNotePath.substring(1)).getParent());
     this.fs.move(src, dest);
   }
 
   @Override
   public void move(String folderPath, String newFolderPath, AuthenticationInfo subject)
       throws IOException {
+    // [ZEPPELIN-4195] newFolderPath parent path maybe not exist
+    this.fs.tryMkDir(new Path(notebookDir, folderPath.substring(1)).getParent());
     this.fs.move(new Path(notebookDir, folderPath.substring(1)),
         new Path(notebookDir, newFolderPath.substring(1)));
   }


### PR DESCRIPTION
### What is this PR for?
Because the latest note storage is saved in a real file directory.
When deleting the note,
Move /note-storage-dir/note1 directly to /note-storage-dir/~Trash/note1,
If the /note-storage-dir/~Trash directory does not exist, then moving the note will fail.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4195

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/545631231)
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
