### PR TITLE
[ZEPPELIN-4968] Provide commented out config for helium registry

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -401,6 +401,14 @@
   <description>Remote Yarn package installer url for Helium dependency loader</description>
 </property>
 
+<!--
+<property>
+  <name>zeppelin.helium.registry</name>
+  <value>helium,https://s3.amazonaws.com/helium-package/helium.json</value>
+  <description>Location of external Helium Registry</description>
+</property>
+-->
+
 <property>
   <name>zeppelin.interpreter.group.default</name>
   <value>spark</value>


### PR DESCRIPTION
### What is this PR for?

It adds commented-out configuration parameter for Helium registry, so people can simply uncomment it, instead of going to docs, and copy/paste from it.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4968

### How should this be tested?
* tested manually

