### PR TITLE
ZEPPELIN-4747. Terminal interpreter support internal and external IP mapping

### DIFF
--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -129,3 +129,30 @@ input any char
 ```
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-terminal.gif" />
+
+## Configuration
+At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property value for Terminal interpreter.
+
+<table class="table-configuration">
+  <tr>
+    <th>Name</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>zeppelin.terminal.ip.mapping</td>
+    <td></td>
+    <td>Internal and external IP mapping of zeppelin server</td>
+  </tr>
+</table>
+
+### zeppelin.terminal.ip.mapping
+
+When running the terminal interpreter in the notebook, the front end of the notebook needs to obtain the IP address of the server where the terminal interpreter is located to communicate.
+
+In a public cloud environment, the cloud host has an internal IP and an external access IP, and the interpreter runs in the cloud host. This will cause the notebook front end to be unable to connect to the terminal interpreter properly, resulting in the terminal interpreter being unusable.
+
+Solution: Set the mapping between internal IP and external IP in the terminal interpreter, and connect the front end of the notebook through the external IP of the terminal interpreter.
+
+Example: 
+{"internal-ip1":"external-ip1", "internal-ip2":"external-ip2"}

--- a/docs/interpreter/shell.md
+++ b/docs/interpreter/shell.md
@@ -74,6 +74,11 @@ At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property v
     <td>false</td>
     <td>Enable ZeppelinContext variable interpolation into paragraph text</td>
   </tr>
+  <tr>
+    <td>zeppelin.terminal.ip.mapping</td>
+    <td></td>
+    <td>Internal and external IP mapping of zeppelin server</td>
+  </tr>
 </table>
 
 ## Example
@@ -129,22 +134,6 @@ input any char
 ```
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/shell-terminal.gif" />
-
-## Configuration
-At the "Interpreters" menu in Zeppelin dropdown menu, you can set the property value for Terminal interpreter.
-
-<table class="table-configuration">
-  <tr>
-    <th>Name</th>
-    <th>Default</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>zeppelin.terminal.ip.mapping</td>
-    <td></td>
-    <td>Internal and external IP mapping of zeppelin server</td>
-  </tr>
-</table>
 
 ### zeppelin.terminal.ip.mapping
 

--- a/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
@@ -19,6 +19,8 @@ package org.apache.zeppelin.shell;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.hubspot.jinjava.Jinjava;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.lang3.StringUtils;
@@ -43,6 +45,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -60,6 +63,9 @@ public class TerminalInterpreter extends KerberosInterpreter {
   private InterpreterContext intpContext;
 
   private int terminalPort = 0;
+
+  // Internal and external IP mapping of zeppelin server
+  private HashMap<String, String> mapIpMapping = new HashMap<>();
 
   // terminal web socket status
   // ui_templates/terminal-dashboard.jinja
@@ -123,6 +129,13 @@ public class TerminalInterpreter extends KerberosInterpreter {
       }
     }
     setParagraphConfig();
+    Properties properties = getProperties();
+    String strIpMapping = properties.getProperty("zeppelin.terminal.ip.mapping");
+    if (!StringUtils.isEmpty(strIpMapping)) {
+      Gson gson = new Gson();
+      mapIpMapping = gson.fromJson(strIpMapping, new TypeToken<Map<String, String>>(){}.getType());
+    }
+
     createTerminalDashboard(context.getNoteId(), context.getParagraphId(), terminalPort);
 
     return new InterpreterResult(Code.SUCCESS);
@@ -137,6 +150,13 @@ public class TerminalInterpreter extends KerberosInterpreter {
       InetAddress addr = InetAddress.getLocalHost();
       hostName = addr.getHostName().toString();
       hostIp = RemoteInterpreterUtils.findAvailableHostAddress();
+
+      // Internal and external IP mapping of zeppelin server
+      if (mapIpMapping.containsKey(hostIp)) {
+        LOGGER.info("Internal IP: {}", hostIp);
+        hostIp = mapIpMapping.get(hostIp);
+        LOGGER.info("External IP: {}", hostIp);
+      }
     } catch (IOException e) {
       LOGGER.error(e.getMessage(), e);
     }

--- a/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
@@ -66,6 +66,7 @@ public class TerminalInterpreter extends KerberosInterpreter {
 
   // Internal and external IP mapping of zeppelin server
   private HashMap<String, String> mapIpMapping = new HashMap<>();
+  private Gson gson = new Gson();
 
   // terminal web socket status
   // ui_templates/terminal-dashboard.jinja
@@ -132,7 +133,6 @@ public class TerminalInterpreter extends KerberosInterpreter {
     Properties properties = getProperties();
     String strIpMapping = properties.getProperty("zeppelin.terminal.ip.mapping");
     if (!StringUtils.isEmpty(strIpMapping)) {
-      Gson gson = new Gson();
       mapIpMapping = gson.fromJson(strIpMapping, new TypeToken<Map<String, String>>(){}.getType());
     }
 

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -59,6 +59,13 @@
     "name": "terminal",
     "className": "org.apache.zeppelin.shell.TerminalInterpreter",
     "properties": {
+      "zeppelin.terminal.ip.mapping": {
+        "envName": null,
+        "propertyName": "zeppelin.terminal.ip.mapping",
+        "defaultValue": "",
+        "description": "Internal and external IP mapping of zeppelin server",
+        "type": "string"
+      }
     },
     "editor": {
       "language": "sh",


### PR DESCRIPTION
### What is this PR for?
When running the terminal interpreter in the notebook, the front end of the notebook needs to obtain the IP address of the server where the terminal interpreter is located to communicate.

In a public cloud environment, the cloud host has an internal IP and an external access IP, and the interpreter runs in the cloud host. This will cause the notebook front end to be unable to connect to the terminal interpreter properly, resulting in the terminal interpreter being unusable.

Solution: Set the mapping between internal IP and external IP in the terminal interpreter, and connect the front end of the notebook through the external IP of the terminal interpreter.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
* https://jira.apache.org/jira/browse/ZEPPELIN-4747

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
