### PR TITLE
[ZEPPELIN-4760] Add description and homepage information on github repository

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,10 @@ github:
   description: "Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more."
   homepage: https://zeppelin.apache.org/
   labels:
+    - spark
+    - flink
+    - database
+    - nosql
     - scala
     - java
     - big-data

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+
+github:
+  description: "Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more."
+  homepage: https://zeppelin.apache.org/
+  labels:
+    - scala
+    - java
+    - big-data
+    - zeppelin
+    - javascript


### PR DESCRIPTION
### What is this PR for?

I'd like to discuss and get ideas on how we can improve Zeppelin GitHub repository description, which looks like
![image](https://user-images.githubusercontent.com/1540981/79534288-fe35a180-802e-11ea-8bec-df46a4c20a0b.png)

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4760

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
