### PR TITLE
[ZEPPELIN-4468]. Allow user to set form type via interpreter local properties

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -399,7 +399,7 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
     }
   }
 
-  // @Test
+  @Test
   public void pySparkTest() throws IOException {
     // create new note
     Note note = null;
@@ -412,6 +412,14 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       note.run(p.getId(), true);
       assertEquals(Status.FINISHED, p.getStatus());
       assertEquals("55\n", p.getReturn().message().get(0).getData());
+
+      // simple form via local properties
+      p = note.addNewParagraph(anonymous);
+      p.setText("%spark.pyspark(form=simple) print('name_' + '${name=abc}')");
+      note.run(p.getId(), true);
+      assertEquals(Status.FINISHED, p.getStatus());
+      assertEquals("name_abc\n", p.getReturn().message().get(0).getData());
+
       if (!isSpark2()) {
         // run sqlContext test
         p = note.addNewParagraph(anonymous);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -465,9 +465,8 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
 
       // inject form
       String script = this.scriptText;
-      if (interpreter.getFormType() == FormType.NATIVE) {
-        settings.clear();
-      } else if (interpreter.getFormType() == FormType.SIMPLE) {
+      if ("simple".equalsIgnoreCase(localProperties.get("form")) ||
+              interpreter.getFormType() == FormType.SIMPLE) {
         // inputs will be built from script body
         LinkedHashMap<String, Input> inputs = Input.extractSimpleQueryForm(script, false);
         LinkedHashMap<String, Input> noteInputs = Input.extractSimpleQueryForm(script, true);
@@ -490,6 +489,8 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
         }
         script = Input.getSimpleQuery(note.getNoteParams(), scriptBody, true);
         script = Input.getSimpleQuery(settings.getParams(), script, false);
+      } else {
+        settings.clear();
       }
 
       LOGGER.debug("RUN : " + script);


### PR DESCRIPTION

### What is this PR for?
Currently the form type is determined in the code of Interpreter. User could not change this unless the update code and rebuild it, it would be nice to allow user to set form type via interpreter local properties. This PR is to allow user to set form type via interpreter local properties. See screenshot below


### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4468

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/70288855-e98a0700-180d-11ea-9003-dece9d1c9b86.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
