### PR TITLE
[Hot Fix][zeppelin-distribution] fix the tag-name 'paht'->'path' in zeppelin-distribution/pom.xml

### DIFF
--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -378,7 +378,7 @@
                         <path>${deb.conf.path}</path>
                         <path>${deb.log.path}</path>
                         <path>${deb.pid.path}</path>
-                        <paht>${deb.notebook.path}</paht>
+                        <path>${deb.notebook.path}</path>
                       </paths>
                     </data>
                   </dataSet>


### PR DESCRIPTION
### What is this PR for?
fix the tag-name `'paht'`->`'path'` in zeppelin-distribution/pom.xml


### What type of PR is it?
[Hot Fix]

### Todos
None.

### What is the Jira issue?
* None.

### How should this be tested?
* None.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?  no.
* Is there breaking changes for older versions? no.
* Does this needs documentation?  no.
