### PR TITLE
[ZEPPELIN-4347]: add seperate shortcuts for run all above/below

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -509,33 +509,18 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
     $scope.$emit('runAllBelowAndCurrent', paragraph, true);
   };
 
-  $scope.runAllToOrFromThis = function(paragraph) {
-    BootstrapDialog.show({
-      message: 'Run paragraphs:',
-      title: '',
-      buttons: [{
-        label: 'Close',
-        action: function(dialog) {
-          dialog.close();
-        },
-      },
-      {
-        label: 'Run all above',
-        cssClass: 'btn-primary',
-        action: function(dialog) {
-          $scope.$emit('runAllAbove', paragraph, false);
-          dialog.close();
-        },
-      },
-      {
-        label: 'Run current and all below',
-        cssClass: 'btn-primary',
-        action: function(dialog) {
-          $scope.$emit('runAllBelowAndCurrent', paragraph, false);
-          dialog.close();
-        },
-      }],
-    });
+  $scope.runAllFromThisFromShortcut = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
+    $scope.$emit('runAllBelowAndCurrent', paragraph, false);
+  };
+
+  $scope.runAllToThisFromShortcut = function(paragraph) {
+    if ($scope.isNoteRunning) {
+      return;
+    }
+    $scope.$emit('runAllAbove', paragraph, false);
   };
 
   $scope.turnOnAutoRun = function(paragraph) {
@@ -1686,9 +1671,11 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         $timeout(() => $scope.$emit('moveFocusToNextParagraph', paragraphId));
       } else if (!keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13) { // Shift + Enter
         $scope.runParagraphFromShortcut($scope.getEditorValue());
-      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 13) { // Ctrl + Shift + Enter
-        $scope.runAllToOrFromThis($scope.paragraph);
-      } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c
+      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 38) { // Ctrl + Shift + UP
+        $scope.runAllToThisFromShortcut($scope.paragraph);
+      } else if (keyEvent.ctrlKey && keyEvent.shiftKey && keyCode === 40) { // Ctrl + Shift + Down
+        $scope.runAllFromThisFromShortcut($scope.paragraph);
+      }else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 67) { // Ctrl + Alt + c
         $scope.cancelParagraph($scope.paragraph);
       } else if (keyEvent.ctrlKey && keyEvent.altKey && keyCode === 68) { // Ctrl + Alt + d
         $scope.removeParagraph($scope.paragraph);

--- a/zeppelin-web/src/app/notebook/shortcut.html
+++ b/zeppelin-web/src/app/notebook/shortcut.html
@@ -39,11 +39,22 @@ limitations under the License.
 
           <tr>
             <td>
-              <div class="col-md-8">Run all above/below paragraphs</div>
+              <div class="col-md-8">Run all above paragraphs (exclusive)</div>
             </td>
             <td>
               <div class="keys">
-                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">Enter</kbd>
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">UP</kbd>
+              </div>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <div class="col-md-8">Run all below paragraphs (inclusive)</div>
+            </td>
+            <td>
+              <div class="keys">
+                <kbd class="kbd-default">Ctrl</kbd> + <kbd class="kbd-default">Shift</kbd> + <kbd class="kbd-default">DOWN</kbd>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
### What is this PR for?
Currently same shortcut is configured for run all above and run all below, clicking on shortcut will again show popup to choose run all above or run all below. With this additional action required from user it doesn't makes sense to use shortcut.


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4347

### How should this be tested?
* Ctrl + Shift + UP shortcut should run all the paragraphs above
* Ctrl  + Shift + Down shortcut should run all the paragraphs below and the current one

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
