### PR TITLE
ZEPPELIN-4711 Fix Docker Permissions

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -75,7 +75,7 @@ RUN echo "$LOG_TAG Install python related packages" && \
     conda info -a && \
     conda config --add channels conda-forge && \
     pip install -q pycodestyle==2.5.0 && \
-    pip install -q numpy==1.17.3 pandas==0.25.0 scipy==1.3.1 grpcio==1.19.0 bkzep==0.6.1 hvplot==0.5.2 protobuf==3.10.0 pandasql==0.7.3 ipython==7.8.0 matplotlib==3.0.3 ipykernel==5.1.2 jupyter_client==5.3.4 bokeh==1.3.4 panel==0.6.0 holoviews==1.12.3 seaborn==0.9.0 plotnine==0.5.1 intake==0.5.3 intake-parquet=0.2.2 altair=3.2.0 pycodestyle==2.5.0 apache_beam==2.15.0
+    pip install -q numpy==1.17.3 pandas==0.25.0 scipy==1.3.1 grpcio==1.19.0 bkzep==0.6.1 hvplot==0.5.2 protobuf==3.10.0 pandasql==0.7.3 ipython==7.8.0 matplotlib==3.0.3 ipykernel==5.1.2 jupyter_client==5.3.4 bokeh==1.3.4 panel==0.6.0 holoviews==1.12.3 seaborn==0.9.0 plotnine==0.5.1 intake==0.5.3 intake-parquet==0.2.2 altair==3.2.0 pycodestyle==2.5.0 apache_beam==2.15.0
 
 RUN echo "$LOG_TAG Install R related packages" && \
     echo "PATH: $PATH" && \
@@ -120,7 +120,7 @@ RUN echo "$LOG_TAG Download Zeppelin binary" && \
     # Allow process to edit /etc/passwd, to create a user entry for zeppelin
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
     # Give access to some specific folders
-    chmod -R 775 "${Z_HOME}/logs" "${Z_HOME}/run" "${Z_HOME}/notebook" "${Z_HOME}/conf" && \
+    chmod -R 775 "${Z_HOME}/logs" "${Z_HOME}/run" "${Z_HOME}/notebook" "${Z_HOME}/conf" "${Z_HOME}/interpreter" && \
     # Allow process to create new folders (e.g. webapps)
     chmod 775 ${Z_HOME}
 


### PR DESCRIPTION
### What is this PR for?
Fix permissions in the Docker build of Zeppelin 0.9.0-preview1


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4711

### How should this be tested?
Tested before and after by running the ./bin/install-interpreter.sh script:

## Without Patch
➜  zeppelin-solr-o19s git:(upgrade-zeppelin-0.9.0-preview) ✗ docker exec zeppelin-090_zeppelin_1 ./bin/install-interpreter.sh --name solr --artifact com.lucidworks.zeppelin:zeppelin-solr:0.1.6
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
 WARN [2020-03-31 17:07:56,968] ({main} ZeppelinConfiguration.java[create]:159) - Failed to load configuration, proceeding with a default
 INFO [2020-03-31 17:07:57,048] ({main} ZeppelinConfiguration.java[create]:171) - Server Host: 0.0.0.0
 INFO [2020-03-31 17:07:57,048] ({main} ZeppelinConfiguration.java[create]:173) - Server Port: 8080
 INFO [2020-03-31 17:07:57,049] ({main} ZeppelinConfiguration.java[create]:177) - Context Path: /
 INFO [2020-03-31 17:07:57,049] ({main} ZeppelinConfiguration.java[create]:178) - Zeppelin Version: 0.9.0-preview1
Install solr(com.lucidworks.zeppelin:zeppelin-solr:0.1.6) to /zeppelin/interpreter/solr ... 
java.io.IOException: Destination '/zeppelin/interpreter/solr' directory cannot be created
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:1085)
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:1038)
	at org.apache.zeppelin.dep.DependencyResolver.load(DependencyResolver.java:98)
	at org.apache.zeppelin.dep.DependencyResolver.load(DependencyResolver.java:85)
	at org.apache.zeppelin.interpreter.install.InstallInterpreter.install(InstallInterpreter.java:170)
	at org.apache.zeppelin.interpreter.install.InstallInterpreter.install(InstallInterpreter.java:148)
	at org.apache.zeppelin.interpreter.install.InstallInterpreter.main(InstallInterpreter.java:276)

## With Patch
docker exec zeppelin-090_zeppelin_1 ./bin/install-interpreter.sh --name solr --artifact com.lucidworks.zeppelin:zeppelin-solr:0.1.6

➜  zeppelin-solr-o19s git:(upgrade-zeppelin-0.9.0-preview) ✗ docker exec zeppelin-090_zeppelin_1 ./bin/install-interpreter.sh --name solr --artifact com.lucidworks.zeppelin:zeppelin-solr:0.1.6
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
 WARN [2020-03-31 17:21:20,635] ({main} ZeppelinConfiguration.java[create]:159) - Failed to load configuration, proceeding with a default
 INFO [2020-03-31 17:21:20,718] ({main} ZeppelinConfiguration.java[create]:171) - Server Host: 0.0.0.0
 INFO [2020-03-31 17:21:20,718] ({main} ZeppelinConfiguration.java[create]:173) - Server Port: 8080
 INFO [2020-03-31 17:21:20,718] ({main} ZeppelinConfiguration.java[create]:177) - Context Path: /
 INFO [2020-03-31 17:21:20,718] ({main} ZeppelinConfiguration.java[create]:178) - Zeppelin Version: 0.9.0-preview1
Install solr(com.lucidworks.zeppelin:zeppelin-solr:0.1.6) to /zeppelin/interpreter/solr ... 
Interpreter solr installed under /zeppelin/interpreter/solr.

1. Restart Zeppelin
2. Create interpreter setting in 'Interpreter' menu on Zeppelin GUI
3. Then you can bind the interpreter on your note


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
