### PR TITLE
[ZEPPELIN-4694]. Limit the number of running interpreter process

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -718,4 +718,10 @@
   Disable it can save lots of memory</description>
 </property>
 
+<property>
+  <name>zeppelin.interpreter.process.max</name>
+  <value>10</value>
+  <description>The max number of interpreter process running in zeppelin machine.</description>
+</property>
+
 </configuration>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -998,7 +998,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SEARCH_INDEX_REBUILD("zeppelin.search.index.rebuild", false),
     ZEPPELIN_SEARCH_USE_DISK("zeppelin.search.use.disk", true),
     ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),
-    ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", true);
+    ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", true),
+    ZEPPELIN_INTERPRETER_PROCESS_MAX("zeppelin.interpreter.process.max", 10);
 
     private String varName;
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
### What is this PR for?
This is to limit the number of running interpreter process to protect zeppelin machine ran out of memory. By default, you can run at most 10 interpreter processes. To be noticed, this won't impact k8s mode. 

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4694

### How should this be tested?
* CI pass and unit test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
