### PR TITLE
[ZEPPELIN-4240] Fixed the date format error in cluster management page

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
@@ -134,8 +134,13 @@ public class ClusterRestApi {
       if (properties.containsKey(ClusterMeta.SERVER_START_TIME)) {
         // format LocalDateTime
         Object serverStartTime = properties.get(ClusterMeta.SERVER_START_TIME);
-        String dateTime = formatDateTime(serverStartTime);
-        sortProperties.put(ClusterMeta.SERVER_START_TIME, dateTime);
+        if (serverStartTime instanceof LocalDateTime) {
+          LocalDateTime localDateTime = (LocalDateTime) serverStartTime;
+          String dateTime = formatLocalDateTime(localDateTime);
+          sortProperties.put(ClusterMeta.SERVER_START_TIME, dateTime);
+        } else {
+          sortProperties.put(ClusterMeta.SERVER_START_TIME, "Wrong time type!");
+        }
       }
       if (properties.containsKey(ClusterMeta.STATUS)) {
         sortProperties.put(ClusterMeta.STATUS, properties.get(ClusterMeta.STATUS));
@@ -143,8 +148,13 @@ public class ClusterRestApi {
       if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
         // format LocalDateTime
         Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
-        String dateTime = formatDateTime(latestHeartbeat);
-        sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+        if (latestHeartbeat instanceof LocalDateTime) {
+          LocalDateTime localDateTime = (LocalDateTime) latestHeartbeat;
+          String dateTime = formatLocalDateTime(localDateTime);
+          sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+        } else {
+          sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, "Wrong time type!");
+        }
       }
       if (properties.containsKey(ClusterMeta.INTP_PROCESS_LIST)) {
         sortProperties.put(ClusterMeta.INTP_PROCESS_LIST, properties.get(ClusterMeta.INTP_PROCESS_LIST));
@@ -160,15 +170,10 @@ public class ClusterRestApi {
     return new JsonResponse(Response.Status.OK, "", nodes).build();
   }
 
-  private String formatDateTime(Object localDateTime) {
-    if (localDateTime instanceof LocalDateTime) {
-      LocalDateTime ldt = (LocalDateTime) localDateTime;
-      DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-      String strDate = ldt.format(dtf);
-      return strDate;
-    }
-
-    return "Wrong time type!";
+  private String formatLocalDateTime(LocalDateTime localDateTime) {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    String strDate = localDateTime.format(dtf);
+    return strDate;
   }
 
   /**
@@ -196,14 +201,24 @@ public class ClusterRestApi {
         // format LocalDateTime
         HashMap<String, Object> properties = intpMetaEntity.getValue();
         if (properties.containsKey(ClusterMeta.INTP_START_TIME)) {
-          Object latestHeartbeat = properties.get(ClusterMeta.INTP_START_TIME);
-          String dateTime = formatDateTime(latestHeartbeat);
-          properties.put(ClusterMeta.INTP_START_TIME, dateTime);
+          Object intpStartTime = properties.get(ClusterMeta.INTP_START_TIME);
+          if (intpStartTime instanceof LocalDateTime) {
+            LocalDateTime localDateTime = (LocalDateTime) intpStartTime;
+            String dateTime = formatLocalDateTime(localDateTime);
+            properties.put(ClusterMeta.INTP_START_TIME, dateTime);
+          } else {
+            properties.put(ClusterMeta.INTP_START_TIME, "Wrong time type!");
+          }
         }
         if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
           Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
-          String dateTime = formatDateTime(latestHeartbeat);
-          properties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+          if (latestHeartbeat instanceof LocalDateTime) {
+            LocalDateTime localDateTime = (LocalDateTime) latestHeartbeat;
+            String dateTime = formatLocalDateTime(localDateTime);
+            properties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+          } else {
+            properties.put(ClusterMeta.LATEST_HEARTBEAT, "Wrong time type!");
+          }
         }
 
         intpProcesses.add(node);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
@@ -32,6 +32,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -130,13 +132,19 @@ public class ClusterRestApi {
       }
 
       if (properties.containsKey(ClusterMeta.SERVER_START_TIME)) {
-        sortProperties.put(ClusterMeta.SERVER_START_TIME, properties.get(ClusterMeta.SERVER_START_TIME));
+        // format LocalDateTime
+        Object serverStartTime = properties.get(ClusterMeta.SERVER_START_TIME);
+        String dateTime = formatDateTime(serverStartTime);
+        sortProperties.put(ClusterMeta.SERVER_START_TIME, dateTime);
       }
       if (properties.containsKey(ClusterMeta.STATUS)) {
         sortProperties.put(ClusterMeta.STATUS, properties.get(ClusterMeta.STATUS));
       }
       if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
-        sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, properties.get(ClusterMeta.LATEST_HEARTBEAT));
+        // format LocalDateTime
+        Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
+        String dateTime = formatDateTime(latestHeartbeat);
+        sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
       }
       if (properties.containsKey(ClusterMeta.INTP_PROCESS_LIST)) {
         sortProperties.put(ClusterMeta.INTP_PROCESS_LIST, properties.get(ClusterMeta.INTP_PROCESS_LIST));
@@ -152,8 +160,15 @@ public class ClusterRestApi {
     return new JsonResponse(Response.Status.OK, "", nodes).build();
   }
 
-  private String formatIntpLink(String intpName) {
-    return String.format("<a href=\"/#/cluster/%s\">%s</a>", intpName, intpName);
+  private String formatDateTime(Object localDateTime) {
+    if (localDateTime instanceof LocalDateTime) {
+      LocalDateTime ldt = (LocalDateTime) localDateTime;
+      DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+      String strDate = ldt.format(dtf);
+      return strDate;
+    }
+
+    return "Wrong time type!";
   }
 
   /**
@@ -177,6 +192,20 @@ public class ClusterRestApi {
         HashMap<String, Object> node = new HashMap<String, Object>();
         node.put(ClusterMeta.NODE_NAME, intpNodeName);
         node.put(PROPERTIES, intpMetaEntity.getValue());
+
+        // format LocalDateTime
+        HashMap<String, Object> properties = intpMetaEntity.getValue();
+        if (properties.containsKey(ClusterMeta.INTP_START_TIME)) {
+          Object latestHeartbeat = properties.get(ClusterMeta.INTP_START_TIME);
+          String dateTime = formatDateTime(latestHeartbeat);
+          properties.put(ClusterMeta.INTP_START_TIME, dateTime);
+        }
+        if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
+          Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
+          String dateTime = formatDateTime(latestHeartbeat);
+          properties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+        }
+
         intpProcesses.add(node);
       }
     }


### PR DESCRIPTION
### What is this PR for?
The startup time of the zeppelin service and the interpreter process in the cluster metadata. The heartbeat time is the LocalDateTime.
The correct format is not displayed in the cluster management page.


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4240

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/558822999)

### Screenshots (if appropriate)

# Before fixed
![cluster-web-page-error-time](https://user-images.githubusercontent.com/3677382/61205136-d8870f00-a721-11e9-9879-174cd5b6ad0e.png)


# After fixed
![FormattedDateTime](https://user-images.githubusercontent.com/3677382/61205142-dd4bc300-a721-11e9-80f6-beb930eed834.gif)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
