### PR TITLE
[ZEPPELIN-4476] Running Trash Restore will result in an error

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1031,7 +1031,13 @@ public class NotebookServer extends WebSocketServlet
   private void emptyTrash(NotebookSocket conn,
                           Message fromMessage) throws IOException {
     getNotebookService().emptyTrash(getServiceContext(fromMessage),
-        new WebSocketServiceCallback(conn));
+        new WebSocketServiceCallback(conn) {
+          @Override
+          public void onSuccess(Object result, ServiceContext context) throws IOException {
+            super.onSuccess(result, context);
+            broadcastNoteList(context.getAutheInfo(), context.getUserAndRoles());
+          }
+        });
   }
 
   private void updateParagraph(NotebookSocket conn,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.notebook;
 
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +42,8 @@ import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
+import org.apache.zeppelin.notebook.NoteManager.Folder;
+import org.apache.zeppelin.notebook.NoteManager.NoteNode;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
@@ -297,11 +298,13 @@ public class Notebook {
   public void restoreAll(AuthenticationInfo subject) throws IOException {
     NoteManager.Folder trash = noteManager.getTrashFolder();
     // restore notes under trash folder
-    for (NoteManager.NoteNode noteNode : trash.getNotes().values()) {
+    List<NoteNode> notes = trash.getNotes().values().stream().collect(Collectors.toList());
+    for (NoteManager.NoteNode noteNode : notes) {
       moveNote(noteNode.getNoteId(), noteNode.getNotePath().replace("/~Trash", ""), subject);
     }
     // restore folders under trash folder
-    for (NoteManager.Folder folder : trash.getFolders().values()) {
+    List<Folder> folders = trash.getFolders().values().stream().collect(Collectors.toList());
+    for (NoteManager.Folder folder : folders) {
       moveFolder(folder.getPath(), folder.getPath().replace("/~Trash", ""), subject);
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -298,6 +298,8 @@ public class Notebook {
   public void restoreAll(AuthenticationInfo subject) throws IOException {
     NoteManager.Folder trash = noteManager.getTrashFolder();
     // restore notes under trash folder
+    // If the value changes in the loop, a concurrent modification exception is thrown.
+    // Collector implementation of collect methods to maintain immutability.
     List<NoteNode> notes = trash.getNotes().values().stream().collect(Collectors.toList());
     for (NoteManager.NoteNode noteNode : notes) {
       moveNote(noteNode.getNoteId(), noteNode.getNotePath().replace("/~Trash", ""), subject);


### PR DESCRIPTION
### What is this PR for?
If you run a restore when there are two or more notes or folders, an error occurs.

<img width="1447" alt="Screen Shot 2019-12-09 at 10 19 15 PM" src="https://user-images.githubusercontent.com/42430609/70450056-65be6c00-1ae6-11ea-9cb8-8ab5668d9d80.png">

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Update note list after emptying the Trash
* [x] - Fixes an error when running Trash restore

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4476

### How should this be tested?
(before)
![Dec-09-2019 22-57-57](https://user-images.githubusercontent.com/42430609/70449831-02ccd500-1ae6-11ea-8cfc-ef0951f4e228.gif)
![Dec-09-2019 23-13-49](https://user-images.githubusercontent.com/42430609/70450026-593a1380-1ae6-11ea-8046-a53eb2b10b9b.gif)

(after)
![Dec-09-2019 23-11-29](https://user-images.githubusercontent.com/42430609/70449863-11b38780-1ae6-11ea-86c2-b4df328ff6df.gif)
![Dec-09-2019 22-55-39](https://user-images.githubusercontent.com/42430609/70449983-458ead00-1ae6-11ea-9aec-f1494327efa1.gif)
