### PR TITLE
avoiding retrieving and redrawing the note on websocket reconnect

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -308,6 +308,9 @@ public class NotebookServer extends WebSocketServlet
         case GET_NOTE:
           getNote(conn, messagereceived);
           break;
+        case REFRESH_NOTE_CONNECTION:
+          refreshNoteConnection(conn, messagereceived);
+          break;
         case NEW_NOTE:
           createNote(conn, messagereceived);
           break;
@@ -823,6 +826,21 @@ public class NotebookServer extends WebSocketServlet
             conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
             updateAngularObjectRegistry(conn, note);
             sendAllAngularObjects(note, context.getAutheInfo().getUser(), conn);
+          }
+        });
+  }
+
+  private void refreshNoteConnection(NotebookSocket conn, Message fromMessage) throws IOException {
+    String noteId = (String) fromMessage.get("id");
+    if (noteId == null) {
+      return;
+    }
+    getNotebookService().getNote(noteId, getServiceContext(fromMessage),
+        new WebSocketServiceCallback<Note>(conn) {
+          @Override
+          public void onSuccess(Note note, ServiceContext context) throws IOException {
+            getConnectionManager().addNoteConnection(note.getId(), conn);
+            conn.send(serializeMessage(new Message(OP.NOTE).put("note", note)));
           }
         });
   }

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -107,7 +107,7 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
 
   $scope.$on('setConnectedStatus', function(event, param) {
     if (connectedOnce && param) {
-      initNotebook();
+      websocketMsgSrv.refreshNote($routeParams.noteId);
     }
     connectedOnce = true;
   });

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -81,6 +81,10 @@ function WebsocketMessageService($rootScope, websocketEvents) {
       websocketEvents.sendNewEvent({op: 'GET_NOTE', data: {id: noteId}});
     },
 
+    refreshNote: function(noteId) {
+      websocketEvents.sendNewEvent({op: 'REFRESH_NOTE_CONNECTION', data: {id: noteId}});
+    },
+
     updateNote: function(noteId, noteName, noteConfig) {
       websocketEvents.sendNewEvent({op: 'NOTE_UPDATE', data: {id: noteId, name: noteName, config: noteConfig}});
     },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/socket/Message.java
@@ -39,6 +39,9 @@ public class Message implements JsonSerializable {
     GET_NOTE,         // [c-s] client load note
                       // @param id note id
 
+    REFRESH_NOTE_CONNECTION,         // [c-s] client load note
+                      // @param id note id
+                  
     NOTE,             // [s-c] note info
                       // @param note serialized Note object
 


### PR DESCRIPTION
### What is this PR for?
Currently, when the websocket reconnects GET_NOTE is called. The purpose of this call on reconnect is to add the note back to the NoteSocketMap (see discussion here: https://github.com/apache/zeppelin/pull/213).

However, GET_NOTE also does two other things:
1. It retrieves the note from storage and
2. Sends that note back to the browser where it is redrawn.

Doing this causes issues for our users:
1. The retrieval of the note means that any work done since the note was last saved will be lost. Notes save often, but we've had users complain about this.
2. The redraw causes the cursor to jump back to the beginning of the line.
3. In our environment, the redraw causes the notebook to scroll down.

This PR creates a new request that will be called instead of GET_NOTE. The purpose of this new request is to simply put the note back into the NoteSocketMap so that we can continue working.


### What type of PR is it?
Improvement

### Todos
None

### What is the Jira issue?
None

### How should this be tested?
* Open a notebook, wait for the websocket to reconnect, ensure that you can still do everything you should be able to do.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

