### PR TITLE
[ZEPPELIN-4554]. Default interpreter for shell interpreter is missing in interpreter-setting.json

### DIFF
--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -3,6 +3,7 @@
     "group": "sh",
     "name": "sh",
     "className": "org.apache.zeppelin.shell.ShellInterpreter",
+    "defaultInterpreter": true,
     "properties": {
       "shell.command.timeout.millisecs": {
         "envName": "SHELL_COMMAND_TIMEOUT",


### PR DESCRIPTION

### What is this PR for?

Default interpreter is missing in shell interpreter's `interpreter-setting.json`, this cause the frontend unable to get right editor setting when using `%sh`. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4554

### How should this be tested?
* Test is manually

### Screenshots (if appropriate)

Before

![image](https://user-images.githubusercontent.com/164491/72487119-e5f39200-3847-11ea-9686-d65bf4e32578.png)

After
![image](https://user-images.githubusercontent.com/164491/72487208-3965e000-3848-11ea-8871-9cede8f3fbc9.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
