### PR TITLE
[ZEPPELIN-4837]. Add property to only check some packages for udf finding

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -147,6 +147,11 @@ You can also set other flink properties which are not listed in the table. For a
     <td>Flink udf jars (comma separated), zeppelin will register udf in this jar automatically for user. The udf name is the class name.</td>
   </tr>
   <tr>
+    <td>flink.udf.jars.packages</td>
+    <td></td>
+    <td>Packages (comma separated) that would be searched for the udf defined in `flink.udf.jars`.</td>
+  </tr>
+  <tr>
     <td>flink.execution.jars</td>
     <td></td>
     <td>Additional user jars (comma separated)</td>

--- a/flink/interpreter/src/main/resources/interpreter-setting.json
+++ b/flink/interpreter/src/main/resources/interpreter-setting.json
@@ -103,6 +103,13 @@
         "description": "Flink udf jars (comma separated), Zeppelin will register udfs in this jar for user automatically",
         "type": "string"
       },
+      "flink.udf.jars.packages": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": "",
+        "description": "Packages (comma separated) that would be searched for the udf defined in `flink.udf.jars`",
+        "type": "string"
+      },
       "flink.execution.jars": {
         "envName": null,
         "propertyName": null,


### PR DESCRIPTION
### What is this PR for?

Add property `flink.udf.jars.packages` to specify the packages that would be searched for udf, otherwise all the classes will be check, which might be very time consuming especially when the udf jars are large (if your udf depends on other third party libraries)


### What type of PR is it?
[Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4837

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/84347276-b3767700-abe4-11ea-9688-f4334dc4d395.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
