### PR TITLE
[ZEPPELIN-4280] Fix an issue that makes an infinite loop while switching the visualizations

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -812,6 +812,9 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
         newConfig.graph.values = newConfig.graph.commonSetting.pivot.values;
         delete newConfig.graph.commonSetting.pivot;
       }
+      if (angular.equals($scope.config, newConfig)) {
+        return;
+      }
       console.debug('committVizConfig', newConfig);
       let newParams = angular.copy(paragraph.settings.params);
       commitParagraphResult(paragraph.title, paragraph.text, newConfig, newParams);


### PR DESCRIPTION
### What is this PR for?
Fix an issue that makes an infinite loop while switching the visualizations.

An infinite loop occurs because the front-end web application tries to commit the paragraph even if there are no changes in the visualization configuration.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4280

### How should this be tested?
If you switch quickly between different visualizations multiple times, the infinite loops should not happen.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No