### PR TITLE
[ZEPPELIN-4469]. Cron is disabled after zeppelin restart

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -55,15 +55,14 @@ public class QuartzSchedulerService implements SchedulerService {
     this.scheduler = new StdSchedulerFactory().getScheduler();
     this.scheduler.start();
 
-    Thread loadingNotesThread = new Thread(){
-      @Override
-      public void run() {
+    // Do in a separated thread because there may be many notes,
+    // loop all notes in the main thread may block the restarting of Zeppelin server
+    Thread loadingNotesThread = new Thread(() -> {
         LOGGER.info("Starting init cronjobs");
         notebook.getNotesInfo().stream()
                 .forEach(entry -> refreshCron(entry.getId()));
         LOGGER.info("Complete init cronjobs");
-      }
-    };
+    });
     loadingNotesThread.setName("Init CronJob Thread");
     loadingNotesThread.setDaemon(true);
     loadingNotesThread.start();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -54,6 +54,19 @@ public class QuartzSchedulerService implements SchedulerService {
     this.notebook = notebook;
     this.scheduler = new StdSchedulerFactory().getScheduler();
     this.scheduler.start();
+
+    Thread loadingNotesThread = new Thread(){
+      @Override
+      public void run() {
+        LOGGER.info("Starting init cronjobs");
+        notebook.getNotesInfo().stream()
+                .forEach(entry -> refreshCron(entry.getId()));
+        LOGGER.info("Complete init cronjobs");
+      }
+    };
+    loadingNotesThread.setName("Init CronJob Thread");
+    loadingNotesThread.setDaemon(true);
+    loadingNotesThread.start();
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
The root cause is that zeppelin didn't init cron job setting after zeppelin restart. This PR add one thread to list all notes to init the cron job. The reason to do in a separated thread is that there may be many notes, loop all notes in the main thread may block the restarting of Zeppelin server.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4469

### How should this be tested?
* Test it manually.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
