### PR TITLE
[ZEPPELIN-4360] Always use Scala 2.11 for Ignite

### DIFF
--- a/conf/interpreter-list
+++ b/conf/interpreter-list
@@ -29,7 +29,7 @@ geode           org.apache.zeppelin:zeppelin-geode:0.9.0                Apache G
 groovy          org.apache.zeppelin:zeppelin-groovy:0.9.0               Groovy interpreter
 hazelcastjet    org.apache.zeppelin:zeppelin-hazelcastjet:0.9.0         Hazelcast Jet interpreter
 hbase           org.apache.zeppelin:zeppelin-hbase:0.9.0                Hbase interpreter
-ignite          org.apache.zeppelin:zeppelin-ignite_2.10:0.9.0          Ignite interpreter built with Scala 2.10
+ignite          org.apache.zeppelin:zeppelin-ignite:0.9.0               Ignite interpreter
 java            org.apache.zeppelin:zeppelin-java:0.9.0                 Java interpreter
 jdbc            org.apache.zeppelin:zeppelin-jdbc:0.9.0                 Jdbc interpreter
 kylin           org.apache.zeppelin:zeppelin-kylin:0.9.0                Kylin interpreter

--- a/docs/interpreter/ignite.md
+++ b/docs/interpreter/ignite.md
@@ -58,12 +58,12 @@ At the "Interpreters" menu, you may edit Ignite interpreter or create new one. Z
   <tr>
     <td>ignite.addresses</td>
     <td>127.0.0.1:47500..47509</td>
-    <td>Coma separated list of Ignite cluster hosts. See [Ignite Cluster Configuration](https://apacheignite.readme.io/docs/cluster-config) section for more details.</td>
+    <td>Coma separated list of Ignite cluster hosts. See <a href="https://apacheignite.readme.io/docs/cluster-config">Ignite Cluster Configuration</a> section for more details.</td>
   </tr>
   <tr>
     <td>ignite.clientMode</td>
     <td>true</td>
-    <td>You can connect to the Ignite cluster as client or server node. See [Ignite Clients vs. Servers](https://apacheignite.readme.io/docs/clients-vs-servers) section for details. Use true or false values in order to connect in client or server mode respectively.</td>
+    <td>You can connect to the Ignite cluster as client or server node. See <a href="https://apacheignite.readme.io/docs/clients-vs-servers">Ignite Clients vs. Servers</a> section for details. Use true or false values in order to connect in client or server mode respectively.</td>
   </tr>
   <tr>
     <td>ignite.config.url</td>
@@ -78,7 +78,7 @@ At the "Interpreters" menu, you may edit Ignite interpreter or create new one. Z
   <tr>
     <td>ignite.peerClassLoadingEnabled</td>
     <td>true</td>
-    <td>Enables peer-class-loading. See [Zero Deployment](https://apacheignite.readme.io/docs/zero-deployment) section for details. Use true or false values in order to enable or disable P2P class loading respectively.</td>
+    <td>Enables peer-class-loading. See <a href="https://apacheignite.readme.io/docs/zero-deployment">Zero Deployment</a> section for details. Use true or false values in order to enable or disable P2P class loading respectively.</td>
   </tr>
 </table>
 
@@ -125,4 +125,4 @@ collectionAsScalaIterable(res).foreach(println _)
 
 ![Using Scala Code]({{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/ignite-scala-example.png)
 
-Apache Ignite also provides a guide docs for Zeppelin ["Ignite with Apache Zeppelin"](https://apacheignite.readme.io/docs/data-analysis-with-apache-zeppelin)
+Apache Ignite also provides a guide docs for Zeppelin ["Ignite with Apache Zeppelin"](https://apacheignite-sql.readme.io/docs/apache-zeppelin)

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -27,14 +27,18 @@
     <relativePath>../zeppelin-interpreter-parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>zeppelin-ignite_2.10</artifactId>
+  <artifactId>zeppelin-ignite</artifactId>
   <packaging>jar</packaging>
   <version>0.9.0-SNAPSHOT</version>
   <name>Zeppelin: Apache Ignite interpreter</name>
 
   <properties>
     <interpreter.name>ignite</interpreter.name>
-    <ignite.version>2.3.0</ignite.version>
+    <ignite.version>2.7.6</ignite.version>
+    <ignite.scala.version>${scala.2.11.version}</ignite.scala.version>
+
+    <!--plugin versions-->
+    <plugin.scala.version>2.15.2</plugin.scala.version>
   </properties>
 
   <dependencies>
@@ -66,25 +70,55 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
+      <version>${ignite.scala.version}</version>
     </dependency>
 
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <version>${plugin.scala.version}</version>
+        <configuration>
+          <scalaVersion>${ignite.scala.version}</scalaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>

--- a/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
+++ b/ignite/src/main/java/org/apache/zeppelin/ignite/IgniteSqlInterpreter.java
@@ -39,7 +39,7 @@ import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
 
 /**
- * Apache Ignite SQL interpreter (http://ignite.incubator.apache.org/).
+ * Apache Ignite SQL interpreter (http://ignite.apache.org/).
  *
  * Use {@code ignite.jdbc.url} property to set up JDBC connection URL.
  * URL has the following pattern:
@@ -60,9 +60,7 @@ public class IgniteSqlInterpreter extends Interpreter {
   private Logger logger = LoggerFactory.getLogger(IgniteSqlInterpreter.class);
 
   private Connection conn;
-
   private Throwable connEx;
-
   private Statement curStmt;
 
   public IgniteSqlInterpreter(Properties property) {
@@ -74,19 +72,17 @@ public class IgniteSqlInterpreter extends Interpreter {
     try {
       Class.forName(IGNITE_JDBC_DRIVER_NAME);
     } catch (ClassNotFoundException e) {
-      logger.error("Can't open connection", e);
+      logger.error("Can't find Ignite JDBC driver", e);
       connEx = e;
       return;
     }
 
     try {
       logger.info("connect to " + getProperty(IGNITE_JDBC_URL));
-
       conn = DriverManager.getConnection(getProperty(IGNITE_JDBC_URL));
       connEx = null;
-
       logger.info("Successfully created JDBC connection");
-    } catch (SQLException e) {
+    } catch (Exception e) {
       logger.error("Can't open connection: ", e);
       connEx = e;
     }
@@ -113,11 +109,8 @@ public class IgniteSqlInterpreter extends Interpreter {
     }
 
     StringBuilder msg = new StringBuilder("%table ");
-
     try (Statement stmt = conn.createStatement()) {
-
       curStmt = stmt;
-
       try (ResultSet res = stmt.executeQuery(st)) {
         ResultSetMetaData md = res.getMetaData();
 
@@ -125,10 +118,8 @@ public class IgniteSqlInterpreter extends Interpreter {
           if (i > 1) {
             msg.append('\t');
           }
-
           msg.append(md.getColumnName(i));
         }
-
         msg.append('\n');
 
         while (res.next()) {


### PR DESCRIPTION
also bump dependencies & update docs

### What is this PR for?

Ignite interpreter uses Scala interface to Ignite that is built only with Scala 2.11, while inside Zeppelin it was compiled with global Scala dependency (Scala 2.10 by default), so it didn't work out of box. Also, the Ignite dependency was updated to the latest version.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4360

### How should this be tested?

unit tests + manual tests were done