### PR TITLE
[ZEPPELIN-5094]. Unable to get EditorSetting for jdbc interpreter

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -587,7 +587,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
             if (interpreterSetting == null) {
               return DEFAULT_EDITOR;
             }
-            return interpreterSetting.getInterpreterInfo(intpName).getEditor();
+            return interpreterSetting.getDefaultInterpreterInfo().getEditor();
           } catch (Exception e) {
             LOGGER.warn(e.getMessage());
             return DEFAULT_EDITOR;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -188,17 +188,14 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
 
   }
 
-  //@Test
-  public void testGetEditor() throws IOException, InterpreterNotFoundException {
-    Interpreter echoInterpreter = interpreterFactory.getInterpreter("test.echo", new ExecutionContextBuilder().setUser("user1").setNoteId("note1").setDefaultInterpreterGroup("test").createExecutionContext());
+  @Test
+  public void testGetEditor() {
     // get editor setting from interpreter-setting.json
-    Map<String, Object> editor = interpreterSettingManager.getEditorSetting("test.echo", "note1");
+    Map<String, Object> editor = interpreterSettingManager.getEditorSetting("%test.echo", "note1");
     assertEquals("java", editor.get("language"));
 
-    // when editor setting doesn't exit, return the default editor
-    Interpreter mock1Interpreter = interpreterFactory.getInterpreter("mock1", new ExecutionContextBuilder().setUser("user1").setNoteId("note1").setDefaultInterpreterGroup("test").createExecutionContext());
-    editor = interpreterSettingManager.getEditorSetting("mock1", "note1");
-    assertEquals("text", editor.get("language"));
+    editor = interpreterSettingManager.getEditorSetting("%mock1", "note1");
+    assertEquals("python", editor.get("language"));
   }
 
   @Test

--- a/zeppelin-zengine/src/test/resources/interpreter/mock1/interpreter-setting.json
+++ b/zeppelin-zengine/src/test/resources/interpreter/mock1/interpreter-setting.json
@@ -5,6 +5,10 @@
     "className": "org.apache.zeppelin.interpreter.mock.MockInterpreter1",
     "properties": {
     },
+    "editor": {
+      "language": "python",
+      "editOnDblClick": false
+    },
     "option": {
       "remote": true,
       "port": -1,


### PR DESCRIPTION
### What is this PR for?

The root cause is that when there's only sub interpreter, zeppelin could not get the right editor setting based in interpreter name (because interpreter name is omitted by users). This PR fix this issue by just using method getDefaultInterpreterInfo to get the correct editor setting.  

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5094

### How should this be tested?
* Manually tested. 

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/95840602-edb07a80-0d76-11eb-88e0-8a7ea9951c20.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
