### PR TITLE
[ZEPPELIN-5016]. Flink interpreter is broken for flink 1.10.2

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -42,7 +42,7 @@
     </modules>
 
     <properties>
-        <flink1.10.version>1.10.1</flink1.10.version>
+        <flink1.10.version>1.10.2</flink1.10.version>
         <flink1.11.version>1.11.1</flink1.11.version>
     </properties>
 

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest110.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest110.java
@@ -29,7 +29,7 @@ public class FlinkIntegrationTest110 extends FlinkIntegrationTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{
-            {"1.10.1"}
+            {"1.10.2"}
     });
   }
 

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinFlinkClusterTest110.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinFlinkClusterTest110.java
@@ -29,7 +29,7 @@ public class ZeppelinFlinkClusterTest110 extends ZeppelinFlinkClusterTest {
   @Parameterized.Parameters
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][]{
-            {"1.10.1"}
+            {"1.10.2"}
     });
   }
 


### PR DESCRIPTION
### What is this PR for?
There's one change in flink 1.10.2 which cause flink interpreter broken. This PR fix this issue and also upgrade flink version to 1.10.2 in pom and integration test.

### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* There's one change in flink 1.10.2 which cause flink interpreter broken. This PR fix this issue and also upgrade flink version to 1.10.2 in pom and integration test.

### How should this be tested?
* https://issues.apache.org/jira/browse/ZEPPELIN-5016

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
