### PR TITLE
[ZEPPELIN-4823]. exported ipynb file name is undefined

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1193,7 +1193,7 @@ public class NotebookServer extends WebSocketServlet
     } else {
       Message resp = new Message(OP.CONVERTED_NOTE_NBFORMAT)
               .put("nbformat", new JupyterUtil().getNbformat(note.toJson()))
-              .put("name", fromMessage.get("name"));
+              .put("noteName", fromMessage.get("noteName"));
       conn.send(serializeMessage(resp));
     }
   }

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -184,7 +184,7 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, sa
     } else if (op === 'PARAS_INFO') {
       $rootScope.$broadcast('updateParaInfos', data);
     } else if (op === 'CONVERTED_NOTE_NBFORMAT') {
-      saveAsService.saveAs(data.nbformat, data.name, 'zepl.ipynb');
+      saveAsService.saveAs(data.nbformat, data.noteName, '.ipynb');
     } else if (op === 'INTERPRETER_INSTALL_STARTED') {
       ngToast.info(data.message);
     } else if (op === 'INTERPRETER_INSTALL_RESULT') {


### PR DESCRIPTION
### What is this PR for?

Before this PR, the exported `ipynb` is always `undefined.zepl.ipynb` because note name is not passed correctly, this PR fix this issue and the exported ipynb will be `{note_name}.ipynb`


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4823

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
