### PR TITLE
[ZEPPELIN-4600] Socket connection between zeppelin server and interpreter is not closed properly for branch 0.8

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
@@ -45,7 +45,6 @@ public class ClientFactory extends BasePooledObjectFactory<Client>{
   }
 
   public void close() {
-
     //Close transfer
     for (TSocket eachTransfer: clientSocketMap.values()) {
       eachTransfer.close();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ClientFactory.java
@@ -44,6 +44,14 @@ public class ClientFactory extends BasePooledObjectFactory<Client>{
     this.port = port;
   }
 
+  public void close() {
+
+    //Close transfer
+    for (TSocket eachTransfer: clientSocketMap.values()) {
+      eachTransfer.close();
+    }
+  }
+
   @Override
   public Client create() throws Exception {
     TSocket transport = new TSocket(host, port);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventPoller.java
@@ -261,6 +261,9 @@ public class RemoteInterpreterEventPoller extends Thread {
     }
     if (appendFuture != null) {
       appendFuture.cancel(true);
+      //Close thread pool
+      appendService.shutdown();
+
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterManagedProcess.java
@@ -229,6 +229,10 @@ public class RemoteInterpreterManagedProcess extends RemoteInterpreterProcess
       } catch (Exception e) {
         logger.warn("ignore the exception when shutting down");
       }
+
+      // Shutdown connection
+      shutdown();
+
       watchdog.destroyProcess();
     }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -19,14 +19,11 @@ package org.apache.zeppelin.interpreter.remote;
 import com.google.gson.Gson;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.thrift.TException;
-import org.apache.thrift.transport.TSocket;
-import org.apache.zeppelin.helium.ApplicationEventListener;
-import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.launcher.InterpreterClient;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.font.TextSource;
+
 
 /**
  * Abstract class for interpreter process
@@ -54,16 +51,11 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient {
     this.remoteInterpreterEventPoller = eventPoller;
   }
 
-  public void shutdown()
-  {
+  public void shutdown() {
 
     // Close client socket connection
-    if (clientFactory != null)
-    {
-      for (TSocket eachTransfer: clientFactory.clientSocketMap.values())
-      {
-        eachTransfer.close();
-      }
+    if (clientFactory != null) {
+      clientFactory.close();
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -19,12 +19,14 @@ package org.apache.zeppelin.interpreter.remote;
 import com.google.gson.Gson;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.thrift.TException;
+import org.apache.thrift.transport.TSocket;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.launcher.InterpreterClient;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterService.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.font.TextSource;
 
 /**
  * Abstract class for interpreter process
@@ -36,6 +38,7 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient {
   private RemoteInterpreterEventPoller remoteInterpreterEventPoller;
   private final InterpreterContextRunnerPool interpreterContextRunnerPool;
   private int connectTimeout;
+  private ClientFactory clientFactory = null;
 
   public RemoteInterpreterProcess(
       int connectTimeout) {
@@ -51,13 +54,27 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient {
     this.remoteInterpreterEventPoller = eventPoller;
   }
 
+  public void shutdown()
+  {
+
+    // Close client socket connection
+    if (clientFactory != null)
+    {
+      for (TSocket eachTransfer: clientFactory.clientSocketMap.values())
+      {
+        eachTransfer.close();
+      }
+    }
+  }
+
   public int getConnectTimeout() {
     return connectTimeout;
   }
 
   public synchronized Client getClient() throws Exception {
     if (clientPool == null || clientPool.isClosed()) {
-      clientPool = new GenericObjectPool<>(new ClientFactory(getHost(), getPort()));
+      clientFactory = new ClientFactory(getHost(), getPort());
+      clientPool = new GenericObjectPool<>(clientFactory);
     }
     return clientPool.borrowObject();
   }


### PR DESCRIPTION

### What is this PR for?
Fix the stability problem of zengin for long time (7day) loop working ,
release the thread pools and socket connection when the interprether is closed
the same bug was found in the version 0.81 and 0.82


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4600

### How should this be tested?
* Single tast works 30 hours with 7 second delay, test passed. 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?No
* Is there breaking changes for older versions?No
* Does this needs documentation?No
