### PR TITLE
[ZEPPELIN-4668]. Use yarn proxy link for spark webui in yarn mode

### DIFF
--- a/docs/interpreter/spark.md
+++ b/docs/interpreter/spark.md
@@ -186,6 +186,10 @@ You can also set other Spark properties which are not listed in the table. For a
     <td></td>
     <td>Overrides Spark UI default URL. Value should be a full URL (ex: http://{hostName}/{uniquePath}</td>
   </tr>
+  <td>spark.webui.yarn.useProxy</td>
+    <td>false</td>
+    <td>whether use yarn proxy url as spark weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004</td>
+  </tr>
 </table>
 
 Without any configuration, Spark interpreter works out of box in local mode. But if you want to connect to your Spark cluster, you'll need to follow below two simple steps.

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -119,6 +119,13 @@
         "description": "Whether to hide spark ui in zeppelin ui",
         "type": "checkbox"
       },
+      "spark.webui.yarn.useProxy": {
+        "envName": null,
+        "propertyName": "",
+        "defaultValue": false,
+        "description": "whether use yarn proxy url as spark weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004",
+        "type": "checkbox"
+      },
       "zeppelin.spark.scala.color": {
         "envName": null,
         "propertyName": "zeppelin.spark.scala.color",


### PR DESCRIPTION
### What is this PR for?
Due to security reason, in some company user can not access spark web ui via the direct url. Instead they have to use yarn proxy url. This PR introduce property `spark.webui.yarn.useProxy` to allow user to use yarn proxy url for spark job url. 


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4668

### How should this be tested?
* CI pass & manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
