### PR TITLE
[ZEPPELIN-4656]. Improvement of FlinkInterpreter

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -132,6 +132,11 @@ You can also set other flink properties which are not listed in the table. For a
     <td>queue name of yarn app</td>
   </tr>
   <tr>
+    <td>flink.webui.yarn.useProxy</td>
+    <td>false</td>
+    <td>whether use yarn proxy url as flink weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004</td>
+  </tr>
+  <tr>
     <td>flink.udf.jars</td>
     <td></td>
     <td>udf jars (comma separated), zeppelin will register udf in this jar automatically for user. The udf name is the class name.</td>
@@ -185,6 +190,16 @@ You can also set other flink properties which are not listed in the table. For a
     <td>zeppelin.flink.maxResult</td>
     <td>1000</td>
     <td>max number of row returned by sql interpreter</td>
+  </tr>
+  <tr>
+    <td>flink.interpreter.close.shutdown_cluster</td>
+    <td>true</td>
+    <td>Whether shutdown application when closing interpreter</td>
+  </tr>
+  <tr>
+    <td>zeppelin.interpreter.close.cancel_job</td>
+    <td>true</td>
+    <td>Whether cancel flink job when closing interpreter</td>
   </tr>
 </table>
 

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
@@ -55,23 +55,10 @@ public class FlinkBatchSqlInterpreter extends FlinkSqlInterrpeter {
 
   @Override
   public void callInnerSelect(String sql, InterpreterContext context) throws IOException {
-    int defaultSqlParallelism = this.tbenv.getConfig().getConfiguration()
-            .getInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM);
-    try {
-      if (context.getLocalProperties().containsKey("parallelism")) {
-        this.tbenv.getConfig().getConfiguration()
-                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
-                        Integer.parseInt(context.getLocalProperties().get("parallelism")));
-      }
-      Table table = this.tbenv.sqlQuery(sql);
-      z.setCurrentSql(sql);
-      String result = z.showData(table);
-      context.out.write(result);
-    } finally {
-      this.tbenv.getConfig().getConfiguration()
-              .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
-                      defaultSqlParallelism);
-    }
+    Table table = this.tbenv.sqlQuery(sql);
+    z.setCurrentSql(sql);
+    String result = z.showData(table);
+    context.out.write(result);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -66,7 +66,16 @@ public class FlinkInterpreter extends Interpreter {
     this.z.setInterpreterContext(context);
     this.z.setGui(context.getGui());
     this.z.setNoteGui(context.getNoteGui());
-    return innerIntp.interpret(st, context);
+
+    // set ClassLoader of current Thread to be the ClassLoader of Flink scala-shell,
+    // otherwise codegen will fail to find classes defined in scala-shell
+    ClassLoader originClassLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(getFlinkScalaShellLoader());
+      return innerIntp.interpret(st, context);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originClassLoader);
+    }
   }
 
   @Override
@@ -122,6 +131,10 @@ public class FlinkInterpreter extends Interpreter {
 
   int getDefaultParallelism() {
     return this.innerIntp.getDefaultParallelism();
+  }
+
+  int getDefaultSqlParallelism() {
+    return this.innerIntp.getDefaultSqlParallelism();
   }
 
   public ClassLoader getFlinkScalaShellLoader() {

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
@@ -69,50 +69,37 @@ public class FlinkStreamSqlInterpreter extends FlinkSqlInterrpeter {
                 .setString("execution.savepoint.path", savepointPath.toString());
       }
     }
-    int defaultSqlParallelism = this.tbenv.getConfig().getConfiguration()
-            .getInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM);
-    try {
-      if (context.getLocalProperties().containsKey("parallelism")) {
-        this.tbenv.getConfig().getConfiguration()
-                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
-                        Integer.parseInt(context.getLocalProperties().get("parallelism")));
-      }
 
-      String streamType = context.getLocalProperties().get("type");
-      if (streamType == null) {
-        throw new IOException("type must be specified for stream sql");
-      }
-      if (streamType.equalsIgnoreCase("single")) {
-        SingleRowStreamSqlJob streamJob = new SingleRowStreamSqlJob(
-                flinkInterpreter.getStreamExecutionEnvironment(),
-                tbenv,
-                flinkInterpreter.getJobManager(),
-                context,
-                flinkInterpreter.getDefaultParallelism());
-        streamJob.run(sql);
-      } else if (streamType.equalsIgnoreCase("append")) {
-        AppendStreamSqlJob streamJob = new AppendStreamSqlJob(
-                flinkInterpreter.getStreamExecutionEnvironment(),
-                flinkInterpreter.getStreamTableEnvironment(),
-                flinkInterpreter.getJobManager(),
-                context,
-                flinkInterpreter.getDefaultParallelism());
-        streamJob.run(sql);
-      } else if (streamType.equalsIgnoreCase("update")) {
-        UpdateStreamSqlJob streamJob = new UpdateStreamSqlJob(
-                flinkInterpreter.getStreamExecutionEnvironment(),
-                flinkInterpreter.getStreamTableEnvironment(),
-                flinkInterpreter.getJobManager(),
-                context,
-                flinkInterpreter.getDefaultParallelism());
-        streamJob.run(sql);
-      } else {
-        throw new IOException("Unrecognized stream type: " + streamType);
-      }
-    } finally {
-      this.tbenv.getConfig().getConfiguration()
-              .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
-                      defaultSqlParallelism);
+    String streamType = context.getLocalProperties().get("type");
+    if (streamType == null) {
+      throw new IOException("type must be specified for stream sql");
+    }
+    if (streamType.equalsIgnoreCase("single")) {
+      SingleRowStreamSqlJob streamJob = new SingleRowStreamSqlJob(
+              flinkInterpreter.getStreamExecutionEnvironment(),
+              tbenv,
+              flinkInterpreter.getJobManager(),
+              context,
+              flinkInterpreter.getDefaultParallelism());
+      streamJob.run(sql);
+    } else if (streamType.equalsIgnoreCase("append")) {
+      AppendStreamSqlJob streamJob = new AppendStreamSqlJob(
+              flinkInterpreter.getStreamExecutionEnvironment(),
+              flinkInterpreter.getStreamTableEnvironment(),
+              flinkInterpreter.getJobManager(),
+              context,
+              flinkInterpreter.getDefaultParallelism());
+      streamJob.run(sql);
+    } else if (streamType.equalsIgnoreCase("update")) {
+      UpdateStreamSqlJob streamJob = new UpdateStreamSqlJob(
+              flinkInterpreter.getStreamExecutionEnvironment(),
+              flinkInterpreter.getStreamTableEnvironment(),
+              flinkInterpreter.getJobManager(),
+              context,
+              flinkInterpreter.getDefaultParallelism());
+      streamJob.run(sql);
+    } else {
+      throw new IOException("Unrecognized stream type: " + streamType);
     }
   }
 

--- a/flink/src/main/java/org/apache/zeppelin/flink/IPyFlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/IPyFlinkInterpreter.java
@@ -39,13 +39,17 @@ public class IPyFlinkInterpreter extends IPythonInterpreter {
 
   private FlinkInterpreter flinkInterpreter;
   private InterpreterContext curInterpreterContext;
+  private boolean opened = false;
 
   public IPyFlinkInterpreter(Properties property) {
     super(property);
   }
 
   @Override
-  public void open() throws InterpreterException {
+  public synchronized void open() throws InterpreterException {
+    if (opened) {
+      return;
+    }
     FlinkInterpreter pyFlinkInterpreter =
         getInterpreterInTheSameSessionByClassName(FlinkInterpreter.class, false);
     setProperty("zeppelin.python",
@@ -53,6 +57,7 @@ public class IPyFlinkInterpreter extends IPythonInterpreter {
     flinkInterpreter = getInterpreterInTheSameSessionByClassName(FlinkInterpreter.class);
     setAdditionalPythonInitFile("python/zeppelin_ipyflink.py");
     super.open();
+    opened = true;
   }
 
   @Override

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -68,6 +68,13 @@
         "description": "yarn queue name",
         "type": "string"
       },
+      "flink.webui.yarn.useProxy": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": false,
+        "description": "whether use yarn proxy url as flink weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004",
+        "type": "checkbox"
+      },
       "flink.udf.jars": {
         "envName": null,
         "propertyName": null,
@@ -103,6 +110,13 @@
         "description": "whether enable hive",
         "type": "checkbox"
       },
+      "zeppelin.flink.hive.version": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": "2.3.4",
+        "description": "hive version that you would like to connect",
+        "type": "string"
+      },
       "zeppelin.flink.printREPLOutput": {
         "envName": null,
         "propertyName": "zeppelin.flink.printREPLOutput",
@@ -127,9 +141,16 @@
       "flink.interpreter.close.shutdown_cluster": {
         "envName": "flink.interpreter.close.shutdown_cluster",
         "propertyName": "flink.interpreter.close.shutdown_cluster",
-        "defaultValue": "true",
+        "defaultValue": true,
         "description": "Whether shutdown application when close interpreter",
-        "type": "string"
+        "type": "checkbox"
+      },
+      "zeppelin.interpreter.close.cancel_job": {
+        "envName": "zeppelin.interpreter.close.cancel_job",
+        "propertyName": "zeppelin.interpreter.close.cancel_job",
+        "defaultValue": true,
+        "description": "Whether cancel flink job when closing interpreter",
+        "type": "checkbox"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?

This is a followup PR of ZEPPELIN-4488. What is done in this PR
1. Add missing properties in `interpreter-setting.json`
2. Fix the concurrency issue of running multiple sql simultaneously. 
3. Add setting `flink.webui.yarn.useProxy` to allow use yarn proxy url.
4. Delete staging dir in yarn mode after cluster is shutdown


### What type of PR is it?
[Bug Fix | Improvement  | Documentation ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4656

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
