### PR TITLE
[ZEPPELIN-4462] Upgrade commons-beanutils to 1.9.4

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -141,7 +141,7 @@ The following components are provided under Apache License.
     (Apache 2.0) akka-remote (com.typesafe.akka:akka-remote_2.10:2.3.7 - http://akka.io/)
     (Apache 2.0) akka-slf4j (com.typesafe.akka:akka-slf4j_2.10:2.3.7 - http://akka.io/)
     (Apache 2.0) Metrics Core Library (com.yammer.metrics:metrics-core:2.2.0 - http://metrics.codahale.com/metrics-core/)
-    (Apache 2.0) Commons BeanUtils Bean Collections (commons-beanutils:commons-beanutils-bean-collections:1.8.3 - http://commons.apache.org/beanutils/)
+    (Apache 2.0) Commons BeanUtils Bean Collections (commons-beanutils:commons-beanutils-bean-collections:1.9.4 - http://commons.apache.org/beanutils/)
     (Apache 2.0) Metrics Core (io.dropwizard.metrics:metrics-core:3.1.0 - http://metrics.codahale.com/metrics-core/)
     (Apache 2.0) Graphite Integration for Metrics (io.dropwizard.metrics:metrics-graphite:3.1.0 - http://metrics.codahale.com/metrics-graphite/)
     (Apache 2.0) Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:3.1.0 - http://metrics.codahale.com/metrics-json/)

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.2</version>
+      <version>1.9.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
This is to upgrade commons-beanutils version to 1.9.4

### What type of PR is it?
[Improvement]

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4462

### How should this be tested?
* Travis build passed: https://travis-ci.org/gkomlossi/zeppelin/builds/621119760

### Questions:
* Does the licenses files need update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? No
