### PR TITLE
[WIP] [ZEPPELIN-4350]. Paragraph pending for a long time when interpreter process fails to launch

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -231,13 +231,16 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess {
     @Override
     public void onProcessComplete(int exitValue) {
       LOGGER.warn("Process is exited with exit value " + exitValue);
+      if (env.getOrDefault("ZEPPELIN_SPARK_YARN_CLUSTER", "false").equals("false")) {
+        // don't call notify in yarn-cluster mode
+        synchronized (this) {
+          notify();
+        }
+      }
       // For yarn-cluster mode, client process will exit with exit value 0
       // after submitting spark app. So don't move to TERMINATED state when exitValue is 0.
       if (exitValue != 0) {
         transition(State.TERMINATED);
-        synchronized (this) {
-          notify();
-        }
       } else {
         transition(State.COMPLETED);
       }


### PR DESCRIPTION
### What is this PR for?
Before this PR, paragraph will be in pending for a long time until timeout when interpreter process fails to launch. After this PR, paragraph will finished with error status at once when interpreter fails to launch.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4350

### How should this be tested?
* CI pass


### Screenshots (if appropriate)
![Untitled](https://user-images.githubusercontent.com/164491/65587098-dd84fc00-dfb7-11e9-81ca-92cbb378e20c.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
