### PR TITLE
[ZEPPELIN-4743] fix MongoNotebookRepo get unstable note path

### DIFF
--- a/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -127,6 +128,7 @@ public class MongoNotebookRepo implements NotebookRepo {
         String id = document.getString(Fields.ID);
         String name = document.getString(Fields.NAME);
         List<Document> fullPath = document.get(Fields.FULL_PATH, List.class);
+        fullPath.sort(Comparator.comparing(pathNode -> pathNode.getString(Fields.ID)));
 
         StringBuilder sb = new StringBuilder();
         for (Document pathNode : fullPath) {

--- a/zeppelin-plugins/notebookrepo/mongo/src/test/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/mongo/src/test/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepoTest.java
@@ -49,7 +49,9 @@ public class MongoNotebookRepoTest {
   @Before
   public void setUp() throws IOException {
     String bindIp = "localhost";
-    int port = new ServerSocket(0).getLocalPort();
+    ServerSocket socket = new ServerSocket(0);
+    int port = socket.getLocalPort();
+    socket.close();
 
     IMongodConfig mongodConfig = new MongodConfigBuilder()
         .version(Version.Main.PRODUCTION)
@@ -122,6 +124,24 @@ public class MongoNotebookRepoTest {
     assertEquals(1, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
 
     notebookRepo.remove("/my_project3", AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
+  }
+
+  @Test
+  public void testGetNotePath() throws IOException {
+    assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
+
+    Note note = new Note();
+    String notePath = "/folder1/folder2/folder3/folder4/folder5/my_note";
+    note.setPath(notePath);
+    notebookRepo.save(note, AuthenticationInfo.ANONYMOUS);
+
+    notebookRepo.init(zConf);
+    Map<String, NoteInfo> noteInfos = notebookRepo.list(AuthenticationInfo.ANONYMOUS);
+    assertEquals(1, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
+    assertEquals(notePath, noteInfos.get(note.getId()).getPath());
+
+    notebookRepo.remove(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
     assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
   }
 }


### PR DESCRIPTION
### What is this PR for?
This PR sorts documents returned by aggregation $graphLookup which used by MongoNotebookRepo to get the path of  note.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4743

### How should this be tested?
2 types of tests:
* Unit test added
* Create notes(more nested folders is better) in zeppelin web UI, then restart zeppelin or call /api/notebook-repositories/reload. After doing the above, check if the note path  is correct.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No