### PR TITLE
[ZEPPELIN-4331] Use latest version of Java driver for Cassandra

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -26,19 +26,19 @@
     </parent>
 
     <groupId>org.apache.zeppelin</groupId>
-    <artifactId>zeppelin-cassandra_2.10</artifactId>
+    <artifactId>zeppelin-cassandra</artifactId>
     <packaging>jar</packaging>
     <version>0.9.0-SNAPSHOT</version>
     <name>Zeppelin: Apache Cassandra interpreter</name>
     <description>Zeppelin cassandra support</description>
 
     <properties>
-        <cassandra.driver.version>3.0.1</cassandra.driver.version>
-        <snappy.version>1.0.5.4</snappy.version>
-        <lz4.version>1.3.0</lz4.version>
+        <cassandra.driver.version>3.7.2</cassandra.driver.version>
+        <snappy.version>1.1.2.6</snappy.version>
+        <lz4.version>1.4.1</lz4.version>
         <commons-lang.version>3.3.2</commons-lang.version>
         <scalate.version>1.7.1</scalate.version>
-        <cassandra.guava.version>16.0.1</cassandra.guava.version>
+        <cassandra.guava.version>19.0</cassandra.guava.version>
 
         <!-- test library versions -->
         <achilles.version>3.2.4-Zeppelin</achilles.version>
@@ -88,8 +88,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
             <version>${lz4.version}</version>
         </dependency>
 

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -812,6 +812,10 @@ Below are the configuration parameters and their default values.
 
 ## Change Log
 
+**3.1** _(Zeppelin {{ site.ZEPPELIN_VERSION }})_ :
+
+* Upgrade Java driver to 3.7.2 ([ZEPPELIN-4331](https://issues.apache.org/jira/browse/ZEPPELIN-4331);
+
 **3.0** _(Zeppelin {{ site.ZEPPELIN_VERSION }})_ :
 
 * Update documentation

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -67,8 +67,9 @@ The following components are provided under Apache License.
     (Apache 2.0) xml apis (xml-apis:xml-apis:jar:1.4.01 - http://xerces.apache.org/xml-commons/components/external)
     (Apache 2.0) java-xmlbuilder (com.jamesmurty.utils:java-xmlbuilder:jar:1.0 - https://github.com/jmurty/java-xmlbuilder)
     (Apache 2.0) compress-lzf (com.ning:compress-lzf:jar:1.0.3 - https://github.com/ning/compress) Copyright 2009-2010 Ning, Inc.
+    (Apache 2.0) java-driver-core (com.datastax.oss:java-driver-core:jar:3.7.2 - https://github.com/datastax/java-driver)
     (Apache 2.0) Snappy-java (org.xerial.snappy:snappy-java:1.1.2.4 - https://github.com/xerial/snappy-java/)
-    (Apache 2.0) lz4-java (net.jpountz.lz4:lz4:jar:1.3.0 - https://github.com/jpountz/lz4-java)
+    (Apache 2.0) lz4-java (org.lz4:lz4-java:jar:1.4.1 - https://github.com/lz4/lz4-java)
     (Apache 2.0) RoaringBitmap (org.roaringbitmap:RoaringBitmap:jar:0.5.11 - https://github.com/lemire/RoaringBitmap)
     (Apache 2.0) json4s (org.json4s:json4s-ast_2.10:jar:3.2.10 - https://github.com/json4s/json4s)
     (Apache 2.0) HPPC Collections (com.carrotsearch:hppc:0.7.1 - http://labs.carrotsearch.com/hppc.html/hppc)


### PR DESCRIPTION
### What is this PR for?

This change will allow to get access to latest fixes & improvements implemented in the
Datastax Java driver for Cassandra.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4331

### How should this be tested?
* Automated build: https://travis-ci.org/alexott/zeppelin/builds/585461796
* Manually tested CQL commands

