### PR TITLE
[ZEPPELIN-4551]. upgrade-note.sh Plugin GitNotebookRepo doesn't exist

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
@@ -100,17 +100,14 @@ public class PluginManager {
    */
   public OldNotebookRepo loadOldNotebookRepo(String notebookRepoClassName) throws IOException {
     LOGGER.info("Loading OldNotebookRepo Plugin: " + notebookRepoClassName);
-    // load plugin from classpath directly when it is test.
-    // otherwise load it from plugin folder
-    String isTest = System.getenv("IS_ZEPPELIN_TEST");
-    if (isTest != null && isTest.equals("true")) {
-      try {
-        OldNotebookRepo notebookRepo = (OldNotebookRepo)
-            (Class.forName(notebookRepoClassName).newInstance());
-        return notebookRepo;
-      } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-        LOGGER.warn("Fail to instantiate notebookrepo from classpath directly:" + notebookRepoClassName);
-      }
+    // load plugin from classpath directly first for these builtin NotebookRepo (such as VFSNoteBookRepo
+    // and GitNotebookRepo). If fails, then try to load it from plugin folder
+    try {
+      OldNotebookRepo notebookRepo = (OldNotebookRepo)
+          (Class.forName(notebookRepoClassName).newInstance());
+      return notebookRepo;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      LOGGER.warn("Fail to instantiate notebookrepo from classpath directly:" + notebookRepoClassName);
     }
 
     String simpleClassName = notebookRepoClassName.substring(notebookRepoClassName.lastIndexOf(".") + 1);


### PR DESCRIPTION
### What is this PR for?

In this PR, we always load NotebookRepo from current classpath first, then fallback to plugin ClassPathLoader. Actually we do it already for new NotebookRepo but miss that for the old NotebookRepo.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4551

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
