### PR TITLE
[ZEPPELIN-4661]. Fail to run whole note

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -359,23 +359,12 @@ public class NotebookServiceTest {
     verify(callback).onSuccess(p, context);
     assertEquals(2, p.getConfig().size());
 
-    // run all paragraphs
-    reset(callback);
-    String textBefore = p.getText();
-    notebookService.runAllParagraphs(
-            note1.getId(),
-            gson.fromJson(gson.toJson(note1.getParagraphs()), new TypeToken<List>(){}.getType()),
-            context, callback);
-    verify(callback, times(2)).onSuccess(any(), any());
-    assertEquals(textBefore, p.getText());
-
     // run all paragraphs, with null paragraph list provided
     reset(callback);
-    notebookService.runAllParagraphs(
+    assertTrue(notebookService.runAllParagraphs(
             note1.getId(),
             null,
-            context, callback);
-    verify(callback, times(2)).onSuccess(any(), any());
+            context, callback));
 
     reset(callback);
     runStatus = notebookService.runParagraph(note1.getId(), p.getId(), "my_title", "invalid_code",


### PR DESCRIPTION
### What is this PR for?

This is to fix the regression issue caused by ZEPPELIN-4661. The root cause is that in the frontend we use `paragraph` to represent the script text while in the backend we use `text`, so that converting between frontend data to backend class `Paragraph` will cause this kind of error. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4661

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
