### PR TITLE
[ZEPPELIN-4413] Added a close note button on zepp ui to shut down sc and release roso…

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -131,6 +131,23 @@ public class NotebookService {
     return note;
   }
 
+  public boolean closeNote(String noteId,
+                           ServiceContext context,
+                           ServiceCallback<Note> callback) throws IOException{
+    Note note = null;
+    if ( noteId != null ) {
+      note = notebook.getNote(noteId);
+    }
+
+    if (note == null) {
+      callback.onFailure(new NoteNotFoundException(noteId), context);
+      return false;
+    }
+
+    notebook.getInterpreterSettingManager().closeNote(context.getAutheInfo().getUser(), noteId);
+    callback.onSuccess(note, context);
+    return true;
+  }
 
   public Note createNote(String notePath,
                          String defaultInterpreterGroup,

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -63,6 +63,15 @@ limitations under the License.
 
       <button type="button"
               class="btn btn-default btn-xs"
+              ng-click="closeNote(note.id)"
+              ng-hide="viewOnly"
+              tooltip-placement="bottom" uib-tooltip="Close this note!"
+              ng-disabled="revisionView">
+        <i class="fa fa-ban fa-fw"></i>
+      </button>
+
+      <button type="button"
+              class="btn btn-default btn-xs"
               ng-hide="viewOnly"
               tooltip-placement="bottom" uib-tooltip="Clone this note" data-source-note-name="{{note.name}}"
               data-toggle="modal" data-target="#noteCreateModal" data-clone="true"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -393,6 +393,10 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     });
   };
 
+  $scope.closeNote = function(noteId) {
+    websocketMsgSrv.closeNote(noteId);
+  };
+
   $scope.saveNote = function() {
     if ($scope.note && $scope.note.paragraphs) {
       _.forEach($scope.note.paragraphs, function(par) {

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -85,6 +85,10 @@ function WebsocketMessageService($rootScope, websocketEvents) {
       websocketEvents.sendNewEvent({op: 'NOTE_UPDATE', data: {id: noteId, name: noteName, config: noteConfig}});
     },
 
+    closeNote: function(noteId) {
+      websocketEvents.sendNewEvent({op: 'CLOSE_NOTE', data: {id: noteId}});
+    },
+
     updatePersonalizedMode: function(noteId, modeValue) {
       websocketEvents.sendNewEvent({op: 'UPDATE_PERSONALIZED_MODE', data: {id: noteId, personalized: modeValue}});
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -191,7 +191,8 @@ public class Message implements JsonSerializable {
     COLLABORATIVE_MODE_STATUS,    // [s-c] collaborative mode status
     PATCH_PARAGRAPH,              // [c-s][s-c] patch editor text
     NOTE_RUNNING_STATUS,        // [s-c] sequential run status will be change
-    NOTICE                        // [s-c] Notice
+    NOTICE,                        // [s-c] Notice
+    CLOSE_NOTE                   // shutdown interpreter for notebook
   }
 
   // these messages will be ignored during the sequential run of the note


### PR DESCRIPTION
### What is this PR for?
Adds the ability to shut down interpreter and free allocated resources for a notebook via zeppelin ui. 

This makes it easy to close the notebook by clicking on one button


### What type of PR is it?
Feature


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4413

### How should this be tested?
- Create a new notebook and use spark interpreter
- Click on close button between "clear output" and "clone this note"

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/51380329/67912825-60b1e880-fb48-11e9-80c8-edc5de76f819.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
