### PR TITLE
[ZEPPELIN-4217]. Remove semicolon at the end of sql statement for JdbcInterpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -710,9 +710,13 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
     try {
       List<String> sqlArray;
+      sql = sql.trim();
       if (splitQuery) {
         sqlArray = splitSqlQueries(sql);
       } else {
+        if (sql.endsWith(";")) {
+          sql = sql.substring(0, sql.length() - 1);
+        }
         sqlArray = Arrays.asList(sql);
       }
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -181,7 +181,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     JDBCInterpreter t = new JDBCInterpreter(properties);
     t.open();
 
-    String sqlQuery = "select * from test_table WHERE ID in ('a', 'b')";
+    String sqlQuery = "select * from test_table WHERE ID in ('a', 'b'); ";
 
     InterpreterResult interpreterResult = t.interpret(sqlQuery, interpreterContext);
 
@@ -229,7 +229,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
         "select '\\', ';';" +
         "select '''', ';';" +
         "select /*+ scan */ * from test_table;" +
-        "--singleLineComment\nselect * from test_table";
+        "--singleLineComment\nselect * from test_table;";
 
 
     Properties properties = new Properties();


### PR DESCRIPTION
### What is this PR for?
It is very possible for user to add semicolon at the end of sql statement. Some jdbc engine will handle the semicolon for users, while others won't, e.g. hive. This PR will remove the semicolon at the end of sql. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4217

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
