### PR TITLE
[ZEPPELIN-4840]. Set zeppelin.spark.concurrentSQL to be true by default

### DIFF
--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -156,7 +156,7 @@
       "zeppelin.spark.concurrentSQL": {
         "envName": null,
         "propertyName": "zeppelin.spark.concurrentSQL",
-        "defaultValue": false,
+        "defaultValue": true,
         "description": "Execute multiple SQL concurrently if set true.",
         "type": "checkbox"
       },


### PR DESCRIPTION
### What is this PR for?

Trivial PR which just make `zeppelin.spark.concurrentSQL` to be `true` by default, this is what user expect usually.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4840

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
