### PR TITLE
[ZEPPELIN-4219] User can start interpreter when interpreter dependencies jars are not downloaded

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/DependencyResolver.java
@@ -96,7 +96,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
         File destFile = new File(destPath, srcFile.getName());
         if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
           FileUtils.copyFile(srcFile, destFile);
-          logger.debug("copy {} to {}", srcFile.getAbsolutePath(), destPath);
+          logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
         }
       }
     }
@@ -114,7 +114,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
 
     if (!destFile.exists() || !FileUtils.contentEquals(srcFile, destFile)) {
       FileUtils.copyFile(srcFile, destFile);
-      logger.debug("copy {} to {}", srcFile.getAbsolutePath(), destPath);
+      logger.info("copy {} to {}", srcFile.getAbsolutePath(), destPath);
     }
   }
 
@@ -142,7 +142,7 @@ public class DependencyResolver extends AbstractDependencyResolver {
     List<File> files = new LinkedList<>();
     for (ArtifactResult artifactResult : listOfArtifact) {
       files.add(artifactResult.getArtifact().getFile());
-      logger.debug("load {}", artifactResult.getArtifact().getFile().getAbsolutePath());
+      logger.info("load {}", artifactResult.getArtifact().getFile().getAbsolutePath());
     }
 
     return files;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -103,7 +103,7 @@ public class InterpreterSetting {
    */
   private Object properties = new Properties();
 
-  private Status status;
+  private Status status = Status.READY;
   private String errorReason;
 
   @SerializedName("interpreterGroup")
@@ -265,7 +265,6 @@ public class InterpreterSetting {
   }
 
   void postProcessing() {
-    this.status = Status.READY;
     this.id = this.name;
     if (this.lifecycleManager == null) {
       this.lifecycleManager = new NullLifecycleManager(conf);
@@ -657,6 +656,7 @@ public class InterpreterSetting {
   }
 
   public void setStatus(Status status) {
+    LOGGER.info(String.format("Set interpreter %s status to %s", name, status.name()));
     this.status = status;
   }
 
@@ -867,6 +867,7 @@ public class InterpreterSetting {
           // load dependencies
           List<Dependency> deps = getDependencies();
           if (deps != null) {
+            LOGGER.info("Start to download dependencies for interpreter: " + name);
             for (Dependency d : deps) {
               File destDir = new File(
                   conf.getRelativeDir(ZeppelinConfiguration.ConfVars.ZEPPELIN_DEP_LOCALREPO));
@@ -879,6 +880,7 @@ public class InterpreterSetting {
                     .load(d.getGroupArtifactVersion(), new File(destDir, id));
               }
             }
+            LOGGER.info("Finish downloading dependencies for interpreter: " + name);
           }
 
           setStatus(Status.READY);


### PR DESCRIPTION
### What is this PR for?
Now interpreter can start even when it is downloading dependencies. It will cause ClassNotFound exception. The root cause is that the status of InterpreterSetting is incorrectly set to `READY`.  This PR fix this issue.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4219

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
