### PR TITLE
[ZEPPELIN-4590]. Miss line break for IRInterpreter

### DIFF
--- a/rlang/src/test/java/org/apache/zeppelin/r/RInterpreterTest.java
+++ b/rlang/src/test/java/org/apache/zeppelin/r/RInterpreterTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -64,13 +65,26 @@ public class RInterpreterTest {
   }
 
   @Test
-  public void testSparkRInterpreter() throws InterpreterException, InterruptedException {
+  public void testSparkRInterpreter() throws InterpreterException, InterruptedException, IOException {
     InterpreterResult result = rInterpreter.interpret("1+1", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     assertTrue(result.message().get(0).getData().contains("2"));
 
-    // plotting
     InterpreterContext context = getInterpreterContext();
+    result = rInterpreter.interpret("foo <- TRUE\n" +
+            "print(foo)\n" +
+            "bare <- c(1, 2.5, 4)\n" +
+            "print(bare)\n" +
+            "double <- 15.0\n" +
+            "print(double)", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertTrue(result.toString(),
+                       result.message().get(0).getData().contains("[1] TRUE\n" +
+                               "[1] 1.0 2.5 4.0\n" +
+                               "[1] 15\n"));
+
+    // plotting
+    context = getInterpreterContext();
     context.getLocalProperties().put("imageWidth", "100");
     result = rInterpreter.interpret("hist(mtcars$mpg)", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -198,15 +198,6 @@ public class SparkInterpreterTest {
             ").toDF()", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
-    // create dataset from case class
-    context = getInterpreterContext();
-    result = interpreter.interpret("case class Person(id:Int, name:String, age:Int, country:String)\n" +
-            "val df2 = spark.createDataFrame(Seq(Person(1, \"andy\", 20, \"USA\"), " +
-            "Person(2, \"jeff\", 23, \"China\"), Person(3, \"james\", 18, \"USA\")))\n" +
-            "df2.printSchema\n" +
-            "df2.show() ", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-
     // spark version
     result = interpreter.interpret("sc.version", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
@@ -229,6 +220,15 @@ public class SparkInterpreterTest {
               "|  2|null|\n" +
               "+---+----+"));
     } else if (version.contains("String = 2.")) {
+      // create dataset from case class
+      context = getInterpreterContext();
+      result = interpreter.interpret("case class Person(id:Int, name:String, age:Int, country:String)\n" +
+              "val df2 = spark.createDataFrame(Seq(Person(1, \"andy\", 20, \"USA\"), " +
+              "Person(2, \"jeff\", 23, \"China\"), Person(3, \"james\", 18, \"USA\")))\n" +
+              "df2.printSchema\n" +
+              "df2.show() ", context);
+      assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
       result = interpreter.interpret("spark", getInterpreterContext());
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelClient.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelClient.java
@@ -168,6 +168,11 @@ public class JupyterKernelClient {
                         curOutput.getType() != InterpreterResult.Type.TEXT) {
                   interpreterOutput.write("%text ".getBytes());
                 }
+                // explicitly use html output for ir kernel in some cases. otherwise some
+                // R packages doesn't work. e.g. googlevis
+                if (executeResponse.getOutput().contains("<script type=\"text/javascript\">")) {
+                  interpreterOutput.write("\n%html ".getBytes());
+                }
                 interpreterOutput.write(executeResponse.getOutput().getBytes());
               }
               interpreterOutput.getInterpreterOutput().flush();

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -245,11 +245,6 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
     interpreterOutput.setInterpreterOutput(context.out);
     jupyterKernelClient.setInterpreterContext(context);
     try {
-      // always use html output for ir kernel. otherwise some R packages doesn't work.
-      // e.g. googlevis
-      if (getKernelName().equals("ir")) {
-        context.out.write("%html\n");
-      }
       ExecuteResponse response =
               jupyterKernelClient.stream_execute(ExecuteRequest.newBuilder().setCode(st).build(),
                       interpreterOutput);

--- a/zeppelin-jupyter-interpreter/src/main/resources/grpc/jupyter/kernel_client.py
+++ b/zeppelin-jupyter-interpreter/src/main/resources/grpc/jupyter/kernel_client.py
@@ -23,14 +23,17 @@ import kernel_pb2_grpc
 def run():
     channel = grpc.insecure_channel('localhost:50053')
     stub = kernel_pb2_grpc.JupyterKernelStub(channel)
-    response = stub.execute(kernel_pb2.ExecuteRequest(code="import time\nfor i in range(1,4):\n\ttime.sleep(1)\n\tprint(i)\n" +
-                                                            "%matplotlib inline\nimport matplotlib.pyplot as plt\ndata=[1,1,2,3,4]\nplt.figure()\nplt.plot(data)"))
+    response = stub.execute(kernel_pb2.ExecuteRequest(code="""
+library(googleVis)
+df=data.frame(country=c("US", "GB", "BR"), 
+              val1=c(10,13,14), 
+              val2=c(23,12,32))
+Bar <- gvisBarChart(df)
+print(Bar, tag = 'chart')
+    """))
     for r in response:
         print("output:" + r.output)
 
-    response = stub.execute(kernel_pb2.ExecuteRequest(code="range?"))
-    for r in response:
-        print(r)
 
 if __name__ == '__main__':
     run()

--- a/zeppelin-jupyter-interpreter/src/main/resources/grpc/jupyter/kernel_server.py
+++ b/zeppelin-jupyter-interpreter/src/main/resources/grpc/jupyter/kernel_server.py
@@ -59,6 +59,8 @@ class KernelServer(kernel_pb2_grpc.JupyterKernelServicer):
         def _output_hook(msg):
             msg_type = msg['header']['msg_type']
             content = msg['content']
+            # print("******************")
+            # print(msg)
             outStatus, outType, output = kernel_pb2.SUCCESS, None, None
             # prepare the reply
             if msg_type == 'stream':

--- a/zeppelin-jupyter-interpreter/src/test/java/org/apache/zeppelin/jupyter/IRKernelTest.java
+++ b/zeppelin-jupyter-interpreter/src/test/java/org/apache/zeppelin/jupyter/IRKernelTest.java
@@ -87,9 +87,25 @@ public class IRKernelTest {
     assertEquals(InterpreterResult.Code.ERROR, result.code());
     resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(1, resultMessages.size());
-    assertEquals(result.toString(), InterpreterResult.Type.HTML, resultMessages.get(0).getType());
+    assertEquals(result.toString(), InterpreterResult.Type.TEXT, resultMessages.get(0).getType());
     assertTrue(resultMessages.toString(),
             resultMessages.get(0).getData().contains("object 'unknown_var' not found"));
+
+    context = getInterpreterContext();
+    result = interpreter.interpret("foo <- TRUE\n" +
+            "print(foo)\n" +
+            "bare <- c(1, 2.5, 4)\n" +
+            "print(bare)\n" +
+            "double <- 15.0\n" +
+            "print(double)", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(1, resultMessages.size());
+    assertEquals(result.toString(), InterpreterResult.Type.TEXT, resultMessages.get(0).getType());
+    assertTrue(resultMessages.toString(),
+            resultMessages.get(0).getData().contains("[1] TRUE\n" +
+                    "[1] 1.0 2.5 4.0\n" +
+                    "[1] 15\n"));
 
     // plotting
     context = getInterpreterContext();
@@ -122,11 +138,11 @@ public class IRKernelTest {
               "print(Bar, tag = 'chart')", context);
       assertEquals(InterpreterResult.Code.SUCCESS, result.code());
       resultMessages = context.out.toInterpreterResultMessage();
-      assertEquals(1, resultMessages.size());
+      assertEquals(2, resultMessages.size());
       assertEquals(resultMessages.toString(),
-              InterpreterResult.Type.HTML, resultMessages.get(0).getType());
-      assertTrue(resultMessages.get(0).getData(),
-              resultMessages.get(0).getData().contains("javascript"));
+              InterpreterResult.Type.HTML, resultMessages.get(1).getType());
+      assertTrue(resultMessages.get(1).getData(),
+              resultMessages.get(1).getData().contains("javascript"));
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

In ZEPPELIN-4562, I fix the googlevis issue, but cause the line break missing. In this PR, I will only make html output when it contains javascript related code https://github.com/apache/zeppelin/compare/master...zjffdu:ZEPPELIN-4590?expand=1#diff-ab59c27de9983f5da6d2b847d441fff3R173



### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4590

### How should this be tested?

Unit test is added

### Screenshots (if appropriate)

* Before

![image](https://user-images.githubusercontent.com/164491/73637898-46862a00-46a4-11ea-9ede-080d49043251.png)


* After

![image](https://user-images.githubusercontent.com/164491/73637278-e6db4f00-46a2-11ea-89dc-eb2dfd81e8c7.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
