### PR TITLE
[ZEPPELIN-5042]. NullPointerException is thrown for the 1st query on presto interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -747,8 +747,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
           }
 
           // start hive monitor thread if it is hive jdbc
-          if (getJDBCConfiguration(user).getPropertyMap(dbPrefix).getProperty(URL_KEY)
-                  .startsWith("jdbc:hive2://")) {
+          String jdbcURL = getJDBCConfiguration(user).getPropertyMap(dbPrefix).getProperty(URL_KEY);
+          if (jdbcURL != null && jdbcURL.startsWith("jdbc:hive2://")) {
             HiveUtils.startHiveMonitorThread(statement, context,
                     Boolean.parseBoolean(getProperty("hive.log.display", "true")));
           }


### PR DESCRIPTION

### What is this PR for?

The root cause is that url is not an valid property of presto, so we remove that before connecting to presto. The null url cause the NPE. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5042

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/95840908-539d0200-0d77-11eb-8c0e-20dbbc51d8cc.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
