### PR TITLE
[ZEPPELIN-4925]. Only display note job info for owner

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/JobManagerService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/JobManagerService.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.service;
 import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Service class for JobManager Page
@@ -40,11 +42,15 @@ public class JobManagerService {
   private static final Logger LOGGER = LoggerFactory.getLogger(JobManagerService.class);
 
   private Notebook notebook;
+  private AuthorizationService authorizationService;
   private ZeppelinConfiguration conf;
 
   @Inject
-  public JobManagerService(Notebook notebook, ZeppelinConfiguration conf) {
+  public JobManagerService(Notebook notebook,
+                           AuthorizationService authorizationService,
+                           ZeppelinConfiguration conf) {
     this.notebook = notebook;
+    this.authorizationService = authorizationService;
     this.conf = conf;
   }
 
@@ -76,12 +82,12 @@ public class JobManagerService {
       return new ArrayList<>();
     }
     List<NoteJobInfo> notesJobInfo = new ArrayList<>();
-    notebook.getNoteStream().forEach(note -> {
-      NoteJobInfo noteJobInfo = new NoteJobInfo(note);
-      if (noteJobInfo.unixTimeLastRun > lastUpdateServerUnixTime) {
-        notesJobInfo.add(noteJobInfo);
-      }
-    });
+    notebook.getNoteStream()
+            .filter(note -> authorizationService.isOwner(context.getUserAndRoles(), note.getId()))
+            .map(note -> new NoteJobInfo(note))
+            .filter(noteJobInfo -> noteJobInfo.unixTimeLastRun > lastUpdateServerUnixTime)
+            .collect(Collectors.toList());
+
     callback.onSuccess(notesJobInfo, context);
     return notesJobInfo;
   }
@@ -107,7 +113,9 @@ public class JobManagerService {
     }
   }
 
-
+  /**
+   * Job info about one paragraph run
+   */
   public static class ParagraphJobInfo {
     private String id;
     private String name;
@@ -124,10 +132,16 @@ public class JobManagerService {
     }
   }
 
+  /**
+   * Job info about note run, including all the job infos of paragraph run.
+   */
   public static class NoteJobInfo {
     private String noteId;
     private String noteName;
     private String noteType;
+    /**
+     * default interpreterGroup.
+     */
     private String interpreter;
     private boolean isRunningJob;
     private boolean isRemoved = false;


### PR DESCRIPTION
### What is this PR for?

This PR only display note job when the login user is the owner, because it doesn't make sense to list all notes for everyone.

### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4925

### How should this be tested?
* CI pass

https://travis-ci.org/github/zjffdu/zeppelin/builds/703178662

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
