### PR TITLE
[ZEPPELIN-4736] The use of SslContextFactory is deprecated

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -85,7 +85,6 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -441,7 +440,7 @@ public class ZeppelinServer extends ResourceConfig {
   }
 
   private static SslContextFactory getSslContextFactory(ZeppelinConfiguration conf) {
-    SslContextFactory sslContextFactory = new SslContextFactory();
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
 
     // Set keystore
     sslContextFactory.setKeyStorePath(conf.getKeyStorePath());


### PR DESCRIPTION
### What is this PR for?
Remove deprecation for SslContextFactory.
https://www.eclipse.org/jetty/javadoc/9.4.26.v20200117/org/eclipse/jetty/util/ssl/SslContextFactory.html#%3Cinit%3E()

Sorry for this little change. My IDE alerts me to this deprecation every time.
### What type of PR is it?
* Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4736

### How should this be tested?
* **Travis-CI**: https://travis-ci.org/github/Reamer/zeppelin/builds/672439814

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
