### PR TITLE
[ZEPPELIN-5069] use frontend-plugin-core insteand of frontend-maven-plugin for zengine

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -170,20 +170,12 @@
 
     <dependency>
       <groupId>com.github.eirslett</groupId>
-      <artifactId>frontend-maven-plugin</artifactId>
+      <artifactId>frontend-plugin-core</artifactId>
       <version>${frontend.maven.plugin.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-utils</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-plugin-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.maven</groupId>
-          <artifactId>maven-artifact</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
### What is this PR for?
This PR replaced the frontend-maven-plugin with the frontend-plugin-core.


### What type of PR is it?
- Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5069

### How should this be tested?
* Travis-CI: https://travis-ci.org/github/Reamer/zeppelin/builds/729893691

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
