### PR TITLE
[ZEPPELIN-4924]. Add params to note run rest api

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/ParametersRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/ParametersRequest.java
@@ -23,14 +23,18 @@ import java.util.Map;
 import org.apache.zeppelin.common.JsonSerializable;
 
 /**
- * RunParagraphWithParametersRequest rest api request message.
+ * ParametersRequest rest api request message.
  */
-public class RunParagraphWithParametersRequest implements JsonSerializable {
-  private static final Gson gson = new Gson();
+public class ParametersRequest implements JsonSerializable {
+  private static final Gson GSON = new Gson();
 
-  Map<String, Object> params;
+  private Map<String, Object> params;
 
-  public RunParagraphWithParametersRequest() {
+  public ParametersRequest() {
+  }
+
+  public ParametersRequest(Map<String, Object> params) {
+    this.params = params;
   }
 
   public Map<String, Object> getParams() {
@@ -38,10 +42,10 @@ public class RunParagraphWithParametersRequest implements JsonSerializable {
   }
 
   public String toJson() {
-    return gson.toJson(this);
+    return GSON.toJson(this);
   }
 
-  public static RunParagraphWithParametersRequest fromJson(String json) {
-    return gson.fromJson(json, RunParagraphWithParametersRequest.class);
+  public static ParametersRequest fromJson(String json) {
+    return GSON.fromJson(json, ParametersRequest.class);
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -419,7 +420,7 @@ public class NotebookService {
       } else {
         try {
           // run note directly when parameter `paragraphs` is null.
-          note.runAll(context.getAutheInfo(), true, false);
+          note.runAll(context.getAutheInfo(), true, false, new HashMap<>());
           return true;
         } catch (Exception e) {
           LOGGER.warn("Fail to run note: " + note.getName(), e);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -447,7 +448,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
       String noteId = note.getId();
 
-      note.runAll(anonymous, true, false);
+      note.runAll(anonymous, true, false, new HashMap<>());
       // wait until job is finished or timeout.
       int timeout = 1;
       while (!paragraph.isTerminated()) {
@@ -509,7 +510,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
       String noteId = note.getId();
 
-      note.runAll(anonymous, true, false);
+      note.runAll(anonymous, true, false, new HashMap<>());
       // assume that status of the paragraph is running
       GetMethod get = httpGet("/notebook/job/" + noteId);
       assertThat("test get note job: ", get, isAllowed());
@@ -563,7 +564,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       TestUtils.getInstance(Notebook.class).saveNote(note, anonymous);
       String noteId = note.getId();
 
-      note.runAll(anonymous, true, false);
+      note.runAll(anonymous, true, false, new HashMap<>());
 
       // Call Run paragraph REST API
       PostMethod postParagraph = httpPost("/notebook/job/" + noteId + "/" + paragraph.getId(),
@@ -601,7 +602,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       config.put("enabled", true);
       paragraph.setConfig(config);
 
-      note.runAll(AuthenticationInfo.ANONYMOUS, false, false);
+      note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
 
       String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
       // right cron expression but not exist note.
@@ -651,7 +652,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       config.put("enabled", true);
       paragraph.setConfig(config);
 
-      note.runAll(AuthenticationInfo.ANONYMOUS, false, false);
+      note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
 
       String jsonRequest = "{\"cron\":\"* * * * * ?\" }";
       // right cron expression.
@@ -663,7 +664,7 @@ public class ZeppelinRestApiTest extends AbstractTestRestApi {
       System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName(), "/System");
 
       note.setName("System/test2");
-      note.runAll(AuthenticationInfo.ANONYMOUS, false, false);
+      note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
       postCron = httpPost("/notebook/cron/" + note.getId(), jsonRequest);
       assertThat("", postCron, isAllowed());
       postCron.releaseConnection();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
@@ -28,6 +28,8 @@ import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+
 /** Cron task for the note. */
 public class CronJob implements org.quartz.Job {
   private static final Logger LOGGER = LoggerFactory.getLogger(CronJob.class);
@@ -56,7 +58,7 @@ public class CronJob implements org.quartz.Job {
                     StringUtils.isEmpty(cronExecutingRoles) ? null : cronExecutingRoles,
                     null);
     try {
-      note.runAll(authenticationInfo, true, true);
+      note.runAll(authenticationInfo, true, true, new HashMap<>());
     } catch (Exception e) {
       LOGGER.warn("Fail to run note: " + note.getName(), e);
     }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -475,7 +475,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     p3.setText("%mock1 p3");
 
     // when
-    note.runAll(anonymous, true, false);
+    note.runAll(anonymous, true, false, new HashMap<>());
 
     assertEquals("repl1: p1", p1.getReturn().message().get(0).getData());
     assertNull(p2.getReturn());
@@ -829,7 +829,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     String simpleText = "hello world";
     p.setText(simpleText);
 
-    note.runAll(anonymous, true, false);
+    note.runAll(anonymous, true, false, new HashMap<>());
 
     String exportedNoteJson = notebook.exportNote(note.getId());
 
@@ -861,7 +861,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
     p.setText("hello world");
-    note.runAll(anonymous, true, false);
+    note.runAll(anonymous, true, false, new HashMap<>());
 
     p.setStatus(Status.RUNNING);
     Note cloneNote = notebook.cloneNote(note.getId(), "clone note", anonymous);
@@ -897,7 +897,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     for (InterpreterGroup intpGroup : interpreterSettingManager.getAllInterpreterGroup()) {
       intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
     }
-    note.runAll(anonymous, true, false);
+    note.runAll(anonymous, true, false, new HashMap<>());
 
     assertEquals(2, interpreterSettingManager.getAllResources().size());
 
@@ -1166,7 +1166,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     p3.setText("%mock1 sleep 1000");
 
 
-    note.runAll(AuthenticationInfo.ANONYMOUS, false, false);
+    note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
 
     // wait until first paragraph finishes and second paragraph starts
     while (p1.getStatus() != Status.FINISHED || p2.getStatus() != Status.RUNNING) Thread.yield();


### PR DESCRIPTION
### What is this PR for?

This PR add params to note run rest api, so that user can specify params for each note run. E.g. user can specify the date to run regular ETL job.

### What type of PR is it?
[Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4924

### How should this be tested?
* Unit test is added in `NotebookRestApiTest`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
