### PR TITLE
[ZEPPELIN-4863]. User credential usage in jdbc interpreter doesn't work when the interpreter name is not jdbc

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -344,12 +344,12 @@ public class JDBCInterpreter extends KerberosInterpreter {
     }
   }
 
-  private String getEntityName(String replName) {
-    StringBuffer entityName = new StringBuffer();
-    entityName.append(INTERPRETER_NAME);
-    entityName.append(".");
-    entityName.append(replName);
-    return entityName.toString();
+  private String getEntityName(String replName, String propertyKey) {
+    if (propertyKey.equals("default")) {
+      return replName;
+    } else {
+      return replName + "." + propertyKey;
+    }
   }
 
   private String getJDBCDriverName(String user, String propertyKey) {
@@ -367,10 +367,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
   }
 
   private UsernamePassword getUsernamePassword(InterpreterContext interpreterContext,
-                                               String replName) {
+                                               String entity) {
     UserCredentials uc = interpreterContext.getAuthenticationInfo().getUserCredentials();
     if (uc != null) {
-      return uc.getUsernamePassword(replName);
+      return uc.getUsernamePassword(entity);
     }
     return null;
   }
@@ -413,7 +413,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     jdbcUserConfigurations.cleanUserProperty(propertyKey);
 
     UsernamePassword usernamePassword = getUsernamePassword(interpreterContext,
-            getEntityName(interpreterContext.getReplName()));
+            getEntityName(interpreterContext.getReplName(), propertyKey));
     if (usernamePassword != null) {
       jdbcUserConfigurations.setUserProperty(propertyKey, usernamePassword);
     } else {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
@@ -29,8 +29,11 @@ import org.apache.zeppelin.user.UsernamePassword;
  */
 public class JDBCUserConfigurations {
   private final Map<String, Statement> paragraphIdStatementMap;
+  // dbPrefix --> PoolingDriver
   private final Map<String, PoolingDriver> poolingDriverMap;
+  // dbPrefix --> Properties
   private final HashMap<String, Properties> propertiesMap;
+  // dbPrefix --> Boolean
   private HashMap<String, Boolean> isSuccessful;
 
   public JDBCUserConfigurations() {
@@ -52,40 +55,40 @@ public class JDBCUserConfigurations {
     isSuccessful.clear();
   }
 
-  public void setPropertyMap(String key, Properties properties) {
+  public void setPropertyMap(String dbPrefix, Properties properties) {
     Properties p = (Properties) properties.clone();
-    propertiesMap.put(key, p);
+    propertiesMap.put(dbPrefix, p);
   }
 
   public Properties getPropertyMap(String key) {
     return propertiesMap.get(key);
   }
 
-  public void cleanUserProperty(String propertyKey) {
-    propertiesMap.get(propertyKey).remove("user");
-    propertiesMap.get(propertyKey).remove("password");
+  public void cleanUserProperty(String dfPrefix) {
+    propertiesMap.get(dfPrefix).remove("user");
+    propertiesMap.get(dfPrefix).remove("password");
   }
 
-  public void setUserProperty(String propertyKey, UsernamePassword usernamePassword) {
-    propertiesMap.get(propertyKey).setProperty("user", usernamePassword.getUsername());
-    propertiesMap.get(propertyKey).setProperty("password", usernamePassword.getPassword());
+  public void setUserProperty(String dbPrefix, UsernamePassword usernamePassword) {
+    propertiesMap.get(dbPrefix).setProperty("user", usernamePassword.getUsername());
+    propertiesMap.get(dbPrefix).setProperty("password", usernamePassword.getPassword());
   }
 
-  public void saveStatement(String key, Statement statement) throws SQLException {
-    paragraphIdStatementMap.put(key, statement);
+  public void saveStatement(String paragraphId, Statement statement) throws SQLException {
+    paragraphIdStatementMap.put(paragraphId, statement);
   }
 
-  public void cancelStatement(String key) throws SQLException {
-    paragraphIdStatementMap.get(key).cancel();
+  public void cancelStatement(String paragraphId) throws SQLException {
+    paragraphIdStatementMap.get(paragraphId).cancel();
   }
 
-  public void removeStatement(String key) {
-    paragraphIdStatementMap.remove(key);
+  public void removeStatement(String paragraphId) {
+    paragraphIdStatementMap.remove(paragraphId);
   }
 
-  public void saveDBDriverPool(String key, PoolingDriver driver) throws SQLException {
-    poolingDriverMap.put(key, driver);
-    isSuccessful.put(key, false);
+  public void saveDBDriverPool(String dbPrefix, PoolingDriver driver) throws SQLException {
+    poolingDriverMap.put(dbPrefix, driver);
+    isSuccessful.put(dbPrefix, false);
   }
   public PoolingDriver removeDBDriverPool(String key) throws SQLException {
     isSuccessful.remove(key);
@@ -96,14 +99,7 @@ public class JDBCUserConfigurations {
     return poolingDriverMap.containsKey(key);
   }
 
-  public void setConnectionInDBDriverPoolSuccessful(String key) {
-    isSuccessful.put(key, true);
-  }
-
-  public boolean isConnectionInDBDriverPoolSuccessful(String key) {
-    if (isSuccessful.containsKey(key)) {
-      return isSuccessful.get(key);
-    }
-    return false;
+  public void setConnectionInDBDriverPoolSuccessful(String dbPrefix) {
+    isSuccessful.put(dbPrefix, true);
   }
 }

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -25,19 +25,19 @@
         "description": "The JDBC user password",
         "type": "password"
       },
-      "default.completer.ttlInSeconds": {
-        "envName": null,
-        "propertyName": "default.completer.ttlInSeconds",
-        "defaultValue": "120",
-        "description": "Time to live sql completer in seconds (-1 to update everytime, 0 to disable update)",
-        "type": "number"
-      },
       "default.driver": {
         "envName": null,
         "propertyName": "default.driver",
         "defaultValue": "org.postgresql.Driver",
         "description": "JDBC Driver Name",
         "type": "string"
+      },
+      "default.completer.ttlInSeconds": {
+        "envName": null,
+        "propertyName": "default.completer.ttlInSeconds",
+        "defaultValue": "120",
+        "description": "Time to live sql completer in seconds (-1 to update everytime, 0 to disable update)",
+        "type": "number"
       },
       "default.completer.schemaFilters": {
         "envName": null,

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -14,11 +14,12 @@
  */
 package org.apache.zeppelin.jdbc;
 
-import com.mockrunner.jdbc.BasicJDBCTestCaseAdapter;
-import net.jodah.concurrentunit.Waiter;
+
 import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
@@ -45,6 +46,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
+import com.mockrunner.jdbc.BasicJDBCTestCaseAdapter;
+import net.jodah.concurrentunit.Waiter;
+
 import static java.lang.String.format;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.COMMON_MAX_LINE;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_DRIVER;
@@ -55,11 +59,12 @@ import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_URL;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.DEFAULT_USER;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.PRECODE_KEY_TEMPLATE;
 import static org.apache.zeppelin.jdbc.JDBCInterpreter.STATEMENT_PRECODE_KEY_TEMPLATE;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 
 /**
  * JDBC interpreter unit tests.
@@ -116,21 +121,21 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     InterpreterContext interpreterContext = InterpreterContext.builder()
         .setLocalProperties(localProperties)
         .build();
-    assertEquals(JDBCInterpreter.DEFAULT_KEY, t.getPropertyKey(interpreterContext));
+    assertEquals(JDBCInterpreter.DEFAULT_KEY, t.getDBPrefix(interpreterContext));
 
     localProperties = new HashMap<>();
     localProperties.put("db", "mysql");
     interpreterContext = InterpreterContext.builder()
         .setLocalProperties(localProperties)
         .build();
-    assertEquals("mysql", t.getPropertyKey(interpreterContext));
+    assertEquals("mysql", t.getDBPrefix(interpreterContext));
 
     localProperties = new HashMap<>();
     localProperties.put("hive", "hive");
     interpreterContext = InterpreterContext.builder()
         .setLocalProperties(localProperties)
         .build();
-    assertEquals("hive", t.getPropertyKey(interpreterContext));
+    assertEquals("hive", t.getDBPrefix(interpreterContext));
   }
 
   @Test
@@ -270,7 +275,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     InterpreterResult interpreterResult = t.interpret(sqlQuery, context);
     List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
-    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertEquals(interpreterResult.toString(),
+            InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
     assertEquals("SOME_OTHER_NAME\na_name\n", resultMessages.get(0).getData());
   }
@@ -491,17 +497,21 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(true, completionList.contains(correctCompletionKeyword));
   }
 
-  private Properties getDBProperty(String dbUser,
+  private Properties getDBProperty(String dbPrefix,
+                                   String dbUser,
                                    String dbPassowrd) throws IOException {
     Properties properties = new Properties();
     properties.setProperty("common.max_count", "1000");
     properties.setProperty("common.max_retry", "3");
-    properties.setProperty("default.driver", "org.h2.Driver");
-    properties.setProperty("default.url", getJdbcConnection());
-    if (dbUser != null) {
+    if (!StringUtils.isBlank(dbPrefix)) {
+      properties.setProperty(dbPrefix + ".driver", "org.h2.Driver");
+      properties.setProperty(dbPrefix + ".url", getJdbcConnection());
+      properties.setProperty(dbPrefix + ".user", dbUser);
+      properties.setProperty(dbPrefix + ".password", dbPassowrd);
+    } else {
+      properties.setProperty("default.driver", "org.h2.Driver");
+      properties.setProperty("default.url", getJdbcConnection());
       properties.setProperty("default.user", dbUser);
-    }
-    if (dbPassowrd != null) {
       properties.setProperty("default.password", dbPassowrd);
     }
     return properties;
@@ -521,75 +531,95 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
   }
 
   @Test
-  public void testMultiTenant() throws IOException, InterpreterException {
-    /*
-     * assume that the database user is 'dbuser' and password is 'dbpassword'
-     * 'jdbc1' interpreter has user('dbuser')/password('dbpassword') property
-     * 'jdbc2' interpreter doesn't have user/password property
-     * 'user1' doesn't have Credential information.
-     * 'user2' has 'jdbc2' Credential information that is 'user2Id' / 'user2Pw' as id and password
-     */
+  public void testMultiTenant_1() throws IOException, InterpreterException {
+    // user1 %jdbc  select from default db
+    // user2 %jdbc  select from default db
+    // user2 %jdbc  select from from hive db
+    Properties properties = getDBProperty("default", "dbuser", "dbpassword");
+    properties.putAll(getDBProperty("hive", "", ""));
 
-    JDBCInterpreter jdbc1 = new JDBCInterpreter(getDBProperty("dbuser", "dbpassword"));
-    JDBCInterpreter jdbc2 = new JDBCInterpreter(getDBProperty("", ""));
-
+    JDBCInterpreter jdbc = new JDBCInterpreter(properties);
     AuthenticationInfo user1Credential = getUserAuth("user1", null, null, null);
-    AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.jdbc2", "user2Id", "user2Pw");
+    AuthenticationInfo user2Credential = getUserAuth("user2", "hive", "user2Id", "user2Pw");
+    jdbc.open();
 
-    // user1 runs jdbc1
-    jdbc1.open();
-    InterpreterContext ctx1 = InterpreterContext.builder()
-        .setAuthenticationInfo(user1Credential)
-        .setInterpreterOut(new InterpreterOutput(null))
-        .setReplName("jdbc1")
-        .build();
-    jdbc1.interpret("", ctx1);
+    // user1 runs default
+    InterpreterContext context = InterpreterContext.builder()
+            .setAuthenticationInfo(user1Credential)
+            .setInterpreterOut(new InterpreterOutput(null))
+            .setReplName("jdbc")
+            .build();
+    jdbc.interpret("", context);
 
-    JDBCUserConfigurations user1JDBC1Conf = jdbc1.getJDBCConfiguration("user1");
+    JDBCUserConfigurations user1JDBC1Conf = jdbc.getJDBCConfiguration("user1");
     assertEquals("dbuser", user1JDBC1Conf.getPropertyMap("default").get("user"));
     assertEquals("dbpassword", user1JDBC1Conf.getPropertyMap("default").get("password"));
-    jdbc1.close();
 
-    // user1 runs jdbc2
-    jdbc2.open();
-    InterpreterContext ctx2 = InterpreterContext.builder()
-        .setAuthenticationInfo(user1Credential)
-        .setReplName("jdbc2")
-        .build();
-    jdbc2.interpret("", ctx2);
-
-    JDBCUserConfigurations user1JDBC2Conf = jdbc2.getJDBCConfiguration("user1");
-    assertNull(user1JDBC2Conf.getPropertyMap("default").get("user"));
-    assertNull(user1JDBC2Conf.getPropertyMap("default").get("password"));
-    jdbc2.close();
-
-    // user2 runs jdbc1
-    jdbc1.open();
-    InterpreterContext ctx3 = InterpreterContext.builder()
-        .setAuthenticationInfo(user2Credential)
-        .setInterpreterOut(new InterpreterOutput(null))
-        .setReplName("jdbc1")
-        .build();
-    jdbc1.interpret("", ctx3);
-
-    JDBCUserConfigurations user2JDBC1Conf = jdbc1.getJDBCConfiguration("user2");
-    assertEquals("dbuser", user2JDBC1Conf.getPropertyMap("default").get("user"));
-    assertEquals("dbpassword", user2JDBC1Conf.getPropertyMap("default").get("password"));
-    jdbc1.close();
-
-    // user2 runs jdbc2
-    jdbc2.open();
-    InterpreterContext ctx4 = InterpreterContext.builder()
+    // user2 run default
+    context = InterpreterContext.builder()
         .setAuthenticationInfo(user2Credential)
         .setInterpreterOut(new InterpreterOutput(null))
         .setReplName("jdbc")
         .build();
-    jdbc2.interpret("", ctx4);
+    jdbc.interpret("", context);
 
-    JDBCUserConfigurations user2JDBC2Conf = jdbc2.getJDBCConfiguration("user2");
-    assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("jdbc2").get("user"));
-    assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("jdbc2").get("password"));
-    jdbc2.close();
+    JDBCUserConfigurations user2JDBC1Conf = jdbc.getJDBCConfiguration("user2");
+    assertEquals("dbuser", user2JDBC1Conf.getPropertyMap("default").get("user"));
+    assertEquals("dbpassword", user2JDBC1Conf.getPropertyMap("default").get("password"));
+
+    // user2 run hive
+    Map<String, String> localProperties = new HashMap<>();
+    localProperties.put("db", "hive");
+    context = InterpreterContext.builder()
+            .setAuthenticationInfo(user2Credential)
+            .setInterpreterOut(new InterpreterOutput(null))
+            .setLocalProperties(localProperties)
+            .setReplName("jdbc")
+            .build();
+    jdbc.interpret("", context);
+
+    user2JDBC1Conf = jdbc.getJDBCConfiguration("user2");
+    assertEquals("user2Id", user2JDBC1Conf.getPropertyMap("hive").get("user"));
+    assertEquals("user2Pw", user2JDBC1Conf.getPropertyMap("hive").get("password"));
+
+    jdbc.close();
+  }
+
+  @Test
+  public void testMultiTenant_2() throws IOException, InterpreterException {
+    // user1 %hive  select from default db
+    // user2 %hive  select from default db
+    Properties properties = getDBProperty("default", "", "");
+    JDBCInterpreter jdbc = new JDBCInterpreter(properties);
+    AuthenticationInfo user1Credential = getUserAuth("user1", "hive", "user1Id", "user1Pw");
+    AuthenticationInfo user2Credential = getUserAuth("user2", "hive", "user2Id", "user2Pw");
+    jdbc.open();
+
+    // user1 runs default
+    InterpreterContext context = InterpreterContext.builder()
+            .setAuthenticationInfo(user1Credential)
+            .setInterpreterOut(new InterpreterOutput(null))
+            .setReplName("hive")
+            .build();
+    jdbc.interpret("", context);
+
+    JDBCUserConfigurations user1JDBC1Conf = jdbc.getJDBCConfiguration("user1");
+    assertEquals("user1Id", user1JDBC1Conf.getPropertyMap("default").get("user"));
+    assertEquals("user1Pw", user1JDBC1Conf.getPropertyMap("default").get("password"));
+
+    // user2 run default
+    context = InterpreterContext.builder()
+            .setAuthenticationInfo(user2Credential)
+            .setInterpreterOut(new InterpreterOutput(null))
+            .setReplName("hive")
+            .build();
+    jdbc.interpret("", context);
+
+    JDBCUserConfigurations user2JDBC1Conf = jdbc.getJDBCConfiguration("user2");
+    assertEquals("user2Id", user2JDBC1Conf.getPropertyMap("default").get("user"));
+    assertEquals("user2Pw", user2JDBC1Conf.getPropertyMap("default").get("password"));
+
+    jdbc.close();
   }
 
   @Test

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -582,13 +582,13 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     InterpreterContext ctx4 = InterpreterContext.builder()
         .setAuthenticationInfo(user2Credential)
         .setInterpreterOut(new InterpreterOutput(null))
-        .setReplName("jdbc2")
+        .setReplName("jdbc")
         .build();
     jdbc2.interpret("", ctx4);
 
     JDBCUserConfigurations user2JDBC2Conf = jdbc2.getJDBCConfiguration("user2");
-    assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("default").get("user"));
-    assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("default").get("password"));
+    assertEquals("user2Id", user2JDBC2Conf.getPropertyMap("jdbc2").get("user"));
+    assertEquals("user2Pw", user2JDBC2Conf.getPropertyMap("jdbc2").get("password"));
     jdbc2.close();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -713,6 +713,16 @@ public class InterpreterSetting {
     return interpreterInfos;
   }
 
+  public String getInterpreterNameByClass(String className) {
+    for (InterpreterInfo interpreterInfo : this.interpreterInfos) {
+      if (interpreterInfo.getClassName().equals(className)) {
+        return interpreterInfo.getName();
+      }
+    }
+    LOGGER.warn("Unable to find interpreter name for class: " + className);
+    return "";
+  }
+
   void appendDependencies(List<Dependency> dependencies) {
     for (Dependency dependency : dependencies) {
       if (!this.dependencies.contains(dependency)) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -713,16 +713,6 @@ public class InterpreterSetting {
     return interpreterInfos;
   }
 
-  public String getInterpreterNameByClass(String className) {
-    for (InterpreterInfo interpreterInfo : this.interpreterInfos) {
-      if (interpreterInfo.getClassName().equals(className)) {
-        return interpreterInfo.getName();
-      }
-    }
-    LOGGER.warn("Unable to find interpreter name for class: " + className);
-    return "";
-  }
-
   void appendDependencies(List<Dependency> dependencies) {
     for (Dependency dependency : dependencies) {
       if (!this.dependencies.contains(dependency)) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -508,10 +508,6 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
       InterpreterSetting interpreterSetting = ((ManagedInterpreterGroup)
               interpreter.getInterpreterGroup()).getInterpreterSetting();
       replName = interpreterSetting.getName();
-      if (interpreterSetting.getInterpreterInfos().size() > 1) {
-        String interpreterName = interpreterSetting.getInterpreterNameByClass(this.interpreter.getClassName());
-        replName = replName + "." + interpreterName;
-      }
     }
 
     Credentials credentials = note.getCredentials();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -501,10 +501,17 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   private InterpreterContext getInterpreterContext() {
     AngularObjectRegistry registry = null;
     ResourcePool resourcePool = null;
-
+    String replName = null;
     if (this.interpreter != null) {
       registry = this.interpreter.getInterpreterGroup().getAngularObjectRegistry();
       resourcePool = this.interpreter.getInterpreterGroup().getResourcePool();
+      InterpreterSetting interpreterSetting = ((ManagedInterpreterGroup)
+              interpreter.getInterpreterGroup()).getInterpreterSetting();
+      replName = interpreterSetting.getName();
+      if (interpreterSetting.getInterpreterInfos().size() > 1) {
+        String interpreterName = interpreterSetting.getInterpreterNameByClass(this.interpreter.getClassName());
+        replName = replName + "." + interpreterName;
+      }
     }
 
     Credentials credentials = note.getCredentials();
@@ -523,7 +530,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
             .setNoteId(note.getId())
             .setNoteName(note.getName())
             .setParagraphId(getId())
-            .setReplName(intpText)
+            .setReplName(replName)
             .setParagraphTitle(title)
             .setParagraphText(text)
             .setAuthenticationInfo(subject)


### PR DESCRIPTION
### What is this PR for?
User credential only works in the default jdbc interpreter. If user create a new jdbc interpreter, e.g. hive, then credential won't work. This PR fix this and also do some code refactoring to make the jdbc interpreter module more readable. 


### What type of PR is it?
[Bug Fix  | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4863

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
