### PR TITLE
[ZEPPELIN-4351] Unittest broken after ZEPPELIN-4311

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -383,6 +383,6 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
   }
 
   private static String getSimulatedMarkdownResult(String markdown) {
-    return String.format("<div class=\"markdown-body\">\n<p>%s</p>\n</div>", markdown);
+    return String.format("<div class=\"markdown-body\">\n<p>%s</p>\n\n</div>", markdown);
   }
 }


### PR DESCRIPTION
### What is this PR for?
Unittest is broken after ZEPPELIN-4311.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4351

### How should this be tested?
* This should make 4th test profile in .travis.yaml pass. 7th profile is broken with other reason.

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
