### PR TITLE
[ZEPPELIN-4697] Zeppelin Quartz scheduler checks for updates against external endpoint

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -55,7 +55,7 @@ public class QuartzSchedulerService implements SchedulerService {
       throws SchedulerException {
     this.zeppelinConfiguration = zeppelinConfiguration;
     this.notebook = notebook;
-    this.scheduler = new StdSchedulerFactory().getScheduler();
+    this.scheduler = getScheduler();
     this.scheduler.start();
 
     // Do in a separated thread because there may be many notes,
@@ -83,6 +83,13 @@ public class QuartzSchedulerService implements SchedulerService {
     loadingNotesThread.setName("Init CronJob Thread");
     loadingNotesThread.setDaemon(true);
     loadingNotesThread.start();
+  }
+
+  private Scheduler getScheduler() throws SchedulerException {
+    // Make sure to not check for Quartz update since this leaks information about running process
+    // http://www.quartz-scheduler.org/documentation/2.4.0-SNAPSHOT/best-practices.html#skip-update-check
+    System.setProperty(StdSchedulerFactory.PROP_SCHED_SKIP_UPDATE_CHECK, "true");
+    return new StdSchedulerFactory().getScheduler();
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?

Zeppelin uses the Quartz scheduler which has a
built in update checker. This reaches out to a
Terracotta update server which leaks some
information about the running server. This is
recommended to be disabled in the docs.

http://www.quartz-scheduler.org/documentation/2.4.0-SNAPSHOT/best-practices.html#skip-update-check

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4697

### How should this be tested?
* CI tests
* Manually confirmed this removes the update check call to the Terracotta server

### Questions:
* Does the licenses files need update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
