### PR TITLE
[ZEPPELIN-5002] Update JDK version in documentation

### DIFF
--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -41,7 +41,7 @@ If you want to build from source, you must first install the following dependenc
     <td>3.1.x or higher</td>
   </tr>
   <tr>
-    <td>OpenJDK or Oracle JDK	</td>
+    <td>OpenJDK or Oracle JDK</td>
     <td>1.8 (151+)<br>(set JAVA_HOME)</td>
   </tr>
 </table>

--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -41,8 +41,8 @@ If you want to build from source, you must first install the following dependenc
     <td>3.1.x or higher</td>
   </tr>
   <tr>
-    <td>JDK</td>
-    <td>1.7</td>
+    <td>OpenJDK or Oracle JDK	</td>
+    <td>1.8 (151+)<br>(set JAVA_HOME)</td>
   </tr>
 </table>
 


### PR DESCRIPTION
### What is this PR for?
Java 8 is required to building from source.

In 'install' page, it is 1.8 (151+)
http://zeppelin.apache.org/docs/0.9.0-preview2/quickstart/install.html


but in 'build' page, it's 1.7
http://zeppelin.apache.org/docs/0.9.0-preview2/setup/basics/how_to_build.html#how-to-build-zeppelin-from-source


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5002

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
