### PR TITLE
[ZEPPELIN-5061] fix note list broadcast

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.zeppelin.socket;
 
-
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -52,6 +51,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
 
 /**
  * Manager class for managing websocket connections
@@ -356,6 +356,19 @@ public class ConnectionManager {
     for (NotebookSocket conn : userSocketMap.get(user)) {
       Message m = new Message(Message.OP.PARAGRAPH).withMsgId(msgId).put("paragraph", p);
       unicast(m, conn);
+    }
+  }
+
+  public static abstract class UserIterator {
+    public abstract void handleUser(String user, Set<String> userAndRoles);
+  }
+
+  public void forAllUsers(UserIterator iterator) {
+    Set<String> userAndRoles;
+    for (String user : userSocketMap.keySet()) {
+      userAndRoles = authorizationService.getRoles(user);
+      userAndRoles.add(user);
+      iterator.handleUser(user, userAndRoles);
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.socket;
 
+
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -51,7 +52,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Function;
 
 /**
  * Manager class for managing websocket connections

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/ConnectionManager.java
@@ -359,14 +359,13 @@ public class ConnectionManager {
     }
   }
 
-  public static abstract class UserIterator {
-    public abstract void handleUser(String user, Set<String> userAndRoles);
+  public interface UserIterator {
+    public void handleUser(String user, Set<String> userAndRoles);
   }
 
   public void forAllUsers(UserIterator iterator) {
-    Set<String> userAndRoles;
     for (String user : userSocketMap.keySet()) {
-      userAndRoles = authorizationService.getRoles(user);
+      Set<String> userAndRoles = authorizationService.getRoles(user);
       userAndRoles.add(user);
       iterator.handleUser(user, userAndRoles);
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -81,6 +81,7 @@ import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.service.SimpleServiceCallback;
+import org.apache.zeppelin.socket.ConnectionManager.UserIterator;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -636,17 +637,22 @@ public class NotebookServer extends WebSocketServlet
   }
 
   public void inlineBroadcastNoteList(AuthenticationInfo subject, Set<String> userAndRoles) {
-    if (subject == null) {
-      subject = new AuthenticationInfo(StringUtils.EMPTY);
-    }
-    //send first to requesting user
-    AuthorizationService authorizationService = getNotebookAuthorizationService();
-    List<NoteInfo> notesInfo = getNotebook().getNotesInfo(
-        noteId -> authorizationService.isReader(noteId, userAndRoles));
-    Message message = new Message(OP.NOTES_INFO).put("notes", notesInfo);
-    getConnectionManager().multicastToUser(subject.getUser(), message);
-    //to others afterwards
-    getConnectionManager().broadcastNoteListExcept(notesInfo, subject);
+    broadcastNoteListUpdate();
+  }
+
+  public void broadcastNoteListUpdate() {
+    getConnectionManager().forAllUsers(new UserIterator() {
+      @Override
+      public void handleUser(String user, Set<String> userAndRoles) {
+        AuthorizationService authorizationService = getNotebookAuthorizationService();
+
+        List<NoteInfo> notesInfo = getNotebook().getNotesInfo(
+            noteId -> authorizationService.isReader(noteId, userAndRoles));
+
+        getConnectionManager().multicastToUser(user,
+          new Message(OP.NOTES_INFO).put("notes", notesInfo));
+      }
+    });
   }
 
   public void broadcastNoteList(AuthenticationInfo subject, Set<String> userAndRoles) {
@@ -772,18 +778,7 @@ public class NotebookServer extends WebSocketServlet
 
   public void broadcastReloadedNoteList(NotebookSocket conn, ServiceContext context)
       throws IOException {
-    getNotebookService().listNotesInfo(true, context,
-        new WebSocketServiceCallback<List<NoteInfo>>(conn) {
-          @Override
-          public void onSuccess(List<NoteInfo> notesInfo,
-                                ServiceContext context) throws IOException {
-            super.onSuccess(notesInfo, context);
-            getConnectionManager().multicastToUser(context.getAutheInfo().getUser(),
-                new Message(OP.NOTES_INFO).put("notes", notesInfo));
-            //to others afterwards
-            getConnectionManager().broadcastNoteListExcept(notesInfo, context.getAutheInfo());
-          }
-        });
+    broadcastNoteListUpdate();
   }
 
   void permissionError(NotebookSocket conn, String op, String userName, Set<String> userAndRoles,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -641,11 +641,11 @@ public class NotebookServer extends WebSocketServlet
   }
 
   public void broadcastNoteListUpdate() {
+    AuthorizationService authorizationService = getNotebookAuthorizationService();
+
     getConnectionManager().forAllUsers(new UserIterator() {
       @Override
       public void handleUser(String user, Set<String> userAndRoles) {
-        AuthorizationService authorizationService = getNotebookAuthorizationService();
-
         List<NoteInfo> notesInfo = getNotebook().getNotesInfo(
             noteId -> authorizationService.isReader(noteId, userAndRoles));
 


### PR DESCRIPTION
### What is this PR for?
As described in the linked issue, there has been a bug where, when a user creates or updates a note, that user's note list is published to all connected users, instead of their own note lists. This has the security problem that it leaks information about a user's note list to other users who may not have permission to see it. This PR fixes that bug by querying each connected user's note list and publishing that instead.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5061

### How should this be tested?
Manual testing:
* Configure a list of users using a `shiro.ini` file. Example:
```
[users]
# List of users with their password allowed to access Zeppelin.
# To use a different strategy (LDAP / Database / ...) check the shiro doc at http://shiro.apache.org/configuration.html#Configuration-INISections
admin = password1, admin
user1 = password2, role1
user2 = password3, role1
```
* Turn off public notebooks in `zeppelin-site.xml` by setting the property `zeppelin.notebook.public` to `false`
* Boot Zeppelin server on this PR
* Log in as user1
* In a separate browser, log in as user2
* As user1, create a note
Previous result: user1's note appears on user2's dashboard. Refreshing user2's browser will cause the note to disappear from their dashboard.
Fixed expectations:
- user1's note does not appear on user2's dashboard.
- the display of any notes created by user1 is not affected when user2 creates a note
- when `zeppelin.notebook.public` is set to `true`, user1's note appears as expected on user1's dashboard
