### PR TITLE
[ZEPPELIN-4237] Fix zeppelin-interpreter-api.jar path error uploaded to container

### DIFF
--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -447,14 +447,16 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
       // 7) ${ZEPPELIN_HOME}/interpreter/spark is uploaded to `${CONTAINER_ZEPPELIN_HOME}`
       //    directory in the container
-      String intpPath = "/interpreter/" + interpreterGroupName;
-      String zeplIntpPath = getPathByHome(zeppelinHome, intpPath);
-      mkdirInContainer(containerId, zeplIntpPath);
-      docker.copyToContainer(new File(zeplIntpPath).toPath(), containerId, zeplIntpPath);
+      String intpGrpPath = "/interpreter/" + interpreterGroupName;
+      String intpGrpAllPath = getPathByHome(zeppelinHome, intpGrpPath);
+      mkdirInContainer(containerId, intpGrpAllPath);
+      docker.copyToContainer(new File(intpGrpAllPath).toPath(), containerId, intpGrpAllPath);
 
-      // 8) ${ZEPPELIN_HOME}/lib/interpreter/zeppelin-interpreter-api-0.9.0-SNAPSHOT.jar
+      // 8) ${ZEPPELIN_HOME}/lib/interpreter/zeppelin-interpreter-api-<version>.jar
       //    is uploaded to `${CONTAINER_ZEPPELIN_HOME}` directory in the container
-      Collection<File> listFiles = FileUtils.listFiles(new File(zeplIntpPath),
+      String intpPath = "/interpreter";
+      String intpAllPath = getPathByHome(zeppelinHome, intpPath);
+      Collection<File> listFiles = FileUtils.listFiles(new File(intpAllPath),
           FileFilterUtils.suffixFileFilter("jar"), null);
       for (File jarfile : listFiles) {
         String jarfilePath = jarfile.getAbsolutePath();

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -26,9 +26,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,43 +145,5 @@ public class DockerInterpreterProcessTest {
     assertTrue(mapEnv.containsKey("ZEPPELIN_FORCE_STOP"));
     assertTrue(mapEnv.containsKey("SPARK_HOME"));
     assertTrue(mapEnv.containsKey("MY_ENV1"));
-  }
-
-  @Test
-  public void findZeppelinInterpreterApiJar() {
-    File file = null;
-    try {
-      Properties properties = new Properties();
-      properties.setProperty(
-          ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
-
-      HashMap<String, String> envs = new HashMap<String, String>();
-      envs.put("MY_ENV1", "V1");
-
-      DockerInterpreterProcess intp = new DockerInterpreterProcess(
-          zconf,
-          "interpreter-container:1.0",
-          "shared_process",
-          "sh",
-          "shell",
-          properties,
-          envs,
-          "zeppelin.server.hostname",
-          "12320",
-          5000);
-
-      file = new File("zeppelin-interpreter-api-0.9.0-SNAPSHOT.jar");
-      if (!file.exists()) {
-        file.createNewFile();
-      }
-      ArrayList<String> jarFiles = intp.findFile("./", "*.jar");
-      assertTrue(jarFiles.size() > 0);
-    } catch (Exception e) {
-      LOGGER.error(e.getMessage(), e);
-    } finally {
-      if (null != file) {
-        file.delete();
-      }
-    }
   }
 }

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -26,7 +26,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,5 +147,43 @@ public class DockerInterpreterProcessTest {
     assertTrue(mapEnv.containsKey("ZEPPELIN_FORCE_STOP"));
     assertTrue(mapEnv.containsKey("SPARK_HOME"));
     assertTrue(mapEnv.containsKey("MY_ENV1"));
+  }
+
+  @Test
+  public void findZeppelinInterpreterApiJar() {
+    File file = null;
+    try {
+      Properties properties = new Properties();
+      properties.setProperty(
+          ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
+
+      HashMap<String, String> envs = new HashMap<String, String>();
+      envs.put("MY_ENV1", "V1");
+
+      DockerInterpreterProcess intp = new DockerInterpreterProcess(
+          zconf,
+          "interpreter-container:1.0",
+          "shared_process",
+          "sh",
+          "shell",
+          properties,
+          envs,
+          "zeppelin.server.hostname",
+          "12320",
+          5000);
+
+      file = new File("zeppelin-interpreter-api-0.9.0-SNAPSHOT.jar");
+      if (!file.exists()) {
+        file.createNewFile();
+      }
+      ArrayList<String> jarFiles = intp.findFile("./", "*.jar");
+      assertTrue(jarFiles.size() > 0);
+    } catch (Exception e) {
+      LOGGER.error(e.getMessage(), e);
+    } finally {
+      if (null != file) {
+        file.delete();
+      }
+    }
   }
 }


### PR DESCRIPTION
### What is this PR for?
1. Because the `zeppelin-interpreter-api-<version>.jar` file modifies the path, it needs to be modified accordingly.
2. Search for the `*.jar` file in the `zeppelin/interpreter/` directory and upload it to the docker container to resolve the issue.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4237

### How should this be tested?
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/566415288)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
