### PR TITLE
[ZEPPELIN-4799] Use spark resource configuration

### DIFF
--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -54,6 +54,14 @@ spec:
     - name: {{key}}
       value: {{value}}
   {% endfor %}
+  {% if zeppelin.k8s.interpreter.cores is defined and zeppelin.k8s.interpreter.memory is defined %}
+    resources:
+      requests:
+        memory: "{{zeppelin.k8s.interpreter.memory}}"
+        cpu: "{{zeppelin.k8s.interpreter.cores}}"
+      limits:
+        cpu: "{{zeppelin.k8s.interpreter.cores}}"
+  {% endif %}
   {% if zeppelin.k8s.interpreter.group.name == "spark" %}
     volumeMounts:
     - name: spark-home

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -59,6 +59,7 @@ spec:
       requests:
         memory: "{{zeppelin.k8s.interpreter.memory}}"
         cpu: "{{zeppelin.k8s.interpreter.cores}}"
+{# limits.memory is not set because of a potential OOM-Killer. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits #}
       limits:
         cpu: "{{zeppelin.k8s.interpreter.cores}}"
   {% endif %}

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -44,6 +44,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   private String userName;
 
   private AtomicBoolean started = new AtomicBoolean(false);
+  private Random rand = new Random();
 
   public K8sRemoteInterpreterProcess(
           Kubectl kubectl,
@@ -273,7 +274,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     }
 
     // environment variables
-    envs.put("SERVICE_DOMAIN", envs.getOrDefault("SERVICE_DOMAIN", System.getenv("SERVICE_DOMAIN")));
+    envs.put(ENV_SERVICE_DOMAIN, envs.getOrDefault(ENV_SERVICE_DOMAIN, System.getenv(ENV_SERVICE_DOMAIN)));
     envs.put("ZEPPELIN_HOME", envs.getOrDefault("ZEPPELIN_HOME", "/zeppelin"));
 
     if (isSpark()) {
@@ -294,7 +295,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
               webUrl,
               webUiPort,
               getPodName(),
-              envs.get("SERVICE_DOMAIN")
+              envs.get(ENV_SERVICE_DOMAIN)
           ));
     }
 
@@ -310,7 +311,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     ImmutableMap<String, Object> binding = ImmutableMap.of(
         "PORT", port,
         "SERVICE_NAME", serviceName,
-        "SERVICE_DOMAIN", serviceDomain
+        ENV_SERVICE_DOMAIN, serviceDomain
     );
 
     ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
@@ -398,9 +399,8 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
 
     StringBuilder sb = new StringBuilder();
-    Random random = new Random();
     for (int i = 0; i < length; i++) {
-      char c = chars[random.nextInt(chars.length)];
+      char c = chars[rand.nextInt(chars.length)];
       sb.append(c);
     }
     return sb.toString();

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
@@ -1,0 +1,59 @@
+package org.apache.zeppelin.interpreter.launcher;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class K8sUtils {
+
+  private static final long K = 1024;
+  private static final long M = K * K;
+  private static final long G = M * K;
+  private static final long T = G * K;
+  private static final long MINIMUM_OVERHEAD = 384;
+
+  private K8sUtils() {
+    // do nothing
+  }
+
+  public static String calculateMemoryWithDefaultOverhead(String memory) {
+    long memoryMB = convertToBytes(memory) / M;
+    long memoryOverheadMB = Math.max((long) (memoryMB * 0.1f), MINIMUM_OVERHEAD);
+    return (memoryMB + memoryOverheadMB) + "Mi";
+  }
+
+  public static String calculateSparkMemory(String memory, String memoryOverhead) {
+    long memoryMB = convertToBytes(memory) / M;
+    long memoryOverheadMB = convertToBytes(memoryOverhead) / M;
+    return (memoryMB + memoryOverheadMB) + "Mi";
+  }
+
+  private static long convertToBytes(String memory) {
+    String lower = memory.toLowerCase().trim();
+    Matcher m = Pattern.compile("([0-9]+)([a-z]+)?").matcher(lower);
+    long value;
+    String suffix;
+    if (m.matches()) {
+      value = Long.parseLong(m.group(1));
+      suffix = m.group(2);
+    } else {
+      throw new NumberFormatException("Failed to parse string: " + memory);
+    }
+
+    long memoryAmountBytes = value;
+    if (StringUtils.containsIgnoreCase(suffix, "k")) {
+      memoryAmountBytes = value * K;
+    } else if (StringUtils.containsIgnoreCase(suffix, "m")) {
+      memoryAmountBytes = value * M;
+    } else if (StringUtils.containsIgnoreCase(suffix, "g")) {
+      memoryAmountBytes = value * G;
+    } else if (StringUtils.containsIgnoreCase(suffix, "t")) {
+      memoryAmountBytes = value * T;
+    }
+    if (0 > memoryAmountBytes) {
+      throw new NumberFormatException("Conversion of " + memory + " exceeds Long.MAX_VALUE");
+    }
+    return memoryAmountBytes;
+  }
+}

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sUtilsTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sUtilsTest.java
@@ -1,0 +1,30 @@
+package org.apache.zeppelin.interpreter.launcher;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class K8sUtilsTest {
+
+  @Test
+  public void testConvert() {
+    assertEquals("484Mi", K8sUtils.calculateMemoryWithDefaultOverhead("100m"));
+    assertEquals("1408Mi", K8sUtils.calculateMemoryWithDefaultOverhead("1Gb"));
+    assertEquals("4505Mi", K8sUtils.calculateMemoryWithDefaultOverhead("4Gb"));
+    assertEquals("6758Mi", K8sUtils.calculateMemoryWithDefaultOverhead("6Gb"));
+    assertEquals("9011Mi", K8sUtils.calculateMemoryWithDefaultOverhead("8Gb"));
+    // some extrem values
+    assertEquals("112640Mi", K8sUtils.calculateMemoryWithDefaultOverhead("100Gb"));
+    assertEquals("115343360Mi", K8sUtils.calculateMemoryWithDefaultOverhead("100Tb"));
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testExceptionMaxLong() {
+    K8sUtils.calculateMemoryWithDefaultOverhead("10000000Tb");
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testExceptionNoValidNumber() {
+    K8sUtils.calculateMemoryWithDefaultOverhead("NoValidNumber10000000Tb");
+  }
+}


### PR DESCRIPTION
### What is this PR for?
With this PR, we use spark configuration values for K8s Pod resources. A memory limit is not set because of a potential OOM-Killer.

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
> If you set a memory limit of 4GiB for that Container, the kubelet (and container runtime ) enforce the limit. The runtime prevents the container from using more than the configured resource limit. For example: when a process in the container tries to consume more than the allowed amount of memory, the system kernel terminates the process that attempted the allocation, with an out of memory (OOM) error.

@zjffdu Are using a YARN cluster to schedule your Interpreters? Maybe we should change the location of the calculation class.

### What type of PR is it?
 - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4799

### How should this be tested?
* **Travis-CI**: https://travis-ci.org/github/Reamer/zeppelin/builds/683269227

### Questions:
* **Maybe a higher default memory overhead?** Edit: No, because we doesn't need it in the past.
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
