### PR TITLE
[ZEPPELIN-4729]. Default value of flink.yarn.queue should be `default`

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -133,7 +133,7 @@ You can also set other flink properties which are not listed in the table. For a
   </tr>
   <tr>
     <td>flink.yarn.queue</td>
-    <td></td>
+    <td>default</td>
     <td>queue name of yarn app</td>
   </tr>
   <tr>

--- a/flink/src/main/resources/interpreter-setting.json
+++ b/flink/src/main/resources/interpreter-setting.json
@@ -85,7 +85,7 @@
       "flink.yarn.queue": {
         "envName": null,
         "propertyName": null,
-        "defaultValue": "",
+        "defaultValue": "default",
         "description": "Yarn queue name",
         "type": "string"
       },


### PR DESCRIPTION
### What is this PR for?

Minor PR too change default value of flink.yarn.queue should be `default` which is usually the default queue of yarn. 


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4729

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
