### PR TITLE
[ZEPPELIN-4524]. Paragraph keep in RUNNING state if its interpreter download is not ready

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -103,6 +103,7 @@ public class NotebookServiceTest {
     InterpreterSetting mockInterpreterSetting = mock(InterpreterSetting.class);
     when(mockInterpreterSetting.isUserAuthorized(any())).thenReturn(true);
     when(mockInterpreterGroup.getInterpreterSetting()).thenReturn(mockInterpreterSetting);
+    when(mockInterpreterSetting.getStatus()).thenReturn(InterpreterSetting.Status.READY);
     SearchService searchService = new LuceneSearch(zeppelinConfiguration);
     Credentials credentials = new Credentials(false, null, null);
     Notebook notebook =

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -449,8 +449,11 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
               getId(), this.interpreter.getClassName(), note.getId(), subject.getUser());
       InterpreterSetting interpreterSetting = ((ManagedInterpreterGroup)
               interpreter.getInterpreterGroup()).getInterpreterSetting();
-      if (interpreterSetting != null) {
-        interpreterSetting.waitForReady();
+      if (interpreterSetting.getStatus() != InterpreterSetting.Status.READY) {
+        String message = String.format("Interpreter Setting '%s' is not ready, its status is %s",
+                interpreterSetting.getName(), interpreterSetting.getStatus());
+        LOGGER.error(message);
+        throw new RuntimeException(message);
       }
       if (this.user != null) {
         if (subject != null && !interpreterSetting.isUserAuthorized(subject.getUsersAndRoles())) {


### PR DESCRIPTION
### What is this PR for?

This PR is a straightforward fix that just throw exception when interpreter setting is not ready, error message will be displayed in frontend. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4524

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/71558604-3c16b600-2a90-11ea-8d07-19b82d85a4b4.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
