### PR TITLE
[ZEPPELIN-4389]. Add new interpreter if it is newly detected in interpreter folder

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -289,6 +289,15 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
       interpreterSettings.put(savedInterpreterSetting.getId(), savedInterpreterSetting);
     }
 
+    for (InterpreterSetting interpreterSettingTemplate : interpreterSettingTemplates.values()) {
+      InterpreterSetting interpreterSetting = new InterpreterSetting(interpreterSettingTemplate);
+      initInterpreterSetting(interpreterSetting);
+      // add newly detected interpreter if it doesn't exist in interpreter.json
+      if (!interpreterSettings.containsKey(interpreterSetting.getId())) {
+        interpreterSettings.put(interpreterSetting.getId(), interpreterSetting);
+      }
+    }
+
     if (infoSaving.interpreterRepositories != null) {
       for (RemoteRepository repo : infoSaving.interpreterRepositories) {
         if (!dependencyResolver.getRepos().contains(repo)) {


### PR DESCRIPTION
### What is this PR for?
For now, if we put or build new interpreter for zeppelin in `ZEPPELIN_HOME/interpreter` folder, it won't be created automatically, user have to manually create new interpreter in interpreter page.  

This PR is to create the newly detected interpreter automatically for user. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4389

### How should this be tested?
* Manually tested. 
Build a fresh new zeppelin without building shell interpreter, and then start it, no shell interpreter in the interpreter setting page. Then build a new shell interpreter and restart it, shell interpreter is displayed in the interpreter setting page.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
