### PR TITLE
[ZEPPELIN-4189] Record INTERPRETER_RUN_COMMAND execution log in the interpreter.sh

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -244,6 +244,7 @@ if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]] && [[ -n "${suid}" || -z "${SPARK_SUB
     INTERPRETER_RUN_COMMAND+="'"
 fi
 
+echo "$INTERPRETER_RUN_COMMAND" >> /tmp/interpreter.log
 echo "Interpreter launch command: $INTERPRETER_RUN_COMMAND"
 eval $INTERPRETER_RUN_COMMAND &
 pid=$!


### PR DESCRIPTION
### What is this PR for?
Record the `INTERPRETER_RUN_COMMAND` execution log in the interpreter.sh file. Can help find the reason why the startup interpreter failed to execute. 
Especially in the container environment, it can play a relatively large role. When creating an interpreter process in the container, if it fails, you can use this log to re-execute and check the problem.

### What type of PR is it?
[Improvement]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4189

### How should this be tested?
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/553071915) 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
