### PR TITLE
[ZEPPELIN-2680] Allow opening notebook as a reader

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -809,7 +809,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
         minimumInputLength: 3,
       };
 
-      $scope.setIamOwner();
+      $scope.setMyPermissions();
       angular.element('#selectOwners').select2(selectJson);
       angular.element('#selectReaders').select2(selectJson);
       angular.element('#selectRunners').select2(selectJson);
@@ -1190,14 +1190,36 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     }
   };
 
-  $scope.setIamOwner = function() {
-    if ($scope.permissions.owners.length > 0 &&
-      _.indexOf($scope.permissions.owners, $rootScope.ticket.principal) < 0) {
-      $scope.isOwner = false;
-      return false;
+  const arrayIntersection = function(arrayFirst, arraySecond) {
+    return arrayFirst.filter(function(x) {
+      if(arraySecond.indexOf(x) !== -1) {
+        return true;
+      } else {
+        return false;
+      }
+    });
+  };
+
+  $scope.setMyPermissions = function() {
+    let myPermissions;
+    try {
+      myPermissions = JSON.parse($rootScope.ticket.roles);
+    } catch(err) {
+      myPermissions = [];
     }
-    $scope.isOwner = true;
-    return true;
+    myPermissions.push($rootScope.ticket.principal);
+
+    $scope.isOwner = !($scope.permissions.owners.length > 0 &&
+       arrayIntersection(myPermissions, $scope.permissions.owners).length === 0);
+
+    $scope.isWriter = !($scope.permissions.writers.length > 0 &&
+       arrayIntersection(myPermissions, $scope.permissions.writers).length === 0);
+
+    if (!$scope.isOwner && !$scope.isWriter) {
+      $scope.viewOnly = true;
+      $scope.note.config.looknfeel = 'report';
+      initializeLookAndFeel();
+    }
   };
 
   $scope.toggleNotePersonalizedMode = function() {

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -744,7 +744,9 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       }, newParagraphConfig.results[resultIndex], paragraph, resultIndex);
       renderResult($scope.type, true);
     } else {
-      return websocketMsgSrv.commitParagraph(paragraph.id, title, text, newParagraphConfig, params);
+      if (! $scope.viewOnly) {
+        return websocketMsgSrv.commitParagraph(paragraph.id, title, text, newParagraphConfig, params);
+      }
     }
   };
 


### PR DESCRIPTION
What is this PR for?
--------------------

When users only have reader permissions over a notebook AND the notebook
contains a chart, the app sends a COMMIT_PARAGRAPH for each paragraph,
which causes a write permission popup to show
("Insufficient privileges to write note").

Ths issue is with function commitParagraphResult in `result.controller.js`.

The original [fix](https://github.com/apache/zeppelin/pull/2439)
introduced a nasty bug that dramatically increased CPU usage and was never
merged.

This PR fixes the bug. It also automatically switches to `report` mode
as it is pointless to show UI features that the user is not allowed
to control.

What type of PR is it?
----------------------
Bug Fix

What is the Jira issue?
-----------------------
[ZEPPELIN-2680](https://issues.apache.org/jira/browse/ZEPPELIN-2680)

Questions:

- Does the licenses files need update? No
- Is there breaking changes for older versions? No
- Does this needs documentation? No