### PR TITLE
[ZEPPELIN-4232]. push local notes to remote upstream when initializing GitHubNotebook

### DIFF
--- a/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
@@ -61,6 +61,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
     configureRemoteStream();
     pullFromRemoteStream();
+    pushToRemoteSteam();
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?

This is a trivial PR that will push local notes to remote upstream when initializing GitHubNotebook


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4232

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
