### PR TITLE
[ZEPPELIN-4409]. Set spark.app.name to know which user is running which notebook

### DIFF
--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -29,7 +29,7 @@
       "spark.app.name": {
         "envName": "",
         "propertyName": "spark.app.name",
-        "defaultValue": "Zeppelin",
+        "defaultValue": "",
         "description": "The name of spark application.",
         "type": "string"
       },

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -78,6 +78,15 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
       }
     }
 
+    // set spark.app.name if it is not set or empty
+    if (!sparkProperties.containsKey("spark.app.name") ||
+            StringUtils.isBlank(sparkProperties.getProperty("spark.app.name"))) {
+      sparkProperties.setProperty("spark.app.name", context.getInterpreterGroupId());
+    } else {
+      String appName = context.getInterpreterGroupId();
+      sparkProperties.setProperty("spark.app.name", appName);
+    }
+
     setupPropertiesForPySpark(sparkProperties);
     setupPropertiesForSparkR(sparkProperties);
     if (isYarnMode() && getDeployMode().equals("cluster")) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -82,9 +82,6 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     if (!sparkProperties.containsKey("spark.app.name") ||
             StringUtils.isBlank(sparkProperties.getProperty("spark.app.name"))) {
       sparkProperties.setProperty("spark.app.name", context.getInterpreterGroupId());
-    } else {
-      String appName = context.getInterpreterGroupId();
-      sparkProperties.setProperty("spark.app.name", appName);
     }
 
     setupPropertiesForPySpark(sparkProperties);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
@@ -108,7 +108,7 @@ public class SparkInterpreterLauncherTest {
     assertEquals(sparkHome, interpreterProcess.getEnv().get("SPARK_HOME"));
     assertFalse(interpreterProcess.getEnv().containsKey("ENV_1"));
     assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.files=file_1" +
-                    " --conf spark.jars=jar_1 --conf spark.master=local[*]"),
+                    " --conf spark.jars=jar_1 --conf spark.app.name=intpGroupId --conf spark.master=local[*]"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -140,7 +140,7 @@ public class SparkInterpreterLauncherTest {
     String sparkFiles = "file_1";
     assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
-                    " --conf spark.yarn.isPython=true --conf spark.master=yarn-client"),
+                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn-client"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -174,7 +174,7 @@ public class SparkInterpreterLauncherTest {
     assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
                     " --conf spark.submit.deployMode=client" +
-                    " --conf spark.yarn.isPython=true --conf spark.master=yarn"),
+                    " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId --conf spark.master=yarn"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
 
@@ -212,6 +212,7 @@ public class SparkInterpreterLauncherTest {
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
                     " --conf spark.yarn.isPython=true" +
                     " --conf spark.yarn.submit.waitAppCompletion=false" +
+                    " --conf spark.app.name=intpGroupId" +
                     " --conf spark.master=yarn-cluster"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
   }
@@ -253,10 +254,12 @@ public class SparkInterpreterLauncherTest {
     String sparkrZip = sparkHome + "/R/lib/sparkr.zip#sparkr";
     String sparkFiles = "file_1," + zeppelinHome + "/conf/log4j_yarn_cluster.properties";
     assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+            " --conf spark.yarn.isPython=true --conf spark.app.name=intpGroupId" +
             " --conf spark.yarn.maxAppAttempts=1" +
+            " --conf spark.master=yarn" +
             " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
-            " --conf spark.submit.deployMode=cluster --conf spark.yarn.isPython=true" +
-            " --conf spark.yarn.submit.waitAppCompletion=false --conf spark.master=yarn" +
+            " --conf spark.submit.deployMode=cluster" +
+            " --conf spark.yarn.submit.waitAppCompletion=false" +
             " --proxy-user user1"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
     Files.deleteIfExists(Paths.get(localRepoPath.toAbsolutePath().toString(), "test.jar"));
@@ -300,11 +303,14 @@ public class SparkInterpreterLauncherTest {
     // escape special characters
     String sparkFiles = "{}," + zeppelinHome + "/conf/log4j_yarn_cluster.properties";
     assertEquals(InterpreterLauncher.escapeSpecialCharacter(" --conf spark.yarn.dist.archives=" + sparkrZip +
+                    " --conf spark.yarn.isPython=true" +
+                    " --conf spark.app.name=intpGroupId" +
                     " --conf spark.yarn.maxAppAttempts=1" +
+                    " --conf spark.master=yarn" +
                     " --conf spark.files=" + sparkFiles + " --conf spark.jars=" + sparkJars +
-                    " --conf spark.submit.deployMode=cluster --conf spark.yarn.isPython=true" +
+                    " --conf spark.submit.deployMode=cluster" +
                     " --conf spark.yarn.submit.waitAppCompletion=false" +
-                    " --conf spark.master=yarn --proxy-user user1"),
+                    " --proxy-user user1"),
             interpreterProcess.getEnv().get("ZEPPELIN_SPARK_CONF"));
     FileUtils.deleteDirectory(localRepoPath.toFile());
   }


### PR DESCRIPTION

### What is this PR for?

Use  the interpreter group id as the spark app name if it is not set. So that user can easily figure out which yarn app is what he is looking for no matter it is note isolated or user isolated. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4409

### How should this be tested?
* CI pass


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
