### PR TITLE
[ZEPPELIN-5088]. Explain statement is broken in flink interpreter

### DIFF
--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
@@ -126,6 +126,8 @@ public abstract class FlinkShims {
 
   public abstract void executeSql(Object tableEnv, String sql);
 
+  public abstract String explain(Object tableEnv, String sql);
+
   public abstract String sqlHelp();
 
   public abstract void setCatalogManagerSchemaResolver(Object catalogManager,

--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/sql/SqlCommandParser.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/sql/SqlCommandParser.java
@@ -112,8 +112,10 @@ public final class SqlCommandParser {
             SINGLE_OPERAND),
 
     EXPLAIN(
-            "EXPLAIN\\s+(.*)",
-            SINGLE_OPERAND),
+            "EXPLAIN\\s+(SELECT|INSERT)\\s+(.*)",
+            (operands) -> {
+              return Optional.of(new String[] { operands[0], operands[1] });
+            }),
 
     CREATE_DATABASE(
             "(CREATE\\s+DATABASE\\s+.*)",

--- a/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/shims110/CollectStreamTableSink.java
+++ b/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/shims110/CollectStreamTableSink.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.flink.shims111;
+package org.apache.zeppelin.flink.shims110;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;

--- a/flink/flink1.10-shims/src/main/scala/org/apache/zeppelin/flink/shims110/Flink110ScalaShims.scala
+++ b/flink/flink1.10-shims/src/main/scala/org/apache/zeppelin/flink/shims110/Flink110ScalaShims.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.zeppelin.flink.shims111
+package org.apache.zeppelin.flink.shims110
 
 import org.apache.flink.api.scala.{DataSet, FlinkILoop}
 import org.apache.flink.table.api.Table

--- a/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
+++ b/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
 import org.apache.flink.table.api.bridge.scala.BatchTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
@@ -371,6 +372,12 @@ public class Flink111Shims extends FlinkShims {
   @Override
   public void executeSql(Object tableEnv, String sql) {
     ((TableEnvironment) tableEnv).executeSql(sql);
+  }
+
+  @Override
+  public String explain(Object tableEnv, String sql) {
+    TableResult tableResult = ((TableEnvironment) tableEnv).executeSql(sql);
+    return tableResult.collect().next().getField(0).toString();
   }
 
   @Override

--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -469,8 +469,7 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
   private void callExplain(String sql, InterpreterContext context) throws IOException {
     try {
       lock.lock();
-      Table table = this.tbenv.sqlQuery(sql);
-      context.out.write(this.tbenv.explain(table) + "\n");
+      context.out.write(this.flinkInterpreter.getFlinkShims().explain(tbenv, sql) + "\n");
     } finally {
       if (lock.isHeldByCurrentThread()) {
         lock.unlock();


### PR DESCRIPTION
### What is this PR for?

This PR fix the explain statement issue in flink interpreter. For flink 1.10, 1.11, explain works in different approach, so we need to use shim to do that. This PR also add unit test to prevent regression in future. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5088

### How should this be tested?
* CI pass
https://travis-ci.org/github/zjffdu/zeppelin/builds/734175742

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
