### PR TITLE
[ZEPPELIN-4585] Add HTTP Cache-Control Header

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -557,6 +557,15 @@
 
 <!--
 <property>
+  <name>zeppelin.server.cache-control</name>
+  <value>no-cache</value>
+  <description>The HTTP X-Content-Type-Options response header helps to prevent MIME type sniffing attacks. It directs the browser to honor the type specified in the Content-Type header, rather than trying to determine the type from the content itself. The default value "nosniff" is really the only meaningful value. This header is supported on all browsers except Safari and Safari on iOS.</description>
+</property>
+-->
+
+
+<!--
+<property>
   <name>zeppelin.interpreter.callback.portRange</name>
   <value>10000:10010</value>
 </property>

--- a/docs/setup/security/http_security_headers.md
+++ b/docs/setup/security/http_security_headers.md
@@ -107,6 +107,19 @@ Zeppelin server will add this header to HTTP response by default. The following 
 </property>
 ```
 
+## Setting up Control-Cache Header
+
+The Cache-Control HTTP header holds directives (instructions) for caching in both requests and responses. A given directive in a request does not mean the same directive should be in the response.
+Zeppelin server will add this header to HTTP response by default. The following property needs to be updated in the zeppelin-site.xml in order to change Control-Cache header value.
+
+```xml
+<property>
+  <name>zeppelin.server.cache-control</name>
+  <value>no-cache</value>
+  <description>The Cache-Control HTTP header holds directives (instructions) for caching in both requests and responses. A given directive in a request does not mean the same directive should be in the response.</description>
+</property>
+```
+
 ## Setting up Server Header
 
 Security conscious organisations does not want to reveal the Application Server name and version to prevent finding this information easily by Attacker while fingerprinting the Application. The exact version number can tell an Attacker if the current Application Server is patched for or vulnerable to certain publicly known CVE associated to it.

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -643,6 +643,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_SERVER_STRICT_TRANSPORT);
   }
 
+  public String getCacheControl() {
+    return getString(ConfVars.ZEPPELIN_SERVER_CACHE_CONTROL);
+  }
+
   public String getLifecycleManagerClass() {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_CLASS);
   }
@@ -895,6 +899,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SERVER_STRICT_TRANSPORT("zeppelin.server.strict.transport", "max-age=631138519"),
     ZEPPELIN_SERVER_X_XSS_PROTECTION("zeppelin.server.xxss.protection", "1"),
     ZEPPELIN_SERVER_X_CONTENT_TYPE_OPTIONS("zeppelin.server.xcontent.type.options", "nosniff"),
+    ZEPPELIN_SERVER_CACHE_CONTROL("zeppelin.server.cache-control", "no-cache"),
 
     ZEPPELIN_SERVER_KERBEROS_KEYTAB("zeppelin.server.kerberos.keytab", ""),
     ZEPPELIN_SERVER_KERBEROS_PRINCIPAL("zeppelin.server.kerberos.principal", ""),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/CorsFilter.java
@@ -77,6 +77,7 @@ public class CorsFilter implements Filter {
     }
     response.setHeader("X-XSS-Protection", zeppelinConfiguration.getXxssProtection());
     response.setHeader("X-Content-Type-Options", zeppelinConfiguration.getXContentTypeOptions());
+    response.setHeader("Cache-Control", zeppelinConfiguration.getCacheControl());
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4585

### How should this be tested?
* Travis-ci should pass
* To test the change:

```
curl -i localhost:8080/api/version
HTTP/1.1 200 OK
Date: Fri, 31 Jan 2020 19:09:04 GMT
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: authorization,Content-Type
Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, HEAD, DELETE
X-FRAME-OPTIONS: SAMEORIGIN
X-XSS-Protection: 1
X-Content-Type-Options: nosniff
Cache-Control: no-cache
Content-Type: text/plain
Content-Length: 144
Server: Jetty(9.4.18.v20190429)

{"status":"OK","message":"Zeppelin version","body":{"git-commit-id":"b4fc38a","git-timestamp":"2020-01-31 14:27:00","version":"0.9.0-SNAPSHOT"}}%  
```

### Questions:
* Does the licenses files need update?
No
* Is there breaking changes for older versions?
No
* Does this needs documentation?
Yes
