### PR TITLE
[ZEPPELIN-4619] Run a note from the commandline

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -19,20 +19,26 @@
 # Run Zeppelin 
 #
 
-USAGE="Usage: bin/zeppelin.sh [--config <conf-dir>]"
+USAGE="Usage: bin/zeppelin.sh [--config <conf-dir>] [--run <noteId>]"
 
-if [[ "$1" == "--config" ]]; then
-  shift
-  conf_dir="$1"
-  if [[ ! -d "${conf_dir}" ]]; then
-    echo "ERROR : ${conf_dir} is not a directory"
-    echo ${USAGE}
-    exit 1
-  else
-    export ZEPPELIN_CONF_DIR="${conf_dir}"
-  fi
-  shift
-fi
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+  case $key in
+    --config)
+    export ZEPPELIN_CONF_DIR="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --run)
+    export ZEPPELIN_NOTEBOOK_RUN_ID="$2"
+    shift # past argument
+    shift # past value
+    ;;
+  esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
 
 bin=$(dirname "${BASH_SOURCE-$0}")
 bin=$(cd "${bin}">/dev/null; pwd)

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -397,6 +397,22 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_DIR);
   }
 
+  public String getNotebookRunId() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_RUN_ID);
+  }
+
+  public String getNotebookRunRev() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_RUN_REV);
+  }
+
+  public String getNotebookRunServiceContext() {
+    return getString(ConfVars.ZEPPELIN_NOTEBOOK_RUN_SERVICE_CONTEXT);
+  }
+
+  public boolean getNotebookRunAutoShutdown() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_RUN_AUTOSHUTDOWN);
+  }
+
   public String getPluginsDir() {
     return getRelativeDir(getString(ConfVars.ZEPPELIN_PLUGINS_DIR));
   }
@@ -831,6 +847,12 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_INTERPRETER_OUTPUT_LIMIT("zeppelin.interpreter.output.limit", 1024 * 100),
     ZEPPELIN_ENCODING("zeppelin.encoding", "UTF-8"),
     ZEPPELIN_NOTEBOOK_DIR("zeppelin.notebook.dir", "notebook"),
+
+    ZEPPELIN_NOTEBOOK_RUN_ID("zeppelin.notebook.run.id", null),   // run particular note id on zeppelin start
+    ZEPPELIN_NOTEBOOK_RUN_REV("zeppelin.notebook.run.rev", null), // revision id for ZEPPELIN_NOTEBOOK_RUN_ID.
+    ZEPPELIN_NOTEBOOK_RUN_SERVICE_CONTEXT("zeppelin.notebook.run.servicecontext", null), // base64 encoded serialized service context to be used ZEPPELIN_NOTEBOOK_RUN_ID.
+    ZEPPELIN_NOTEBOOK_RUN_AUTOSHUTDOWN("zeppelin.notebook.run.autoshutdown", true), // after specified note (ZEPPELIN_NOTEBOOK_RUN_ID) run, shutdown zeppelin server
+
     ZEPPELIN_RECOVERY_DIR("zeppelin.recovery.dir", "recovery"),
     ZEPPELIN_RECOVERY_STORAGE_CLASS("zeppelin.recovery.storage.class",
         "org.apache.zeppelin.interpreter.recovery.NullRecoveryStorage"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -345,6 +345,7 @@ public class ZeppelinServer extends ResourceConfig {
   private static void runNoteOnStart(ZeppelinConfiguration conf) throws IOException, InterruptedException {
     String noteIdToRun = conf.getNotebookRunId();
     if (!Strings.isEmpty(noteIdToRun)) {
+      LOG.info("Running note {} on start", noteIdToRun);
       NotebookService notebookService = (NotebookService) ServiceLocatorUtilities.getService(
               sharedServiceLocator, NotebookService.class.getName());
 
@@ -359,7 +360,7 @@ public class ZeppelinServer extends ResourceConfig {
                 ServiceContext.class);
       }
 
-      boolean success = notebookService.runNote(noteIdToRun, serviceContext, new ServiceCallback<Paragraph>() {
+      boolean success = notebookService.runAllParagraphs(noteIdToRun, serviceContext, new ServiceCallback<Paragraph>() {
         @Override
         public void onStart(String message, ServiceContext context) throws IOException {
         }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -360,7 +360,7 @@ public class ZeppelinServer extends ResourceConfig {
                 ServiceContext.class);
       }
 
-      boolean success = notebookService.runAllParagraphs(noteIdToRun, serviceContext, new ServiceCallback<Paragraph>() {
+      boolean success = notebookService.runAllParagraphs(noteIdToRun, null, serviceContext, new ServiceCallback<Paragraph>() {
         @Override
         public void onStart(String message, ServiceContext context) throws IOException {
         }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -22,6 +22,8 @@ package org.apache.zeppelin.service;
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN;
 
 import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -30,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
+
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObject;
@@ -82,6 +86,7 @@ public class NotebookService {
   private Notebook notebook;
   private AuthorizationService authorizationService;
   private SchedulerService schedulerService;
+  private Gson gson = new Gson();
 
   @Inject
   public NotebookService(
@@ -344,55 +349,42 @@ public class NotebookService {
     }
   }
 
-  public boolean runNote(String noteId,
+  public boolean runAllParagraphs(String noteId,
                       ServiceContext context,
                       ServiceCallback<Paragraph> callback) throws IOException {
-    if (!checkPermission(noteId, Permission.RUNNER, Message.OP.RUN_ALL_PARAGRAPHS, context,
-            callback)) {
-      return false;
-    }
-
     Note note = notebook.getNote(noteId);
     if (note == null) {
       callback.onFailure(new NoteNotFoundException(noteId), context);
       return false;
     }
 
-    note.setRunning(true);
-    try {
-      for (Paragraph p : note.getParagraphs()) {
-        String paragraphId = p.getId();
-        String text = p.getText();
-        String title = p.getTitle();
-        Map<String, Object> params = p.settings.getParams();
-        Map<String, Object> config = p.getConfig();
+    List<Paragraph> paragraphs = note.getParagraphs();
+    List<Map<String, Object>> rawParagraphs = paragraphs.stream()
+            .map(p ->
+                    (Map<String, Object>) gson.fromJson(gson.toJson(p), new TypeToken<Map<String, Object>>(){}.getType()))
+            .collect(Collectors.toList());
 
-        if (!runParagraph(noteId, paragraphId, title, text, params, config, false, true,
-                context, callback)) {
-          // stop execution when one paragraph fails.
-          return false;
-        }
-      }
-    } finally {
-      note.setRunning(false);
-    }
-
-    return true;
+    return runAllParagraphs(
+            noteId,
+            rawParagraphs,
+            context,
+            callback
+    );
   }
 
-  public void runAllParagraphs(String noteId,
+  public boolean runAllParagraphs(String noteId,
                                List<Map<String, Object>> paragraphs,
                                ServiceContext context,
                                ServiceCallback<Paragraph> callback) throws IOException {
     if (!checkPermission(noteId, Permission.RUNNER, Message.OP.RUN_ALL_PARAGRAPHS, context,
         callback)) {
-      return;
+      return false;
     }
 
     Note note = notebook.getNote(noteId);
     if (note == null) {
       callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
+      return false;
     }
 
     note.setRunning(true);
@@ -410,12 +402,14 @@ public class NotebookService {
         if (!runParagraph(noteId, paragraphId, title, text, params, config, false, true,
                 context, callback)) {
           // stop execution when one paragraph fails.
-          break;
+          return false;
         }
       }
     } finally {
       note.setRunning(false);
     }
+
+    return true;
   }
 
   public void cancelParagraph(String noteId,

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -361,20 +361,22 @@ public class NotebookServiceTest {
 
     // run all paragraphs
     reset(callback);
+    String textBefore = p.getText();
     notebookService.runAllParagraphs(
             note1.getId(),
             gson.fromJson(gson.toJson(note1.getParagraphs()), new TypeToken<List>(){}.getType()),
             context, callback);
     verify(callback, times(2)).onSuccess(any(), any());
+    assertEquals(textBefore, p.getText());
 
-    // run paragraph synchronously via invalid code
-    //TODO(zjffdu) must sleep for a while, otherwise will get wrong status. This should be due to
-    //bug of job component.
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+    // run all paragraphs, with null paragraph list provided
+    reset(callback);
+    notebookService.runAllParagraphs(
+            note1.getId(),
+            null,
+            context, callback);
+    verify(callback, times(2)).onSuccess(any(), any());
+
     reset(callback);
     runStatus = notebookService.runParagraph(note1.getId(), p.getId(), "my_title", "invalid_code",
         new HashMap<>(), new HashMap<>(), false, true, context, callback);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -414,14 +414,4 @@ public class NotebookServiceTest {
       assertEquals("Note name can not contain '..'", e.getMessage());
     }
   }
-
-  @Test
-  public void testRunNote() throws IOException {
-    // given
-    Note note1 = notebookService.createNote("note1", "python", context, callback);
-    Paragraph p = notebookService.insertParagraph(note1.getId(), 1, new HashMap<>(), context, callback);
-
-    p.setText("%");
-
-  }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -412,4 +412,14 @@ public class NotebookServiceTest {
       assertEquals("Note name can not contain '..'", e.getMessage());
     }
   }
+
+  @Test
+  public void testRunNote() throws IOException {
+    // given
+    Note note1 = notebookService.createNote("note1", "python", context, callback);
+    Paragraph p = notebookService.insertParagraph(note1.getId(), 1, new HashMap<>(), context, callback);
+
+    p.setText("%");
+
+  }
 }


### PR DESCRIPTION
### What is this PR for?
This PR adds a command-line option to run a single note.
The code is pickled from https://github.com/apache/zeppelin/pull/3356.

Usage is

```
bin/zeppelin.sh --run <noteId>
```

The command will launch a Zeppelin server and run a given note, and terminate on after all paragraph's successful run (with exit 0) or terminate on any paragraph error (with exit 1).

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4619


### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
