### PR TITLE
[ZEPPELIN-4926] Fix null pointer exception when the repository's url protocol is http

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositorySystemFactory.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositorySystemFactory.java
@@ -21,6 +21,7 @@ import org.apache.maven.repository.internal.DefaultServiceLocator;
 import org.apache.maven.wagon.Wagon;
 import org.apache.maven.wagon.providers.http.HttpWagon;
 import org.apache.maven.wagon.providers.http.LightweightHttpWagon;
+import org.apache.maven.wagon.providers.http.LightweightHttpWagonAuthenticator;
 import org.sonatype.aether.RepositorySystem;
 import org.sonatype.aether.connector.file.FileRepositoryConnectorFactory;
 import org.sonatype.aether.connector.wagon.WagonProvider;
@@ -48,7 +49,9 @@ public class RepositorySystemFactory {
     @Override
     public Wagon lookup(String roleHint) throws Exception {
       if ("http".equals(roleHint)) {
-        return new LightweightHttpWagon();
+        LightweightHttpWagon lightweightHttpWagon = new LightweightHttpWagon();
+        lightweightHttpWagon.setAuthenticator(new LightweightHttpWagonAuthenticator());
+        return lightweightHttpWagon;
       }
 
       if ("https".equals(roleHint)) {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/dep/DependencyResolverTest.java
@@ -86,6 +86,14 @@ public class DependencyResolverTest {
     assertEquals(testCopyPath.list().length, 3);
     FileUtils.cleanDirectory(testCopyPath);
 
+    // load from added http repository
+    resolver.addRepo("httpmvn",
+        "http://insecure.repo1.maven.org/maven2/", false);
+    resolver.load("com.databricks:spark-csv_2.10:1.3.0", testCopyPath);
+    assertEquals(testCopyPath.list().length, 4);
+    FileUtils.cleanDirectory(testCopyPath);
+    resolver.delRepo("httpmvn");
+
     // load from added repository
     resolver.addRepo("sonatype",
         "https://oss.sonatype.org/content/repositories/ksoap2-android-releases/", false);


### PR DESCRIPTION
### What is this PR for?
This PR is to fix null pointer exception when the interpreter repository's url protocol is http.

### What type of PR is it?
[ Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4926

### How should this be tested?
* Travis-CI : https://travis-ci.org/github/morningmemo/zeppelin
* Unit test is added.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO