### PR TITLE
[ZEPPELIN-4207]. zeppelin-interpreter.jar and zeppelin-interpreter-api are both used by interpreter process

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -84,7 +84,6 @@ if [[ -d "${ZEPPELIN_HOME}/zeppelin-zengine/target/test-classes" ]]; then
 fi
 
 addJarInDirForIntp "${ZEPPELIN_HOME}/zeppelin-interpreter-api/target"
-addJarInDirForIntp "${ZEPPELIN_HOME}/lib/interpreter"
 addJarInDirForIntp "${INTERPRETER_DIR}"
 
 HOSTNAME=$(hostname)

--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -39,15 +39,8 @@
       <useTransitiveDependencies>false</useTransitiveDependencies>
     </dependencySet>
     <dependencySet>
-      <outputDirectory>/lib/interpreter</outputDirectory>
-      <includes>
-        <include>${project.groupId}:zeppelin-interpreter</include>
-      </includes>
-    </dependencySet>
-    <dependencySet>
       <outputDirectory>/lib</outputDirectory>
       <excludes>
-        <exclude>${project.groupId}:zeppelin-interpreter</exclude>
         <exclude>${project.groupId}:zeppelin-web</exclude>
       </excludes>
       <useProjectArtifact>false</useProjectArtifact>
@@ -96,10 +89,6 @@
     </fileSet>
     <fileSet>
       <directory>../k8s</directory>
-    </fileSet>
-    <fileSet>
-      <outputDirectory>/lib/interpreter</outputDirectory>
-      <directory>../zeppelin-interpreter/target/lib</directory>
     </fileSet>
     <fileSet>
       <outputDirectory>/lib/node_modules/zeppelin-vis</outputDirectory>


### PR DESCRIPTION
### What is this PR for?
zeppelin-interpreter jar (unshaded jar) should be used by zeppelin server and zeppelin-interpreter-api jar (shaded jar) should be used by interpreter process.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4207

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
