### PR TITLE
[ZEPPELIN-5036]. zeppelin.interpreter.dep.mvnRepo doesn't take effect

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/Booter.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.dep;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.maven.repository.internal.MavenRepositorySystemSession;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositorySystem;
@@ -74,7 +75,8 @@ public class Booter {
   public static RemoteRepository newCentralRepository() {
     String mvnRepo = System.getenv("ZEPPELIN_INTERPRETER_DEP_MVNREPO");
     if (mvnRepo == null) {
-      mvnRepo = System.getProperty("zeppelin.interpreter.dep.mvnRepo");
+      mvnRepo = ZeppelinConfiguration.create().getString(
+              ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_DEP_MVNREPO);
     }
     if (mvnRepo == null) {
       mvnRepo = "https://repo1.maven.org/maven2/";


### PR DESCRIPTION
### What is this PR for?

Simple PR to fix the issue of `zeppelin.interpreter.dep.mvnRepo` doesn't take effect. Should use ZeppelinConfiguration instead of System.getProperty


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5036

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
