### PR TITLE
ZEPPELIN-5081: Add loopPostInit to bind $intp

### DIFF
--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -136,6 +136,9 @@ public class SparkInterpreterTest {
     result = interpreter.interpret("/*line 1 \n line 2*/print(\"hello world\")", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
+    // test $intp
+    result = interpreter.interpret("$intp", getInterpreterContext());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 
     // Companion object with case class
     result = interpreter.interpret("import scala.math._\n" +


### PR DESCRIPTION
### What is this PR for?
There is a bug in the project: $intp variable is not defined for Spark/Scala 2.12 interpreter. It looks like this part of REPL in Spark 2.12 and in Spark 2.11 is the same, so I use the code from Spark/Scala 2.11 interpreter to fix it.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
[ZEPPELIN-5081]

### How should this be tested?
* Tested manually with master and Spark 2.4.2/Scala 2.12.8
