### PR TITLE
[ZEPPELIN-4598]. upgrade-note.sh GitNotebookRepo cannot be cast to OldNotebookRepo

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/plugin/PluginManager.java
@@ -99,15 +99,16 @@ public class PluginManager {
    * @throws IOException
    */
   public OldNotebookRepo loadOldNotebookRepo(String notebookRepoClassName) throws IOException {
-    LOGGER.info("Loading OldNotebookRepo Plugin: " + notebookRepoClassName);
+    String oldNotebookRepoClassName = getOldNotebookRepoClassName(notebookRepoClassName);
+    LOGGER.info("Loading OldNotebookRepo Plugin: " + oldNotebookRepoClassName);
     // load plugin from classpath directly first for these builtin NotebookRepo (such as VFSNoteBookRepo
     // and GitNotebookRepo). If fails, then try to load it from plugin folder
     try {
       OldNotebookRepo notebookRepo = (OldNotebookRepo)
-          (Class.forName(notebookRepoClassName).newInstance());
+          (Class.forName(oldNotebookRepoClassName).newInstance());
       return notebookRepo;
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-      LOGGER.warn("Fail to instantiate notebookrepo from classpath directly:" + notebookRepoClassName);
+      LOGGER.warn("Fail to instantiate notebookrepo from classpath directly:" + oldNotebookRepoClassName);
     }
 
     String simpleClassName = notebookRepoClassName.substring(notebookRepoClassName.lastIndexOf(".") + 1);
@@ -117,14 +118,13 @@ public class PluginManager {
     }
     OldNotebookRepo notebookRepo = null;
     try {
-      notebookRepoClassName = getOldNotebookRepoClassName(notebookRepoClassName);
-      notebookRepo = (OldNotebookRepo) (Class.forName(notebookRepoClassName, true, pluginClassLoader)).newInstance();
+      notebookRepo = (OldNotebookRepo) (Class.forName(oldNotebookRepoClassName, true, pluginClassLoader)).newInstance();
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-      LOGGER.warn("Fail to instantiate notebookrepo from plugin classpath:" + notebookRepoClassName, e);
+      LOGGER.warn("Fail to instantiate notebookrepo from plugin classpath:" + oldNotebookRepoClassName, e);
     }
 
     if (notebookRepo == null) {
-      LOGGER.warn("Unable to load NotebookRepo Plugin: " + notebookRepoClassName);
+      LOGGER.warn("Unable to load NotebookRepo Plugin: " + oldNotebookRepoClassName);
     }
     return notebookRepo;
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/plugin/PluginManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/plugin/PluginManagerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.plugin;
+
+import org.apache.zeppelin.notebook.repo.GitNotebookRepo;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.apache.zeppelin.notebook.repo.OldGitNotebookRepo;
+import org.apache.zeppelin.notebook.repo.OldNotebookRepo;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class PluginManagerTest {
+
+  @Test
+  public void testLoadGitNotebookRepo() throws IOException {
+    NotebookRepo notebookRepo = PluginManager.get()
+            .loadNotebookRepo("org.apache.zeppelin.notebook.repo.GitNotebookRepo");
+    assertTrue(notebookRepo instanceof GitNotebookRepo);
+
+    OldNotebookRepo oldNotebookRepo = PluginManager.get()
+            .loadOldNotebookRepo("org.apache.zeppelin.notebook.repo.GitNotebookRepo");
+    assertTrue(oldNotebookRepo instanceof OldGitNotebookRepo);
+  }
+}


### PR DESCRIPTION
### What is this PR for?

This PR fix the issue that `OldGitNotebookRepo` not loaded correctly because we still try to load `GitNotebookRepo`

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4598

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
