### PR TITLE
[ZEPPELIN-4930]. User can restart interpreter in notebook without running permissions

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
@@ -342,7 +342,7 @@ public class AuthorizationService implements ClusterEventListener {
     if (userAndRoles == null) {
       return false;
     }
-    return isReader(noteId, userAndRoles);
+    return isRunner(noteId, userAndRoles);
   }
 
   public boolean isPublic() {


### PR DESCRIPTION

### What is this PR for?

Before this PR, you can restart the interpreter in note page even if you don't have run permission. This PR would check the permission before restarting interpreter.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4930

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/86253513-3b99dc00-bbe7-11ea-8fca-420c1b437d30.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
