### PR TITLE
[ZEPPELIN-4337] Make Zeppelin runs on kubernetes with different domain suffix

### DIFF
--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -61,7 +61,7 @@ data:
         server_name "~(?<svc_port>[0-9]+)-(?<svc_name>[^.]*)\.(.*)";
         location / {
           resolver 127.0.0.1:53 ipv6=off;
-          proxy_pass http://$svc_name.NAMESPACE.svc.cluster.local:$svc_port;
+          proxy_pass http://$svc_name.NAMESPACE.svc:$svc_port;
           proxy_set_header Host $host;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -321,7 +321,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   }
 
   private String getInterpreterPodDnsName() {
-    return String.format("%s.%s.svc.cluster.local",
+    return String.format("%s.%s.svc",
         getPodName(), // service name and pod name is the same
         kubectl.getNamespace());
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -103,12 +103,12 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
 
   /**
    * get Zeppelin server host dns.
-   * return <hostname>.<namespace>.svc.cluster.local
+   * return <hostname>.<namespace>.svc
    * @throws IOException
    */
   private String getZeppelinServiceHost() throws IOException {
     if (isRunningOnKubernetes()) {
-      return String.format("%s.%s.svc.cluster.local",
+      return String.format("%s.%s.svc",
               getHostname(), // service name and pod name should be the same
               getNamespace());
     } else {

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -60,7 +60,7 @@ public class K8sRemoteInterpreterProcessTest {
     int port = intp.getPort();
 
     // then
-    assertEquals(String.format("%s.%s.svc.cluster.local", intp.getPodName(), kubectl.getNamespace()), intp.getHost());
+    assertEquals(String.format("%s.%s.svc", intp.getPodName(), kubectl.getNamespace()), intp.getHost());
     assertEquals(12321, intp.getPort());
   }
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
@@ -53,7 +53,7 @@ public class K8sStandardInterpreterLauncherTest {
     Properties properties = new Properties();
     properties.setProperty("ENV_1", "VALUE_1");
     properties.setProperty("property_1", "value_1");
-    properties.setProperty("CALLBACK_HOST", "zeppelin-server.default.svc.cluster.local");
+    properties.setProperty("CALLBACK_HOST", "zeppelin-server.default.svc");
     properties.setProperty("CALLBACK_PORT", "12320");
     InterpreterOption option = new InterpreterOption();
     option.setUserImpersonate(true);


### PR DESCRIPTION
### What is this PR for?

A couple of hardcoded dns suffix in the source code (cluster.local). Remove them so Zeppelin have better compatibility with Kubernetes cluster with dns name.

### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4337

### How should this be tested?
Should work on Kubernetes cluster with different cluster dns name than 'cluster.local'

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
