### PR TITLE
[ZEPPELIN-4618] Zeppelin on Kubernetes does not automatically configure Spark on Kubernetes

### DIFF
--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -28,7 +28,7 @@ data:
   # Default value is 'local.zeppelin-project.org' while it points 127.0.0.1 and `kubectl port-forward zeppelin-server` will give localhost to connects.
   # If you have your ingress controller configured to connect to `zeppelin-server` service and have a domain name for it (with wildcard subdomain point the same address), you can replace serviceDomain field with your own domain.
   serviceDomain: local.zeppelin-project.org:8080
-  sparkContainerImage: spark:2.4.0
+  sparkContainerImage: spark:2.4.5
   nginx.conf: |
     daemon off;
     worker_processes auto;
@@ -118,8 +118,10 @@ spec:
         configMapKeyRef:
           name: zeppelin-server-conf
           key: serviceDomain
-    - name: MASTER   # default value of master property for spark interpreter.
+    - name: MASTER   # default value of 'master' property for spark interpreter.
       value: k8s://https://kubernetes.default.svc
+    - name: SPARK_HOME # default value of 'SPARK_HOME' property for spark interpreter.
+      value: /spark
     # volumeMounts:
     #  - name: zeppelin-server-notebook-volume     # configure this to persist notebook
     #    mountPath: /zeppelin/notebook

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -13,7 +13,7 @@
         "type": "string"
       },
       "master": {
-        "envName": "",
+        "envName": "MASTER",
         "propertyName": "spark.master",
         "defaultValue": "local[*]",
         "description": "Spark master uri. ex) spark://master_host:7077",


### PR DESCRIPTION
### What is this PR for?
Since https://github.com/apache/zeppelin/pull/3577, Zeppelin on Kubernetes does not automatically configure Spark on Kubernetes.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4618

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
