### PR TITLE
[ZEPPELIN-4870] Improve parsing of the paragraph properties

### DIFF
--- a/docs/usage/interpreter/overview.md
+++ b/docs/usage/interpreter/overview.md
@@ -38,7 +38,13 @@ When you click the ```+Create``` button on the interpreter page, the interpreter
 
 You can create multiple interpreters for the same engine with different interpreter setting. e.g. You can create `spark2` for Spark 2.x and create `spark1` for Spark 1.x.
 
-For each paragraph you write in Zeppelin, you need to specify its interpreter first via `%interpreter_group.interpreter_name`. e.g. `%spark.pyspark`, `%spark.r`
+For each paragraph you write in Zeppelin, you need to specify its interpreter first via `%interpreter_group.interpreter_name`. e.g. `%spark.pyspark`, `%spark.r`.
+
+If you specify interpreter, you can also pass local properties to it (if it needs them).  This is done by providing a set of key/value pairs, separated by comma, inside the round brackets right after the interpreter name. If key or value contain characters like `=`, or `,`, then you can either escape them with `\` character, or wrap the whole value inside the double quotes For example:
+
+```
+%cassandra(outputFormat=cql, dateFormat="E, d MMM yy", timeFormat=E\, d MMM yy)
+```
 
 ## What are the Interpreter Settings?
 The interpreter settings are the configuration of a given interpreter on the Zeppelin server. For example, certain properties need to be set for the Apache Hive JDBC interpreter to connect to the Hive server.

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTextParserTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTextParserTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.zeppelin.notebook;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -33,30 +35,119 @@ public class ParagraphTextParserTest {
   }
 
   @Test
-  public void testParagraphText() {
+  public void testParagraphTextLocalPropertiesAndText() {
     ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("%spark.pyspark(pool=pool_1) sc.version");
     assertEquals("spark.pyspark", parseResult.getIntpText());
     assertEquals(1, parseResult.getLocalProperties().size());
     assertEquals("pool_1", parseResult.getLocalProperties().get("pool"));
     assertEquals("sc.version", parseResult.getScriptText());
+  }
 
-    // no script text
-    parseResult = ParagraphTextParser.parse("%spark.pyspark(pool=pool_1)");
+  @Test
+  public void testParagraphTextLocalPropertiesNoText() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("%spark.pyspark(pool=pool_1)");
     assertEquals("spark.pyspark", parseResult.getIntpText());
     assertEquals(1, parseResult.getLocalProperties().size());
     assertEquals("pool_1", parseResult.getLocalProperties().get("pool"));
     assertEquals("", parseResult.getScriptText());
+  }
 
-    // no paragraph local properties
-    parseResult = ParagraphTextParser.parse("%spark.pyspark sc.version");
+  @Test
+  public void testParagraphTextLocalPropertyNoValueNoText() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("%spark.pyspark(pool)");
+    assertEquals("spark.pyspark", parseResult.getIntpText());
+    assertEquals(1, parseResult.getLocalProperties().size());
+    assertEquals("pool", parseResult.getLocalProperties().get("pool"));
+    assertEquals("", parseResult.getScriptText());
+  }
+
+  @Test
+  public void testParagraphTextNoLocalProperties() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("%spark.pyspark sc.version");
     assertEquals("spark.pyspark", parseResult.getIntpText());
     assertEquals(0, parseResult.getLocalProperties().size());
     assertEquals("sc.version", parseResult.getScriptText());
+  }
 
-    // no intp text and paragraph local properties
-    parseResult = ParagraphTextParser.parse("sc.version");
+  @Test
+  public void testParagraphNoInterpreter() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("sc.version");
     assertEquals("", parseResult.getIntpText());
     assertEquals(0, parseResult.getLocalProperties().size());
     assertEquals("sc.version", parseResult.getScriptText());
+  }
+
+  @Test
+  public void testParagraphInterpreterWithoutProperties() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse("%spark() sc.version");
+    assertEquals("spark", parseResult.getIntpText());
+    assertEquals(0, parseResult.getLocalProperties().size());
+    assertEquals("sc.version", parseResult.getScriptText());
+  }
+
+  @Test
+  public void testParagraphTextQuotedPropertyValue1() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse(
+            "%spark.pyspark(pool=\"value with = inside\")");
+    assertEquals("spark.pyspark", parseResult.getIntpText());
+    assertEquals(1, parseResult.getLocalProperties().size());
+    assertEquals("value with = inside", parseResult.getLocalProperties().get("pool"));
+    assertEquals("", parseResult.getScriptText());
+  }
+
+  @Test
+  public void testParagraphTextQuotedPropertyValue2() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse(
+            "%spark.pyspark(pool=\"value with \\\" inside\", p=\"eol\\ninside\" )");
+    assertEquals("spark.pyspark", parseResult.getIntpText());
+    assertEquals(2, parseResult.getLocalProperties().size());
+    assertEquals("value with \" inside", parseResult.getLocalProperties().get("pool"));
+    assertEquals("eol\ninside", parseResult.getLocalProperties().get("p"));
+    assertEquals("", parseResult.getScriptText());
+  }
+
+  @Test
+  public void testParagraphTextQuotedPropertyKeyAndValue() {
+    ParagraphTextParser.ParseResult parseResult = ParagraphTextParser.parse(
+            "%spark.pyspark(\"po ol\"=\"value with \\\" inside\")");
+    assertEquals("spark.pyspark", parseResult.getIntpText());
+    assertEquals(1, parseResult.getLocalProperties().size());
+    assertEquals("value with \" inside", parseResult.getLocalProperties().get("po ol"));
+    assertEquals("", parseResult.getScriptText());
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testParagraphTextUnfinishedConfig() {
+    exceptionRule.expect(RuntimeException.class);
+    exceptionRule.expectMessage(
+            "Problems by parsing paragraph. Not finished interpreter configuration");
+    ParagraphTextParser.parse("%spark.pyspark(pool=");
+  }
+
+  @Test
+  public void testParagraphTextUnfinishedQuote() {
+    exceptionRule.expect(RuntimeException.class);
+    exceptionRule.expectMessage(
+            "Problems by parsing paragraph. Not finished interpreter configuration");
+    ParagraphTextParser.parse("%spark.pyspark(pool=\"2314234) sc.version");
+  }
+
+  @Test
+  public void testParagraphTextUnclosedBackslash() {
+    exceptionRule.expect(RuntimeException.class);
+    exceptionRule.expectMessage(
+            "Problems by parsing paragraph. Unfinished escape sequence");
+    ParagraphTextParser.parse("%spark.pyspark(pool=\\");
+  }
+
+  @Test
+  public void testParagraphTextEmptyKey() {
+    exceptionRule.expect(RuntimeException.class);
+    exceptionRule.expectMessage(
+            "Problems by parsing paragraph. Local property key is empty");
+    ParagraphTextParser.parse("%spark.pyspark(pool=123, ,)");
   }
 }


### PR DESCRIPTION
### What is this PR for?

We can provide properties that are local to the paragraph, that could be used to pass an additional information for interpreter that could affect its behavior.  Unfortunately existing parsing functionality relies on the fact that key/value pairs need to be separated by `,` character, and doesn't handle values with special characters (`,`, `=`, ...) inside, like this:

```
%cassandra(locale=ruRU, timeFormat="E, d MMM yy", floatPrecision = 5, outputFormat=cql)
```

This PR changes the parsing logic to perform character-by-character parsing, and handling of the quoted keys & values, escaping of the special characters, etc.

### What type of PR is it?

Improvement 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4870

### How should this be tested?
* https://travis-ci.org/github/alexott/zeppelin/builds/697522260
* additional unit tests were added
