### PR TITLE
[MINOR] Fix notebook filter search

### DIFF
--- a/zeppelin-web/src/app/home/home.controller.js
+++ b/zeppelin-web/src/app/home/home.controller.js
@@ -139,7 +139,7 @@ function HomeCtrl($scope, noteListFactory, websocketMsgSrv, $rootScope, arrayOrd
       return true;
     }
 
-    let noteName = note.path;
+    let noteName = note.name;
     if (noteName.toLowerCase().indexOf($scope.query.q.toLowerCase()) > -1) {
       return true;
     }


### PR DESCRIPTION
### What is this PR for?
Unlike the navigation bar, the home notebook filter returns values ​​that belong to a path rather than a note name.


### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [x] - Filter by note name

### What is the Jira issue?
No

### Screenshots (if appropriate)
(before)
<img width="1077" alt="Screen Shot 2019-12-09 at 8 44 55 PM" src="https://user-images.githubusercontent.com/42430609/70434966-0140e400-1ac9-11ea-9a2b-a288a53d3111.png">
(after)
<img width="1077" alt="Screen Shot 2019-12-09 at 8 46 52 PM" src="https://user-images.githubusercontent.com/42430609/70434974-03a33e00-1ac9-11ea-99bc-3698d40ee604.png">


