### PR TITLE
[ZEPPELIN-4417]. Logging Interpreter launch command in log4j

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
@@ -155,7 +155,12 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
 
     @Override
     protected void processLine(String s, int i) {
-      LOGGER.debug("Process Output: " + s);
+      // print Interpreter launch command for diagnose purpose
+      if (s.startsWith("Interpreter launch command")) {
+        LOGGER.info(s);
+      } else {
+        LOGGER.debug("Process Output: " + s);
+      }
       if (catchLaunchOutput) {
         launchOutput.append(s + "\n");
       }


### PR DESCRIPTION
### What is this PR for?

This PR is to logging interpreter launch command in log4j for diagnose purpose. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4417

### How should this be tested?
* Manually tested, launching spark interpreter, and see the spark submit command in log4j
Here's the sample log:

```
 INFO [2019-11-04 21:59:46,077] ({SchedulerFactory2} ProcessLauncher.java[transition]:86) - Process state is transitioned to LAUNCHED
 INFO [2019-11-04 21:59:46,077] ({SchedulerFactory2} ProcessLauncher.java[launch]:73) - Process is launched: [/Users/jzhang/github/zeppelin/bin/interpreter.sh, -d, /Users/jzhang/github/zeppelin/interpreter/python, -c, 0.0.0.0, -p, 49739, -r, :, -i, python-shared_process, -l, /Users/jzhang/github/zeppelin/local-repo/python, -g, python]
 INFO [2019-11-04 21:59:46,126] ({Exec Stream Pumper} ProcessLauncher.java[processLine]:160) - Interpreter launch command:  /Library/Java/JavaVirtualMachines/jdk1.8.0_211.jdk/Contents/Home/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///Users/jzhang/github/zeppelin/conf/log4j.properties -Dzeppelin.log.file='/Users/jzhang/github/zeppelin/logs/zeppelin-interpreter-python-shared_process-jzhang-JeffdeMacBook-Pro.local.log' -Xms1024m -Xmx1024m -XX:MaxPermSize=512m -cp ":/Users/jzhang/github/zeppelin/interpreter/python/*:/Users/jzhang/github/zeppelin/zeppelin-interpreter-api/target/*:/Users/jzhang/github/zeppelin/zeppelin-zengine/target/test-classes/*::/Users/jzhang/github/zeppelin/interpreter/zeppelin-interpreter-api-0.9.0-SNAPSHOT.jar:/Users/jzhang/github/zeppelin/zeppelin-interpreter/target/classes:/Users/jzhang/github/zeppelin/zeppelin-zengine/target/test-classes" org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer 0.0.0.0 49739 "python-shared_process" :
 INFO [2019-11-04 21:59:46,770] ({pool-5-thread-1} ProcessLauncher.java[transition]:86) - Process state is transitioned to RUNNING
```

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
