### PR TITLE
[ZEPPELIN-5103]. Simply jdbc interpreter error message

### DIFF
--- a/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/IPythonInterpreterTest.java
@@ -298,7 +298,7 @@ public class IPythonInterpreterTest extends BasePythonInterpreterTest {
     assertEquals(context.out.toInterpreterResultMessage().get(0).getData(),
             InterpreterResult.Code.SUCCESS, result.code());
     interpreterResultMessages = context.out.toInterpreterResultMessage();
-
+    
     assertEquals(context.out.toString(), 5, interpreterResultMessages.size());
     // the first message is the warning text message.
     assertEquals(InterpreterResult.Type.HTML, interpreterResultMessages.get(1).getType());


### PR DESCRIPTION
### What is this PR for?

In this PR, I would only print exception message when it is SQLException, otherwise would print the full stacktrace, because in this case it is most likely due to jdbc interpreter's internal error.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5103

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/96952163-c0a35b00-1520-11eb-9bcf-c7355a151184.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
