### PR TITLE
[ZEPPELIN-4606]. Run paragraph rest api cause the paragraph configuration missing after execution

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -309,16 +309,24 @@ public class NotebookService {
     p.setText(text);
     p.setTitle(title);
     p.setAuthenticationInfo(context.getAutheInfo());
-    p.settings.setParams(params);
-    p.setConfig(config);
+    if (params != null && !params.isEmpty()) {
+      p.settings.setParams(params);
+    }
+    if (config != null && !config.isEmpty()) {
+      p.setConfig(config);
+    }
 
     if (note.isPersonalizedMode()) {
       p = p.getUserParagraph(context.getAutheInfo().getUser());
       p.setText(text);
       p.setTitle(title);
       p.setAuthenticationInfo(context.getAutheInfo());
-      p.settings.setParams(params);
-      p.setConfig(config);
+      if (params != null && !params.isEmpty()) {
+        p.settings.setParams(params);
+      }
+      if (config != null && !config.isEmpty()) {
+        p.setConfig(config);
+      }
     }
 
     try {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -343,10 +343,13 @@ public class NotebookServiceTest {
 
     // run paragraph asynchronously
     reset(callback);
+    p.getConfig().put("colWidth", "6.0");
+    p.getConfig().put("title", true);
     boolean runStatus = notebookService.runParagraph(note1.getId(), p.getId(), "my_title", "1+1",
         new HashMap<>(), new HashMap<>(), false, false, context, callback);
     assertTrue(runStatus);
     verify(callback).onSuccess(p, context);
+    assertEquals(2, p.getConfig().size());
 
     // run paragraph synchronously via correct code
     reset(callback);
@@ -354,6 +357,7 @@ public class NotebookServiceTest {
         new HashMap<>(), new HashMap<>(), false, true, context, callback);
     assertTrue(runStatus);
     verify(callback).onSuccess(p, context);
+    assertEquals(2, p.getConfig().size());
 
     // run all paragraphs
     reset(callback);


### PR DESCRIPTION
### What is this PR for?
This PR fix the issue by only setting config and setting when they are not empty. Because when invoking rest api, the paragraph config won't be passed to backend, in that case it would use an empty Map to override the existing config. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4606

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
