### PR TITLE
Zeppelin 4582

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ tramp
 
 # Git properties
 **/git.properties
+
+# To keep track of the scala version used in the build
+/dev/current_scala_version

--- a/pom.xml
+++ b/pom.xml
@@ -93,10 +93,12 @@
     <module>ksql</module>
     <module>sparql</module>
     <module>zeppelin-web</module>
+    <module>zeppelin-web-angular</module>
     <module>zeppelin-server</module>
     <module>zeppelin-jupyter</module>
     <module>zeppelin-plugins</module>
     <module>zeppelin-distribution</module>
+    <module>zeppelin-web-angular</module>
   </modules>
 
   <properties>
@@ -106,6 +108,7 @@
     <scala.version>${scala.2.10.version}</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
     <scala.2.11.version>2.11.8</scala.2.11.version>
+    <scala.2.12.version>2.12.10</scala.2.12.version>
     <scalatest.version>3.0.7</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 
@@ -947,6 +950,13 @@
       <properties>
         <scala.version>${scala.2.11.version}</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala-2.12</id>
+      <properties>
+          <scala.version>${scala.2.12.version}</scala.version>
+          <scala.binary.version>2.12</scala.binary.version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
     <module>ksql</module>
     <module>sparql</module>
     <module>zeppelin-web</module>
-    <module>zeppelin-web-angular</module>
     <module>zeppelin-server</module>
     <module>zeppelin-jupyter</module>
     <module>zeppelin-plugins</module>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
     <module>zeppelin-jupyter</module>
     <module>zeppelin-plugins</module>
     <module>zeppelin-distribution</module>
-    <module>zeppelin-web-angular</module>
   </modules>
 
   <properties>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -45,21 +45,21 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>${scala.version}</version>
+        <version>${scala.2.10.version}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-compiler</artifactId>
-        <version>${scala.version}</version>
+        <version>${scala.2.10.version}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scalap</artifactId>
-        <version>${scala.version}</version>
+        <version>${scala.2.10.version}</version>
         <scope>provided</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
### What is this PR for?
Add scala 2.12 support for interpreters

### What type of PR is it?
Improvement

### Todos
* [ ] - `scalate-maven-plugin` used in `cassandra` does not exist for scala 2.12 and has not been in development since 2015. However, there's a [version](https://github.com/stephennancekivell/scalate-maven-plugin) compiled for scala 2.12 [here](https://search.maven.org/artifact/com.stephenn/scalate-maven-plugin_2.12/0.0.2/maven-plugin). But no single version compiled for the three scala version (which would be needed for Zeppelin's pom.xml). I've hacked my way [like this](
https://github.com/redsk/zeppelin/commit/cb0fa2c5af547974dd995d0db93d90f54a9437f2) just to compile Zeppelin but we probably need a better solution.
* [] - Beam. `beam-runners-flink_2.12` does not exist. There seem to be a [workaround](https://issues.apache.org/jira/browse/BEAM-7544?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel) but I've not tried it. I've just disabled Beam from the modules for testing Zeppelin.

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4582

### How should this be tested?
Not done yet.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Unsure
* Does this needs documentation? Probably
