### PR TITLE
[ZEPPELIN-4733]Upgrade jetty 9.4.18.v20190429  to 9.4.24.v20191120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <libthrift.version>0.13.0</libthrift.version>
     <gson.version>2.2</gson.version>
     <gson-extras.version>0.2.1</gson-extras.version>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.24.v20191120</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.1</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>


### PR DESCRIPTION
### What is this PR for?
With this PR we upgrade jetty 9.4.18.v20190429  to 9.4.24.v20191120 , Cause jetty improvement https://github.com/eclipse/jetty.project/issues/3892 


### What type of PR is it?
Improvement

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4733

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
