### PR TITLE
[ZEPPELIN-5022]. InterpreterSetting's status is not saved after downloading dependencies

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -690,7 +690,9 @@ public class InterpreterSetting {
 
   public void setDependencies(List<Dependency> dependencies) {
     this.dependencies = dependencies;
-    loadInterpreterDependencies();
+    if (!this.dependencies.isEmpty()) {
+      loadInterpreterDependencies();
+    }
   }
 
   public InterpreterOption getOption() {
@@ -719,7 +721,9 @@ public class InterpreterSetting {
         this.dependencies.add(dependency);
       }
     }
-    loadInterpreterDependencies();
+    if (!dependencies.isEmpty()) {
+      loadInterpreterDependencies();
+    }
   }
 
   void setInterpreterOption(InterpreterOption interpreterOption) {
@@ -1006,6 +1010,12 @@ public class InterpreterSetting {
               getGroup(), e.getLocalizedMessage()), e);
           setErrorReason(e.getLocalizedMessage());
           setStatus(Status.ERROR);
+        }
+
+        try {
+          interpreterSettingManager.saveToFile();
+        } catch (IOException e) {
+          LOGGER.error("Fail to save interpreter.json", e);
         }
       }
     };


### PR DESCRIPTION

### What is this PR for?

Straightforward PR which just save interpreter setting file when dependencies downloading are completed. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5022

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
