### PR TITLE
[ZEPPELIN-4951]. Set paragraph status to be abort when recovery is disabled

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -129,7 +129,7 @@ public class Note implements JsonSerializable {
   private transient ParagraphJobListener paragraphJobListener;
   private transient List<NoteEventListener> noteEventListeners = new ArrayList<>();
   private transient Credentials credentials;
-
+  private transient ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
 
   public Note() {
     generateId();
@@ -148,7 +148,7 @@ public class Note implements JsonSerializable {
     this.version = Util.getVersion();
     generateId();
 
-    setCronSupported(ZeppelinConfiguration.create());
+    setCronSupported(zConf);
   }
 
   public Note(NoteInfo noteInfo) {
@@ -1130,6 +1130,9 @@ public class Note implements JsonSerializable {
       p.setAuthenticationInfo(AuthenticationInfo.ANONYMOUS);
 
       if (p.getStatus() == Status.PENDING) {
+        p.setStatus(Status.ABORT);
+      }
+      if (p.getStatus() == Status.RUNNING && !zConf.isRecoveryEnabled()) {
         p.setStatus(Status.ABORT);
       }
 


### PR DESCRIPTION

### What is this PR for?

A simple PR which set paragraph status to be abort when loading note and recovery is disabled. Otherwise we would see paragraph is in running state and we are unable to abort it because we have lost the connection to the interpreter process when recovery is disabled. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4951

### How should this be tested?
* CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
