### PR TITLE
[ZEPPELIN-4996]. Improve table streaming display

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterOutput.java
@@ -51,6 +51,10 @@ public class InterpreterOutput extends OutputStream {
   private int size = 0;
   private int lastCRIndex = -1;
 
+  // disable table append by default, because table append may cause frontend output shaking.
+  // so just refresh all output for streaming application, such as flink streaming sql output.
+  private boolean enableTableAppend = false;
+
   // change static var to set interpreter output limit
   // limit will be applied to all InterpreterOutput object.
   // so we can expect the consistent behavior
@@ -68,6 +72,13 @@ public class InterpreterOutput extends OutputStream {
     this.changeListener = listener;
   }
 
+  public void setEnableTableAppend(boolean enableTableAppend) {
+    this.enableTableAppend = enableTableAppend;
+    if (currentOut != null) {
+      currentOut.setEnableTableAppend(enableTableAppend);
+    }
+  }
+
   public void setType(InterpreterResult.Type type) throws IOException {
     InterpreterResultMessageOutput out = null;
 
@@ -81,6 +92,7 @@ public class InterpreterOutput extends OutputStream {
       } else {
         out = new InterpreterResultMessageOutput(type, listener, changeListener);
       }
+      out.setEnableTableAppend(enableTableAppend);
       out.setResourceSearchPaths(resourceSearchPaths);
 
       buffer.reset();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
@@ -44,6 +44,7 @@ public class InterpreterResultMessageOutput extends OutputStream {
   private final InterpreterResultMessageOutputListener flushListener;
   private InterpreterResult.Type type = InterpreterResult.Type.TEXT;
   private boolean firstWrite = true;
+  private boolean enableTableAppend = true;
 
   public InterpreterResultMessageOutput(
       InterpreterResult.Type type,
@@ -60,6 +61,10 @@ public class InterpreterResultMessageOutput extends OutputStream {
     this.flushListener = flushListener;
     watcher = new InterpreterOutputChangeWatcher(listener);
     watcher.start();
+  }
+
+  public void setEnableTableAppend(boolean enableTableAppend) {
+    this.enableTableAppend = enableTableAppend;
   }
 
   public InterpreterResult.Type getType() {
@@ -240,7 +245,7 @@ public class InterpreterResultMessageOutput extends OutputStream {
   }
 
   public boolean isAppendSupported() {
-    return type == InterpreterResult.Type.TEXT || type == InterpreterResult.Type.TABLE;
+    return type == InterpreterResult.Type.TEXT || (type == InterpreterResult.Type.TABLE && enableTableAppend);
   }
 
   private void copyStream(InputStream in, OutputStream out) throws IOException {


### PR DESCRIPTION
### What is this PR for?

This ticket improve the table streaming display by disabling the table append. Instead just refresh the whole output at once. This could make the frontend display more smooth without any shaking. (See screenshot below)

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4996

### How should this be tested?
Manually tested

### Screenshots (if appropriate)
* Before
![before](https://user-images.githubusercontent.com/164491/90308002-52ce2800-df0e-11ea-840c-11d91d13a83d.gif)

* Now

![now](https://user-images.githubusercontent.com/164491/90307844-e69ef480-df0c-11ea-97a4-18d3481a3f1f.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
