### PR TITLE
[ZEPPELIN-4967]. hive dialect doesn't work in flink interpreter

### DIFF
--- a/flink/interpreter/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/interpreter/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -482,6 +482,9 @@ public abstract class SqlInterpreterTest {
               "set table.sql-dialect=hive", context);
       assertEquals(context.out.toString(), InterpreterResult.Code.SUCCESS, result.code());
 
+      sqlInterpreter.interpret("create table test_hive_table(a string, b int)\n" +
+              "partitioned by (dt string)", context);
+      assertEquals(context.out.toString(), InterpreterResult.Code.SUCCESS, result.code());
     } else {
       // Flink1.10 doesn't support set table.sql-dialet which is introduced in flink 1.11
       InterpreterContext context = getInterpreterContext();


### PR DESCRIPTION
### What is this PR for?

The root cause is that we only set table config in select and insert statement, but setting dialect is for DDL. This PR remove the paragraph configuration setting, instead would set table config in global scope.

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4967

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
