### PR TITLE
ZEPPELIN-4679: Add API validation for creating interpreter

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -259,7 +259,7 @@ public class InterpreterRestApiTest extends AbstractTestRestApi {
         + "\"session\": false"
         + "}"
         + "}";
-    JsonObject jsonRequest = gson.fromJson(StringUtils.replace(reqBody, "mdName", "md2"), JsonElement.class).getAsJsonObject();
+    JsonObject jsonRequest = gson.fromJson(StringUtils.replace(reqBody, "mdName", "mdValidName"), JsonElement.class).getAsJsonObject();
     PostMethod post = httpPost("/interpreter/setting/", jsonRequest.toString());
     String postResponse = post.getResponseBodyAsString();
     LOG.info("testSetting with valid name\n" + post.getResponseBodyAsString());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -29,6 +29,8 @@ import com.google.gson.reflect.TypeToken;
 import java.util.Properties;
 import java.util.LinkedHashMap;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -767,9 +769,17 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
                                                     InterpreterOption option,
                                                     Map<String, InterpreterProperty> properties)
       throws IOException {
-    if (name.indexOf(".") >= 0) {
-      throw new IOException("'.' is invalid for InterpreterSetting name.");
+    if (name == null) {
+      throw new IOException("Interpreter name shouldn't be empty.");
     }
+
+    // check if name is valid
+    Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
+    Matcher matcher = pattern.matcher(name);
+    if(!matcher.find()){
+      throw new IOException("Interpreter name shouldn't be empty, and can consist only of: -_a-zA-Z0-9");
+    }
+
     // check if name is existed
     for (InterpreterSetting interpreterSetting : interpreterSettings.values()) {
       if (interpreterSetting.getName().equals(name)) {
@@ -827,7 +837,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
     dependencyResolver.delRepo(id);
     saveToFile();
   }
-  
+
   /** restart in interpreter setting page */
   private InterpreterSetting inlineSetPropertyAndRestart(
       String id,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -26,17 +26,14 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.Properties;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
 import org.apache.zeppelin.cluster.ClusterManagerServer;
 import org.apache.zeppelin.cluster.event.ClusterEvent;
 import org.apache.zeppelin.cluster.event.ClusterEventListener;
@@ -107,6 +104,7 @@ import static org.apache.zeppelin.cluster.ClusterManagerServer.CLUSTER_INTP_SETT
 @ManagedObject("interpreterSettingManager")
 public class InterpreterSettingManager implements NoteEventListener, ClusterEventListener {
 
+  private static final Pattern VALID_INTERPRETER_NAME = Pattern.compile("^[-_a-zA-Z0-9]+$");
   private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterSettingManager.class);
   private static final Map<String, Object> DEFAULT_EDITOR = ImmutableMap.of(
       "language", (Object) "text",
@@ -774,8 +772,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
     }
 
     // check if name is valid
-    Pattern pattern = Pattern.compile("^[-_a-zA-Z0-9]+$");
-    Matcher matcher = pattern.matcher(name);
+    Matcher matcher = VALID_INTERPRETER_NAME.matcher(name);
     if(!matcher.find()){
       throw new IOException("Interpreter name shouldn't be empty, and can consist only of: -_a-zA-Z0-9");
     }


### PR DESCRIPTION
### What is this PR for?
This is an extension of ZEPPELIN-4377, I believe we should have an API validation for the same.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4679

### How should this be tested?
Calling directly API should fail, and if somehow this is by pass from UI, UI should also return proper error.
```
curl 'http://localhost:8080/api/interpreter/setting' -H 'Content-Type: application/json;charset=UTF-8' --data-binary '{"name":"test space","group":"angular","properties":{},"dependencies":[],"option":{"remote":true,"isExistingProcess":false,"setPermission":false,"session":false,"process":false,"perNote":"shared","perUser":"shared","owners":[]},"propertyValue":"","propertyKey":"","propertyType":"textarea"}' 
```

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
