### PR TITLE
[ZEPPELIN-4797]. Enable multiple sql in jdbc interpreter by default

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -139,11 +139,6 @@ The JDBC interpreter properties are defined by default like below.
     <td>120</td>
     <td>Time to live sql completer in seconds (-1 to update everytime, 0 to disable update)</td>
   </tr>
-  <tr>
-    <td>default.splitQueries</td>
-    <td>false</td>
-    <td>Each query is executed apart and returns the result</td>
-  </tr>
 </table>
 
 If you want to connect other databases such as `Mysql`, `Redshift` and `Hive`, you need to edit the property values.
@@ -244,6 +239,19 @@ If the paragraph is `FINISHED` without any errors, a new paragraph will be autom
 So you don't need to type this prefix in every paragraphs' header.
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/docs-img/run_paragraph_with_jdbc.png" width="600px" />
+
+
+### Multiple SQL statements
+
+You can write multiple sql statements in one paragraph, just separate them with semi-colon. e.g
+
+```sql
+
+USE zeppelin_demo;
+
+CREATE TABLE pet (name VARCHAR(20), owner VARCHAR(20),
+       species VARCHAR(20), sex CHAR(1), birth DATE, death DATE);
+```
 
 ### Apply Zeppelin Dynamic Forms
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -112,7 +112,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String COMPLETER_SCHEMA_FILTERS_KEY = "completer.schemaFilters";
   static final String COMPLETER_TTL_KEY = "completer.ttlInSeconds";
   static final String DEFAULT_COMPLETER_TTL = "120";
-  static final String SPLIT_QURIES_KEY = "splitQueries";
   static final String JDBC_JCEKS_FILE = "jceks.file";
   static final String JDBC_JCEKS_CREDENTIAL_KEY = "jceks.credentialKey";
   static final String PRECODE_KEY_TEMPLATE = "%s.precode";
@@ -668,12 +667,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
     String paragraphId = context.getParagraphId();
     String user = context.getAuthenticationInfo().getUser();
 
-    boolean splitQuery = false;
-    String splitQueryProperty = getProperty(String.format("%s.%s", propertyKey, SPLIT_QURIES_KEY));
-    if (StringUtils.isNotBlank(splitQueryProperty) && splitQueryProperty.equalsIgnoreCase("true")) {
-      splitQuery = true;
-    }
-
     try {
       connection = getConnection(propertyKey, context);
     } catch (Exception e) {
@@ -695,17 +688,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     }
 
     try {
-      List<String> sqlArray;
-      sql = sql.trim();
-      if (splitQuery) {
-        sqlArray = sqlSplitter.splitSql(sql);
-      } else {
-        if (sql.endsWith(";")) {
-          sql = sql.substring(0, sql.length() - 1);
-        }
-        sqlArray = Arrays.asList(sql);
-      }
-
+      List<String> sqlArray = sqlSplitter.splitSql(sql);
       for (int i = 0; i < sqlArray.size(); i++) {
         String sqlToExecute = sqlArray.get(i);
         statement = connection.createStatement();

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -689,8 +689,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
     try {
       List<String> sqlArray = sqlSplitter.splitSql(sql);
-      for (int i = 0; i < sqlArray.size(); i++) {
-        String sqlToExecute = sqlArray.get(i);
+      for (String sqlToExecute : sqlArray) {
         statement = connection.createStatement();
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -60,13 +60,6 @@
         "description": "Runs before each run of the paragraph, in the same connection",
         "type": "textarea"
       },
-      "default.splitQueries": {
-        "envName": null,
-        "propertyName": "default.splitQueries",
-        "defaultValue": false,
-        "description": "Each query is executed apart and returns the result",
-        "type": "checkbox"
-      },
       "common.max_count": {
         "envName": null,
         "propertyName": "common.max_count",

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -391,11 +391,14 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
 
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
-    assertEquals(1, resultMessages.size());
+    assertEquals(2, resultMessages.size());
 
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
     assertEquals("ID\tNAME\na\ta_name\nb\tb_name\nc\tnull\n",
             resultMessages.get(0).getData());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(1).getType());
+    assertEquals("ID\tNAME\n",
+            resultMessages.get(1).getData());
   }
 
   @Test
@@ -612,12 +615,15 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
-    assertEquals(2, resultMessages.size());
+    assertEquals(3, resultMessages.size());
     assertEquals(InterpreterResult.Type.TEXT, resultMessages.get(0).getType());
     assertEquals("Query executed successfully. Affected rows : 0\n",
             resultMessages.get(0).getData());
-    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(1).getType());
-    assertEquals("ID\n1\n", resultMessages.get(1).getData());
+    assertEquals(InterpreterResult.Type.TEXT, resultMessages.get(1).getType());
+    assertEquals("Query executed successfully. Affected rows : 1\n",
+            resultMessages.get(1).getData());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(2).getType());
+    assertEquals("ID\n1\n", resultMessages.get(2).getData());
   }
 
   @Test
@@ -670,12 +676,15 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
 
-    assertEquals(2, resultMessages.size());
+    assertEquals(3, resultMessages.size());
     assertEquals(InterpreterResult.Type.TEXT, resultMessages.get(0).getType());
     assertEquals("Query executed successfully. Affected rows : 0\n",
             resultMessages.get(0).getData());
-    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(1).getType());
-    assertEquals("ID\n2\n", resultMessages.get(1).getData());
+    assertEquals(InterpreterResult.Type.TEXT, resultMessages.get(1).getType());
+    assertEquals("Query executed successfully. Affected rows : 1\n",
+            resultMessages.get(1).getData());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(2).getType());
+    assertEquals("ID\n2\n", resultMessages.get(2).getData());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

Before this PR, user have to set property `default.splitQueries` to enable multiple queries in one paragraph, this PR remove this property, this PR remove this property, and make multiple sql query in support by default.


### What type of PR is it?
[Feature | Documentation]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4797

### How should this be tested?
* Unit test is updated

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
