### PR TITLE
[ZEPPELIN-4373]. Specify ZEPPELIN_ADDR to 0.0.0.0 in Dockerfile

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -18,10 +18,12 @@ MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
 # `Z_VERSION` will be updated by `dev/change_zeppelin_version.sh`
 ENV Z_VERSION="0.9.0-SNAPSHOT"
+
 ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     Z_HOME="/zeppelin" \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    ZEPPELIN_ADDR="0.0.0.0"
 
 RUN echo "$LOG_TAG update and install basic packages" && \
     apt-get -y update && \


### PR DESCRIPTION
### What is this PR for?

Straightforward change to specify env `ZEPPELIN_ADDR` to `0.0.0.0` to Dockerfile


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4373

### How should this be tested?
* Build docker image, and verify it manually.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
