### PR TITLE
[ZEPPELIN-4393] Support for '--' comment in Cassandra interpreter

### DIFF
--- a/cassandra/src/main/scala/org/apache/zeppelin/cassandra/ParagraphParser.scala
+++ b/cassandra/src/main/scala/org/apache/zeppelin/cassandra/ParagraphParser.scala
@@ -136,8 +136,9 @@ class ParagraphParser extends RegexParsers{
   import ParagraphParser._
 
   def singleLineCommentHash: Parser[Comment] = """\s*#.*""".r ^^ {case text => Comment(text.trim.replaceAll("#",""))}
-  def singleLineCommentDoubleSlashes: Parser[Comment] = """\s*//.*""".r ^^ {case text => Comment(text.trim.replaceAll("//",""))}
-  def singleLineComment: Parser[Comment] = singleLineCommentHash | singleLineCommentDoubleSlashes
+  def singleLineCommentDoubleSlashes: Parser[Comment] = """\s*//.*""".r ^^ {case text => Comment(text.trim.replaceFirst("//\\s*",""))}
+  def singleLineCommentDoubleDash: Parser[Comment] = """\s*--.*""".r ^^ {case text => Comment(text.trim.replaceFirst("//\\s*",""))}
+  def singleLineComment: Parser[Comment] = singleLineCommentHash | singleLineCommentDoubleSlashes | singleLineCommentDoubleDash
 
   def multiLineComment: Parser[Comment] = """(?s)/\*(.*)\*/""".r ^^ {case text => Comment(text.trim.replaceAll("""/\*""","").replaceAll("""\*/""",""))}
 

--- a/cassandra/src/test/java/org/apache/zeppelin/cassandra/InterpreterLogicTest.java
+++ b/cassandra/src/test/java/org/apache/zeppelin/cassandra/InterpreterLogicTest.java
@@ -103,6 +103,34 @@ public class InterpreterLogicTest {
   }
 
   @Test
+  public void should_parse_input_string_block_with_comment_dash() throws Exception {
+    //Given
+    String input = "SELECT * FROM users LIMIT 10; -- this is a comment";
+
+    //When
+    final List<AnyBlock> anyBlocks = this.<AnyBlock>toJavaList(helper.parseInput(input));
+
+    //Then
+    assertThat(anyBlocks).hasSize(2);
+    assertThat(anyBlocks.get(0)).isInstanceOf(SimpleStm.class);
+    assertThat(anyBlocks.get(1)).isInstanceOf(TextBlockHierarchy.Comment.class);
+  }
+
+  @Test
+  public void should_parse_input_string_block_with_comment_slash() throws Exception {
+    //Given
+    String input = "SELECT * FROM users LIMIT 10; // this is a comment";
+
+    //When
+    final List<AnyBlock> anyBlocks = this.<AnyBlock>toJavaList(helper.parseInput(input));
+
+    //Then
+    assertThat(anyBlocks).hasSize(2);
+    assertThat(anyBlocks.get(0)).isInstanceOf(SimpleStm.class);
+    assertThat(anyBlocks.get(1)).isInstanceOf(TextBlockHierarchy.Comment.class);
+  }
+
+  @Test
   public void should_exception_while_parsing_input() throws Exception {
     //Given
     String input = "SELECT * FROM users LIMIT 10";

--- a/docs/interpreter/cassandra.md
+++ b/docs/interpreter/cassandra.md
@@ -202,14 +202,16 @@ The complete list of all CQL statements and versions can be found below:
 
 ## Comments in statements
 
-It is possible to add comments between statements. Single line comments start with the **hash sign** (#) or **double slashes** (//). Multi-line comments are enclosed between /** and **/. Ex:
+It is possible to add comments between statements. Single line comments start with the **hash sign** (`#`), **double slashes** (`//`),  **double dash** (`--`). Multi-line comments are enclosed between `/**` and `**/`. Ex:
 
 ```sql
 
-#Single line comment style 1
+# Single line comment style 1
 INSERT INTO users(login,name) VALUES('jdoe','John DOE');
 
-//Single line comment style 2
+// Single line comment style 2
+
+// Single line comment style 3
 
 /**
  Multi line


### PR DESCRIPTION
### What is this PR for?

Cassandra Query Language (CQL) supports 2 types of end-of-line comments - `//` and `--`, but Cassandra interpreter supports only first one, resulting in error when using `--` comment in the query.

### What type of PR is it?
Bug

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-4393

### How should this be tested?
* 2 unit tests were added - for both comments types
* Tested manually
* Travis build: https://travis-ci.org/alexott/zeppelin/builds/603532433

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Documentation was updated
