### PR TITLE
[ZEPPELIN-4899]. Injected variables in ZeppelinServer are lazy loaded

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -264,6 +264,11 @@ public class ZeppelinServer extends ResourceConfig {
 
     Runtime.getRuntime().addShutdownHook(shutdown(conf));
 
+    // Try to get Notebook from ServiceLocator, because Notebook instantiation is lazy, it is
+    // created when user open zeppelin in browser if we don't get it explicitly here.
+    // Lazy loading will cause paragraph recovery and cron job initialization is delayed.
+    sharedServiceLocator.getService(Notebook.class);
+
     // when zeppelin is started inside of ide (especially for eclipse)
     // for graceful shutdown, input any key in console window
     if (System.getenv("ZEPPELIN_IDENT_STRING") == null) {


### PR DESCRIPTION
### What is this PR for?

Trivial PR to create these injected variables when starting zeppelin server. Now these variables are
created when user open zeppelin in browser if we don't get it explicitly here.
Lazy loading will cause paragraph recovery and cron job initialization is delayed. 


### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4899

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
