### PR TITLE
[ZEPPELIN-4672]. Display interpreter property description in interpreter setting page

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterProperty.java
@@ -24,6 +24,14 @@ public class InterpreterProperty {
   private String name;
   private Object value;
   private String type;
+  private String description;
+
+  public InterpreterProperty(String name, Object value, String type, String description) {
+    this.name = name;
+    this.value = value;
+    this.type = type;
+    this.description = description;
+  }
 
   public InterpreterProperty(String name, Object value, String type) {
     this.name = name;
@@ -61,8 +69,13 @@ public class InterpreterProperty {
     this.type = type;
   }
 
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
   @Override
   public String toString() {
-    return String.format("{name=%s, value=%s, type=%s}", name, value, type);
+    return String.format("{name=%s, value=%s, type=%s, description=%s}",
+            name, value, type, description);
   }
 }

--- a/zeppelin-web/src/app/interpreter/interpreter.controller.js
+++ b/zeppelin-web/src/app/interpreter/interpreter.controller.js
@@ -623,8 +623,8 @@ function InterpreterCtrl($rootScope, $scope, $http, baseUrlSrv, ngToast, $timeou
         return;
       }
 
-      setting.properties[setting.propertyKey] =
-        {name: setting.propertyKey, value: setting.propertyValue, type: setting.propertyType};
+      setting.properties[setting.propertyKey] = {name: setting.propertyKey, value: setting.propertyValue,
+        type: setting.propertyType, description: setting.description};
 
       emptyNewProperty(setting);
     }

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -393,14 +393,15 @@ limitations under the License.
         <table class="table table-striped">
           <thead>
             <tr>
-              <th style="width:40%">name</th>
-              <th style="width:40%">value</th>
-              <th style="width:20%" ng-if="valueform.$visible">action</th>
+              <th style="width:25%;text-align: left">Name</th>
+              <th style="width:30%;text-align: left">Value</th>
+              <th style="width:30%;text-align: left">Description</th>
+              <th style="width:15%;text-align: left" ng-if="valueform.$visible">Action</th>
             </tr>
           </thead>
           <tr ng-repeat="property in setting.properties" >
-            <td style="vertical-align: middle;">{{property.name}}</td>
-            <td style="vertical-align: middle;">
+            <td style="vertical-align: middle;text-align: left;">{{property.name}}</td>
+            <td style="vertical-align: middle;text-align: left;">
               <span ng-if="property.type === 'textarea'"
                     editable-textarea="property.value" e-form="valueform" e-msd-elastic>
                  {{property.value | breakFilter}}
@@ -426,9 +427,12 @@ limitations under the License.
                 {{property.value}}
               </span>
             </td>
+            <td style="vertical-align: middle; text-align: left">
+              {{property.description}}
+            </td>
             <td style="vertical-align: middle;" ng-if="valueform.$visible">
               <button class="btn btn-default btn-sm fa fa-remove"
-                   ng-click="removeInterpreterProperty(key, setting.id)">
+                   ng-click="removeInterpreterProperty(property.name, setting.id)">
               </button>
             </td>
           </tr>
@@ -445,6 +449,10 @@ limitations under the License.
               <input ng-switch-when="url" type="text" msd-elastic ng-model="setting.propertyValue" />
               <input ng-switch-when="password" type="password" msd-elastic ng-model="setting.propertyValue" />
               <input ng-switch-when="checkbox" type="checkbox" msd-elastic ng-model="setting.propertyValue" />
+            </td>
+            <td style="vertical-align: middle;">
+              <input ng-model="setting.description"
+                     pu-elastic-input pu-elastic-input-minwidth="280px" />
             </td>
             <td style="vertical-align: middle;">
               <select ng-model="setting.propertyType" ng-init="setting.propertyType=interpreterPropertyTypes[0]"

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -560,6 +560,28 @@ public class InterpreterSetting {
   }
 
   /**
+   * This is just to fix the issue of ZEPPELIN-4672.
+   * (TODO zjffdu), we should remove these ungly code after we unify the interpreter properties in
+   * interpreter.json & interpreter-setting.json
+   * @param propertiesInTemplate
+   */
+  public void fillPropertyDescription(Object propertiesInTemplate) {
+    if (propertiesInTemplate instanceof LinkedHashMap) {
+      LinkedHashMap<String, DefaultInterpreterProperty> propertiesInTemplate2 =
+              (LinkedHashMap<String, DefaultInterpreterProperty>) propertiesInTemplate;
+      if (this.properties instanceof LinkedHashMap) {
+        LinkedHashMap<String, InterpreterProperty> newInterpreterProperties = (LinkedHashMap)this.properties;
+        for (Map.Entry<String, InterpreterProperty> entry : newInterpreterProperties.entrySet()) {
+          if (propertiesInTemplate2.containsKey(entry.getKey())) {
+            entry.getValue().setDescription(propertiesInTemplate2.get(entry.getKey()).getDescription());
+          }
+        }
+        this.properties = newInterpreterProperties;
+      }
+    }
+  }
+
+  /**
    * This method will sort the properties by the order defined in template.
    * It is because when interpreter setting is loaded in interpreter-setting.json, it is
    * still not in correct order.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -258,6 +258,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
       // the user saved interpreter setting
       if (interpreterSettingTemplate != null) {
         savedInterpreterSetting.sortPropertiesByTemplate(interpreterSettingTemplate.getProperties());
+        savedInterpreterSetting.fillPropertyDescription(interpreterSettingTemplate.getProperties());
         // merge InterpreterDir, InterpreterInfo & InterpreterRunner
         savedInterpreterSetting.setInterpreterDir(
             interpreterSettingTemplate.getInterpreterDir());


### PR DESCRIPTION
# What is this PR for?

This PR is just to display property description in interpreter setting page, so that user can easily see what does each property mean when they configure the interpreter. It also handles the upgrade scenario where there's no property description in `interpreter.json`. 

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4672

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

Before
![image](https://user-images.githubusercontent.com/164491/76228384-a18ade00-625b-11ea-9125-f242e015d0da.png)

After
![image](https://user-images.githubusercontent.com/164491/76228718-0f370a00-625c-11ea-9a64-20cca6c66801.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? NO
* Does this needs documentation? No
