### PR TITLE
[ZEPPELIN-4411] Added current notebook location and name to ui header 

### DIFF
--- a/zeppelin-web/src/app/app.controller.js
+++ b/zeppelin-web/src/app/app.controller.js
@@ -50,6 +50,12 @@ function MainCtrl($scope, $rootScope, $window, arrayOrderingSrv) {
     }
   };
 
+  $rootScope.notePath = function(note) {
+    if (!_.isEmpty(note)) {
+      return arrayOrderingSrv.getNotePath(note);
+    }
+  };
+
   BootstrapDialog.defaultOptions.onshown = function() {
     angular.element('#' + this.id).find('.btn:last').focus();
   };

--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -150,6 +150,10 @@ function HomeCtrl($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOrd
     return arrayOrderingSrv.getNoteName(note);
   };
 
+  $scope.getNotePath = function(note) {
+    return arrayOrderingSrv.getNotePath(note);
+  };
+
   $scope.noteComparator = function(note1, note2) {
     return arrayOrderingSrv.noteComparator(note1, note2);
   };

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -24,7 +24,7 @@ limitations under the License.
          tooltip-placement="bottom"
          uib-tooltip={{noteName(note)}}
          ng-click="input.showEditor = !revisionView; input.value = note.name"
-         ng-show="!input.showEditor"><span>{{noteName(note)}}</span></p>
+         ng-show="!input.showEditor"><span>{{notePath(note)}}</span></p>
     </div>
     <div style="float: left; padding-bottom: 10px">
       <span class="labelBtn btn-group">

--- a/zeppelin-web/src/components/array-ordering/array-ordering.service.js
+++ b/zeppelin-web/src/components/array-ordering/array-ordering.service.js
@@ -59,4 +59,12 @@ function ArrayOrderingService(TRASH_FOLDER_ID) {
 
     return noteName1.localeCompare(noteName2);
   };
+
+  this.getNotePath = function(note) {
+    if (note.path === undefined || note.path.trim() === '') {
+      return 'Note ' + note.id;
+    } else {
+      return note.path;
+    }
+  };
 }


### PR DESCRIPTION
This makes it easier to find the notebook since multiple notebooks can have same name under different path

### What is this PR for?
This makes it easier to know which notebook you're currently running and the location of the notebook. 

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4411

### How should this be tested?
- Create a notebook under a directory
- location of the notebook and name will be on the top 

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/51380329/67912250-9655d200-fb46-11e9-8d1e-ca0c68391465.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
