### PR TITLE
[ZEPPELIN-4238] Fixed `gson-2.2.jar` file not dependency in shellInterpreter pom

### DIFF
--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -36,11 +36,12 @@
     <interpreter.name>sh</interpreter.name>
 
     <!--library versions -->
-    <commons.lang3.version>3.4</commons.lang3.version>
     <commons.exec.version>1.3</commons.exec.version>
     <pty4j.version>0.9.3</pty4j.version>
     <jinjava.version>2.4.0</jinjava.version>
     <guava.version>20.0</guava.version>
+    <gson.version>2.2</gson.version>
+    <commons-lang.version>2.5</commons-lang.version>
   </properties>
 
   <!-- pty4j library not in maven central repository (http://repo.maven.apache.org/maven2) -->
@@ -54,14 +55,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-      <version>${commons.exec.version}</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang3.version}</version>
+      <artifactId>commons-exec</artifactId>
+      <version>${commons.exec.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
### What is this PR for?

1. `%sh.terminal` need dependency `commons-lang-2.5.jar` and `gson-2.2.jar`
2. All interpreters pass the `zeppelin-interpreter-api` module, dependency `zeppelin-interpreter`,
`gson-2.2.jar` is included in `zeppelin-interpreter`.
3. But the `zeppelin-interpreter-api` module shaded `gson-2.2.jar` to avoid package conflicts.

So you need to re-dependency `commons-lang-2.5.jar` and `gson-2.2.jar` in the shell interpreter

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4238

### How should this be tested?
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/557792720)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
