### PR TITLE
Revert "[ZEPPELIN-4681]. Shade thrift in zeppelin-interpreter-shaded"

### DIFF
--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GObject.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GObject.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.groovy;
 
 import groovy.lang.Closure;
 import groovy.xml.MarkupBuilder;
+import org.apache.thrift.TException;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -239,7 +240,7 @@ public class GObject extends groovy.lang.GroovyObjectSupport {
   }
 
   @SuppressWarnings("unchecked")
-  public void angularBind(String name, Object o, String noteId) {
+  public void angularBind(String name, Object o, String noteId) throws TException {
     z.angularBind(name, o, noteId);
   }
 
@@ -250,7 +251,7 @@ public class GObject extends groovy.lang.GroovyObjectSupport {
    * @param name name of the variable
    * @param o value
    */
-  public void angularBind(String name, Object o) {
+  public void angularBind(String name, Object o) throws TException {
     angularBind(name, o, interpreterContext.getNoteId());
   }
 

--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -104,6 +104,8 @@
                 <exclude>org/apache/zeppelin/**/*</exclude>
                 <exclude>org/apache/hadoop/*</exclude>
                 <exclude>org/apache/hadoop/**</exclude>
+                <exclude>org/apache/thrift/*</exclude>
+                <exclude>org/apache/thrift/**/*</exclude>
                 <exclude>org/slf4j/*</exclude>
                 <exclude>org/slf4j/**/*</exclude>
                 <exclude>org/apache/commons/logging/*</exclude>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ZeppelinContext.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/ZeppelinContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.interpreter;
 
+import org.apache.thrift.TException;
 import org.apache.zeppelin.annotation.Experimental;
 import org.apache.zeppelin.annotation.ZeppelinApi;
 import org.apache.zeppelin.display.AngularObject;
@@ -672,9 +673,10 @@ public abstract class ZeppelinContext {
    *
    * @param name name of the variable
    * @param o    value
+   * @throws TException
    */
   @ZeppelinApi
-  public void angularBind(String name, Object o) {
+  public void angularBind(String name, Object o) throws TException {
     angularBind(name, o, interpreterContext.getNoteId());
   }
 
@@ -686,7 +688,7 @@ public abstract class ZeppelinContext {
    * @param o    value
    */
   @Deprecated
-  public void angularBindGlobal(String name, Object o) {
+  public void angularBindGlobal(String name, Object o) throws TException {
     angularBind(name, o, (String) null);
   }
 
@@ -699,7 +701,7 @@ public abstract class ZeppelinContext {
    * @param watcher watcher of the variable
    */
   @ZeppelinApi
-  public void angularBind(String name, Object o, AngularObjectWatcher watcher) {
+  public void angularBind(String name, Object o, AngularObjectWatcher watcher) throws TException {
     angularBind(name, o, interpreterContext.getNoteId(), watcher);
   }
 
@@ -712,7 +714,8 @@ public abstract class ZeppelinContext {
    * @param watcher watcher of the variable
    */
   @Deprecated
-  public void angularBindGlobal(String name, Object o, AngularObjectWatcher watcher) {
+  public void angularBindGlobal(String name, Object o, AngularObjectWatcher watcher)
+      throws TException {
     angularBind(name, o, null, watcher);
   }
 
@@ -788,7 +791,7 @@ public abstract class ZeppelinContext {
    * @param name
    */
   @ZeppelinApi
-  public void angularUnbind(String name) {
+  public void angularUnbind(String name) throws TException {
     String noteId = interpreterContext.getNoteId();
     angularUnbind(name, noteId);
   }
@@ -799,7 +802,7 @@ public abstract class ZeppelinContext {
    * @param name
    */
   @Deprecated
-  public void angularUnbindGlobal(String name) {
+  public void angularUnbindGlobal(String name) throws TException {
     angularUnbind(name, null);
   }
 
@@ -811,7 +814,7 @@ public abstract class ZeppelinContext {
    * @param o    value
    * @param noteId
    */
-  public void angularBind(String name, Object o, String noteId) {
+  public void angularBind(String name, Object o, String noteId) throws TException {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, null) == null) {
@@ -830,7 +833,7 @@ public abstract class ZeppelinContext {
    * @param noteId
    * @param paragraphId
    */
-  public void angularBind(String name, Object o, String noteId, String paragraphId) {
+  public void angularBind(String name, Object o, String noteId, String paragraphId) throws TException {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, paragraphId) == null) {
@@ -849,7 +852,8 @@ public abstract class ZeppelinContext {
    * @param o       value
    * @param watcher watcher of the variable
    */
-  private void angularBind(String name, Object o, String noteId, AngularObjectWatcher watcher) {
+  private void angularBind(String name, Object o, String noteId, AngularObjectWatcher watcher)
+      throws TException {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
 
     if (registry.get(name, noteId, null) == null) {
@@ -904,7 +908,7 @@ public abstract class ZeppelinContext {
    *
    * @param name
    */
-  private void angularUnbind(String name, String noteId) {
+  private void angularUnbind(String name, String noteId) throws TException {
     AngularObjectRegistry registry = interpreterContext.getAngularObjectRegistry();
     registry.remove(name, noteId, null);
   }


### PR DESCRIPTION
This reverts commit 39af1878c7b7d5423b5abdca1fde2bea940bb0d8.

### What is this PR for?

thrift is used explicitly in zeppelin, we should not shade it. e.g. TException could not be found if we shade it.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4997

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
