### PR TITLE
[ZEPPELIN-4943]. Support hdfs jars for flink.execution.jars & flink.udf.jars

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -148,7 +148,7 @@ You can also add and set other flink properties which are not listed in the tabl
   <tr>
     <td>flink.udf.jars</td>
     <td></td>
-    <td>Flink udf jars (comma separated), zeppelin will register udf in this jar automatically for user. The udf name is the class name.</td>
+    <td>Flink udf jars (comma separated), zeppelin will register udf in this jar automatically for user. These udf jars could be either local files or hdfs files if you have hadoop installed. The udf name is the class name.</td>
   </tr>
   <tr>
     <td>flink.udf.jars.packages</td>
@@ -158,7 +158,7 @@ You can also add and set other flink properties which are not listed in the tabl
   <tr>
     <td>flink.execution.jars</td>
     <td></td>
-    <td>Additional user jars (comma separated)</td>
+    <td>Additional user jars (comma separated), these jars could be either local files or hdfs files if you have hadoop installed.</td>
   </tr>
   <tr>
     <td>flink.execution.packages</td>

--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.zeppelin.flink;
 
+import com.google.common.io.Files;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -29,6 +30,7 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -64,5 +66,14 @@ public class HadoopUtils {
     } catch (IOException e){
         LOGGER.warn("Failed to cleanup staging dir", e);
     }
+  }
+
+  public static String downloadJar(String jarOnHdfs) throws IOException {
+    File tmpDir = Files.createTempDir();
+    FileSystem fs = FileSystem.get(new Configuration());
+    Path sourcePath = fs.makeQualified(new Path(jarOnHdfs));
+    Path destPath = new Path(tmpDir.getAbsolutePath() + "/" + sourcePath.getName());
+    fs.copyToLocalFile(sourcePath, destPath);
+    return new File(destPath.toString()).getAbsolutePath();
   }
 }

--- a/flink/interpreter/src/main/resources/interpreter-setting.json
+++ b/flink/interpreter/src/main/resources/interpreter-setting.json
@@ -107,7 +107,7 @@
         "envName": null,
         "propertyName": null,
         "defaultValue": "",
-        "description": "Flink udf jars (comma separated), Zeppelin will register udfs in this jar for user automatically",
+        "description": "Flink udf jars (comma separated), Zeppelin will register udfs in this jar for user automatically, these udf jars could be either local files or hdfs files if you have hadoop installed, the udf name is the class name",
         "type": "string"
       },
       "flink.udf.jars.packages": {
@@ -121,7 +121,7 @@
         "envName": null,
         "propertyName": null,
         "defaultValue": "",
-        "description": "Additional user jars (comma separated)",
+        "description": "Additional user jars (comma separated), these jars could be either local files or hdfs files if you have hadoop installed",
         "type": "string"
       },
       "flink.execution.packages": {


### PR DESCRIPTION
### What is this PR for?

This PR is to support using hdfs jars for `flink.execution.jars` and `flink.udf.jars`. So that user don't need to copy jars to the zeppelin machine in case that they don't have permission to do that.

### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4943

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/87223352-c4b2cf00-c3ae-11ea-801f-aa92b0c5f1b3.png)

![image](https://user-images.githubusercontent.com/164491/87223353-c9778300-c3ae-11ea-9e3d-4f2fbbb9fc4e.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
