### PR TITLE
[ZEPPELIN-4410] Added exception handling when converting old notebooks to newer format

### DIFF
--- a/zeppelin-plugins/notebookrepo/s3/src/main/java/org/apache/zeppelin/notebook/repo/OldS3NotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/s3/src/main/java/org/apache/zeppelin/notebook/repo/OldS3NotebookRepo.java
@@ -187,6 +187,8 @@ public class OldS3NotebookRepo implements OldNotebookRepo {
             info = getNoteInfo(objectSummary.getKey());
             if (info != null) {
               infos.add(info);
+            } else {
+              LOG.debug("Unable to get notebook info for key: " + objectSummary.getKey());
             }
           }
         }
@@ -215,7 +217,7 @@ public class OldS3NotebookRepo implements OldNotebookRepo {
 
   private OldNoteInfo getNoteInfo(String key) throws IOException {
     Note note = getNote(key);
-    return new OldNoteInfo(note);
+    return note != null ? new OldNoteInfo(note) : null;
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -1029,11 +1029,19 @@ public class Note implements JsonSerializable {
   }
 
   public static Note fromJson(String json) {
-    Note note = gson.fromJson(json, Note.class);
-    convertOldInput(note);
-    note.info.remove("isRunning");
-    note.postProcessParagraphs();
-    return note;
+    try
+    {
+      Note note = gson.fromJson(json, Note.class);
+      convertOldInput(note);
+      note.info.remove("isRunning");
+      note.postProcessParagraphs();
+
+      return note;
+    } catch (Exception e) {
+      logger.error("Unable to parse notebook: " + e.toString());
+
+      return null;
+    }
   }
 
   public void postProcessParagraphs() {


### PR DESCRIPTION
### What is this PR for?
Added exception handling when creating a Note object from a json string. 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4410

### How should this be tested?
- Create a notebook on zeppelin 0.7.3
- Create a spark interpreter 
- Run paragraph that creates a runtime exception
- Run upgrade-note.sh on the created notebook
- This will crash the script because it'll not be able to construct a java object from the given note.json

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
