### PR TITLE
[ZEPPELIN-4682]. Should initialize NoteAuth for the note without permission set

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -117,7 +117,7 @@ public class NotebookServiceTest {
     SearchService searchService = new LuceneSearch(zeppelinConfiguration);
     Credentials credentials = new Credentials(false, null, null);
     NoteManager noteManager = new NoteManager(notebookRepo);
-    AuthorizationService authorizationService = new AuthorizationService(zeppelinConfiguration);
+    AuthorizationService authorizationService = new AuthorizationService(noteManager, zeppelinConfiguration);
     Notebook notebook =
         new Notebook(
             zeppelinConfiguration,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
@@ -57,7 +57,7 @@ public class AuthorizationService implements ClusterEventListener {
   private Map<String, NoteAuth> notesAuth = new HashMap<>();
 
   @Inject
-  public AuthorizationService(ZeppelinConfiguration conf) {
+  public AuthorizationService(NoteManager noteManager, ZeppelinConfiguration conf) {
     this.conf = conf;
     try {
       this.configStorage = ConfigStorage.getInstance(conf);
@@ -68,6 +68,13 @@ public class AuthorizationService implements ClusterEventListener {
           String noteId = entry.getKey();
           Map<String, Set<String>> permissions = entry.getValue();
           notesAuth.put(noteId, new NoteAuth(noteId, permissions));
+        }
+      }
+
+      // initialize NoteAuth for the notes without permission set explicitly.
+      for (String noteId : noteManager.getNotesInfo().keySet()) {
+        if (!notesAuth.containsKey(noteId)) {
+          notesAuth.put(noteId, new NoteAuth(noteId));
         }
       }
     } catch (IOException e) {
@@ -142,7 +149,7 @@ public class AuthorizationService implements ClusterEventListener {
     entities = normalizeUsers(entities);
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      throw new IOException("No note found for noteId: " + noteId);
+      throw new IOException("No noteAuth found for noteId: " + noteId);
     }
     noteAuth.setOwners(entities);
     if (broadcast) {
@@ -154,7 +161,7 @@ public class AuthorizationService implements ClusterEventListener {
     entities = normalizeUsers(entities);
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      throw new IOException("No note found for noteId: " + noteId);
+      throw new IOException("No noteAuth found for noteId: " + noteId);
     }
     noteAuth.setReaders(entities);
     if (broadcast) {
@@ -166,7 +173,7 @@ public class AuthorizationService implements ClusterEventListener {
     entities = normalizeUsers(entities);
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      throw new IOException("No note found for noteId: " + noteId);
+      throw new IOException("No noteAuth found for noteId: " + noteId);
     }
     noteAuth.setRunners(entities);
     if (broadcast) {
@@ -178,7 +185,7 @@ public class AuthorizationService implements ClusterEventListener {
     entities = normalizeUsers(entities);
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      throw new IOException("No note found for noteId: " + noteId);
+      throw new IOException("No noteAuth found for noteId: " + noteId);
     }
     noteAuth.setWriters(entities);
     if (broadcast) {
@@ -201,7 +208,7 @@ public class AuthorizationService implements ClusterEventListener {
   public void clearPermission(String noteId, boolean broadcast) throws IOException {
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      throw new IOException("No note found for noteId: " + noteId);
+      throw new IOException("No noteAuth found for noteId: " + noteId);
     }
     noteAuth.setReaders(Sets.newHashSet());
     noteAuth.setRunners(Sets.newHashSet());
@@ -216,7 +223,7 @@ public class AuthorizationService implements ClusterEventListener {
   public Set<String> getOwners(String noteId) {
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      LOGGER.warn("No note found for noteId: " + noteId);
+      LOGGER.warn("No noteAuth found for noteId: " + noteId);
       return EMPTY_SET;
     }
     return noteAuth.getOwners();
@@ -225,7 +232,7 @@ public class AuthorizationService implements ClusterEventListener {
   public Set<String> getReaders(String noteId) {
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      LOGGER.warn("No note found for noteId: " + noteId);
+      LOGGER.warn("No noteAuth found for noteId: " + noteId);
       return EMPTY_SET;
     }
     return noteAuth.getReaders();
@@ -234,7 +241,7 @@ public class AuthorizationService implements ClusterEventListener {
   public Set<String> getRunners(String noteId) {
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      LOGGER.warn("No note found for noteId: " + noteId);
+      LOGGER.warn("No noteAuth found for noteId: " + noteId);
       return EMPTY_SET;
     }
     return noteAuth.getRunners();
@@ -243,7 +250,7 @@ public class AuthorizationService implements ClusterEventListener {
   public Set<String> getWriters(String noteId) {
     NoteAuth noteAuth = notesAuth.get(noteId);
     if (noteAuth == null) {
-      LOGGER.warn("No note found for noteId: " + noteId);
+      LOGGER.warn("No noteAuth found for noteId: " + noteId);
       return EMPTY_SET;
     }
     return noteAuth.getWriters();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -814,7 +814,7 @@ public class Note implements JsonSerializable {
   }
 
   public List<Paragraph> getParagraphs() {
-    return this.paragraphs;
+    return new ArrayList<>(this.paragraphs);
   }
 
   // TODO(zjffdu) how does this used ?

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -95,7 +95,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     notebookRepo = new VFSNotebookRepo();
     notebookRepo.init(conf);
     noteManager = new NoteManager(notebookRepo);
-    authorizationService = new AuthorizationService(conf);
+    authorizationService = new AuthorizationService(noteManager, conf);
 
     credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, search,

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -101,7 +101,7 @@ public class NotebookRepoSyncTest {
     search = mock(SearchService.class);
     notebookRepoSync = new NotebookRepoSync(conf);
     noteManager = new NoteManager(notebookRepoSync);
-    authorizationService = new AuthorizationService(conf);
+    authorizationService = new AuthorizationService(noteManager, conf);
     credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
     notebook = new Notebook(conf, authorizationService, notebookRepoSync, noteManager, factory, interpreterSettingManager, search, credentials, null);
     anonymous = new AuthenticationInfo("anonymous");


### PR DESCRIPTION

### What is this PR for?

It is a simple PR just to initialize NoteAuth for the note without permission set (not in `notebook-authorization.json`). So that we won't get annoying warning log. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4682

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
