### PR TITLE
[ZEPPELIN-4851]. Add property to flink interpreter to allow replace the yarn address

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -139,7 +139,12 @@ You can also set other flink properties which are not listed in the table. For a
   <tr>
     <td>flink.webui.yarn.useProxy</td>
     <td>false</td>
-    <td>whether use yarn proxy url as flink weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004</td>
+    <td>whether use yarn proxy url as flink weburl, e.g. http://resource-manager:8088/proxy/application_1583396598068_0004</td>
+  </tr>
+  <tr>
+    <td>flink.webui.yarn.yarnAddress</td>
+    <td></td>
+    <td>Set this value only when your yarn address is mapped to some other address, e.g. some cloud vender will map `http://resource-manager:8088` to `https://xxx-yarn.yy.cn/gateway/kkk/yarn`</td>
   </tr>
   <tr>
     <td>flink.udf.jars</td>

--- a/flink/interpreter/pom.xml
+++ b/flink/interpreter/pom.xml
@@ -626,6 +626,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.11</artifactId>
+      <version>3.0.8</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -722,6 +729,12 @@
             <FLINK_CONF_DIR>${project.build.directory}/test-classes</FLINK_CONF_DIR>
           </environmentVariables>
         </configuration>
+      </plugin>
+
+      <!-- Scalatest runs all Scala tests -->
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
       </plugin>
 
       <!-- Eclipse Integration -->

--- a/flink/interpreter/src/main/resources/interpreter-setting.json
+++ b/flink/interpreter/src/main/resources/interpreter-setting.json
@@ -96,6 +96,13 @@
         "description": "Whether use yarn proxy url as flink weburl, e.g. http://localhost:8088/proxy/application_1583396598068_0004",
         "type": "checkbox"
       },
+      "flink.webui.yarn.yarnAddress": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": "",
+        "description": "Set this value only when your yarn address is mapped to some other address, e.g. some cloud vender will map `http://resource-manager:8088` to `https://xxx-yarn.yy.cn/gateway/kkk/yarn`",
+        "type": "checkbox"
+      },
       "flink.udf.jars": {
         "envName": null,
         "propertyName": null,

--- a/flink/interpreter/src/test/scala/org/apache/zeppelin/flink/FlinkScalaInterpreterTest.scala
+++ b/flink/interpreter/src/test/scala/org/apache/zeppelin/flink/FlinkScalaInterpreterTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.flink
+
+
+import java.util.Properties
+
+import org.junit.Assert.assertEquals
+import org.scalatest.FunSuite
+
+class FlinkScalaInterpreterTest extends FunSuite {
+
+  test("testReplaceYarnAddress") {
+    val flinkScalaInterpreter = new FlinkScalaInterpreter(new Properties())
+    var targetURL = flinkScalaInterpreter.replaceYarnAddress("http://localhost:8081",
+      "http://my-server:9090/gateway")
+    assertEquals("http://my-server:9090/gateway", targetURL)
+
+    targetURL = flinkScalaInterpreter.replaceYarnAddress("https://localhost:8081/",
+      "https://my-server:9090/gateway")
+    assertEquals("https://my-server:9090/gateway/", targetURL)
+
+    targetURL = flinkScalaInterpreter.replaceYarnAddress("https://localhost:8081/proxy/app_1",
+      "https://my-server:9090/gateway")
+    assertEquals("https://my-server:9090/gateway/proxy/app_1", targetURL)
+  }
+}


### PR DESCRIPTION

### What is this PR for?

Trivial PR which add property `flink.webui.yarn.yarnAddress` that allow user to replace the yarn address. This is for some cases that cloud vender would map the internal resource manager address to other url. e.g. some cloud vender will map `http://resource-manager:8088` to `https://xxx-yarn.yy.cn/gateway/kkk/yarn`


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4851

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
