### PR TITLE
[ZEPPELIN-4963] Fix typo in pom.xml

### DIFF
--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -37,7 +37,7 @@
         <spark.version>2.4.5</spark.version>
         <spark.scala.binary.version>2.11</spark.scala.binary.version>
         <spark.scala.version>2.11.12</spark.scala.version>
-        <saprk.scala.compile.version>${spark.scala.binary.version}</saprk.scala.compile.version>
+        <spark.scala.compile.version>${spark.scala.binary.version}</spark.scala.compile.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What is this PR for?
Fixes typo (replaced saprk to spark) in spark/spark-scala-parent/pom.xml

### What type of PR is it?
Bug Fix

### Todos
None

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-4963

### How should this be tested?
I think the existing CI tests would be enough.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
