### PR TITLE
[ZEPPELIN-4777] Fix - Number types are not sorted correctly

### DIFF
--- a/zeppelin-web/src/app/visualization/builtins/visualization-table.js
+++ b/zeppelin-web/src/app/visualization/builtins/visualization-table.js
@@ -140,7 +140,7 @@ export default class TableVisualization extends Visualization {
           sortingAlgorithm: function(a, b, row1, row2, sortType, gridCol) {
             const colType = gridCol.colDef.type.toLowerCase();
             if (colType === TableColumnType.NUMBER) {
-              return self.getSortedValue(a, b);
+              return self.getSortedValue(Number(a), Number(b));
             } else if (colType === TableColumnType.STRING) {
               return self.getSortedValue(a.toString(), b.toString());
             } else if (colType === TableColumnType.DATE) {


### PR DESCRIPTION
### What is this PR for?


**Before**
set sort type 'Number' but still sorted with string 
![image](https://user-images.githubusercontent.com/3839771/90523012-5d571e80-e1a7-11ea-8721-2586dbbf7407.png)

After
Sorted with correct type
![image](https://user-images.githubusercontent.com/3839771/90523292-a8713180-e1a7-11ea-9ae7-9d896fe4bfe9.png)


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5002

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
