### PR TITLE
[ZEPPELIN-5055]. Interpreter log is missing in zeppelin server docker container

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -140,11 +140,17 @@ if [[ ( -z "${ZEPPELIN_INTP_MEM}" ) && ( "${ZEPPELIN_INTERPRETER_LAUNCHER}" != "
 fi
 
 JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"
-JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
+if [[ -n "${ZEPPELIN_IN_DOCKER}" ]]; then
+    JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j_docker.properties"
+else
+    JAVA_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties"
+fi
 export JAVA_OPTS
 
 JAVA_INTP_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
-if [[ -z "${ZEPPELIN_SPARK_YARN_CLUSTER}" ]]; then
+if [[ -n "${ZEPPELIN_IN_DOCKER}" ]]; then
+    JAVA_INTP_OPTS+=" -Dlog4j.configuration='file://${ZEPPELIN_CONF_DIR}/log4j_docker.properties' -Dlog4j.configurationFile='file://${ZEPPELIN_CONF_DIR}/log4j2_docker.properties'"
+elif [[ -z "${ZEPPELIN_SPARK_YARN_CLUSTER}" ]]; then
     JAVA_INTP_OPTS+=" -Dlog4j.configuration='file://${ZEPPELIN_CONF_DIR}/log4j.properties' -Dlog4j.configurationFile='file://${ZEPPELIN_CONF_DIR}/log4j2.properties'"
 else
     JAVA_INTP_OPTS+=" -Dlog4j.configuration=log4j_yarn_cluster.properties"

--- a/docs/setup/deployment/docker.md
+++ b/docs/setup/deployment/docker.md
@@ -34,8 +34,11 @@ You need to [install docker](https://docs.docker.com/engine/installation/) on yo
 ### Running docker image for Zeppelin distribution
 
 ```bash
-docker run -p 8080:8080 --rm --name zeppelin apache/zeppelin-server:<release-version>
+docker run -p 8080:8080 -e ZEPPELIN_IN_DOCKER=true --rm --name zeppelin apache/zeppelin-server:<release-version>
 ```
+
+Notice, please specify environment variable `ZEPPELIN_IN_DOCKER` when starting zeppelin in docker, 
+otherwise you can not see the interpreter log.
 
 * Zeppelin will run at `http://localhost:8080`.
 
@@ -47,6 +50,7 @@ docker run -p 8080:8080 --rm \
 -v $PWD/notebook:/notebook \
 -e ZEPPELIN_LOG_DIR='/logs' \
 -e ZEPPELIN_NOTEBOOK_DIR='/notebook' \
+-e ZEPPELIN_IN_DOCKER=true \
 --name zeppelin apache/zeppelin-server:<release-version> # e.g '0.9.0'
 ```
 

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -16,7 +16,7 @@
 FROM ubuntu:16.04
 MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
-ENV Z_VERSION="0.9.0-preview1"
+ENV Z_VERSION="0.9.0-preview2"
 
 ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     Z_HOME="/zeppelin" \
@@ -117,6 +117,7 @@ RUN echo "$LOG_TAG Download Zeppelin binary" && \
     chmod 775 ${Z_HOME}
 
 COPY log4j.properties ${Z_HOME}/conf/
+COPY log4j_docker.properties ${Z_HOME}/conf/
 
 USER 1000
 

--- a/scripts/docker/zeppelin/bin/log4j_docker.properties
+++ b/scripts/docker/zeppelin/bin/log4j_docker.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger = INFO, dailyfile
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n
+
+log4j.appender.dailyfile.DatePattern=.yyyy-MM-dd
+log4j.appender.dailyfile = org.apache.log4j.DailyRollingFileAppender
+log4j.appender.dailyfile.File = ${zeppelin.log.file}
+log4j.appender.dailyfile.layout = org.apache.log4j.PatternLayout
+log4j.appender.dailyfile.layout.ConversionPattern=%5p [%d] ({%t} %F[%M]:%L) - %m%n


### PR DESCRIPTION

### What is this PR for?

The root cause in the log4j.properties in the zeppelin server image. For k8s, we should use stdout for logging, but for the single zeppelin server container, we should use dailyfile for logging (both zeppelin server and interpreter). This PR add a new env `ZEPPELIN_IN_DOCKER` to choose the right log4j properties file for the right scenario. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5055

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
