### PR TITLE
[ZEPPELIN-4407] Add the ability to copy/paste result table

### DIFF
--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -138,7 +138,10 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
         InterpreterResult.Code.INCOMPLETE
     }
 
-    new InterpreterResult(lastStatus)
+    lastStatus match {
+      case InterpreterResult.Code.INCOMPLETE => new InterpreterResult( lastStatus, "Incomplete expression" )
+      case _ => new InterpreterResult(lastStatus)
+    }
   }
 
   protected def interpret(code: String): InterpreterResult =

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -138,10 +138,7 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
         InterpreterResult.Code.INCOMPLETE
     }
 
-    lastStatus match {
-      case InterpreterResult.Code.INCOMPLETE => new InterpreterResult( lastStatus, "Incomplete expression" )
-      case _ => new InterpreterResult(lastStatus)
-    }
+    new InterpreterResult(lastStatus)
   }
 
   protected def interpret(code: String): InterpreterResult =

--- a/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result-chart-selector.html
@@ -78,8 +78,8 @@ limitations under the License.
      style="margin-bottom: 10px;">
   <button type="button" class="btn btn-default btn-sm"
           style="margin-left:10px"
-          ng-click="exportToDSV(',')"
-          uib-tooltip="Download Data as CSV" tooltip-placement="bottom">
+          ng-click="copyToClipboard('\t')"
+          uib-tooltip="Copy All" tooltip-placement="bottom">
     <i class="fa fa-download"></i>
   </button>
   <button type="button" class="btn btn-default btn-sm dropdown-toggle caretBtn"
@@ -88,8 +88,10 @@ limitations under the License.
     <span class="sr-only">Toggle Dropdown</span>
   </button>
   <ul class="dropdown-menu" role="menu" style="min-width: 70px;">
-    <li ng-click="exportToDSV(',')"><a>CSV</a></li>
-    <li ng-click="exportToDSV('\t')"><a>TSV</a></li>
+    <li ng-click="copyToClipboard('\t')"><a>Copy as TSV</a></li>
+    <li ng-click="copyToClipboard(',')"><a>Copy as CSV</a></li>
+    <li ng-click="exportToDSV('\t')"><a>Download as TCV</a></li>
+    <li ng-click="exportToDSV(',')"><a>Download as CSV</a></li>
   </ul>
 </div>
 

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -890,6 +890,36 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
     saveAsService.saveAs(dsv, exportedFileName, extension);
   };
 
+  $scope.copyToClipboard = function(delimiter) {
+    let copy = '';
+    for (let r in tableData.rows) {
+      if (tableData.rows.hasOwnProperty(r)) {
+        let row = tableData.rows[r];
+        let dsvRow = '';
+        for (let index in row) {
+          if (row.hasOwnProperty(index)) {
+            let stringValue = (row[index]).toString();
+            if (stringValue.indexOf(delimiter) > -1) {
+              dsvRow += '"' + stringValue + '"' + delimiter;
+            } else {
+              dsvRow += row[index] + delimiter;
+            }
+          }
+        }
+        copy += dsvRow.substring(0, dsvRow.length - 1) + '\n';
+      }
+    }
+
+    let el = document.createElement('textarea');
+    el.value = copy;
+    el.setAttribute('readonly', '');
+    el.style = {position: 'absolute', left: '-9999px'};
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+  };
+
   $scope.getBase64ImageSrc = function(base64Data) {
     return 'data:image/png;base64,' + base64Data;
   };


### PR DESCRIPTION
### What is this PR for?
This PR provides the ability to copy/paste the entire result table from a paragraph.

Currently, there's an option to download the result table into a csv or tsv file, but it creates a new file for each result table per paragraph. In order to copy multiple result tables from same and different notebooks we've to download each file, copy the dataset, and paste it into one external app. 

With this new approach there's no need to download multiple files. Simply click on either CopyAll (copies data in TSV format) or pick the options from drop down menu to download or copy table as TSV/CSV. This makes it easier to copy dataset of multiple tables into one external app without creating and opening multiple files.

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4407

### How should this be tested?
 - Create a dataframe 
- use z.show(df)
- Click on CopyAll
- Paste into external app

### Screenshots (if appropriate)
#
![image](https://user-images.githubusercontent.com/51380329/67910009-7b7f5f80-fb3e-11e9-9b51-580d66df9a23.png)
## Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
