### PR TITLE
[ZEPPELIN-5035]. ZeppelinClient#getSession should return null when there's no such session

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
@@ -20,9 +20,12 @@ package org.apache.zeppelin.integration;
 import org.apache.zeppelin.client.ClientConfig;
 import org.apache.zeppelin.client.NoteResult;
 import org.apache.zeppelin.client.ParagraphResult;
+
 import org.apache.zeppelin.client.Status;
 import org.apache.zeppelin.client.ZeppelinClient;
+
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.common.SessionInfo;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.utils.TestUtils;
@@ -35,6 +38,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -374,5 +378,13 @@ public class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
     ParagraphResult p2 = noteResult.getParagraphResultList().get(2);
     assertEquals(Status.READY, p2.getStatus());
     assertEquals(0, p2.getResults().size());
+  }
+
+  @Test
+  public void testSession() throws Exception {
+    SessionInfo sessionInfo = zeppelinClient.getSession("invalid_session");
+    assertNull(sessionInfo);
+
+    zeppelinClient.stopSession("invalid_session");
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SessionRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SessionRestApi.java
@@ -23,6 +23,7 @@ import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.common.SessionInfo;
+import org.apache.zeppelin.rest.exception.SessionNoteFoundException;
 import org.apache.zeppelin.server.JsonResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +99,7 @@ public class SessionRestApi {
   public Response getSession(@PathParam("sessionId") String sessionId) throws Exception {
     SessionInfo session = sessionManager.getSession(sessionId);
     if (session == null) {
-      return new JsonResponse<>(Response.Status.NOT_FOUND).build();
+      throw new SessionNoteFoundException(sessionId);
     } else {
       return new JsonResponse<>(Response.Status.OK, "", session).build();
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/SessionNoteFoundException.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/exception/SessionNoteFoundException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.rest.exception;
+
+import org.apache.zeppelin.utils.ExceptionUtils;
+
+import javax.ws.rs.WebApplicationException;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+public class SessionNoteFoundException extends WebApplicationException {
+
+  public SessionNoteFoundException(String sessionId) {
+    super(ExceptionUtils.jsonResponseContent(NOT_FOUND, "No such session: " + sessionId));
+  }
+}


### PR DESCRIPTION
### What is this PR for?

Currently it would throw exception when there's no such session, it would make the api user confused. It is better to just return null when there's no such session.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5035

### How should this be tested?
* Unit test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
