### PR TITLE
[ZEPPELIN-4687]. Allow to run multiple sql as one flink job

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -90,8 +90,8 @@ public class AppendStreamSqlJob extends AbstractStreamSqlJob {
 
     // sort it by the first column
     materializedTable.sort((r1, r2) -> {
-      String f1 = r1.getField(0).toString();
-      String f2 = r2.getField(0).toString();
+      String f1 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r1.getField(0)));
+      String f2 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r2.getField(0)));
       return f1.compareTo(f2);
     });
 

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
@@ -22,8 +22,10 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.scala.StreamTableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.StringUtils;
 import org.apache.zeppelin.flink.JobManager;
 import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.tabledata.TableDataUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +67,8 @@ public class SingleRowStreamSqlJob extends AbstractStreamSqlJob {
     builder.append("%html\n");
     String outputText = template;
     for (int i = 0; i < latestRow.getArity(); ++i) {
-      outputText = outputText.replace("{" + i + "}", latestRow.getField(i).toString());
+      outputText = outputText.replace("{" + i + "}",
+              TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(latestRow.getField(i))));
     }
     builder.append(outputText);
     return builder.toString();

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
@@ -75,7 +75,7 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
     StringBuilder builder = new StringBuilder();
     builder.append("%table\n");
     for (int i = 0; i < schema.getFieldCount(); ++i) {
-      String field = schema.getFieldName(i).get();
+      String field = schema.getFieldNames()[i];
       builder.append(field);
       if (i != (schema.getFieldCount() - 1)) {
         builder.append("\t");
@@ -84,8 +84,8 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
     builder.append("\n");
     // sort it by the first column
     materializedTable.sort((r1, r2) -> {
-      String f1 = r1.getField(0).toString();
-      String f2 = r2.getField(0).toString();
+      String f1 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r1.getField(0)));
+      String f2 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r2.getField(0)));
       return f1.compareTo(f2);
     });
     for (Row row : materializedTable) {


### PR DESCRIPTION
### What is this PR for?

This PR is to allow user to run multiple sql as one flink job in one paragraph. User can just specify paragraph local properties `runAsOne` to be `true` to enable this feature. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4687

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/76941313-c3105780-6936-11ea-9b5b-bc58d8205792.png)

![image](https://user-images.githubusercontent.com/164491/76941325-c9063880-6936-11ea-8be4-1b87577ea086.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
