### PR TITLE
[ZEPPELIN-4927]. Use the original order of interpreter properties from backend

### DIFF
--- a/zeppelin-web/src/app/interpreter/interpreter-create.html
+++ b/zeppelin-web/src/app/interpreter/interpreter-create.html
@@ -270,33 +270,33 @@ limitations under the License.
           <h5>Properties</h5>
           <table class="table table-striped properties">
             <tr>
-              <th>name</th>
-              <th>value</th>
-              <th>action</th>
-              <th>description</th>
+              <th style="width:25%;text-align: left">Name</th>
+              <th style="width:30%;text-align: left">Value</th>
+              <th style="width:30%;text-align: left">Description</th>
+              <th style="width:15%;text-align: right">Action</th>
             </tr>
-            <tr ng-repeat="key in newInterpreterSetting.properties | sortByKey">
-              <td>{{key}}</td>
-              <td style="vertical-align: middle;">
-                <textarea ng-if="newInterpreterSetting.properties[key].type === 'textarea'"
-                          msd-elastic ng-model="newInterpreterSetting.properties[key].value"></textarea>
-                <input ng-if="newInterpreterSetting.properties[key].type === 'string'"
-                       type="text" msd-elastic ng-model="newInterpreterSetting.properties[key].value" />
-                <input ng-if="newInterpreterSetting.properties[key].type === 'number'"
-                       type="text" number-widget msd-elastic ng-model="newInterpreterSetting.properties[key].value" />
-                <input ng-if="newInterpreterSetting.properties[key].type === 'url'"
-                       type="text" msd-elastic ng-model="newInterpreterSetting.properties[key].value" />
-                <input ng-if="newInterpreterSetting.properties[key].type === 'password'"
-                       type="password" msd-elastic ng-model="newInterpreterSetting.properties[key].value" />
-                <input ng-if="newInterpreterSetting.properties[key].type === 'checkbox'"
-                       type="checkbox" msd-elastic ng-model="newInterpreterSetting.properties[key].value" />
+            <tr ng-repeat="(key, property) in newInterpreterSetting.properties">
+              <td style="vertical-align: middle;text-align: left;">{{key}}</td>
+              <td style="vertical-align: middle;text-align: left;">
+                <textarea ng-if="property.type === 'textarea'"
+                          msd-elastic ng-model="property.value"></textarea>
+                <input ng-if="property.type === 'string'"
+                       type="text" msd-elastic ng-model="property.value" />
+                <input ng-if="property.type === 'number'"
+                       type="text" number-widget msd-elastic ng-model="property.value" />
+                <input ng-if="property.type === 'url'"
+                       type="text" msd-elastic ng-model="property.value" />
+                <input ng-if="property.type === 'password'"
+                       type="password" msd-elastic ng-model="property.value" />
+                <input ng-if="property.type === 'checkbox'"
+                       type="checkbox" msd-elastic ng-model="property.value" />
+              </td>
+              <td style="vertical-align: middle; text-align: left">
+                {{property.description}}
               </td>
               <td style="vertical-align: middle;">
                 <button class="btn btn-default btn-sm fa fa-remove" ng-click="removeInterpreterProperty(key)">
                 </button>
-              </td>
-              <td style="vertical-align: middle;">
-                {{newInterpreterSetting.properties[key].description}}
               </td>
             </tr>
 
@@ -329,9 +329,9 @@ limitations under the License.
           <h5>Dependencies</h5>
           <table class="table table-striped properties">
             <tr>
-              <th>artifact</th>
-              <th>exclude</th>
-              <th>action</th>
+              <th style="width:40%;text-align: left">Artifact</th>
+              <th style="width:40%;text-align: left">Exclude</th>
+              <th style="width:20%">Action</th>
             </tr>
 
             <tr ng-repeat="dep in newInterpreterSetting.dependencies">

--- a/zeppelin-web/src/app/interpreter/interpreter.html
+++ b/zeppelin-web/src/app/interpreter/interpreter.html
@@ -396,10 +396,10 @@ limitations under the License.
               <th style="width:25%;text-align: left">Name</th>
               <th style="width:30%;text-align: left">Value</th>
               <th style="width:30%;text-align: left">Description</th>
-              <th style="width:15%;text-align: left" ng-if="valueform.$visible">Action</th>
+              <th style="width:15%;text-align: right" ng-if="valueform.$visible">Action</th>
             </tr>
           </thead>
-          <tr ng-repeat="property in setting.properties" >
+          <tr ng-repeat="property in setting.properties">
             <td style="vertical-align: middle;text-align: left;">{{property.name}}</td>
             <td style="vertical-align: middle;text-align: left;">
               <span ng-if="property.type === 'textarea'"
@@ -475,9 +475,9 @@ limitations under the License.
         <table class="table table-striped">
           <thead>
             <tr>
-              <th style="width:40%">artifact</th>
-              <th style="width:40%">exclude</th>
-              <th style="width:20%" ng-if="valueform.$visible">action</th>
+              <th style="width:40%;text-align: left">Artifact</th>
+              <th style="width:40%;text-align: left">Exclude</th>
+              <th style="width:20%" ng-if="valueform.$visible">Action</th>
             </tr>
           </thead>
           <tr ng-repeat="dep in setting.dependencies">


### PR DESCRIPTION
### What is this PR for?

The interpreter properties returned from backend is already ordered as the ordering of `interpreter-setting.json`, frontend should not order it again by alphabeta. We already fix it in the interpreter listing page, but didn't fix it in the creating interpreter page. This PR fix that. 

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4927

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

Before
![image](https://user-images.githubusercontent.com/164491/85970182-34fb4100-b9fc-11ea-8b9c-78a40f5f0ddc.png)


After
![image](https://user-images.githubusercontent.com/164491/85970164-290f7f00-b9fc-11ea-955b-c9a69a58a3ec.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
