### PR TITLE
[ZEPPELIN-4593]. Failed to get completion in ShinyInterpreter

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/AbstractInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/AbstractInterpreter.java
@@ -17,6 +17,10 @@
 
 package org.apache.zeppelin.interpreter;
 
+import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 public abstract class AbstractInterpreter extends Interpreter {
@@ -52,4 +56,11 @@ public abstract class AbstractInterpreter extends Interpreter {
   protected abstract InterpreterResult internalInterpret(
           String st,
           InterpreterContext context) throws InterpreterException;
+
+  @Override
+  public List<InterpreterCompletion> completion(String buf,
+                                                int cursor,
+                                                InterpreterContext interpreterContext) throws InterpreterException {
+    return new ArrayList<>();
+  }
 }


### PR DESCRIPTION
### What is this PR for?
The root cause is that we didn't implement `completion` method, so it would always return null which cause the error. This PR fix it by always return empty List for `completion` method in `AbstractInterpreter`.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4593

### How should this be tested?
* Tested manully

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
