### PR TITLE
ZEPPELIN-4335 Deleting a Notebook is vulnerable to XSS attach 

### DIFF
--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -107,7 +107,7 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, ng
         closeByBackdrop: false,
         closeByKeyboard: false,
         title: 'Insufficient privileges',
-        message: data.info.toString(),
+        message: _.escape(data.info.toString()),
         buttons: btn,
       });
     } else if (op === 'PARAGRAPH') {


### PR DESCRIPTION
### What is this PR for?
Fix of : ZEPPELIN-4335 Deleting a Notebook is vulnerable to XSS attach 

Issue reproduction steps :

1) create a notebook
2) give the permission to notebook as : <script>alert('hi')</script> (press space after writing this, not enter key)
3) after this, try to delete the notebook, the BootstrapDialog that popups stating insufficient privilages is vulnerable to XSS attack

### What type of PR is it?
BUG FIX ZEPPELIN-4335 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4335

### How should this be tested?

Test as per reproduction steps : 
1) create a notebook
2) give the permission to notebook as : <script>alert('hi')</script> (press space after writing this, not enter key)
3) after this, try to delete the notebook, the BootstrapDialog that popups stating insufficient privilages is vulnerable to XSS attack

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
