### PR TITLE
[ZEPPELIN-4241] Configure the interpreter docker container time zone

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -60,6 +60,8 @@
 # export ZEPPELIN_NOTEBOOK_ONE_WAY_SYNC	# If there are multiple notebook storages, should we treat the first one as the only source of truth?
 # export ZEPPELIN_NOTEBOOK_PUBLIC   # Make notebook public by default when created, private otherwise
 
+# export DOCKER_TIME_ZONE # Set to the same time zone as the zeppelin server. E.g, "America/New_York" or "Asia/Shanghai"
+
 #### Spark interpreter configuration ####
 
 ## Kerberos ticket refresh setting

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -203,7 +203,7 @@ Zeppelin can run locally (such as inside your IDE in debug mode) and able to run
 
 1. zeppelin-site.xml
 
-| Environment variable | Value | Description |
+| Configuration variable | Value | Description |
 | ----- | ----- | ----- |
 | ZEPPELIN_RUN_MODE | docker | Make Zeppelin run interpreter on Docker |
 | ZEPPELIN_DOCKER_CONTAINER_IMAGE | <image>:<version> | Zeppelin interpreter docker image to use |

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -99,7 +99,7 @@ ENV HADOOP_VERSION=2.7
 # support Kerberos certification
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq krb5-user libpam-krb5 && apt-get clean
 
-RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata
+RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata && apt-get clean
 
 # auto upload zeppelin interpreter lib
 RUN rm -rf /zeppelin

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -58,21 +58,28 @@ vi `/etc/docker/daemon.json`, Add `tcp://0.0.0.0:2375` to the `hosts` configurat
 
 ## Quickstart
 
-Modify these 2 configuration items in `zeppelin-site.xml`.
+1. Modify these 2 configuration items in `zeppelin-site.xml`.
 
 ```
-  <property>
-    <name>zeppelin.run.mode</name>
-    <value>docker</value>
-    <description>'auto|local|k8s|docker'</description>
-  </property>
+<property>
+  <name>zeppelin.run.mode</name>
+  <value>docker</value>
+  <description>'auto|local|k8s|docker'</description>
+</property>
 
-  <property>
-    <name>zeppelin.docker.container.image</name>
-    <value>apache/zeppelin</value>
-    <description>Docker image for interpreters</description>
-  </property>
+<property>
+  <name>zeppelin.docker.container.image</name>
+  <value>apache/zeppelin</value>
+  <description>Docker image for interpreters</description>
+</property>
+```
 
+2. set timezone in zeppelin-env.sh
+
+Set to the same time zone as the zeppelin server, keeping the time zone in the interpreter docker container the same as the server. E.g, `"America/New_York"` or `"Asia/Shanghai"`
+
+```
+export DOCKER_TIME_ZONE="America/New_York"
 ```
 
 
@@ -90,12 +97,14 @@ ENV SPARK_VERSION=2.3.3
 ENV HADOOP_VERSION=2.7
 
 # support Kerberos certification
-RUN install -yq curl unzip wget grep sed vim krb5-user libpam-krb5 && apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq krb5-user libpam-krb5 && apt-get clean
+
+RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata
 
 # auto upload zeppelin interpreter lib
-RUN rm /zeppelin -R
+RUN rm -rf /zeppelin
 
-RUN rm /spark -R
+RUN rm -rf /spark
 RUN wget https://www-us.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
@@ -192,8 +201,9 @@ Instead of build Zeppelin distribution package and docker image everytime during
 Zeppelin can run locally (such as inside your IDE in debug mode) and able to run Interpreter using [DockerInterpreterLauncher](https://github.com/apache/zeppelin/blob/master/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterLauncher.java) by configuring following environment variables.
 
 
+1. zeppelin-site.xml
+
 | Environment variable | Value | Description |
 | ----- | ----- | ----- |
 | ZEPPELIN_RUN_MODE | docker | Make Zeppelin run interpreter on Docker |
 | ZEPPELIN_DOCKER_CONTAINER_IMAGE | <image>:<version> | Zeppelin interpreter docker image to use |
-

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -20,12 +20,14 @@ ENV SPARK_VERSION=2.3.3
 ENV HADOOP_VERSION=2.7
 
 # support Kerberos certification
-RUN install -yq curl unzip wget grep sed vim krb5-user libpam-krb5 && apt-get clean
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq krb5-user libpam-krb5 && apt-get clean
+
+RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata
 
 # auto upload zeppelin interpreter lib
-RUN rm /zeppelin -R
+RUN rm -rf /zeppelin
 
-RUN rm /spark -R
+RUN rm -rf /spark
 RUN wget https://www-us.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -22,7 +22,7 @@ ENV HADOOP_VERSION=2.7
 # support Kerberos certification
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq krb5-user libpam-krb5 && apt-get clean
 
-RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata
+RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata && apt-get clean
 
 # auto upload zeppelin interpreter lib
 RUN rm -rf /zeppelin

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -459,9 +459,10 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
       // 8) ${ZEPPELIN_HOME}/lib/interpreter is uploaded to `${CONTAINER_ZEPPELIN_HOME}`
       //    directory in the container
-      String intpApiJarPath = "/interpreter/zeppelin-interpreter-api-0.9.0-SNAPSHOT.jar";
-      String zeplIntpApiJarPath = getPathByHome(zeppelinHome, intpApiJarPath);
-      copyFiles.put(zeplIntpApiJarPath, zeplIntpApiJarPath);
+      String libIntpPath = "/lib/interpreter";
+      String zeplLibIntpPath = getPathByHome(zeppelinHome, libIntpPath);
+      mkdirInContainer(containerId, zeplLibIntpPath);
+      docker.copyToContainer(new File(zeplLibIntpPath).toPath(), containerId, zeplLibIntpPath);
     }
 
     deployToContainer(containerId, copyFiles);

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -132,14 +132,14 @@ public class DockerInterpreterProcessTest {
     assertTrue(null != dockerProperties.get("zeppelin.interpreter.connect.timeout"));
 
     List<String> listEnvs = intp.getListEnvs();
-    assertEquals(listEnvs.size(), 5);
+    assertEquals(listEnvs.size(), 6);
     Map<String, String> mapEnv = new HashMap<>();
     for (int i = 0; i < listEnvs.size(); i++) {
       String env = listEnvs.get(i);
       String kv[] = env.split("=");
       mapEnv.put(kv[0], kv[1]);
     }
-    assertEquals(mapEnv.size(), 5);
+    assertEquals(mapEnv.size(), 6);
     assertTrue(mapEnv.containsKey("ZEPPELIN_HOME"));
     assertTrue(mapEnv.containsKey("ZEPPELIN_CONF_DIR"));
     assertTrue(mapEnv.containsKey("ZEPPELIN_FORCE_STOP"));


### PR DESCRIPTION
### What is this PR for?
Need to set the interpreter container and zeppelin service to have the same time zone
Otherwise, the time in the container is inconsistent with the zeppelin server time.

### What type of PR is it?
[Improvement]


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4241

### How should this be tested?
[CI pass](https://travis-ci.org/liuxunorg/zeppelin/builds/566315011)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
