### PR TITLE
[ZEPPELIN-5090] Migrate to org.apache.httpcomponents:httpclient

### DIFF
--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -215,7 +215,6 @@ The following components are provided under Apache License.
     (Apache 2.0) Maven Wagon HTTP Lightweight 1.0 (org.apache.maven.wagon:wagon-http-lightweight:2.7 - https://mvnrepository.com/artifact/org.apache.maven.wagon/wagon-http-lightweight/2.7)
     (Apache 2.0) Maven Wagon HTTP 1.0 (org.apache.maven.wagon:wagon-http:2.7 - https://mvnrepository.com/artifact/org.apache.maven.wagon/wagon-http/2.7)
     (Apache 2.0) Maven Wagon HTTP Shared 1.0 (org.apache.maven.wagon:wagon-http-shared:2.7 - https://mvnrepository.com/artifact/org.apache.maven.wagon/wagon-http-shared/2.7)
-    (Apache 2.0) Commons HTTP Client 3.1 (commons-httpclient:commons-httpclient:3.1 - https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient/3.1)
     (Apache 2.0) Scalatest 2.2.4 (org.scalatest:scalatest_2.10:2.2.4 - https://github.com/scalatest/scalatest)
     (Apache 2.0) frontend-maven-plugin 1.3 (com.github.eirslett:frontend-maven-plugin:1.3 - https://github.com/eirslett/frontend-maven-plugin/blob/frontend-plugins-1.3/LICENSE
     (Apache 2.0) frontend-plugin-core 1.3 (com.github.eirslett:frontend-plugin-core) - https://github.com/eirslett/frontend-maven-plugin/blob/frontend-plugins-1.3/LICENSE

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -44,7 +44,6 @@
     <wagon.version>2.7</wagon.version>
     <jline.version>2.14.3</jline.version>
     <atomix.version>3.0.0-rc4</atomix.version>
-    <commons-math3.version>3.1.1</commons-math3.version>
 
     <!--plugin versions-->
     <plugin.shade.version>2.3</plugin.shade.version>
@@ -64,10 +63,6 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>
-          <artifactId>commons-math3</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
@@ -83,12 +78,6 @@
       <groupId>io.atomix</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${atomix.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-math3</artifactId>
-      <version>${commons-math3.version}</version>
     </dependency>
 
     <dependency>
@@ -111,11 +100,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.danilopianini</groupId>
-      <artifactId>gson-extras</artifactId>
     </dependency>
 
     <dependency>
@@ -188,11 +172,6 @@
       <groupId>org.sonatype.aether</groupId>
       <artifactId>aether-impl</artifactId>
       <version>${aether.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -221,19 +221,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <exclusions>
-        <!-- using jcl-over-slf4j instead -->
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
       <version>${wagon.version}</version>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -36,7 +36,6 @@
   <properties>
 
     <!--library versions-->
-    <commons.httpclient.version>4.3.6</commons.httpclient.version>
     <jersey.version>2.27</jersey.version>
     <jersey.servlet.version>1.13</jersey.servlet.version>
     <javax.ws.rsapi.version>2.1</javax.ws.rsapi.version>
@@ -91,6 +90,11 @@
           <artifactId>jcl-over-slf4j</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ZeppelinServerMock.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ZeppelinServerMock.java
@@ -16,22 +16,30 @@
  */
 package org.apache.zeppelin.cluster;
 
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethodBase;
-import org.apache.commons.httpclient.cookie.CookiePolicy;
-import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
-import org.apache.commons.httpclient.methods.DeleteMethod;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
-import org.apache.commons.httpclient.methods.RequestEntity;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.plugin.PluginManager;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.server.ZeppelinServer;
 import org.apache.zeppelin.utils.TestUtils;
 import org.hamcrest.Description;
@@ -43,6 +51,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -51,9 +61,7 @@ import java.util.regex.Pattern;
 public class ZeppelinServerMock {
   protected static final Logger LOG = LoggerFactory.getLogger(ZeppelinServerMock.class);
 
-  static final String REST_API_URL = "/api";
-  static final String URL = getUrlToTest();
-  protected static final boolean WAS_RUNNING = checkIfServerIsRunning();
+  protected static final boolean WAS_RUNNING = AbstractTestRestApi.checkIfServerIsRunning();
 
   protected static File zeppelinHome;
   protected static File confDir;
@@ -66,19 +74,11 @@ public class ZeppelinServerMock {
     } else {
       url = "http://localhost:8080";
     }
-    url += REST_API_URL;
+    url += AbstractTestRestApi.REST_API_URL;
     if (path != null) {
       url += path;
     }
 
-    return url;
-  }
-
-  protected static String getUrlToTest() {
-    String url = "http://localhost:8080" + REST_API_URL;
-    if (System.getProperty("url") != null) {
-      url = System.getProperty("url");
-    }
     return url;
   }
 
@@ -139,7 +139,7 @@ public class ZeppelinServerMock {
       boolean started = false;
       while (System.currentTimeMillis() - s < 1000 * 60 * 3) {  // 3 minutes
         Thread.sleep(2000);
-        started = checkIfServerIsRunning();
+        started = AbstractTestRestApi.checkIfServerIsRunning();
         if (started == true) {
           break;
         }
@@ -184,7 +184,7 @@ public class ZeppelinServerMock {
       boolean started = true;
       while (System.currentTimeMillis() - s < 1000 * 60 * 3) {  // 3 minutes
         Thread.sleep(2000);
-        started = checkIfServerIsRunning();
+        started = AbstractTestRestApi.checkIfServerIsRunning();
         if (started == false) {
           break;
         }
@@ -208,186 +208,5 @@ public class ZeppelinServerMock {
     }
   }
 
-  protected static boolean checkIfServerIsRunning() {
-    GetMethod request = null;
-    boolean isRunning;
-    try {
-      request = httpGet("/version");
-      isRunning = request.getStatusCode() == 200;
-    } catch (IOException e) {
-      LOG.error("AbstractTestRestApi.checkIfServerIsRunning() fails .. ZeppelinServer is not " +
-          "running");
-      isRunning = false;
-    } finally {
-      if (request != null) {
-        request.releaseConnection();
-      }
-    }
-    return isRunning;
-  }
 
-  protected static GetMethod httpGet(String path) throws IOException {
-    return httpGet(path, StringUtils.EMPTY, StringUtils.EMPTY);
-  }
-
-  protected static GetMethod httpGet(String path, String user, String pwd) throws IOException {
-    return httpGet(path, user, pwd, StringUtils.EMPTY);
-  }
-
-  protected static GetMethod httpGet(String path, String user, String pwd, String cookies)
-      throws IOException {
-    LOG.info("Connecting to {}", URL + path);
-    HttpClient httpClient = new HttpClient();
-    GetMethod getMethod = new GetMethod(URL + path);
-    getMethod.addRequestHeader("Origin", URL);
-    if (userAndPasswordAreNotBlank(user, pwd)) {
-      getMethod.setRequestHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
-    }
-    if (!StringUtils.isBlank(cookies)) {
-      getMethod.setRequestHeader("Cookie", getMethod.getResponseHeader("Cookie") + ";" + cookies);
-    }
-    httpClient.executeMethod(getMethod);
-    LOG.info("{} - {}", getMethod.getStatusCode(), getMethod.getStatusText());
-    return getMethod;
-  }
-
-  protected static PutMethod httpPut(String path, String body) throws IOException {
-    return httpPut(path, body, StringUtils.EMPTY, StringUtils.EMPTY);
-  }
-
-  protected static PutMethod httpPut(String path, String body, String user, String pwd)
-      throws IOException {
-    LOG.info("Connecting to {}", URL + path);
-    HttpClient httpClient = new HttpClient();
-    PutMethod putMethod = new PutMethod(URL + path);
-    putMethod.addRequestHeader("Origin", URL);
-    RequestEntity entity = new ByteArrayRequestEntity(body.getBytes("UTF-8"));
-    putMethod.setRequestEntity(entity);
-    if (userAndPasswordAreNotBlank(user, pwd)) {
-      putMethod.setRequestHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
-    }
-    httpClient.executeMethod(putMethod);
-    LOG.info("{} - {}", putMethod.getStatusCode(), putMethod.getStatusText());
-    return putMethod;
-  }
-
-  protected static PostMethod httpPost(String path, String body) throws IOException {
-    return httpPost(path, body, StringUtils.EMPTY, StringUtils.EMPTY);
-  }
-
-  protected static DeleteMethod httpDelete(String path) throws IOException {
-    return httpDelete(path, StringUtils.EMPTY, StringUtils.EMPTY);
-  }
-
-  protected static DeleteMethod httpDelete(String path, String user, String pwd)
-      throws IOException {
-    LOG.info("Connecting to {}", URL + path);
-    HttpClient httpClient = new HttpClient();
-    DeleteMethod deleteMethod = new DeleteMethod(URL + path);
-    deleteMethod.addRequestHeader("Origin", URL);
-    if (userAndPasswordAreNotBlank(user, pwd)) {
-      deleteMethod.setRequestHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
-    }
-    httpClient.executeMethod(deleteMethod);
-    LOG.info("{} - {}", deleteMethod.getStatusCode(), deleteMethod.getStatusText());
-    return deleteMethod;
-  }
-
-  protected static PostMethod httpPost(String path, String request, String user, String pwd)
-      throws IOException {
-    LOG.info("Connecting to {}", URL + path);
-    HttpClient httpClient = new HttpClient();
-    PostMethod postMethod = new PostMethod(URL + path);
-    postMethod.setRequestBody(request);
-    postMethod.getParams().setCookiePolicy(CookiePolicy.IGNORE_COOKIES);
-    if (userAndPasswordAreNotBlank(user, pwd)) {
-      postMethod.setRequestHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
-    }
-    httpClient.executeMethod(postMethod);
-    LOG.info("{} - {}", postMethod.getStatusCode(), postMethod.getStatusText());
-    return postMethod;
-  }
-
-  private static String getCookie(String user, String password) throws IOException {
-    HttpClient httpClient = new HttpClient();
-    PostMethod postMethod = new PostMethod(URL + "/login");
-    postMethod.addRequestHeader("Origin", URL);
-    postMethod.setParameter("password", password);
-    postMethod.setParameter("userName", user);
-    httpClient.executeMethod(postMethod);
-    LOG.info("{} - {}", postMethod.getStatusCode(), postMethod.getStatusText());
-    Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]*)");
-    Header[] setCookieHeaders = postMethod.getResponseHeaders("Set-Cookie");
-    String jsessionId = null;
-    for (Header setCookie : setCookieHeaders) {
-      java.util.regex.Matcher matcher = pattern.matcher(setCookie.toString());
-      if (matcher.find()) {
-        jsessionId = matcher.group(1);
-      }
-    }
-
-    if (jsessionId != null) {
-      return jsessionId;
-    } else {
-      return StringUtils.EMPTY;
-    }
-  }
-
-  protected static boolean userAndPasswordAreNotBlank(String user, String pwd) {
-    if (StringUtils.isBlank(user) && StringUtils.isBlank(pwd)) {
-      return false;
-    }
-    return true;
-  }
-
-  protected Matcher<HttpMethodBase> responsesWith(final int expectedStatusCode) {
-    return new TypeSafeMatcher<HttpMethodBase>() {
-      WeakReference<HttpMethodBase> method;
-
-      @Override
-      public boolean matchesSafely(HttpMethodBase httpMethodBase) {
-        method = (method == null) ? new WeakReference<>(httpMethodBase) : method;
-        return httpMethodBase.getStatusCode() == expectedStatusCode;
-      }
-
-      @Override
-      public void describeTo(Description description) {
-        description.appendText("HTTP response ").appendValue(expectedStatusCode)
-            .appendText(" from ").appendText(method.get().getPath());
-      }
-
-      @Override
-      protected void describeMismatchSafely(HttpMethodBase item, Description description) {
-        description.appendText("got ").appendValue(item.getStatusCode()).appendText(" ")
-            .appendText(item.getStatusText());
-      }
-    };
-  }
-
-  /**
-   * Status code matcher.
-   */
-  protected Matcher<? super HttpMethodBase> isForbidden() {
-    return responsesWith(403);
-  }
-
-  protected Matcher<? super HttpMethodBase> isAllowed() {
-    return responsesWith(200);
-  }
-
-  protected Matcher<? super HttpMethodBase> isCreated() {
-    return responsesWith(201);
-  }
-
-  protected Matcher<? super HttpMethodBase> isBadRequest() {
-    return responsesWith(400);
-  }
-
-  protected Matcher<? super HttpMethodBase> isNotFound() {
-    return responsesWith(404);
-  }
-
-  protected Matcher<? super HttpMethodBase> isNotAllowed() {
-    return responsesWith(405);
-  }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ConfigurationsRestApiTest.java
@@ -23,12 +23,14 @@ import com.google.common.collect.Iterators;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class ConfigurationsRestApiTest extends AbstractTestRestApi {
@@ -46,8 +48,8 @@ public class ConfigurationsRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testGetAll() throws IOException {
-    GetMethod get = httpGet("/configurations/all");
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    CloseableHttpResponse get = httpGet("/configurations/all");
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
         new TypeToken<Map<String, Object>>(){}.getType());
     Map<String, String> body = (Map<String, String>) resp.get("body");
     assertTrue(body.size() > 0);
@@ -59,13 +61,14 @@ public class ConfigurationsRestApiTest extends AbstractTestRestApi {
         }
       }
     ));
+    get.close();
   }
 
   @Test
   public void testGetViaPrefix() throws IOException {
     final String prefix = "zeppelin.server";
-    GetMethod get = httpGet("/configurations/prefix/" + prefix);
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    CloseableHttpResponse get = httpGet("/configurations/prefix/" + prefix);
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
         new TypeToken<Map<String, Object>>(){}.getType());
     Map<String, String> body = (Map<String, String>) resp.get("body");
     assertTrue(body.size() > 0);
@@ -76,5 +79,6 @@ public class ConfigurationsRestApiTest extends AbstractTestRestApi {
           }
         }
     ));
+    get.close();
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/KnoxRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/KnoxRestApiTest.java
@@ -18,17 +18,21 @@ package org.apache.zeppelin.rest;
 
 import com.google.gson.Gson;
 
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class KnoxRestApiTest extends AbstractTestRestApi {
@@ -58,22 +62,18 @@ public class KnoxRestApiTest extends AbstractTestRestApi {
   public void setUp() {
   }
 
-  //  @Test
+  @Test
+  @Ignore
   public void testThatOtherUserCanAccessNoteIfPermissionNotSet() throws IOException {
-    GetMethod loginWithoutCookie = httpGet("/api/security/ticket");
-    Map result = gson.fromJson(loginWithoutCookie.getResponseBodyAsString(), Map.class);
-    collector.checkThat("Path is redirected to /login", loginWithoutCookie.getPath(),
-        CoreMatchers.containsString("login"));
-
-    collector.checkThat("Path is redirected to /login", loginWithoutCookie.getPath(),
-        CoreMatchers.containsString("login"));
+    CloseableHttpResponse loginWithoutCookie = httpGet("/api/security/ticket");
+    Map result = gson.fromJson(EntityUtils.toString(loginWithoutCookie.getEntity(), StandardCharsets.UTF_8), Map.class);
 
     collector.checkThat("response contains redirect URL",
         ((Map) result.get("body")).get("redirectURL").toString(), CoreMatchers.equalTo(
             "https://domain.example.com/gateway/knoxsso/knoxauth/login.html?originalUrl="));
 
-    GetMethod loginWithCookie = httpGet("/api/security/ticket", "", "", knoxCookie);
-    result = gson.fromJson(loginWithCookie.getResponseBodyAsString(), Map.class);
+    CloseableHttpResponse loginWithCookie = httpGet("/api/security/ticket", "", "", knoxCookie);
+    result = gson.fromJson(EntityUtils.toString(loginWithCookie.getEntity(), StandardCharsets.UTF_8), Map.class);
 
     collector.checkThat("User logged in as admin",
         ((Map) result.get("body")).get("principal").toString(), CoreMatchers.equalTo("admin"));

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -27,9 +27,6 @@ import com.google.gson.Gson;
 import com.google.gson.internal.StringMap;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.notebook.Notebook;
@@ -44,11 +41,14 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Paragraph;
@@ -89,15 +89,16 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
 
       String paragraphId = note1.getLastParagraph().getId();
 
-      GetMethod get = httpGet("/notebook/job/" + note1.getId() + "/" + paragraphId);
+      CloseableHttpResponse get = httpGet("/notebook/job/" + note1.getId() + "/" + paragraphId);
       assertThat(get, isAllowed());
-      Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       Map<String, Set<String>> paragraphStatus = (Map<String, Set<String>>) resp.get("body");
 
       // Check id and status have proper value
       assertEquals(paragraphStatus.get("id"), paragraphId);
       assertEquals(paragraphStatus.get("status"), "READY");
+      get.close();
     } finally {
       // cleanup
       if (null != note1) {
@@ -117,23 +118,23 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       Paragraph p = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
       // run blank paragraph
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
       p.waitUntilFinished();
-      assertEquals(p.getStatus(), Job.Status.FINISHED);
+      assertEquals(Job.Status.FINISHED, p.getStatus());
 
       // run non-blank paragraph
       p.setText("test");
       post = httpPost("/notebook/job/" + note1.getId() + "/" + p.getId(), "");
       assertThat(post, isAllowed());
-      resp = gson.fromJson(post.getResponseBodyAsString(),
+      resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
       p.waitUntilFinished();
       assertNotEquals(p.getStatus(), Job.Status.FINISHED);
     } finally {
@@ -160,12 +161,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p.setTitle(title);
       p.setText(text);
 
-      PostMethod post = httpPost("/notebook/run/" + note1.getId() + "/" + p.getId(), "");
+      CloseableHttpResponse post = httpPost("/notebook/run/" + note1.getId() + "/" + p.getId(), "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
           new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
       assertNotEquals(p.getStatus(), Job.Status.READY);
 
       // Check if the paragraph is emptied
@@ -178,8 +179,8 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p.setText(text);
 
       post = httpPost("/notebook/run/" + note1.getId() + "/" + p.getId(), "");
-      assertEquals(200, post.getStatusCode());
-      resp = gson.fromJson(post.getResponseBodyAsString(),
+      assertEquals(200, post.getStatusLine().getStatusCode());
+      resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       assertEquals("OK", resp.get("status"));
       StringMap stringMap = (StringMap) resp.get("body");
@@ -187,7 +188,7 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       List<StringMap> interpreterResults = (List<StringMap>) stringMap.get("msg");
       assertTrue(interpreterResults.get(0).toString(),
               interpreterResults.get(0).get("data").toString().contains("invalid_cmd: command not found"));
-      post.releaseConnection();
+      post.close();
       assertNotEquals(p.getStatus(), Job.Status.READY);
 
       // Check if the paragraph is emptied
@@ -223,12 +224,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python from __future__ import print_function\nimport time\ntime.sleep(1)\nuser='abc'");
       p2.setText("%python print(user)");
 
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
 
       assertEquals(Job.Status.FINISHED, p1.getStatus());
       assertEquals(Job.Status.FINISHED, p2.getStatus());
@@ -263,12 +264,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python import time\ntime.sleep(5)\nname='hello'\nz.put('name', name)");
       p2.setText("%sh(interpolate=true) echo '{name}'");
 
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
 
       p1.waitUntilFinished();
       p2.waitUntilFinished();
@@ -311,12 +312,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python from __future__ import print_function\nimport time\ntime.sleep(1)\nuser='abc'");
       p2.setText("%python print(user)");
 
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true&isolated=true", "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true&isolated=true", "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
 
       assertEquals(Job.Status.FINISHED, p1.getStatus());
       assertEquals(Job.Status.FINISHED, p2.getStatus());
@@ -359,12 +360,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python from __future__ import print_function\nimport time\ntime.sleep(1)\nuser='abc'");
       p2.setText("%python print(user)");
 
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=false&isolated=true", "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=false&isolated=true", "");
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
 
       // wait for all the paragraphs are done
       while(note1.isRunning()) {
@@ -406,13 +407,13 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       Map<String, Object> paramsMap = new HashMap<>();
       paramsMap.put("name", "zeppelin");
       ParametersRequest parametersRequest = new ParametersRequest(paramsMap);
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=false&isolated=true&",
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=false&isolated=true&",
               parametersRequest.toJson());
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK",resp.get("status"));
+      post.close();
 
       // wait for all the paragraphs are done
       while(note1.isRunning()) {
@@ -426,10 +427,10 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       // another attempt rest api call without params
       post = httpPost("/notebook/job/" + note1.getId() + "?blocking=false&isolated=true", "");
       assertThat(post, isAllowed());
-      resp = gson.fromJson(post.getResponseBodyAsString(),
+      resp = gson.fromJson(EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post.close();
 
       // wait for all the paragraphs are done
       while(note1.isRunning()) {
@@ -471,12 +472,13 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python from __future__ import print_function\nimport time\ntime.sleep(1)\nprint(user2)");
       p2.setText("%python user2='abc'\nprint(user2)");
 
-      PostMethod post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
+      CloseableHttpResponse post = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
       assertThat(post, isAllowed());
 
       assertEquals(Job.Status.ERROR, p1.getStatus());
       // p2 will be skipped because p1 is failed.
       assertEquals(Job.Status.READY, p2.getStatus());
+      post.close();
     } finally {
       // cleanup
       if (null != note1) {
@@ -492,22 +494,23 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
     String clonedNoteId = null;
     try {
       note1 = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      PostMethod post = httpPost("/notebook/" + note1.getId(), "");
-      LOG.info("testCloneNote response\n" + post.getResponseBodyAsString());
+      CloseableHttpResponse post = httpPost("/notebook/" + note1.getId(), "");
+      String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
+      LOG.info("testCloneNote response\n" + postResponse);
       assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(postResponse,
               new TypeToken<Map<String, Object>>() {}.getType());
       clonedNoteId = (String) resp.get("body");
-      post.releaseConnection();
+      post.close();
 
-      GetMethod get = httpGet("/notebook/" + clonedNoteId);
+      CloseableHttpResponse get = httpGet("/notebook/" + clonedNoteId);
       assertThat(get, isAllowed());
-      Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
+      Map<String, Object> resp2 = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
 
       //    assertEquals(resp2Body.get("name"), "Note " + clonedNoteId);
-      get.releaseConnection();
+      get.close();
     } finally {
       // cleanup
       if (null != note1) {
@@ -535,9 +538,9 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       final String newName = "testName";
       String jsonRequest = "{\"name\": " + newName + "}";
 
-      PutMethod put = httpPut("/notebook/" + noteId + "/rename/", jsonRequest);
+      CloseableHttpResponse put = httpPut("/notebook/" + noteId + "/rename/", jsonRequest);
       assertThat("test testRenameNote:", put, isAllowed());
-      put.releaseConnection();
+      put.close();
 
       assertEquals(note.getName(), newName);
     } finally {
@@ -560,15 +563,15 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       String paragraphId = p.getId();
       String jsonRequest = "{\"colWidth\": 6.0}";
 
-      PutMethod put = httpPut("/notebook/" + noteId + "/paragraph/" + paragraphId + "/config",
+      CloseableHttpResponse put = httpPut("/notebook/" + noteId + "/paragraph/" + paragraphId + "/config",
               jsonRequest);
       assertThat("test testUpdateParagraphConfig:", put, isAllowed());
 
-      Map<String, Object> resp = gson.fromJson(put.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       Map<String, Object> respBody = (Map<String, Object>) resp.get("body");
       Map<String, Object> config = (Map<String, Object>) respBody.get("config");
-      put.releaseConnection();
+      put.close();
 
       assertEquals(config.get("colWidth"), 6.0);
       note = TestUtils.getInstance(Notebook.class).getNote(noteId);
@@ -597,26 +600,27 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p2.setReturn(result, new Throwable());
 
       // clear paragraph result
-      PutMethod put = httpPut("/notebook/" + note.getId() + "/clear", "");
-      LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
+      CloseableHttpResponse put = httpPut("/notebook/" + note.getId() + "/clear", "");
+      LOG.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
       assertThat(put, isAllowed());
-      put.releaseConnection();
+      put.close();
 
       // check if paragraph results are cleared
-      GetMethod get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p1.getId());
+      CloseableHttpResponse get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p1.getId());
       assertThat(get, isAllowed());
-      Map<String, Object> resp1 = gson.fromJson(get.getResponseBodyAsString(),
+      Map<String, Object> resp1 = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       Map<String, Object> resp1Body = (Map<String, Object>) resp1.get("body");
       assertNull(resp1Body.get("result"));
+      get.close();
 
       get = httpGet("/notebook/" + note.getId() + "/paragraph/" + p2.getId());
       assertThat(get, isAllowed());
-      Map<String, Object> resp2 = gson.fromJson(get.getResponseBodyAsString(),
+      Map<String, Object> resp2 = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
               new TypeToken<Map<String, Object>>() {}.getType());
       Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
       assertNull(resp2Body.get("result"));
-      get.releaseConnection();
+      get.close();
     } finally {
       // cleanup
       if (null != note) {
@@ -647,13 +651,13 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1.setText("%python from __future__ import print_function\nimport time\ntime.sleep(1)\nuser='abc'");
       p2.setText("%python print(user)");
 
-      PostMethod post1 = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
+      CloseableHttpResponse post1 = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
       assertThat(post1, isAllowed());
-      post1.releaseConnection();
-      PutMethod put = httpPut("/notebook/" + note1.getId() + "/clear", "");
-      LOG.info("test clear paragraph output response\n" + put.getResponseBodyAsString());
+      post1.close();
+      CloseableHttpResponse put = httpPut("/notebook/" + note1.getId() + "/clear", "");
+      LOG.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
       assertThat(put, isAllowed());
-      put.releaseConnection();
+      put.close();
 
       // restart server (while keeping interpreter configuration)
       AbstractTestRestApi.shutDown(false);
@@ -663,12 +667,12 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
       p1 = note1.getParagraph(p1.getId());
       p2 = note1.getParagraph(p2.getId());
 
-      PostMethod post2 = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
+      CloseableHttpResponse post2 = httpPost("/notebook/job/" + note1.getId() + "?blocking=true", "");
       assertThat(post2, isAllowed());
-      Map<String, Object> resp = gson.fromJson(post2.getResponseBodyAsString(),
+      Map<String, Object> resp = gson.fromJson(EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8),
           new TypeToken<Map<String, Object>>() {}.getType());
-      assertEquals(resp.get("status"), "OK");
-      post2.releaseConnection();
+      assertEquals("OK", resp.get("status"));
+      post2.close();
 
       assertEquals(Job.Status.FINISHED, p1.getStatus());
       assertEquals(p2.getReturn().toString(), Job.Status.FINISHED, p2.getStatus());

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.zeppelin.rest;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -24,12 +24,11 @@ import static org.junit.Assert.assertThat;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import org.apache.commons.httpclient.HttpMethodBase;
-import org.apache.commons.httpclient.methods.DeleteMethod;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.utils.TestUtils;
@@ -55,7 +54,7 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
 
   @Before
   public void setUp() {}
-  
+
   @Test
   public void testThatUserCanCreateAndRemoveNote() throws IOException {
     String noteId = createNoteForUser("test_1", "admin", "password1");
@@ -64,83 +63,83 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     assertThat(id, is(noteId));
     deleteNoteForUser(noteId, "admin", "password1");
   }
-  
+
   @Test
   public void testThatOtherUserCanAccessNoteIfPermissionNotSet() throws IOException {
     String noteId = createNoteForUser("test_2", "admin", "password1");
-    
+
     userTryGetNote(noteId, "user1", "password2", isAllowed());
-    
+
     deleteNoteForUser(noteId, "admin", "password1");
   }
-  
+
   @Test
   public void testThatOtherUserCannotAccessNoteIfPermissionSet() throws IOException {
     String noteId = createNoteForUser("test_3", "admin", "password1");
-    
+
     //set permission
     String payload = "{ \"owners\": [\"admin\"], \"readers\": [\"user2\"], " +
             "\"runners\": [\"user2\"], \"writers\": [\"user2\"] }";
-    PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
+    CloseableHttpResponse put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
     assertThat("test set note permission method:", put, isAllowed());
-    put.releaseConnection();
-    
+    put.close();
+
     userTryGetNote(noteId, "user1", "password2", isForbidden());
-    
+
     userTryGetNote(noteId, "user2", "password3", isAllowed());
-    
+
     deleteNoteForUser(noteId, "admin", "password1");
   }
-  
+
   @Test
   public void testThatWriterCannotRemoveNote() throws IOException {
     String noteId = createNoteForUser("test_4", "admin", "password1");
-    
+
     //set permission
     String payload = "{ \"owners\": [\"admin\", \"user1\"], \"readers\": [\"user2\"], " +
             "\"runners\": [\"user2\"], \"writers\": [\"user2\"] }";
-    PutMethod put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
+    CloseableHttpResponse put = httpPut("/notebook/" + noteId + "/permissions", payload , "admin", "password1");
     assertThat("test set note permission method:", put, isAllowed());
-    put.releaseConnection();
-    
+    put.close();
+
     userTryRemoveNote(noteId, "user2", "password3", isForbidden());
     userTryRemoveNote(noteId, "user1", "password2", isAllowed());
-    
+
     Note deletedNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
     assertNull("Deleted note should be null", deletedNote);
   }
 
   private void userTryRemoveNote(String noteId, String user, String pwd,
-          Matcher<? super HttpMethodBase> m) throws IOException {
-    DeleteMethod delete = httpDelete(("/notebook/" + noteId), user, pwd);
+          Matcher<? super CloseableHttpResponse> m) throws IOException {
+    CloseableHttpResponse delete = httpDelete(("/notebook/" + noteId), user, pwd);
     assertThat(delete, m);
-    delete.releaseConnection();
+    delete.close();
   }
-  
+
   private void userTryGetNote(String noteId, String user, String pwd,
-          Matcher<? super HttpMethodBase> m) throws IOException {
-    GetMethod get = httpGet("/notebook/" + noteId, user, pwd);
+          Matcher<? super CloseableHttpResponse> m) throws IOException {
+    CloseableHttpResponse get = httpGet("/notebook/" + noteId, user, pwd);
     assertThat(get, m);
-    get.releaseConnection();
+    get.close();
   }
 
   private String getNoteIdForUser(String noteId, String user, String pwd) throws IOException {
-    GetMethod get = httpGet("/notebook/" + noteId, user, pwd);
+    CloseableHttpResponse get = httpGet("/notebook/" + noteId, user, pwd);
     assertThat("test note create method:", get, isAllowed());
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
             new TypeToken<Map<String, Object>>() {}.getType());
-    get.releaseConnection();
+    get.close();
     return (String) ((Map<String, Object>) resp.get("body")).get("id");
   }
-  
+
   private String createNoteForUser(String noteName, String user, String pwd) throws IOException {
     String jsonRequest = "{\"name\":\"" + noteName + "\"}";
-    PostMethod post = httpPost("/notebook/", jsonRequest, user, pwd);
+    CloseableHttpResponse post = httpPost("/notebook/", jsonRequest, user, pwd);
     assertThat("test note create method:", post, isAllowed());
     Map<String, Object> resp =
         gson.fromJson(
-            post.getResponseBodyAsString(), new TypeToken<Map<String, Object>>() {}.getType());
-    post.releaseConnection();
+          EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8), new TypeToken<Map<String, Object>>() {}.getType());
+    post.close();
     String newNoteId = (String) resp.get("body");
     Notebook notebook = TestUtils.getInstance(Notebook.class);
     Note newNote = notebook.getNote(newNoteId);
@@ -149,9 +148,9 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
   }
 
   private void deleteNoteForUser(String noteId, String user, String pwd) throws IOException {
-    DeleteMethod delete = httpDelete(("/notebook/" + noteId), user, pwd);
+    CloseableHttpResponse delete = httpDelete(("/notebook/" + noteId), user, pwd);
     assertThat("Test delete method:", delete, isAllowed());
-    delete.releaseConnection();
+    delete.close();
     // make sure note is deleted
     if (!noteId.isEmpty()) {
       Note deletedNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
@@ -162,14 +161,14 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
   private void createParagraphForUser(String noteId, String user, String pwd,
           String title, String text) throws IOException {
     String payload = "{\"title\": \"" + title + "\",\"text\": \"" + text + "\"}";
-    PostMethod post = httpPost(("/notebook/" + noteId + "/paragraph"), payload, user, pwd);
-    post.releaseConnection();
+    CloseableHttpResponse post = httpPost(("/notebook/" + noteId + "/paragraph"), payload, user, pwd);
+    post.close();
   }
 
   private void setPermissionForNote(String noteId, String user, String pwd) throws IOException {
     String payload = "{\"owners\":[\"" + user + "\"],\"readers\":[\"" + user +
             "\"],\"runners\":[\"" + user + "\"],\"writers\":[\"" + user + "\"]}";
-    PutMethod put = httpPut(("/notebook/" + noteId + "/permissions"), payload, user, pwd);
-    put.releaseConnection();
+    CloseableHttpResponse put = httpPut(("/notebook/" + noteId + "/permissions"), payload, user, pwd);
+    put.close();
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/SecurityRestApiTest.java
@@ -19,7 +19,8 @@ package org.apache.zeppelin.rest;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -28,6 +29,7 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -49,51 +51,48 @@ public class SecurityRestApiTest extends AbstractTestRestApi {
 
   @Test
   public void testTicket() throws IOException {
-    GetMethod get = httpGet("/security/ticket", "admin", "password1");
-    get.addRequestHeader("Origin", "http://localhost");
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    CloseableHttpResponse get = httpGet("/security/ticket", "admin", "password1");
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
         new TypeToken<Map<String, Object>>(){}.getType());
     Map<String, String> body = (Map<String, String>) resp.get("body");
     collector.checkThat("Paramater principal", body.get("principal"),
         CoreMatchers.equalTo("admin"));
     collector.checkThat("Paramater ticket", body.get("ticket"),
         CoreMatchers.not("anonymous"));
-    get.releaseConnection();
+    get.close();
   }
 
   @Test
   public void testGetUserList() throws IOException {
-    GetMethod get = httpGet("/security/userlist/admi", "admin", "password1");
-    get.addRequestHeader("Origin", "http://localhost");
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    CloseableHttpResponse get = httpGet("/security/userlist/admi", "admin", "password1");
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
         new TypeToken<Map<String, Object>>(){}.getType());
     List<String> userList = (List) ((Map) resp.get("body")).get("users");
     collector.checkThat("Search result size", userList.size(),
         CoreMatchers.equalTo(1));
     collector.checkThat("Search result contains admin", userList.contains("admin"),
         CoreMatchers.equalTo(true));
-    get.releaseConnection();
+    get.close();
 
-    GetMethod notUser = httpGet("/security/userlist/randomString", "admin", "password1");
-    notUser.addRequestHeader("Origin", "http://localhost");
-    Map<String, Object> notUserResp = gson.fromJson(notUser.getResponseBodyAsString(),
+    CloseableHttpResponse notUser = httpGet("/security/userlist/randomString", "admin", "password1");
+    Map<String, Object> notUserResp = gson.fromJson(EntityUtils.toString(notUser.getEntity(), StandardCharsets.UTF_8),
         new TypeToken<Map<String, Object>>(){}.getType());
     List<String> emptyUserList = (List) ((Map) notUserResp.get("body")).get("users");
     collector.checkThat("Search result size", emptyUserList.size(),
         CoreMatchers.equalTo(0));
 
-    notUser.releaseConnection();
+    notUser.close();
   }
 
   @Test
   public void testRolesEscaped() throws IOException {
-    GetMethod get = httpGet("/security/ticket", "admin", "password1");
-    Map<String, Object> resp = gson.fromJson(get.getResponseBodyAsString(),
+    CloseableHttpResponse get = httpGet("/security/ticket", "admin", "password1");
+    Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
             new TypeToken<Map<String, Object>>(){}.getType());
     String roles = (String) ((Map) resp.get("body")).get("roles");
     collector.checkThat("Paramater roles", roles,
             CoreMatchers.equalTo("[\"admin\"]"));
-    get.releaseConnection();
+    get.close();
   }
 
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
@@ -16,15 +16,17 @@
  */
 package org.apache.zeppelin.security;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.junit.Test;
-
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 
 import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
 
 public class DirAccessTest extends AbstractTestRestApi {
   @Test
@@ -34,12 +36,10 @@ public class DirAccessTest extends AbstractTestRestApi {
         System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED
                 .getVarName(), "false");
         AbstractTestRestApi.startUp(DirAccessTest.class.getSimpleName());
-        HttpClient httpClient = new HttpClient();
-        GetMethod getMethod = new GetMethod(getUrlToTest() + "/app/");
-        LOG.info("Invoke getMethod");
-        httpClient.executeMethod(getMethod);
-        assertEquals(getMethod.getResponseBodyAsString(),
-                HttpStatus.SC_FORBIDDEN, getMethod.getStatusCode());
+        CloseableHttpResponse getMethod = getHttpClient().execute(new HttpGet(getUrlToTest() + "/app/"));
+        LOG.info("Invoke getMethod - " + EntityUtils.toString(getMethod.getEntity(), StandardCharsets.UTF_8));
+
+        assertEquals(HttpStatus.SC_FORBIDDEN, getMethod.getStatusLine().getStatusCode());
       } finally {
         AbstractTestRestApi.shutDown();
       }
@@ -53,12 +53,9 @@ public class DirAccessTest extends AbstractTestRestApi {
         System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_DEFAULT_DIR_ALLOWED
                 .getVarName(), "true");
         AbstractTestRestApi.startUp(DirAccessTest.class.getSimpleName());
-        HttpClient httpClient = new HttpClient();
-        GetMethod getMethod = new GetMethod(getUrlToTest() + "/app/");
-        LOG.info("Invoke getMethod");
-        httpClient.executeMethod(getMethod);
-        assertEquals(getMethod.getResponseBodyAsString(),
-                HttpStatus.SC_OK, getMethod.getStatusCode());
+        CloseableHttpResponse getMethod = getHttpClient().execute(new HttpGet(getUrlToTest() + "/app/"));
+        LOG.info("Invoke getMethod - " + EntityUtils.toString(getMethod.getEntity(), StandardCharsets.UTF_8));
+        assertEquals(HttpStatus.SC_OK, getMethod.getStatusLine().getStatusCode());
       } finally {
         AbstractTestRestApi.shutDown();
       }

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -100,6 +100,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
+
+
+    <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-webdav</artifactId>
       <version>${jackrabbit.webdav.version}</version>


### PR DESCRIPTION
### What is this PR for?
This PR includes:
 - Migration from commons-httpclient:commons-httpclient to org.apache.httpcomponents:httpclient
 - Drop some unneeded interpreter dependencies

### What type of PR is it?
 - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5090

### How should this be tested?
* Travis-CI: https://travis-ci.org/github/Reamer/zeppelin/builds/734928234

### Questions:
* Does the licenses files need update? Yes (done)
* Is there breaking changes for older versions? No
* Does this needs documentation? No
