### PR TITLE
[ZEPPELIN-4565] Fixed Spark interpreter to allow ZeppelinContext binding in windows

### DIFF
--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -423,7 +423,7 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
       }
     }
 
-    extraJars ++= sparkInterpreterClassLoader.getURLs().map(_.toString)
+    extraJars ++= sparkInterpreterClassLoader.getURLs().map(_.getPath())
     LOGGER.debug("User jar for spark repl: " + extraJars.mkString(","))
     extraJars
   }


### PR DESCRIPTION
### What is this PR for?
ZeppelinContext binding fails for Spark Interpreter in Windows because of the jars not being added to the classpath. This happens because the path of the jars is not supported in Windows. 

### What type of PR is it?
Bug Fix 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4565

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE SOFTWARE FOUNDATION SOFTWARE GRANT AND CORPORATE CONTRIBUTOR LICENSE AGREEMENT VERSION R190612. 

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.