### PR TITLE
[ZEPPELIN-5030]. InterpreterSettingManager is created twice

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -271,7 +271,8 @@ public class ZeppelinServer extends ResourceConfig {
     // Try to get Notebook from ServiceLocator, because Notebook instantiation is lazy, it is
     // created when user open zeppelin in browser if we don't get it explicitly here.
     // Lazy loading will cause paragraph recovery and cron job initialization is delayed.
-    Notebook notebook = sharedServiceLocator.getService(Notebook.class);
+    Notebook notebook = ServiceLocatorUtilities.getService(
+            sharedServiceLocator, Notebook.class.getName());
     // Try to recover here, don't do it in constructor of Notebook, because it would cause deadlock.
     notebook.recoveryIfNecessary();
 

--- a/zeppelin-server/src/main/resources/log4j.properties
+++ b/zeppelin-server/src/main/resources/log4j.properties
@@ -15,22 +15,8 @@
 # limitations under the License.
 #
 
-[users]
-# List of users with their password allowed to access Zeppelin.
-# To use a different strategy (LDAP / Database / ...) check the shiro doc at http://shiro.apache.org/configuration.html#Configuration-INISections
-admin = password, admin
-user1 = user1, role1
+log4j.rootLogger = INFO,stdout
 
-
-[urls]
-# anon means the access is anonymous.
-# authcBasic means Basic Auth Security
-# To enfore security, comment the line below and uncomment the next one
-/** = anon
-#/** = authc
-
-[roles]
-role1 = *
-role2 = *
-role3 = *
-admin = *
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -255,7 +255,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
     //TODO(zjffdu) still ugly (should move all to InterpreterInfoSaving)
     for (InterpreterSetting savedInterpreterSetting : infoSaving.interpreterSettings.values()) {
       if (!shouldRegister(savedInterpreterSetting.getGroup())) {
-        break;
+        continue;
       }
       savedInterpreterSetting.setProperties(InterpreterSetting.convertInterpreterProperties(
           savedInterpreterSetting.getProperties()
@@ -292,7 +292,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
         }
       }
       savedInterpreterSetting.postProcessing();
-      LOGGER.info("Create Interpreter Setting {} from interpreter.json",
+      LOGGER.info("Create interpreter setting {} from interpreter.json",
           savedInterpreterSetting.getName());
       interpreterSettings.put(savedInterpreterSetting.getId(), savedInterpreterSetting);
     }
@@ -302,6 +302,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
       initInterpreterSetting(interpreterSetting);
       // add newly detected interpreter if it doesn't exist in interpreter.json
       if (!interpreterSettings.containsKey(interpreterSetting.getId())) {
+        LOGGER.info("Create interpreter setting: {} from interpreter setting template", interpreterSetting.getId());
         interpreterSettings.put(interpreterSetting.getId(), interpreterSetting);
       }
     }


### PR DESCRIPTION
### What is this PR for?

This PR is to fix the issue of creating InterpreterSettingManager twice. Besides that, it also fix a minor bug in InterpreterSettingManager (use continue instead of break)

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5030

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
