### PR TITLE
[ZEPPELIN-4226] Fix "View in Spark web UI" in kubernetes mode

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -60,8 +60,6 @@ public class SparkInterpreter extends AbstractInterpreter {
 
   private SparkVersion sparkVersion;
   private boolean enableSupportedVersionCheck;
-  private String sparkUrl;
-
 
   public SparkInterpreter(Properties properties) {
     super(properties);
@@ -109,11 +107,6 @@ public class SparkInterpreter extends AbstractInterpreter {
       }
       sqlContext = this.innerInterpreter.getSqlContext();
       sparkSession = this.innerInterpreter.getSparkSession();
-      sparkUrl = this.innerInterpreter.getSparkUrl();
-      String sparkUrlProp = getProperty("zeppelin.spark.uiWebUrl", "");
-      if (!StringUtils.isBlank(sparkUrlProp)) {
-        sparkUrl = sparkUrlProp;
-      }
 
       SESSION_NUM.incrementAndGet();
     } catch (Exception e) {
@@ -258,10 +251,6 @@ public class SparkInterpreter extends AbstractInterpreter {
       }
     }
     return depFiles;
-  }
-
-  public String getSparkUIUrl() {
-    return sparkUrl;
   }
 
   public boolean isUnsupportedSparkVersion() {

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class SparkInterpreterTest {
@@ -88,8 +89,6 @@ public class SparkInterpreterTest {
     interpreter = new SparkInterpreter(properties);
     interpreter.setInterpreterGroup(mock(InterpreterGroup.class));
     interpreter.open();
-
-    assertEquals("fake_spark_weburl", interpreter.getSparkUIUrl());
 
     InterpreterResult result = interpreter.interpret("val a=\"hello world\"", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
@@ -181,7 +180,9 @@ public class SparkInterpreterTest {
     assertEquals("pid_2", captorEvent.getValue().get("paraId"));
 
     // spark job url is sent
-    verify(mockRemoteEventClient).onParaInfosReceived(any(Map.class));
+    ArgumentCaptor<Map> onParaInfosReceivedArg = ArgumentCaptor.forClass(Map.class);
+    verify(mockRemoteEventClient).onParaInfosReceived(onParaInfosReceivedArg.capture());
+    assertTrue(((String) onParaInfosReceivedArg.getValue().get("jobUrl")).startsWith("fake_spark_weburl"));
 
     // case class
     result = interpreter.interpret("val bankText = sc.textFile(\"bank.csv\")", getInterpreterContext());

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -23,6 +23,7 @@ import java.net.URLClassLoader
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.zeppelin.interpreter.util.InterpreterOutputStream
@@ -304,7 +305,7 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
   protected def createZeppelinContext(): Unit = {
     val sparkShims = SparkShims.getInstance(sc.version, properties)
     var webUiUrl = properties.getProperty("zeppelin.spark.uiWebUrl");
-    if (webUiUrl == null || webUiUrl.trim().length() == 0) {
+    if (StringUtils.isBlank(webUiUrl)) {
       webUiUrl = sparkUrl;
     }
     sparkShims.setupSparkListener(sc.master, webUiUrl, InterpreterContext.get)

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -303,7 +303,11 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
 
   protected def createZeppelinContext(): Unit = {
     val sparkShims = SparkShims.getInstance(sc.version, properties)
-    sparkShims.setupSparkListener(sc.master, sparkUrl, InterpreterContext.get)
+    var webUiUrl = properties.getProperty("zeppelin.spark.uiWebUrl");
+    if (webUiUrl == null || webUiUrl.trim().length() == 0) {
+      webUiUrl = sparkUrl;
+    }
+    sparkShims.setupSparkListener(sc.master, webUiUrl, InterpreterContext.get)
 
     z = new SparkZeppelinContext(sc, sparkShims,
       interpreterGroup.getInterpreterHookRegistry,


### PR DESCRIPTION
### What is this PR for?
When Zeppelin is running in Kubernetes, "View in Spark web UI" gives internal address, instead of address defined in SERVICE_DOMAIN.

I think this problem is side effect of https://github.com/apache/zeppelin/pull/3375 and this PR includes fix and updated unittest.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4226

### How should this be tested?
Run Zeppelin on kubernetes, and run spark job, click "View in Spark web UI" button.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
