### PR TITLE
ZEPPELIN-4272: Zeppelin fails to compile when hadoop3 is enabled

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -48,6 +48,8 @@
     <aws.sdk.s3.version>1.10.62</aws.sdk.s3.version>
     <commons.vfs2.version>2.2</commons.vfs2.version>
     <eclipse.jgit.version>4.5.4.201711221230-r</eclipse.jgit.version>
+    <jettison.version>1.4.0</jettison.version>
+    <kerberos-client.version>2.0.0-M15</kerberos-client.version>
     <!--test library versions-->
     <google.truth.version>0.27</google.truth.version>
     <google.testing.nio.version>0.32.0-alpha</google.testing.nio.version>
@@ -157,12 +159,6 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-highlighter</artifactId>
       <version>${lucene.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-s3</artifactId>
-      <version>${aws.sdk.s3.version}</version>
     </dependency>
 
     <dependency>
@@ -312,6 +308,12 @@
       </activation>
 
       <dependencies>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-s3</artifactId>
+          <version>${aws.sdk.s3.version}</version>
+        </dependency>
+
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
@@ -650,6 +652,21 @@
           <version>${hadoop.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.codehaus.jettison</groupId>
+          <artifactId>jettison</artifactId>
+          <version>${jettison.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-aws</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+		<dependency>
+		  <groupId>org.apache.directory.server</groupId>
+		  <artifactId>kerberos-client</artifactId>
+		  <version>${kerberos-client.version}</version>
+	    </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/zeppelinhub/websocket/ZeppelinhubClient.java
@@ -37,6 +37,9 @@ import org.apache.zeppelin.notebook.repo.zeppelinhub.websocket.utils.Zeppelinhub
 import org.apache.zeppelin.notebook.socket.Message;
 import org.apache.zeppelin.notebook.socket.Message.OP;
 import org.apache.zeppelin.ticket.TicketContainer;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -44,9 +47,6 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amazonaws.util.json.JSONArray;
-import com.amazonaws.util.json.JSONException;
-import com.amazonaws.util.json.JSONObject;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;


### PR DESCRIPTION
### What is this PR for?
To compile and build Zeppelin with hadoop3 added couple of missing dependencies

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* [ZEPPELIN-4272](https://issues.apache.org/jira/browse/ZEPPELIN-4272)

### How should this be tested?
* CI green

### Screenshots (if appropriate)

![apache_zepp](https://user-images.githubusercontent.com/9100442/61625654-dc261300-ac98-11e9-88c3-a85668e050e3.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes, added 'kerberos-client' dependency for hadoop3
* Does this needs documentation? No
