### PR TITLE
[ZEPPELIN-4298] Fix broken link on credentials page

### DIFF
--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -14,7 +14,7 @@
 
 angular.module('zeppelinWebApp').controller('CredentialCtrl', CredentialController);
 
-function CredentialController($scope, $http, baseUrlSrv, ngToast) {
+function CredentialController($scope, $rootScope, $http, baseUrlSrv, ngToast) {
   'ngInject';
 
   ngToast.dismiss();
@@ -197,6 +197,17 @@ function CredentialController($scope, $http, baseUrlSrv, ngToast) {
       ngToast.danger({content: message, verticalPosition: verticalPosition, timeout: timeout});
     }
   }
+
+  $scope.getCredentialDocsLink = function() {
+    const currentVersion = $rootScope.zeppelinVersion;
+    const isVersionOver0Point7 = currentVersion && currentVersion.split('.')[1] > 7;
+    /*
+     * Add '/setup' to doc link on the version over 0.7.0
+     */
+    return `https://zeppelin.apache.org/docs/${currentVersion}${
+      isVersionOver0Point7 ? '/setup' : ''
+    }/security/datasource_authorization.html`;
+  };
 
   let init = function() {
     getAvailableInterpreters();

--- a/zeppelin-web/src/app/credential/credential.html
+++ b/zeppelin-web/src/app/credential/credential.html
@@ -21,7 +21,7 @@ limitations under the License.
         <div class="pull-right" style="margin-top:10px;">
           <a style="cursor:pointer;margin-right:10px;text-decoration:none;"
              target="_blank"
-             ng-href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/security/datasource_authorization.html"
+             ng-href="{{getCredentialDocsLink()}}"
              tooltip-placement="bottom" uib-tooltip="Learn more">
             <i class="icon-question" ng-style="{color: showRepositoryInfo ? '#3071A9' : 'black' }"></i>
           </a>


### PR DESCRIPTION
### What is this PR for?
Fix broken link on credentials page

Problem: The doc url changed for the `datasource_authorization.html` changed over the version 0.7

(Under version 0.7)
https://zeppelin.apache.org/docs/`0.7.3/`security/datasource_authorization.html

(Over version 0.7)
https://zeppelin.apache.org/docs/`0.8.1/setup/`security/datasource_authorization.html
https://zeppelin.apache.org/docs/`0.9.0-SNAPSHOT/setup/`security/datasource_authorization.html


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4307

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
![Sep-03-2019 00-14-43](https://user-images.githubusercontent.com/3839771/64123633-e54de800-cddf-11e9-8047-e3c7ea23cf7b.gif)


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
