### PR TITLE
[ZEPPELIN-4409] Set spark.app.name to know which user is running which notebook

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -725,13 +725,14 @@ public class InterpreterSetting {
   ///////////////////////////////////////////////////////////////////////////////////////
   // This is the only place to create interpreters. For now we always create multiple interpreter
   // together (one session). We don't support to create single interpreter yet.
-  List<Interpreter> createInterpreters(String user, String interpreterGroupId, String sessionId) {
+  List<Interpreter> createInterpreters(String user, String interpreterGroupId, String sessionId, String noteId) {
     List<Interpreter> interpreters = new ArrayList<>();
     List<InterpreterInfo> interpreterInfos = getInterpreterInfos();
     Properties intpProperties = getJavaProperties();
+    intpProperties.put( "spark.app.name", "Zeppelin Notebook " + noteId + " for user " + user );
     for (InterpreterInfo info : interpreterInfos) {
       Interpreter interpreter = new RemoteInterpreter(intpProperties, sessionId,
-          info.getClassName(), user, lifecycleManager);
+          info.getClassName(), user, lifecycleManager, noteId);
       if (info.isDefaultInterpreter()) {
         interpreters.add(0, interpreter);
       } else {
@@ -773,7 +774,7 @@ public class InterpreterSetting {
     Preconditions.checkNotNull(interpreterGroup, "No InterpreterGroup existed for user {}, " +
         "noteId {}", user, noteId);
     String sessionId = getInterpreterSessionId(user, noteId);
-    return interpreterGroup.getOrCreateSession(user, sessionId);
+    return interpreterGroup.getOrCreateSession(user, sessionId, noteId);
   }
 
   public Interpreter getDefaultInterpreter(String user, String noteId) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -158,11 +158,11 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
     SchedulerFactory.singleton().removeScheduler(scheduler.getName());
   }
 
-  public synchronized List<Interpreter> getOrCreateSession(String user, String sessionId) {
+  public synchronized List<Interpreter> getOrCreateSession(String user, String sessionId, String noteId) {
     if (sessions.containsKey(sessionId)) {
       return sessions.get(sessionId);
     } else {
-      List<Interpreter> interpreters = interpreterSetting.createInterpreters(user, id, sessionId);
+      List<Interpreter> interpreters = interpreterSetting.createInterpreters(user, id, sessionId, noteId);
       for (Interpreter interpreter : interpreters) {
         interpreter.setInterpreterGroup(this);
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -62,6 +62,7 @@ public class RemoteInterpreter extends Interpreter {
   private String className;
   private String sessionId;
   private FormType formType;
+  private String noteId;
 
   private RemoteInterpreterProcess interpreterProcess;
   private volatile boolean isOpened = false;
@@ -76,12 +77,14 @@ public class RemoteInterpreter extends Interpreter {
                            String sessionId,
                            String className,
                            String userName,
-                           LifecycleManager lifecycleManager) {
+                           LifecycleManager lifecycleManager,
+                           String noteId) {
     super(properties);
     this.sessionId = sessionId;
     this.className = className;
     this.setUserName(userName);
     this.lifecycleManager = lifecycleManager;
+    this.noteId = noteId;
   }
 
   public boolean isOpened() {
@@ -125,7 +128,7 @@ public class RemoteInterpreter extends Interpreter {
         // depends on other interpreter. e.g. PySparkInterpreter depends on SparkInterpreter.
         // also see method Interpreter.getInterpreterInTheSameSessionByClassName
         for (Interpreter interpreter : getInterpreterGroup()
-                                        .getOrCreateSession(this.getUserName(), sessionId)) {
+                                        .getOrCreateSession(this.getUserName(), sessionId, noteId)) {
           try {
             if (!(interpreter instanceof ConfInterpreter)) {
               ((RemoteInterpreter) interpreter).internal_create();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroupTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroupTest.java
@@ -63,18 +63,18 @@ public class ManagedInterpreterGroupTest {
     assertEquals(0, interpreterGroup.getSessionNum());
 
     // create session_1
-    List<Interpreter> interpreters = interpreterGroup.getOrCreateSession("user1", "session_1");
+    List<Interpreter> interpreters = interpreterGroup.getOrCreateSession("user1", "session_1", "notebook_1");
     assertEquals(3, interpreters.size());
     assertEquals(EchoInterpreter.class.getName(), interpreters.get(0).getClassName());
     assertEquals(DoubleEchoInterpreter.class.getName(), interpreters.get(1).getClassName());
     assertEquals(1, interpreterGroup.getSessionNum());
 
     // get the same interpreters when interpreterGroup.getOrCreateSession is invoked again
-    assertEquals(interpreters, interpreterGroup.getOrCreateSession("user1", "session_1"));
+    assertEquals(interpreters, interpreterGroup.getOrCreateSession("user1", "session_1", "notebook_1"));
     assertEquals(1, interpreterGroup.getSessionNum());
 
     // create session_2
-    List<Interpreter> interpreters2 = interpreterGroup.getOrCreateSession("user1", "session_2");
+    List<Interpreter> interpreters2 = interpreterGroup.getOrCreateSession("user1", "session_2", "notebook_1");
     assertEquals(3, interpreters2.size());
     assertEquals(EchoInterpreter.class.getName(), interpreters2.get(0).getClassName());
     assertEquals(DoubleEchoInterpreter.class.getName(), interpreters2.get(1).getClassName());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/SessionConfInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/SessionConfInterpreterTest.java
@@ -45,7 +45,7 @@ public class SessionConfInterpreterTest {
         properties, "session_1", "group_1", mockInterpreterSetting);
 
     RemoteInterpreter remoteInterpreter =
-        new RemoteInterpreter(properties, "session_1", "clasName", "user1", null);
+        new RemoteInterpreter(properties, "session_1", "clasName", "user1", null, "notebook_1");
     List<Interpreter> interpreters = new ArrayList<>();
     interpreters.add(confInterpreter);
     interpreters.add(remoteInterpreter);


### PR DESCRIPTION
### What is this PR for?
This PR sets spark.app.name to "Zeppelin Notebook xxxxx for user test" which makes it helpful to know which notebooks are currently being used and how much resources are being allocated by which user and notebook. 

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4409

### How should this be tested?
- Create a notebook with spark interpreter
- Run println("hello")
- spark app name will be set to user name and note id 

### Screenshots (if appropriate)

#
![image](https://user-images.githubusercontent.com/51380329/67911008-21809900-fb42-11e9-9cf0-49ebee07a7f8.png)

## Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
