### PR TITLE
[ZEPPELIN-4647]. zeppelin.notebook.cron.folders doesn't work for regular folder

### DIFF
--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -57,4 +57,4 @@ Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/co
 
 ### Run cron selectively on folders
 
-In `$ZEPPELIN_HOME/conf/zeppelin-site.xml` make sure the property **zeppelin.notebook.cron.enable** is set to **true**, and then set property **zeppelin.notebook.cron.folders** to the desired folder as comma-separated values, e.g. `*yst*, Sys?em, System`. This property accepts wildcard and joker.
+In `$ZEPPELIN_HOME/conf/zeppelin-site.xml` make sure the property **zeppelin.notebook.cron.enable** is set to **true**, and then set property **zeppelin.notebook.cron.folders** to the desired folder as comma-separated values, e.g. `/cron,/test/cron`.

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -590,6 +590,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
     // create a note and a paragraph
     Note note = null;
     try {
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
       note = TestUtils.getInstance(Notebook.class).createNote("note1_testJobs", anonymous);
 
       note.setName("note for run test");
@@ -630,6 +631,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       if (null != note) {
         TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
       }
+      System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName());
     }
   }
 
@@ -658,7 +660,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       postCron.releaseConnection();
 
       System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
-      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "System/*");
+      System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "/System");
 
       note.setName("System/test2");
       note.runAll(AuthenticationInfo.ANONYMOUS, false);
@@ -679,6 +681,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       if (null != note) {
         TestUtils.getInstance(Notebook.class).removeNote(note.getId(), anonymous);
       }
+      System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName());
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -129,7 +129,6 @@ public class Note implements JsonSerializable {
 
   public Note() {
     generateId();
-    setCronSupported(ZeppelinConfiguration.create());
   }
 
   public Note(String path, String defaultInterpreterGroup, InterpreterFactory factory,
@@ -395,12 +394,11 @@ public class Note implements JsonSerializable {
   public Boolean isCronSupported(ZeppelinConfiguration config) {
     if (config.isZeppelinNotebookCronEnable()) {
       config.getZeppelinNotebookCronFolders();
-      if (config.getZeppelinNotebookCronFolders() == null) {
+      if (StringUtils.isBlank(config.getZeppelinNotebookCronFolders())) {
         return true;
       } else {
         for (String folder : config.getZeppelinNotebookCronFolders().split(",")) {
-          folder = folder.replaceAll("\\*", "\\.*").replaceAll("\\?", "\\.");
-          if (getName().matches(folder)) {
+          if (this.path.startsWith(folder)) {
             return true;
           }
         }
@@ -1116,7 +1114,6 @@ public class Note implements JsonSerializable {
   public static Note fromJson(String json) throws IOException {
     try {
       Note note = gson.fromJson(json, Note.class);
-      note.setCronSupported(ZeppelinConfiguration.create());
       convertOldInput(note);
       note.info.remove("isRunning");
       note.postProcessParagraphs();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -19,6 +19,7 @@
 package org.apache.zeppelin.notebook;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -523,6 +524,7 @@ public class NoteManager {
         } else {
           note.setPath(parent.toString() + "/" + note.getName());
         }
+        note.setCronSupported(ZeppelinConfiguration.create());
         note.setLoaded(true);
       }
       return note;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -615,7 +615,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   @Test
   public void testScheduleDisabledWithName() throws InterruptedException, IOException {
 
-    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "System/*");
+    System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "/System");
     try {
       final int timeout = 10;
       final String everySecondCron = "* * * * * ?";
@@ -638,8 +638,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       terminateScheduledNote(note);
       afterStatusChangedListener = null;
 
-      final Note noteNameSystem = notebook.createNote("note1", anonymous);
-      noteNameSystem.setName("System/test1");
+      final Note noteNameSystem = notebook.createNote("/System/test1", anonymous);
       final CountDownLatch jobsToExecuteCountNameSystem = new CountDownLatch(5);
 
       executeNewParagraphByCron(noteNameSystem, everySecondCron);


### PR DESCRIPTION
### What is this PR for?

This PR fix the issue of `zeppelin.notebook.cron.folders`  doesn't work for regular folder, but only for regular expression. IMHO, specify regular folder is enough for users, regular expression is not necessary. So I change `zeppelin.notebook.cron.folders` to regular folder instead of regular expression.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://github.com/zjffdu/zeppelin/tree/ZEPPELIN-4647

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
