### PR TITLE
[ZEPPELIN-4832]. run note in non-blocking way could not guarantee the paragraph execution order

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -391,11 +391,24 @@ public class RemoteInterpreter extends Interpreter {
   public Scheduler getScheduler() {
     // one session own one Scheduler, so that when one session is closed, all the jobs/paragraphs
     // running under the scheduler of this session will be aborted.
-    Scheduler s = new RemoteScheduler(
-        RemoteInterpreter.class.getSimpleName() + "-" + getInterpreterGroup().getId() + "-" + sessionId,
-        SchedulerFactory.singleton().getExecutor(),
-        this);
-    return SchedulerFactory.singleton().createOrGetScheduler(s);
+    String executionMode = getProperty(".execution.mode", "paragraph");
+    if (executionMode.equals("paragraph")) {
+      Scheduler s = new RemoteScheduler(
+              RemoteInterpreter.class.getSimpleName() + "-" + getInterpreterGroup().getId() + "-" + sessionId,
+              SchedulerFactory.singleton().getExecutor(),
+              this);
+      return SchedulerFactory.singleton().createOrGetScheduler(s);
+    } else if (executionMode.equals("note")) {
+      String noteId = getProperty(".noteId");
+      Scheduler s = new RemoteScheduler(
+              RemoteInterpreter.class.getSimpleName() + "-" + noteId,
+              SchedulerFactory.singleton().getExecutor(),
+              this);
+      return SchedulerFactory.singleton().createOrGetScheduler(s);
+    } else {
+      throw new RuntimeException("Invalid execution mode: " + executionMode);
+    }
+
   }
 
   private RemoteInterpreterContext convert(InterpreterContext ic) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -707,6 +707,14 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
     }
   }
 
+  @VisibleForTesting
+  public void waitUntilFinished() throws Exception {
+    while(!isTerminated()) {
+      LOGGER.debug("Wait for paragraph to be finished");
+      Thread.sleep(1000);
+    }
+  }
+
   private GUI getNoteGui() {
     GUI gui = new GUI();
     gui.setParams(this.note.getNoteParams());


### PR DESCRIPTION
### What is this PR for?

Before this PR, if user run the note in non-blocking way via rest api, the execution order of paragraphs is not determined, paragraph 2 will start to run after paragraph 1 enter running state. But we should only start paragraph 2 when paragraph 1 is finished. 

This PR fix this issue by minor change the `RemoteScheduler` and introduce `.execution.mode` to tell `RemoteScheduler` that whether the job is running as individual paragraph or as part of note execution. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4832

### How should this be tested?
* Unit test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
