### PR TITLE
[ZEPPELIN-4364]credentials.json should use Hadoop Config Storage

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -521,7 +521,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   }
 
   public String getCredentialsPath() {
-    return getRelativeDir(String.format("%s/credentials.json", getConfDir()));
+    return getConfigFSDir() + "/credentials.json";
   }
 
   public String getShiroPath() {


### PR DESCRIPTION
### What is this PR for?
As described in https://medium.com/@zjffdu/zeppelin-0-8-0-new-features-ea53e8810235. when `zeppelin.config.storage.class` set to `org.apache.zeppelin.storage.FileSystemConfigStorage`
`interpreter.json, notebook-authorization.json , credentials.json` should use Hadoop Config Storage instead. This PR is for fixing `credentials.json` does not work with that setting.
### What type of PR is it?
Bug Fix

### Todos
* [x] - Fix credentials.json does not get stored on HDFS

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4364
### How should this be tested?
Automatically tested.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
