### PR TITLE
[ZEPPELIN-4305] LocalStorageConfig.atomicWriteToFile throws exception

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.storage;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterInfoSaving;
@@ -103,11 +104,15 @@ public class LocalConfigStorage extends ConfigStorage {
     atomicWriteToFile(credentials, credentialPath);
   }
 
-  private String readFromFile(File file) throws IOException {
-    return IOUtils.toString(new FileInputStream(file));
+  @VisibleForTesting
+  static String readFromFile(File file) throws IOException {
+    try (FileInputStream is = new FileInputStream(file)) {
+      return IOUtils.toString(is);
+    }
   }
 
-  private void atomicWriteToFile(String content, File file) throws IOException {
+  @VisibleForTesting
+  static void atomicWriteToFile(String content, File file) throws IOException {
     FileSystem defaultFileSystem = FileSystems.getDefault();
     Path destinationFilePath = defaultFileSystem.getPath(file.getCanonicalPath());
     File tempFile = Files.createTempFile(destinationFilePath.getParent(), file.getName(), null).toFile();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/LocalConfigStorage.java
@@ -123,8 +123,9 @@ public class LocalConfigStorage extends ConfigStorage {
     Path destinationFilePath = defaultFileSystem.getPath(file.getCanonicalPath());
     try {
       file.getParentFile().mkdirs();
-      Files.move(tempFile.toPath(), destinationFilePath,
-              StandardCopyOption.ATOMIC_MOVE);
+      Path tempDestinationFile = defaultFileSystem.getPath(file.getCanonicalPath() + ".tmp");
+      Files.move(tempFile.toPath(), tempDestinationFile);
+      Files.move(tempDestinationFile, destinationFilePath,  StandardCopyOption.ATOMIC_MOVE);
     } catch (IOException iox) {
       if (!tempFile.delete()) {
         tempFile.deleteOnExit();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/storage/LocalConfigStorageTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/storage/LocalConfigStorageTest.java
@@ -1,0 +1,50 @@
+package org.apache.zeppelin.storage;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class LocalConfigStorageTest {
+    public static final String TEST_STRING = "this is a test!";
+
+    @Test
+    public void testWritingAtomically() throws IOException {
+        final Path destination = Files.createTempFile("test-", "file");
+        final File destinationFile = destination.toFile();
+        try {
+            LocalConfigStorage.atomicWriteToFile(TEST_STRING, destinationFile);
+            try (InputStream is = Files.newInputStream(destination)) {
+                String read = IOUtils.toString(is);
+                assertEquals(TEST_STRING, read);
+            }
+        } finally {
+            Files.deleteIfExists(destination);
+        }
+    }
+
+    @Test
+    public void testReading() throws IOException {
+        final Path destination = Files.createTempFile("test-", "file");
+        final File destinationFile = destination.toFile();
+
+        try {
+            try (BufferedWriter writer = Files.newBufferedWriter(destination)) {
+                writer.write(TEST_STRING);
+            }
+            String read = LocalConfigStorage.readFromFile(destinationFile);
+            assertEquals(TEST_STRING, read);
+        } finally {
+            Files.deleteIfExists(destination);
+        }
+    }
+
+
+}


### PR DESCRIPTION
### What is this PR for?

The hotfix that was made several weeks ago changed behavior of LocalStorageConfig.atomicWriteToFile, that started to atomically move files to destination. But this works without errors only when temporary directory and destination are on the same disk. When they are on different disks, atomic move isn't possible, so the exception is thrown.

This PR fixes this by performing non-atomic move to temp file on destination file system, and then atomically rename it to destination file.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

ZEPPELIN-4305

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No
