### PR TITLE
[ZEPPELIN-5100]. Cancel paragraph when no sufficient resources for hive job

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -126,6 +126,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private static final char TAB = '\t';
   private static final String TABLE_MAGIC_TAG = "%table ";
   private static final String EXPLAIN_PREDICATE = "EXPLAIN ";
+  private static final String CANCEL_REASON = "cancel_reason";
 
   static final String COMMON_MAX_LINE = COMMON_KEY + DOT + MAX_LINE_KEY;
 
@@ -161,7 +162,6 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   private int maxLineResults;
   private int maxRows;
-
   private SqlSplitter sqlSplitter;
 
   private Map<String, ScheduledExecutorService> refreshExecutorServices = new HashMap<>();
@@ -749,7 +749,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
           String jdbcURL = getJDBCConfiguration(user).getPropertyMap(dbPrefix).getProperty(URL_KEY);
           if (jdbcURL != null && jdbcURL.startsWith("jdbc:hive2://")) {
             HiveUtils.startHiveMonitorThread(statement, context,
-                    Boolean.parseBoolean(getProperty("hive.log.display", "true")));
+                    Boolean.parseBoolean(getProperty("hive.log.display", "true")), this);
           }
           boolean isResultSetAvailable = statement.execute(sqlToExecute);
           getJDBCConfiguration(user).setConnectionInDBDriverPoolSuccessful(dbPrefix);
@@ -946,8 +946,21 @@ public class JDBCInterpreter extends KerberosInterpreter {
     } catch (SQLException e) {
       LOGGER.error("Error while cancelling...", e);
     }
+
+    String cancelReason = context.getLocalProperties().get(CANCEL_REASON);
+    if (StringUtils.isNotBlank(cancelReason)) {
+      try {
+        context.out.write(cancelReason);
+      } catch (IOException e) {
+        LOGGER.error("Fail to write cancel reason");
+      }
+    }
   }
 
+  public void cancel(InterpreterContext context, String errorMessage) {
+    context.getLocalProperties().put(CANCEL_REASON, errorMessage);
+    cancel(context);
+  }
   /**
    *
    *

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -122,6 +122,13 @@
         "defaultValue": "1000",
         "description": "Maximum number of rows fetched from the query.",
         "type": "number"
+      },
+      "zeppelin.jdbc.hive.timeout.threshold": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.hive.timeout.threshold",
+        "defaultValue": "60000",
+        "description": "Timeout for hive job timeout",
+        "type": "number"
       }
     },
     "editor": {

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
@@ -28,7 +28,7 @@ public class HiveUtilsTest {
 
   @Test
   public void testJobURL() {
-    Optional<String> jobURL = HiveUtils.extractJobURL(
+    Optional<String> jobURL = HiveUtils.extractMRJobURL(
             "INFO  : The url to track the job: " +
             "http://localhost:8088/proxy/application_1591195707498_0064/\n" +
             "INFO  : Starting Job = job_1591195707498_0064, " +


### PR DESCRIPTION

### What is this PR for?

This PR is to cancel paragraph is no sufficient resources for hive jobs in jdbc interpreter.

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5100

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
