### PR TITLE
[ZEPPELIN-4281] Fixed unusable after cluster mode restarts interpreter

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterCallback.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterCallback.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.cluster;
+
+import org.apache.zeppelin.interpreter.launcher.InterpreterClient;
+
+public interface ClusterCallback<T> {
+  InterpreterClient online(T result);
+
+  void offline();
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterManagerServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterManagerServer.java
@@ -285,7 +285,8 @@ public class ClusterManagerServer extends ClusterManager {
   }
 
   public void unicastClusterEvent(String host, int port, String topic, String msg) {
-    LOGGER.info("send unicastClusterEvent message {}", msg);
+    LOGGER.info("send unicastClusterEvent host:{} port:{} topic:{} message:{}",
+        host, port, topic, msg);
 
     Address address = Address.from(host, port);
     CompletableFuture<byte[]> response = messagingService.sendAndReceive(address,
@@ -293,8 +294,6 @@ public class ClusterManagerServer extends ClusterManager {
     response.whenComplete((r, e) -> {
       if (null == e) {
         LOGGER.error(e.getMessage(), e);
-      } else {
-        LOGGER.info("unicastClusterEvent success! {}", msg);
       }
     });
   }

--- a/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/cluster/src/test/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterLauncherTest.java
@@ -23,6 +23,8 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -31,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ClusterInterpreterLauncherTest extends ClusterMockTest {
+  private static Logger LOGGER = LoggerFactory.getLogger(ClusterInterpreterLauncherTest.class);
 
   @BeforeClass
   public static void startTest() throws IOException, InterruptedException {
@@ -63,12 +66,12 @@ public class ClusterInterpreterLauncherTest extends ClusterMockTest {
     InterpreterLaunchContext context = new InterpreterLaunchContext(properties, option, null,
         "user1", "intpGroupId", "groupId",
         "groupName", "name", 0, "host");
+
     InterpreterClient client = launcher.launch(context);
 
     assertTrue(client instanceof RemoteInterpreterRunningProcess);
     RemoteInterpreterRunningProcess interpreterProcess = (RemoteInterpreterRunningProcess) client;
-    assertEquals("INTP_TSERVER_HOST", interpreterProcess.getHost());
-    assertEquals(0, interpreterProcess.getPort());
+    assertEquals("127.0.0.1", interpreterProcess.getHost());
     assertEquals("name", interpreterProcess.getInterpreterSettingName());
     assertEquals(5000, interpreterProcess.getConnectTimeout());
   }

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -223,8 +223,10 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       execInContainer(containerId, dockerCommand, false);
     } catch (DockerException e) {
       LOGGER.error(e.getMessage(), e);
+      throw new IOException(e.getMessage());
     } catch (InterruptedException e) {
       LOGGER.error(e.getMessage(), e);
+      throw new IOException(e.getMessage());
     }
 
     long startTime = System.currentTimeMillis();
@@ -236,6 +238,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
           dockerStarted.wait(getConnectTimeout());
         } catch (InterruptedException e) {
           LOGGER.error("Remote interpreter is not accessible");
+          throw new IOException(e.getMessage());
         }
       }
     }


### PR DESCRIPTION
### What is this PR for?
In cluster mode,
After restarting the interpreter,
The cluster metadata sets the process state of the interpreter to offline.
The interpreter could not be executed again due to a judgment error.

### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4281

### How should this be tested?
[CI Pass](https://travis-ci.org/liuxunorg/zeppelin/builds/577750017) And completed 4 test cases

1. ClusterInterpreterLauncherTest::testConnectExistOnlineIntpProcess()
2. ClusterInterpreterLauncherTest::testConnectExistOfflineIntpProcess()
3. ClusterInterpreterLauncherTest::testCreateIntpProcessDockerMode()
4. ClusterInterpreterLauncherTest::testCreateIntpProcessLocalMode()

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
