### PR TITLE
[ZEPPELIN-4326][spark]Spark Interpreter restart failed when no suffic…

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -117,14 +117,16 @@ public class IPySparkInterpreter extends IPythonInterpreter {
 
   @Override
   public void cancel(InterpreterContext context) throws InterpreterException {
-    super.cancel(context);
-    sparkInterpreter.cancel(context);
+    if (sparkInterpreter != null) {
+      super.cancel(context);
+      sparkInterpreter.cancel(context);
+    }
   }
 
   @Override
   public void close() throws InterpreterException {
-    super.close();
     if (sparkInterpreter != null) {
+      super.close();
       sparkInterpreter.close();
     }
   }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/NewSparkInterpreter.java
@@ -149,7 +149,9 @@ public class NewSparkInterpreter extends AbstractSparkInterpreter {
 
   @Override
   public void cancel(InterpreterContext context) {
-    sc.cancelJobGroup(Utils.buildJobGroupId(context));
+    if (sc != null) {
+      sc.cancelJobGroup(Utils.buildJobGroupId(context));
+    }
   }
 
   @Override

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -321,9 +321,11 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       iPySparkInterpreter.close();
       return;
     }
-    executor.getWatchdog().destroyProcess();
-    new File(scriptPath).delete();
-    gatewayServer.shutdown();
+    if (executor != null) {
+      executor.getWatchdog().destroyProcess();
+      new File(scriptPath).delete();
+      gatewayServer.shutdown();
+    }
   }
 
   PythonInterpretRequest pythonInterpretRequest = null;
@@ -520,11 +522,13 @@ public class PySparkInterpreter extends Interpreter implements ExecuteResultHand
       return;
     }
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    sparkInterpreter.cancel(context);
-    try {
-      interrupt();
-    } catch (IOException e) {
-      LOGGER.error("Error", e);
+    if (sparkInterpreter.getSparkContext() != null) {
+      sparkInterpreter.cancel(context);
+      try {
+        interrupt();
+      } catch (IOException e) {
+        LOGGER.error("Error", e);
+      }
     }
   }
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -142,9 +142,10 @@ public class SparkSqlInterpreter extends Interpreter {
   public void cancel(InterpreterContext context) throws InterpreterException {
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
     SQLContext sqlc = sparkInterpreter.getSQLContext();
-    SparkContext sc = sqlc.sparkContext();
-
-    sc.cancelJobGroup(Utils.buildJobGroupId(context));
+    if (sqlc != null) {
+      SparkContext sc = sqlc.sparkContext();
+      sc.cancelJobGroup(Utils.buildJobGroupId(context));
+    }
   }
 
   @Override
@@ -156,7 +157,11 @@ public class SparkSqlInterpreter extends Interpreter {
   @Override
   public int getProgress(InterpreterContext context) throws InterpreterException {
     SparkInterpreter sparkInterpreter = getSparkInterpreter();
-    return sparkInterpreter.getProgress(context);
+    if (sparkInterpreter.getSparkContext() == null) {
+      return 0;
+    }else {
+      return sparkInterpreter.getProgress(context);
+    }
   }
 
   @Override

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -164,6 +164,8 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
     if (BaseSparkScalaInterpreter.sessionNum.decrementAndGet() == 0) {
       if (sc != null) {
         sc.stop()
+      }else {
+        System.exit(1)
       }
       if (sparkHttpServer != null) {
         sparkHttpServer.getClass.getMethod("stop").invoke(sparkHttpServer)


### PR DESCRIPTION
### What is this PR for?
The pr is the last fix of the [ZEPPELIN-4326](https://issues.apache.org/jira/browse/ZEPPELIN-4326) The user can still restart the spark interpreter successfullywhen no sufficient yarn queue resources

   When the queue resource is insufficient, the spark task will remain in the ACCEPTED state. If the spark interpreter is restarted at this time, the restart interface will be stuck[**thread blocking  in the LazyOpenInterpreter.open method, this is a synchronized method**]. Restarting the spark interpreter fails. only use the yarn applicaiton -kill appID command or the kill -9 SparkSubmit process to restart the spark interpreter., which is very unfriendly to the user.
   At present, I use the system.exit(1) rough way to exit the JVM to achieve the purpose of restarting successfully, similar to the task of ending the ACCEPTED state by using Ctrl+C in the spark-shell.Spark only has **cancelJob** / **cancelStage** APIs,i thinks Spark is unable to do 

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4326


### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/11769953/69037105-2db19500-0a22-11ea-883e-93640c5e1553.png)


### Questions:
* Add another ACCETTED state to tell the user that the task is in the ACCEPTED state instead of the running state?【PENDING -> ACCEPTED -> RUNNING】 
* For a spark task in the ACCEPTED state, the user can only restart the interpreter and cannot cancel with the cancel button.
