### PR TITLE
[ZEPPELIN-5096] Error message for K8s launcher and Pending Status Improvement

### DIFF
--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -431,6 +431,12 @@ If both are defined, then the **environment variables** will take priority.
     <td>zeppelin-server</td>
     <td>Name of the Zeppelin server service resources</td>
   </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_K8S_TIMEOUT_DURING_PENDING</h6></td>
+    <td><h6 class="properties">zeppelin.k8s.timeout.during.pending</h6></td>
+    <td>true</td>
+    <td>Value to enable/disable timeout handling when starting Interpreter Pods. Caution: This can lead to an infinity loop</td>
+  </tr>
 </table>
 
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -872,6 +872,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_K8S_SERVICE_NAME);
   }
 
+  public boolean getK8sTimeoutDuringPending() {
+    return getBoolean(ConfVars.ZEPPELIN_K8S_TIMEOUT_DURING_PENDING);
+  }
+
   public String getDockerContainerImage() {
     return getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_IMAGE);
   }
@@ -1082,6 +1086,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE("zeppelin.k8s.spark.container.image", "apache/spark:latest"),
     ZEPPELIN_K8S_TEMPLATE_DIR("zeppelin.k8s.template.dir", "k8s"),
     ZEPPELIN_K8S_SERVICE_NAME("zeppelin.k8s.service.name", "zeppelin-server"),
+    ZEPPELIN_K8S_TIMEOUT_DURING_PENDING("zeppelin.k8s.timeout.during.pending", true),
 
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -48,6 +48,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   private final String sparkImage;
   private LocalPortForward localPortForward;
   private int podPort = K8S_INTERPRETER_SERVICE_PORT;
+  private String errorMessage;
 
   private final boolean isUserImpersonatedForSpark;
 
@@ -138,16 +139,18 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
 
     // wait until interpreter send started message through thrift rpc
     synchronized (started) {
-      while (!started.get()) {
+      while (!started.get() && !Thread.currentThread().isInterrupted()) {
         long timetoTimeout = timeoutTime - System.currentTimeMillis();
         if (timetoTimeout <= 0) {
+          errorMessage = "The start process was aborted while waiting for the interpreter to start. PodPhase before stop: " + getPodPhase();
           stop();
           throw new IOException("Launching zeppelin interpreter on kubernetes is time out, kill it now");
         }
         try {
           started.wait(timetoTimeout);
         } catch (InterruptedException e) {
-          LOGGER.error("Interrupt received. Try to stop the interpreter and interrupt the current thread.", e);
+          LOGGER.error("Interrupt received during started wait. Try to stop the interpreter and interrupt the current thread.", e);
+          errorMessage = "The start process was interrupted while waiting for the interpreter to start. PodPhase before stop: " + getPodPhase();
           stop();
           Thread.currentThread().interrupt();
         }
@@ -155,15 +158,17 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     }
 
     // waits for interpreter thrift rpc server ready
-    while (!RemoteInterpreterUtils.checkIfRemoteEndpointAccessible(getHost(), getPort())) {
+    while (!RemoteInterpreterUtils.checkIfRemoteEndpointAccessible(getHost(), getPort()) && !Thread.currentThread().isInterrupted()) {
       if (System.currentTimeMillis() - timeoutTime > 0) {
+        errorMessage = "The start process was aborted while waiting for the accessibility check of the remote end point. PodPhase before stop: " + getPodPhase();
         stop();
         throw new IOException("Launching zeppelin interpreter on kubernetes is time out, kill it now");
       }
       try {
         Thread.sleep(1000);
       } catch (InterruptedException e) {
-        LOGGER.error("Interrupt received. Try to stop the interpreter and interrupt the current thread.", e);
+        LOGGER.error("Interrupt received during remote endpoint accessible check. Try to stop the interpreter and interrupt the current thread.", e);
+        errorMessage = "The start process was interrupted while waiting for the accessibility check of the remote end point. PodPhase before stop: " + getPodPhase();
         stop();
         Thread.currentThread().interrupt();
       }
@@ -223,6 +228,13 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     return false;
   }
 
+  public String getPodPhase() {
+    Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
+    if (pod != null) {
+      return pod.getStatus().getPhase();
+    }
+    return "Unknown";
+  }
   /**
    * Apply spec file(s) in the path.
    * @param path
@@ -438,6 +450,6 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
 
   @Override
   public String getErrorMessage() {
-    return null;
+    return String.format("%s%ncurrent PodPhase: %s", errorMessage, getPodPhase());
   }
 }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -153,7 +153,8 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
             zConf.getK8sSparkContainerImage(),
             getConnectTimeout(),
             getConnectPoolSize(),
-            isUserImpersonateForSparkInterpreter(context));
+            isUserImpersonateForSparkInterpreter(context),
+            zConf.getK8sTimeoutDuringPending());
   }
 
   protected Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context) {
@@ -173,7 +174,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
     return env;
   }
 
-  String readFile(String path, Charset encoding) throws IOException {
+  private String readFile(String path, Charset encoding) throws IOException {
     byte[] encoded = Files.readAllBytes(Paths.get(path));
     return new String(encoded, encoding);
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -58,6 +58,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // then
@@ -87,6 +88,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
 
@@ -121,6 +123,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // when
@@ -173,6 +176,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // when
@@ -224,7 +228,8 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
-        true);
+        true,
+        false);
 
     // when
     Properties p = intp.getTemplateBindings("mytestUser");
@@ -274,7 +279,8 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
-        true);
+        true,
+        false);
 
     // when
     Properties p = intp.getTemplateBindings("anonymous");
@@ -313,6 +319,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // when non template url
@@ -357,6 +364,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // when
@@ -393,6 +401,7 @@ public class K8sRemoteInterpreterProcessTest {
         "spark-container:1.0",
         10,
         10,
+        false,
         false);
 
     // when


### PR DESCRIPTION
### What is this PR for?
This PR includes:
 - an error message from K8s launcher to help users understand why the Pod won't start
 - give the option to disable the timeout handling during the initial pod lifecycle phase `pending`

### What type of PR is it?
 - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5096

### How should this be tested?
* Travis-CI: https://travis-ci.org/github/Reamer/zeppelin/builds/735737408

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
