### PR TITLE
[ZEPPELIN-5004] support running flink interpreter on kubernetes

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -100,6 +100,16 @@ function addEachJarInDirRecursiveForIntp(){
   fi
 }
 
+function addJarInDirRecursiveForIntpWithoutLog4j(){
+  if [[ -d "${1}" ]]; then
+    for jar in ${1}/*.jar; do
+      if [ "$(echo $jar | grep log4j)" = "" ]; then
+        ZEPPELIN_INTP_CLASSPATH="$jar:${ZEPPELIN_INTP_CLASSPATH}"
+      fi
+    done
+  fi
+}
+
 function addJarInDir(){
   if [[ -d "${1}" ]]; then
     ZEPPELIN_CLASSPATH="${1}/*:${ZEPPELIN_CLASSPATH}"

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -238,7 +238,7 @@ elif [[ "${INTERPRETER_ID}" == "pig" ]]; then
     echo "TEZ_CONF_DIR is not set, configuration might not be loaded"
   fi
 elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
-  addEachJarInDirRecursiveForIntp "${FLINK_HOME}/lib"
+  addJarInDirRecursiveForIntpWithoutLog4j "${FLINK_HOME}/lib"
 
   FLINK_PYTHON_JAR=$(find "${FLINK_HOME}/opt" -name 'flink-python_*.jar')
   ZEPPELIN_INTP_CLASSPATH+=":${FLINK_PYTHON_JAR}"

--- a/flink/interpreter/src/main/resources/interpreter-setting.json
+++ b/flink/interpreter/src/main/resources/interpreter-setting.json
@@ -6,7 +6,7 @@
     "defaultInterpreter": true,
     "properties": {
       "FLINK_HOME": {
-        "envName": null,
+        "envName": "FLINK_HOME",
         "propertyName": null,
         "defaultValue": "",
         "description": "Location of flink distribution",

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -81,7 +81,7 @@ spec:
   {% if zeppelin.k8s.interpreter.group.name == "flink" %}
     volumeMounts:
     - name: flink-home
-      mountPath: /flink
+      mountPath: /opt/flink
   initContainers:
   - name: flink-home-init
     image: {{zeppelin.k8s.flink.container.image}}

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -78,6 +78,21 @@ spec:
   - name: spark-home
     emptyDir: {}
   {% endif %}
+  {% if zeppelin.k8s.interpreter.group.name == "flink" %}
+    volumeMounts:
+    - name: flink-home
+      mountPath: /flink
+  initContainers:
+  - name: flink-home-init
+    image: {{zeppelin.k8s.flink.container.image}}
+    command: ["sh", "-c", "cp -r /opt/flink/* /flink/"]
+    volumeMounts:
+    - name: flink-home
+      mountPath: /flink
+  volumes:
+  - name: flink-home
+    emptyDir: {}
+  {% endif %}
 ---
 kind: Service
 apiVersion: v1

--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -38,7 +38,7 @@ data:
   # default value of 'SPARK_HOME' property for spark interpreter.
   SPARK_HOME: /spark
   # default value of 'FLINK_HOME' property for flink interpreter.
-  FLINK_HOME: /flink
+  FLINK_HOME: /opt/flink
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -29,6 +29,7 @@ data:
   # If you have your ingress controller configured to connect to `zeppelin-server` service and have a domain name for it (with wildcard subdomain point the same address), you can replace serviceDomain field with your own domain.
   SERVICE_DOMAIN: local.zeppelin-project.org:8080
   ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE: spark:2.4.5
+  ZEPPELIN_K8S_FLINK_CONTAINER_IMAGE: flink:1.11.1-scala_2.11-java11
   ZEPPELIN_K8S_CONTAINER_IMAGE: apache/zeppelin:0.9.0-SNAPSHOT
   ZEPPELIN_HOME: /zeppelin
   ZEPPELIN_SERVER_RPC_PORTRANGE: 12320:12320
@@ -36,6 +37,8 @@ data:
   SPARK_MASTER: k8s://https://kubernetes.default.svc
   # default value of 'SPARK_HOME' property for spark interpreter.
   SPARK_HOME: /spark
+  # default value of 'FLINK_HOME' property for flink interpreter.
+  FLINK_HOME: /flink
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -59,6 +59,9 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   private static final String SPARK_DRIVER_CORES = "spark.driver.cores";
   private static final String ENV_SERVICE_DOMAIN = "SERVICE_DOMAIN";
 
+  private static final String ENV_FLINK_HOME = "FLINK_HOME";
+  private static final String ENV_FLINK_IMAGE = "ZEPPELIN_K8S_FLINK_CONTAINER_IMAGE";
+
   public K8sRemoteInterpreterProcess(
           KubernetesClient client,
           String namespace,
@@ -318,6 +321,11 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
       }
     }
 
+    if(isFlink()){
+      k8sProperties.put("zeppelin.k8s.flink.container.image", envs.getOrDefault(ENV_FLINK_IMAGE, System.getenv(ENV_FLINK_IMAGE)));
+      envs.put(ENV_FLINK_HOME, envs.getOrDefault(ENV_FLINK_HOME, System.getenv(ENV_FLINK_HOME)));
+    }
+
     k8sProperties.put("zeppelin.k8s.envs", envs);
 
     // interpreter properties overrides the values
@@ -346,6 +354,11 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   @VisibleForTesting
   boolean isSpark() {
     return "spark".equalsIgnoreCase(interpreterGroupName);
+  }
+
+  @VisibleForTesting
+  boolean isFlink() {
+    return "flink".equalsIgnoreCase(interpreterGroupName);
   }
 
   boolean isSparkOnKubernetes(Properties interpreteProperties) {


### PR DESCRIPTION
### What is this PR for?
add support to run flink interpreter on kubernetes


### What type of PR is it?
[Improvement]

### Todos
* [x] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5004

### How should this be tested?
* manually tested in kubernetes cluster 
* https://travis-ci.org/github/zhoulii/zeppelin/builds/719203579

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? **NO**
* Is there breaking changes for older versions? **NO**
* Does this needs documentation? **NO**
