### PR TITLE
[ZEPPELIN-4505] Save notebook on clear all paragraph output 

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -600,6 +600,7 @@ public class NotebookService {
     }
 
     note.clearAllParagraphOutput();
+    notebook.saveNote(note, context.getAutheInfo());
     callback.onSuccess(note, context);
   }
 


### PR DESCRIPTION
### What is this PR for?
Currently clear all paragraph output changes are only stored in memory. So, when zeppelin is restarted all of the output is displayed again on all of the notebooks.

This PR saves the changes made to notebook and updates are reflected also on a restart. So there's no inconsistencies before and after a restart.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4505

### How should this be tested?
- Create a notebook using Spark interpreter
- Create any output
- Trigger clear all paragraph output 
- Restart zeppelin and paragraph output will be erased as expected.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
