### PR TITLE
[ZEPPELIN-4757] Fix startup script errors/warnings

### DIFF
--- a/bin/common.cmd
+++ b/bin/common.cmd
@@ -58,11 +58,11 @@ if not defined ZEPPELIN_ENCODING (
 )
 
 if not defined ZEPPELIN_MEM (
-    set ZEPPELIN_MEM=-Xms1024m -Xmx1024m -XX:MaxPermSize=512m
+    set ZEPPELIN_MEM=-Xms1024m -Xmx1024m
 )
 
 if not defined ZEPPELIN_INTP_MEM (
-    set ZEPPELIN_INTP_MEM=-Xms1024m -Xmx1024m -XX:MaxPermSize=512m
+    set ZEPPELIN_INTP_MEM=-Xms1024m -Xmx1024m
 )
 
 if not defined ZEPPELIN_JAVA_OPTS (

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -118,11 +118,11 @@ if [[ -z "${ZEPPELIN_ENCODING}" ]]; then
 fi
 
 if [[ -z "${ZEPPELIN_MEM}" ]]; then
-  export ZEPPELIN_MEM="-Xms1024m -Xmx1024m -XX:MaxPermSize=512m"
+  export ZEPPELIN_MEM="-Xms1024m -Xmx1024m"
 fi
 
 if [[ -z "${ZEPPELIN_INTP_MEM}" ]]; then
-  export ZEPPELIN_INTP_MEM="-Xms1024m -Xmx2048m -XX:MaxPermSize=512m"
+  export ZEPPELIN_INTP_MEM="-Xms1024m -Xmx2048m"
 fi
 
 JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"


### PR DESCRIPTION
### What is this PR for?

Errors & warnings are produced from the checks that are assuming that Zeppelin is running
on Linux (`getent` is present) & in the container environment (`/etc/passwd` is
writable).

This patch fixes following:
 - added check for presence of the `getent`
 - added explicit check that script is running in the container by checking
   `/proc/self/cgroup`
 - also removed `MaxPermSize` JVM flag that isn't supported in Java 8

### What type of PR is it?

Bug Fix

### What is the Jira issue?

* ZEPPELIN-4757

### How should this be tested?

* https://travis-ci.org/github/alexott/zeppelin/builds/675356068
