### PR TITLE
[ZEPPELIN-4509]. Make JupyterKernelInterpreter extends AbstractInterpreter

### DIFF
--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -25,8 +25,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.zeppelin.interpreter.AbstractInterpreter;
 import org.apache.zeppelin.interpreter.BaseZeppelinContext;
-import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -61,7 +61,7 @@ import java.util.Properties;
  * Jupyter Kernel. You can enhance the jupyter kernel by extending this class.
  * e.g. IPythonInterpreter.
  */
-public class JupyterKernelInterpreter extends Interpreter {
+public class JupyterKernelInterpreter extends AbstractInterpreter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JupyterKernelInterpreter.class);
 
@@ -238,7 +238,7 @@ public class JupyterKernelInterpreter extends Interpreter {
   }
 
   @Override
-  public InterpreterResult interpret(String st,
+  public InterpreterResult internalInterpret(String st,
                                      InterpreterContext context) throws InterpreterException {
     zeppelinContext.setGui(context.getGui());
     zeppelinContext.setNoteGui(context.getNoteGui());


### PR DESCRIPTION

### What is this PR for?

This is a straightforward PR which just make `JupyterKernelInterpreter` extends `AbstractInterpreter` so that we can leverage the features in `JupyterKernelInterpreter` such as variable interpolation.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4509

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
