### PR TITLE
[ZEPPELIN-4556]. Can't use hive variable substitution due to dynamic forms

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -470,8 +470,8 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
 
       // inject form
       String script = this.scriptText;
-      if ("simple".equalsIgnoreCase(localProperties.get("form")) ||
-              interpreter.getFormType() == FormType.SIMPLE) {
+      String form = localProperties.getOrDefault("form", interpreter.getFormType().name());
+      if (form.equalsIgnoreCase("simple")) {
         // inputs will be built from script body
         LinkedHashMap<String, Input> inputs = Input.extractSimpleQueryForm(script, false);
         LinkedHashMap<String, Input> noteInputs = Input.extractSimpleQueryForm(script, true);


### PR DESCRIPTION
### What is this PR for?

This PR allow user to override the form type via paragraph local properties. e.g.

```
%jdbc(form=native)

...
```


### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4556

### How should this be tested?
* Verify it manually.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
