### PR TITLE
[ZEPPELIN-4756] Cassandra: Show "No Results" message folded

### DIFF
--- a/cassandra/src/main/resources/scalate/noResult.ssp
+++ b/cassandra/src/main/resources/scalate/noResult.ssp
@@ -17,8 +17,8 @@
 */
 --%>
 <div class="container">
-    <div class="row text-center">
-        <h4>No Result</h4>
+    <div class="row">
+        <h5>No Result</h5>
     </div>
     <br>
 </div>

--- a/cassandra/src/main/resources/scalate/noResultWithExecutionInfo.ssp
+++ b/cassandra/src/main/resources/scalate/noResultWithExecutionInfo.ssp
@@ -16,45 +16,57 @@
 * limitations under the License.
 */
 --%>
+#import(java.util.UUID)
+
+#import(com.datastax.oss.driver.api.core.uuid.Uuids)
+
+<%@ val execId: UUID = Uuids.random() %>
 <%@ val query: String%>
 <%@ val triedHosts: String%>
 <%@ val queriedHosts: String%>
 <%@ val schemaInAgreement: String%>
 <div class="container">
-<div class="row text-center">
-<h4>No Result</h4>
+<div class="row">
+  <h5>No Result &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <a role="button" data-toggle="collapse" data-target="#${execId}" aria-expanded="false">
+      <span class="text-info"><strong>Last query execution info</strong></span>
+    </a>
+  </h5>
 </div>
-<br/>
-    <div class="row">
-    <div class="col-md-3"></div>
-    <div class="col-md-6 col-offset-md-3 table-responsive table-bordered">
-        <table class="table">
-            <caption><h5>Last query execution info</h5></caption>
+<div class="panel panel-default">
+  <div id="${execId}" class="panel-collapse collapse" role="tabpanel">
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-md-3"></div>
+        <div class="col-md-6 col-offset-md-3 table-responsive table-bordered">
+          <table class="table">
             <thead>
-                <tr>
-                    <th>Info</th>
-                    <th>Value</th>
-                </tr>
+              <tr>
+                <th>Info</th>
+                <th>Value</th>
+              </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>Statement</td>
-                    <td>${query}</td>
-                </tr>
-                <tr>
-                    <td>Tried Hosts</td>
-                    <td>${triedHosts}</td>
-                </tr>
-                <tr>
-                    <td>Queried Hosts</td>
-                    <td>${queriedHosts}</td>
-                </tr>
-                <tr>
-                    <td>Schema in Agreement</td>
-                    <td>${schemaInAgreement}</td>
-                </tr>
+              <tr>
+                <td>Statement</td>
+                <td>${query}</td>
+              </tr>
+              <tr>
+                <td>Tried Hosts</td>
+                <td>${triedHosts}</td>
+              </tr>
+              <tr>
+                <td>Queried Hosts</td>
+                <td>${queriedHosts}</td>
+              </tr>
+              <tr>
+                <td>Schema in Agreement</td>
+                <td>${schemaInAgreement}</td>
+              </tr>
             </tbody>
-        </table>
+          </table>
+        </div>
+      </div>
     </div>
-    </div>
+  </div>
 </div>

--- a/cassandra/src/test/resources/scalate/NoResult.html
+++ b/cassandra/src/test/resources/scalate/NoResult.html
@@ -1,6 +1,6 @@
 <div class="container">
-    <div class="row text-center">
-        <h4>No Result</h4>
+    <div class="row">
+        <h5>No Result</h5>
     </div>
     <br>
 </div>

--- a/cassandra/src/test/resources/scalate/NoResultWithExecutionInfo.html
+++ b/cassandra/src/test/resources/scalate/NoResultWithExecutionInfo.html
@@ -1,1 +1,45 @@
-<div class="container"><div class="row text-center"><h4>No Result</h4></div><br/><div class="row"><div class="col-md-3"></div><div class="col-md-6 col-offset-md-3 table-responsive table-bordered"><table class="table"><caption><h5>Last query execution info</h5></caption><thead><tr><th>Info</th><th>Value</th></tr></thead><tbody><tr><td>Statement</td><td>CREATE TABLE IF NOT EXISTS no_select(id int PRIMARY KEY);</td></tr><tr><td>Tried Hosts</td><td>localhost:9142</td></tr><tr><td>Queried Hosts</td><td>localhost:9142</td></tr><tr><td>Schema in Agreement</td><td>true</td></tr></tbody></table></div></div></div>
+<div class="container">
+<div class="row">
+  <h5>No Result &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <a role="button" data-toggle="collapse" data-target="#72c620c4-bb6c-4a26-a604-ee10ae22c301" aria-expanded="false">
+      <span class="text-info"><strong>Last query execution info</strong></span>
+    </a>
+  </h5>
+</div>
+<div class="panel panel-default">
+  <div id="72c620c4-bb6c-4a26-a604-ee10ae22c301" class="panel-collapse collapse" role="tabpanel">
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-md-3"></div>
+        <div class="col-md-6 col-offset-md-3 table-responsive table-bordered">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Info</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Statement</td>
+                <td>CREATE TABLE IF NOT EXISTS no_select(id int PRIMARY KEY);</td>
+              </tr>
+              <tr>
+                <td>Tried Hosts</td>
+                <td>localhost:9142</td>
+              </tr>
+              <tr>
+                <td>Queried Hosts</td>
+                <td>localhost:9142</td>
+              </tr>
+              <tr>
+                <td>Schema in Agreement</td>
+                <td>true</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### What is this PR for?

Right now, when operation returns no results, for example, when executing most operations other than `SELECT` (DDL/INSERT/UPDATE/DELETE/...), interpreter shows the extended information - what hosts were used to execute command, etc. This information occupies a significant amount of the screen space and isn't critical for execution.

Given PR provides the same information but folds it by default, saving the screen space.

### What type of PR is it?
Improvement 


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4756

### How should this be tested?
* https://travis-ci.org/github/alexott/zeppelin/builds/698161348

### Screenshots (if appropriate)

Old view:

![Screen Shot 2020-04-15 at 08 47 20](https://user-images.githubusercontent.com/30342/84589948-aea70280-ae32-11ea-8839-d5585de2c47c.png)

New view:

![Screenshot from 2020-06-14 11-33-14](https://user-images.githubusercontent.com/30342/84589981-eb72f980-ae32-11ea-99e8-c6bb7ec54843.png)

![Screenshot from 2020-06-14 11-33-38](https://user-images.githubusercontent.com/30342/84589983-ee6dea00-ae32-11ea-8112-c3694e51a425.png)



