### PR TITLE
[ZEPPELIN-4791] Fix Java version check on MacOS

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -65,9 +65,9 @@ ZEPPELIN_CLASSPATH+=":${ZEPPELIN_CONF_DIR}"
 function check_java_version() {
     java_ver_output=$("${JAVA:-java}" -version 2>&1)
     jvmver=$(echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}' | cut -d\- -f1)
-    JVM_VERSION=$(echo "$jvmver"|sed -e 's|^\([0-9]\+\)\..*$|\1|')
+    JVM_VERSION=$(echo "$jvmver"|sed -e 's|^\([0-9][0-9]*\)\..*$|\1|')
     if [ "$JVM_VERSION" = "1" ]; then
-        JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9]\+\)\..*$|\1|')
+        JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9][0-9]*\)\..*$|\1|')
     fi
 
     if [ "$JVM_VERSION" -lt 8 ] || ([ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]) ; then


### PR DESCRIPTION
### What is this PR for?

on MacOS, `[0-9]\+` doesn't work, so it was replaced with `[0-9][0-9]*`


### What type of PR is it?
Bug Fix


### What is the Jira issue?
* ZEPPELIN-4791

### How should this be tested?
* Tested manually on Mac & Linux
* https://travis-ci.org/github/alexott/zeppelin/builds/682342684

