### PR TITLE
[ZEPPELIN-4766] Fix SSL regression

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -312,7 +312,7 @@ public class ZeppelinServer extends ResourceConfig {
     HttpConfiguration httpConfig = new HttpConfiguration();
     httpConfig.addCustomizer(new ForwardedRequestCustomizer());
     if (conf.useSsl()) {
-      LOG.debug("Enabling SSL for Zeppelin Server on port " + sslPort);
+      LOG.debug("Enabling SSL for Zeppelin Server on port {}", sslPort);
       httpConfig.setSecureScheme("https");
       httpConfig.setSecurePort(sslPort);
       httpConfig.setOutputBufferSize(32768);
@@ -328,6 +328,7 @@ public class ZeppelinServer extends ResourceConfig {
                       server,
                       new SslConnectionFactory(getSslContextFactory(conf), HttpVersion.HTTP_1_1.asString()),
                       new HttpConnectionFactory(httpsConfig));
+      connector.setPort(sslPort);
     } else {
       connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
       connector.setPort(port);


### PR DESCRIPTION
### What is this PR for?
This PR fixes a small part of #3571, which introduced a SSL-connector regression.

The port definition of the SSL connector has been deleted.
https://github.com/apache/zeppelin/pull/3571/files#diff-3477d79f3012453f20c3727ec60338e9L337-L341


### What type of PR is it?
 - Hot Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4766

### How should this be tested?
* **Travis-CI:** https://travis-ci.org/github/Reamer/zeppelin/builds/677349664

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
