### PR TITLE
[ZEPPELIN-4988] fix bug when running zeppelin on the machine where k8s is installed

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -809,7 +809,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
   public RUN_MODE getRunMode() {
     String mode = getString(ConfVars.ZEPPELIN_RUN_MODE);
     if ("auto".equalsIgnoreCase(mode)) { // auto detect
-      if (new File("/var/run/secrets/kubernetes.io").exists()) {
+      if (new File("/var/run/secrets/kubernetes.io/serviceaccount/namespace").exists()) {
         return RUN_MODE.K8S;
       } else {
         return RUN_MODE.LOCAL;

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -63,7 +63,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
    * @return
    */
   boolean isRunningOnKubernetes() {
-    return new File("/var/run/secrets/kubernetes.io").exists();
+    return new File(Config.KUBERNETES_NAMESPACE_PATH).exists();
   }
 
   /**


### PR DESCRIPTION
### What is this PR for?
solve a issue mentioned in [ZEPPELIN-4988](https://issues.apache.org/jira/browse/ZEPPELIN-4988)


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* [ZEPPELIN-4988](https://issues.apache.org/jira/browse/ZEPPELIN-4988)

### How should this be tested?
* covered by the existed unit tests
* travis-ci: https://travis-ci.org/github/zhoulii/zeppelin/builds/715721363
* manually test: run zeppelin on a k8s node, the exception in [ZEPPELIN-4988](https://issues.apache.org/jira/browse/ZEPPELIN-4988) does not appear

### Questions:
* Does the licenses files need update? **NO**
* Is there breaking changes for older versions? **NO**
* Does this needs documentation? **NO**
