### PR TITLE
[ZEPPELIN-5060]. Disabled paragraph cause Zeppelin notebook to hang

### DIFF
--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -208,14 +208,6 @@ function WebsocketMessageService($rootScope, websocketEvents) {
     },
 
     runAllParagraphs: function(noteId, paragraphs) {
-      // short circuit update paragraph status for immediate visual feedback without waiting for server response
-      paragraphs.forEach((p) => {
-        $rootScope.$broadcast('updateStatus', {
-          id: p.id,
-          status: 'PENDING',
-        });
-      });
-
       // send message to server
       websocketEvents.sendNewEvent({
         op: 'RUN_ALL_PARAGRAPHS',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -356,6 +356,8 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
       if (getConfig().get("enabled") == null || (Boolean) getConfig().get("enabled")) {
         setAuthenticationInfo(getAuthenticationInfo());
         interpreter.getScheduler().submit(this);
+      } else {
+        return true;
       }
 
       if (blocking) {


### PR DESCRIPTION
### What is this PR for?

There're 2 things cause this issue, one is in the frontend that will change paragraph status to PENDING when `RUN_ALL_PARAGRAPH` is triggered, another issue is in the zeppelin server side which should return at once when paragraph is disabled. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5060

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
