### PR TITLE
[ZEPPELIN-4721]Fix the ConcurrentModificationException occured when connect presto via JDBC generic interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -422,8 +422,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
     if (driverClass != null && (driverClass.equals("com.facebook.presto.jdbc.PrestoDriver")
             || driverClass.equals("io.prestosql.jdbc.PrestoDriver"))) {
       // Only add valid properties otherwise presto won't work.
-      for (Object key : properties.keySet()) {
-        if (!PRESTO_PROPERTIES.contains(key.toString())) {
+      for (String key : properties.stringPropertyNames()) {
+        if (!PRESTO_PROPERTIES.contains(key)) {
           properties.remove(key);
         }
       }


### PR DESCRIPTION
### What is this PR for?
This PR is to fix a issue of connect presto via jdbc interpreter when more than one element needs to be removed from the jdbc properties. In this PR, I only change a method which iterate keys from jdbc properties. I tested it manully with presto-0.215.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4721
### How should this be tested?
Compiles locally, no unit test performed.
There should has more than one element needs to be removed in the properties.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
