### PR TITLE
[ZEPPELIN-4691]restart interpreter blocked after interpreter process exited unexpectedly

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -48,7 +48,7 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient {
       clientFactory = new ClientFactory(getHost(), getPort());
       clientPool = new GenericObjectPool<>(clientFactory);
     }
-    return clientPool.borrowObject();
+    return clientPool.borrowObject(5_000);
   }
 
   public void shutdown() {


### PR DESCRIPTION
### What is this PR for?
- added timeout for getting Thrift client to avoid situations where the interpreter may not be restarted when the interpreter process exits unexpectedly


### What type of PR is it?
- Bug Fix

### What is the Jira issue?
- https://issues.apache.org/jira/browse/ZEPPELIN-4691

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
