### PR TITLE
ZEPPELIN-4483. Job stautus in zeppelin server side may be always in RUNNING while the job is finished in interpreter process

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -889,7 +889,6 @@ public class RemoteInterpreterServer extends Thread
     synchronized (interpreterGroup) {
       List<Interpreter> interpreters = interpreterGroup.get(sessionId);
       if (interpreters == null) {
-        logger.info("getStatus:" + Status.UNKNOWN.name());
         return Status.UNKNOWN.name();
       }
 
@@ -902,7 +901,6 @@ public class RemoteInterpreterServer extends Thread
         }
       }
     }
-    logger.info("getStatus:" + Status.UNKNOWN.name());
     return Status.UNKNOWN.name();
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/AbstractScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/AbstractScheduler.java
@@ -120,25 +120,26 @@ public abstract class AbstractScheduler implements Scheduler {
     }
     runningJob.run();
     Object jobResult = runningJob.getReturn();
-    if (runningJob.isAborted()) {
-      runningJob.setStatus(Job.Status.ABORT);
-      LOGGER.debug("Job Aborted, " + runningJob.getId() + ", " +
-          runningJob.getErrorMessage());
-    } else if (runningJob.getException() != null) {
-      LOGGER.debug("Job Error, " + runningJob.getId() + ", " +
-          runningJob.getReturn());
-      runningJob.setStatus(Job.Status.ERROR);
-    } else if (jobResult != null && jobResult instanceof InterpreterResult
-        && ((InterpreterResult) jobResult).code() == InterpreterResult.Code.ERROR) {
-      LOGGER.debug("Job Error, " + runningJob.getId() + ", " +
-          runningJob.getReturn());
-      runningJob.setStatus(Job.Status.ERROR);
-    } else {
-      LOGGER.debug("Job Finished, " + runningJob.getId() + ", Result: " +
-          runningJob.getReturn());
-      runningJob.setStatus(Job.Status.FINISHED);
+    synchronized (runningJob) {
+      if (runningJob.isAborted()) {
+        runningJob.setStatus(Job.Status.ABORT);
+        LOGGER.debug("Job Aborted, " + runningJob.getId() + ", " +
+                runningJob.getErrorMessage());
+      } else if (runningJob.getException() != null) {
+        LOGGER.debug("Job Error, " + runningJob.getId() + ", " +
+                runningJob.getReturn());
+        runningJob.setStatus(Job.Status.ERROR);
+      } else if (jobResult != null && jobResult instanceof InterpreterResult
+              && ((InterpreterResult) jobResult).code() == InterpreterResult.Code.ERROR) {
+        LOGGER.debug("Job Error, " + runningJob.getId() + ", " +
+                runningJob.getReturn());
+        runningJob.setStatus(Job.Status.ERROR);
+      } else {
+        LOGGER.debug("Job Finished, " + runningJob.getId() + ", Result: " +
+                runningJob.getReturn());
+        runningJob.setStatus(Job.Status.FINISHED);
+      }
     }
-
     LOGGER.info("Job " + runningJob.getId() + " finished by scheduler " + name);
     // reset aborted flag to allow retry
     runningJob.aborted = false;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1831,10 +1831,6 @@ public class NotebookServer extends WebSocketServlet
 
     p.setStatusToUserParagraph(p.getStatus());
     broadcastParagraph(p.getNote(), p);
-    //    for (NoteEventListener listener : notebook.getNoteEventListeners()) {
-    //      listener.onParagraphStatusChange(p, after);
-    //    }
-
     try {
       broadcastUpdateNoteJobInfo(System.currentTimeMillis() - 5000);
     } catch (IOException e) {


### PR DESCRIPTION

### What is this PR for?

There's 2 places that job will update its status, one is JobStatusPoller thread, another is Job itself. It is possible that job is finished, and after it get rpc request that tell the job is in RUNNING state. In this case, the job would be never complete in frontend. This PR fix this issue.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4483

### How should this be tested?
* CI pass. I run the following code in a cron job which run every 1 minute, before this PR, I can reproduce this issue. With this PR, I didn't see this issue for more than 2 days. 

```
sc.range(1,10).sum()
```
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
