### PR TITLE
[ZEPPELIN-4278]: Fixed closing bracket in bin/common.cmd

### DIFF
--- a/bin/common.cmd
+++ b/bin/common.cmd
@@ -74,7 +74,7 @@ if not defined ZEPPELIN_JAVA_OPTS (
 if defined ZEPPELIN_JMX_ENABLE (
   if not defined ZEPPELIN_JMX_PORT (
     set ZEPPELIN_JMX_PORT="9996"
-  }
+  )
   set JMX_JAVA_OPTS=" -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${ZEPPELIN_JMX_PORT} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
   set ZEPPELIN_JAVA_OPTS=%JMX_JAVA_OPTS% %ZEPPELIN_JAVA_OPTS
 )


### PR DESCRIPTION
### What is this PR for?
Fixed closing bracket in common.cmd file, that was causing error on running zeppelin in Windows environment


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4278

### How should this be tested?
User should be able to run Zeppelin on Windows environment

### Questions:
* Does the licenses files need update?
  * No
* Is there breaking changes for older versions?
  * No
* Does this needs documentation?
  * No

