### PR TITLE
[ZEPPELIN-4216]. Introduce ZEPPELIN_SERVER_IP to specify the ip address of thrift server

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -18,6 +18,7 @@
 
 # export JAVA_HOME=
 # export MASTER=                 		# Spark master url. eg. spark://master_addr:7077. Leave empty if you want to use local mode.
+# export ZEPPELIN_LOCAL_IP              # Zeppelin's thrift server ip address, if not specified, one random IP address will be choosen.
 # export ZEPPELIN_JAVA_OPTS      		# Additional jvm options. for example, export ZEPPELIN_JAVA_OPTS="-Dspark.executor.memory=8g -Dspark.cores.max=16"
 # export ZEPPELIN_MEM            		# Zeppelin jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m
 # export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
@@ -94,6 +94,11 @@ public class RemoteInterpreterUtils {
   }
 
   public static String findAvailableHostAddress() throws UnknownHostException, SocketException {
+    String zeppelinServerIP = System.getenv("ZEPPELIN_LOCAL_IP");
+    if (zeppelinServerIP != null) {
+      return zeppelinServerIP;
+    }
+
     InetAddress address = InetAddress.getLocalHost();
     if (address.isLoopbackAddress()) {
       for (NetworkInterface networkInterface : Collections


### PR DESCRIPTION
### What is this PR for?

This PR use introduce env `ZEPPELIN_SERVER_IP` to specify the ip address of thrift server. It is used when you are in a complex network environment where yo might have multiple network cards or you use proxy. If it is not specified, it would still use the old approach to choose one IP randomly. 

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4216

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
