### PR TITLE
[ZEPPELIN-4727] Fix HDFS Credentials storage 

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -145,12 +145,7 @@ public class ZeppelinServer extends ResourceConfig {
         new AbstractBinder() {
           @Override
           protected void configure() {
-            Credentials credentials =
-                new Credentials(
-                    conf.credentialsPersist(),
-                    conf.getCredentialsPath(),
-                    conf.getCredentialsEncryptKey());
-
+            Credentials credentials = new Credentials(conf);
             bindAsContract(InterpreterFactory.class).in(Singleton.class);
             bindAsContract(NotebookRepoSync.class).to(NotebookRepo.class).in(Immediate.class);
             bind(LuceneSearch.class).to(SearchService.class).in(Singleton.class);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/CredentialsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/CredentialsRestApiTest.java
@@ -44,8 +44,7 @@ public class CredentialsRestApiTest {
 
   @Before
   public void setUp() throws IOException {
-    credentials =
-        new Credentials(false, Files.createTempFile("credentials", "test").toString(), null);
+    credentials = new Credentials();
     authenticationService = new NoAuthenticationService();
     credentialRestApi = new CredentialRestApi(credentials, authenticationService);
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -115,7 +115,7 @@ public class NotebookServiceTest {
     when(mockInterpreterGroup.getInterpreterSetting()).thenReturn(mockInterpreterSetting);
     when(mockInterpreterSetting.getStatus()).thenReturn(InterpreterSetting.Status.READY);
     SearchService searchService = new LuceneSearch(zeppelinConfiguration);
-    Credentials credentials = new Credentials(false, null, null);
+    Credentials credentials = new Credentials();
     NoteManager noteManager = new NoteManager(notebookRepo);
     AuthorizationService authorizationService = new AuthorizationService(noteManager, zeppelinConfiguration);
     Notebook notebook =

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -526,13 +526,17 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
 
     Credentials credentials = note.getCredentials();
     if (subject != null) {
-      UserCredentials userCredentials =
-          credentials.getUserCredentials(subject.getUser());
+      UserCredentials userCredentials;
+      try {
+        userCredentials = credentials.getUserCredentials(subject.getUser());
+      } catch (IOException e) {
+        LOGGER.warn("Unable to get Usercredentials. Working with empty UserCredentials", e);
+        userCredentials = new UserCredentials();
+      }
       subject.setUserCredentials(userCredentials);
     }
 
-    InterpreterContext interpreterContext =
-        InterpreterContext.builder()
+    return InterpreterContext.builder()
             .setNoteId(note.getId())
             .setNoteName(note.getName())
             .setParagraphId(getId())
@@ -547,7 +551,6 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
             .setAngularObjectRegistry(registry)
             .setResourcePool(resourcePool)
             .build();
-    return interpreterContext;
   }
 
   public void setStatusToUserParagraph(Status status) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/ConfigStorage.java
@@ -22,12 +22,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.helium.HeliumConf;
 import org.apache.zeppelin.interpreter.InterpreterInfoSaving;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
-import org.apache.zeppelin.user.Credentials;
-import org.apache.zeppelin.user.CredentialsInfoSaving;
 import org.apache.zeppelin.util.ReflectionUtils;
 
 import java.io.IOException;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/FileSystemConfigStorage.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/storage/FileSystemConfigStorage.java
@@ -18,20 +18,18 @@
 
 package org.apache.zeppelin.storage;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import org.apache.hadoop.fs.Path;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.helium.HeliumConf;
 import org.apache.zeppelin.interpreter.InterpreterInfoSaving;
-import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.FileSystemStorage;
 import org.apache.zeppelin.notebook.NotebookAuthorizationInfoSaving;
-import org.apache.zeppelin.user.CredentialsInfoSaving;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * It could be used either local file system or hadoop distributed file system,
@@ -50,8 +48,7 @@ public class FileSystemConfigStorage extends ConfigStorage {
   public FileSystemConfigStorage(ZeppelinConfiguration zConf) throws IOException {
     super(zConf);
     this.fs = new FileSystemStorage(zConf, zConf.getConfigFSDir());
-    LOGGER.info("Creating FileSystem: " + this.fs.getFs().getClass().getName() +
-        " for Zeppelin Config");
+    LOGGER.info("Creating FileSystem: {} for Zeppelin Config", this.fs.getFs().getClass().getName());
     Path configPath = this.fs.makeQualified(new Path(zConf.getConfigFSDir()));
     this.fs.tryMkDir(configPath);
     LOGGER.info("Using folder {} to store Zeppelin Config", configPath);
@@ -62,7 +59,7 @@ public class FileSystemConfigStorage extends ConfigStorage {
 
   @Override
   public void save(InterpreterInfoSaving settingInfos) throws IOException {
-    LOGGER.info("Save Interpreter Settings to " + interpreterSettingPath);
+    LOGGER.info("Save Interpreter Settings to {}", interpreterSettingPath);
     fs.writeFile(settingInfos.toJson(), interpreterSettingPath, false);
   }
 
@@ -72,13 +69,14 @@ public class FileSystemConfigStorage extends ConfigStorage {
       LOGGER.warn("Interpreter Setting file {} is not existed", interpreterSettingPath);
       return null;
     }
-    LOGGER.info("Load Interpreter Setting from file: " + interpreterSettingPath);
+    LOGGER.info("Load Interpreter Setting from file: {}", interpreterSettingPath);
     String json = fs.readFile(interpreterSettingPath);
     return buildInterpreterInfoSaving(json);
   }
 
+  @Override
   public void save(NotebookAuthorizationInfoSaving authorizationInfoSaving) throws IOException {
-    LOGGER.info("Save notebook authorization to file: " + authorizationPath);
+    LOGGER.info("Save notebook authorization to file: {}", authorizationPath);
     fs.writeFile(authorizationInfoSaving.toJson(), authorizationPath, false);
   }
 
@@ -88,7 +86,7 @@ public class FileSystemConfigStorage extends ConfigStorage {
       LOGGER.warn("Notebook Authorization file {} is not existed", authorizationPath);
       return null;
     }
-    LOGGER.info("Load notebook authorization from file: " + authorizationPath);
+    LOGGER.info("Load notebook authorization from file: {}", authorizationPath);
     String json = this.fs.readFile(authorizationPath);
     return NotebookAuthorizationInfoSaving.fromJson(json);
   }
@@ -99,14 +97,15 @@ public class FileSystemConfigStorage extends ConfigStorage {
       LOGGER.warn("Credential file {} is not existed", credentialPath);
       return null;
     }
-    LOGGER.info("Load Credential from file: " + credentialPath);
+    LOGGER.info("Load Credential from file: {}", credentialPath);
     return this.fs.readFile(credentialPath);
   }
 
   @Override
   public void saveCredentials(String credentials) throws IOException {
-    LOGGER.info("Save Credentials to file: " + credentialPath);
-    fs.writeFile(credentials, credentialPath, false);
+    LOGGER.info("Save Credentials to file: {}", credentialPath);
+    Set<PosixFilePermission> permissions = EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+    fs.writeFile(credentials, credentialPath, false, permissions);
   }
 
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -18,69 +18,79 @@
 package org.apache.zeppelin.user;
 
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.storage.ConfigStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.nio.file.Files;
-import java.nio.file.attribute.PosixFilePermission;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
-import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * Class defining credentials for data source authorization
  */
 public class Credentials {
+
   private static final Logger LOG = LoggerFactory.getLogger(Credentials.class);
 
+  private ConfigStorage storage;
   private Map<String, UserCredentials> credentialsMap;
   private Gson gson;
-  private Boolean credentialsPersist = true;
-  File credentialsFile;
-
   private Encryptor encryptor;
-  
+
   /**
-   * Wrapper fro user credentials. It can load credentials from a file if credentialsPath is
-   * supplied, and will encrypt the file if an encryptKey is supplied.
+   * Wrapper for user credentials. It can load credentials from a file
+   * and will encrypt the file if an encryptKey is configured.
    *
-   * @param credentialsPersist
-   * @param credentialsPath
-   * @param encryptKey
+   * @param conf
+   * @throws IOException
    */
-  public Credentials(Boolean credentialsPersist, String credentialsPath, String encryptKey) {
-    if (encryptKey != null) {
-      this.encryptor = new Encryptor(encryptKey);
-    }
-
-    this.credentialsPersist = credentialsPersist;
-    if (credentialsPath != null) {
-      credentialsFile = new File(credentialsPath);
-    }
+  public Credentials(ZeppelinConfiguration conf) {
     credentialsMap = new HashMap<>();
-
-    if (credentialsPersist) {
-      GsonBuilder builder = new GsonBuilder();
-      builder.setPrettyPrinting();
-      gson = builder.create();
-      loadFromFile();
+    if (conf.credentialsPersist().booleanValue()) {
+      String encryptKey = conf.getCredentialsEncryptKey();
+      if (StringUtils.isNotBlank(encryptKey)) {
+        this.encryptor = new Encryptor(encryptKey);
+      }
+      try {
+        storage = ConfigStorage.getInstance(conf);
+        GsonBuilder builder = new GsonBuilder();
+        builder.setPrettyPrinting();
+        gson = builder.create();
+        loadFromFile();
+      } catch (IOException e) {
+        LOG.error("Fail to create ConfigStorage for Credentials. Persistenz will be disabled", e);
+        encryptor = null;
+        storage = null;
+        gson = null;
+      }
+    } else {
+      encryptor = null;
+      storage = null;
+      gson = null;
     }
   }
 
-  public UserCredentials getUserCredentials(String username) {
+  /**
+   * Wrapper for inmemory user credentials.
+   *
+   * @param conf
+   * @throws IOException
+   */
+  public Credentials() {
+    credentialsMap = new HashMap<>();
+    encryptor = null;
+    storage = null;
+    gson = null;
+  }
+
+  public UserCredentials getUserCredentials(String username) throws IOException {
+    loadCredentials();
     UserCredentials uc = credentialsMap.get(username);
     if (uc == null) {
       uc = new UserCredentials();
@@ -89,20 +99,22 @@ public class Credentials {
   }
 
   public void putUserCredentials(String username, UserCredentials uc) throws IOException {
+    loadCredentials();
     credentialsMap.put(username, uc);
     saveCredentials();
   }
 
   public UserCredentials removeUserCredentials(String username) throws IOException {
-    UserCredentials uc;
-    uc = credentialsMap.remove(username);
+    loadCredentials();
+    UserCredentials uc = credentialsMap.remove(username);
     saveCredentials();
     return uc;
   }
 
   public boolean removeCredentialEntity(String username, String entity) throws IOException {
+    loadCredentials();
     UserCredentials uc = credentialsMap.get(username);
-    if (uc != null && uc.existUsernamePassword(entity) == false) {
+    if (uc == null || !uc.existUsernamePassword(entity)) {
       return false;
     }
 
@@ -112,41 +124,30 @@ public class Credentials {
   }
 
   public void saveCredentials() throws IOException {
-    if (credentialsPersist) {
+    if (storage != null) {
       saveToFile();
     }
   }
 
-  private void loadFromFile() {
-    LOG.info(credentialsFile.getAbsolutePath());
-    if (!credentialsFile.exists()) {
-      // nothing to read
-      return;
+  private void loadCredentials() throws IOException {
+    if (storage != null) {
+      loadFromFile();
     }
+  }
 
+  private void loadFromFile() throws IOException {
     try {
-      FileInputStream fis = new FileInputStream(credentialsFile);
-      InputStreamReader isr = new InputStreamReader(fis);
-      BufferedReader bufferedReader = new BufferedReader(isr);
-      StringBuilder sb = new StringBuilder();
-      String line;
-      while ((line = bufferedReader.readLine()) != null) {
-        sb.append(line);
-      }
-      isr.close();
-      fis.close();
-
-      String json = sb.toString();
-
+      String json = storage.loadCredentials();
       if (encryptor != null) {
         json = encryptor.decrypt(json);
       }
 
       CredentialsInfoSaving info = CredentialsInfoSaving.fromJson(json);
-      this.credentialsMap = info.credentialsMap;
+      if (info != null) {
+        this.credentialsMap = info.credentialsMap;
+      }
     } catch (IOException e) {
-      LOG.error("Error loading credentials file", e);
-      e.printStackTrace();
+      throw new IOException("Error loading credentials file", e);
     }
   }
 
@@ -160,25 +161,12 @@ public class Credentials {
     }
 
     try {
-      if (!credentialsFile.exists()) {
-        credentialsFile.createNewFile();
-
-        Set<PosixFilePermission> permissions = EnumSet.of(OWNER_READ, OWNER_WRITE);
-        Files.setPosixFilePermissions(credentialsFile.toPath(), permissions);
-      }
-
-      FileOutputStream fos = new FileOutputStream(credentialsFile, false);
-      OutputStreamWriter out = new OutputStreamWriter(fos);
-
       if (encryptor != null) {
         jsonString = encryptor.encrypt(jsonString);
       }
-
-      out.append(jsonString);
-      out.close();
-      fos.close();
+      storage.saveCredentials(jsonString);
     } catch (IOException e) {
-      LOG.error("Error saving credentials file", e);
+      throw new IOException("Error saving credentials file", e);
     }
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -70,7 +70,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
             interpreterFactory,
             interpreterSettingManager,
             search,
-            new Credentials(false, null, null));
+            new Credentials());
 
     heliumAppFactory = new HeliumApplicationFactory(notebook, null);
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -97,7 +97,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     noteManager = new NoteManager(notebookRepo);
     authorizationService = new AuthorizationService(noteManager, conf);
 
-    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
+    credentials = new Credentials(conf);
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, search,
             credentials, null);
     notebook.setParagraphJobListener(this);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -102,7 +102,7 @@ public class NotebookRepoSyncTest {
     notebookRepoSync = new NotebookRepoSync(conf);
     noteManager = new NoteManager(notebookRepoSync);
     authorizationService = new AuthorizationService(noteManager, conf);
-    credentials = new Credentials(conf.credentialsPersist(), conf.getCredentialsPath(), null);
+    credentials = new Credentials(conf);
     notebook = new Notebook(conf, authorizationService, notebookRepoSync, noteManager, factory, interpreterSettingManager, search, credentials, null);
     anonymous = new AuthenticationInfo("anonymous");
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/user/CredentialsTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/user/CredentialsTest.java
@@ -27,7 +27,7 @@ public class CredentialsTest {
 
   @Test
   public void testDefaultProperty() throws IOException {
-    Credentials credentials = new Credentials(false, null, null);
+    Credentials credentials = new Credentials();
     UserCredentials userCredentials = new UserCredentials();
     UsernamePassword up1 = new UsernamePassword("user2", "password");
     userCredentials.putUsernamePassword("hive(vertica)", up1);


### PR DESCRIPTION
### What is this PR for?
With this PR we are switching to the abstract class `ConfigStorage` to save/load Credentials. We have child classes of `ConfigStorage` which are able to save to disc or HDFS.

NOTE: Cluster communication with changed user credentials is very simple. The `credential.json` content change is the only communication between cluster members. This leads to many rereads.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4727

### How should this be tested?
* **Travis-CI**: https://travis-ci.org/github/Reamer/zeppelin/builds/673728600

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
