### PR TITLE
[ZEPPELIN-4613]. Scheduler thread is not closed properly

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/AbstractScheduler.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/AbstractScheduler.java
@@ -40,7 +40,7 @@ public abstract class AbstractScheduler implements Scheduler {
   protected volatile boolean terminate = false;
   protected BlockingQueue<Job> queue = new LinkedBlockingQueue<>();
   protected Map<String, Job> jobs = new ConcurrentHashMap<>();
-
+  private Thread schedulerThread;
 
   public AbstractScheduler(String name) {
     this.name = name;
@@ -63,7 +63,11 @@ public abstract class AbstractScheduler implements Scheduler {
   @Override
   public void submit(Job job) {
     job.setStatus(Job.Status.PENDING);
-    queue.add(job);
+    try {
+      queue.put(job);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(String.format("Unable to submit job %s", job.getId()), e);
+    }
     jobs.put(job.getId(), job);
   }
 
@@ -76,7 +80,8 @@ public abstract class AbstractScheduler implements Scheduler {
 
   @Override
   public void run() {
-    while (!terminate && !Thread.currentThread().isInterrupted()) {
+    schedulerThread = Thread.currentThread();
+    while (!terminate && !schedulerThread.isInterrupted()) {
       Job runningJob = null;
       try {
         runningJob = queue.take();
@@ -98,6 +103,9 @@ public abstract class AbstractScheduler implements Scheduler {
       job.aborted = true;
       job.jobAbort();
     }
+    if (schedulerThread != null) {
+      schedulerThread.interrupt();
+    }
   }
 
   /**
@@ -108,6 +116,7 @@ public abstract class AbstractScheduler implements Scheduler {
    */
   protected void runJob(Job runningJob) {
     if (runningJob.isAborted()) {
+      LOGGER.info("Job {} is aborted", runningJob.getId());
       runningJob.setStatus(Job.Status.ABORT);
       runningJob.aborted = false;
       return;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -385,6 +385,13 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
       setReturn(intpResult, e);
       setStatus(Job.Status.ERROR);
       return false;
+    } catch (Throwable e) {
+      InterpreterResult intpResult =
+              new InterpreterResult(InterpreterResult.Code.ERROR,
+                      "Unexpected exception: " + ExceptionUtils.getStackTrace(e));
+      setReturn(intpResult, e);
+      setStatus(Job.Status.ERROR);
+      return false;
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
@@ -41,6 +41,7 @@ public class CronJob implements org.quartz.Job {
 
     Notebook notebook = (Notebook) jobDataMap.get("notebook");
     String noteId = jobDataMap.getString("noteId");
+    logger.info("Start cron job of note: " + noteId);
     Note note = null;
     try {
       note = notebook.getNote(noteId);


### PR DESCRIPTION
### What is this PR for?
The root cause is that we didn't shutdown the scheduler thread properly. It is always stuck in the following line
```
runningJob = queue.take();
```

This PR fix this issue by interrupt that thread. Besidies that I also add more logging in this PR. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4613


### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
