### PR TITLE
[ZEPPELIN-5040]. USE_HADOOP should be true by default

### DIFF
--- a/bin/zeppelin-daemon.sh
+++ b/bin/zeppelin-daemon.sh
@@ -84,17 +84,16 @@ addJarInDir "${ZEPPELIN_HOME}/zeppelin-web/target/lib"
 addJarInDir "${ZEPPELIN_HOME}/zeppelin-web-angular/target/lib"
 
 ## Add hadoop jars when env USE_HADOOP is true
-if [[ "${USE_HADOOP}" == "true"  ]]; then
+if [[ "${USE_HADOOP}" != "false"  ]]; then
   if [[ -z "${HADOOP_CONF_DIR}" ]]; then
     echo "Please specify HADOOP_CONF_DIR if USE_HADOOP is true"
-    exit 1
   else
     ZEPPELIN_CLASSPATH+=":${HADOOP_CONF_DIR}"
     if ! [ -x "$(command -v hadoop)" ]; then
-        echo 'Error: hadoop is not in PATH when HADOOP_CONF_DIR is specified.'
-        exit 1
+      echo 'hadoop command is not in PATH when HADOOP_CONF_DIR is specified.'
+    else
+      ZEPPELIN_CLASSPATH+=":`hadoop classpath`"
     fi
-    ZEPPELIN_CLASSPATH+=":`hadoop classpath`"
   fi
 fi
 

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -17,6 +17,7 @@
 #
 
 # export JAVA_HOME=
+# export USE_HADOOP=                            # Whether include hadoop jars into zeppelin server process. (true or false)
 # export SPARK_MASTER=                          # Spark master url. eg. spark://master_addr:7077. Leave empty if you want to use local mode.
 # export ZEPPELIN_ADDR                          # Bind address (default 127.0.0.1)
 # export ZEPPELIN_PORT                          # port number to listen (default 8080)


### PR DESCRIPTION
### What is this PR for?

Trivial PR to include hadoop jars in zeppelin by default. Hadoop jars will be excluded unless user specify `USE_HADOOP` as false.

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5040

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
