### PR TITLE
[ZEPPELIN-4166] Change default binding address to 127.0.0.1 (previously 0.0.0.0)

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -18,6 +18,8 @@
 
 # export JAVA_HOME=
 # export MASTER=                 		# Spark master url. eg. spark://master_addr:7077. Leave empty if you want to use local mode.
+# export ZEPPELIN_ADDR                  # Bind address (default 127.0.0.1)
+# export ZEPPELIN_PORT                  # port number to listen (default 8080)
 # export ZEPPELIN_LOCAL_IP              # Zeppelin's thrift server ip address, if not specified, one random IP address will be choosen.
 # export ZEPPELIN_JAVA_OPTS      		# Additional jvm options. for example, export ZEPPELIN_JAVA_OPTS="-Dspark.executor.memory=8g -Dspark.cores.max=16"
 # export ZEPPELIN_MEM            		# Zeppelin jvm mem options Default -Xms1024m -Xmx1024m -XX:MaxPermSize=512m

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -27,8 +27,8 @@
 
 <property>
   <name>zeppelin.server.addr</name>
-  <value>0.0.0.0</value>
-  <description>Server address</description>
+  <value>127.0.0.1</value>
+  <description>Server binding address</description>
 </property>
 
 <property>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -40,6 +40,12 @@ If both are defined, then the **environment variables** will take priority.
     <th class="col-md-4">Description</th>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_ADDR</h6></td>
+    <td><h6 class="properties">zeppelin.server.addr</h6></td>
+    <td>127.0.0.1</td>
+    <td>Zeppelin server binding address</td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_PORT</h6></td>
     <td><h6 class="properties">zeppelin.server.port</h6></td>
     <td>8080</td>

--- a/docs/setup/operation/upgrading.md
+++ b/docs/setup/operation/upgrading.md
@@ -39,7 +39,11 @@ So, copying `notebook` and `conf` directory should be enough.
 
  - From 0.9, we change the notes file name structure ([ZEPPELIN-2619](https://issues.apache.org/jira/browse/ZEPPELIN-2619)) and move permissions info from `notebook-authorization.json` into note file itself [ZEPPELIN-3985](https://issues.apache.org/jira/browse/ZEPPELIN-3985). So when you upgrading zeppelin to 0.9, you need to upgrade note file. Here's steps you need to follow:
    1. Backup your notes file in case the upgrade fails
-   2. Call `bin/upgrade-note.sh -d` to upgrade note, `-d` option means to delete the old note file, missing this option will keep the old file.  
+   2. Call `bin/upgrade-note.sh -d` to upgrade note, `-d` option means to delete the old note file, missing this option will keep the old file.
+ - From 0.9, Zeppelin server bind `127.0.0.1` by default instead of `0.0.0.0`. Configure `zeppelin.server.addr` property or `ZEPPELIN_ADDR` env variable to change.   
+   
+### Upgrading from Zeppelin 0.8.1 (and before) to 0.8.2 (and later)
+ - From 0.8.2, Zeppelin server bind `127.0.0.1` by default instead of `0.0.0.0`. Configure `zeppelin.server.addr` property or `ZEPPELIN_ADDR` env variable to change.         
 
 ### Upgrading from Zeppelin 0.7 to 0.8
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -787,7 +787,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
    */
   public enum ConfVars {
     ZEPPELIN_HOME("zeppelin.home", "./"),
-    ZEPPELIN_ADDR("zeppelin.server.addr", "0.0.0.0"),
+    ZEPPELIN_ADDR("zeppelin.server.addr", "127.0.0.1"),
     ZEPPELIN_PORT("zeppelin.server.port", 8080),
     ZEPPELIN_SERVER_CONTEXT_PATH("zeppelin.server.context.path", "/"),
     ZEPPELIN_SSL("zeppelin.ssl", false),


### PR DESCRIPTION
### What is this PR for?
This PR changes default Zeppelin server binding address from `0.0.0.0` to `127.0.0.1`.
Also update related configuration templates and document.

### What type of PR is it?
mprovement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4166

### How should this be tested?
Build and run Zeppelin server with default configuration and see if default port is listening in address 127.0.0.1 instead of 0.0.0.0 (netstat -na | grep 8080) 

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? yes
