### PR TITLE
[ZEPPELIN-4829] NPE in RemoteInterpreterServer#getStatus when interpreter is not opened yet

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -904,9 +904,12 @@ public class RemoteInterpreterServer extends Thread
       }
 
       for (Interpreter intp : interpreters) {
-        Job job = intp.getScheduler().getJob(jobId);
-        if (job != null) {
-          return job.getStatus().name();
+        Scheduler scheduler = intp.getScheduler();
+        if (scheduler != null) {
+          Job job = scheduler.getJob(jobId);
+          if (job != null) {
+            return job.getStatus().name();
+          }
         }
       }
     }


### PR DESCRIPTION
### What is this PR for?

The NPE happens because the scheduler of interpreter is null. This is because the interpreter is not opened yet. (https://github.com/apache/zeppelin/blob/v0.9.0-preview1/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java#L232)

This PR would check wether interpreter is opened before using its scheduler.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4829

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
