### PR TITLE
[ZEPPELIN-4934] add jars to sys.path as done in pyspark shell

### DIFF
--- a/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
@@ -73,3 +73,8 @@ class IPySparkZeppelinContext(PyZeppelinContext):
             super(IPySparkZeppelinContext, self).show(obj, **kwargs)
 
 z = __zeppelin__ = IPySparkZeppelinContext(intp.getZeppelinContext(), gateway)
+
+# add jars to path
+import sys
+jarlist = map(lambda url: url.replace("file:/", "/"), sc.getConf().get("spark.jars").split(","))
+sys.path.extend(filter(lambda jar: jar not in sys.path, jarlist))

--- a/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_ipyspark.py
@@ -76,5 +76,5 @@ z = __zeppelin__ = IPySparkZeppelinContext(intp.getZeppelinContext(), gateway)
 
 # add jars to path
 import sys
-jarlist = map(lambda url: url.replace("file:/", "/"), sc.getConf().get("spark.jars").split(","))
+jarlist = map(lambda url: url.replace("file:/", "/"), (conf.get("spark.jars") or "").split(","))
 sys.path.extend(filter(lambda jar: jar not in sys.path, jarlist))

--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -74,5 +74,5 @@ __zeppelin__._setup_matplotlib()
 
 # add jars to path
 import sys
-jarlist = map(lambda url: url.replace("file:/", "/"), sc.getConf().get("spark.jars").split(","))
+jarlist = map(lambda url: url.replace("file:/", "/"), (conf.get("spark.jars") or "").split(","))
 sys.path.extend(filter(lambda jar: jar not in sys.path, jarlist))

--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -71,3 +71,8 @@ class PySparkZeppelinContext(PyZeppelinContext):
 
 z = __zeppelin__ = PySparkZeppelinContext(intp.getZeppelinContext(), gateway)
 __zeppelin__._setup_matplotlib()
+
+# add jars to path
+import sys
+jarlist = map(lambda url: url.replace("file:/", "/"), sc.getConf().get("spark.jars").split(","))
+sys.path.extend(filter(lambda jar: jar not in sys.path, jarlist))

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -1026,6 +1026,7 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
   @Test
   public void testConfInterpreter() throws IOException {
     Note note = null;
+    Note note2 = null;
     try {
       TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
       note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
@@ -1038,9 +1039,32 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       p1.setText("%spark\nimport com.databricks.spark.csv._");
       note.run(p1.getId(), true);
       assertEquals(Status.FINISHED, p1.getStatus());
+
+      // test pyspark imports
+      TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
+      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
+      Paragraph p2 = note2.addNewParagraph(anonymous);
+      p2.setText("%spark.conf spark.jars.packages\tcom.microsoft.ml.spark:mmlspark_2.11:1.0.0-rc1\nspark.jars.repositories\thttps://mmlspark.azureedge.net/maven");
+      note2.run(p2.getId(), true);
+      assertEquals(Status.FINISHED, p2.getStatus());
+
+      Paragraph p3 = note2.addNewParagraph(anonymous);
+      p3.setText("%spark.pyspark\nimport mmlspark");
+      note2.run(p3.getId(), true);
+      assertEquals(Status.FINISHED, p3.getStatus());
+
+
+      Paragraph p4 = note2.addNewParagraph(anonymous);
+      p4.setText("%spark.ipyspark\nimport mmlspark");
+      note2.run(p4.getId(), true);
+      assertEquals(Status.FINISHED, p4.getStatus());
+
     } finally {
       if (null != note) {
         TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      }
+      if (null != note2) {
+        TestUtils.getInstance(Notebook.class).removeNote(note2, anonymous);
       }
     }
   }

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -1044,7 +1044,7 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
       note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
       Paragraph p2 = note2.addNewParagraph(anonymous);
-      p2.setText("%spark.conf spark.jars.packages\tcom.microsoft.ml.spark:mmlspark_2.11:1.0.0-rc1\nspark.jars.repositories\thttps://mmlspark.azureedge.net/maven");
+      p2.setText("%spark.conf spark.jars.packages\tAzure:mmlspark:0.17\nspark.jars.repositories\thttps://mmlspark.azureedge.net/maven");
       note2.run(p2.getId(), true);
       assertEquals(Status.FINISHED, p2.getStatus());
 

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -1026,7 +1026,6 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
   @Test
   public void testConfInterpreter() throws IOException {
     Note note = null;
-    Note note2 = null;
     try {
       TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
       note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
@@ -1040,31 +1039,22 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       note.run(p1.getId(), true);
       assertEquals(Status.FINISHED, p1.getStatus());
 
-      // test pyspark imports
-      TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
-      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
-      Paragraph p2 = note2.addNewParagraph(anonymous);
-      p2.setText("%spark.conf spark.jars.packages\tAzure:mmlspark:0.17\nspark.jars.repositories\thttps://mmlspark.azureedge.net/maven");
-      note2.run(p2.getId(), true);
+      // test pyspark imports path
+      Paragraph p2 = note.addNewParagraph(anonymous);
+      p2.setText("%spark.pyspark\nimport sys\nsys.path");
+      note.run(p2.getId(), true);
       assertEquals(Status.FINISHED, p2.getStatus());
+      assertTrue(p2.getReturn().toString().contains("databricks_spark"));
 
-      Paragraph p3 = note2.addNewParagraph(anonymous);
-      p3.setText("%spark.pyspark\nimport mmlspark");
-      note2.run(p3.getId(), true);
+      Paragraph p3 = note.addNewParagraph(anonymous);
+      p3.setText("%spark.ipyspark\nimport sys\nsys.path");
+      note.run(p3.getId(), true);
       assertEquals(Status.FINISHED, p3.getStatus());
-
-
-      Paragraph p4 = note2.addNewParagraph(anonymous);
-      p4.setText("%spark.ipyspark\nimport mmlspark");
-      note2.run(p4.getId(), true);
-      assertEquals(Status.FINISHED, p4.getStatus());
+      assertTrue(p3.getReturn().toString().contains("databricks_spark"));
 
     } finally {
       if (null != note) {
         TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
-      }
-      if (null != note2) {
-        TestUtils.getInstance(Notebook.class).removeNote(note2, anonymous);
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

Some jars include python code. These must be added to sys.path to support importing those packages in python.

pyspark include these jars to the path at context initialization. From the spark repo see:

* core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
* python/pyspark/context.py
* python/pyspark/shell.py

In pyspark, the jars passed with "–packages" are passed onto "spark.submit.pyFiles" (in prepareSubmitEnvironment function) and then added to sys.path by the context initialization.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4934

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
