### PR TITLE
libthrift version upgraded from 0.9.2 to 0.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!-- common library versions -->
     <slf4j.version>1.7.10</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <libthrift.version>0.9.2</libthrift.version>
+    <libthrift.version>0.9.3</libthrift.version>
     <gson.version>2.2</gson.version>
     <gson-extras.version>0.2.1</gson-extras.version>
     <jetty.version>9.4.14.v20181114</jetty.version>


### PR DESCRIPTION
### What is this PR for?
Apache Thrift version should be upgraded from 0.9.2 to 0.9.3 because of the FacebookService$Client.sendBaseOneway error.

### What type of PR is it?
[ Improvement ]

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5008

### Questions:
* Does the licenses files need update? yes
* Is there breaking changes for older versions? no
* Does this needs documentation? no
