### PR TITLE
[ZEPPELIN-4911]. [dynamic_form] form name or display name not rendered in zeppelin ui

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -290,7 +290,11 @@ public class Input<T> implements Serializable {
       throw new RuntimeException("Could not recognize dynamic form with type: " + type);
     }
     input.setArgument(arg);
-    input.setDisplayName(displayName);
+    if (!StringUtils.isBlank(displayName)) {
+      // only set displayName when it is not empty (user explicitly specify it)
+      // e.g. ${name(display_name)=value)
+      input.setDisplayName(displayName);
+    }
     input.setHidden(hidden);
     return input;
   }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
@@ -42,7 +42,7 @@ public class InputTest {
     assertEquals(1, forms.size());
     Input form = forms.get("input_form");
     assertEquals("input_form", form.name);
-    assertNull(form.displayName);
+    assertEquals("input_form", form.displayName);
     assertEquals("", form.defaultValue);
     assertTrue(form instanceof TextBox);
 
@@ -78,6 +78,7 @@ public class InputTest {
     script = "${checkbox:checkbox_form=op1,op1|op2|op3}";
     form = Input.extractSimpleQueryForm(script, false).get("checkbox_form");
     assertEquals("checkbox_form", form.name);
+    assertEquals("checkbox_form", form.displayName);
     assertTrue(form instanceof CheckBox);
 
     assertArrayEquals(new Object[]{"op1"}, (Object[]) form.defaultValue);


### PR DESCRIPTION

### What is this PR for?

form name is not rendered in frontend because displayName is not set correctly. This PR fix it in `Input.java`

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4911

### How should this be tested?
* Unit test is added

### Screenshots (if appropriate)

Before
![image](https://user-images.githubusercontent.com/164491/86019263-f778d100-ba58-11ea-970c-f078e799dce7.png)

After
![image](https://user-images.githubusercontent.com/164491/86019302-0069a280-ba59-11ea-86e3-5681c254ea26.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
