### PR TITLE
[ZEPPELIN-4790]. Throw exception when using flink for scala 2.12

### DIFF
--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -17,13 +17,10 @@
 
 package org.apache.zeppelin.flink;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.scala.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.scala.StreamTableEnvironment;
 import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -50,27 +47,21 @@ public class FlinkInterpreter extends Interpreter {
     super(properties);
   }
 
-  private String extractScalaVersion() throws InterpreterException {
+  private void checkScalaVersion() throws InterpreterException {
     String scalaVersionString = scala.util.Properties.versionString();
     LOGGER.info("Using Scala: " + scalaVersionString);
-    if (scalaVersionString.contains("version 2.10")) {
-      return "2.10";
-    } else if (scalaVersionString.contains("version 2.11")) {
-      return "2.11";
-    } else if (scalaVersionString.contains("version 2.12")) {
-      return "2.12";
+    if (scalaVersionString.contains("version 2.11")) {
+      return;
     } else {
-      throw new InterpreterException("Unsupported scala version: " + scalaVersionString);
+      throw new InterpreterException("Unsupported scala version: " + scalaVersionString +
+              ", Only scala 2.11 is supported");
     }
   }
 
   @Override
   public void open() throws InterpreterException {
-    String scalaVersion = extractScalaVersion();
-    if (!scalaVersion.equals("2.11")) {
-      throw new InterpreterException("Only scala 2.11 is supported for flink, " +
-              "but the current scala version is: " + scalaVersion);
-    }
+    checkScalaVersion();
+    
     this.innerIntp = new FlinkScalaInterpreter(getProperties());
     this.innerIntp.open();
     this.z = this.innerIntp.getZeppelinContext();

--- a/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -48,18 +48,39 @@ public class FlinkInterpreter extends Interpreter {
 
   public FlinkInterpreter(Properties properties) {
     super(properties);
-    this.innerIntp = new FlinkScalaInterpreter(getProperties());
+  }
+
+  private String extractScalaVersion() throws InterpreterException {
+    String scalaVersionString = scala.util.Properties.versionString();
+    LOGGER.info("Using Scala: " + scalaVersionString);
+    if (scalaVersionString.contains("version 2.10")) {
+      return "2.10";
+    } else if (scalaVersionString.contains("version 2.11")) {
+      return "2.11";
+    } else if (scalaVersionString.contains("version 2.12")) {
+      return "2.12";
+    } else {
+      throw new InterpreterException("Unsupported scala version: " + scalaVersionString);
+    }
   }
 
   @Override
   public void open() throws InterpreterException {
+    String scalaVersion = extractScalaVersion();
+    if (!scalaVersion.equals("2.11")) {
+      throw new InterpreterException("Only scala 2.11 is supported for flink, " +
+              "but the current scala version is: " + scalaVersion);
+    }
+    this.innerIntp = new FlinkScalaInterpreter(getProperties());
     this.innerIntp.open();
     this.z = this.innerIntp.getZeppelinContext();
   }
 
   @Override
   public void close() throws InterpreterException {
-    this.innerIntp.close();
+    if (this.innerIntp != null) {
+      this.innerIntp.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
### What is this PR for?

This PR will throw exception when using flink for scala 2.12 which is not supported now. See the screenshot below.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4790

### How should this be tested?
* Manually tested.

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/81144289-4f89de80-8fa6-11ea-9df0-8abba0406b7c.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
