### PR TITLE
[ZEPPELIN-5097]. FileNotFoundException after running flink interpreter for a long time

### DIFF
--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkILoop.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkILoop.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.flink
+
+import java.io.{BufferedReader, File}
+
+import org.apache.flink.configuration.Configuration
+
+import scala.tools.nsc.interpreter._
+
+
+class FlinkILoop(
+    override val flinkConfig: Configuration,
+    override val externalJars: Option[Array[String]],
+    in0: Option[BufferedReader],
+    out0: JPrintWriter) extends org.apache.flink.api.scala.FlinkILoop(flinkConfig, externalJars, in0, out0) {
+
+  override def writeFilesToDisk(): File = {
+    // create tmpDirBase again in case it is deleted by system, because it is in the system temp folder.
+    val field = getClass.getSuperclass.getDeclaredField("tmpDirBase")
+    field.setAccessible(true)
+    val tmpDir = field.get(this).asInstanceOf[File]
+    if (!tmpDir.exists()) {
+      tmpDir.mkdir()
+    }
+    super.writeFilesToDisk()
+  }
+}
+

--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -28,7 +28,7 @@ import java.util.jar.JarFile
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.flink.api.common.JobExecutionResult
-import org.apache.flink.api.scala.{ExecutionEnvironment, FlinkILoop}
+import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration._
 import org.apache.flink.core.execution.{JobClient, JobListener}


### PR DESCRIPTION
### What is this PR for?

The root cause is that by default FlinkILoop would create tmp folder for storing jars, but tmp folder may be delete by system. So this PR would always create this folder if it doesn't exist. 

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5097

### How should this be tested?
* CI pass
https://travis-ci.org/github/zjffdu/zeppelin/builds/736268130

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
