### PR TITLE
[ZEPPELIN-5070] Improve start/shutdown and signal handling

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -25,7 +25,8 @@ fi
 if [[ -z "${ZEPPELIN_HOME}" ]]; then
   # Make ZEPPELIN_HOME look cleaner in logs by getting rid of the
   # extra ../
-  export ZEPPELIN_HOME="$(cd "${FWDIR}/.."; pwd)"
+  ZEPPELIN_HOME="$(cd "${FWDIR}/.." || exit; pwd)"
+  export ZEPPELIN_HOME
 fi
 
 if [[ -z "${ZEPPELIN_CONF_DIR}" ]]; then
@@ -44,7 +45,8 @@ if [[ -z "${ZEPPELIN_WAR}" ]]; then
   if [[ -d "${ZEPPELIN_HOME}/zeppelin-web/dist" ]]; then
     export ZEPPELIN_WAR="${ZEPPELIN_HOME}/zeppelin-web/dist"
   else
-    export ZEPPELIN_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web-[0-9]*.war")
+    ZEPPELIN_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web-[0-9]*.war")
+    export ZEPPELIN_WAR
   fi
 fi
 
@@ -52,7 +54,8 @@ if [[ -z "${ZEPPELIN_ANGULAR_WAR}" ]]; then
   if [[ -d "${ZEPPELIN_HOME}/zeppelin-web/dist" ]]; then
     export ZEPPELIN_ANGULAR_WAR="${ZEPPELIN_HOME}/zeppelin-web-angular/dist/zeppelin"
   else
-    export ZEPPELIN_ANGULAR_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web-angular*.war")
+    ZEPPELIN_ANGULAR_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web-angular*.war")
+    export ZEPPELIN_ANGULAR_WAR
   fi
 fi
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -81,7 +81,7 @@ function check_java_version() {
 
 function addEachJarInDir(){
   if [[ -d "${1}" ]]; then
-    for jar in $(find -L "${1}" -maxdepth 1 -name '*jar'); do
+    for jar in "${1}"/*.jar ; do
       ZEPPELIN_CLASSPATH="$jar:$ZEPPELIN_CLASSPATH"
     done
   fi
@@ -89,7 +89,7 @@ function addEachJarInDir(){
 
 function addEachJarInDirRecursive(){
   if [[ -d "${1}" ]]; then
-    for jar in $(find -L "${1}" -type f -name '*jar'); do
+    for jar in "${1}"/**/*.jar ; do
       ZEPPELIN_CLASSPATH="$jar:$ZEPPELIN_CLASSPATH"
     done
   fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-if [ -L ${BASH_SOURCE-$0} ]; then
-  FWDIR=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+if [ -L "${BASH_SOURCE-$0}" ]; then
+  FWDIR=$(dirname "$(readlink "${BASH_SOURCE-$0}")")
 else
   FWDIR=$(dirname "${BASH_SOURCE-$0}")
 fi
@@ -94,7 +94,7 @@ function addEachJarInDirRecursive(){
 
 function addEachJarInDirRecursiveForIntp(){
   if [[ -d "${1}" ]]; then
-    for jar in ${1}/*.jar; do
+    for jar in "${1}"/*.jar; do
       ZEPPELIN_INTP_CLASSPATH="$jar:${ZEPPELIN_INTP_CLASSPATH}"
     done
   fi
@@ -120,7 +120,7 @@ function getZeppelinVersion(){
     fi
     addJarInDir "${ZEPPELIN_HOME}/zeppelin-server/target/lib"
     CLASSPATH+=":${ZEPPELIN_CLASSPATH}"
-    $ZEPPELIN_RUNNER -cp $CLASSPATH $ZEPPELIN_COMMANDLINE_MAIN -v
+    $ZEPPELIN_RUNNER -cp "${CLASSPATH}" "${ZEPPELIN_COMMANDLINE_MAIN}" -v
     exit 0
 }
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -149,9 +149,9 @@ export JAVA_OPTS
 
 JAVA_INTP_OPTS="${ZEPPELIN_INTP_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING}"
 if [[ -n "${ZEPPELIN_IN_DOCKER}" ]]; then
-    JAVA_INTP_OPTS+=" -Dlog4j.configuration='file://${ZEPPELIN_CONF_DIR}/log4j_docker.properties' -Dlog4j.configurationFile='file://${ZEPPELIN_CONF_DIR}/log4j2_docker.properties'"
+    JAVA_INTP_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j_docker.properties -Dlog4j.configurationFile=file://${ZEPPELIN_CONF_DIR}/log4j2_docker.properties"
 elif [[ -z "${ZEPPELIN_SPARK_YARN_CLUSTER}" ]]; then
-    JAVA_INTP_OPTS+=" -Dlog4j.configuration='file://${ZEPPELIN_CONF_DIR}/log4j.properties' -Dlog4j.configurationFile='file://${ZEPPELIN_CONF_DIR}/log4j2.properties'"
+    JAVA_INTP_OPTS+=" -Dlog4j.configuration=file://${ZEPPELIN_CONF_DIR}/log4j.properties -Dlog4j.configurationFile=file://${ZEPPELIN_CONF_DIR}/log4j2.properties"
 else
     JAVA_INTP_OPTS+=" -Dlog4j.configuration=log4j_yarn_cluster.properties"
 fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -73,7 +73,7 @@ function check_java_version() {
         JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9][0-9]*\)\..*$|\1|')
     fi
 
-    if [ "$JVM_VERSION" -lt 8 ] || ([ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]) ; then
+    if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then
         echo "Apache Zeppelin requires either Java 8 update 151 or newer"
         exit 1;
     fi

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -140,7 +140,7 @@ if [[ -n "$ZEPPELIN_IMPERSONATE_USER" ]]; then
     ZEPPELIN_LOGFILE+="${ZEPPELIN_IMPERSONATE_USER}-"
 fi
 ZEPPELIN_LOGFILE+="${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.log"
-JAVA_INTP_OPTS+=" -Dzeppelin.log.file='${ZEPPELIN_LOGFILE}'"
+JAVA_INTP_OPTS+=" -Dzeppelin.log.file=${ZEPPELIN_LOGFILE}"
 
 if [[ ! -d "${ZEPPELIN_LOG_DIR}" ]]; then
   echo "Log dir doesn't exist, create ${ZEPPELIN_LOG_DIR}"

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -160,8 +160,7 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
     # This will evantually passes SPARK_APP_JAR to classpath of SparkIMain
     ZEPPELIN_INTP_CLASSPATH+=":${SPARK_APP_JAR}"
 
-    pattern="$SPARK_HOME/python/lib/py4j-*-src.zip"
-    py4j=($pattern)
+    py4j=("${SPARK_HOME}"/python/lib/py4j-*-src.zip)
     # pick the first match py4j zip - there should only be one
     export PYTHONPATH="$SPARK_HOME/python/:$PYTHONPATH"
     export PYTHONPATH="${py4j[0]}:$PYTHONPATH"
@@ -178,8 +177,7 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
 
     addJarInDirForIntp "${INTERPRETER_DIR}/dep"
 
-    pattern="${ZEPPELIN_HOME}/interpreter/spark/pyspark/py4j-*-src.zip"
-    py4j=($pattern)
+    py4j=("${ZEPPELIN_HOME}"/interpreter/spark/pyspark/py4j-*-src.zip)
     # pick the first match py4j zip - there should only be one
     PYSPARKPATH="${ZEPPELIN_HOME}/interpreter/spark/pyspark/pyspark.zip:${py4j[0]}"
 

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -129,7 +129,7 @@ ZEPPELIN_LOGFILE="${ZEPPELIN_LOG_DIR}/zeppelin-interpreter-${INTERPRETER_GROUP_I
 
 if [[ -z "$ZEPPELIN_IMPERSONATE_CMD" ]]; then
     if [[ "${INTERPRETER_ID}" != "spark" || "$ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER" == "false" ]]; then
-        ZEPPELIN_IMPERSONATE_RUN_CMD=`echo "ssh ${ZEPPELIN_IMPERSONATE_USER}@localhost" `
+        ZEPPELIN_IMPERSONATE_RUN_CMD="ssh ${ZEPPELIN_IMPERSONATE_USER}@localhost"
     fi
 else
     ZEPPELIN_IMPERSONATE_RUN_CMD=$(eval "echo ${ZEPPELIN_IMPERSONATE_CMD} ")
@@ -144,7 +144,7 @@ JAVA_INTP_OPTS+=" -Dzeppelin.log.file='${ZEPPELIN_LOGFILE}'"
 
 if [[ ! -d "${ZEPPELIN_LOG_DIR}" ]]; then
   echo "Log dir doesn't exist, create ${ZEPPELIN_LOG_DIR}"
-  $(mkdir -p "${ZEPPELIN_LOG_DIR}")
+  mkdir -p "${ZEPPELIN_LOG_DIR}"
 fi
 
 # set spark related env variables
@@ -251,7 +251,7 @@ elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
         echo 'Error: hadoop is not in PATH when HADOOP_CONF_DIR is specified and no flink-shaded-hadoop jar '
         exit 1
       fi
-      ZEPPELIN_INTP_CLASSPATH+=":`hadoop classpath`"
+      ZEPPELIN_INTP_CLASSPATH+=":$(hadoop classpath)"
     fi
     export HADOOP_CONF_DIR=${HADOOP_CONF_DIR}
   else

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -152,11 +152,11 @@ if [[ "${INTERPRETER_ID}" == "spark" ]]; then
 
   # run kinit
   if [[ -n "${ZEPPELIN_SERVER_KERBEROS_KEYTAB}" ]] && [[ -n "${ZEPPELIN_SERVER_KERBEROS_PRINCIPAL}" ]]; then
-    kinit -kt ${ZEPPELIN_SERVER_KERBEROS_KEYTAB} ${ZEPPELIN_SERVER_KERBEROS_PRINCIPAL}
+    kinit -kt "${ZEPPELIN_SERVER_KERBEROS_KEYTAB}" "${ZEPPELIN_SERVER_KERBEROS_PRINCIPAL}"
   fi
   if [[ -n "${SPARK_HOME}" ]]; then
     export SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
-    SPARK_APP_JAR="$(ls ${ZEPPELIN_HOME}/interpreter/spark/spark-interpreter*.jar)"
+    SPARK_APP_JAR="$(ls "${ZEPPELIN_HOME}"/interpreter/spark/spark-interpreter*.jar)"
     # This will evantually passes SPARK_APP_JAR to classpath of SparkIMain
     ZEPPELIN_INTP_CLASSPATH+=":${SPARK_APP_JAR}"
 
@@ -271,7 +271,7 @@ addJarInDirForIntp "${LOCAL_INTERPRETER_REPO}"
 
 if [[ -n "$ZEPPELIN_IMPERSONATE_USER" ]]; then
   if [[ "${INTERPRETER_ID}" != "spark" || "$ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER" == "false" ]]; then
-    suid="$(id -u ${ZEPPELIN_IMPERSONATE_USER})"
+    suid="$(id -u "${ZEPPELIN_IMPERSONATE_USER}")"
     if [[ -n  "${suid}" || -z "${SPARK_SUBMIT}" ]]; then
        INTERPRETER_RUN_COMMAND=${ZEPPELIN_IMPERSONATE_RUN_CMD}" '"
        if [[ -f "${ZEPPELIN_CONF_DIR}/zeppelin-env.sh" ]]; then

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -35,7 +35,7 @@ if [ -f /proc/self/cgroup ] && [ -n "$(command -v getent)" ]; then
         set +e
         uidentry="$(getent passwd "$myuid")"
         set -e
-        
+
         # If there is no passwd entry for the container UID, attempt to create one
         if [ -z "$uidentry" ] ; then
             if [ -w /etc/passwd ] ; then

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -136,7 +136,7 @@ else
 fi
 
 
-if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]]; then
+if [[ -n "$ZEPPELIN_IMPERSONATE_USER" ]]; then
     ZEPPELIN_LOGFILE+="${ZEPPELIN_IMPERSONATE_USER}-"
 fi
 ZEPPELIN_LOGFILE+="${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.log"
@@ -244,7 +244,7 @@ elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
     ZEPPELIN_INTP_CLASSPATH+=":${HADOOP_CONF_DIR}"
     # Don't use `hadoop classpath` if flink-hadoop-shaded in in lib folder
     flink_hadoop_shaded_jar=$(find "${FLINK_HOME}/lib" -name 'flink-shaded-hadoop-*.jar')
-    if [[ ! -z "$flink_hadoop_shaded_jar" ]]; then
+    if [[ -n "$flink_hadoop_shaded_jar" ]]; then
       echo ""
     else
       if [[ ! ( -x "$(command -v hadoop)" ) && ( "${ZEPPELIN_INTERPRETER_LAUNCHER}" != "yarn" ) ]]; then
@@ -269,7 +269,7 @@ fi
 
 addJarInDirForIntp "${LOCAL_INTERPRETER_REPO}"
 
-if [[ ! -z "$ZEPPELIN_IMPERSONATE_USER" ]]; then
+if [[ -n "$ZEPPELIN_IMPERSONATE_USER" ]]; then
   if [[ "${INTERPRETER_ID}" != "spark" || "$ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER" == "false" ]]; then
     suid="$(id -u ${ZEPPELIN_IMPERSONATE_USER})"
     if [[ -n  "${suid}" || -z "${SPARK_SUBMIT}" ]]; then

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -44,11 +44,6 @@ spec:
   - name: {{zeppelin.k8s.interpreter.container.name}}
     image: {{zeppelin.k8s.interpreter.container.image}}
     command: ["sh", "-c", "$(ZEPPELIN_HOME)/bin/interpreter.sh -d $(ZEPPELIN_HOME)/interpreter/{{zeppelin.k8s.interpreter.group.name}} -r {{zeppelin.k8s.interpreter.rpc.portRange}} -c {{zeppelin.k8s.server.rpc.service}} -p {{zeppelin.k8s.server.rpc.portRange}} -i {{zeppelin.k8s.interpreter.group.id}} -l {{zeppelin.k8s.interpreter.localRepo}} -g {{zeppelin.k8s.interpreter.setting.name}}"]
-    lifecycle:
-      preStop:
-        exec:
-          # SIGTERM triggers a quick exit; gracefully terminate instead
-          command: ["sh", "-c", "ps -ef | grep org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer | grep -v grep | awk '{print $2}' | xargs kill"]
     env:
   {% for key, value in zeppelin.k8s.envs.items() %}
     - name: {{key}}

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -43,7 +43,22 @@ spec:
   containers:
   - name: {{zeppelin.k8s.interpreter.container.name}}
     image: {{zeppelin.k8s.interpreter.container.image}}
-    command: ["sh", "-c", "$(ZEPPELIN_HOME)/bin/interpreter.sh -d $(ZEPPELIN_HOME)/interpreter/{{zeppelin.k8s.interpreter.group.name}} -r {{zeppelin.k8s.interpreter.rpc.portRange}} -c {{zeppelin.k8s.server.rpc.service}} -p {{zeppelin.k8s.server.rpc.portRange}} -i {{zeppelin.k8s.interpreter.group.id}} -l {{zeppelin.k8s.interpreter.localRepo}} -g {{zeppelin.k8s.interpreter.setting.name}}"]
+    args:
+      - "$(ZEPPELIN_HOME)/bin/interpreter.sh"
+      - "-d"
+      - "$(ZEPPELIN_HOME)/interpreter/{{zeppelin.k8s.interpreter.group.name}}"
+      - "-r"
+      - "{{zeppelin.k8s.interpreter.rpc.portRange}}"
+      - "-c"
+      - "{{zeppelin.k8s.server.rpc.service}}"
+      - "-p"
+      - "{{zeppelin.k8s.server.rpc.portRange}}"
+      - "-i"
+      - "{{zeppelin.k8s.interpreter.group.id}}"
+      - "-l"
+      - "{{zeppelin.k8s.interpreter.localRepo}}/{{zeppelin.k8s.interpreter.setting.name}}"
+      - "-g"
+      - "{{zeppelin.k8s.interpreter.setting.name}}"
     env:
   {% for key, value in zeppelin.k8s.envs.items() %}
     - name: {{key}}

--- a/scripts/docker/zeppelin-interpreter/Dockerfile
+++ b/scripts/docker/zeppelin-interpreter/Dockerfile
@@ -26,7 +26,7 @@ ENV VERSION="${version}" \
 
 RUN set -ex && \
     apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jre-headless wget && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jre-headless wget tini && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \
@@ -80,4 +80,5 @@ RUN mkdir -p "${Z_HOME}/logs" "${Z_HOME}/run" "${Z_HOME}/local-repo" && \
     chmod -R 775 "${Z_HOME}/logs" "${Z_HOME}/run" "${Z_HOME}/local-repo"
 
 USER 1000
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
 WORKDIR ${Z_HOME}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -698,7 +698,7 @@ public class RemoteInterpreterServer extends Thread
 
       if (server.isServing()) {
         LOGGER.info("Force shutting down");
-        System.exit(0);
+        System.exit(1);
       }
 
       LOGGER.info("Shutting down");

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -129,8 +129,6 @@ public class RemoteInterpreterServer extends Thread
   private final Map<String, RunningApplication> runningApplications =
       Collections.synchronizedMap(new HashMap<String, RunningApplication>());
 
-  private Map<String, Object> remoteWorksResponsePool;
-
   // Hold information for manual progress update
   private ConcurrentMap<String, Integer> progressMap = new ConcurrentHashMap<>();
 
@@ -194,7 +192,6 @@ public class RemoteInterpreterServer extends Thread
         .stopTimeoutVal(DEFAULT_SHUTDOWN_TIMEOUT)
         .stopTimeoutUnit(TimeUnit.MILLISECONDS)
         .processor(processor));
-    remoteWorksResponsePool = Collections.synchronizedMap(new HashMap<String, Object>());
 
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtils.java
@@ -18,8 +18,6 @@
 package org.apache.zeppelin.interpreter.remote;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.thrift.transport.TServerSocket;
-import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,31 +44,18 @@ public class RemoteInterpreterUtils {
   }
 
   public static int findRandomAvailablePortOnAllLocalInterfaces() throws IOException {
-    int port;
-    try (ServerSocket socket = new ServerSocket(0);) {
-      port = socket.getLocalPort();
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
     }
-    return port;
   }
 
-  /**
-   * start:end
-   *
-   * @param portRange
-   * @return
-   * @throws IOException
-   */
-  public static TServerSocket createTServerSocket(String portRange)
-      throws IOException {
-
-    TServerSocket tSocket = null;
+  public static int findAvailablePort(String portRange) throws IOException {
     // ':' is the default value which means no constraints on the portRange
     if (StringUtils.isBlank(portRange) || portRange.equals(":")) {
-      try {
-        tSocket = new TServerSocket(0);
-        return tSocket;
-      } catch (TTransportException e) {
-        throw new IOException("Fail to create TServerSocket", e);
+      try (ServerSocket socket = new ServerSocket(0)) {
+        return socket.getLocalPort();
+      } catch (IOException e) {
+        throw new IOException("Failed to allocate a automatic port", e);
       }
     }
     // valid user registered port https://en.wikipedia.org/wiki/Registered_port
@@ -84,10 +69,9 @@ public class RemoteInterpreterUtils {
       end = Integer.parseInt(ports[1]);
     }
     for (int i = start; i <= end; ++i) {
-      try {
-        tSocket = new TServerSocket(i);
-        return tSocket;
-      } catch (Exception e) {
+      try (ServerSocket socket = new ServerSocket(i)) {
+        return socket.getLocalPort();
+      } catch (IOException e) {
         // ignore this
       }
     }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/YarnUtils.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/YarnUtils.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class YarnUtils {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(YarnUtils.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(YarnUtils.class);
 
   private static AMRMClient<ContainerRequest> amClient = AMRMClient.createAMRMClient();
   private static Configuration conf = new YarnConfiguration();
@@ -46,7 +46,7 @@ public class YarnUtils {
   }
 
   public static void register(String host, int port) throws Exception {
-    LOGGER.info("Registering yarn app at " + host + ":" + port);
+    LOGGER.info("Registering yarn app at {}:{}", host, port);
     try {
       amClient.registerApplicationMaster(host, port, null);
     } catch (YarnException e) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
@@ -96,7 +96,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
       LOGGER.info("Process is launched: {}", commandLine);
     } catch (IOException e) {
       this.processOutput.stopCatchLaunchOutput();
-      LOGGER.error("Fail to launch process: " + commandLine, e);
+      LOGGER.error("Fail to launch process: {}", commandLine, e);
       transition(State.TERMINATED);
       errorMessage = e.getMessage();
     }
@@ -106,7 +106,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
 
   public void transition(State state) {
     this.state = state;
-    LOGGER.info("Process state is transitioned to " + state);
+    LOGGER.info("Process state is transitioned to {}", state);
   }
 
   public void onTimeout() {
@@ -121,7 +121,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
 
   @Override
   public void onProcessComplete(int exitValue) {
-    LOGGER.warn("Process is exited with exit value " + exitValue);
+    LOGGER.warn("Process is exited with exit value {}", exitValue);
     if (exitValue == 0) {
       transition(State.COMPLETED);
     } else {
@@ -131,7 +131,8 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
 
   @Override
   public void onProcessFailed(ExecuteException e) {
-    LOGGER.warn("Process is failed due to " + e);
+    LOGGER.warn("Process with cmd {} is failed due to", commandLine, e);
+
     errorMessage = ExceptionUtils.getStackTrace(e);
     transition(State.TERMINATED);
   }
@@ -187,7 +188,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
       if (s.startsWith("Interpreter launch command")) {
         LOGGER.info(s);
       } else {
-        LOGGER.debug("Process Output: " + s);
+        LOGGER.debug("Process Output: {}", s);
       }
       if (catchLaunchOutput) {
         launchOutput.append(s + "\n");

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtilsTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterUtilsTest.java
@@ -26,23 +26,18 @@ import static org.junit.Assert.assertTrue;
 public class RemoteInterpreterUtilsTest {
 
   @Test
-  public void testCreateTServerSocket() throws IOException {
-    assertTrue(RemoteInterpreterUtils.createTServerSocket(":")
-        .getServerSocket().getLocalPort() > 0);
+  public void testfindAvailablePort() throws IOException {
+    assertTrue(RemoteInterpreterUtils.findAvailablePort(":") > 0);
 
     String portRange = ":30000";
-    assertTrue(RemoteInterpreterUtils.createTServerSocket(portRange)
-        .getServerSocket().getLocalPort() <= 30000);
+    assertTrue(RemoteInterpreterUtils.findAvailablePort(portRange) <= 30000);
 
     portRange = "30000:";
-    assertTrue(RemoteInterpreterUtils.createTServerSocket(portRange)
-        .getServerSocket().getLocalPort() >= 30000);
+    assertTrue(RemoteInterpreterUtils.findAvailablePort(portRange) >= 30000);
 
     portRange = "30000:40000";
-    int port = RemoteInterpreterUtils.createTServerSocket(portRange)
-        .getServerSocket().getLocalPort();
+    int port = RemoteInterpreterUtils.findAvailablePort(portRange);
     assertTrue(port >= 30000 && port <= 40000);
   }
-
 
 }

--- a/zeppelin-plugins/notebookrepo/s3/src/test/resources/logback.xml
+++ b/zeppelin-plugins/notebookrepo/s3/src/test/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -144,7 +144,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
                         && jar.toFile().getName().endsWith(".jar"))
                 .map(jar -> jar.toAbsolutePath().toString())
                 .collect(Collectors.toList());
-        if (interpreterJars.size() == 0) {
+        if (interpreterJars.isEmpty()) {
           throw new IOException("zeppelin-interpreter-shaded jar is not found");
         } else if (interpreterJars.size() > 1) {
           throw new IOException("more than 1 zeppelin-interpreter-shaded jars are found: "
@@ -171,7 +171,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
       sparkConfBuilder.append(" --proxy-user " + context.getUserName());
     }
 
-    env.put("ZEPPELIN_SPARK_CONF", escapeSpecialCharacter(sparkConfBuilder.toString()));
+    env.put("ZEPPELIN_SPARK_CONF", sparkConfBuilder.toString());
 
     // set these env in the order of
     // 1. interpreter-setting
@@ -215,10 +215,10 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
         env.put("ZEPPELIN_INTP_CLASSPATH", driverExtraClassPath);
       }
     } else {
-      LOGGER.warn("spark-defaults.conf doesn't exist: " + sparkDefaultFile.getAbsolutePath());
+      LOGGER.warn("spark-defaults.conf doesn't exist: {}", sparkDefaultFile.getAbsolutePath());
     }
 
-    LOGGER.debug("buildEnvFromProperties: " + env);
+    LOGGER.debug("buildEnvFromProperties: {}", env);
     return env;
 
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
@@ -107,8 +107,8 @@ public class SparkInterpreterLauncherTest {
     assertTrue(interpreterProcess.getEnv().size() >= 2);
     assertEquals(sparkHome, interpreterProcess.getEnv().get("SPARK_HOME"));
     assertFalse(interpreterProcess.getEnv().containsKey("ENV_1"));
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.files=file_1" +
-                    " --conf spark.jars=jar_1 --conf spark.app.name=intpGroupId --conf spark.master=local[*]"),
+    assertEquals(" --conf spark.files=file_1" +
+                    " --conf spark.jars=jar_1 --conf spark.app.name=intpGroupId --conf spark.master=local[*]",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -138,9 +138,9 @@ public class SparkInterpreterLauncherTest {
     String sparkJars = "jar_1";
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     String sparkFiles = "file_1";
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+    assertEquals(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
-                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn-client"),
+                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn-client",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -171,10 +171,10 @@ public class SparkInterpreterLauncherTest {
     String sparkJars = "jar_1";
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     String sparkFiles = "file_1";
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+    assertEquals(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
                     " --conf spark.submit.deployMode=client" +
-                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn"),
+                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -207,13 +207,13 @@ public class SparkInterpreterLauncherTest {
             zeppelinHome + "/interpreter/zeppelin-interpreter-shaded-" + Util.getVersion() + ".jar";
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     String sparkFiles = "file_1," + zeppelinHome + "/conf/log4j_yarn_cluster.properties";
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+    assertEquals(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.yarn.maxAppAttempts=1" +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
                     " --conf spark.yarn.isPython=true" +
                     " --conf spark.yarn.submit.waitAppCompletion=false" +
                     " --conf spark.app.name=intpGroupId" +
-                    " --conf spark.master=yarn-cluster"),
+                    " --conf spark.master=yarn-cluster",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -253,14 +253,14 @@ public class SparkInterpreterLauncherTest {
             zeppelinHome + "/interpreter/zeppelin-interpreter-shaded-" + Util.getVersion() + ".jar";
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     String sparkFiles = "file_1," + zeppelinHome + "/conf/log4j_yarn_cluster.properties";
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+    assertEquals(" --conf spark.yarn.dist.archives=" + sparkrZip +
             " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId" +
             " --conf spark.yarn.maxAppAttempts=1" +
             " --conf spark.master=yarn" +
             " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
             " --conf spark.submit.deployMode=cluster" +
             " --conf spark.yarn.submit.waitAppCompletion=false" +
-            " --proxy-user user1"),
+            " --proxy-user user1",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
     Files.deleteIfExists(Paths.get(localRepoPath.toAbsolutePath().toString(), "test.jar"));
     FileUtils.deleteDirectory(localRepoPath.toFile());
@@ -302,7 +302,7 @@ public class SparkInterpreterLauncherTest {
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     // escape special characters
     String sparkFiles = "{}," + zeppelinHome + "/conf/log4j_yarn_cluster.properties";
-    assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+    assertEquals(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.yarn.isPython=true" +
                     " --conf spark.app.name=intpGroupId" +
                     " --conf spark.yarn.maxAppAttempts=1" +
@@ -310,7 +310,7 @@ public class SparkInterpreterLauncherTest {
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
                     " --conf spark.submit.deployMode=cluster" +
                     " --conf spark.yarn.submit.waitAppCompletion=false" +
-                    " --proxy-user user1"),
+                    " --proxy-user user1",
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
     FileUtils.deleteDirectory(localRepoPath.toFile());
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -85,6 +85,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   private StatusChangedListener afterStatusChangedListener;
   private QuartzSchedulerService schedulerService;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
@@ -105,6 +106,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     schedulerService.waitForFinishInit();
   }
 
+  @Override
   @After
   public void tearDown() throws Exception {
     super.tearDown();


### PR DESCRIPTION
### What is this PR for?
These PR touch the start and stop procedures of all interpreters.
 - improved start script with [shellcheck](https://www.shellcheck.net/) recommendations
 - Use `exec [...]` instead of `eval [..] &`, which means that the Java interpreter process is not a fork of the shell script
   -> no trap handling required in the start script
   -> signals land in the JVM
 - Correct escaping is done by the start-script
 - remove anonymous threads in 'RemoteInterpreterServer.java and give the thread nice names
 - Use TServer's StopTimeoutVal and stopTimeoutUnit for faster shutdown
 - remove special K8s shutdown handling
 - unregister interpreter during unpredictable shutdown

### What type of PR is it?
 - Improvement 

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5070

### How should this be tested?
* Travis-CI: https://travis-ci.com/github/Reamer/zeppelin/builds/198263926

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
