### PR TITLE
[ZEPPELIN-4540] Convert code editor font size units

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -31,6 +31,7 @@ import IEditor = monaco.editor.IEditor;
 import { InterpreterBindingItem } from '@zeppelin/sdk';
 import { CompletionService, MessageService } from '@zeppelin/services';
 
+import { pt2px } from '@zeppelin/utility/css-unit-conversion';
 import { NotebookParagraphControlComponent } from '../control/control.component';
 
 @Component({
@@ -139,7 +140,7 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
     if (this.editor) {
       this.editor.updateOptions({
         readOnly: this.readOnly,
-        fontSize: this.fontSize,
+        fontSize: pt2px(this.fontSize),
         renderLineHighlight: this.focus ? 'all' : 'none',
         minimap: { enabled: false },
         lineNumbers: this.lineNumbers ? 'on' : 'off',

--- a/zeppelin-web-angular/src/app/utility/css-unit-conversion.ts
+++ b/zeppelin-web-angular/src/app/utility/css-unit-conversion.ts
@@ -1,0 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function pt2px(pt: number): number {
+  return pt / (3 / 4);
+}


### PR DESCRIPTION
### What is this PR for?

Convert code editor font size units (from pt to px).

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4540

### How should this be tested?

N/A

### Screenshots (if appropriate)

N/A

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
