### PR TITLE
[ZEPPELIN-4833] misleading logging when fail to load plugin from classpath directly

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -81,10 +81,8 @@ public class NotebookRepoSync implements NotebookRepoWithVersionControl {
     // init the underlying NotebookRepo
     for (int i = 0; i < Math.min(storageClassNames.length, getMaxRepoNum()); i++) {
       NotebookRepo notebookRepo = PluginManager.get().loadNotebookRepo(storageClassNames[i].trim());
-      if (notebookRepo != null) {
-        notebookRepo.init(conf);
-        repos.add(notebookRepo);
-      }
+      notebookRepo.init(conf);
+      repos.add(notebookRepo);
     }
 
     // couldn't initialize any storage, use default

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncInitializationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncInitializationTest.java
@@ -31,10 +31,11 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 //TODO(zjffdu) move it to zeppelin-zengine
 public class NotebookRepoSyncInitializationTest {
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoSyncInitializationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookRepoSyncInitializationTest.class);
   private String validFirstStorageClass = "org.apache.zeppelin.notebook.repo.VFSNotebookRepo";
   private String validSecondStorageClass = "org.apache.zeppelin.notebook.repo.mock.VFSNotebookRepoMock";
   private String invalidStorageClass = "org.apache.zeppelin.notebook.repo.DummyNotebookRepo";
@@ -47,12 +48,12 @@ public class NotebookRepoSyncInitializationTest {
   @Before
   public void setUp(){
     System.setProperty(ConfVars.ZEPPELIN_PLUGINS_DIR.getVarName(), new File("../../../plugins").getAbsolutePath());
-    //setup routine
+    System.setProperty("zeppelin.isTest", "true");
   }
 
   @After
   public void tearDown() {
-    //tear-down routine
+    System.clearProperty("zeppelin.isTest");
   }
 
   @Test
@@ -101,11 +102,13 @@ public class NotebookRepoSyncInitializationTest {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), invalidTwoStorageConf);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
-    // check that second didn't initialize
-    LOG.info(" " + notebookRepoSync.getRepoCount());
-    assertEquals(notebookRepoSync.getRepoCount(), 1);
-    assertTrue(notebookRepoSync.getRepo(0) instanceof VFSNotebookRepo);
+    try {
+      NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+      fail("Should throw exception due to invalid NotebookRepo");
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage());
+      assertTrue(e.getMessage().contains("Fail to instantiate notebookrepo from classpath directly"));
+    }
   }
 
   @Test
@@ -148,14 +151,16 @@ public class NotebookRepoSyncInitializationTest {
   }
 
   @Test
-  public void initOneDummyStorageTest() throws IOException {
- // set confs
+  public void initOneDummyStorageTest() {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_STORAGE.getVarName(), invalidStorageClass);
     ZeppelinConfiguration conf = ZeppelinConfiguration.create();
     // create repo
-    NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
-    // check initialization of one default storage instead of invalid one
-    assertEquals(notebookRepoSync.getRepoCount(), 1);
-    assertTrue(notebookRepoSync.getRepo(0) instanceof NotebookRepo);
+    try {
+      NotebookRepoSync notebookRepoSync = new NotebookRepoSync(conf);
+      fail("Should throw exception due to invalid NotebookRepo");
+    } catch (IOException e) {
+      LOGGER.error(e.getMessage());
+      assertTrue(e.getMessage().contains("Fail to instantiate notebookrepo from classpath directly"));
+    }
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -72,6 +72,7 @@ public class NotebookRepoSyncTest {
 
   @Before
   public void setUp() throws Exception {
+    System.setProperty("zeppelin.isTest", "true");
     ZEPPELIN_HOME = Files.createTempDir();
     new File(ZEPPELIN_HOME, "conf").mkdirs();
     String mainNotePath = ZEPPELIN_HOME.getAbsolutePath() + "/notebook";
@@ -110,6 +111,7 @@ public class NotebookRepoSyncTest {
   @After
   public void tearDown() throws Exception {
     delete(ZEPPELIN_HOME);
+    System.clearProperty("zeppelin.isTest");
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

Previous plugin loading strategy is to load them from system classloader first, if fails, then fallback to plugin folder classloader. This would produce misleading logging which make user think that the plugin is failed to load. This PR would load plugin from system classloader only when they are builtin plugins.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4833

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
