### PR TITLE
[ZEPPELIN-4675] Add commons-configuration2 for shiro string interpolation

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -43,6 +43,7 @@
     <javax.ws.rsapi.version>2.1</javax.ws.rsapi.version>
     <libpam4j.version>1.8</libpam4j.version>
     <jna.version>4.1.0</jna.version>
+    <commons.configuration2.version>2.2</commons.configuration2.version>
 
     <!--test library versions-->
     <selenium.java.version>2.48.2</selenium.java.version>
@@ -175,6 +176,19 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.9.4</version>
+    </dependency>
+
+    <!-- Needed for string interpolation in shiro.ini -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>${commons.configuration2.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### What is this PR for?
Adding the library commons-configuration2 with is needed by Apache/shiro for string interpolation.
String interpolation is useful, when working with containers. You can interpolate several values, when starting the container.

Guide for String interpolation with shiro: https://stormpath.com/blog/string-interpolation-apache-shiro
Shiro-Commit with includes string interpolation: https://github.com/apache/shiro/commit/af75fb584ef6981c3c5263d00a396ec5f900716c

### What type of PR is it?
* Feature

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4675

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
