### PR TITLE
[ZEPPELIN-4641]. Close interpreter in LazyOpenInterpreter when fail to open interpreter

### DIFF
--- a/rlang/src/main/java/org/apache/zeppelin/r/RInterpreter.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/RInterpreter.java
@@ -110,7 +110,7 @@ public class RInterpreter extends AbstractInterpreter {
       zeppelinR.open();
       LOGGER.info("ZeppelinR is opened successfully.");
     } catch (IOException e) {
-      throw new InterpreterException("Exception while opening SparkRInterpreter", e);
+      throw new InterpreterException("Exception while opening RInterpreter", e);
     }
 
     if (useKnitr) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -66,8 +66,15 @@ public class LazyOpenInterpreter
 
     synchronized (intp) {
       if (opened == false) {
-        intp.open();
-        opened = true;
+        try {
+          intp.open();
+          opened = true;
+        } catch (Throwable e) {
+          // close interpreter to release resource,
+          // otherwise these resources may leak when open it again.
+          intp.close();
+          throw new InterpreterException(e);
+        }
       }
     }
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
@@ -153,7 +153,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
   }
 
   public void stop() {
-    if (watchdog != null) {
+    if (watchdog != null && isRunning()) {
       watchdog.destroyProcess();
       watchdog = null;
     }


### PR DESCRIPTION
### What is this PR for?
Currently, resource may leak if interpreter fail to open, and reopen it again. e.g
In flink interpreter, we will create a yarn app in open method, but may fail in the following initialization. Then if user open it again, he would create another yarn app, the first yarn app is leaked. 

This PR fix it via close interpreter in LazyOpenInterpreter. Besides that it fix one bug in `ProcessLauncher`, otherwise the CI will fail.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4641

### How should this be tested?
* Manually Tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
