### PR TITLE
[ZEPPELIN-4771]. Bokeh output in IPythonInterpreter is not in correct format

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -57,7 +57,7 @@ public class IPythonInterpreter extends JupyterKernelInterpreter {
   private String py4jGatewaySecret;
 
   public IPythonInterpreter(Properties properties) {
-    super(properties);
+    super("python", properties);
   }
 
   @Override

--- a/rlang/src/main/java/org/apache/zeppelin/r/IRInterpreter.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/IRInterpreter.java
@@ -54,7 +54,7 @@ public class IRInterpreter extends JupyterKernelInterpreter {
   private SparkRBackend sparkRBackend;
 
   public IRInterpreter(Properties properties) {
-    super(properties);
+    super("ir", properties);
   }
 
   /**

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -125,7 +125,7 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
 
       jupyterKernelClient = new JupyterKernelClient(ManagedChannelBuilder.forAddress("127.0.0.1",
               kernelPort).usePlaintext(true).maxInboundMessageSize(message_size),
-              getProperties());
+              getProperties(), kernel);
       launchJupyterKernel(kernelPort);
     } catch (Exception e) {
       throw new InterpreterException("Fail to open JupyterKernelInterpreter:\n" +


### PR DESCRIPTION
### What is this PR for?

Without this PR, the bokeh output will is not in correct format (see below screenshot). This root cause is the output type is not correct. We should only use html when it is ir kernel for jupyter interpreter. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4771

### How should this be tested?
* CI pass


### Screenshots (if appropriate)
Before
![image](https://user-images.githubusercontent.com/164491/80295130-b76c4800-87a2-11ea-8cb2-f7d213d6b714.png)

After
![image](https://user-images.githubusercontent.com/164491/80295171-2cd81880-87a3-11ea-9a80-bffffc4accc0.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
