### PR TITLE
[ZEPPELIN-5060] Disabled paragraph cause Zeppelin notebook to hang

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -226,7 +226,7 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
       ZeppelinITUtils.sleep(2000, false);
 
       collector.checkThat("Paragraph status is ",
-          getParagraphStatus(1), CoreMatchers.equalTo("PENDING")
+          getParagraphStatus(1), CoreMatchers.equalTo("FINISHED")
       );
 
       driver.navigate().refresh();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -347,16 +347,23 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
               = interpreterSetting.getConfig(interpreter.getClassName());
       mergeConfig(config);
 
+      setStatus(Status.PENDING);
+
       if (shouldSkipRunParagraph()) {
         LOGGER.info("Skip to run blank paragraph. {}", getId());
         setStatus(Job.Status.FINISHED);
         return true;
       }
 
-      if (getConfig().get("enabled") == null || (Boolean) getConfig().get("enabled")) {
+      if (isEnabled()) {
         setAuthenticationInfo(getAuthenticationInfo());
         interpreter.getScheduler().submit(this);
+       } else {
+        LOGGER.info("Skip disabled paragraph. {}", getId());
+        setStatus(Job.Status.FINISHED);
+        return true;
       }
+
 
       if (blocking) {
         while (!getStatus().isCompleted()) {


### PR DESCRIPTION
### What is this PR for?

When trying to run a disabled paragraph, backend hangs because the paragraph is not started, but we are still waiting for it to finish. Instead, we should skip it just like empty paragraphs.

Also, we need to change paragraph state to pending, so next state change to finished is broadcasted to client.

### What type of PR is it?

Bug Fix

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-5060

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
