### PR TITLE
[ZEPPELIN-4722] User Impersonation via --proxy-user for Spark Interpreter with K8s

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -697,6 +697,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_LIFECYCLE_MANAGER_CLASS);
   }
 
+  public boolean getZeppelinImpersonateSparkProxyUser() {
+      return getBoolean(ConfVars.ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER);
+  }
+
   public String getZeppelinNotebookGitURL() {
     return  getString(ConfVars.ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL);
   }
@@ -998,6 +1002,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
 
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
 
+    ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER("zeppelin.impersonate.spark.proxy.user", true),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_ACCESS_TOKEN("zeppelin.notebook.git.remote.access-token", ""),

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
-  private static final Logger LOGGER = LoggerFactory.getLogger(K8sStandardInterpreterLauncher.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(K8sRemoteInterpreterProcess.class);
   private static final int K8S_INTERPRETER_SERVICE_PORT = 12321;
   private final Kubectl kubectl;
   private final String interpreterGroupId;
@@ -114,9 +114,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     }
 
     if (!started.get()) {
-      LOGGER.info(
-          String.format("Interpreter pod creation is time out in %d seconds",
-              getConnectTimeout()/1000));
+      LOGGER.info("Interpreter pod creation is time out in {} seconds", getConnectTimeout()/1000);
     }
 
     // waits for interpreter thrift rpc server ready
@@ -208,7 +206,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
    */
   void apply(File path, boolean delete) throws IOException {
     if (path.getName().startsWith(".") || path.isHidden() || path.getName().endsWith("~")) {
-      LOGGER.info("Skip " + path.getAbsolutePath());
+      LOGGER.info("Skip {}", path.getAbsolutePath());
     }
 
     if (path.isDirectory()) {
@@ -222,7 +220,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
         apply(f, delete);
       }
     } else if (path.isFile()) {
-      LOGGER.info("Apply " + path.getAbsolutePath());
+      LOGGER.info("Apply {}", path.getAbsolutePath());
       K8sSpecTemplate specTemplate = new K8sSpecTemplate();
       specTemplate.loadProperties(getTemplateBindings());
 
@@ -233,12 +231,12 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
         kubectl.apply(spec);
       }
     } else {
-      LOGGER.error("Can't apply " + path.getAbsolutePath());
+      LOGGER.error("Can't apply {}", path.getAbsolutePath());
     }
   }
 
   @VisibleForTesting
-  Properties getTemplateBindings() throws IOException {
+  Properties getTemplateBindings() {
     Properties k8sProperties = new Properties();
 
     // k8s template properties
@@ -292,11 +290,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
 
   boolean isSparkOnKubernetes(Properties interpreteProperties) {
     String propertySparkMaster = (String) interpreteProperties.getOrDefault("master", "");
-    if (propertySparkMaster.startsWith("k8s://")) {
-      return true;
-    } else {
-      return false;
-    }
+    return propertySparkMaster.startsWith("k8s://");
   }
 
   @VisibleForTesting
@@ -366,9 +360,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
       char c = chars[random.nextInt(chars.length)];
       sb.append(c);
     }
-    String randomStr = sb.toString();
-
-    return randomStr;
+    return sb.toString();
   }
 
   @Override

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -70,11 +70,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
    * @return
    */
   boolean isRunningOnKubernetes() {
-    if (new File("/var/run/secrets/kubernetes.io").exists()) {
-      return true;
-    } else {
-      return false;
-    }
+    return new File("/var/run/secrets/kubernetes.io").exists();
   }
 
   /**
@@ -132,7 +128,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
 
   @Override
   public InterpreterClient launch(InterpreterLaunchContext context) throws IOException {
-    LOGGER.info("Launching Interpreter: " + context.getInterpreterSettingGroup());
+    LOGGER.info("Launching Interpreter: {}", context.getInterpreterSettingGroup());
     this.context = context;
     this.properties = context.getProperties();
     int connectTimeout = getConnectTimeout();

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/Kubectl.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/Kubectl.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.interpreter.launcher;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -31,9 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Kubectl {
-  private final Logger LOGGER = LoggerFactory.getLogger(Kubectl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Kubectl.class);
   private final String kubectlCmd;
-  private final Gson gson = new Gson();
   private String namespace;
 
   public Kubectl(String kubectlCmd) {
@@ -118,7 +116,7 @@ public class Kubectl {
       argsToOverride.add("--namespace=" + namespace);
     }
 
-    LOGGER.info("kubectl " + argsToOverride);
+    LOGGER.info("kubectl {}", argsToOverride);
     LOGGER.debug(stdin);
 
     try {
@@ -130,8 +128,7 @@ public class Kubectl {
       );
 
       if (exitCode == 0) {
-        String output = new String(stdout.toByteArray());
-        return output;
+        return new String(stdout.toByteArray());
       } else {
         String output = new String(stderr.toByteArray());
         throw new IOException(String.format("non zero return code (%d). %s", exitCode, output));
@@ -147,7 +144,7 @@ public class Kubectl {
     CommandLine cmd = new CommandLine(kubectlCmd);
     cmd.addArguments(args);
 
-    ExecuteWatchdog watchdog = new ExecuteWatchdog(60 * 1000);
+    ExecuteWatchdog watchdog = new ExecuteWatchdog(60 * 1000L);
     executor.setWatchdog(watchdog);
 
     PumpStreamHandler streamHandler = new PumpStreamHandler(stdout, stderr, stdin);

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,11 +54,8 @@ public class K8sRemoteInterpreterProcessTest {
         "12320",
         false,
         "spark-container:1.0",
-        10);
-
-    // when
-    String host = intp.getHost();
-    int port = intp.getPort();
+        10,
+        false);
 
     // then
     assertEquals(String.format("%s.%s.svc", intp.getPodName(), kubectl.getNamespace()), intp.getHost());
@@ -86,7 +84,8 @@ public class K8sRemoteInterpreterProcessTest {
         "12320",
         false,
         "spark-container:1.0",
-        10);
+        10,
+        false);
 
 
     // following values are hardcoded in k8s/interpreter/100-interpreter.yaml.
@@ -120,7 +119,8 @@ public class K8sRemoteInterpreterProcessTest {
         "12320",
         false,
         "spark-container:1.0",
-        10);
+        10,
+        false);
 
     // when
     Properties p = intp.getTemplateBindings();
@@ -172,9 +172,11 @@ public class K8sRemoteInterpreterProcessTest {
         "12320",
         false,
         "spark-container:1.0",
-        10);
+        10,
+        false);
 
     // when
+    intp.start("mytestUser");
     Properties p = intp.getTemplateBindings();
 
     // then
@@ -192,5 +194,104 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getHost()));
     assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
     assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockmanagerPort()));
+    assertFalse(sparkSubmitOptions.contains("--proxy-user"));
+    assertTrue(intp.isSpark());
+  }
+
+  @Test
+  public void testGetTemplateBindingsForSparkWithProxyUser() throws IOException {
+    // given
+    Kubectl kubectl = mock(Kubectl.class);
+    when(kubectl.getNamespace()).thenReturn("default");
+
+    Properties properties = new Properties();
+    properties.put("my.key1", "v1");
+    properties.put("master", "k8s://http://api");
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("MY_ENV1", "V1");
+    envs.put("SPARK_SUBMIT_OPTIONS", "my options");
+    envs.put("SERVICE_DOMAIN", "mydomain");
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+        kubectl,
+        new File(".skip"),
+        "interpreter-container:1.0",
+        "shared_process",
+        "spark",
+        "myspark",
+        properties,
+        envs,
+        "zeppelin.server.hostname",
+        "12320",
+        false,
+        "spark-container:1.0",
+        10,
+        true);
+
+    // when
+    intp.start("mytestUser");
+    Properties p = intp.getTemplateBindings();
+    // then
+    assertEquals("spark-container:1.0", p.get("zeppelin.k8s.spark.container.image"));
+    assertEquals(String.format("//4040-%s.%s", intp.getPodName(), "mydomain"), p.get("zeppelin.spark.uiWebUrl"));
+
+    envs = (HashMap<String, String>) p.get("zeppelin.k8s.envs");
+    assertTrue( envs.containsKey("SPARK_HOME"));
+
+    String sparkSubmitOptions = envs.get("SPARK_SUBMIT_OPTIONS");
+    assertTrue(sparkSubmitOptions.startsWith("my options "));
+    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.namespace=" + kubectl.getNamespace()));
+    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
+    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.container.image=spark-container:1.0"));
+    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getHost()));
+    assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
+    assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockmanagerPort()));
+    assertTrue(sparkSubmitOptions.contains("--proxy-user mytestUser"));
+    assertTrue(intp.isSpark());
+  }
+
+  @Test
+  public void testGetTemplateBindingsForSparkWithProxyUserAnonymous() throws IOException {
+    // given
+    Kubectl kubectl = mock(Kubectl.class);
+    when(kubectl.getNamespace()).thenReturn("default");
+
+    Properties properties = new Properties();
+    properties.put("my.key1", "v1");
+    properties.put("master", "k8s://http://api");
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("MY_ENV1", "V1");
+    envs.put("SPARK_SUBMIT_OPTIONS", "my options");
+    envs.put("SERVICE_DOMAIN", "mydomain");
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+        kubectl,
+        new File(".skip"),
+        "interpreter-container:1.0",
+        "shared_process",
+        "spark",
+        "myspark",
+        properties,
+        envs,
+        "zeppelin.server.hostname",
+        "12320",
+        false,
+        "spark-container:1.0",
+        10,
+        true);
+
+    // when
+    intp.start("anonymous");
+    Properties p = intp.getTemplateBindings();
+    // then
+    assertEquals("spark-container:1.0", p.get("zeppelin.k8s.spark.container.image"));
+    assertEquals(String.format("//4040-%s.%s", intp.getPodName(), "mydomain"), p.get("zeppelin.spark.uiWebUrl"));
+
+    envs = (HashMap<String, String>) p.get("zeppelin.k8s.envs");
+    assertTrue( envs.containsKey("SPARK_HOME"));
+
+    String sparkSubmitOptions = envs.get("SPARK_SUBMIT_OPTIONS");
+    assertFalse(sparkSubmitOptions.contains("--proxy-user"));
+    assertTrue(intp.isSpark());
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -156,9 +156,8 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     for (String name : sparkProperties.stringPropertyNames()) {
       sparkConfBuilder.append(" --conf " + name + "=" + sparkProperties.getProperty(name));
     }
-    String useProxyUserEnv = System.getenv("ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER");
-    if (context.getOption().isUserImpersonate() && (StringUtils.isBlank(useProxyUserEnv) ||
-            !useProxyUserEnv.equals("false"))) {
+
+    if (context.getOption().isUserImpersonate() && zConf.getZeppelinImpersonateSparkProxyUser()) {
       sparkConfBuilder.append(" --proxy-user " + context.getUserName());
     }
 


### PR DESCRIPTION
### What is this PR for?
This PullRequest fixes the impersonation issue when running Spark Zeppelin interpreter on K8s. A general user impersonation should not be necessary and possible on K8s, since the interpreter process runs unprivileged - without the right to change the user via ssh.


### What type of PR is it?
* Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4722

### How should this be tested?
* **Travic-CI**: https://travis-ci.org/github/Reamer/zeppelin/builds/674723139

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
