### PR TITLE
[ZEPPELIN-4322] Flaky test: NotebookRestApiTest#testRunWithServerRestart

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ZeppelinServerMock.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ZeppelinServerMock.java
@@ -174,6 +174,12 @@ public class ZeppelinServerMock {
       ZeppelinServer.jettyWebServer.stop();
       executor.shutdown();
       PluginManager.reset();
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName());
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_WAR.getVarName());
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_CONF_DIR.getVarName());
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_CONFIG_FS_DIR.getVarName());
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT.getVarName());
+      System.clearProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName());
 
       long s = System.currentTimeMillis();
       boolean started = true;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -53,6 +53,7 @@ public class NoteManager {
   private Folder trash;
 
   private NotebookRepo notebookRepo;
+  // noteId -> notePath
   private Map<String, String> notesInfo;
 
   public NoteManager(NotebookRepo notebookRepo) throws IOException {


### PR DESCRIPTION
### What is this PR for?
The root cause of this flaky test is due to that the note may be removed when paragraph job is still running. And the job will still send rpc message to zeppelin-server side which may cause unexpected exception. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4322

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
