### PR TITLE
ZEPPELIN-4463. Remove table name prefix in column name

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -560,9 +560,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
         msg.append(TAB);
       }
       if (StringUtils.isNotEmpty(md.getColumnLabel(i))) {
-        msg.append(replaceReservedChars(md.getColumnLabel(i)));
+        msg.append(removeTablePrefix(replaceReservedChars(md.getColumnLabel(i))));
       } else {
-        msg.append(replaceReservedChars(md.getColumnName(i)));
+        msg.append(removeTablePrefix(replaceReservedChars(md.getColumnName(i))));
       }
     }
     msg.append(NEWLINE);
@@ -810,6 +810,20 @@ public class JDBCInterpreter extends KerberosInterpreter {
       return EMPTY_COLUMN_VALUE;
     }
     return str.replace(TAB, WHITESPACE).replace(NEWLINE, WHITESPACE);
+  }
+
+  /**
+   * Hive will prefix table name before the column
+   * @param columnName
+   * @return
+   */
+  private String removeTablePrefix(String columnName) {
+    int index = columnName.indexOf(".");
+    if (index > 0) {
+      return columnName.substring(index + 1);
+    } else {
+      return columnName;
+    }
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?

This PR is to remove the table name prefix in column name.  See the screenshot belows


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4463

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

Before
![image](https://user-images.githubusercontent.com/164491/70127566-3fe43200-16b6-11ea-9341-b7cc2dac4654.png)

After
![image](https://user-images.githubusercontent.com/164491/70127624-55595c00-16b6-11ea-8320-85173078f188.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
