### PR TITLE
[ZEPPELIN-4224]. commons-exec is missing in zeppelin-interpreter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>
     <commons.lang.version>2.5</commons.lang.version>
     <commons.configuration.version>1.9</commons.configuration.version>
+    <commons.exec.version>1.3</commons.exec.version>
     <commons.codec.version>1.5</commons.codec.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.collections.version>3.2.2</commons.collections.version>
@@ -207,6 +208,12 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${commons.lang.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-exec</artifactId>
+        <version>${commons.exec.version}</version>
       </dependency>
 
       <dependency>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -63,6 +63,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -38,7 +38,6 @@
   <properties>
     <!--library versions-->
     <commons.pool2.version>2.3</commons.pool2.version>
-    <commons.exec.version>1.3</commons.exec.version>
     <maven.plugin.api.version>3.0</maven.plugin.api.version>
     <aether.version>1.12</aether.version>
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
@@ -116,7 +115,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>${commons.exec.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?

commons-exec is excluded in zeppelin-interpeter-api which is the shaded zeppelin-interpreter. So we should add common-exec explicitly in zeppelin-interpreter-parent so that all interpreter can use it and include it their packaged jar.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4224

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
