### PR TITLE
[ZEPPELIN-4319] Fix spell interpreter parse text logic

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -374,9 +374,9 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
 
     try {
       // remove magic from paragraphText
-      const splited = paragraphText.split(magic);
+      const splited = paragraphText.slice(paragraphText.indexOf(magic) + magic.length);
       // remove leading spaces
-      const textWithoutMagic = splited[1].replace(/^\s+/g, '');
+      const textWithoutMagic = splited.replace(/^\s+/g, '');
 
       if (!propagated) {
         $scope.paragraph.dateStarted = $scope.getFormattedParagraphTime();


### PR DESCRIPTION
### What is this PR for?
Spell interpreter returns incorrect results when paragraph having magic in between text, with current approach to get text without magic 


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4319

### How should this be tested?
* Enable zeppelin-markdown-spell
* Run %markdown paragraph with containing %markdown as text within it
* Verify if result is valid and complete

### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/7022342/64242037-72995580-cf22-11e9-9e8f-491673986991.png)
After:
![image](https://user-images.githubusercontent.com/7022342/64242045-76c57300-cf22-11e9-8bc0-dc54239525e0.png)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
