### PR TITLE
[ZEPPELIN-4580] check the instance type rather than the class name

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -149,11 +149,7 @@ public class LoginRestApi {
     Collection<Realm> realmsList = authenticationService.getRealmsList();
     if (realmsList != null) {
       for (Realm realm : realmsList) {
-        String name = realm.getClass().getName();
-
-        LOG.debug("RealmClass.getName: {}", name);
-
-        if (name.equals("org.apache.zeppelin.realm.jwt.KnoxJwtRealm")) {
+        if (realm instanceof KnoxJwtRealm) {
           return (KnoxJwtRealm) realm;
         }
       }
@@ -165,9 +161,7 @@ public class LoginRestApi {
     Collection<Realm> realmsList = authenticationService.getRealmsList();
     if (realmsList != null) {
       for (Realm realm : realmsList) {
-        String name = realm.getClass().getName();
-        LOG.debug("RealmClass.getName: {}", name);
-        if (name.equals("org.apache.zeppelin.realm.jwt.KnoxJwtRealm")) {
+        if (realm instanceof KnoxJwtRealm) {
           return true;
         }
       }


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

This checks if the realm is an instance of KnoxJwtRealm instead of checking for it by name to enable subclassing of KnoxJwtRealm.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

https://issues.apache.org/jira/browse/ZEPPELIN-4580

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

CI run is at https://travis-ci.org/LeapYear/zeppelin-source/builds/650518752 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
