### PR TITLE
[ZEPPELIN-4935]. IRInterpreter is broken due to missing of hadoop jars

### DIFF
--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -110,6 +110,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>2.7.7</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>


### PR DESCRIPTION
### What is this PR for?

Trivial PR to add hadoop jars to rlang module, otherwise IRInterpreter won't work because IRInterpreter depends on SparkBackend to communicate between R process and Java process. and SparkBackend depends on hadoop jar.

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4935

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
