### PR TITLE
[ZEPPELIN-4522]. Support multiple sql statements for SparkSqlInterpreter

### DIFF
--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -298,13 +298,13 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
         "df.hvplot()", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     interpreterResultMessages = context.out.toInterpreterResultMessage();
-    assertEquals(5, interpreterResultMessages.size());
+    assertEquals(4, interpreterResultMessages.size());
+    assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(0).getType());
     assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(1).getType());
     assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(2).getType());
     assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(3).getType());
-    assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(4).getType());
     // docs_json is the source data of plotting which bokeh would use to render the plotting.
-    assertTrue(interpreterResultMessages.get(4).getData().contains("docs_json"));
+    assertTrue(interpreterResultMessages.get(3).getData().contains("docs_json"));
   }
 
 

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -171,6 +171,45 @@ public class SparkSqlInterpreterTest {
   }
 
   @Test
+  public void testMultipleStatements() throws InterpreterException {
+    sparkInterpreter.interpret("case class P(age:Int)", context);
+    sparkInterpreter.interpret(
+            "val gr = sc.parallelize(Seq(P(1),P(2),P(3),P(4),P(5),P(6),P(7),P(8)))",
+            context);
+    sparkInterpreter.interpret("gr.toDF.registerTempTable(\"gr\")", context);
+
+    // Two correct sql
+    InterpreterResult ret = sqlInterpreter.interpret(
+            "select * --comment_1\nfrom gr;select count(1) from gr", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(ret.message().toString(), 5, ret.message().size());
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(0).getType());
+    assertEquals(ret.message().toString(), "\n", ret.message().get(0).getData());
+    assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(1).getType());
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
+    assertEquals(ret.message().toString(), "\n", ret.message().get(2).getData());
+    assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(3).getType());
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(4).getType());
+    assertEquals(ret.message().toString(), "", ret.message().get(4).getData());
+
+    // One correct sql + One invalid sql
+    ret = sqlInterpreter.interpret("select * from gr;invalid_sql", context);
+    assertEquals(InterpreterResult.Code.ERROR, ret.code());
+    assertEquals(ret.message().toString(), 3, ret.message().size());
+    assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(1).getType());
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
+    assertTrue(ret.message().toString(), ret.message().get(2).getData().contains("ParseException"));
+
+    // One correct sql + One invalid sql + One valid sql (skipped)
+    ret = sqlInterpreter.interpret("select * from gr;invalid_sql; select count(1) from gr", context);
+    assertEquals(InterpreterResult.Code.ERROR, ret.code());
+    assertEquals(ret.message().toString(), 3, ret.message().size());
+    assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(1).getType());
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
+    assertTrue(ret.message().toString(), ret.message().get(2).getData().contains("ParseException"));
+  }
+
+  @Test
   public void testConcurrentSQL() throws InterpreterException, InterruptedException {
     if (sparkInterpreter.getSparkVersion().isSpark2()) {
       sparkInterpreter.interpret("spark.udf.register(\"sleep\", (e:Int) => {Thread.sleep(e*1000); e})", context);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -195,18 +195,20 @@ public class SparkSqlInterpreterTest {
     // One correct sql + One invalid sql
     ret = sqlInterpreter.interpret("select * from gr;invalid_sql", context);
     assertEquals(InterpreterResult.Code.ERROR, ret.code());
-    assertEquals(ret.message().toString(), 3, ret.message().size());
+    assertEquals(ret.message().toString(), 4, ret.message().size());
     assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(1).getType());
     assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
-    assertTrue(ret.message().toString(), ret.message().get(2).getData().contains("ParseException"));
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(3).getType());
+    assertTrue(ret.message().toString(), ret.message().get(3).getData().contains("ParseException"));
 
     // One correct sql + One invalid sql + One valid sql (skipped)
     ret = sqlInterpreter.interpret("select * from gr;invalid_sql; select count(1) from gr", context);
     assertEquals(InterpreterResult.Code.ERROR, ret.code());
-    assertEquals(ret.message().toString(), 3, ret.message().size());
+    assertEquals(ret.message().toString(), 4, ret.message().size());
     assertEquals(ret.message().toString(), Type.TABLE, ret.message().get(1).getType());
     assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
-    assertTrue(ret.message().toString(), ret.message().get(2).getData().contains("ParseException"));
+    assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(3).getType());
+    assertTrue(ret.message().toString(), ret.message().get(3).getData().contains("ParseException"));
   }
 
   @Test

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -209,6 +209,12 @@ public class SparkSqlInterpreterTest {
     assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(2).getType());
     assertEquals(ret.message().toString(), Type.TEXT, ret.message().get(3).getType());
     assertTrue(ret.message().toString(), ret.message().get(3).getData().contains("ParseException"));
+
+    // Two 2 comments
+    ret = sqlInterpreter.interpret(
+            "--comment_1\n--comment_2", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(ret.message().toString(), 0, ret.message().size());
   }
 
   @Test

--- a/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
+++ b/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
@@ -70,7 +70,7 @@ public class Spark1Shims extends SparkShims {
       // fetch maxResult+1 rows so that we can check whether it is larger than zeppelin.spark.maxResult
       List<Row> rows = df.takeAsList(maxResult + 1);
       StringBuilder msg = new StringBuilder();
-      msg.append("%table ");
+      msg.append("\n%table ");
       msg.append(StringUtils.join(columns, "\t"));
       msg.append("\n");
       boolean isLargerThanMaxResult = rows.size() > maxResult;

--- a/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
+++ b/spark/spark2-shims/src/main/scala/org/apache/zeppelin/spark/Spark2Shims.java
@@ -71,7 +71,7 @@ public class Spark2Shims extends SparkShims {
       // fetch maxResult+1 rows so that we can check whether it is larger than zeppelin.spark.maxResult
       List<Row> rows = df.takeAsList(maxResult + 1);
       StringBuilder msg = new StringBuilder();
-      msg.append("%table ");
+      msg.append("\n%table ");
       msg.append(StringUtils.join(columns, "\t"));
       msg.append("\n");
       boolean isLargerThanMaxResult = rows.size() > maxResult;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
@@ -17,6 +17,7 @@
 package org.apache.zeppelin.interpreter;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -328,6 +329,12 @@ public class InterpreterOutput extends OutputStream {
     List<InterpreterResultMessage> list = new LinkedList<>();
     synchronized (resultMessageOutputs) {
       for (InterpreterResultMessageOutput out : resultMessageOutputs) {
+        if (out.toInterpreterResultMessage().getType() == InterpreterResult.Type.TEXT &&
+                StringUtils.isBlank(out.toInterpreterResultMessage().getData())) {
+          // skip blank text, because when print table data we usually need to print '%text \n'
+          // first to separate it from previous other kind of data. e.g. z.show(df)
+          continue;
+        }
         list.add(out.toInterpreterResultMessage());
       }
     }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterResultTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterResultTest.java
@@ -33,7 +33,7 @@ public class InterpreterResultTest {
     result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "%this is a TEXT type");
     assertEquals("No magic", InterpreterResult.Type.TEXT, result.message().get(0).getType());
     result = new InterpreterResult(InterpreterResult.Code.SUCCESS, "%\n");
-    assertEquals("No magic", InterpreterResult.Type.TEXT, result.message().get(0).getType());
+    assertEquals(0, result.message().size());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

Use the SqlSplitter in `zeppelin-interpreter` to split sql and execute in SparkSqlInterpreter. Nothing changes for the previous single sql statement paragraph. But just multiple result will be displayed for multiple sql statements. 


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4522

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
