### PR TITLE
[ZEPPELIN-4681]. Shade thrift in zeppelin-interpreter-shaded

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GObject.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GObject.java
@@ -18,7 +18,6 @@ package org.apache.zeppelin.groovy;
 
 import groovy.lang.Closure;
 import groovy.xml.MarkupBuilder;
-import org.apache.thrift.TException;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -240,7 +239,7 @@ public class GObject extends groovy.lang.GroovyObjectSupport {
   }
 
   @SuppressWarnings("unchecked")
-  public void angularBind(String name, Object o, String noteId) throws TException {
+  public void angularBind(String name, Object o, String noteId) {
     z.angularBind(name, o, noteId);
   }
 
@@ -251,7 +250,7 @@ public class GObject extends groovy.lang.GroovyObjectSupport {
    * @param name name of the variable
    * @param o value
    */
-  public void angularBind(String name, Object o) throws TException {
+  public void angularBind(String name, Object o) {
     angularBind(name, o, interpreterContext.getNoteId());
   }
 

--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -105,8 +105,6 @@
               <excludes>
                 <exclude>org/apache/zeppelin/*</exclude>
                 <exclude>org/apache/zeppelin/**/*</exclude>
-                <exclude>org/apache/thrift/*</exclude>
-                <exclude>org/apache/thrift/**/*</exclude>
                 <exclude>org/slf4j/*</exclude>
                 <exclude>org/slf4j/**/*</exclude>
                 <exclude>org/apache/commons/logging/*</exclude>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ZeppelinContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ZeppelinContext.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.interpreter;
 
-import org.apache.thrift.TException;
 import org.apache.zeppelin.annotation.Experimental;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.display.AngularObject;
@@ -673,10 +672,9 @@ public abstract class ZeppelinContext {
    *
    * @param name name of the variable
    * @param o    value
-   * @throws TException
    */
   @ZeppelinApi
-  public void angularBind(String name, Object o) throws TException {
+  public void angularBind(String name, Object o) {
     angularBind(name, o, interpreterContext.getNoteId());
   }
 
@@ -688,7 +686,7 @@ public abstract class ZeppelinContext {
    * @param o    value
    */
   @Deprecated
-  public void angularBindGlobal(String name, Object o) throws TException {
+  public void angularBindGlobal(String name, Object o) {
     angularBind(name, o, (String) null);
   }
 
@@ -701,7 +699,7 @@ public abstract class ZeppelinContext {
    * @param watcher watcher of the variable
    */
   @ZeppelinApi
-  public void angularBind(String name, Object o, AngularObjectWatcher watcher) throws TException {
+  public void angularBind(String name, Object o, AngularObjectWatcher watcher) {
     angularBind(name, o, interpreterContext.getNoteId(), watcher);
   }
 
@@ -714,8 +712,7 @@ public abstract class ZeppelinContext {
    * @param watcher watcher of the variable
    */
   @Deprecated
-  public void angularBindGlobal(String name, Object o, AngularObjectWatcher watcher)
-      throws TException {
+  public void angularBindGlobal(String name, Object o, AngularObjectWatcher watcher) {
     angularBind(name, o, null, watcher);
   }
 
@@ -791,7 +788,7 @@ public abstract class ZeppelinContext {
    * @param name
    */
   @ZeppelinApi
-  public void angularUnbind(String name) throws TException {
+  public void angularUnbind(String name) {
     String noteId = interpreterContext.getNoteId();
     angularUnbind(name, noteId);
   }
@@ -802,7 +799,7 @@ public abstract class ZeppelinContext {
    * @param name
    */
   @Deprecated
-  public void angularUnbindGlobal(String name) throws TException {
+  public void angularUnbindGlobal(String name) {
     angularUnbind(name, null);
   }
 
@@ -814,7 +811,7 @@ public abstract class ZeppelinContext {
    * @param o    value
    * @param noteId
    */
-  public void angularBind(String name, Object o, String noteId) throws TException {
+  public void angularBind(String name, Object o, String noteId) {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, null) == null) {
@@ -833,7 +830,7 @@ public abstract class ZeppelinContext {
    * @param noteId
    * @param paragraphId
    */
-  public void angularBind(String name, Object o, String noteId, String paragraphId) throws TException {
+  public void angularBind(String name, Object o, String noteId, String paragraphId) {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, paragraphId) == null) {
@@ -852,8 +849,7 @@ public abstract class ZeppelinContext {
    * @param o       value
    * @param watcher watcher of the variable
    */
-  private void angularBind(String name, Object o, String noteId, AngularObjectWatcher watcher)
-      throws TException {
+  private void angularBind(String name, Object o, String noteId, AngularObjectWatcher watcher) {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, null) == null) {
@@ -908,7 +904,7 @@ public abstract class ZeppelinContext {
    *
    * @param name
    */
-  private void angularUnbind(String name, String noteId) throws TException {
+  private void angularUnbind(String name, String noteId) {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
     registry.remove(name, noteId, null);
   }


### PR DESCRIPTION
### What is this PR for?
This is a minor PR which just shade thrift in zeppelin-interpreter-shaded as well. Besides that I also remove the TException, this is thrift exception, we should expose it to users. Otherwise we need to use the shaded version of TException which is inconvenient for users.



### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4681

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
