### PR TITLE
ZEPPELIN-4992 Editor settings are being set to the default interpreter regardless of the interpreter specified in the paragraph.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -594,7 +594,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
             if (interpreterSetting == null) {
               return DEFAULT_EDITOR;
             }
-            return interpreterSetting.getDefaultInterpreterInfo().getEditor();
+            return interpreterSetting.getInterpreterInfo(intpName).getEditor();
           } catch (Exception e) {
             LOGGER.warn(e.getMessage());
             return DEFAULT_EDITOR;


### PR DESCRIPTION
### What is this PR for?
I wrote up this [defect](https://issues.apache.org/jira/browse/ZEPPELIN-4992) based on the behavior of the zeppelin 0.9.0 image found on the docker [hub](https://hub.docker.com/r/apache/zeppelin/tags). Currently, the editor settings aren't being applied to each interpreter, instead only the default interpreter editor settings get applied to every paragraph regardless of the interpreter specified.

This PR should fix that issue.


### What type of PR is it?
[Bug Fix]

### Todos
* None

### What is the Jira issue?
* [ZEPPELIN-4992](https://issues.apache.org/jira/browse/ZEPPELIN-4992)

### How should this be tested?
* Ensure that the various niceties for each interpreter are applied. E.G. syntax highlighting, code auto-hiding.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? 
No
* Is there breaking changes for older versions? 
No
* Does this needs documentation? 
No
