### PR TITLE
[ZEPPELIN-4416]. Don't merge properties from inteprreter-setting.json if it already exists

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -933,8 +933,12 @@ public class InterpreterSetting {
               InterpreterPropertyType.STRING.getValue());
           newProperties.put(entry.getKey().toString(), newProperty);
         } else {
-          // already converted
-          return (Map<String, InterpreterProperty>) properties;
+          StringMap stringMap = (StringMap) entry.getValue();
+          InterpreterProperty newProperty = new InterpreterProperty(
+                  entry.getKey().toString(),
+                  stringMap.get("value"),
+                  stringMap.containsKey("type") ? stringMap.get("type").toString() : "string");
+          newProperties.put(newProperty.getName(), newProperty);
         }
       }
       return newProperties;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -245,26 +245,13 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
 
       InterpreterSetting interpreterSettingTemplate =
           interpreterSettingTemplates.get(savedInterpreterSetting.getGroup());
-      // InterpreterSettingTemplate is from interpreter-setting.json which represent the latest
+      // InterpreterSettingTemplate is from interpreter-setting.json which represent the initialized
       // InterpreterSetting, while InterpreterSetting is from interpreter.json which represent
       // the user saved interpreter setting
       if (interpreterSettingTemplate != null) {
-        savedInterpreterSetting.setInterpreterDir(interpreterSettingTemplate.getInterpreterDir());
-        // merge properties from interpreter-setting.json and interpreter.json
-        Map<String, InterpreterProperty> mergedProperties =
-            new HashMap<>(InterpreterSetting.convertInterpreterProperties(
-                interpreterSettingTemplate.getProperties()));
-        Map<String, InterpreterProperty> savedProperties = InterpreterSetting
-            .convertInterpreterProperties(savedInterpreterSetting.getProperties());
-        for (Map.Entry<String, InterpreterProperty> entry : savedProperties.entrySet()) {
-          // only merge properties whose value is not empty
-          if (entry.getValue().getValue() != null && !
-              StringUtils.isBlank(entry.getValue().toString())) {
-            mergedProperties.put(entry.getKey(), entry.getValue());
-          }
-        }
-        savedInterpreterSetting.setProperties(mergedProperties);
-        // merge InterpreterInfo
+        // merge InterpreterDir, InterpreterInfo & InterpreterRunner
+        savedInterpreterSetting.setInterpreterDir(
+            interpreterSettingTemplate.getInterpreterDir());
         savedInterpreterSetting.setInterpreterInfos(
             interpreterSettingTemplate.getInterpreterInfos());
         savedInterpreterSetting.setInterpreterRunner(


### PR DESCRIPTION
### What is this PR for?

Currently zeppelin will merge the setting in `interpreter-setting.json` with setting in `interpreter.json`, usually this is not what user expect. E.g. if user delete one property defined in `interpreter-setting.json` and then restart zeppelin, he would see this property again as we merged it from `interpreter-setting.json`. So this PR is to remove the logic of merging properties from interpreter-setting.json if it already exists.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4416

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
