### PR TITLE
[ZEPPELIN-5076] Update to Apache Software Foundation Parent POM 

### DIFF
--- a/file/pom.xml
+++ b/file/pom.xml
@@ -36,10 +36,6 @@
     <interpreter.name>file</interpreter.name>
     <ws.rsapi.version>2.0</ws.rsapi.version>
     <jersey.common.version>2.22.2</jersey.common.version>
-
-    <!--plugin versions-->
-    <plugin.surefire.version>2.18.1</plugin.surefire.version>
-    <interpreter.name>file</interpreter.name>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,9 @@
 
     <!-- to be able to exclude some tests using command line -->
     <tests.to.exclude/>
+
+    <!-- Timestamp for https://reproducible-builds.org/ -->
+    <project.build.outputTimestamp>2020-10-01T13:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencyManagement>
@@ -1980,6 +1983,9 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <notimestamp>true</notimestamp>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1388,7 +1388,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${plugin.compiler.version}</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -1420,7 +1419,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${plugin.jar.version}</version>
         <configuration>
           <archive>
             <manifest>
@@ -1435,7 +1433,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
-        <version>${plugin.remote.resource.version}</version>
         <executions>
           <execution>
             <id>process-remote-resources</id>
@@ -1454,7 +1451,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>${plugin.scm.version}</version>
         <configuration>
           <connectionType>developerConnection</connectionType>
           <scmVersion>branch-0.1</scmVersion>
@@ -1465,7 +1461,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${plugin.enforcer.version}</version>
         <executions>
           <execution>
             <id>enforce</id>
@@ -1499,13 +1494,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${plugin.deploy.version}</version>
       </plugin>
 
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>${plugin.git.commit.id.version}</version>
         <executions>
           <execution>
             <goals>
@@ -1547,15 +1540,52 @@
 
     <pluginManagement>
       <plugins>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <version>${plugin.shade.version}</version>
-          </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${plugin.shade.version}</version>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>${plugin.install.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${plugin.jar.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>${plugin.scm.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>${plugin.git.commit.id.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${plugin.enforcer.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${plugin.deploy.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-remote-resources-plugin</artifactId>
+          <version>${plugin.remote.resource.version}</version>
         </plugin>
 
         <plugin>
@@ -1733,90 +1763,90 @@
           </executions>
         </plugin>
 
-      <plugin>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-maven-plugin</artifactId>
-        <version>${plugin.scalatest.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.scalatest</groupId>
+          <artifactId>scalatest-maven-plugin</artifactId>
+          <version>${plugin.scalatest.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>${plugin.buildhelper.version}</version>
-      </plugin>
 
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>${plugin.frontend.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${plugin.buildhelper.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${plugin.failsafe.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+          <version>${plugin.frontend.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>${plugin.protobuf.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${plugin.failsafe.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>com.bazaarvoice.maven.plugins</groupId>
-        <artifactId>s3-upload-maven-plugin</artifactId>
-        <version>${plugin.s3.upload.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>com.github.os72</groupId>
+          <artifactId>protoc-jar-maven-plugin</artifactId>
+          <version>${plugin.protobuf.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>${plugin.buildnumber.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>com.bazaarvoice.maven.plugins</groupId>
+          <artifactId>s3-upload-maven-plugin</artifactId>
+          <version>${plugin.s3.upload.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.vafer</groupId>
-        <artifactId>jdeb</artifactId>
-        <version>${plugin.jdeb.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>${plugin.buildnumber.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro-maven-plugin</artifactId>
-        <version>${plugin.avro.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.vafer</groupId>
+          <artifactId>jdeb</artifactId>
+          <version>${plugin.jdeb.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.scalatra.scalate</groupId>
-        <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
-        <version>${plugin.scalate.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-maven-plugin</artifactId>
+          <version>${plugin.avro.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>${plugin.source.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.scalatra.scalate</groupId>
+          <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
+          <version>${plugin.scalate.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${plugin.javadoc.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${plugin.source.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${plugin.gpg.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${plugin.javadoc.version}</version>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>${plugin.rat.version}</version>
-      </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>${plugin.gpg.version}</version>
+        </plugin>
 
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <version>${plugin.rat.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <plugin.scalate.version>1.7.1</plugin.scalate.version>
     <plugin.scalatest.version>2.0.0</plugin.scalatest.version>
     <plugin.scm.version>1.11.2</plugin.scm.version>
-    <plugin.shade.version>3.2.2</plugin.shade.version>
+    <plugin.shade.version>3.2.4</plugin.shade.version>
     <plugin.source.version>3.2.1</plugin.source.version>
     <plugin.surefire.version>2.22.2</plugin.surefire.version>
 

--- a/zeppelin-client-examples/pom.xml
+++ b/zeppelin-client-examples/pom.xml
@@ -64,13 +64,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/zeppelin-client/pom.xml
+++ b/zeppelin-client/pom.xml
@@ -95,12 +95,6 @@
         <filtering>true</filtering>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/zeppelin-display/pom.xml
+++ b/zeppelin-display/pom.xml
@@ -30,12 +30,6 @@
   <packaging>jar</packaging>
   <name>Zeppelin: Display system apis</name>
 
-  <properties>
-    <!--plugin versions -->
-    <plugin.failsafe.version>2.16</plugin.failsafe.version>
-    <plugin.scalatest.version>1.0</plugin.scalatest.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/zeppelin-integration/pom.xml
+++ b/zeppelin-integration/pom.xml
@@ -37,14 +37,9 @@
   </prerequisites>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <!--test library versions-->
     <selenium.java.version>3.141.59</selenium.java.version>
     <commons.lang3.version>3.7</commons.lang3.version>
-
-    <!--plugin library versions-->
-    <plugin.failsafe.version>2.16</plugin.failsafe.version>
   </properties>
 
   <dependencies>

--- a/zeppelin-interpreter-integration/pom.xml
+++ b/zeppelin-interpreter-integration/pom.xml
@@ -165,10 +165,6 @@
           </environmentVariables>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -111,6 +111,7 @@
               <filter>
                 <artifact>*:*</artifact>
                 <excludes>
+                  <exclude>META-INF/MANIFEST.MF</exclude>
                   <exclude>META-INF/*.SF</exclude>
                   <exclude>META-INF/*.DSA</exclude>
                   <exclude>META-INF/*.RSA</exclude>
@@ -120,8 +121,18 @@
             </filters>
             <transformers>
               <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <manifestEntries>
+                  <X-Compile-Source-JDK>${java.version}</X-Compile-Source-JDK>
+                  <X-Compile-Target-JDK>${java.version}</X-Compile-Target-JDK>
+                </manifestEntries>
+              </transformer>
               <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                 <resource>reference.conf</resource>
+              </transformer>
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                <addHeader>true</addHeader>
               </transformer>
             </transformers>
             <artifactSet>

--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -33,7 +33,6 @@
   <description>Zeppelin Interpreter Shaded</description>
 
   <properties>
-    <!--plugin versions-->
     <shaded.dependency.prefix>org.apache.zeppelin.shaded</shaded.dependency.prefix>
   </properties>
 

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -41,9 +41,6 @@
     <sisu.plexus.version>0.3.4</sisu.plexus.version>
     <jline.version>2.14.3</jline.version>
     <atomix.version>3.0.0-rc4</atomix.version>
-
-    <!--plugin versions-->
-    <plugin.shade.version>2.3</plugin.shade.version>
   </properties>
 
   <dependencies>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -37,7 +37,6 @@
     <lucene.version>8.7.0</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
-    <frontend.maven.plugin.version>1.3</frontend.maven.plugin.version>
     <commons.vfs2.version>2.6.0</commons.vfs2.version>
     <eclipse.jgit.version>4.5.4.201711221230-r</eclipse.jgit.version>
   </properties>
@@ -176,7 +175,7 @@
     <dependency>
       <groupId>com.github.eirslett</groupId>
       <artifactId>frontend-plugin-core</artifactId>
-      <version>${frontend.maven.plugin.version}</version>
+      <version>${plugin.frontend.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
### What is this PR for?
Includes:
 - update Apache Software Foundation Parent POM 
   - Documentation: http://maven.apache.org/pom/asf/
   - complete diff: https://github.com/apache/maven-apache-parent/compare/apache-17...apache-23
   - parent pom introduced reproducible builds
 - Add some transformers for interpreter shading
 - remove unused `maven-dependency-plugin` plugin (in most cases this plugin in skipped)


### What type of PR is it?
 - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5076

### How should this be tested?
* Travis-CI: https://travis-ci.org/github/Reamer/zeppelin/builds/731909107

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
