### PR TITLE
[ZEPPELIN-4809]. Zeppelin FlinkInterpreterLauncher not work in Zeppelin cluster mode

### DIFF
--- a/zeppelin-plugins/launcher/docker/pom.xml
+++ b/zeppelin-plugins/launcher/docker/pom.xml
@@ -42,6 +42,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>launcher-flink</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
       <version>2.4.12</version>

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterLauncher.java
@@ -55,6 +55,8 @@ public class DockerInterpreterLauncher extends InterpreterLauncher {
     StandardInterpreterLauncher interpreterLauncher = null;
     if (isSpark()) {
       interpreterLauncher = new SparkInterpreterLauncher(zConf, recoveryStorage);
+    } else if (isFlink()) {
+      interpreterLauncher = new FlinkInterpreterLauncher(zConf, recoveryStorage);
     } else {
       interpreterLauncher = new StandardInterpreterLauncher(zConf, recoveryStorage);
     }
@@ -76,5 +78,9 @@ public class DockerInterpreterLauncher extends InterpreterLauncher {
 
   boolean isSpark() {
     return "spark".equalsIgnoreCase(context.getInterpreterSettingName());
+  }
+
+  boolean isFlink() {
+    return "flink".equalsIgnoreCase(context.getInterpreterSettingName());
   }
 }


### PR DESCRIPTION

### What is this PR for?

Flink doesn't work in cluster mode because we didn't use `FlinkInterpreterLauncher` in `DockerInterpreterLauncher` which is used in cluster mode. It is a straightforward change to just use `FlinkInterpreterLauncher` in `DockerInterpreterLauncher`


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4809

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
