### PR TITLE
[ZEPPELIN-4239] Fix `netty-all-4.0.23.Final.jar` version conflict

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -349,6 +349,10 @@
               <artifactId>netty</artifactId>
             </exclusion>
             <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-all</artifactId>
+            </exclusion>
+            <exclusion>
               <groupId>commons-httpclient</groupId>
               <artifactId>commons-httpclient</artifactId>
             </exclusion>
@@ -531,6 +535,10 @@
             <exclusion>
               <groupId>com.google.guava</groupId>
               <artifactId>guava</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>io.netty</groupId>
+              <artifactId>netty-all</artifactId>
             </exclusion>
           </exclusions>
         </dependency>


### PR DESCRIPTION
### What is this PR for?
Cluster mode depends on `netty-*-4.1.27.Final.jar` and zeppelin-zengine's `netty-all-4.0.23.Final.jar` version conflicts

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4239

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/558725065)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
