### PR TITLE
ZEPPELIN-4304 Allow to override useNativeGit property of the gitcommitid plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,8 @@
     <plugin.deploy.version>2.8.2</plugin.deploy.version>
     <plugin.shade.version>3.1.1</plugin.shade.version>
 
+    <plugin.gitcommitid.useNativeGit>false</plugin.gitcommitid.useNativeGit>
+
     <PermGen>64m</PermGen>
     <MaxPermGen>512m</MaxPermGen>
 
@@ -527,6 +529,7 @@
         <configuration>
           <skipPoms>false</skipPoms>
           <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+          <useNativeGit>${plugin.gitcommitid.useNativeGit}</useNativeGit>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <failOnNoGitDirectory>false</failOnNoGitDirectory>


### PR DESCRIPTION
## What is this PR for?

It's now possible to override value of the `useNativeGit` configuration property of the
git commit id plugin with `plugin.gitcommitid.useNativeGit` property, like this:

```
mvn package -Dplugin.gitcommitid.useNativeGit=true
```

### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?

ZEPPELIN-4304

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No