### PR TITLE
[ZEPPELIN-4472] Upgrade Shiro to 1.4.2 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.logging.version>1.1.1</commons.logging.version>
     <commons.cli.version>1.3.1</commons.cli.version>
-    <shiro.version>1.4.0</shiro.version>
+    <shiro.version>1.4.2</shiro.version>
     <joda.version>2.9.9</joda.version>
 
     <!-- test library versions -->


### PR DESCRIPTION
### What is this PR for?

Bumps Shiro dependency to 1.4.2 to fix possible problems with CVE.

### What type of PR is it?
Improvement

### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-4472

### How should this be tested?

* Travis-CI build: https://travis-ci.org/alexott/zeppelin/builds/622262158 - one test is failing, something wrong with Livy interpreter.
