### PR TITLE
[ZEPPELIN-4714]. Flink table api doesn't work in multiple threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -239,3 +239,4 @@ after_failure:
   - cat livy/target/tmp/livy-int-test/MiniYarnMain/target/org.apache.livy.test.framework.MiniYarnMain/*/*/*/stdout
   - cat livy/target/tmp/livy-int-test/MiniYarnMain/target/org.apache.livy.test.framework.MiniYarnMain/*/*/*/stderr
   - cat zeppelin-zengine/target/org.apache.zeppelin.interpreter.MiniHadoopCluster/*/*/*/stdout
+  - cat flink/*.log

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -637,7 +637,10 @@
           <skip>false</skip>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx3072m -XX:MaxPermSize=256m </argLine>
+          <!-- set sun.zip.disableMemoryMapping=true because of
+          https://blogs.oracle.com/poonam/crashes-in-zipgetentry
+          https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8191484 -->
+          <argLine>-Xmx3072m -XX:MaxMetaspaceSize=512m -Dsun.zip.disableMemoryMapping=true</argLine>
 
           <environmentVariables>
             <FLINK_HOME>${project.build.directory}/flink-${flink.version}</FLINK_HOME>

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -137,6 +137,13 @@ public class FlinkInterpreter extends Interpreter {
     return this.innerIntp.getDefaultSqlParallelism();
   }
 
+  /**
+   * Workaround for issue of FLINK-16936.
+   */
+  public void createPlannerAgain() {
+    this.innerIntp.createPlannerAgain();
+  }
+
   public ClassLoader getFlinkScalaShellLoader() {
     return innerIntp.getFlinkScalaShellLoader();
   }

--- a/flink/src/main/java/org/apache/zeppelin/flink/TableEnvFactory.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/TableEnvFactory.java
@@ -182,6 +182,20 @@ public class TableEnvFactory {
             settings.isStreamingMode());
   }
 
+  public void createPlanner(EnvironmentSettings settings) {
+    Map<String, String> executorProperties = settings.toExecutorProperties();
+    Executor executor = lookupExecutor(executorProperties, senv.getJavaEnv());
+
+    Map<String, String> plannerProperties = settings.toPlannerProperties();
+    ComponentFactoryService.find(PlannerFactory.class, plannerProperties)
+            .create(
+                    plannerProperties,
+                    executor,
+                    tblConfig,
+                    blinkFunctionCatalog,
+                    catalogManager);
+  }
+
   public StreamTableEnvironment createJavaBlinkStreamTableEnvironment(
           EnvironmentSettings settings) {
 

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
@@ -84,7 +84,7 @@ public class FlinkBatchSqlInterpreterTest extends SqlInterpreterTest {
     // select which use scala udf
     context = getInterpreterContext();
     result = sqlInterpreter.interpret("SELECT addOne(id) as add_one FROM source_table", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
     resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(1, resultMessages.size());
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());

--- a/flink/src/test/java/org/apache/zeppelin/flink/PyFlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/PyFlinkInterpreterTest.java
@@ -19,7 +19,6 @@ package org.apache.zeppelin.flink;
 
 
 import com.google.common.io.Files;
-import org.apache.commons.io.IOUtils;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -32,6 +31,8 @@ import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.apache.zeppelin.python.PythonInterpreterTest;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -48,7 +49,7 @@ public class PyFlinkInterpreterTest extends PythonInterpreterTest {
   private RemoteInterpreterEventClient mockRemoteEventClient =
           mock(RemoteInterpreterEventClient.class);
 
-  private Interpreter flinkInterpreter;
+  private Interpreter flinkScalaInterpreter;
   private Interpreter streamSqlInterpreter;
   private Interpreter batchSqlInterpreter;
 
@@ -77,9 +78,9 @@ public class PyFlinkInterpreterTest extends PythonInterpreterTest {
         .setIntpEventClient(mockRemoteEventClient)
         .build();
     InterpreterContext.set(context);
-    flinkInterpreter = new LazyOpenInterpreter(new FlinkInterpreter(properties));
-    intpGroup.get("session_1").add(flinkInterpreter);
-    flinkInterpreter.setInterpreterGroup(intpGroup);
+    flinkScalaInterpreter = new LazyOpenInterpreter(new FlinkInterpreter(properties));
+    intpGroup.get("session_1").add(flinkScalaInterpreter);
+    flinkScalaInterpreter.setInterpreterGroup(intpGroup);
 
     LazyOpenInterpreter iPyFlinkInterpreter =
         new LazyOpenInterpreter(new IPyFlinkInterpreter(properties));
@@ -108,9 +109,9 @@ public class PyFlinkInterpreterTest extends PythonInterpreterTest {
   }
 
   @Test
-  public void testPyFlink() throws InterpreterException {
-    IPyFlinkInterpreterTest.testBatchPyFlink(interpreter);
-    IPyFlinkInterpreterTest.testStreamPyFlink(interpreter);
+  public void testPyFlink() throws InterpreterException, IOException {
+    IPyFlinkInterpreterTest.testBatchPyFlink(interpreter, flinkScalaInterpreter);
+    IPyFlinkInterpreterTest.testStreamPyFlink(interpreter, flinkScalaInterpreter);
   }
 
   protected InterpreterContext getInterpreterContext() {

--- a/flink/src/test/resources/log4j.properties
+++ b/flink/src/test/resources/log4j.properties
@@ -15,11 +15,12 @@
 # limitations under the License.
 #
 
-log4j.rootLogger = WARN, stdout
+log4j.rootLogger = INFO, stdout
 
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n
 
 log4j.logger.org.apache.hive=WARN
+log4j.logger.org.apache.flink=WARN
 

--- a/flink/src/test/resources/log4j2.properties
+++ b/flink/src/test/resources/log4j2.properties
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-status = WARN
+status = INFO
 name = HiveLog4j2
 packages = org.apache.hadoop.hive.ql.log
 

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.python;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import org.apache.commons.exec.CommandLine;
@@ -60,7 +59,7 @@ public class PythonInterpreter extends Interpreter {
   private static final int MAX_TIMEOUT_SEC = 30;
 
   private GatewayServer gatewayServer;
-  private PythonProcessLauncher pythonProcessLauncher;
+  protected PythonProcessLauncher pythonProcessLauncher;
   private File pythonWorkDir;
   protected boolean useBuiltinPy4j = true;
 
@@ -163,7 +162,6 @@ public class PythonInterpreter extends Interpreter {
     }
   }
 
-  @VisibleForTesting
   public PythonProcessLauncher getPythonProcessLauncher() {
     return pythonProcessLauncher;
   }
@@ -572,7 +570,7 @@ public class PythonInterpreter extends Interpreter {
     LOGGER.debug("Python Process Output: " + message);
   }
 
-  class PythonProcessLauncher extends ProcessLauncher {
+  public class PythonProcessLauncher extends ProcessLauncher {
 
     PythonProcessLauncher(CommandLine commandLine, Map<String, String> envs) {
       super(commandLine, envs);

--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -146,7 +146,7 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
     assertEquals(Code.ERROR, result.code());
     output = context.out.toInterpreterResultMessage().get(0);
     assertTrue(output.getData(),
-            output.getData().equals("Ipython kernel has been stopped. Please check logs. "
+            output.getData().contains("Ipython kernel has been stopped. Please check logs. "
         + "It might be because of an out of memory issue."));
   }
 

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.jupyter;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannelBuilder;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.environment.EnvironmentUtils;
@@ -213,7 +212,6 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
     return EnvironmentUtils.getProcEnvironment();
   }
 
-  @VisibleForTesting
   public JupyterKernelProcessLauncher getKernelProcessLauncher() {
     return jupyterKernelProcessLauncher;
   }


### PR DESCRIPTION
### What is this PR for?
This PR is to fix the issue of FLINK-16936 by a workaround, already creating tableenv before execution scala or python code. Building tablenv is pretty light which won't cost much time. So it is acceptable for this workaround. Another this PR try to fix is the ClassLoader issue for PyFlinkInterpreter. This PR will always set classloader before executing python code so that pyflink api can call udf defined in scala.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4714

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
