### PR TITLE
[ZEPPELIN-4643]. Fail to start zeppelin server because zeppelin-interpreter-shaded is under lib

### DIFF
--- a/zeppelin-jupyter/pom.xml
+++ b/zeppelin-jupyter/pom.xml
@@ -58,6 +58,12 @@
       <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-markdown</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zeppelin</groupId>
+          <artifactId>zeppelin-interpreter-shaded</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
### What is this PR for?

This PR just exclude zeppelin-interpreter-shaded from `zeppelin-markdown` in `zeppelin-jupyter/pom.xml`. So that we won't include it under lib when building zeppelin distribution. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4643

### How should this be tested?
* Tested manaully

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
