### PR TITLE
[ZEPPELIN-4659]. S3NotebookRepo doesn't work for new note file structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -266,6 +266,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (Apache 2.0) concurrentunit (https://github.com/jhalterman/concurrentunit)
     (Apache 2.0) Embedded MongoDB (https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo)
     (Apache 2.0) Kotlin (https://github.com/JetBrains/kotlin)
+    (Apache 2.0) s3proxy (https://github.com/gaul/s3proxy)
 
 ========================================================================
 BSD 3-Clause licenses

--- a/zeppelin-plugins/notebookrepo/s3/pom.xml
+++ b/zeppelin-plugins/notebookrepo/s3/pom.xml
@@ -36,7 +36,7 @@
     <description>NotebookRepo implementation based on S3</description>
 
     <properties>
-        <aws.sdk.s3.version>1.10.62</aws.sdk.s3.version>
+        <aws.sdk.s3.version>1.11.736</aws.sdk.s3.version>
         <plugin.name>NotebookRepo/S3NotebookRepo</plugin.name>
     </properties>
 
@@ -45,6 +45,46 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws.sdk.s3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>s3proxy</artifactId>
+            <version>1.6.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/zeppelin-plugins/notebookrepo/s3/src/test/java/org/apache/zeppelin/notebook/repo/S3NotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/s3/src/test/java/org/apache/zeppelin/notebook/repo/S3NotebookRepoTest.java
@@ -1,0 +1,135 @@
+package org.apache.zeppelin.notebook.repo;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.gaul.s3proxy.junit.S3ProxyRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class S3NotebookRepoTest {
+
+  private AuthenticationInfo anonymous = AuthenticationInfo.ANONYMOUS;
+  private S3NotebookRepo notebookRepo;
+
+  @Rule
+  public S3ProxyRule s3Proxy = S3ProxyRule.builder()
+          .withCredentials("access", "secret")
+          .build();
+
+
+  @Before
+  public void setUp() throws IOException {
+    String bucket = "test-bucket";
+    notebookRepo = new S3NotebookRepo();
+    ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_S3_ENDPOINT.getVarName(),
+            s3Proxy.getUri().toString());
+    System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_S3_BUCKET.getVarName(),
+            bucket);
+    System.setProperty("aws.accessKeyId", s3Proxy.getAccessKey());
+    System.setProperty("aws.secretKey", s3Proxy.getSecretKey());
+
+    notebookRepo.init(conf);
+
+    // create bucket for notebook
+    AmazonS3 s3Client = AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(
+                    new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(s3Proxy.getAccessKey(),
+                                    s3Proxy.getSecretKey())))
+            .withEndpointConfiguration(
+                    new AwsClientBuilder.EndpointConfiguration(s3Proxy.getUri().toString(),
+                            Regions.US_EAST_1.getName()))
+            .build();
+    s3Client.createBucket(bucket);
+  }
+
+  @After
+  public void tearDown() {
+    if (notebookRepo != null) {
+      notebookRepo.close();
+    }
+  }
+
+  @Test
+  public void testNotebookRepo() throws IOException {
+    Map<String, NoteInfo> notesInfo = notebookRepo.list(anonymous);
+    assertEquals(0, notesInfo.size());
+
+    // create Note note1
+    Note note1 = new Note();
+    note1.setPath("/spark/note_1");
+    notebookRepo.save(note1, anonymous);
+
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(1, notesInfo.size());
+    assertEquals("/spark/note_1", notesInfo.get(note1.getId()).getPath());
+
+    // Get note1
+    Note noteFromRepo = notebookRepo.get(note1.getId(), note1.getPath(), anonymous);
+    assertEquals(note1.getName(), noteFromRepo.getName());
+
+    // Get non-existed note
+    try {
+      notebookRepo.get("invalid_id", "/invalid_path", anonymous);
+      fail("Should fail to get non-existed note1");
+    } catch (IOException e) {
+      assertEquals("Fail to get note: /invalid_path from S3", e.getMessage());
+    }
+
+    // create another Note note2
+    Note note2 = new Note();
+    note2.setPath("/spark/note_2");
+    notebookRepo.save(note2, anonymous);
+
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(2, notesInfo.size());
+    assertEquals("/spark/note_1", notesInfo.get(note1.getId()).getPath());
+    assertEquals("/spark/note_2", notesInfo.get(note2.getId()).getPath());
+
+    // move note1
+    notebookRepo.move(note1.getId(), note1.getPath(), "/spark2/note_1", anonymous);
+
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(2, notesInfo.size());
+    assertEquals("/spark2/note_1", notesInfo.get(note1.getId()).getPath());
+    assertEquals("/spark/note_2", notesInfo.get(note2.getId()).getPath());
+
+    // move folder
+    notebookRepo.move("/spark2", "/spark3", anonymous);
+
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(2, notesInfo.size());
+    assertEquals("/spark3/note_1", notesInfo.get(note1.getId()).getPath());
+    assertEquals("/spark/note_2", notesInfo.get(note2.getId()).getPath());
+
+    // delete note
+    notebookRepo.remove(note1.getId(), notesInfo.get(note1.getId()).getPath(), anonymous);
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(1, notesInfo.size());
+    assertEquals("/spark/note_2", notesInfo.get(note2.getId()).getPath());
+
+    // delete folder
+    notebookRepo.remove("/spark", anonymous);
+    notesInfo = notebookRepo.list(anonymous);
+    assertEquals(0, notesInfo.size());
+  }
+}

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -76,6 +76,10 @@
           <groupId>com.sun.jersey</groupId>
           <artifactId>jersey-server</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -45,7 +45,7 @@
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
     <frontend.maven.plugin.version>1.3</frontend.maven.plugin.version>
-    <aws.sdk.s3.version>1.10.62</aws.sdk.s3.version>
+    <aws.sdk.s3.version>1.11.736</aws.sdk.s3.version>
     <commons.vfs2.version>2.2</commons.vfs2.version>
     <eclipse.jgit.version>4.5.4.201711221230-r</eclipse.jgit.version>
     <jettison.version>1.4.0</jettison.version>


### PR DESCRIPTION
### What is this PR for?

This PR improve the S3NotebookRepo to adapt the new note file structure. Besides that I use s3proxy to add unit test for S3NotebookRepo. Unfortunately I don't have aws account, so I didn't test it against the real s3. I would be very appreciated if someone can help test it against rest s3.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4659

### How should this be tested?
CI pass


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
