### PR TITLE
[ZEPPELIN-4740]. Display streaming data in flink table api

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -634,7 +634,7 @@
           <!-- set sun.zip.disableMemoryMapping=true because of
           https://blogs.oracle.com/poonam/crashes-in-zipgetentry
           https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8191484 -->
-          <argLine>-Xmx3072m -XX:MaxMetaspaceSize=512m -Dsun.zip.disableMemoryMapping=true</argLine>
+          <argLine>-Xmx4096m -XX:MaxMetaspaceSize=512m -Dsun.zip.disableMemoryMapping=true</argLine>
 
           <environmentVariables>
             <FLINK_HOME>${project.build.directory}/flink-${flink.version}</FLINK_HOME>

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -110,7 +110,7 @@ public class FlinkInterpreter extends Interpreter {
   }
 
   StreamTableEnvironment getStreamTableEnvironment() {
-    return this.innerIntp.getStreamTableEnvironment();
+    return this.innerIntp.getStreamTableEnvironment("blink");
   }
 
   org.apache.flink.table.api.TableEnvironment getJavaBatchTableEnvironment(String planner) {
@@ -122,7 +122,7 @@ public class FlinkInterpreter extends Interpreter {
   }
 
   TableEnvironment getBatchTableEnvironment() {
-    return this.innerIntp.getBatchTableEnvironment();
+    return this.innerIntp.getBatchTableEnvironment("blink");
   }
 
   JobManager getJobManager() {

--- a/flink/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -140,6 +140,12 @@ public class JobManager {
     jobProgressPoller.interrupt();
   }
 
+  public void shutdown() {
+    for (FlinkJobProgressPoller jobProgressPoller : jobProgressPollerMap.values()) {
+      jobProgressPoller.cancel();
+    }
+  }
+
   class FlinkJobProgressPoller extends Thread {
 
     private String flinkWebUI;

--- a/flink/src/main/resources/python/zeppelin_ipyflink.py
+++ b/flink/src/main/resources/python/zeppelin_ipyflink.py
@@ -60,7 +60,10 @@ class IPyFlinkZeppelinContext(PyZeppelinContext):
     def show(self, obj, **kwargs):
         from pyflink.table import Table
         if isinstance(obj, Table):
-            print(self.z.showData(obj._j_table))
+            if 'stream_type' in kwargs:
+                self.z.show(obj._j_table, kwargs['stream_type'], kwargs)
+            else:
+                print(self.z.showData(obj._j_table))
         else:
             super(IPyFlinkZeppelinContext, self).show(obj, **kwargs)
 

--- a/flink/src/main/resources/python/zeppelin_pyflink.py
+++ b/flink/src/main/resources/python/zeppelin_pyflink.py
@@ -52,7 +52,10 @@ class PyFlinkZeppelinContext(PyZeppelinContext):
   def show(self, obj, **kwargs):
     from pyflink.table import Table
     if isinstance(obj, Table):
-      print(self.z.showData(obj._j_table))
+      if 'stream_type' in kwargs:
+        self.z.show(obj._j_table, kwargs['stream_type'], kwargs)
+      else:
+        print(self.z.showData(obj._j_table))
     else:
       super(PyFlinkZeppelinContext, self).show(obj, **kwargs)
 

--- a/flink/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -360,7 +360,7 @@ class FlinkScalaInterpreter(val properties: Properties) {
     flinkILoop.interpret("import org.apache.flink.table.functions.AggregateFunction")
     flinkILoop.interpret("import org.apache.flink.table.functions.TableFunction")
 
-    this.z = new FlinkZeppelinContext(this.btenv, this.btenv_2, new InterpreterHookRegistry(),
+    this.z = new FlinkZeppelinContext(this, new InterpreterHookRegistry(),
       Integer.parseInt(properties.getProperty("zeppelin.flink.maxResult", "1000")))
     val modifiers = new java.util.ArrayList[String]()
     modifiers.add("@transient")
@@ -638,7 +638,6 @@ class FlinkScalaInterpreter(val properties: Properties) {
             LOGGER.info("Don't close the Remote FlinkCluster")
         }
       }
-
     } else {
       LOGGER.info("Keep cluster alive when closing interpreter")
     }
@@ -646,6 +645,9 @@ class FlinkScalaInterpreter(val properties: Properties) {
     if (flinkILoop != null) {
       flinkILoop.closeInterpreter()
       flinkILoop = null
+    }
+    if (jobManager != null) {
+      jobManager.shutdown()
     }
   }
 
@@ -666,9 +668,19 @@ class FlinkScalaInterpreter(val properties: Properties) {
 
   def getStreamExecutionEnvironment(): StreamExecutionEnvironment = this.senv
 
-  def getBatchTableEnvironment(): TableEnvironment = this.btenv
+  def getBatchTableEnvironment(planner: String = "blink"): TableEnvironment = {
+    if (planner == "blink")
+      this.btenv
+    else
+      this.btenv_2
+  }
 
-  def getStreamTableEnvironment(): StreamTableEnvironment = this.stenv
+  def getStreamTableEnvironment(planner: String = "blink"): StreamTableEnvironment = {
+    if (planner == "blink")
+      this.stenv
+    else
+      this.stenv_2
+  }
 
   def getJavaBatchTableEnvironment(planner: String): TableEnvironment = {
     if (planner == "blink") {

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkInterpreterTest.java
@@ -216,7 +216,7 @@ public class FlinkInterpreterTest {
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
     context = getInterpreterContext();
     result = interpreter.interpret("z.show(data)", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
     assertEquals("_1\t_2\n1\tjeff\n2\tandy\n3\tjames\n", resultMessages.get(0).getData());

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
@@ -19,10 +19,6 @@ package org.apache.zeppelin.flink;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
@@ -65,6 +61,23 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
   }
 
   @Test
+  public void testSingleStreamTableApi() throws IOException, InterpreterException {
+    String initStreamScalaScript = IOUtils.toString(getClass().getResource("/init_stream.scala"));
+    InterpreterContext context = getInterpreterContext();
+    InterpreterResult result = flinkInterpreter.interpret(initStreamScalaScript, context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    context = getInterpreterContext();
+    String code = "val table = stenv.sqlQuery(\"select max(rowtime), count(1) from log\")\nz.show(table,streamType=\"single\", configs = Map(\"template\" -> \"Total Count: {1} <br/> {0}\"))";
+    result = flinkInterpreter.interpret(code, context);
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
+    List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Type.HTML, resultMessages.get(0).getType());
+    assertTrue(resultMessages.toString(),
+            resultMessages.get(0).getData().contains("Total Count"));
+  }
+
+  @Test
   public void testUpdateStreamSql() throws IOException, InterpreterException {
     String initStreamScalaScript = IOUtils.toString(getClass().getResource("/init_stream.scala"));
     InterpreterResult result = flinkInterpreter.interpret(initStreamScalaScript,
@@ -76,6 +89,23 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
     result = sqlInterpreter.interpret("select url, count(1) as pv from " +
             "log group by url", context);
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertTrue(resultMessages.toString(),
+            resultMessages.get(0).getData().contains("url\tpv\n"));
+  }
+
+  @Test
+  public void testUpdateStreamTableApi() throws IOException, InterpreterException {
+    String initStreamScalaScript = IOUtils.toString(getClass().getResource("/init_stream.scala"));
+    InterpreterResult result = flinkInterpreter.interpret(initStreamScalaScript,
+            getInterpreterContext());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    InterpreterContext context = getInterpreterContext();
+    String code = "val table = stenv.sqlQuery(\"select url, count(1) as pv from log group by url\")\nz.show(table, streamType=\"update\")";
+    result = flinkInterpreter.interpret(code, context);
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
     assertTrue(resultMessages.toString(),
@@ -102,6 +132,25 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
   }
 
   @Test
+  public void testAppendStreamTableApi() throws IOException, InterpreterException {
+    String initStreamScalaScript = IOUtils.toString(getClass().getResource("/init_stream.scala"));
+    InterpreterResult result = flinkInterpreter.interpret(initStreamScalaScript,
+            getInterpreterContext());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    InterpreterContext context = getInterpreterContext();
+    String code = "val table = stenv.sqlQuery(\"select TUMBLE_START(rowtime, INTERVAL '5' SECOND) as " +
+            "start_time, url, count(1) as pv from log group by " +
+            "TUMBLE(rowtime, INTERVAL '5' SECOND), url\")\nz.show(table, streamType=\"append\")";
+    result = flinkInterpreter.interpret(code, context);
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
+    List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertTrue(resultMessages.toString(),
+            resultMessages.get(0).getData().contains("url\tpv\n"));
+  }
+
+  @Test
   public void testStreamUDF() throws IOException, InterpreterException {
     String initStreamScalaScript = IOUtils.toString(getClass().getResource("/init_stream.scala"));
     InterpreterResult result = flinkInterpreter.interpret(initStreamScalaScript,
@@ -118,7 +167,7 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
     context.getLocalProperties().put("type", "update");
     result = sqlInterpreter.interpret("select myupper(url), count(1) as pv from " +
             "log group by url", context);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
 //    assertEquals(InterpreterResult.Type.TABLE,
 //            updatedOutput.toInterpreterResultMessage().getType());
 //    assertTrue(updatedOutput.toInterpreterResultMessage().getData(),

--- a/flink/src/test/java/org/apache/zeppelin/flink/PyFlinkInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/PyFlinkInterpreterTest.java
@@ -31,16 +31,12 @@ import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
 import org.apache.zeppelin.interpreter.LazyOpenInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.apache.zeppelin.python.PythonInterpreterTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.Properties;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 
@@ -109,9 +105,28 @@ public class PyFlinkInterpreterTest extends PythonInterpreterTest {
   }
 
   @Test
-  public void testPyFlink() throws InterpreterException, IOException {
+  public void testBatchPyFlink() throws InterpreterException, IOException {
     IPyFlinkInterpreterTest.testBatchPyFlink(interpreter, flinkScalaInterpreter);
+  }
+
+  @Test
+  public void testStreamIPyFlink() throws InterpreterException, IOException {
     IPyFlinkInterpreterTest.testStreamPyFlink(interpreter, flinkScalaInterpreter);
+  }
+
+  @Test
+  public void testSingleStreamTableApi() throws InterpreterException, IOException {
+    IPyFlinkInterpreterTest.testSingleStreamTableApi(interpreter, flinkScalaInterpreter);
+  }
+
+  @Test
+  public void testUpdateStreamTableApi() throws InterpreterException, IOException {
+    IPyFlinkInterpreterTest.testUpdateStreamTableApi(interpreter, flinkScalaInterpreter);
+  }
+
+  @Test
+  public void testAppendStreamTableApi() throws InterpreterException, IOException {
+    IPyFlinkInterpreterTest.testAppendStreamTableApi(interpreter, flinkScalaInterpreter);
   }
 
   protected InterpreterContext getInterpreterContext() {

--- a/flink/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -42,10 +42,8 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterOutput;
-import org.apache.zeppelin.interpreter.InterpreterOutputListener;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
-import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterEventClient;
 import org.junit.After;
 import org.junit.Before;
@@ -62,7 +60,8 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.Properties;
 
-import static org.apache.zeppelin.interpreter.InterpreterResult.*;
+import static org.apache.zeppelin.interpreter.InterpreterResult.Code;
+import static org.apache.zeppelin.interpreter.InterpreterResult.Type;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -358,6 +357,7 @@ public abstract class SqlInterpreterTest {
 
   protected InterpreterContext getInterpreterContext() {
     return InterpreterContext.builder()
+            .setParagraphId("paragraphId")
             .setInterpreterOut(new InterpreterOutput(null))
             .setAngularObjectRegistry(new AngularObjectRegistry("flink", null))
             .setIntpEventClient(mock(RemoteInterpreterEventClient.class))


### PR DESCRIPTION
### What is this PR for?
This PR is to allow user to display streaming data in flink table api just like displaying streaming data in stream sql (%flink.ssql). I implement it in both scala and pyflink. 

Here's one example in flink scala table api

```
val table = stenv.from("cdn_access_log")
   .select("uuid, ip_to_province(client_ip) as province, response_size, request_time")
   .groupBy("province")
   .select( "province, count(uuid) as access_count, sum(response_size) as total_download,  sum(response_size) * 1.0 / sum(request_time) as download_speed")
z.show(table, streamType="update")
```


### What type of PR is it?
[Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4740

### How should this be tested?
Unit test is added and also verify it manually.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/78974396-75a59580-7b44-11ea-91be-e962d630e739.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
