### PR TITLE
[ZEPPELIN-4885]. Add property to specify Module order of flink interpreter

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -202,6 +202,11 @@ You can also set other flink properties which are not listed in the table. For a
     <td>Hive version that you would like to connect</td>
   </tr>
   <tr>
+    <td>zeppelin.flink.module.enableHive</td>
+    <td>false</td>
+    <td>Whether enable hive module, hive udf take precedence over flink udf if hive module is enabled.</td>
+  </tr>
+  <tr>
     <td>zeppelin.flink.maxResult</td>
     <td>1000</td>
     <td>max number of row returned by sql interpreter</td>

--- a/flink/interpreter/src/main/resources/interpreter-setting.json
+++ b/flink/interpreter/src/main/resources/interpreter-setting.json
@@ -145,6 +145,13 @@
         "description": "Hive version that you would like to connect",
         "type": "string"
       },
+      "zeppelin.flink.module.enableHive": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": false,
+        "description": "Whether enable hive module, hive udf take precedence over flink udf if hive module is enabled.",
+        "type": "checkbox"
+      },
       "zeppelin.flink.printREPLOutput": {
         "envName": null,
         "propertyName": "zeppelin.flink.printREPLOutput",

--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -455,7 +455,9 @@ class FlinkScalaInterpreter(val properties: Properties) {
     this.btenv.registerCatalog("hive", hiveCatalog)
     this.btenv.useCatalog("hive")
     this.btenv.useDatabase(database)
-    this.btenv.loadModule("hive", new HiveModule(hiveVersion))
+    if (properties.getProperty("zeppelin.flink.module.enableHive", "false").toBoolean) {
+      this.btenv.loadModule("hive", new HiveModule(hiveVersion))
+    }
   }
 
   private def loadUDFJar(jar: String): Unit = {


### PR DESCRIPTION
### What is this PR for?

It is a trivial PR which add property `zeppelin.flink.module.enableHive` to control whether load hive udf first when there's same udf name in both hive and flink. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4885

### How should this be tested?
* CI pass, and manually tested.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
