### PR TITLE
[ZEPPELIN-5001]. Drop view doesn't work in flink interpreter

### DIFF
--- a/flink/interpreter/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/interpreter/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -353,6 +353,14 @@ public abstract class SqlInterpreterTest {
     assertEquals(1, resultMessages.size());
     assertEquals("View has been dropped.\n", resultMessages.get(0).getData());
 
+    // show tables again
+    context = getInterpreterContext();
+    result = sqlInterpreter.interpret("show tables", context);
+    assertEquals(Code.SUCCESS, result.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(Type.TABLE, resultMessages.get(0).getType());
+    assertEquals("table\nsource_table\n", resultMessages.get(0).getData());
+
     // create temporary view
     if (!flinkInterpreter.getFlinkVersion().isFlink110()) {
       context = getInterpreterContext();


### PR DESCRIPTION
### What is this PR for?

The root cause is that in flink 1.10 there's only temporary view, but in 1.11 flink introduce permanent view, so we should always use ddl to drop view instead of calling `tbenv.dropTemporaryView`

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5101


### How should this be tested?
* Unit test is added
https://travis-ci.org/github/zjffdu/zeppelin/builds/737948009

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
