### PR TITLE
[ZEPPELIN-4236] Cluster mode support interpreter running in docker

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -722,6 +722,11 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     }
   }
 
+  @VisibleForTesting
+  public void setRunMode(RUN_MODE runMode) {
+    properties.put(ConfVars.ZEPPELIN_RUN_MODE.getVarName(), runMode.name());
+  }
+
   public boolean getK8sPortForward() {
     return getBoolean(ConfVars.ZEPPELIN_K8S_PORTFORWARD);
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/launcher/InterpreterLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/launcher/InterpreterLauncher.java
@@ -44,7 +44,7 @@ public abstract class InterpreterLauncher {
   protected int getConnectTimeout() {
     int connectTimeout =
         zConf.getInt(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT);
-    if (properties.containsKey(
+    if (properties != null && properties.containsKey(
         ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName())) {
       connectTimeout = Integer.parseInt(properties.getProperty(
           ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName()));

--- a/zeppelin-plugins/launcher/cluster/pom.xml
+++ b/zeppelin-plugins/launcher/cluster/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>launcher-standard</artifactId>
       <version>0.9.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>launcher-docker</artifactId>
+      <version>0.9.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterProcess.java
@@ -36,9 +36,6 @@ public class ClusterInterpreterProcess extends RemoteInterpreterManagedProcess {
 
   @Override
   public void start(String userName) throws IOException {
-    ClusterInterpreterCheckThread interpreterCheckThread = new ClusterInterpreterCheckThread(this);
-    interpreterCheckThread.start();
-
     super.start(userName);
   }
 

--- a/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
@@ -99,4 +99,42 @@ public class ClusterInterpreterLauncherTest extends ClusterMockTest {
     assertTrue(interpreterProcess.getEnv().size() >= 1);
     assertEquals(true, interpreterProcess.isUserImpersonated());
   }
+
+  @Test
+  public void testCreateIntpProcessDockerMode() throws IOException {
+    zconf.setRunMode(ZeppelinConfiguration.RUN_MODE.DOCKER);
+
+    ClusterInterpreterLauncher launcher
+        = new ClusterInterpreterLauncher(zconf, null);
+    Properties properties = new Properties();
+    properties.setProperty(
+        ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "1000");
+    InterpreterOption option = new InterpreterOption();
+    option.setUserImpersonate(true);
+    InterpreterLaunchContext context = new InterpreterLaunchContext(properties, option, null,
+        "user1", "intpGroupId3", "groupId3",
+        "groupName", "name", 0, "host");
+    InterpreterClient client = launcher.launch(context);
+
+    assertTrue(client instanceof DockerInterpreterProcess);
+  }
+
+  @Test
+  public void testCreateIntpProcessLocalMode() throws IOException {
+    zconf.setRunMode(ZeppelinConfiguration.RUN_MODE.LOCAL);
+
+    ClusterInterpreterLauncher launcher
+        = new ClusterInterpreterLauncher(zconf, null);
+    Properties properties = new Properties();
+    properties.setProperty(
+        ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "1000");
+    InterpreterOption option = new InterpreterOption();
+    option.setUserImpersonate(true);
+    InterpreterLaunchContext context = new InterpreterLaunchContext(properties, option, null,
+        "user1", "intpGroupId4", "groupId4",
+        "groupName", "name", 0, "host");
+    InterpreterClient client = launcher.launch(context);
+
+    assertTrue(client instanceof ClusterInterpreterProcess);
+  }
 }


### PR DESCRIPTION
### What is this PR for?
Now that zeppelin is set up in cluster mode, the interpreter will not work in docker mode.
We need to mix these two modes together.
This will allow more users to use the interpreter container.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4236

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/557797483)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
