### PR TITLE
[ZEPPELIN-4671]. Interpreter properties is still not in order when interpreter.json exist

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -624,7 +624,7 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
       }
 
       setting.properties[setting.propertyKey] =
-        {value: setting.propertyValue, type: setting.propertyType};
+        {name: setting.propertyKey, value: setting.propertyValue, type: setting.propertyType};
 
       emptyNewProperty(setting);
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -145,6 +145,7 @@ public class InterpreterSetting {
   private transient RemoteInterpreterEventServer interpreterEventServer;
 
   public static final String CLUSTER_INTERPRETER_LAUNCHER_NAME = "ClusterInterpreterLauncher";
+
   ///////////////////////////////////////////////////////////////////////////////////////////
 
   /**
@@ -558,6 +559,38 @@ public class InterpreterSetting {
     }
   }
 
+  /**
+   * This method will sort the properties by the order defined in template.
+   * It is because when interpreter setting is loaded in interpreter-setting.json, it is
+   * still not in correct order.
+   * @param propertiesInTemplate
+   */
+  public void sortPropertiesByTemplate(Object propertiesInTemplate) {
+    if (propertiesInTemplate instanceof LinkedHashMap) {
+      List<String> sortedKeys = new ArrayList(((LinkedHashMap) propertiesInTemplate).keySet());
+      if (this.properties instanceof LinkedHashMap) {
+        LinkedHashMap<String, InterpreterProperty> unSortedProperties = (LinkedHashMap) this.properties;
+        List<String> keys = new ArrayList(unSortedProperties.keySet());
+        keys.sort((o1, o2) -> {
+          int i1 = sortedKeys.indexOf(o1);
+          int i2 = sortedKeys.indexOf(o2);
+          if (i1 < i2) {
+            return -1;
+          } else if (i1 > i2) {
+            return 1;
+          } else {
+            return 0;
+          }
+        });
+
+        LinkedHashMap<String, InterpreterProperty> sortedProperties = new LinkedHashMap<>();
+        for (String key : keys) {
+          sortedProperties.put(key, unSortedProperties.get(key));
+        }
+        this.properties = sortedProperties;
+      }
+    }
+  }
 
   public Object getProperties() {
     return properties;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -257,6 +257,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
       // InterpreterSetting, while InterpreterSetting is from interpreter.json which represent
       // the user saved interpreter setting
       if (interpreterSettingTemplate != null) {
+        savedInterpreterSetting.sortPropertiesByTemplate(interpreterSettingTemplate.getProperties());
         // merge InterpreterDir, InterpreterInfo & InterpreterRunner
         savedInterpreterSetting.setInterpreterDir(
             interpreterSettingTemplate.getInterpreterDir());


### PR DESCRIPTION

### What is this PR for?
This is a followup of ZEPPELIN-4467. This issue happens when interpreter.json exist. That means this is an issue for upgrade scenario.  This PR will sort the properties by the order in interpreter template. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4671

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
