### PR TITLE
[ZEPPELIN-4700] Cleanup Maven warnings & unify plugin management

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -43,10 +43,6 @@
         <achilles.version>3.2.4-Zeppelin</achilles.version>
         <jna.version>4.2.0</jna.version>
 
-        <!-- plugin versions -->
-        <plugin.scala.version>2.15.2</plugin.scala.version>
-        <plugin.scalatest.version>1.0</plugin.scalatest.version>
-        <plugin.scalate.version>1.7.1</plugin.scalate.version>
         <interpreter.name>cassandra</interpreter.name>
     </properties>
 
@@ -199,7 +195,6 @@
             <plugin>
                 <groupId>org.scala-tools</groupId>
                 <artifactId>maven-scala-plugin</artifactId>
-                <version>${plugin.scala.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -227,7 +222,6 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>${plugin.scalatest.version}</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -241,7 +235,6 @@
             <plugin>
                 <groupId>org.scalatra.scalate</groupId>
                 <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
-                <version>${plugin.scalate.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -47,12 +47,6 @@
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.12</scala.version>
 
-    <!--plugin versions-->
-    <plugin.scalamaven.version>3.2.2</plugin.scalamaven.version>
-    <plugin.eclipse.version>2.8</plugin.eclipse.version>
-    <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
-    <plugin.scalastyle.version>0.5.0</plugin.scalastyle.version>
-
     <flink.bin.download.url>https://archive.apache.org/dist/flink/flink-${flink.version}/flink-${flink.version}-bin-scala_${scala.binary.version}.tgz</flink.bin.download.url>
   </properties>
 
@@ -559,7 +553,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.2</version>
         <executions>
           <execution>
             <id>eclipse-add-source</id>
@@ -635,6 +628,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skip>false</skip>
+          <forkMode>always</forkMode>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <argLine>-Xmx3072m -XX:MaxPermSize=256m </argLine>
@@ -646,12 +640,10 @@
         </configuration>
       </plugin>
 
-
       <!-- Eclipse Integration -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
-        <version>${plugin.eclipse.version}</version>
         <configuration>
           <downloadSources>true</downloadSources>
           <projectnatures>
@@ -676,7 +668,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>${plugin.buildhelper.version}</version>
         <executions>
           <!-- Add src/main/scala to eclipse build path -->
           <execution>
@@ -708,16 +699,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkMode>always</forkMode>
-          <environmentVariables>
-            <FLINK_CONF_DIR>${project.build.directory}/test-classes</FLINK_CONF_DIR>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
@@ -729,7 +710,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -92,7 +92,6 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>${plugin.scala.version}</version>
         <configuration>
           <scalaVersion>${ignite.scala.version}</scalaVersion>
         </configuration>

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -44,9 +44,6 @@
         <livy.version>0.5.0-incubating</livy.version>
         <spark.version>2.1.0</spark.version>
         <hadoop.version>2.6.0</hadoop.version>
-        <!--plugin versions-->
-        <plugin.failsafe.version>2.16</plugin.failsafe.version>
-        <plugin.antrun.version>1.8</plugin.antrun.version>
     </properties>
 
     <dependencies>
@@ -319,7 +316,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${plugin.failsafe.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -343,7 +339,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>${plugin.antrun.version}</version>
                 <executions>
                     <!-- Cleans up files that tests append to (because we have two test plugins). -->
                     <execution>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -76,7 +76,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce</id>

--- a/pom.xml
+++ b/pom.xml
@@ -143,24 +143,43 @@
     <powermock.version>1.6.4</powermock.version>
 
     <!-- plugin versions -->
-    <plugin.compiler.version>3.1</plugin.compiler.version>
-    <plugin.resource.version>2.7</plugin.resource.version>
-    <plugin.dependency.version>2.8</plugin.dependency.version>
-    <plugin.jar.version>2.4</plugin.jar.version>
-    <plugin.remote.resource.version>1.5</plugin.remote.resource.version>
-    <plugin.scm.version>1.8.1</plugin.scm.version>
-    <plugin.enforcer.version>1.3.1</plugin.enforcer.version>
-    <plugin.checkstyle.version>2.13</plugin.checkstyle.version>
-    <plugin.surefire.version>2.17</plugin.surefire.version>
-    <plugin.assembly.version>3.0.0</plugin.assembly.version>
-    <plugin.exec.version>1.2.1</plugin.exec.version>
+    <plugin.antrun.version>1.8</plugin.antrun.version>
+    <plugin.assembly.version>3.2.0</plugin.assembly.version>
+    <plugin.avro.version>1.7.7</plugin.avro.version>
+    <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
+    <plugin.buildnumber.version>1.4</plugin.buildnumber.version>
+    <plugin.checkstyle.version>2.17</plugin.checkstyle.version>
+    <plugin.clean.version>3.1.0</plugin.clean.version>
     <plugin.cobertura.version>2.7</plugin.cobertura.version>
-    <plugin.clean.version>2.6.1</plugin.clean.version>
-    <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
-    <plugin.antrun.version>1.7</plugin.antrun.version>
-    <plugin.download.version>1.3.0</plugin.download.version>
+    <plugin.compiler.version>3.8.1</plugin.compiler.version>
+    <plugin.dependency.version>3.1.2</plugin.dependency.version>
     <plugin.deploy.version>2.8.2</plugin.deploy.version>
-    <plugin.shade.version>3.1.1</plugin.shade.version>
+    <plugin.download.version>1.3.0</plugin.download.version>
+    <plugin.eclipse.version>2.8</plugin.eclipse.version>
+    <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
+    <plugin.exec.version>1.6.0</plugin.exec.version>
+    <plugin.failsafe.version>2.17</plugin.failsafe.version>
+    <plugin.git.commit.id.version>4.0.0</plugin.git.commit.id.version>
+    <plugin.gpg.version>1.6</plugin.gpg.version>
+    <plugin.install.version>3.0.0-M1</plugin.install.version>
+    <plugin.jar.version>3.2.0</plugin.jar.version>
+    <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
+    <plugin.jdeb.version>1.8</plugin.jdeb.version>
+    <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
+    <plugin.protobuf.version>0.5.0</plugin.protobuf.version>
+    <plugin.rat.version>0.13</plugin.rat.version>
+    <plugin.remote.resource.version>1.7.0</plugin.remote.resource.version>
+    <plugin.resource.version>3.1.0</plugin.resource.version>
+    <plugin.s3.upload.version>1.4</plugin.s3.upload.version>
+    <plugin.scala.alchim31.version>3.4.6</plugin.scala.alchim31.version>
+    <plugin.scala.tools.version>2.15.2</plugin.scala.tools.version>
+    <plugin.scalate.version>1.7.1</plugin.scalate.version>
+    <plugin.scalatest.version>2.0.0</plugin.scalatest.version>
+    <plugin.scm.version>1.11.2</plugin.scm.version>
+    <plugin.shade.version>3.2.2</plugin.shade.version>
+    <plugin.source.version>3.2.1</plugin.source.version>
+    <plugin.surefire.version>2.17</plugin.surefire.version>
+    <plugin.xml.version>1.0.2</plugin.xml.version>
 
     <plugin.gitcommitid.useNativeGit>false</plugin.gitcommitid.useNativeGit>
 
@@ -375,6 +394,7 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${plugin.compiler.version}</version>
         <configuration>
@@ -434,13 +454,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>${plugin.checkstyle.version}</version>
         <configuration>
           <skip>true</skip>
           <failOnViolation>false</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <sourceDirectories>${basedir}/src/main/java,${basedir}/src/main/scala</sourceDirectories>
-          <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
+          <testSourceDirectories>${basedir}/src/test/java</testSourceDirectories>
           <configLocation>_tools/checkstyle.xml</configLocation>
           <outputFile>${basedir}/target/checkstyle-output.xml</outputFile>
           <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
@@ -472,6 +492,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>${plugin.jar.version}</version>
         <configuration>
@@ -486,6 +507,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <version>${plugin.remote.resource.version}</version>
         <executions>
@@ -504,6 +526,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
         <version>${plugin.scm.version}</version>
         <configuration>
@@ -514,6 +537,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${plugin.enforcer.version}</version>
         <executions>
@@ -529,6 +553,20 @@
               <goal>enforce</goal>
             </goals>
           </execution>
+          <!-- https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html -->
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.1.0,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -541,7 +579,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.2</version>
+        <version>${plugin.git.commit.id.version}</version>
         <executions>
           <execution>
             <goals>
@@ -583,11 +621,16 @@
 
     <pluginManagement>
       <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-shade-plugin</artifactId>
+              <version>${plugin.shade.version}</version>
+          </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>${plugin.install.version}</version>
         </plugin>
 
         <plugin>
@@ -597,6 +640,19 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${plugin.clean.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>${plugin.scala.alchim31.version}</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.surefire.version}</version>
           <configuration combine.children="append">
@@ -616,6 +672,7 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${plugin.assembly.version}</version>
         </plugin>
@@ -635,7 +692,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>1.0.1</version>
+          <version>${plugin.xml.version}</version>
           <executions>
             <execution>
               <phase>verify</phase>
@@ -725,6 +782,13 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-eclipse-plugin</artifactId>
+          <version>${plugin.eclipse.version}</version>
+        </plugin>
+        
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${plugin.dependency.version}</version>
           <executions>
@@ -746,6 +810,7 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${plugin.resource.version}</version>
           <executions>
@@ -771,6 +836,96 @@
           </executions>
         </plugin>
 
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>${plugin.scalatest.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${plugin.buildhelper.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${plugin.frontend.version}</version>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${plugin.failsafe.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>${plugin.protobuf.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>com.bazaarvoice.maven.plugins</groupId>
+        <artifactId>s3-upload-maven-plugin</artifactId>
+        <version>${plugin.s3.upload.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>${plugin.buildnumber.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.vafer</groupId>
+        <artifactId>jdeb</artifactId>
+        <version>${plugin.jdeb.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>${plugin.avro.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.scalatra.scalate</groupId>
+        <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
+        <version>${plugin.scalate.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <version>${plugin.scala.tools.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>${plugin.source.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>${plugin.javadoc.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>${plugin.gpg.version}</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>${plugin.rat.version}</version>
+      </plugin>
+      
       </plugins>
     </pluginManagement>
   </build>
@@ -847,6 +1002,7 @@
         <pluginManagement>
           <plugins>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
                 <skipTests>true</skipTests>
@@ -854,6 +1010,7 @@
             </plugin>
 
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-assembly-plugin</artifactId>
               <executions>
                 <execution>
@@ -879,6 +1036,7 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <skipTests>true</skipTests>
@@ -888,7 +1046,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -902,7 +1059,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -927,8 +1083,8 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -953,7 +1109,6 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.11</version>
           <configuration>
             <excludes>
               <exclude>**/*.keywords</exclude>
@@ -963,6 +1118,7 @@
               <exclude>.git/</exclude>
               <exclude>.github/*</exclude>
               <exclude>.gitignore</exclude>
+              <exclude>git.properties</exclude>
               <exclude>.repository/</exclude>
               <exclude>.rat-excludes/</exclude>
               <exclude>.Rhistory</exclude>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -102,7 +102,6 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -117,7 +116,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>
@@ -149,7 +147,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -185,7 +185,6 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>${plugin.scalatest.version}</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
@@ -208,7 +207,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -158,7 +158,6 @@
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
                 <executions>
                     <execution>
                         <id>copy-sparkr-files</id>
@@ -183,7 +182,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>${plugin.shade.version}</version>
                 <configuration>
                     <filters>
                         <filter>
@@ -230,7 +228,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -158,7 +158,6 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -42,10 +42,6 @@
     <scio.scala.version>${scala.2.10.version}</scio.scala.version>
     <scio.scala.binary.version>2.10</scio.scala.binary.version>
 
-    <!--plugin versions-->
-    <plugin.scala.version>2.15.2</plugin.scala.version>
-    <plugin.avro.version>1.7.7</plugin.avro.version>
-
     <!--test library versions-->
     <hamcrest.all.version>1.3</hamcrest.all.version>
   </properties>
@@ -138,7 +134,6 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>${plugin.scala.version}</version>
         <configuration>
           <scalaVersion>${scio.scala.version}</scalaVersion>
         </configuration>
@@ -170,7 +165,6 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>${plugin.avro.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -369,6 +369,7 @@
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
         <executions>
+          <!-- include pyspark by default -->
           <execution>
             <id>download-pyspark-files</id>
             <phase>validate</phase>
@@ -380,6 +381,21 @@
               <retries>5</retries>
               <unpack>true</unpack>
               <url>${spark.src.download.url}</url>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+            </configuration>
+          </execution>
+          <!-- include sparkr by default -->
+          <execution>
+            <id>download-sparkr-files</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <readTimeOut>60000</readTimeOut>
+              <retries>5</retries>
+              <url>${spark.bin.download.url}</url>
+              <unpack>true</unpack>
               <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
           </execution>
@@ -407,30 +423,8 @@
         </executions>
       </plugin>
 
-      <!-- include sparkr by default -->
-      <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>download-sparkr-files</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <readTimeOut>60000</readTimeOut>
-              <retries>5</retries>
-              <url>${spark.bin.download.url}</url>
-              <unpack>true</unpack>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <id>copy-sparkr-files</id>
@@ -447,6 +441,16 @@
                   </directory>
                 </resource>
               </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-interpreter-setting</id>
+            <phase>package</phase>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/../../../interpreter/${interpreter.name}</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -478,7 +482,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>
@@ -585,22 +588,6 @@
             </configuration>
           </execution>
 
-        </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-interpreter-setting</id>
-            <phase>package</phase>
-            <goals>
-              <goal>resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/../../../interpreter/${interpreter.name}</outputDirectory>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -40,8 +40,6 @@
         <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
         <datanucleus.core.version>3.2.10</datanucleus.core.version>
 
-        <!--plugin versions-->
-        <plugin.scala.version>2.15.2</plugin.scala.version>
         <!-- spark versions -->
         <spark.version>2.4.4</spark.version>
         <spark.scala.version>2.11.12</spark.scala.version>
@@ -109,14 +107,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${plugin.clean.version}</version>
                 <configuration combine.self="override"></configuration>
             </plugin>
 
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <id>eclipse-add-source</id>

--- a/spark/spark-dependencies/pom.xml
+++ b/spark/spark-dependencies/pom.xml
@@ -172,15 +172,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <version>${plugin.download.version}</version>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <filters>
             <filter>

--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -133,7 +133,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${plugin.clean.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -219,7 +218,6 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <id>eclipse-add-source</id>
@@ -268,7 +266,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
                 <configuration>
                     <outputDirectory>${project.basedir}/../../interpreter/spark/scala-${spark.scala.binary.version}</outputDirectory>
                 </configuration>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -115,7 +115,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -132,7 +131,6 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
-        <version>${plugin.scala.version}</version>
         <executions>
           <execution>
             <id>compile</id>
@@ -160,7 +158,6 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>${plugin.scalatest.version}</version>
         <executions>
           <execution>
             <id>test</id>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -203,7 +203,6 @@
           <plugin>
             <groupId>com.bazaarvoice.maven.plugins</groupId>
             <artifactId>s3-upload-maven-plugin</artifactId>
-            <version>1.2</version>
             <configuration>
               <bucketName>zeppel.in</bucketName>
               <endpoint>s3-ap-northeast-1.amazonaws.com</endpoint>
@@ -248,7 +247,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>buildnumber-maven-plugin</artifactId>
-            <version>1.2</version>
             <executions>
               <execution>
                 <phase>validate</phase>
@@ -264,7 +262,6 @@
           <plugin>
             <groupId>org.vafer</groupId>
             <artifactId>jdeb</artifactId>
-            <version>1.4</version>
             <executions>
               <execution>
                 <phase>package</phase>

--- a/zeppelin-examples/zeppelin-example-clock/pom.xml
+++ b/zeppelin-examples/zeppelin-example-clock/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
+++ b/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -90,7 +89,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>

--- a/zeppelin-integration/pom.xml
+++ b/zeppelin-integration/pom.xml
@@ -125,7 +125,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -140,7 +139,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${plugin.surefire.version}</version>
         <configuration combine.children="append">
           <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
           <excludes>

--- a/zeppelin-interpreter-integration/pom.xml
+++ b/zeppelin-interpreter-integration/pom.xml
@@ -150,7 +150,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -103,7 +103,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>${plugin.shade.version}</version>
           <configuration>
             <filters>
               <filter>
@@ -158,7 +157,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${plugin.clean.version}</version>
           <configuration>
             <filesets>
               <fileset>

--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -55,7 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${plugin.shade.version}</version>
         <configuration>
           <artifactSet>
             <excludes>
@@ -152,7 +151,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
         <executions>
           <execution>
             <id>copy-to-interpreter</id>

--- a/zeppelin-jupyter-interpreter-shaded/pom.xml
+++ b/zeppelin-jupyter-interpreter-shaded/pom.xml
@@ -47,7 +47,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -59,6 +58,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <filters>

--- a/zeppelin-jupyter-interpreter/pom.xml
+++ b/zeppelin-jupyter-interpreter/pom.xml
@@ -130,7 +130,6 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.0</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
@@ -148,7 +147,6 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -192,7 +190,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -50,8 +50,6 @@
     <xml.apis.version>1.4.01</xml.apis.version>
     <powermock.version>1.6.6</powermock.version>
 
-    <!--plugin library versions-->
-    <plugin.failsafe.version>2.16</plugin.failsafe.version>
   </properties>
 
   <dependencies>
@@ -352,7 +350,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -368,7 +365,6 @@
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${plugin.surefire.version}</version>
         <configuration combine.children="append">
           <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
           <excludes>
@@ -384,7 +380,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>

--- a/zeppelin-web-angular/pom.xml
+++ b/zeppelin-web-angular/pom.xml
@@ -59,7 +59,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>${plugin.frontend.version}</version>
         <configuration>
           <nodeDownloadRoot>${plugin.frontend.nodeDownloadRoot}</nodeDownloadRoot>
           <npmDownloadRoot>${plugin.frontend.npmDownloadRoot}</npmDownloadRoot>
@@ -166,7 +165,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>${plugin.resource.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -33,11 +33,6 @@
   <version>0.9.0-SNAPSHOT</version>
   <name>Zeppelin: web Application</name>
 
-  <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->
-  <prerequisites>
-    <maven>3.1.0</maven>
-  </prerequisites>
-
   <properties>
     <web.e2e.disabled>true</web.e2e.disabled>
     <web.e2e.enabled>false</web.e2e.enabled>
@@ -63,7 +58,6 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>${plugin.frontend.version}</version>
         <configuration>
           <nodeDownloadRoot>${plugin.frontend.nodeDownloadRoot}</nodeDownloadRoot>
           <npmDownloadRoot>${plugin.frontend.npmDownloadRoot}</npmDownloadRoot>
@@ -212,8 +206,8 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>${plugin.resource.version}</version>
       </plugin>
+
     </plugins>
   </build>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -295,7 +295,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### What is this PR for?

This commit declares all plugins in the `pluginManagement` section and unifies versions of
all plugins - they are now declared as properties in the top-level `pom.xml`.  All other
`pom.xml` files shouldn't specify version explicitly.

### What type of PR is it?
Improvement

### What is the Jira issue?

* ZEPPELIN-4700

### How should this be tested?
* One build was clean: https://travis-ci.org/github/alexott/zeppelin/builds/668812389, but after removing the not necessary files from commit, some tests began to fail: https://travis-ci.org/github/alexott/zeppelin/builds/669129366 - not sure if it's a case of flaky tests (yes, it looks like it the case - after restart of failed builds - they are all green)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
