### PR TITLE
[ZEPPELIN-4806]. Throw proper exception when hadoop jar is missing in yarn mode for flink interpreter

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -236,6 +236,10 @@ elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
 
   if [[ -n "${HADOOP_CONF_DIR}" ]] && [[ -d "${HADOOP_CONF_DIR}" ]]; then
     ZEPPELIN_INTP_CLASSPATH+=":${HADOOP_CONF_DIR}"
+    if ! [ -x "$(command -v hadoop)" ]; then
+      echo 'Error: hadoop is not in PATH when HADOOP_CONF_DIR is specified.'
+      exit 1
+    fi
     ZEPPELIN_INTP_CLASSPATH+=":`hadoop classpath`"
     export HADOOP_CONF_DIR=${HADOOP_CONF_DIR}
   else

--- a/flink/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
+++ b/flink/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.flink;
+
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Move the hadoop related operation (depends on hadoop api) out of FlinkScalaInterpreter to this
+ * class is because in this way we don't need to load hadoop class for non-yarn mode. Otherwise
+ * even in non-yarn mode, user still need hadoop shaded jar which doesnt' make sense.
+ */
+public class HadoopUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HadoopUtils.class);
+
+  public static String getYarnAppTrackingUrl(ClusterClient clusterClient) throws IOException, YarnException {
+    ApplicationId yarnAppId = (ApplicationId) clusterClient.getClusterId();
+    YarnClient yarnClient = YarnClient.createYarnClient();
+    YarnConfiguration yarnConf = new YarnConfiguration();
+    // disable timeline service as we only query yarn app here.
+    // Otherwise we may hit this kind of ERROR:
+    // java.lang.ClassNotFoundException: com.sun.jersey.api.client.config.ClientConfig
+    yarnConf.set("yarn.timeline-service.enabled", "false");
+    yarnClient.init(yarnConf);
+    yarnClient.start();
+    return yarnClient.getApplicationReport(yarnAppId).getTrackingUrl();
+  }
+
+  public static void cleanupStagingDirInternal(ClusterClient clusterClient) {
+    try {
+      ApplicationId appId = (ApplicationId) clusterClient.getClusterId();
+      FileSystem fs = FileSystem.get(new Configuration());
+      Path stagingDirPath = new Path(fs.getHomeDirectory(), ".flink/" + appId.toString());
+      if (fs.delete(stagingDirPath, true)) {
+        LOGGER.info("Deleted staging directory " + stagingDirPath);
+      }
+    } catch (IOException e){
+        LOGGER.warn("Failed to cleanup staging dir", e);
+    }
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This PR actually solve 2 things in flink yarn mode.
1. You don't need flink-hadoop-shaded jar when flink is not in yarn mode (before this PR, it is still needed even when it is not in yarn mode)
2. Throw proper error message when hadoop jar is missing in yarn mode.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4806

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/81463335-843aa780-91eb-11ea-95ee-c8e475cdfa0e.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
