### PR TITLE
[ZEPPELIN-4014] Show note name on the search list, not the note id

### DIFF
--- a/zeppelin-web/src/components/note-list/note-list.factory.js
+++ b/zeppelin-web/src/components/note-list/note-list.factory.js
@@ -25,8 +25,12 @@ function NoteListFactory(arrayOrderingSrv, TRASH_FOLDER_ID) {
     setNotes: function(notesList) {
       // a flat list to boost searching
       notes.flatList = _.map(notesList, (note) => {
+        let notePath = note.path || note.id;
+        let nodes = notePath.match(/([^\/][^\/]*)/g) || [];
+
         note.isTrash = note.path
           ? note.path.split('/')[1] === TRASH_FOLDER_ID : false;
+        note.name = nodes.pop();
         return note;
       });
 


### PR DESCRIPTION
### What is this PR for?

The note IDs were shown on the search list(even if it's filtered by note's name)
Need to show note name rather than id.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4014

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
(Before: Notebook IDs are shown)
![image](https://user-images.githubusercontent.com/3839771/64126895-8346b000-cdea-11e9-87a7-54cf5c3a21d9.png)

(After: Notebook names are shown)
![image](https://user-images.githubusercontent.com/3839771/64126858-5f836a00-cdea-11e9-9604-91622c52bfba.png)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
