### PR TITLE
[Hotfix] Add logging libraries into zeppelin interpreter process

### DIFF
--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -53,6 +53,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
     </dependency>


### PR DESCRIPTION
### What is this PR for?
With #3914 I removed the logging libraries for Zeppelin-Interpreters which are not shipped with their own logging libraries (e.g. Markdown). The logging libraries are not part of zeppelin-interpreter-shaded. With this change we add the logging libraries back to interpreter-parent, so that they are present in every Zeppelin-Interpreters process.

### What type of PR is it?
 - Hot Fix

### How should this be tested?
* Travis-CI: https://travis-ci.org/github/Reamer/zeppelin/builds/732966733

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
