### PR TITLE
[ZEPPELIN-4802]. pyspark warnings with spark-3.0.0-preview - Sync of properties between JVM and PVM

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -148,6 +148,10 @@ public class IPySparkInterpreter extends IPythonInterpreter {
     return sparkInterpreter.getSparkVersion().getMajorVersion() == 1;
   }
 
+  public boolean isSpark3() {
+    return sparkInterpreter.getSparkVersion().getMajorVersion() == 3;
+  }
+
   public JavaSparkContext getJavaSparkContext() {
     return sparkInterpreter.getJavaSparkContext();
   }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -221,4 +221,8 @@ public class PySparkInterpreter extends PythonInterpreter {
   public boolean isSpark1() {
     return sparkInterpreter.getSparkVersion().getMajorVersion() == 1;
   }
+
+  public boolean isSpark3() {
+    return sparkInterpreter.getSparkVersion().getMajorVersion() == 3;
+  }
 }

--- a/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
@@ -39,6 +39,10 @@ java_import(gateway.jvm, "org.apache.spark.api.python.*")
 java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
 
 intp = gateway.entry_point
+
+if intp.isSpark3():
+    warnings.filterwarnings(action='ignore', module='pyspark.util')
+
 jsc = intp.getJavaSparkContext()
 
 java_import(gateway.jvm, "org.apache.spark.sql.*")

--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import warnings
+
 from py4j.java_gateway import java_import
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
@@ -23,6 +25,9 @@ from pyspark.context import SparkContext
 from pyspark.sql import SQLContext, Row
 
 intp = gateway.entry_point
+
+if intp.isSpark3():
+  warnings.filterwarnings(action='ignore', module='pyspark.util')
 
 jsc = intp.getJavaSparkContext()
 java_import(gateway.jvm, "org.apache.spark.SparkEnv")

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -187,6 +187,8 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     } else {
       LOGGER.info("Run Spark under non-secure mode as no keytab and principal is specified");
     }
+
+    env.put("PYSPARK_PIN_THREAD", "true");
     LOGGER.debug("buildEnvFromProperties: " + env);
     return env;
 


### PR DESCRIPTION
### What is this PR for?

This PR will first set env `PYSPARK_PIN_THREAD` to be `true` and then suppress the warning message in `pyspark.util`.


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4802

### How should this be tested?
* CI pass
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? No
* Does this needs documentation?
