### PR TITLE
[ZEPPELIN-4750]. Don't display temporary tables in show tables of flink interpreter

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -18,6 +18,7 @@
 
 package org.apache.zeppelin.flink;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -55,6 +56,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 public abstract class FlinkSqlInterrpeter extends Interpreter {
 
@@ -416,7 +418,9 @@ public abstract class FlinkSqlInterrpeter extends Interpreter {
   }
 
   private void callShowTables(InterpreterContext context) throws IOException {
-    String[] tables = this.tbenv.listTables();
+    List<String> tables =
+            Lists.newArrayList(this.tbenv.listTables()).stream()
+                    .filter(tbl -> !tbl.startsWith("UnnamedTable")).collect(Collectors.toList());
     context.out.write(
             "%table table\n" + StringUtils.join(tables, "\n") + "\n");
   }

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
@@ -97,7 +97,7 @@ public abstract class AbstractStreamSqlJob {
 
   public InterpreterResult run(String st) throws IOException {
     Table table = stenv.sqlQuery(st);
-    String tableName = st + "_" + SQL_INDEX.getAndIncrement();
+    String tableName = "UnnamedTable_" + st + "_" + SQL_INDEX.getAndIncrement();
     return run(table, tableName);
   }
 

--- a/flink/src/main/scala/org/apache/zeppelin/flink/FlinkZeppelinContext.scala
+++ b/flink/src/main/scala/org/apache/zeppelin/flink/FlinkZeppelinContext.scala
@@ -134,7 +134,7 @@ class FlinkZeppelinContext(val flinkInterpreter: FlinkScalaInterpreter,
     val stenv = flinkInterpreter.getStreamTableEnvironment()
     val context = InterpreterContext.get()
     configs.foreach(e => context.getLocalProperties.put(e._1, e._2))
-    val tableName = context.getParagraphId.replace("-", "_") + "_" + SQL_INDEX.getAndIncrement()
+    val tableName = "UnnamedTable_" + context.getParagraphId.replace("-", "_") + "_" + SQL_INDEX.getAndIncrement()
     if (streamType.equalsIgnoreCase("single")) {
       val streamJob = new SingleRowStreamSqlJob(flinkInterpreter.getStreamExecutionEnvironment,
         stenv, flinkInterpreter.getJobManager, context, flinkInterpreter.getDefaultParallelism)

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
@@ -135,6 +135,18 @@ public class FlinkBatchSqlInterpreterTest extends SqlInterpreterTest {
     assertEquals(1, resultMessages.size());
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
     assertEquals("name\nA\nB\n", resultMessages.get(0).getData());
+
+    // after these select queries, `show tables` should still show only one source table,
+    // other temporary tables should not be displayed.
+    context = getInterpreterContext();
+    result = sqlInterpreter.interpret("show tables", context);
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(1, resultMessages.size());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertEquals(resultMessages.get(0).toString(),
+            "table\nsource_table\n", resultMessages.get(0).getData());
+
   }
 
   @Test

--- a/flink/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
@@ -75,6 +75,13 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
     assertEquals(InterpreterResult.Type.HTML, resultMessages.get(0).getType());
     assertTrue(resultMessages.toString(),
             resultMessages.get(0).getData().contains("Total Count"));
+
+    context = getInterpreterContext();
+    result = sqlInterpreter.interpret("show tables", context);
+    assertEquals(new String(context.out.toByteArray()), InterpreterResult.Code.SUCCESS, result.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertEquals("table\nlog\n", resultMessages.get(0).getData());
   }
 
   @Test
@@ -198,6 +205,17 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
             getInterpreterContext());
 
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    // after these select queries, `show tables` should still show only one source table,
+    // other temporary tables should not be displayed.
+    InterpreterContext context = getInterpreterContext();
+    result = sqlInterpreter.interpret("show tables", context);
+    List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+    assertEquals(1, resultMessages.size());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertEquals(resultMessages.get(0).toString(),
+            "table\ndest_table\nsource_table\n", resultMessages.get(0).getData());
   }
 
   @Test

--- a/flink/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -331,6 +331,14 @@ public abstract class SqlInterpreterTest {
     assertEquals(Type.TEXT, resultMessages.get(0).getType());
     assertTrue(resultMessages.get(0).getData(), resultMessages.get(0).getData().contains("already exists"));
 
+    // show tables
+    context = getInterpreterContext();
+    result = sqlInterpreter.interpret("show tables", context);
+    assertEquals(Code.SUCCESS, result.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(Type.TABLE, resultMessages.get(0).getType());
+    assertEquals("table\nmy_view\nsource_table\n", resultMessages.get(0).getData());
+
     // drop table
     context = getInterpreterContext();
     result = sqlInterpreter.interpret("drop view my_view", context);


### PR DESCRIPTION
### What is this PR for?

This PR would filter the temporary tables in show tables, only show the permanent tables. Otherwise it would confuse users if they see lots of temporary tables created by zeppelin.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4750

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
