### PR TITLE
[ZEPPELIN-4695] Bump dependencies to fix CVEs

### DIFF
--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -44,7 +44,6 @@
     <!-- library versions -->
     <netty.version>4.1.42.Final</netty.version>
     <servlet.api.version>3.1.0</servlet.api.version>
-    <commons.exec.version>1.3</commons.exec.version>
     <avro.version>1.8.1</avro.version> <!-- should match beam dependency -->
   </properties>
   

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -42,7 +42,7 @@
     <!-- library versions -->
     <bigquery.api.version>v2-rev20190917-1.30.3</bigquery.api.version>
     <gson.version>2.8.6</gson.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>24.1.1-jre</guava.version>
 
     <interpreter.name>bigquery</interpreter.name>
   </properties>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -173,6 +173,10 @@
                     <groupId>net.java.dev.jna</groupId>
                     <artifactId>jna</artifactId>
                 </exclusion>
+                <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -37,7 +37,6 @@
     <!--library versions-->
     <interpreter.name>geode</interpreter.name>
     <geode.version>1.1.0</geode.version>
-    <commons.exec.version>1.3</commons.exec.version>
   </properties>
 
   <dependencies>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -36,10 +36,9 @@
     <!--library versions-->
     <interpreter.name>hbase</interpreter.name>
     <hbase.hbase.version>1.0.0</hbase.hbase.version>
-    <hbase.hadoop.version>2.6.0</hbase.hadoop.version>
+    <hbase.hadoop.version>${hadoop2.6.version}</hbase.hadoop.version>
     <jruby.version>1.6.8</jruby.version>
     <protobuf.version>2.5.0</protobuf.version>
-    <commons.exec.version>1.1</commons.exec.version>
     <jline.version>2.12.1</jline.version>
 
     <!--test library versions-->

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -108,7 +108,7 @@
     <profile>
       <id>jdbc-hadoop2</id>
       <properties>
-        <hadoop-common.version>2.7.3</hadoop-common.version>
+        <hadoop-common.version>${hadoop2.7.version}</hadoop-common.version>
       </properties>
       <dependencies>
         <dependency>
@@ -169,7 +169,7 @@
     <profile>
       <id>jdbc-hadoop3</id>
       <properties>
-        <hadoop-common.version>3.0.0</hadoop-common.version>
+        <hadoop-common.version>${hadoop3.0.version}</hadoop-common.version>
       </properties>
       <dependencies>
         <dependency>
@@ -232,7 +232,7 @@
     <!--library versions-->
     <interpreter.name>jdbc</interpreter.name>
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
-    <hadoop.common.version>2.7.2</hadoop.common.version>
+    <hadoop.common.version>${hadoop2.7.version}</hadoop.common.version>
     <h2.version>1.4.190</h2.version>
     <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
 

--- a/ksql/pom.xml
+++ b/ksql/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.10.3</version>
     </dependency>
 
     <dependency>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -38,10 +38,10 @@
     <interpreter.name>lens</interpreter.name>
     <lens.version>2.5.0-beta</lens.version>
     <spring-shell.version>1.1.0.RELEASE</spring-shell.version>
-    <hadoop-common.version>2.4.0</hadoop-common.version>
+    <hadoop-common.version>${hadoop2.6.version}</hadoop-common.version>
     <checkerframework.jdk7.version>1.9.1</checkerframework.jdk7.version>
     <jackson.asl.version>1.9.13</jackson.asl.version>
-    <jackson.version>1.9.11</jackson.version>
+    <jackson.version>1.9.13</jackson.version>
     <jersey.core.version>2.3.1</jersey.core.version>
   </properties>
 

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -43,7 +43,7 @@
         <!--test library versions-->
         <livy.version>0.5.0-incubating</livy.version>
         <spark.version>2.1.0</spark.version>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>${hadoop2.6.version}</hadoop.version>
     </properties>
 
     <dependencies>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -37,7 +37,7 @@
   	<neo4j.driver.version>1.7.1</neo4j.driver.version>
   	<test.neo4j.kernel.version>3.4.10</test.neo4j.kernel.version>
   	<neo4j.version>3.4.10</neo4j.version>
-  	<jackson.version>2.8.9</jackson.version>
+  	<jackson.version>2.10.3</jackson.version>
     <interpreter.name>neo4j</interpreter.name>
   </properties>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <interpreter.name>pig</interpreter.name>
         <pig.version>0.17.0</pig.version>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>${hadoop2.6.version}</hadoop.version>
         <tez.version>0.7.0</tez.version>
         <pig.spark.version>1.6.3</pig.spark.version>
         <pig.scala.version>2.10</pig.scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <plugin.frontend.version>1.6</plugin.frontend.version>
 
     <!-- common library versions -->
-    <slf4j.version>1.7.10</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <libthrift.version>0.13.0</libthrift.version>
     <gson.version>2.2</gson.version>
@@ -124,17 +124,24 @@
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.1</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>
-    <commons.lang.version>2.5</commons.lang.version>
-    <commons.lang3.version>3.7</commons.lang3.version>
+    <commons.compress.version>1.20</commons.compress.version>
+    <commons.lang3.version>3.10</commons.lang3.version>
     <commons.configuration.version>1.9</commons.configuration.version>
     <commons.exec.version>1.3</commons.exec.version>
-    <commons.codec.version>1.5</commons.codec.version>
-    <commons.io.version>2.4</commons.io.version>
+    <commons.codec.version>1.14</commons.codec.version>
+    <commons.io.version>2.6</commons.io.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.logging.version>1.1.1</commons.logging.version>
-    <commons.cli.version>1.3.1</commons.cli.version>
+    <commons.cli.version>1.4</commons.cli.version>
     <shiro.version>1.4.2</shiro.version>
     <joda.version>2.9.9</joda.version>
+
+    <hadoop2.7.version>2.7.7</hadoop2.7.version>
+    <hadoop2.6.version>2.6.5</hadoop2.6.version>
+    <hadoop3.0.version>3.0.3</hadoop3.0.version>
+    <hadoop3.1.version>3.1.3</hadoop3.1.version>
+    <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
+    <jsoup.version>1.13.1</jsoup.version>
 
     <!-- test library versions -->
     <junit.version>4.12</junit.version>
@@ -238,12 +245,6 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpasyncclient</artifactId>
         <version>${httpcomponents.asyncclient.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${commons.lang.version}</version>
       </dependency>
 
       <dependency>

--- a/r/pom.xml
+++ b/r/pom.xml
@@ -39,7 +39,6 @@
     <path.separator>/</path.separator>
     <!--library versions-->
     <spark.version>1.4.1</spark.version>
-    <jsoup.version>[1.8.0,)</jsoup.version>
 
     <!--test library versions-->
     <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -36,8 +36,7 @@
 
     <properties>
         <interpreter.name>r</interpreter.name>
-        <jsoup.version>1.12.1</jsoup.version>
-        <spark.version>2.4.4</spark.version>
+        <spark.version>2.4.5</spark.version>
         <grpc.version>1.15.0</grpc.version>
 
         <spark.archive>spark-${spark.version}</spark.archive>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -36,9 +36,8 @@
   <properties>
     <interpreter.name>scalding</interpreter.name>
     <!--library versions-->
-    <hadoop.version>2.6.0</hadoop.version>
+    <hadoop.version>${hadoop2.6.version}</hadoop.version>
     <scalding.version>0.16.1-RC1</scalding.version>
-    <commons.exec.version>1.3</commons.exec.version>
 
     <!--plugin versions-->
     <plugin.scala.version>2.15.2</plugin.scala.version>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -37,10 +37,9 @@
     <interpreter.name>sh</interpreter.name>
 
     <!--library versions -->
-    <commons.exec.version>1.3</commons.exec.version>
     <pty4j.version>0.9.3</pty4j.version>
     <jinjava.version>2.4.0</jinjava.version>
-    <guava.version>20.0</guava.version>
+    <guava.version>24.1.1-jre</guava.version>
     <gson.version>2.2</gson.version>
   </properties>
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -37,9 +37,6 @@
   <properties>
     <interpreter.name>spark</interpreter.name>
     <!--library versions-->
-    <jsoup.version>1.12.1</jsoup.version>
-    <commons.exec.version>1.3</commons.exec.version>
-    <commons.compress.version>1.9</commons.compress.version>
     <maven.plugin.api.version>3.0</maven.plugin.api.version>
     <aether.version>1.12</aether.version>
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -41,10 +41,9 @@
         <datanucleus.core.version>3.2.10</datanucleus.core.version>
 
         <!-- spark versions -->
-        <spark.version>2.4.4</spark.version>
+        <spark.version>2.4.5</spark.version>
         <spark.scala.version>2.11.12</spark.scala.version>
         <spark.scala.binary.version>2.11</spark.scala.binary.version>
-        <py4j.version>0.10.7</py4j.version>
 
         <spark.archive>spark-${spark.version}</spark.archive>
         <spark.src.download.url>
@@ -208,7 +207,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <spark.version>2.4.4</spark.version>
+                <spark.version>2.4.5</spark.version>
                 <protobuf.version>2.5.0</protobuf.version>
                 <py4j.version>0.10.7</py4j.version>
             </properties>
@@ -234,8 +233,8 @@
         <profile>
             <id>spark-2.1</id>
             <properties>
-                <spark.version>2.1.2</spark.version>
-                <py4j.version>0.10.4</py4j.version>
+                <spark.version>2.1.3</spark.version>
+                <py4j.version>0.10.7</py4j.version>
             </properties>
         </profile>
 

--- a/spark/scala-2.11/pom.xml
+++ b/spark/scala-2.11/pom.xml
@@ -32,7 +32,7 @@
   <name>Zeppelin: Spark Interpreter Scala_2.11</name>
 
   <properties>
-    <spark.version>2.4.4</spark.version>
+    <spark.version>2.4.5</spark.version>
     <spark.scala.version>2.11.12</spark.scala.version>
     <spark.scala.binary.version>2.11</spark.scala.binary.version>
     <spark.scala.compile.version>${spark.scala.version}</spark.scala.compile.version>

--- a/spark/scala-2.12/pom.xml
+++ b/spark/scala-2.12/pom.xml
@@ -33,7 +33,7 @@
   <name>Zeppelin: Spark Interpreter Scala_2.12</name>
 
   <properties>
-    <spark.version>2.4.4</spark.version>
+    <spark.version>2.4.5</spark.version>
     <spark.scala.version>2.12.10</spark.scala.version>
     <spark.scala.binary.version>2.12</spark.scala.binary.version>
     <spark.scala.compile.version>${spark.scala.version}</spark.scala.compile.version>

--- a/spark/spark-dependencies/pom.xml
+++ b/spark/spark-dependencies/pom.xml
@@ -44,7 +44,7 @@
          instead of changing spark.version in this section.
     -->
 
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>${hadoop2.7.version}</hadoop.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <avro.version>1.7.7</avro.version>
     <avro.mapred.classifier/>

--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -34,7 +34,7 @@
     <name>Zeppelin: Spark Scala Parent</name>
 
     <properties>
-        <spark.version>2.4.4</spark.version>
+        <spark.version>2.4.5</spark.version>
         <spark.scala.binary.version>2.11</spark.scala.binary.version>
         <spark.scala.version>2.11.12</spark.scala.version>
         <saprk.scala.compile.version>${spark.scala.binary.version}</saprk.scala.compile.version>

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>2.6.0</version>
+      <version>${hadoop2.6.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -35,10 +35,10 @@
   <properties>
     <!--library versions-->
     <interpreter.name>submarine</interpreter.name>
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>${hadoop2.7.version}</hadoop.version>
     <jinjava.version>2.4.0</jinjava.version>
     <squirrel.version>0.3.8</squirrel.version>
-    <guava.version>20.0</guava.version>
+    <guava.version>24.1.1-jre</guava.version>
     <!--test library versions-->
     <hamcrest.all.version>1.3</hamcrest.all.version>
   </properties>

--- a/zeppelin-interpreter-integration/pom.xml
+++ b/zeppelin-interpreter-integration/pom.xml
@@ -40,10 +40,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <hadoop.version>2.7.3</hadoop.version>
-
-    <!--plugin library versions-->
-    <plugin.failsafe.version>2.16</plugin.failsafe.version>
+    <hadoop.version>${hadoop2.7.version}</hadoop.version>
   </properties>
 
   <dependencies>
@@ -518,7 +515,7 @@
     <profile>
       <id>hadoop3</id>
       <properties>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>${hadoop3.1.version}</hadoop.version>
       </properties>
       <dependencies>
         <dependency>

--- a/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+++ b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
@@ -53,7 +53,7 @@
         <profile>
             <id>hadoop2-azure</id>
             <properties>
-                <hadoop.version>2.7.3</hadoop.version>
+                <hadoop.version>${hadoop2.7.version}</hadoop.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -100,7 +100,7 @@
         <profile>
             <id>hadoop2-aws</id>
             <properties>
-                <hadoop.version>2.7.3</hadoop.version>
+                <hadoop.version>${hadoop2.7.version}</hadoop.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -132,7 +132,7 @@
         <profile>
             <id>hadoop3-azure</id>
             <properties>
-                <hadoop.version>3.0.0</hadoop.version>
+                <hadoop.version>${hadoop3.0.version}</hadoop.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -211,7 +211,7 @@
         <profile>
             <id>hadoop3-aws</id>
             <properties>
-                <hadoop.version>3.0.0</hadoop.version>
+                <hadoop.version>${hadoop3.0.version}</hadoop.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -38,10 +38,9 @@
     <!--library versions-->
     <commons.httpclient.version>4.3.6</commons.httpclient.version>
     <jersey.version>2.27</jersey.version>
-    <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
     <jersey.servlet.version>1.13</jersey.servlet.version>
     <javax.ws.rsapi.version>2.1</javax.ws.rsapi.version>
-    <libpam4j.version>1.8</libpam4j.version>
+    <libpam4j.version>1.11</libpam4j.version>
     <jna.version>4.1.0</jna.version>
     <commons.configuration2.version>2.2</commons.configuration2.version>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -37,9 +37,8 @@
 
   <properties>
     <!--library versions-->
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>${hadoop2.7.version}</hadoop.version>
     <jackrabbit.webdav.version>1.5.2</jackrabbit.webdav.version>
-    <quartz.scheduler.version>2.2.1</quartz.scheduler.version>
     <lucene.version>5.3.1</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -88,7 +88,7 @@ public class QuartzSchedulerService implements SchedulerService {
   private Scheduler getScheduler() throws SchedulerException {
     // Make sure to not check for Quartz update since this leaks information about running process
     // http://www.quartz-scheduler.org/documentation/2.4.0-SNAPSHOT/best-practices.html#skip-update-check
-    System.setProperty(StdSchedulerFactory.PROP_SCHED_SKIP_UPDATE_CHECK, "true");
+    System.setProperty("org.terracotta.quartz.skipUpdateCheck", "true");
     return new StdSchedulerFactory().getScheduler();
   }
 


### PR DESCRIPTION
### What is this PR for?

This patch bumps versions of some components that were reported as having (potential?) vulnerabilities.  It also unifies usage of different hadoop versions, etc., moving version configuration to a top-level pom.xml, instead of specification of them inside individual poms. This for example, also fixes #3702. 

### What type of PR is it?
Refactoring

### TODOs

We'll need to followup on the other items, like:
* Check dependencies in the Docker image

### What is the Jira issue?
* ZEPPELIN-4695

### How should this be tested?
* https://travis-ci.org/github/alexott/zeppelin/builds/678099649

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
