### PR TITLE
[ZEPPELIN-4444] Fix schema disagreement when execute DDL statements

### DIFF
--- a/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
+++ b/cassandra/src/main/scala/org/apache/zeppelin/cassandra/InterpreterLogic.scala
@@ -332,7 +332,7 @@ class InterpreterLogic(val session: Session)  {
             case Some(value) => statement.replaceAll(escapedExp,value.toString)
             case None => {
               val listChoices:List[String] = choices.trim.split(CHOICES_SEPARATOR).toList
-              val paramOptions= listChoices.map(choice => new ParamOption(choice, choice))
+              val paramOptions = listChoices.map(choice => new ParamOption(choice, choice))
               val selected = context.getGui.select(variable, paramOptions.toArray, listChoices.head)
               statement.replaceAll(escapedExp,selected.toString)
             }

--- a/cassandra/src/test/scala/org/apache/zeppelin/cassandra/EnhancedSessionTest.scala
+++ b/cassandra/src/test/scala/org/apache/zeppelin/cassandra/EnhancedSessionTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.cassandra
+
+import com.datastax.driver.core.{BatchStatement, SimpleStatement}
+import org.scalatest.FlatSpec
+
+class EnhancedSessionTest extends FlatSpec {
+
+  "Query" should "be detected as DDL for create" in {
+    assertResult(true){
+      EnhancedSession.isDDLStatement("create TABLE if not exists test.test(id int primary key);")
+    }
+  }
+
+  it should "be detected as DDL for drop" in {
+    assertResult(true) {
+      EnhancedSession.isDDLStatement("DROP KEYSPACE if exists test;")
+    }
+  }
+
+  it should "be detected as DDL for alter" in {
+    assertResult(true) {
+      EnhancedSession.isDDLStatement("ALTER TABLE test.test WITH comment = 'some comment' ;")
+    }
+  }
+
+  it should "not be detected as DDL for select" in {
+    assertResult(false) {
+      EnhancedSession.isDDLStatement("select * from test.test;")
+    }
+  }
+
+  it should "be detected as DDL for create in simple statement" in {
+    assertResult(true) {
+      EnhancedSession.isDDLStatement(new SimpleStatement("create TABLE if not exists test.test(id int primary key);"))
+    }
+  }
+
+  it should "be detected as DDL for create in batch statement" in {
+    val batch = new BatchStatement
+    batch.add(new SimpleStatement("create TABLE if not exists test.test(id int primary key);"))
+    batch.add(new SimpleStatement("insert into test.test(id) values(1);"))
+    assertResult(true) {
+      EnhancedSession.isDDLStatement(batch)
+    }
+  }
+
+  it should "not be detected as DDL for only inserts in batch statement" in {
+    val batch = new BatchStatement
+    batch.add(new SimpleStatement("insert into test.test(id) values(1);"))
+    batch.add(new SimpleStatement("insert into test.test(id) values(2);"))
+    batch.add(new SimpleStatement("insert into test.test(id) values(3);"))
+    assertResult(false) {
+      EnhancedSession.isDDLStatement(batch)
+    }
+  }
+
+}


### PR DESCRIPTION
### What is this PR for?

When executing DDL statements (`CREATE`/`ALTER`/`DROP`) it's possible to get schema disagreement in Cassandra, especially for big/geo-distributed clusters. Java driver has a special handling of such statements, with increased timeout, but it's still possible that next DDL statement will be executed before all nodes agree on the schema version, and this could lead to schema disagreement that need to be resolved by administrators.

### What type of PR is it?
Improvement

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4444

### How should this be tested?

* Added the unit test
* Tested manually
* Travis CI: https://travis-ci.org/alexott/zeppelin/builds/620614700
