### PR TITLE
[ZEPPELIN-4726] Use entry.user & entry.password instead of user.entry and password.entry for credential injection

### DIFF
--- a/docs/setup/operation/upgrading.md
+++ b/docs/setup/operation/upgrading.md
@@ -42,7 +42,8 @@ So, copying `notebook` and `conf` directory should be enough.
    2. Call `bin/upgrade-note.sh -d` to upgrade notes, `-d` option means to delete the old note file, missing this option will keep the old file.
  - From 0.9, Zeppelin server bind `127.0.0.1` by default instead of `0.0.0.0`. Configure `zeppelin.server.addr` property or `ZEPPELIN_ADDR` env variable to change it to `0.0.0.0` if you want to access it remotely.
  - From 0.9, we have removed `zeppelin.anonymous.allowed` ([ZEPPELIN-4489](https://issues.apache.org/jira/browse/ZEPPELIN-4489)). So, when you upgrade Zeppelin to 0.9 and if `shiro.ini` file does not exist in conf path then all the Zeppelin-Users runs as anonymous.
-
+ - From 0.9, we use `{crendential_entry.user}` and `{crendential_entry.password}` for credential injection, while before 0.9 we use `{user.crendential_entry}` and `{password.crendential_entry}`
+ 
 ### Upgrading from Zeppelin 0.8.1 (and before) to 0.8.2 (and later)
  - From 0.8.2, Zeppelin server bind `127.0.0.1` by default instead of `0.0.0.0`. Configure `zeppelin.server.addr` property or `ZEPPELIN_ADDR` env variable to change.
 

--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -131,7 +131,7 @@ Snippet of code (language of interpreter) that executes after initialization of 
 
 ## Credential Injection
 
-Credentials from the credential manager can be injected into Notebooks. Credential injection works by replacing the following patterns in Notebooks with matching credentials for the Credential Manager: `{user.CREDENTIAL_ENTITY}` and `{password.CREDENTIAL_ENTITY}`. However, credential injection must be enabled per Interpreter, by adding a boolean `injectCredentials` setting in the Interpreters configuration. Injected passwords are removed from Notebook output to prevent accidentally leaking passwords.
+Credentials from the credential manager can be injected into Notebooks. Credential injection works by replacing the following patterns in Notebooks with matching credentials for the Credential Manager: `{CREDENTIAL_ENTITY.user}` and `{CREDENTIAL_ENTITY.password}`. However, credential injection must be enabled per Interpreter, by adding a boolean `injectCredentials` setting in the Interpreters configuration. Injected passwords are removed from Notebook output to prevent accidentally leaking passwords.
 
 **Credential Injection Setting**
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/screenshots/credential_injection_setting.png" width="500px">
@@ -142,9 +142,9 @@ Credentials from the credential manager can be injected into Notebooks. Credenti
 **Credential Injection Example**
 
 ```scala
-val password = "{password.SOME_CREDENTIAL_ENTITY}"
+val password = "{SOME_CREDENTIAL_ENTITY.password}"
 
-val username = "{user.SOME_CREDENTIAL_ENTITY}"
+val username = "{SOME_CREDENTIAL_ENTITY.user}"
 ```
 
 ## Interpreter Process Recovery (Experimental)

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/CredentialInjector.java
@@ -37,8 +37,8 @@ class CredentialInjector {
 
   private Set<String> passwords = new HashSet<>();
   private final UserCredentials creds;
-  private static final Pattern userpattern = Pattern.compile("\\{user\\.([^\\}]+)\\}");
-  private static final Pattern passwordpattern = Pattern.compile("\\{password\\.([^\\}]+)\\}");
+  private static final Pattern userpattern = Pattern.compile("\\{([^\\}]+)\\.user\\}");
+  private static final Pattern passwordpattern = Pattern.compile("\\{([^\\}]+)\\.password\\}");
 
 
   public CredentialInjector(UserCredentials creds) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/CredentialInjectorTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class CredentialInjectorTest {
 
   private static final String TEMPLATE =
-    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={user.mysql}&password={password.mysql}\"";
+    "val jdbcUrl = \"jdbc:mysql://localhost/emp?user={mysql.user}&password={mysql.password}\"";
   private static final String CORRECT_REPLACED =
     "val jdbcUrl = \"jdbc:mysql://localhost/emp?user=username&password=pwd\"";
 


### PR DESCRIPTION
### What is this PR for?

This is a refactoring PR which just use entry.user & entry.password instead of user.entry and password.entry for credential injection .


### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4726

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
