### PR TITLE
[ZEPPELIN-4235] pass environment variable for pyspark  with impersonate

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -227,7 +227,7 @@ if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]]; then
     if [[ -n  "${suid}" || -z "${SPARK_SUBMIT}" ]]; then
        INTERPRETER_RUN_COMMAND=${ZEPPELIN_IMPERSONATE_RUN_CMD}" '"
        if [[ -f "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh" ]]; then
-           INTERPRETER_RUN_COMMAND+=" source "${ZEPPELIN_CONF_DIR}'/zeppelin-env.sh;'
+           INTERPRETER_RUN_COMMAND+=" source "${ZEPPELIN_CONF_DIR}'/zeppelin-env.sh;'" export PYTHONPATH=$PYTHONPATH; export ZEPPELIN_HOME=$ZEPPELIN_HOME;"
        fi
     fi
   fi


### PR DESCRIPTION
### What is this PR for?
Pass 2 environment variable for pyspark with impersonate
- PYTHONPATH
- ZEPPELIN_HOME

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4235

### How should this be tested?
* Run paragraph that use pyspark interpreter with impersonate setting without `PYTHONPATH` in `zeppelin-env.sh`.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    - No
* Is there breaking changes for older versions?
    - No
* Does this needs documentation?
    - No