### PR TITLE
[ZEPPELIN-4583] Fix artifact resolving issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,10 @@ Thumbs.db
 .idea/
 *.iml
 
+# VSCode project files
+.vscode/
+**/.factorypath
+
 # maven target files
 target/
 **/target/

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
@@ -87,10 +87,9 @@ public class DependencyResolverTest {
     FileUtils.cleanDirectory(testCopyPath);
 
     // load from added repository
-    resolver.addRepo("sonatype",
-        "https://oss.sonatype.org/content/repositories/ksoap2-android-releases/", false);
-    resolver.load("com.google.code.ksoap2-android:ksoap2-jsoup:3.6.3", testCopyPath);
-    assertEquals(testCopyPath.list().length, 10);
+    resolver.addRepo("sonatype", "https://oss.sonatype.org/content/repositories/releases/", false);
+    resolver.load("org.mortbay.jetty:jetty-runner:7.6.16.v20140903", testCopyPath);
+    assertEquals(testCopyPath.list().length, 27);
 
     // load invalid artifact
     resolver.delRepo("sonatype");


### PR DESCRIPTION
### What is this PR for?
Fixes the problem with install-interpreter script when it tries to resolve Maven artifacts in sonatype, in which only accepts https connections recently.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4583

### How should this be tested?
* Build a zeppelin distribution with no interpreters installed
* Run install-interpreter script to install any interpreter
