### PR TITLE
[ZEPPELIN-4150] Livy interpreter session auto restart doesn't work with livy 0.6.0

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -86,7 +86,7 @@ public abstract class BaseLivyInterpreter extends Interpreter {
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterpreter.class);
   private static Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-  private static final String SESSION_NOT_FOUND_PATTERN = "\"Session '\\d+' not found.\"";
+  private static final String SESSION_NOT_FOUND_PATTERN = "(.*)\"Session '\\d+' not found.\"(.*)";
 
   protected volatile SessionInfo sessionInfo;
   private String livyURL;


### PR DESCRIPTION
### What is this PR for?
Change SESSION_NOT_FOUND_PATTERN to match JSON response body from Livy 0.6.0.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4150

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
