### PR TITLE
[ZEPPELIN-4850]. Include charting option for single value

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -19,7 +19,6 @@ package org.apache.zeppelin.spark;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.spark.SparkContext;
-import org.apache.spark.sql.SQLContext;
 import org.apache.zeppelin.interpreter.AbstractInterpreter;
 import org.apache.zeppelin.interpreter.ZeppelinContext;
 import org.apache.zeppelin.interpreter.InterpreterContext;
@@ -41,7 +40,7 @@ import java.util.Properties;
  * Spark SQL interpreter for Zeppelin.
  */
 public class SparkSqlInterpreter extends AbstractInterpreter {
-  private Logger logger = LoggerFactory.getLogger(SparkSqlInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkSqlInterpreter.class);
 
   private SparkInterpreter sparkInterpreter;
   private SqlSplitter sqlSplitter;
@@ -111,7 +110,7 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
       if (Boolean.parseBoolean(getProperty("zeppelin.spark.sql.stacktrace", "false"))) {
         builder.append(ExceptionUtils.getStackTrace(e));
       } else {
-        logger.error("Invocation target exception", e);
+        LOGGER.error("Invocation target exception", e);
         String msg = e.getMessage()
                 + "\nset zeppelin.spark.sql.stacktrace = true to see full stacktrace";
         builder.append(msg);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkShimsTest.java
@@ -95,7 +95,7 @@ public class SparkShimsTest {
                                            InterpreterContext context) {}
 
             @Override
-            public String showDataFrame(Object obj, int maxResult) {
+            public String showDataFrame(Object obj, int maxResult, InterpreterContext context) {
               return null;
             }
 

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -174,6 +174,32 @@ public class SparkSqlInterpreterTest {
   }
 
   @Test
+  public void testSingleRowResult() throws InterpreterException {
+    sparkInterpreter.interpret("case class P(age:Int)", context);
+    sparkInterpreter.interpret(
+            "val gr = sc.parallelize(Seq(P(1),P(2),P(3),P(4),P(5),P(6),P(7),P(8),P(9),P(10)))",
+            context);
+    sparkInterpreter.interpret("gr.toDF.registerTempTable(\"gr\")", context);
+
+    context = InterpreterContext.builder()
+            .setNoteId("noteId")
+            .setParagraphId("paragraphId")
+            .setParagraphTitle("title")
+            .setAngularObjectRegistry(new AngularObjectRegistry(intpGroup.getId(), null))
+            .setResourcePool(new LocalResourcePool("id"))
+            .setInterpreterOut(new InterpreterOutput(null))
+            .setIntpEventClient(mock(RemoteInterpreterEventClient.class))
+            .build();
+    context.getLocalProperties().put("template", "Total count: <h1>{0}</h1>, Total age: <h1>{1}</h1>");
+
+    InterpreterResult ret = sqlInterpreter.interpret("select count(1), sum(age) from gr", context);
+    context.getLocalProperties().remove("template");
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(Type.HTML, ret.message().get(0).getType());
+    assertEquals("Total count: <h1>10</h1>, Total age: <h1>55</h1>", ret.message().get(0).getData());
+  }
+
+  @Test
   public void testMultipleStatements() throws InterpreterException {
     sparkInterpreter.interpret("case class P(age:Int)", context);
     sparkInterpreter.interpret(

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/SparkZeppelinContext.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/SparkZeppelinContext.scala
@@ -67,7 +67,7 @@ class SparkZeppelinContext(val sc: SparkContext,
 
   override def getInterpreterClassMap: util.Map[String, String] = interpreterClassMap.asJava
 
-  override def showData(obj: Any, maxResult: Int): String = sparkShims.showDataFrame(obj, maxResult)
+  override def showData(obj: Any, maxResult: Int): String = sparkShims.showDataFrame(obj, maxResult, interpreterContext)
 
   /**
    * create paragraph level of dynamic form of Select with no item selected.

--- a/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
+++ b/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
@@ -99,7 +99,7 @@ public abstract class SparkShims {
                                           String sparkWebUrl,
                                           InterpreterContext context);
 
-  public abstract String showDataFrame(Object obj, int maxResult);
+  public abstract String showDataFrame(Object obj, int maxResult, InterpreterContext context);
 
   public abstract Object getAsDataFrame(String value);
 

--- a/spark/spark3-shims/src/main/scala/org/apache/zeppelin/spark/Spark3Shims.java
+++ b/spark/spark3-shims/src/main/scala/org/apache/zeppelin/spark/Spark3Shims.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.ResultMessages;
+import org.apache.zeppelin.interpreter.SingleRowInterpreterResult;
 import org.apache.zeppelin.tabledata.TableDataUtils;
 
 import java.util.ArrayList;
@@ -61,7 +62,7 @@ public class Spark3Shims extends SparkShims {
   }
 
   @Override
-  public String showDataFrame(Object obj, int maxResult) {
+  public String showDataFrame(Object obj, int maxResult, InterpreterContext context) {
     if (obj instanceof Dataset) {
       Dataset<Row> df = ((Dataset) obj).toDF();
       String[] columns = df.columns();
@@ -71,6 +72,15 @@ public class Spark3Shims extends SparkShims {
       }
       // fetch maxResult+1 rows so that we can check whether it is larger than zeppelin.spark.maxResult
       List<Row> rows = df.takeAsList(maxResult + 1);
+      String template = context.getLocalProperties().get("template");
+      if (!StringUtils.isBlank(template)) {
+        if (rows.size() >= 1) {
+          return new SingleRowInterpreterResult(sparkRowToList(rows.get(0)), template, context).toHtml();
+        } else {
+          return "";
+        }
+      }
+
       StringBuilder msg = new StringBuilder();
       msg.append("%table ");
       msg.append(StringUtils.join(TableDataUtils.normalizeColumns(columns), "\t"));
@@ -99,6 +109,14 @@ public class Spark3Shims extends SparkShims {
     } else {
       return obj.toString();
     }
+  }
+
+  private List sparkRowToList(Row row) {
+    List list = new ArrayList();
+    for (int i = 0; i< row.size(); i++) {
+      list.add(row.get(i));
+    }
+    return list;
   }
 
   @Override

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/SingleRowInterpreterResult.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/SingleRowInterpreterResult.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter;
+
+import org.apache.zeppelin.tabledata.TableDataUtils;
+
+import java.util.List;
+
+/**
+ * Represent the single row interpreter result, usually this is for the sql result.
+ * Where you would like to build dashboard for the sql output via just single row. e.g. KPI
+ *
+ */
+public class SingleRowInterpreterResult {
+
+  private String template;
+  private List values;
+  private InterpreterContext context;
+
+  public SingleRowInterpreterResult(List values, String template, InterpreterContext context) {
+    this.values = values;
+    this.template = template;
+    this.context = context;
+  }
+
+  public String toHtml() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("%html ");
+    String outputText = template;
+    for (int i = 0; i < values.size(); ++i) {
+      outputText = outputText.replace("{" + i + "}", values.get(i).toString());
+    }
+    builder.append(outputText);
+    return builder.toString();
+  }
+
+  public String toAngular() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("%angular ");
+    String outputText = template;
+    for (int i = 0; i < values.size(); ++i) {
+      outputText = outputText.replace("{" + i + "}", "{{value_" + i + "}}");
+    }
+    builder.append(outputText);
+    return builder.toString();
+  }
+
+  public void pushAngularObjects() {
+    for (int i = 0; i < values.size(); ++i) {
+      context.getAngularObjectRegistry().add("value_" + i,
+              TableDataUtils.normalizeColumn(values.get(i)),
+              context.getNoteId(),
+              context.getParagraphId());
+    }
+  }
+}

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/SingleRowInterpreterResultTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/SingleRowInterpreterResultTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter;
+
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SingleRowInterpreterResultTest {
+
+  @Test
+  public void testHtml() {
+    List list = Lists.newArrayList("2020-01-01", 10);
+    String template = "Total count:{1} for {0}";
+    InterpreterContext context = InterpreterContext.builder().build();
+    SingleRowInterpreterResult singleRowInterpreterResult = new SingleRowInterpreterResult(list, template, context);
+    String htmlOutput = singleRowInterpreterResult.toHtml();
+    assertEquals("%html Total count:10 for 2020-01-01", htmlOutput);
+  }
+
+  @Test
+  public void testAngular() {
+    List list = Lists.newArrayList("2020-01-01", 10);
+    String template = "Total count:{1} for {0}";
+    InterpreterContext context = InterpreterContext.builder().build();
+    SingleRowInterpreterResult singleRowInterpreterResult = new SingleRowInterpreterResult(list, template, context);
+    String angularOutput = singleRowInterpreterResult.toAngular();
+    assertEquals("%angular Total count:{{value_1}} for {{value_0}}", angularOutput);
+  }
+}


### PR DESCRIPTION
### What is this PR for?

This PR to support single row result displaying in frontend. For now we always use table format for sql output, but sometimes user want to just display a single value or single row in frontend (e.g. displaying KPI value). This PR use `SingleRowInterpreterResult` to represent such sql output, and refactor existing code to leverage this class to display single row in frontend. Besides that this PR also support the single row result in spark sql. 


### What type of PR is it?
[ Improvement | Feature | Documentation ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://github.com/zjffdu/zeppelin/compare/ZEPPELIN-4850

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
