### PR TITLE
[ZEPPELIN-4397] Allow random userid for zeppelin process in container image

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -69,7 +69,7 @@ RUN echo "$LOG_TAG Install python related packages" && \
     apt-get install -y libpng-dev libfreetype6-dev libxft-dev && \
     # for tkinter
     apt-get install -y python-tk libxml2-dev libxslt-dev zlib1g-dev && \
-    pip install numpy==1.12.1 pandas==0.21.1 matplotlib==2.1.1 pandasql==0.7.3 ipython==5.4.1 jupyter_client==5.1.0 ipykernel==4.7.0 bokeh==0.12.10 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
+    pip install numpy==1.12.1 pandas==0.21.1 matplotlib==2.1.1 pandasql==0.7.3 ipython==5.4.1 jupyter_client==5.1.0 ipykernel==4.7.0 bokeh==0.12.10 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0 statsmodels==0.10.2
 
 RUN echo "$LOG_TAG Install R related packages" && \
     echo "deb http://cran.rstudio.com/bin/linux/ubuntu xenial/" | tee -a /etc/apt/sources.list && \

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -16,9 +16,6 @@
 FROM ubuntu:16.04
 MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
-ARG ZEPPELIN_USER_ID=2100
-ARG ZEPPELIN_GROUP_ID=2100
-
 # `Z_VERSION` will be updated by `dev/change_zeppelin_version.sh`
 ENV Z_VERSION="0.9.0-SNAPSHOT"
 
@@ -27,9 +24,6 @@ ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     ZEPPELIN_ADDR="0.0.0.0"
-
-RUN groupadd --gid $ZEPPELIN_GROUP_ID zeppelin \
-    && useradd -ms /bin/bash -d ${Z_HOME} zeppelin --uid $ZEPPELIN_USER_ID --gid $ZEPPELIN_GROUP_ID
 
 RUN echo "$LOG_TAG update and install basic packages" && \
     apt-get -y update && \
@@ -105,15 +99,23 @@ RUN echo "$LOG_TAG Cleanup" && \
     apt-get clean
 
 RUN echo "$LOG_TAG Download Zeppelin binary" && \
-    wget -O /tmp/zeppelin-${Z_VERSION}-bin-all.tgz http://archive.apache.org/dist/zeppelin/zeppelin-${Z_VERSION}/zeppelin-${Z_VERSION}-bin-all.tgz && \
+    wget --quiet -O /tmp/zeppelin-${Z_VERSION}-bin-all.tgz http://archive.apache.org/dist/zeppelin/zeppelin-${Z_VERSION}/zeppelin-${Z_VERSION}-bin-all.tgz && \
     tar -zxvf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
     rm -rf /tmp/zeppelin-${Z_VERSION}-bin-all.tgz && \
+    mkdir -p ${Z_HOME} && \
     mv /zeppelin-${Z_VERSION}-bin-all/* ${Z_HOME}/ && \
-    chown -R zeppelin:zeppelin ${Z_HOME}/  
+    chown -R root:root ${Z_HOME} && \
+    mkdir -p ${Z_HOME}/logs ${Z_HOME}/run ${Z_HOME}/webapps && \
+    # Allow process to edit /etc/passwd, to create a user entry for zeppelin
+    chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
+    # Give access to some specific folders
+    chmod -R 775 "${Z_HOME}/logs" "${Z_HOME}/run" "${Z_HOME}/notebook" "${Z_HOME}/conf" && \
+    # Allow process to create new folders (e.g. webapps)
+    chmod 775 ${Z_HOME}
 
 COPY log4j.properties ${Z_HOME}/conf/
 
-USER zeppelin
+USER 1000
 
 EXPOSE 8080
 


### PR DESCRIPTION
### What is this PR for?
With this pull requests, we build zeppelin images, which are able to start as a random user. Random users are a security concept in some k8s products like Openshift ([reason](https://cookbook.openshift.org/users-and-role-based-access-control/why-do-my-applications-run-as-a-random-user-id.html))
In start script we write a user entry in `/etc/passwd`, because a user entry is needed for Hadoop. Logins for zeppelin are not allowed (`/bin/false`).
The zeppelin process doesn't need write access to binaries in zeppelin home folder. Only a few folder are writable.


### What type of PR is it?
Improvement

### What is the Jira issue?
* [ZEPPELIN-4397](https://issues.apache.org/jira/browse/ZEPPELIN-4397)

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### How it can be tested
- Build image
- Run image with 
```bash
# the number 12345 can be random, default 1000
docker run -ti --user 12345 -p 8080:8080 -e ZEPPELIN_ADDR="0.0.0.0" my-zeppelin-image:latest
```

### Questions:
* Does the licenses files need update?
  No
* Is there breaking changes for older versions?
  No
* Does this needs documentation?
  No
