### PR TITLE
[ZEPPELIN-4836]. set zeppelin.spark.sql.stacktrace to true as default value

### DIFF
--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -170,7 +170,7 @@
       "zeppelin.spark.sql.stacktrace": {
         "envName": null,
         "propertyName": "zeppelin.spark.sql.stacktrace",
-        "defaultValue": false,
+        "defaultValue": true,
         "description": "Show full exception stacktrace for SQL queries if set to true.",
         "type": "checkbox"
       },


### PR DESCRIPTION

### What is this PR for?

Trivial PR to set `zeppelin.spark.sql.stacktrace` to `true` as default value


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4836

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
