### PR TITLE
ZEPPELIN-4329 fix building Scio with Scala 2.11

### DIFF
--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -34,15 +34,18 @@
   <name>Zeppelin: Beam interpreter</name>
   
   <properties>
+    <interpreter.name>beam</interpreter.name>
+
     <beam.hadoop.version>2.3.0</beam.hadoop.version>
     <beam.spark.version>1.6.2</beam.spark.version>
     <beam.beam.version>2.0.0</beam.beam.version>
+    <beam.scala.binary.version>2.10</beam.scala.binary.version>
 
     <!-- library versions -->
     <netty.version>4.1.1.Final</netty.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <commons.exec.version>1.3</commons.exec.version>
-    <interpreter.name>beam</interpreter.name>
+    <avro.version>1.8.1</avro.version> <!-- should match beam dependency -->
   </properties>
   
   <dependencies>
@@ -54,7 +57,7 @@
     
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_${beam.scala.binary.version}</artifactId>
       <version>${beam.spark.version}</version>
       <exclusions>
         <exclusion>
@@ -66,15 +69,15 @@
           <groupId>io.netty</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-actor_2.10</artifactId>
+          <artifactId>akka-actor_${beam.scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-remote_2.10</artifactId>
+          <artifactId>akka-remote_${beam.scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>akka-slf4j_2.10</artifactId>
+          <artifactId>akka-slf4j_${beam.scala.binary.version}</artifactId>
           <groupId>org.spark-project.akka</groupId>
         </exclusion>
       </exclusions>
@@ -82,7 +85,7 @@
   
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-streaming_2.10</artifactId>
+      <artifactId>spark-streaming_${beam.scala.binary.version}</artifactId>
       <version>${beam.spark.version}</version>
     </dependency>
 
@@ -118,7 +121,7 @@
 
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
-      <artifactId>zeppelin-scio_${scala.binary.version}</artifactId>
+      <artifactId>zeppelin-scio</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -222,10 +225,8 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-flink_${scala.binary.version}</artifactId>
+      <artifactId>beam-runners-flink_${beam.scala.binary.version}</artifactId>
       <version>${beam.beam.version}</version>
-      <exclusions>
-      </exclusions>
     </dependency>
   
     <dependency>
@@ -238,6 +239,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>${commons.exec.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,10 @@
   <properties>
     <!-- language versions -->
     <java.version>1.8</java.version>
-    <scala.version>2.10.5</scala.version>
+    <scala.2.10.version>2.10.5</scala.2.10.version>
+    <scala.version>${scala.2.10.version}</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
+    <scala.2.11.version>2.11.8</scala.2.11.version>
     <scalatest.version>3.0.7</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 
@@ -752,7 +754,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <scala.version>2.10.5</scala.version>
+        <scala.version>${scala.2.10.version}</scala.version>
         <scala.binary.version>2.10</scala.binary.version>
       </properties>
     </profile>
@@ -760,7 +762,7 @@
     <profile>
       <id>scala-2.11</id>
       <properties>
-        <scala.version>2.11.8</scala.version>
+        <scala.version>${scala.2.11.version}</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
       </properties>
     </profile>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <groupId>org.apache.zeppelin</groupId>
-  <artifactId>zeppelin-scio_2.10</artifactId>
+  <artifactId>zeppelin-scio</artifactId>
   <packaging>jar</packaging>
   <version>0.9.0-SNAPSHOT</version>
   <name>Zeppelin: Scio</name>
@@ -39,6 +39,8 @@
     <!--library versions-->
     <scio.version>0.2.4</scio.version>
     <guava.version>14.0.1</guava.version> <!-- update needed -->
+    <scio.scala.version>${scala.2.10.version}</scio.scala.version>
+    <scio.scala.binary.version>2.10</scio.scala.binary.version>
 
     <!--plugin versions-->
     <plugin.scala.version>2.15.2</plugin.scala.version>
@@ -52,7 +54,7 @@
 
     <dependency>
       <groupId>com.spotify</groupId>
-      <artifactId>scio-repl_${scala.binary.version}</artifactId>
+      <artifactId>scio-repl_${scio.scala.binary.version}</artifactId>
       <version>${scio.version}</version>
     </dependency>
 
@@ -65,25 +67,25 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${scala.2.10.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${scala.2.10.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${scala.2.10.version}</version>
     </dependency>
 
     <!-- test libraries -->
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <artifactId>scalatest_${scio.scala.binary.version}</artifactId>
       <version>${scalatest.version}</version>
       <scope>test</scope>
     </dependency>
@@ -137,6 +139,9 @@
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
         <version>${plugin.scala.version}</version>
+        <configuration>
+          <scalaVersion>${scio.scala.version}</scalaVersion>
+        </configuration>
         <executions>
           <execution>
             <id>compile</id>
@@ -177,15 +182,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
### What is this PR for?

Goal is to make Scio & Beam interpreters buildable with Scala 2.11 profile.

Now both Scio & Beam interpreters explicitly use Scala 2.10, so it's possible
to compile both if Scala 2.11 profile is enabled.

Also was need to add missing dependency for Beam interpreter, otherwise it didn't work.

Plus small rework of the properties, so the Scala 2.10 version could be explicitly used in
the interpreters. (Also, tried Scala 2.10.7, and it didn't work, so we must stay on 2.10.5).

### What type of PR is it?
Bug Fix 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4329

### How should this be tested?

* Tested manually by building both default & Scala 2.10 profiles 
* Travis CI build: https://travis-ci.org/alexott/zeppelin/builds/585186691