### PR TITLE
[ZEPPELIN-4284] Fix cluster metadata interpreter offline timeout calculation error

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterMonitor.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterMonitor.java
@@ -157,7 +157,7 @@ public class ClusterMonitor {
         if (heartbeat instanceof LocalDateTime) {
           LocalDateTime dHeartbeat = (LocalDateTime) heartbeat;
           Duration duration = Duration.between(dHeartbeat, now);
-          long timeInterval = duration.getSeconds();
+          long timeInterval = duration.getSeconds() * 1000; // Convert to milliseconds
           if (timeInterval > heartbeatTimeout) {
             // Set the metadata for the heartbeat timeout to offline
             // Cannot delete metadata


### PR DESCRIPTION
### What is this PR for?
The interpreter heartbeat time unit recorded in the cluster metadata is seconds.
The timeout calculation formula was incorrectly used in milliseconds.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4284

### How should this be tested?
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/572129364)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
