### PR TITLE
[ZEPPELIN-4783] Avoid warning on PUBKEY when apt update cran.rstudio

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -81,8 +81,7 @@ RUN echo "$LOG_TAG Install R related packages" && \
     echo "PATH: $PATH" && \
     ls /opt/conda/bin && \
     echo "deb http://cran.rstudio.com/bin/linux/ubuntu xenial/" | tee -a /etc/apt/sources.list && \
-    gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9 && \
-    gpg -a --export E084DAB9 | apt-key add - && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9 && \
     apt-get -y update && \
     apt-get -y --allow-unauthenticated install r-base r-base-dev && \
     R -e "install.packages('evaluate', repos = 'https://cloud.r-project.org')" && \


### PR DESCRIPTION
### What is this PR for?
Solves https://issues.apache.org/jira/browse/ZEPPELIN-4783  

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4783

### How should this be tested?
Run the docker build and see no warning with the new Key.
Checks that from an inherited docker image we can now apt-get update without warnings and apt-get install succeed also, so the build of he inherited file is OK.

### Questions:
* Does the licenses files need update?  No
* Is there breaking changes for older versions? No
* Does this needs documentation?  No
