### PR TITLE
[ZEPPELIN-4428] Fix bug - Highlighted line number disappears

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.css
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.css
@@ -354,8 +354,9 @@ table.table-shortcut {
 }
 
 /** set highlight line color */
-#main .ace-chrome .ace_marker-layer .ace_active-line {
-  background: rgba(114, 127, 222, 0.08);
+#main .ace-chrome .ace_marker-layer .ace_active-line,
+#main .ace-chrome .ace_gutter-active-line {
+  background: rgba(114, 127, 222, 0.15);
 }
 
 /** hide not focused cursors */


### PR DESCRIPTION
### What is this PR for?
Fix bug that highlighted line number disappeared.

(Before)
![image](https://user-images.githubusercontent.com/3839771/69491677-8f1eab80-0edb-11ea-96ef-c96276e73507.png)

(Problem)
In paragraph.css file, there was a custom css that changes background color of the line number.
Need to apply that css line to this UI together.

(After)
![image](https://user-images.githubusercontent.com/3839771/69491674-84641680-0edb-11ea-99cc-eb5cbfc9a98c.png)



### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4428

* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
