### PR TITLE
[ZEPPELIN-4408] Return exception message when Interpreter code is incomplete 

### DIFF
--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -106,6 +106,7 @@ public class SparkInterpreterTest {
     // incomplete
     result = interpreter.interpret("println(a", getInterpreterContext());
     assertEquals(InterpreterResult.Code.INCOMPLETE, result.code());
+    assertEquals("Incomplete expression", result.message());
 
     // syntax error
     result = interpreter.interpret("println(b)", getInterpreterContext());

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -138,7 +138,10 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
         InterpreterResult.Code.INCOMPLETE
     }
 
-    new InterpreterResult(lastStatus)
+    lastStatus match {
+      case InterpreterResult.Code.INCOMPLETE => new InterpreterResult( lastStatus, "Incomplete expression" )
+      case _ => new InterpreterResult(lastStatus)
+    }
   }
 
   protected def interpret(code: String): InterpreterResult =


### PR DESCRIPTION
### What is this PR for?
When there's a syntax error in your code such as missing a closing parentheses etc. an exception message "Incomplete expression" will be returned to make it easier to debug.

Currently paragraph simply goes into finish state and makes it harder to know if the code is complete or not.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4408

### How should this be tested?
- On Spark interpreter run (println("Hello World")

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
