### PR TITLE
[ZEPPELIN-4627]. Codegen fails for SparkInterpreter

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -68,4 +68,6 @@ public abstract class AbstractSparkScalaInterpreter {
   public abstract List<InterpreterCompletion> completion(String buf,
                                                          int cursor,
                                                          InterpreterContext interpreterContext);
+
+  public abstract ClassLoader getScalaShellClassLoader();
 }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/KotlinSparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/KotlinSparkInterpreter.java
@@ -21,6 +21,7 @@ import static org.apache.zeppelin.spark.Utils.buildJobDesc;
 import static org.apache.zeppelin.spark.Utils.buildJobGroupId;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,10 +79,11 @@ public class KotlinSparkInterpreter extends Interpreter {
 
     z = sparkInterpreter.getZeppelinContext();
 
+    // convert Object to SQLContext explicitly, that means Kotlin Spark may not work with Spark 1.x
     SparkKotlinReceiver ctx = new SparkKotlinReceiver(
         sparkInterpreter.getSparkSession(),
         jsc,
-        sparkInterpreter.getSQLContext(),
+        (SQLContext) sparkInterpreter.getSQLContext(),
         z);
 
     List<String> classpath = sparkClasspath();

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -198,7 +198,7 @@ public class PySparkInterpreter extends PythonInterpreter {
     }
   }
 
-  public SQLContext getSQLContext() {
+  public Object getSQLContext() {
     if (sparkInterpreter == null) {
       return null;
     } else {

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -205,7 +205,14 @@ public class SparkInterpreter extends AbstractInterpreter {
     return this.sc;
   }
 
-  public SQLContext getSQLContext() {
+  /**
+   * Must use Object, because the its api signature in Spark 1.x is different from
+   * that of Spark 2.x.
+   * e.g. SqlContext.sql(sql) return different type.
+   *
+   * @return
+   */
+  public Object getSQLContext() {
     return sqlContext;
   }
 
@@ -235,6 +242,10 @@ public class SparkInterpreter extends AbstractInterpreter {
     }
   }
 
+  public boolean isScala212() throws InterpreterException {
+    return extractScalaVersion().contains("2.12");
+  }
+
   private List<String> getDependencyFiles() throws InterpreterException {
     List<String> depFiles = new ArrayList<>();
     // add jar from local repo
@@ -251,6 +262,10 @@ public class SparkInterpreter extends AbstractInterpreter {
       }
     }
     return depFiles;
+  }
+
+  public ClassLoader getScalaShellClassLoader() {
+    return innerInterpreter.getScalaShellClassLoader();
   }
 
   public boolean isUnsupportedSparkVersion() {

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/ZeppelinRContext.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/ZeppelinRContext.java
@@ -27,7 +27,7 @@ import org.apache.zeppelin.interpreter.ZeppelinContext;
  */
 public class ZeppelinRContext {
   private static SparkContext sparkContext;
-  private static SQLContext sqlContext;
+  private static Object sqlContext;
   private static ZeppelinContext zeppelinContext;
   private static Object sparkSession;
   private static JavaSparkContext javaSparkContext;
@@ -40,7 +40,7 @@ public class ZeppelinRContext {
     ZeppelinRContext.zeppelinContext = zeppelinContext;
   }
 
-  public static void setSqlContext(SQLContext sqlContext) {
+  public static void setSqlContext(Object sqlContext) {
     ZeppelinRContext.sqlContext = sqlContext;
   }
 
@@ -52,7 +52,7 @@ public class ZeppelinRContext {
     return sparkContext;
   }
 
-  public static SQLContext getSqlContext() {
+  public static Object getSqlContext() {
     return sqlContext;
   }
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,7 +43,7 @@
         <!--plugin versions-->
         <plugin.scala.version>2.15.2</plugin.scala.version>
         <!-- spark versions -->
-        <spark.version>2.2.3</spark.version>
+        <spark.version>2.4.4</spark.version>
         <spark.scala.version>2.11.12</spark.scala.version>
         <spark.scala.binary.version>2.11</spark.scala.binary.version>
         <py4j.version>0.10.7</py4j.version>

--- a/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
+++ b/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
@@ -58,8 +58,9 @@ class SparkScala210Interpreter(override val conf: SparkConf,
       interpreterOutput.setInterpreterOutput(InterpreterContext.get().out)
     }
     val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
-    val outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+    this.outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
     outputDir.deleteOnExit()
+    LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
     // Only Spark1 requires to create http server, Spark2 removes HttpServer class.
     startHttpServer(outputDir).foreach { case (server, uri) =>
@@ -70,7 +71,9 @@ class SparkScala210Interpreter(override val conf: SparkConf,
     val settings = new Settings()
     settings.embeddedDefaults(sparkInterpreterClassLoader)
     settings.usejavacp.value = true
-    settings.classpath.value = getUserJars.mkString(File.pathSeparator)
+    this.userJars = getUserJars()
+    LOGGER.info("UserJars: " + userJars.mkString(File.pathSeparator))
+    settings.classpath.value = userJars.mkString(File.pathSeparator)
     if (properties.getProperty("zeppelin.spark.printREPLOutput", "true").toBoolean) {
       Console.setOut(interpreterOutput)
     }
@@ -107,4 +110,8 @@ class SparkScala210Interpreter(override val conf: SparkConf,
     }
   }
 
+  override def getScalaShellClassLoader: ClassLoader = {
+    val sparkIMain = sparkILoop.interpreter
+    callMethod(sparkIMain, "classLoader").asInstanceOf[ClassLoader]
+  }
 }

--- a/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
+++ b/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
@@ -58,7 +58,8 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     }
     // Only Spark1 requires to create http server, Spark2 removes HttpServer class.
     val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
-    val outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+    this.outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+    LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
     outputDir.deleteOnExit()
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
     startHttpServer(outputDir).foreach { case (server, uri) =>
@@ -71,7 +72,10 @@ class SparkScala211Interpreter(override val conf: SparkConf,
       "-Yrepl-outdir", s"${outputDir.getAbsolutePath}"), true)
     settings.embeddedDefaults(sparkInterpreterClassLoader)
     settings.usejavacp.value = true
-    settings.classpath.value = getUserJars.mkString(File.pathSeparator)
+
+    this.userJars = getUserJars()
+    LOGGER.info("UserJars: " + userJars.mkString(File.pathSeparator))
+    settings.classpath.value = userJars.mkString(File.pathSeparator)
 
     val printReplOutput = properties.getProperty("zeppelin.spark.printREPLOutput", "true").toBoolean
     val replOut = if (printReplOutput) {
@@ -122,6 +126,9 @@ class SparkScala211Interpreter(override val conf: SparkConf,
   def scalaInterpret(code: String): scala.tools.nsc.interpreter.IR.Result =
     sparkILoop.interpret(code)
 
+  override def getScalaShellClassLoader: ClassLoader = {
+    sparkILoop.classLoader
+  }
 }
 
 private object SparkScala211Interpreter {
@@ -191,4 +198,5 @@ private object SparkScala211Interpreter {
 
     loopPostInit()
   }
+
 }

--- a/spark/scala-2.12/pom.xml
+++ b/spark/scala-2.12/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <spark.version>2.4.4</spark.version>
-    <spark.scala.version>2.12.8</spark.scala.version>
+    <spark.scala.version>2.12.10</spark.scala.version>
     <spark.scala.binary.version>2.12</spark.scala.binary.version>
     <spark.scala.compile.version>${spark.scala.version}</spark.scala.compile.version>
   </properties>

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -19,7 +19,7 @@ package org.apache.zeppelin.spark
 
 
 import java.io.File
-import java.net.URLClassLoader
+import java.net.{URL, URLClassLoader}
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.zeppelin.interpreter.util.InterpreterOutputStream
-import org.apache.zeppelin.interpreter.{ZeppelinContext, InterpreterContext, InterpreterGroup, InterpreterResult}
+import org.apache.zeppelin.interpreter.{InterpreterContext, InterpreterGroup, InterpreterResult, ZeppelinContext}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
@@ -57,6 +57,10 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
   protected var sqlContext: SQLContext = _
 
   protected var sparkSession: Object = _
+
+  protected var outputDir: File = _
+
+  protected var userJars: Seq[String] = _
 
   protected var sparkHttpServer: Object = _
 


### PR DESCRIPTION
### What is this PR for?

The root cause is classloader issue. This PR use the scala shell classloader as the classloader in SparkSqlInterpreter to execute sql. But scala 2.12 still doesn't work for now, I will leave it for future as scala 2.12 is not used widely.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4627

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
