### PR TITLE
[ZEPPELIN-4312] enable livy to run as remote interpreter in docker

### DIFF
--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -404,6 +404,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       LOGGER.warn("{} file not found, Did not upload the krb5.conf to the container!", krb5conf);
     }
 
+    // TODO: Interpreter specific settings, we should consider general property or some other more elegant solution
     // 3) Get the keytab file in each interpreter properties
     // Upload Keytab file to container, Keep the same directory as local host
     // 3.1) shell interpreter properties keytab file

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -194,6 +194,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     // Create container with exposed ports
     final ContainerConfig containerConfig = ContainerConfig.builder()
         .hostConfig(hostConfig)
+        .hostname(this.zeppelinServiceHost)
         .image(containerImage)
         .workingDir("/")
         .env(listEnv)
@@ -416,14 +417,18 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       intpKeytab = properties.getProperty("submarine.hadoop.keytab", "");
     }
     if (StringUtils.isBlank(intpKeytab)) {
-      // 3.4) jdbc interpreter properties keytab file
+      // 3.4) livy interpreter properties keytab file
+      intpKeytab = properties.getProperty("zeppelin.livy.keytab", "");
+    }
+    if (StringUtils.isBlank(intpKeytab)) {
+      // 3.5) jdbc interpreter properties keytab file
       intpKeytab = properties.getProperty("zeppelin.jdbc.keytab.location", "");
     }
     if (!StringUtils.isBlank(intpKeytab) && !copyFiles.containsKey(intpKeytab)) {
       LOGGER.info("intpKeytab : {}", intpKeytab);
       copyFiles.put(intpKeytab, intpKeytab);
     }
-    // 3.5) zeppelin server keytab file
+    // 3.6) zeppelin server keytab file
     String zeppelinServerKeytab = zconf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
     if (!StringUtils.isBlank(zeppelinServerKeytab)
         && !copyFiles.containsKey(zeppelinServerKeytab)) {


### PR DESCRIPTION
### What is this PR for?
This pull request enables livy interpreter to run as remote interpreter in docker. This is (hopefully) improvement of @liuxunorg `s work on running remote interpreters in docker

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4312

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
No