### PR TITLE
[ZEPPELIN-3751]. Interpreter Binding menu of note only shows default interpreter

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -543,6 +543,7 @@ public class NotebookServer extends WebSocketServlet
   }
 
   public void saveInterpreterBindings(NotebookSocket conn, Message fromMessage) throws IOException {
+    List<InterpreterSettingsList> settingList = new ArrayList<>();
     String noteId = (String) fromMessage.data.get("noteId");
     Note note = getNotebook().getNote(noteId);
     if (note != null) {
@@ -552,7 +553,15 @@ public class NotebookServer extends WebSocketServlet
       if (!settingIdList.isEmpty()) {
         note.setDefaultInterpreterGroup(settingIdList.get(0));
       }
+      List<InterpreterSetting> bindedSettings = note.getBindedInterpreterSettings();
+      for (InterpreterSetting setting : bindedSettings) {
+        settingList.add(new InterpreterSettingsList(setting.getId(), setting.getName(),
+                setting.getInterpreterInfos(), true));
+      }
     }
+
+    conn.send(serializeMessage(
+            new Message(OP.INTERPRETER_BINDINGS).put("interpreterBindings", settingList)));
   }
 
   public void broadcastNote(Note note) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -422,6 +422,9 @@ public class NotebookServer extends WebSocketServlet
         case GET_INTERPRETER_BINDINGS:
           getInterpreterBindings(conn, messagereceived);
           break;
+        case SAVE_INTERPRETER_BINDINGS:
+          saveInterpreterBindings(conn, messagereceived);
+          break;
         case EDITOR_SETTING:
           getEditorSetting(conn, messagereceived);
           break;
@@ -537,6 +540,19 @@ public class NotebookServer extends WebSocketServlet
     }
     conn.send(serializeMessage(
         new Message(OP.INTERPRETER_BINDINGS).put("interpreterBindings", settingList)));
+  }
+
+  public void saveInterpreterBindings(NotebookSocket conn, Message fromMessage) throws IOException {
+    String noteId = (String) fromMessage.data.get("noteId");
+    Note note = getNotebook().getNote(noteId);
+    if (note != null) {
+      List<String> settingIdList =
+              gson.fromJson(String.valueOf(fromMessage.data.get("selectedSettingIds")),
+                      new TypeToken<ArrayList<String>>() {}.getType());
+      if (!settingIdList.isEmpty()) {
+        note.setDefaultInterpreterGroup(settingIdList.get(0));
+      }
+    }
   }
 
   public void broadcastNote(Note note) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1251,11 +1251,11 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
   };
 
   const isSettingDirty = function() {
-    // if (angular.equals($scope.interpreterBindings, $scope.interpreterBindingsOrig)) {
-    //   return false;
-    // } else {
-    return false;
-    // }
+    if (angular.equals($scope.interpreterBindings, $scope.interpreterBindingsOrig)) {
+      return false;
+    } else {
+      return false;
+    }
   };
 
   const isPermissionsDirty = function() {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -1254,7 +1254,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     if (angular.equals($scope.interpreterBindings, $scope.interpreterBindingsOrig)) {
       return false;
     } else {
-      return false;
+      return true;
     }
   };
 

--- a/zeppelin-web/src/app/notebook/notebook.html
+++ b/zeppelin-web/src/app/notebook/notebook.html
@@ -42,12 +42,10 @@ limitations under the License.
         <div data-ng-repeat="item in interpreterBindings" as-sortable-item>
           <div>
             <a ng-click="restartInterpreter(item)"
-               ng-class="{'inactivelink': !item.selected}"
                uib-tooltip="Restart">
               <span class="glyphicon glyphicon-refresh btn-md"></span>
             </a>&nbsp
             <div as-sortable-item-handle
-                 ng-click="item.selected = !item.selected"
                  class="btn"
                  ng-class="{'btn-info': item.selected, 'btn-default': !item.selected}">
               <font style="font-size:16px">{{item.name}}</font>

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -363,8 +363,8 @@ function WebsocketMessageService($rootScope, websocketEvents) {
     },
 
     saveInterpreterBindings: function(noteId, selectedSettingIds) {
-      // websocketEvents.sendNewEvent({op: 'SAVE_INTERPRETER_BINDINGS',
-      //   data: {noteId: noteId, selectedSettingIds: selectedSettingIds}});
+      websocketEvents.sendNewEvent({op: 'SAVE_INTERPRETER_BINDINGS',
+        data: {noteId: noteId, selectedSettingIds: selectedSettingIds}});
     },
 
     listConfigurations: function() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -975,7 +975,22 @@ public class Note implements JsonSerializable {
   }
 
   public List<InterpreterSetting> getBindedInterpreterSettings() {
-    Set<InterpreterSetting> settings = new HashSet<>();
+    // use LinkedHashSet because order matters, the first one represent the default interpreter setting.
+    Set<InterpreterSetting> settings = new LinkedHashSet<>();
+    // add the default interpreter group
+    InterpreterSetting defaultIntpSetting =
+            interpreterSettingManager.getByName(getDefaultInterpreterGroup());
+    if (defaultIntpSetting != null) {
+      settings.add(defaultIntpSetting);
+    }
+    // add the interpreter setting with the same group of default interpreter group
+    for (InterpreterSetting intpSetting : interpreterSettingManager.get()) {
+      if (intpSetting.getGroup().equals(defaultIntpSetting.getGroup())) {
+        settings.add(intpSetting);
+      }
+    }
+
+    // add interpreter group used by each paragraph
     for (Paragraph p : getParagraphs()) {
       try {
         Interpreter intp = p.getBindedInterpreter();
@@ -985,12 +1000,7 @@ public class Note implements JsonSerializable {
         // ignore this
       }
     }
-    // add the default interpreter group
-    InterpreterSetting defaultIntpSetting =
-            interpreterSettingManager.getByName(getDefaultInterpreterGroup());
-    if (defaultIntpSetting != null) {
-      settings.add(defaultIntpSetting);
-    }
+
     return new ArrayList<>(settings);
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -172,6 +172,7 @@ public class Message implements JsonSerializable {
     UNSUBSCRIBE_UPDATE_NOTE_JOBS, // [c-s] unsubscribe job information for job management
     // @param unixTime
     GET_INTERPRETER_BINDINGS,    // [c-s] get interpreter bindings
+    SAVE_INTERPRETER_BINDINGS,    // [c-s] save interpreter bindings
     INTERPRETER_BINDINGS,         // [s-c] interpreter bindings
 
     GET_INTERPRETER_SETTINGS,     // [c-s] get interpreter settings


### PR DESCRIPTION
### What is this PR for?
This PR allow user to set default interpreter in frontend.  After this PR, user can only change default interpreter group in frontend via move it to the first of interpreter binding list. User still don't need to bind/unbind interpreters explicitly. They can use what ever interpreter they want. And we will list the default interpreter group, interpreter group with the same group of default interpreter group and all the interpreters used in the note.

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-3751

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![spark_switch](https://user-images.githubusercontent.com/164491/74298501-f33b6800-4d84-11ea-8352-f63d227a996f.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
