### PR TITLE
[ZEPPELIN-4669]. spark staging dir is not deleted in yarn cluster mode

### DIFF
--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -34,7 +34,7 @@
     <name>Zeppelin: Spark Scala Parent</name>
 
     <properties>
-        <spark.version>2.4.0</spark.version>
+        <spark.version>2.4.4</spark.version>
         <spark.scala.binary.version>2.11</spark.scala.binary.version>
         <spark.scala.version>2.11.12</spark.scala.version>
         <saprk.scala.compile.version>${spark.scala.binary.version}</saprk.scala.compile.version>


### PR DESCRIPTION
### What is this PR for?

This PR will delete the staging directory in yarn-cluster mode before stop the SparkContext.


### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4669

### How should this be tested?
* Manually tested, run spark interpreter in yarn cluster mode and verify the staging folder is deleted after close the spark interpreter.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
