### PR TITLE
ZEPPELIN-4275. No error message when no interpreter is found

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -426,10 +426,11 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
       }
     } catch (InterpreterNotFoundException e) {
       InterpreterResult intpResult =
-          new InterpreterResult(InterpreterResult.Code.ERROR);
+          new InterpreterResult(InterpreterResult.Code.ERROR,
+                  String.format("Interpreter %s not found", this.intpText));
       setReturn(intpResult, e);
       setStatus(Job.Status.ERROR);
-      throw new RuntimeException(e);
+      return false;
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -433,6 +433,23 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   }
 
   @Test
+  public void testInvalidInterpreter() throws IOException, InterruptedException {
+    Note note = notebook.createNote("note1", anonymous);
+    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    p1.setText("%invalid abc");
+    p1.setAuthenticationInfo(anonymous);
+    note.run(p1.getId());
+
+    Thread.sleep(2 * 1000);
+    assertEquals(p1.getStatus(), Status.ERROR);
+    InterpreterResult result = p1.getReturn();
+    assertEquals(InterpreterResult.Code.ERROR, result.code());
+    assertEquals("Interpreter invalid not found", result.message().get(0).getData());
+    assertNull(p1.getDateStarted());
+    notebook.removeNote(note.getId(), anonymous);
+  }
+
+  @Test
   public void testRunAll() throws IOException {
     Note note = notebook.createNote("note1", anonymous);
 


### PR DESCRIPTION
### What is this PR for?

This is a trivial PR to display an error message when user specifies invalid interpreter name. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4275

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
