### PR TITLE
[ZEPPELIN-4354]. Enhance z.angular for more flexiable data sharing

### DIFF
--- a/python/src/main/resources/python/zeppelin_context.py
+++ b/python/src/main/resources/python/zeppelin_context.py
@@ -61,6 +61,12 @@ class PyZeppelinContext(object):
     def get(self, key):
         return self.__getitem__(key)
 
+    def angular(self, key, noteId = None, paragraphId = None):
+        return self.z.angular(key, noteId, paragraphId)
+
+    def angularBind(self, key, value, noteId = None, paragraphId = None):
+        return self.z.angularBind(key, value, noteId, paragraphId)
+
     def getInterpreterContext(self):
         return self.z.getInterpreterContext()
 

--- a/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
+++ b/spark/interpreter/src/main/resources/R/zeppelin_sparkr.R
@@ -66,6 +66,14 @@ z.put <- function(name, object) {
 z.get <- function(name) {
   SparkR:::callJMethod(.zeppelinContext, "get", name)
 }
+z.angular <- function(name, noteId=NULL, paragraphId=NULL) {
+  SparkR:::callJMethod(.zeppelinContext, "angular", name, noteId, paragraphId)
+}
+
+z.angularBind <- function(name, value, noteId=NULL, paragraphId=NULL) {
+  SparkR:::callJMethod(.zeppelinContext, "angularBind", name, value, noteId, paragraphId)
+}
+
 z.input <- function(name, value) {
   SparkR:::callJMethod(.zeppelinContext, "input", name, value)
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectRegistry.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObjectRegistry.java
@@ -35,9 +35,7 @@ public class AngularObjectRegistry {
   private final String GLOBAL_KEY = "_GLOBAL_";
   private AngularObjectRegistryListener listener;
   private String interpreterId;
-  
-
-  AngularObjectListener angularObjectListener;
+  private AngularObjectListener angularObjectListener;
 
   public AngularObjectRegistry(final String interpreterId,
       final AngularObjectRegistryListener listener) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/BaseZeppelinContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/BaseZeppelinContext.java
@@ -407,19 +407,12 @@ public abstract class BaseZeppelinContext {
     runNote(context.getNoteId());
   }
 
-  private AngularObject getAngularObject(String name, InterpreterContext interpreterContext) {
+  private AngularObject getAngularObject(String name,
+                                         String noteId,
+                                         String paragraphId,
+                                         InterpreterContext interpreterContext) {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
-    String noteId = interpreterContext.getNoteId();
-    // try get local object
-    AngularObject paragraphAo = registry.get(name, noteId, interpreterContext.getParagraphId());
-    AngularObject noteAo = registry.get(name, noteId, null);
-
-    AngularObject ao = paragraphAo != null ? paragraphAo : noteAo;
-
-    if (ao == null) {
-      // then global object
-      ao = registry.get(name, null, null);
-    }
+    AngularObject ao = registry.get(name, noteId, paragraphId);
     return ao;
   }
 
@@ -432,7 +425,27 @@ public abstract class BaseZeppelinContext {
    */
   @ZeppelinApi
   public Object angular(String name) {
-    AngularObject ao = getAngularObject(name, interpreterContext);
+    AngularObject ao = getAngularObject(name, interpreterContext.getNoteId(),
+            interpreterContext.getParagraphId(), interpreterContext);
+    if (ao == null) {
+      return null;
+    } else {
+      return ao.get();
+    }
+  }
+
+  public Object angular(String name, String noteId) {
+    AngularObject ao = getAngularObject(name, noteId,
+            interpreterContext.getParagraphId(), interpreterContext);
+    if (ao == null) {
+      return null;
+    } else {
+      return ao.get();
+    }
+  }
+
+  public Object angular(String name, String noteId, String paragraphId) {
+    AngularObject ao = getAngularObject(name, noteId, paragraphId, interpreterContext);
     if (ao == null) {
       return null;
     } else {
@@ -601,6 +614,7 @@ public abstract class BaseZeppelinContext {
    *
    * @param name name of the variable
    * @param o    value
+   * @param noteId
    */
   public void angularBind(String name, Object o, String noteId) throws TException {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
@@ -609,6 +623,25 @@ public abstract class BaseZeppelinContext {
       registry.add(name, o, noteId, null);
     } else {
       registry.get(name, noteId, null).set(o);
+    }
+  }
+
+  /**
+   * Create angular variable in notebook scope and bind with front end Angular display system.
+   * If variable exists, it'll be overwritten.
+   *
+   * @param name name of the variable
+   * @param o    value
+   * @param noteId
+   * @param paragraphId
+   */
+  public void angularBind(String name, Object o, String noteId, String paragraphId) throws TException {
+    AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
+
+    if (registry.get(name, noteId, paragraphId) == null) {
+      registry.add(name, o, noteId, paragraphId);
+    } else {
+      registry.get(name, noteId, paragraphId).set(o);
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

This PR enhance method `z.angular` in `%spark.r` and `%spark.pyspark` so that angular variables defined in frontend can be shared in backend `%spark`, `%spark.r`, `%spark.pyspark`



### What type of PR is it?
[ Improvement | Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4354


### How should this be tested?
* CI pass

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/67553926-e694f480-f740-11e9-826c-4e16034d659c.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
