### PR TITLE
[ZEPPELIN-4902] Pom cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1834,21 +1834,6 @@
         <curator.version>2.13.0</curator.version>
         <kerberos-client.version>2.0.0-M15</kerberos-client.version>
       </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-aws</artifactId>
-          <version>${hadoop.version}</version>
-          <scope>${hadoop.deps.scope}</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.directory.server</groupId>
-          <artifactId>kerberos-client</artifactId>
-          <version>${kerberos-client.version}</version>
-          <scope>${hadoop.deps.scope}</scope>
-        </dependency>
-      </dependencies>
     </profile>
 
   </profiles>

--- a/zeppelin-interpreter-integration/pom.xml
+++ b/zeppelin-interpreter-integration/pom.xml
@@ -56,35 +56,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.zeppelin</groupId>
-      <artifactId>zeppelin-zengine</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>20.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.zeppelin</groupId>
-      <artifactId>zeppelin-server</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -123,21 +97,52 @@
 
     <!--test libraries-->
     <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-zengine</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-server</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-server-tests</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeppelin-plugins/pom.xml
+++ b/zeppelin-plugins/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>zeppelin-zengine</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test libraries -->

--- a/zeppelin-plugins/pom.xml
+++ b/zeppelin-plugins/pom.xml
@@ -34,6 +34,10 @@
     <version>0.9.0-SNAPSHOT</version>
     <name>Zeppelin: Plugins Parent</name>
     <description>Zeppelin Plugins Parent</description>
+    <properties>
+        <!-- no need to include hadoop jar, because it's already included in zeppelin-zengine -->
+        <hadoop.deps.scope>provided</hadoop.deps.scope>
+    </properties>
 
     <modules>
         <module>notebookrepo/s3</module>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -249,10 +249,12 @@
       <artifactId>hadoop-client</artifactId>
     </dependency>
 
+    <!--test libraries-->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -260,6 +262,7 @@
       <artifactId>zeppelin-zengine</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -268,7 +271,6 @@
       </exclusions>
     </dependency>
 
-    <!--test libraries-->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -436,6 +436,17 @@
         </zeppelin.daemon.package.base>
       </properties>
     </profile>
+    <profile>
+      <id>hadoop3</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.directory.server</groupId>
+          <artifactId>kerberos-client</artifactId>
+          <version>${kerberos-client.version}</version>
+          <scope>${hadoop.deps.scope}</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
### What is this PR for?
This PR fixes the problem, that hadoop libraries are not in every submodule.

### What type of PR is it?
 - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4902

### How should this be tested?
* **Travis-CI**: https://travis-ci.org/github/Reamer/zeppelin/builds/700094748

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
