### PR TITLE
[ZEPPELIN-5077] Run all paragraphs does not stop on failing paragraph

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -238,6 +238,47 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
     }
   }
 
+  @Test
+  public void testRunAllUserCodeFail() throws Exception {
+    try {
+      createNewNote();
+      waitForParagraph(1, "READY");
+      setTextOfParagraph(1, "syntax error");
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click=\"insertNew('below')\"]"))
+              .click();
+      waitForParagraph(2, "READY");
+      setTextOfParagraph(2, "println (\"abcd\")");
+
+
+      driver.findElement(By.xpath(".//*[@id='main']//button[contains(@ng-click, 'runAllParagraphs')]")).sendKeys(Keys.ENTER);
+      ZeppelinITUtils.sleep(1000, false);
+      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Run all paragraphs?')]" +
+              "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+      ZeppelinITUtils.sleep(2000, false);
+
+
+      collector.checkThat("First paragraph status is ",
+              getParagraphStatus(1), CoreMatchers.equalTo("ERROR")
+      );
+      collector.checkThat("Second paragraph status is ",
+              getParagraphStatus(2), CoreMatchers.equalTo("READY")
+      );
+
+      String xpathToOutputField = getParagraphXPath(2) + "//div[contains(@id,\"_text\")]";
+      collector.checkThat("Second paragraph output is ",
+              driver.findElements(By.xpath(xpathToOutputField)).size(),
+              CoreMatchers.equalTo(0));
+
+
+      driver.navigate().refresh();
+      ZeppelinITUtils.sleep(3000, false);
+      deleteTestNotebook(driver);
+    } catch (Exception e) {
+      handleException("Exception in ParagraphActionsIT while testRunAllUserCodeFail ", e);
+    }
+  }
+
 //  @Test
   public void testRunOnSelectionChange() throws Exception {
     try {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.service;
 
 
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN;
+import static org.apache.zeppelin.interpreter.InterpreterResult.Code.ERROR;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -49,7 +50,6 @@ import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.scheduler.SchedulerService;
 import org.apache.zeppelin.common.Message;
-import org.apache.zeppelin.rest.SessionManager;
 import org.apache.zeppelin.rest.exception.BadRequestException;
 import org.apache.zeppelin.rest.exception.ForbiddenException;
 import org.apache.zeppelin.rest.exception.NoteNotFoundException;
@@ -424,6 +424,12 @@ public class NotebookService {
             if (!runParagraph(noteId, paragraphId, title, text, params, config, null, false, true,
                     context, callback)) {
               // stop execution when one paragraph fails.
+              return false;
+            }
+            // also stop execution when user code in a paragraph fails
+            Paragraph p = note.getParagraph(paragraphId);
+            InterpreterResult result = p.getReturn();
+            if (result.code() == ERROR) {
               return false;
             }
           } catch (Exception e) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1488,8 +1488,15 @@ public class NotebookServer extends WebSocketServlet
             new TypeToken<List<Map<String, Object>>>() {
             }.getType());
 
-    getNotebookService().runAllParagraphs(noteId, paragraphs, getServiceContext(fromMessage),
-        new WebSocketServiceCallback<Paragraph>(conn));
+    if (!getNotebookService().runAllParagraphs(noteId, paragraphs, getServiceContext(fromMessage),
+        new WebSocketServiceCallback<Paragraph>(conn))) {
+      Note note = getNotebookService().getNote(noteId, getServiceContext(fromMessage), new SimpleServiceCallback());
+      if (note != null) {
+        for (Paragraph p : note.getParagraphs()) {
+          broadcastParagraph(note, p, null);
+        }
+      }
+    }
   }
 
   private void broadcastSpellExecution(NotebookSocket conn,

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1490,6 +1490,8 @@ public class NotebookServer extends WebSocketServlet
 
     if (!getNotebookService().runAllParagraphs(noteId, paragraphs, getServiceContext(fromMessage),
         new WebSocketServiceCallback<Paragraph>(conn))) {
+      // If one paragraph fails, we need to broadcast paragraph states to the client,
+      // or paragraphs not run will stay in PENDING state.
       Note note = getNotebookService().getNote(noteId, getServiceContext(fromMessage), new SimpleServiceCallback());
       if (note != null) {
         for (Paragraph p : note.getParagraphs()) {


### PR DESCRIPTION
### What is this PR for?

If a paragraph fails on something other than exception in Zeppelin, notebook will continue running paragraphs after it. This is unintuitive and regression from previous version.

To fix it, return "false" from running a paragraph, if it the actual user code fails. Also, after a failing "run all" operation, we need to broadcast paragraph states to client, so they wont stay in pending state after a failed run.


### What type of PR is it?

Bug Fix

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-5077

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
