### PR TITLE
[MINOR] Use the deprecated setSoLingerTime Jetty method, a warning is displayed

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -333,7 +333,6 @@ public class ZeppelinServer extends ResourceConfig {
     // Set some timeout options to make debugging easier.
     int timeout = 1000 * 30;
     connector.setIdleTimeout(timeout);
-    connector.setSoLingerTime(-1);
     connector.setHost(conf.getServerAddress());
     if (conf.useSsl()) {
       connector.setPort(conf.getServerSslPort());


### PR DESCRIPTION
### What is this PR for?
You should remove the call to the deprecated Jetty method setSoLingerTime.


### What type of PR is it?
[Improvement]

### Todos
* [x] - Remove call to deprecated jetty method

### Screenshots (if appropriate)
(Before)
<img width="1337" alt="Screen Shot 2019-12-19 at 11 20 48 PM" src="https://user-images.githubusercontent.com/42430609/71183041-95296180-22ba-11ea-8983-9af20bbe2c4c.png">

(After)
<img width="1337" alt="Screen Shot 2019-12-19 at 11 21 16 PM" src="https://user-images.githubusercontent.com/42430609/71183048-9bb7d900-22ba-11ea-9605-0908346c66cf.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
