### PR TITLE
[ZEPPELIN-4412] Added REST Api to shut down spark context for notebook

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -704,6 +704,28 @@ public class NotebookRestApi extends AbstractRestApi {
   }
 
   /**
+   * Shut down notebook interpreter REST API.
+   *
+   * @param noteId ID of Note
+   * @return JSON with status.OK
+   * @throws IOException
+   * @throws IllegalArgumentException
+   */
+  @GET
+  @Path("close/{noteId}")
+  @ZeppelinApi
+  public Response closeNote(@PathParam("noteId") String noteId)
+          throws IOException, IllegalArgumentException {
+    LOG.info("stop note jobs {} ", noteId);
+    Note note = notebook.getNote(noteId);
+    checkIfNoteIsNotNull(note);
+    checkIfUserCanRun(noteId, "Insufficient privileges you cannot close this notebook");
+
+    notebook.getInterpreterSettingManager().closeNote(authenticationService.getPrincipal(), noteId);
+    return new JsonResponse<>(Status.OK).build();
+  }
+
+  /**
    * Get note job status REST API.
    *
    * @param noteId ID of Note


### PR DESCRIPTION
### What is this PR for?
This provides the ability to shut down interpreter for a specific notebook.

This makes it easier to release any allocated resources or close spark context when a paragraph is stuck on pending state.

This helps with resetting the state of the notebook. 

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4412

### How should this be tested?
- Create a notebook with spark interpreter 
- Make a call to http://[zeppelin-server]:[zeppelin-port]/api/notebook/close/[noteid]

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
