### PR TITLE
[ZEPPELIN-4892] Delete plugin dir in clean phase

### DIFF
--- a/zeppelin-plugins/pom.xml
+++ b/zeppelin-plugins/pom.xml
@@ -101,7 +101,7 @@
                                 <goal>copy-dependencies</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>${project.build.directory}/../../../../plugins/${plugin.name}</outputDirectory>
+                                <outputDirectory>${project.basedir}/../../../plugins/${plugin.name}</outputDirectory>
                                 <overWriteReleases>false</overWriteReleases>
                                 <overWriteSnapshots>false</overWriteSnapshots>
                                 <overWriteIfNewer>true</overWriteIfNewer>
@@ -115,7 +115,7 @@
                                 <goal>copy</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>${project.build.directory}/../../../../plugins/${plugin.name}</outputDirectory>
+                                <outputDirectory>${project.basedir}/../../../plugins/${plugin.name}</outputDirectory>
                                 <overWriteReleases>false</overWriteReleases>
                                 <overWriteSnapshots>false</overWriteSnapshots>
                                 <overWriteIfNewer>true</overWriteIfNewer>
@@ -127,6 +127,27 @@
                                         <type>${project.packaging}</type>
                                     </artifactItem>
                                 </artifactItems>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>delete-plugin-dir</id>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                            <phase>clean</phase>
+                            <configuration>
+                                <filesets>
+                                    <fileset>
+                                        <directory>${project.basedir}/../../../plugins/${plugin.name}</directory>
+                                        <followSymlinks>true</followSymlinks>
+                                        <useDefaultExcludes>false</useDefaultExcludes>
+                                    </fileset>
+                                </filesets>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
### What is this PR for?
This PR will delete the content of the plugin folders. Unfortunately the main folder is still present after a `mvn clean`


### What type of PR is it?
- Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4892

### How should this be tested?
* **Travis-CI:** https://travis-ci.org/github/Reamer/zeppelin/builds/699667326

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
