### PR TITLE
[ZEPPELIN-4778]. Each getInterpreterContext call will load user credential file

### DIFF
--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -131,7 +131,7 @@ Snippet of code (language of interpreter) that executes after initialization of 
 
 ## Credential Injection
 
-Credentials from the credential manager can be injected into Notebooks. Credential injection works by replacing the following patterns in Notebooks with matching credentials for the Credential Manager: `{user.CREDENTIAL_ENTITY}` and `{password.CREDENTIAL_ENTITY}`. However, credential injection must be enabled per Interpreter, by adding a boolean `injectCredentials` setting in the Interpreters configuration. Injected passwords are removed from Notebook output to prevent accidentally leaking passwords.
+Credentials from the credential manager can be injected into Notebooks. Credential injection works by replacing the following patterns in Notebooks with matching credentials for the Credential Manager: `{CREDENTIAL_ENTITY.user}` and `{CREDENTIAL_ENTITY.password}`. However, credential injection must be enabled per Interpreter, by adding a boolean `injectCredentials` setting in the Interpreters configuration. Injected passwords are removed from Notebook output to prevent accidentally leaking passwords.
 
 **Credential Injection Setting**
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/credential_injection_setting.png" width="500px">
@@ -142,9 +142,9 @@ Credentials from the credential manager can be injected into Notebooks. Credenti
 **Credential Injection Example**
 
 ```scala
-val password = "{password.SOME_CREDENTIAL_ENTITY}"
+val password = "{SOME_CREDENTIAL_ENTITY.password}"
 
-val username = "{user.SOME_CREDENTIAL_ENTITY}"
+val username = "{SOME_CREDENTIAL_ENTITY.user}"
 ```
 
 ## Interpreter Process Recovery (Experimental)

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
@@ -37,8 +37,8 @@ class CredentialInjector {
 
   private Set<String> passwords = new HashSet<>();
   private final UserCredentials creds;
-  private static final Pattern userpattern = Pattern.compile("\\{user\\.([^\\}]+)\\}");
-  private static final Pattern passwordpattern = Pattern.compile("\\{password\\.([^\\}]+)\\}");
+  private static final Pattern userpattern = Pattern.compile("\\{([^\\}]+)\\.user\\}");
+  private static final Pattern passwordpattern = Pattern.compile("\\{([^\\}]+)\\.password\\}");
 
 
   public CredentialInjector(UserCredentials creds) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -90,7 +90,6 @@ public class Credentials {
   }
 
   public UserCredentials getUserCredentials(String username) throws IOException {
-    loadCredentials();
     UserCredentials uc = credentialsMap.get(username);
     if (uc == null) {
       uc = new UserCredentials();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class CredentialInjectorTest {
 
   private static final String TEMPLATE =
-    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={user.mysql}&password={password.mysql}\"";
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={mysql.user}&password={mysql.password}\"";
   private static final String CORRECT_REPLACED =
     "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=username&password=pwd\"";
 


### PR DESCRIPTION
### What is this PR for?

This is a trivial PR which remove `loadCredentials` in `getUserCredentials`. It is not necessary and it would cause each `getInterpreterContext` call will load user credential file.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4778

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
