### PR TITLE
[ZEPPELIN-4938] Allow execution of arbitrary CQL commands

### DIFF
--- a/cassandra/src/main/scala/org/apache/zeppelin/cassandra/ParagraphParser.scala
+++ b/cassandra/src/main/scala/org/apache/zeppelin/cassandra/ParagraphParser.scala
@@ -71,7 +71,7 @@ object ParagraphParser {
 
   val GENERIC_STATEMENT_PREFIX: Regex =
     """(?is)\s*(?:INSERT|UPDATE|DELETE|SELECT|CREATE|ALTER|
-      |DROP|GRANT|REVOKE|TRUNCATE|LIST|USE)\s+""".r
+      |DROP|GRANT|REVOKE|TRUNCATE|LIST|USE|[a-z]\w+)\s+""".r
 
   val VALID_IDENTIFIER = "[a-z][a-z0-9_]*"
 


### PR DESCRIPTION
### What is this PR for?

Right now, Cassandra interpreter is very restrictive & allows execution only of the predefined set of the commands, and this doesn't allow to execute CQL commands that are extension of the core of CQL.  This also may require additional changes in the Cassandra interpreter if language will be extended.  This PR allows to execute any command, not only hardcoded.

### What type of PR is it?
Improvement 

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4938

### How should this be tested?
*  Tested manually
* https://travis-ci.org/github/alexott/zeppelin/jobs/705358648
