### PR TITLE
[ZEPPELIN-4776]. The same flink job url is duplicated in fronted for streaming job

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -124,7 +124,6 @@ public class AppendStreamSqlJob extends AbstractStreamSqlJob {
   protected void refresh(InterpreterContext context) {
     context.out().clear(false);
     try {
-      jobManager.sendFlinkJobUrl(context);
       String result = buildResult();
       context.out.write(result);
       context.out.flush();

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/SingleRowStreamSqlJob.java
@@ -83,7 +83,6 @@ public class SingleRowStreamSqlJob extends AbstractStreamSqlJob {
     context.out().clear(false);
     String output = buildResult();
     context.out.write(output);
-    jobManager.sendFlinkJobUrl(context);
     LOGGER.debug("Refresh Output: " + output);
     context.out.flush();
   }

--- a/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
@@ -106,7 +106,6 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
   protected void refresh(InterpreterContext context) {
     context.out().clear(false);
     try {
-      jobManager.sendFlinkJobUrl(context);
       String result = buildResult();
       context.out.write(result);
       context.out.flush();


### PR DESCRIPTION
### What is this PR for?

This PR is to remove duplicated flink job url. In ZEPPELIN-4759, I remove the refresh step in frontend, so it is not necessary to send job url again for each data refresh. So in this PR, I remove sendFlinkJobUrl in flink streaming job.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4776

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
