### PR TITLE
[ZEPPELIN-4568] Fix can not update output when the data is empty

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -212,7 +212,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
         $scope.paragraph.results.msg = [];
       }
 
-      let update = ($scope.paragraph.results.msg[data.index]) ? true : false;
+      let update = typeof $scope.paragraph.results.msg[data.index] !== 'undefined';
 
       $scope.paragraph.results.msg[data.index] = {
         data: data.data,

--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -216,7 +216,12 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
       callback(elem);
     }
 
-    $timeout(retry);
+    if(isDOMLoaded(targetElemId)) {
+      const elem = angular.element(`#${targetElemId}`);
+      callback(elem);
+    } else {
+      $timeout(retry);
+    }
   }
 
   $scope.$on('updateResult', function(event, result, newConfig, paragraphRef, index) {

--- a/zeppelin-web/src/app/spell/spell-result.js
+++ b/zeppelin-web/src/app/spell/spell-result.js
@@ -217,7 +217,7 @@ export class SpellResult {
   }
 
   static isObject(data) {
-    return (data &&
+    return (typeof data !== 'undefined' &&
       !SpellResult.isFunction(data) &&
       !SpellResult.isPromise(data));
   }


### PR DESCRIPTION
### What is this PR for?

Fix can not update output when the data is empty


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4568

### How should this be tested?

Try the following code:

```pythone
import sys
import time
from IPython.display import display, clear_output
for i in range(10):
    time.sleep(0.25)
    clear_output(wait=True)
    print(i)
    sys.stdout.flush()
```

Should be updated instead of append the output

### Screenshots (if appropriate)

![Kapture 2020-02-10 at 17 07 46](https://user-images.githubusercontent.com/22736418/74135832-f4a34e00-4c27-11ea-9af8-9ab1f8da218d.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
