### PR TITLE
[ZEPPELIN-4759] Paragraph refreshing make the other paragraph shaking

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -199,10 +199,10 @@ public class JobManager {
           if (isStreamingInsertInto) {
             StringBuilder builder = new StringBuilder("%html ");
             builder.append("<h1>Duration: " +
-                    Integer.parseInt(rootNode.getObject().getString("duration")) / 1000 +
+                    rootNode.getObject().getLong("duration") / 1000 +
                     " seconds");
             builder.append("\n%text ");
-            context.out.clear();
+            context.out.clear(false);
             sendFlinkJobUrl(context);
             context.out.write(builder.toString());
             context.out.flush();

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -122,7 +122,7 @@ public class AppendStreamSqlJob extends AbstractStreamSqlJob {
 
   @Override
   protected void refresh(InterpreterContext context) {
-    context.out().clear();
+    context.out().clear(false);
     try {
       jobManager.sendFlinkJobUrl(context);
       String result = buildResult();

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
@@ -80,7 +80,7 @@ public class SingleRowStreamSqlJob extends AbstractStreamSqlJob {
       LOGGER.warn("Skip RefreshTask as no data available");
       return;
     }
-    context.out().clear();
+    context.out().clear(false);
     String output = buildResult();
     context.out.write(output);
     jobManager.sendFlinkJobUrl(context);

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
@@ -104,7 +104,7 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
 
   @Override
   protected void refresh(InterpreterContext context) {
-    context.out().clear();
+    context.out().clear(false);
     try {
       jobManager.sendFlinkJobUrl(context);
       String result = buildResult();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
@@ -139,6 +139,14 @@ public class InterpreterOutput extends OutputStream {
   }
 
   public void clear() {
+    clear(true);
+  }
+
+  /**
+   *
+   * @param sendUpdateToFrontend  Whether send empty result to frontend to clear the paragraph output
+   */
+  public void clear(boolean sendUpdateToFrontend) {
     size = 0;
     lastCRIndex = -1;
     truncated = false;
@@ -146,7 +154,7 @@ public class InterpreterOutput extends OutputStream {
 
     synchronized (resultMessageOutputs) {
       for (InterpreterResultMessageOutput out : resultMessageOutputs) {
-        out.clear();
+        out.clear(sendUpdateToFrontend);
         try {
           out.close();
         } catch (IOException e) {
@@ -159,7 +167,9 @@ public class InterpreterOutput extends OutputStream {
       currentOut = null;
       startOfTheNewLine = true;
       firstCharIsPercentSign = false;
-      updateAllResultMessages();
+      if (sendUpdateToFrontend) {
+        updateAllResultMessages();
+      }
     }
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
@@ -74,6 +74,14 @@ public class InterpreterResultMessageOutput extends OutputStream {
   }
 
   public void clear() {
+     clear(true);
+  }
+
+  /**
+   *
+   * @param sendUpdateToFrontend Whether send empty result to frontend to clear the paragraph output
+   */
+  public void clear(boolean sendUpdateToFrontend) {
     synchronized (outList) {
       buffer.reset();
       outList.clear();
@@ -81,7 +89,7 @@ public class InterpreterResultMessageOutput extends OutputStream {
         watcher.clear();
       }
 
-      if (flushListener != null) {
+      if (flushListener != null && sendUpdateToFrontend) {
         flushListener.onUpdate(this);
       }
     }


### PR DESCRIPTION
### What is this PR for?
This PR just resolve the paragraph shaking issue. Before this PR, I will refresh paragraph output by 2 steps: step 1. clear previous output, step 2. update paragraph with new output.

After this PR, I will just make it as just one step: update paragraph with new output. The main change is o method  InterpreterOutput#clear. I add one flag to indicate whether it should send the update to frontend to refresh the output.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4759

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

* Before
![before](https://user-images.githubusercontent.com/164491/79842462-70213880-83eb-11ea-9033-053c59f6019a.gif)

* After
![after](https://user-images.githubusercontent.com/164491/79842477-731c2900-83eb-11ea-962a-7f72aeef3b17.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
