### PR TITLE
[ZEPPELIN-4584] Configuration for 404 error page

### DIFF
--- a/zeppelin-web/src/WEB-INF/404.html
+++ b/zeppelin-web/src/WEB-INF/404.html
@@ -83,70 +83,6 @@ limitations under the License.
         margin: 0 auto;
       }
 
-      /* google search */
-
-      #goog-fixurl ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
-
-      #goog-fixurl form {
-        margin: 0;
-      }
-
-      #goog-wm-qt,
-      #goog-wm-sb {
-        border: 1px solid #bbb;
-        font-size: 16px;
-        line-height: normal;
-        vertical-align: top;
-        color: #444;
-        border-radius: 2px;
-      }
-
-      #goog-wm-qt {
-        width: 220px;
-        height: 20px;
-        padding: 5px;
-        margin: 5px 10px 0 0;
-        box-shadow: inset 0 1px 1px #ccc;
-      }
-
-      #goog-wm-sb {
-        display: inline-block;
-        height: 32px;
-        padding: 0 10px;
-        margin: 5px 0 0;
-        white-space: nowrap;
-        cursor: pointer;
-        background-color: #f5f5f5;
-        background-image: -webkit-linear-gradient(rgba(255,255,255,0), #f1f1f1);
-        background-image: -moz-linear-gradient(rgba(255,255,255,0), #f1f1f1);
-        background-image: -ms-linear-gradient(rgba(255,255,255,0), #f1f1f1);
-        background-image: -o-linear-gradient(rgba(255,255,255,0), #f1f1f1);
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
-        *overflow: visible;
-        *display: inline;
-        *zoom: 1;
-      }
-
-      #goog-wm-sb:hover,
-      #goog-wm-sb:focus {
-        border-color: #aaa;
-        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
-        background-color: #f8f8f8;
-      }
-
-      #goog-wm-qt:hover,
-      #goog-wm-qt:focus {
-        border-color: #105cb6;
-        outline: 0;
-        color: #222;
-      }
-
       input::-moz-focus-inner {
         padding: 0;
         border: 0;
@@ -162,10 +98,6 @@ limitations under the License.
         <li>a mistyped address</li>
         <li>an out-of-date link</li>
       </ul>
-      <script>
-        var GOOG_FIXURL_LANG = (navigator.language || '').slice(0,2),GOOG_FIXURL_SITE = location.host;
-      </script>
-      <script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
     </div>
   </body>
 </html>

--- a/zeppelin-web/src/WEB-INF/web.xml
+++ b/zeppelin-web/src/WEB-INF/web.xml
@@ -31,7 +31,10 @@
 
 		<load-on-startup>1</load-on-startup>
 	</servlet>
-
+	<error-page>
+	  <error-code>404</error-code>
+	  <location>/WEB-INF/404.html</location>
+	</error-page>
 	<context-param>
 		<param-name>configuration</param-name>
 		<param-value>deployment</param-value>


### PR DESCRIPTION
### What is this PR for?
Whenever a User encounters a non-existing resource and get a HTTP 404 error message, it reveals the Jetty version which can be masked using [ZEPPELIN-2461] in response header.


### What type of PR is it?
[Improvement]

### Todos
* Add documentation for configuration

### What is the Jira issue?
* [ZEPPELIN-4584](https://issues.apache.org/jira/browse/ZEPPELIN-4584)

### How should this be tested?
Try hitting an arbitrary non-existent resource for e.g. https://<zeppelin_host>:<zeppelin_port>/<I_D0nt_Exi$t> 
This should display a generic error page without revealing Server Version.

### Screenshots (if appropriate)
Without this PR
<img width="378" alt="Screenshot 2020-01-30 at 19 05 36" src="https://user-images.githubusercontent.com/6433184/73586935-9d400800-44da-11ea-9207-f531539900fb.png">

With this PR
<img width="561" alt="Screenshot 2020-02-01 at 10 09 34" src="https://user-images.githubusercontent.com/6433184/73586970-117aab80-44db-11ea-9b8b-b67abdcde377.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
