### PR TITLE
[ZEPPELIN-4431]. submarine fail to build due to missing jar

### DIFF
--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -130,6 +130,13 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>jerbrain</id>
+      <url>https://dl.bintray.com/jetbrains/pty4j/</url>
+    </repository>
+  </repositories>
+
   <build>
     <testResources>
       <testResource>


### PR DESCRIPTION
### What is this PR for?

Add repository in pom.xml so that it can download dependency pty4j


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4431

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
