### PR TITLE
[ZEPPELIN-4680]. Add method to release note memory and add option to disable JobManager

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -711,4 +711,11 @@
   <description>path for storing search index on disk.</description>
 </property>
 
+<property>
+  <name>zeppelin.jobmanager.enable</name>
+  <value>true</value>
+  <description>The Job tab in zeppelin page seems not so useful instead it cost lots of memory and affect the performance.
+  Disable it can save lots of memory</description>
+</property>
+
 </configuration>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -609,6 +609,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return anonymousAllowed;
   }
 
+  public boolean isJobManagerEnabled() {
+    return getBoolean(ConfVars.ZEPPELIN_JOBMANAGER_ENABLE);
+  }
+
   public boolean isUsernameForceLowerCase() {
     return getBoolean(ConfVars.ZEPPELIN_USERNAME_FORCE_LOWERCASE);
   }
@@ -993,7 +997,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_PROXY_PASSWORD("zeppelin.proxy.password", null),
     ZEPPELIN_SEARCH_INDEX_REBUILD("zeppelin.search.index.rebuild", false),
     ZEPPELIN_SEARCH_USE_DISK("zeppelin.search.use.disk", true),
-    ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index");
+    ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),
+    ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", true);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/JobManagerService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/JobManagerService.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.service;
 
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -39,16 +40,21 @@ public class JobManagerService {
   private static final Logger LOGGER = LoggerFactory.getLogger(JobManagerService.class);
 
   private Notebook notebook;
+  private ZeppelinConfiguration conf;
 
   @Inject
-  public JobManagerService(Notebook notebook) {
+  public JobManagerService(Notebook notebook, ZeppelinConfiguration conf) {
     this.notebook = notebook;
+    this.conf = conf;
   }
 
   public List<NoteJobInfo> getNoteJobInfo(String noteId,
                                           ServiceContext context,
                                           ServiceCallback<List<NoteJobInfo>> callback)
       throws IOException {
+    if (!conf.isJobManagerEnabled()) {
+      return new ArrayList<>();
+    }
     List<NoteJobInfo> notesJobInfo = new ArrayList<>();
     Note jobNote = notebook.getNote(noteId);
     if (jobNote == null) {
@@ -66,6 +72,9 @@ public class JobManagerService {
                                                     ServiceContext context,
                                                     ServiceCallback<List<NoteJobInfo>> callback)
       throws IOException {
+    if (!conf.isJobManagerEnabled()) {
+      return new ArrayList<>();
+    }
     List<Note> notes = notebook.getAllNotes();
     List<NoteJobInfo> notesJobInfo = new ArrayList<>();
     for (Note note : notes) {
@@ -81,6 +90,9 @@ public class JobManagerService {
   public void removeNoteJobInfo(String noteId,
                                 ServiceContext context,
                                 ServiceCallback<List<NoteJobInfo>> callback) throws IOException {
+    if (!conf.isJobManagerEnabled()) {
+      return;
+    }
     List<NoteJobInfo> notesJobInfo = new ArrayList<>();
     notesJobInfo.add(new NoteJobInfo(noteId, true));
     callback.onSuccess(notesJobInfo, context);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterEventTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterEventTest.java
@@ -86,7 +86,7 @@ public class ClusterEventTest extends ZeppelinServerMock {
 
   private static Notebook notebook;
   private static NotebookServer notebookServer;
-  private static SchedulerService schedulerService;
+  private static QuartzSchedulerService schedulerService;
   private static NotebookService notebookService;
   private static AuthorizationService authorizationService;
   private HttpServletRequest mockRequest;
@@ -103,6 +103,7 @@ public class ClusterEventTest extends ZeppelinServerMock {
     authorizationService = TestUtils.getInstance(AuthorizationService.class);
 
     schedulerService = new QuartzSchedulerService(zconf, notebook);
+    schedulerService.waitForFinishInit();
     notebookServer = spy(NotebookServer.getInstance());
     notebookService = new NotebookService(notebook, authorizationService, zconf, schedulerService);
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -130,7 +130,8 @@ public class NotebookServiceTest {
             credentials,
             null);
 
-    SchedulerService schedulerService = new QuartzSchedulerService(zeppelinConfiguration, notebook);
+    QuartzSchedulerService schedulerService = new QuartzSchedulerService(zeppelinConfiguration, notebook);
+    schedulerService.waitForFinishInit();
     notebookService =
         new NotebookService(
             notebook, authorizationService, zeppelinConfiguration, schedulerService);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -180,6 +180,19 @@ public class Note implements JsonSerializable {
     this.loaded = loaded;
   }
 
+  /**
+   * Release note memory
+   */
+  public void unLoad() {
+    this.setLoaded(false);
+    this.paragraphs = null;
+    this.config = null;
+    this.info = null;
+    this.noteForms = null;
+    this.noteParams = null;
+    this.angularObjects = null;
+  }
+
   public boolean isPersonalizedMode() {
     Object v = getConfig().get("personalizedMode");
     return null != v && "true".equals(v);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -275,6 +275,22 @@ public class NoteManager {
    * @return return null if not found on NotebookRepo.
    * @throws IOException
    */
+  public Note getNote(String noteId, boolean forceLoad) throws IOException {
+    String notePath = this.notesInfo.get(noteId);
+    if (notePath == null) {
+      return null;
+    }
+    NoteNode noteNode = getNoteNode(notePath);
+    return noteNode.getNote(forceLoad);
+  }
+
+  /**
+   * Get note from NotebookRepo.
+   *
+   * @param noteId
+   * @return return null if not found on NotebookRepo.
+   * @throws IOException
+   */
   public Note getNote(String noteId) throws IOException {
     String notePath = this.notesInfo.get(noteId);
     if (notePath == null) {
@@ -511,14 +527,18 @@ public class NoteManager {
       this.notebookRepo = notebookRepo;
     }
 
+    public synchronized Note getNote() throws IOException {
+        return getNote(true);
+    }
+
     /**
      * This method will load note from NotebookRepo. If you just want to get noteId, noteName or
      * notePath, you can call method getNoteId, getNoteName & getNotePath
      * @return
      * @throws IOException
      */
-    public synchronized Note getNote() throws IOException {
-      if (!note.isLoaded()) {
+    public synchronized Note getNote(boolean forceLoad) throws IOException {
+      if (!note.isLoaded() && forceLoad) {
         note = notebookRepo.get(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
         if (parent.toString().equals("/")) {
           note.setPath("/" + note.getName());

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/NoSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/NoSchedulerService.java
@@ -22,8 +22,8 @@ import java.util.Set;
 
 public class NoSchedulerService implements SchedulerService {
   @Override
-  public void refreshCron(String noteId) {
-    // Do nothing
+  public boolean refreshCron(String noteId) {
+    return false;
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
@@ -20,6 +20,6 @@ package org.apache.zeppelin.notebook.scheduler;
 import java.util.Set;
 
 public interface SchedulerService {
-  void refreshCron(String noteId);
+  boolean refreshCron(String noteId);
   Set<?> getJobs();
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -42,6 +42,7 @@ public abstract class AbstractInterpreterTest {
     interpreterDir = new File(zeppelinHome, "interpreter_" + getClass().getSimpleName());
     confDir = new File(zeppelinHome, "conf_" + getClass().getSimpleName());
     notebookDir = new File(zeppelinHome, "notebook_" + getClass().getSimpleName());
+    FileUtils.deleteDirectory(notebookDir);
 
     interpreterDir.mkdirs();
     confDir.mkdirs();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -83,7 +83,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   private Credentials credentials;
   private AuthenticationInfo anonymous = AuthenticationInfo.ANONYMOUS;
   private StatusChangedListener afterStatusChangedListener;
-  private SchedulerService schedulerService;
+  private QuartzSchedulerService schedulerService;
 
   @Before
   public void setUp() throws Exception {
@@ -102,6 +102,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
             credentials, null);
     notebook.setParagraphJobListener(this);
     schedulerService = new QuartzSchedulerService(conf, notebook);
+    schedulerService.waitForFinishInit();
   }
 
   @After


### PR DESCRIPTION
### What is this PR for?

For zeppelin will load all notes in 2 places. One is QuartzSchedulerService.java where it would read all notes and refresh their cron job. Another is JobManagerService. In order to solve the memory issue,  I introduce the `unLoad` method in `Note` to release memory in `QuartzSchedulerService` after refreshing cron job. Another approach is to disable JobManager (Job tab in zeppelin UI), The Job tab is not so useful IMHO. We should redesign that only to show the cron enabled jobs. But this redesign should be done later in another PR. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4680

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
