### PR TITLE
[ZEPPELIN-4299] disable autocomplete in note-name-filter and interpreter search

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -41,10 +41,12 @@ limitations under the License.
     <div class="row">
       <div class="col-md-4">
         <div class="input-group" style="margin-top: 10px">
-          <input type="text" ng-model="searchInterpreter"
-                 class="form-control ng-pristine ng-untouched ng-valid ng-empty"
-                 ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
-                 placeholder="Search interpreters"/>
+          <form>
+            <input type="text" ng-model="searchInterpreter"
+                   class="form-control ng-pristine ng-untouched ng-valid ng-empty"
+                   ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }"
+                   placeholder="Search interpreters"/>
+          </form>
           <span class="input-group-btn">
             <button type="submit" class="btn btn-default" ng-disabled="!navbar.connected">
               <i class="glyphicon glyphicon-search"></i>

--- a/zeppelin-web/src/components/note-name-filter/note-name-filter.html
+++ b/zeppelin-web/src/components/note-name-filter/note-name-filter.html
@@ -11,9 +11,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<form>
 <input type="text"
        class="note-name-query form-control"
        ng-click="$event.stopPropagation()"
        placeholder="&#xf002 Filter"
        ng-model="$parent.query.q"
        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 300, 'blur': 0 } }" />
+</form>


### PR DESCRIPTION
### What is this PR for?
In chrome browser,
After login with saved-autocomplete feature in chrome and input username in note filter then refresh, note filter is filled username automatically.
It also happen in interpreter page.

this happening with just chrome.
in past, it is not happening this in chrome.

I think that disable auto-complete feature in note filter is better.

### What type of PR is it?
[Improvement]

### Todos
* [x] - modify

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4299

### How should this be tested?
* Login with autocomplete feature in chrome
* input username in note filter
* refresh
* refresh In interpreter page

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No
