### PR TITLE
[ZEPPELIN-4650]. Allow to keep job running while close interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -141,10 +141,15 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
   private void closeInterpreter(Interpreter interpreter) {
     Scheduler scheduler = interpreter.getScheduler();
 
-    for (final Job job : scheduler.getAllJobs()) {
-      job.abort();
-      job.setStatus(Job.Status.ABORT);
-      LOGGER.info("Job " + job.getJobName() + " aborted ");
+    if (Boolean.parseBoolean(
+            interpreter.getProperty("zeppelin.interpreter.close.cancel_job", "true"))) {
+      for (final Job job : scheduler.getAllJobs()) {
+        job.abort();
+        job.setStatus(Job.Status.ABORT);
+        LOGGER.info("Job " + job.getJobName() + " aborted ");
+      }
+    } else {
+      LOGGER.info("Keep job running while closing interpreter: " + interpreter.getClassName());
     }
 
     try {


### PR DESCRIPTION
### What is this PR for?

This PR is to allow keeping job running while close interpreter. This is pretty useful for streaming jobs that you would like to keep it running even after the the interpreter is closed. Such as flink/spark streaming job. This PR introduce property `zeppelin.interpreter.close.cancel_job` to control that, each interpreter can configure it in its interpreter properties.


### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4650

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
