### PR TITLE
[ZEPPELIN-4873]. Display rich duration info for insert into flink job

### DIFF
--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -111,7 +111,7 @@ public class JobManager {
   }
 
   public void cancelJob(InterpreterContext context) throws InterpreterException {
-    LOGGER.info("Canceling job associated of paragraph: " + context.getParagraphId());
+    LOGGER.info("Canceling job associated of paragraph: {}", context.getParagraphId());
     JobClient jobClient = this.jobs.get(context.getParagraphId());
     if (jobClient == null) {
       LOGGER.warn("Unable to remove Job from paragraph {} as no job associated to this paragraph",

--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -234,6 +235,12 @@ public class JobManager {
     }
   }
 
+  /**
+   * Convert duration in seconds to rich time duration format. e.g. 2 days 3 hours 4 minutes 5 seconds
+   *
+   * @param duration in second
+   * @return
+   */
   static String toRichTimeDuration(long duration) {
     long days = TimeUnit.SECONDS.toDays(duration);
     duration -= TimeUnit.DAYS.toSeconds(days);

--- a/flink/interpreter/src/test/java/org/apache/zeppelin/flink/JobManagerTest.java
+++ b/flink/interpreter/src/test/java/org/apache/zeppelin/flink/JobManagerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.flink;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobManagerTest {
+
+  @Test
+  public void testRichDuration() {
+    String richDuration = JobManager.toRichTimeDuration(18);
+    assertEquals("18 seconds", richDuration);
+
+    richDuration = JobManager.toRichTimeDuration(120);
+    assertEquals("2 minutes 0 seconds", richDuration);
+
+    richDuration = JobManager.toRichTimeDuration(60 * 60 + 1);
+    assertEquals("1 hours 0 minutes 1 seconds", richDuration);
+
+    richDuration = JobManager.toRichTimeDuration(60 * 60 + 60 + 1);
+    assertEquals("1 hours 1 minutes 1 seconds", richDuration);
+
+    richDuration = JobManager.toRichTimeDuration(24 * 60 * 60 + 60 + 1);
+    assertEquals("1 days 0 hours 1 minutes 1 seconds", richDuration);
+  }
+}


### PR DESCRIPTION
### What is this PR for?

Trivial PR which display rich duration info instead of just x seconds. See screenshot below.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4873

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/84286308-19291b80-ab71-11ea-96ef-b237d2463b8c.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
