### PR TITLE
[HOTFIX] [ZEPPELIN-4356] revert ShiroAuthenticationService to Singleton

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -154,7 +154,7 @@ public class ZeppelinServer extends ResourceConfig {
             bindAsContract(AuthorizationService.class).to(Singleton.class);
             // TODO(jl): Will make it more beautiful
             if (!StringUtils.isBlank(conf.getShiroPath())) {
-              bind(ShiroAuthenticationService.class).to(AuthenticationService.class).in(Immediate.class);
+              bind(ShiroAuthenticationService.class).to(AuthenticationService.class).in(Singleton.class);
             } else {
               // TODO(jl): Will be added more type
               bind(NoAuthenticationService.class).to(AuthenticationService.class).in(Singleton.class);


### PR DESCRIPTION
### What is this PR for?
This is caused due to the merge of #3468.
Before merging this I tried this on my local, but guess I had some cache jar causing it to work, however it was broken.


### What type of PR is it?
[Hot Fix]


### How should this be tested?
* Zeppelin should work with authentication enabled

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
