### PR TITLE
[ZEPPELIN-4209] Fixed the ClusterInterpreterLauncher can not listen cluster events

### DIFF
--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterCheckThread.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterCheckThread.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import org.apache.zeppelin.cluster.ClusterManagerServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_HOST;
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_PORT;
+import static org.apache.zeppelin.cluster.meta.ClusterMetaType.INTP_PROCESS_META;
+
+// Metadata registered in the cluster by the interpreter process,
+// Keep the interpreter process started
+public class ClusterInterpreterCheckThread extends Thread {
+  private static final Logger LOGGER
+      = LoggerFactory.getLogger(ClusterInterpreterCheckThread.class);
+
+  private ClusterInterpreterProcess intpProcess;
+
+  ClusterInterpreterCheckThread(ClusterInterpreterProcess intpProcess) {
+    this.intpProcess = intpProcess;
+  }
+
+  @Override
+  public void run() {
+    LOGGER.info("ClusterInterpreterCheckThread run() >>>");
+
+    ClusterManagerServer clusterServer = ClusterManagerServer.getInstance();
+
+    String intpGroupId = intpProcess.getInterpreterGroupId();
+
+    HashMap<String, Object> intpMeta = clusterServer
+        .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
+    int connectTimeout = intpProcess.getConnectTimeout();
+
+    int MAX_RETRY_GET_META = connectTimeout / ClusterInterpreterLauncher.CHECK_META_INTERVAL;
+    int retryGetMeta = 0;
+    while ((retryGetMeta++ < MAX_RETRY_GET_META)
+        && (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
+        || !intpMeta.containsKey(INTP_TSERVER_PORT))) {
+      try {
+        Thread.sleep(ClusterInterpreterLauncher.CHECK_META_INTERVAL);
+        intpMeta = clusterServer
+            .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
+        LOGGER.info("retry {} times to get {} meta!", retryGetMeta, intpGroupId);
+      } catch (InterruptedException e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+
+      if (null != intpMeta && intpMeta.containsKey(INTP_TSERVER_HOST)
+          && intpMeta.containsKey(INTP_TSERVER_PORT)) {
+        String intpHost = (String) intpMeta.get(INTP_TSERVER_HOST);
+        int intpPort = (int) intpMeta.get(INTP_TSERVER_PORT);
+        LOGGER.info("Found cluster interpreter {}:{}", intpHost, intpPort);
+
+        intpProcess.processStarted(intpPort, intpHost);
+        break;
+      }
+    }
+
+    if (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
+        || !intpMeta.containsKey(INTP_TSERVER_PORT)) {
+      LOGGER.error("Can not found interpreter meta!");
+    }
+
+    LOGGER.info("ClusterInterpreterCheckThread run() <<<");
+  }
+}

--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncher.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.interpreter.launcher;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.cluster.ClusterManagerServer;
 import org.apache.zeppelin.cluster.event.ClusterEvent;
 import org.apache.zeppelin.cluster.event.ClusterEventListener;
@@ -38,8 +39,10 @@ import java.util.Map;
 import static org.apache.zeppelin.cluster.event.ClusterEvent.CREATE_INTP_PROCESS;
 import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_HOST;
 import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_PORT;
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.ONLINE_STATUS;
 import static org.apache.zeppelin.cluster.meta.ClusterMeta.SERVER_HOST;
 import static org.apache.zeppelin.cluster.meta.ClusterMeta.SERVER_PORT;
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.STATUS;
 import static org.apache.zeppelin.cluster.meta.ClusterMetaType.INTP_PROCESS_META;
 
 /**
@@ -71,7 +74,8 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
     HashMap<String, Object> intpProcMeta = clusterServer
         .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
     if (null != intpProcMeta && intpProcMeta.containsKey(INTP_TSERVER_HOST)
-        && intpProcMeta.containsKey(INTP_TSERVER_PORT)) {
+        && intpProcMeta.containsKey(INTP_TSERVER_PORT) && intpProcMeta.containsKey(STATUS)
+        && StringUtils.equals((String) intpProcMeta.get(STATUS), ONLINE_STATUS)) {
       // connect exist Interpreter Process
       String intpTserverHost = (String) intpProcMeta.get(INTP_TSERVER_HOST);
       int intpTserverPort = (int) intpProcMeta.get(INTP_TSERVER_PORT);

--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncher.java
@@ -91,9 +91,9 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
       String srvHost = (String) meta.get(SERVER_HOST);
       String localhost = RemoteInterpreterUtils.findAvailableHostAddress();
 
-      if (localhost.equalsIgnoreCase(srvHost) && false) {
+      if (localhost.equalsIgnoreCase(srvHost)) {
         // launch interpreter on local
-        return super.launch(context);
+        return createInterpreterProcess(context);
       } else {
         int srvPort = (int) meta.get(SERVER_PORT);
 
@@ -104,15 +104,20 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
         mapEvent.put(CLUSTER_EVENT, CREATE_INTP_PROCESS);
         mapEvent.put(CLUSTER_EVENT_MSG, sContext);
         String strEvent = gson.toJson(mapEvent);
+        // Notify other server in the cluster that the resource is idle to create an interpreter
         clusterServer.unicastClusterEvent(
             srvHost, srvPort, ClusterManagerServer.CLUSTER_INTP_EVENT_TOPIC, strEvent);
 
+        // Find the ip and port of thrift registered by the remote interpreter process
+        // through the cluster metadata
         HashMap<String, Object> intpMeta = clusterServer
             .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
-        int retryGetMeta = connectTimeout / CHECK_META_INTERVAL;
-        while ((retryGetMeta-- > 0) &
-            (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
-                || !intpMeta.containsKey(INTP_TSERVER_PORT)) ) {
+
+        int MAX_RETRY_GET_META = connectTimeout / ClusterInterpreterLauncher.CHECK_META_INTERVAL;
+        int retryGetMeta = 0;
+        while ((retryGetMeta++ < MAX_RETRY_GET_META)
+            && (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
+            || !intpMeta.containsKey(INTP_TSERVER_PORT)) ) {
           try {
             Thread.sleep(CHECK_META_INTERVAL);
             intpMeta = clusterServer
@@ -126,11 +131,9 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
         // Check if the remote creation process is successful
         if (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
             || !intpMeta.containsKey(INTP_TSERVER_PORT)) {
-          LOGGER.error("Creating process {} failed on remote server {}:{}",
+          String errorInfo = String.format("Creating process %s failed on remote server %s:%d",
               intpGroupId, srvHost, srvPort);
-
-          // launch interpreter on local
-          return super.launch(context);
+          throw new IOException(errorInfo);
         } else {
           // connnect remote interpreter process
           String intpTSrvHost = (String) intpMeta.get(INTP_TSERVER_HOST);
@@ -151,29 +154,38 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
       LOGGER.debug(msg);
     }
 
-    Gson gson = new Gson();
-    Map<String, Object> mapEvent = gson.fromJson(msg,
-        new TypeToken<Map<String, Object>>(){}.getType());
-    String sEvent = (String) mapEvent.get(CLUSTER_EVENT);
-    ClusterEvent clusterEvent = ClusterEvent.valueOf(sEvent);
+    try {
+      Gson gson = new Gson();
+      Map<String, Object> mapEvent = gson.fromJson(msg,
+          new TypeToken<Map<String, Object>>(){}.getType());
+      String sEvent = (String) mapEvent.get(CLUSTER_EVENT);
+      ClusterEvent clusterEvent = ClusterEvent.valueOf(sEvent);
 
-    switch (clusterEvent) {
-      case CREATE_INTP_PROCESS:
-        onCreateIntpProcess(mapEvent);
-        break;
-      default:
-        LOGGER.error("Unknown clusterEvent:{}, msg:{} ", clusterEvent, msg);
-        break;
+      switch (clusterEvent) {
+        case CREATE_INTP_PROCESS:
+          // 1）Other zeppelin servers in the cluster send requests to create an interpreter process
+          // 2）After the interpreter process is created, and the interpreter is started,
+          //    the interpreter registers the thrift ip and port into the cluster metadata.
+          // 3）Other servers connect through the IP and port of thrift in the cluster metadata,
+          //    using this remote interpreter process
+          String eventMsg = (String) mapEvent.get(CLUSTER_EVENT_MSG);
+          InterpreterLaunchContext context = gson.fromJson(
+              eventMsg, new TypeToken<InterpreterLaunchContext>() {}.getType());
+          ClusterInterpreterProcess clusterInterpreterProcess = createInterpreterProcess(context);
+          clusterInterpreterProcess.start(context.getUserName());
+          break;
+        default:
+          LOGGER.error("Unknown clusterEvent:{}, msg:{} ", clusterEvent, msg);
+          break;
+      }
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage(), e);
     }
   }
 
-  private void onCreateIntpProcess(Map<String, Object> mapEvent) {
-    String eventMsg = (String) mapEvent.get(CLUSTER_EVENT_MSG);
+  private ClusterInterpreterProcess createInterpreterProcess(InterpreterLaunchContext context) {
+    ClusterInterpreterProcess clusterInterpreterProcess = null;
     try {
-      Gson gson = new Gson();
-      InterpreterLaunchContext context = gson.fromJson(
-          eventMsg, new TypeToken<InterpreterLaunchContext>() {}.getType());
-
       this.properties = context.getProperties();
       InterpreterOption option = context.getOption();
       InterpreterRunner runner = context.getRunner();
@@ -183,8 +195,7 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
       String localRepoPath = zConf.getInterpreterLocalRepoPath() + "/"
           + context.getInterpreterSettingId();
 
-      ClusterInterpreterProcess clusterInterpreterProcess
-          = new ClusterInterpreterProcess(
+      clusterInterpreterProcess = new ClusterInterpreterProcess(
           runner != null ? runner.getPath() : zConf.getInterpreterRemoteRunnerPath(),
           context.getZeppelinServerRPCPort(),
           context.getZeppelinServerHost(),
@@ -196,10 +207,10 @@ public class ClusterInterpreterLauncher extends StandardInterpreterLauncher
           intpSetName,
           context.getInterpreterGroupId(),
           option.isUserImpersonate());
-
-      clusterInterpreterProcess.start(context.getUserName());
     } catch (IOException e) {
       LOGGER.error(e.getMessage(), e);
     }
+
+    return clusterInterpreterProcess;
   }
 }

--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterProcess.java
@@ -1,28 +1,12 @@
 package org.apache.zeppelin.interpreter.launcher;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.zeppelin.cluster.ClusterManagerServer;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_HOST;
-import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_PORT;
-import static org.apache.zeppelin.cluster.meta.ClusterMetaType.INTP_PROCESS_META;
-
 
 public class ClusterInterpreterProcess extends RemoteInterpreterManagedProcess {
-  private static final Logger LOGGER
-      = LoggerFactory.getLogger(ClusterInterpreterProcess.class);
-
-  private String intpHost = "";
-  private int intpPort = 0;
-
-  private ClusterManagerServer clusterServer = ClusterManagerServer.getInstance();
 
   public ClusterInterpreterProcess(
       String intpRunner,
@@ -52,28 +36,10 @@ public class ClusterInterpreterProcess extends RemoteInterpreterManagedProcess {
 
   @Override
   public void start(String userName) throws IOException {
-    CheckIntpRunStatusThread checkIntpRunStatusThread = new CheckIntpRunStatusThread(this);
-    checkIntpRunStatusThread.start();
+    ClusterInterpreterCheckThread interpreterCheckThread = new ClusterInterpreterCheckThread(this);
+    interpreterCheckThread.start();
 
     super.start(userName);
-  }
-
-  @Override
-  public void processStarted(int port, String host) {
-    // Cluster mode, discovering interpreter processes through metadata registration
-    this.intpHost = host;
-    this.intpPort = port;
-    super.processStarted(port, host);
-  }
-
-  @Override
-  public String getHost() {
-    return intpHost;
-  }
-
-  @Override
-  public int getPort() {
-    return intpPort;
   }
 
   @Override
@@ -87,55 +53,5 @@ public class ClusterInterpreterProcess extends RemoteInterpreterManagedProcess {
   @Override
   public String getErrorMessage() {
     return null;
-  }
-
-  // Metadata registered in the cluster by the interpreter process,
-  // Keep the interpreter process started
-  private class CheckIntpRunStatusThread extends Thread {
-    private ClusterInterpreterProcess intpProcess;
-
-    CheckIntpRunStatusThread(ClusterInterpreterProcess intpProcess) {
-      this.intpProcess = intpProcess;
-    }
-
-    @Override
-    public void run() {
-      LOGGER.info("checkIntpRunStatusThread run() >>>");
-
-      String intpGroupId = getInterpreterGroupId();
-
-      HashMap<String, Object> intpMeta = clusterServer
-          .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
-      int connectTimeout = intpProcess.getConnectTimeout();
-      int retryGetMeta = connectTimeout / ClusterInterpreterLauncher.CHECK_META_INTERVAL;
-      while ((retryGetMeta-- > 0)
-          && (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
-          || !intpMeta.containsKey(INTP_TSERVER_PORT))) {
-        try {
-          Thread.sleep(ClusterInterpreterLauncher.CHECK_META_INTERVAL);
-          intpMeta = clusterServer
-              .getClusterMeta(INTP_PROCESS_META, intpGroupId).get(intpGroupId);
-          LOGGER.info("retry {} times to get {} meta!", retryGetMeta, intpGroupId);
-        } catch (InterruptedException e) {
-          LOGGER.error(e.getMessage(), e);
-        }
-
-        if (null != intpMeta && intpMeta.containsKey(INTP_TSERVER_HOST)
-            && intpMeta.containsKey(INTP_TSERVER_PORT)) {
-          String intpHost = (String) intpMeta.get(INTP_TSERVER_HOST);
-          int intpPort = (int) intpMeta.get(INTP_TSERVER_PORT);
-          LOGGER.info("Found cluster interpreter {}:{}", intpHost, intpPort);
-
-          intpProcess.processStarted(intpPort, intpHost);
-        }
-      }
-
-      if (null == intpMeta || !intpMeta.containsKey(INTP_TSERVER_HOST)
-          || !intpMeta.containsKey(INTP_TSERVER_PORT)) {
-        LOGGER.error("Can not found interpreter meta!");
-      }
-
-      LOGGER.info("checkIntpRunStatusThread run() <<<");
-    }
   }
 }

--- a/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
@@ -18,7 +18,6 @@ package org.apache.zeppelin.interpreter.launcher;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterOption;
-import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterRunningProcess;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -51,8 +50,8 @@ public class ClusterInterpreterLauncherTest extends ClusterMockTest {
   }
 
   @Test
-  public void testConnectExistIntpProcess() throws IOException {
-    mockIntpProcessMeta("intpGroupId");
+  public void testConnectExistOnlineIntpProcess() throws IOException {
+    mockIntpProcessMeta("intpGroupId", true);
 
     ClusterInterpreterLauncher launcher
         = new ClusterInterpreterLauncher(ClusterMockTest.zconf, null);
@@ -75,7 +74,9 @@ public class ClusterInterpreterLauncherTest extends ClusterMockTest {
   }
 
   @Test
-  public void testCreateIntpProcess() throws IOException {
+  public void testConnectExistOfflineIntpProcess() throws IOException {
+    mockIntpProcessMeta("intpGroupId2", false);
+
     ClusterInterpreterLauncher launcher
         = new ClusterInterpreterLauncher(ClusterMockTest.zconf, null);
     Properties properties = new Properties();
@@ -84,12 +85,12 @@ public class ClusterInterpreterLauncherTest extends ClusterMockTest {
     InterpreterOption option = new InterpreterOption();
     option.setUserImpersonate(true);
     InterpreterLaunchContext context = new InterpreterLaunchContext(properties, option, null,
-        "user1", "intpGroupId", "groupId",
+        "user1", "intpGroupId2", "groupId",
         "groupName", "name", 0, "host");
     InterpreterClient client = launcher.launch(context);
 
-    assertTrue(client instanceof RemoteInterpreterManagedProcess);
-    RemoteInterpreterManagedProcess interpreterProcess = (RemoteInterpreterManagedProcess) client;
+    assertTrue(client instanceof ClusterInterpreterProcess);
+    ClusterInterpreterProcess interpreterProcess = (ClusterInterpreterProcess) client;
     assertEquals("name", interpreterProcess.getInterpreterSettingName());
     assertEquals(".//interpreter/groupName", interpreterProcess.getInterpreterDir());
     assertEquals(".//local-repo/groupId", interpreterProcess.getLocalRepoDir());

--- a/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterMockTest.java
+++ b/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterMockTest.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.OFFLINE_STATUS;
+import static org.apache.zeppelin.cluster.meta.ClusterMeta.ONLINE_STATUS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -114,7 +116,7 @@ public class ClusterMockTest {
     LOGGER.info("serverMeta <<<");
   }
 
-  public void mockIntpProcessMeta(String metaKey) {
+  public void mockIntpProcessMeta(String metaKey, boolean online) {
     // mock IntpProcess Meta
     HashMap<String, Object> meta = new HashMap<>();
     meta.put(ClusterMeta.SERVER_HOST, "SERVER_HOST");
@@ -125,7 +127,11 @@ public class ClusterMockTest {
     meta.put(ClusterMeta.CPU_USED, "CPU_USED");
     meta.put(ClusterMeta.MEMORY_CAPACITY, "MEMORY_CAPACITY");
     meta.put(ClusterMeta.MEMORY_USED, "MEMORY_USED");
-
+    if (online) {
+      meta.put(ClusterMeta.STATUS, ONLINE_STATUS);
+    } else {
+      meta.put(ClusterMeta.STATUS, OFFLINE_STATUS);
+    }
     // put IntpProcess Meta
     clusterClient.putClusterMeta(ClusterMetaType.INTP_PROCESS_META, metaKey, meta);
 
@@ -137,6 +143,6 @@ public class ClusterMockTest {
 
     assertNotNull(check);
     assertNotNull(check.get(metaKey));
-    assertEquals(true, check.get(metaKey).size() == 8);
+    assertEquals(true, check.get(metaKey).size() == 9);
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -131,6 +131,8 @@ public class InterpreterSetting {
   private transient LifecycleManager lifecycleManager;
   private transient RecoveryStorage recoveryStorage;
   private transient RemoteInterpreterEventServer interpreterEventServer;
+
+  public static final String CLUSTER_INTERPRETER_LAUNCHER_NAME = "ClusterInterpreterLauncher";
   ///////////////////////////////////////////////////////////////////////////////////////////
 
   /**
@@ -671,7 +673,7 @@ public class InterpreterSetting {
     if (isRunningOnKubernetes()) {
       return "K8sStandardInterpreterLauncher";
     } else if (isRunningOnCluster()) {
-      return "ClusterInterpreterLauncher";
+      return InterpreterSetting.CLUSTER_INTERPRETER_LAUNCHER_NAME;
     } if (isRunningOnDocker()) {
       return "DockerInterpreterLauncher";
     } else {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -47,7 +47,6 @@ import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteEventListener;
 import org.apache.zeppelin.notebook.Paragraph;
-import org.apache.zeppelin.plugin.PluginManager;
 import org.apache.zeppelin.resource.Resource;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.resource.ResourceSet;
@@ -211,18 +210,6 @@ public class InterpreterSettingManager implements NoteEventListener {
         .setRecoveryStorage(recoveryStorage)
         .setInterpreterEventServer(interpreterEventServer)
         .postProcessing();
-    
-    // Since the ClusterInterpreterLauncher is lazy, dynamically generated, So in cluster mode,
-    // when the zeppelin service starts, Create a ClusterInterpreterLauncher object,
-    // This allows the ClusterInterpreterLauncher to listen for cluster events.
-    if (conf.isClusterMode()) {
-      try {
-        String pluginName = interpreterSetting.getLauncherPlugin();
-        PluginManager.get().loadInterpreterLauncher(pluginName, recoveryStorage);
-      } catch (IOException e) {
-        LOGGER.error(e.getMessage(), e);
-      }
-    }
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -47,6 +47,7 @@ import org.apache.zeppelin.notebook.ApplicationState;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteEventListener;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.plugin.PluginManager;
 import org.apache.zeppelin.resource.Resource;
 import org.apache.zeppelin.resource.ResourcePool;
 import org.apache.zeppelin.resource.ResourceSet;
@@ -210,6 +211,18 @@ public class InterpreterSettingManager implements NoteEventListener {
         .setRecoveryStorage(recoveryStorage)
         .setInterpreterEventServer(interpreterEventServer)
         .postProcessing();
+    
+    // Since the ClusterInterpreterLauncher is lazy, dynamically generated, So in cluster mode,
+    // when the zeppelin service starts, Create a ClusterInterpreterLauncher object,
+    // This allows the ClusterInterpreterLauncher to listen for cluster events.
+    if (conf.isClusterMode()) {
+      try {
+        String pluginName = interpreterSetting.getLauncherPlugin();
+        PluginManager.get().loadInterpreterLauncher(pluginName, recoveryStorage);
+      } catch (IOException e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
1. **ClusterInterpreterLauncher can not listen cluster events**
In Cluster mode, The `ClusterInterpreterLauncher` needs to listen for cluster events, Accept requests from other zeppelin servers to create interpreter processes.
Since the `ClusterInterpreterLauncher` is lazy, dynamically generated, So in cluster mode, when the zeppelin service starts, Create a `ClusterInterpreterLauncher` object, This allows the `ClusterInterpreterLauncher` to listen for cluster events.

2. **Replace `RemoteInterpreterManagedProcess` with `ClusterInterpreterProcess` for local interpreter process creation**
Because in cluster mode, `RemoteInterpreterServer` performs service discovery by registering thrift's `ip` and `port` into the cluster metadata, not through the thrift interface `callback`.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4209

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/552320897)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
