### PR TITLE
[ZEPPELIN-5106]. Only save note when it is loaded or newly created

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -433,7 +433,7 @@ public class NotebookService {
               return false;
             }
           } catch (Exception e) {
-            throw new IOException("Fail to run paragraph json: " + raw);
+            throw new IOException("Fail to run paragraph json: " + raw, e);
           }
         }
       } finally {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
@@ -171,7 +171,11 @@ public class SessionManagerService {
         if (remoteInterpreterProcess.isRunning()) {
           sessionInfo.setState(SessionState.RUNNING.name());
         } else {
-          sessionInfo.setState(SessionState.STOPPED.name());
+          // if it is running before, but interpreterGroup is not running now, that means the session is stopped.
+          // e.g. InterpreterProcess is terminated for whatever unexpected reason.
+          if (sessionInfo.getState().equals(SessionState.RUNNING.name())) {
+            sessionInfo.setState(SessionState.STOPPED.name());
+          }
         }
       }
     } else {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -191,13 +191,28 @@ public class Note implements JsonSerializable {
    * Release note memory
    */
   public void unLoad() {
-    this.setLoaded(false);
-    this.paragraphs = null;
-    this.config = null;
-    this.info = null;
-    this.noteForms = null;
-    this.noteParams = null;
-    this.angularObjects = null;
+    if (isRunning() || isParagraphRunning()) {
+      LOGGER.warn("Unable to unload note because it is in RUNNING");
+    } else {
+      this.setLoaded(false);
+      this.paragraphs = null;
+      this.config = null;
+      this.info = null;
+      this.noteForms = null;
+      this.noteParams = null;
+      this.angularObjects = null;
+    }
+  }
+
+  public boolean isParagraphRunning() {
+    if (paragraphs != null) {
+      for (Paragraph p : paragraphs) {
+        if (p.isRunning()) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   public boolean isPersonalizedMode() {
@@ -1084,6 +1099,10 @@ public class Note implements JsonSerializable {
     info.remove("startTime");
   }
 
+  /**
+   * Is note running
+   * @return
+   */
   public boolean isRunning() {
     return (boolean) getInfo().getOrDefault("isRunning", false);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -124,6 +124,7 @@ public class Note implements JsonSerializable {
 
   /********************************** transient fields ******************************************/
   private transient boolean loaded = false;
+  private transient boolean saved = false;
   private transient InterpreterFactory interpreterFactory;
   private transient InterpreterSettingManager interpreterSettingManager;
   private transient ParagraphJobListener paragraphJobListener;
@@ -1199,5 +1200,13 @@ public class Note implements JsonSerializable {
 
   public void setNoteEventListeners(List<NoteEventListener> noteEventListeners) {
     this.noteEventListeners = noteEventListeners;
+  }
+
+  public void setSaved(boolean saved) {
+    this.saved = saved;
+  }
+
+  public boolean isSaved() {
+    return saved;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -174,9 +174,13 @@ public class NoteManager {
    * @throws IOException
    */
   public void saveNote(Note note, AuthenticationInfo subject) throws IOException {
-    addOrUpdateNoteNode(note);
-    this.notebookRepo.save(note, subject);
-    note.setLoaded(true);
+    if (note.isLoaded()) {
+      addOrUpdateNoteNode(note);
+      this.notebookRepo.save(note, subject);
+      note.setLoaded(true);
+    } else {
+      LOGGER.warn("Try to save note: {} when it is unloaded", note.getId());
+    }
   }
 
   public void addNote(Note note, AuthenticationInfo subject) throws IOException {
@@ -191,11 +195,7 @@ public class NoteManager {
    * @throws IOException
    */
   public void saveNote(Note note) throws IOException {
-    if (note.isLoaded()) {
-      saveNote(note, AuthenticationInfo.ANONYMOUS);
-    } else {
-      LOGGER.warn("Try to save note: {} when it is unloaded", note.getId());
-    }
+    saveNote(note, AuthenticationInfo.ANONYMOUS);
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -191,7 +191,11 @@ public class NoteManager {
    * @throws IOException
    */
   public void saveNote(Note note) throws IOException {
-    saveNote(note, AuthenticationInfo.ANONYMOUS);
+    if (note.isLoaded()) {
+      saveNote(note, AuthenticationInfo.ANONYMOUS);
+    } else {
+      LOGGER.warn("Try to save note: {} when it is unloaded", note.getId());
+    }
   }
 
   /**

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -168,16 +168,19 @@ public class NoteManager {
 
   /**
    * Save note to NoteManager, it won't check duplicates, this is used when updating note.
+   * Only save note in 2 cases:
+   *  1. Note is new created, isSaved is false
+   *  2. Note is in loaded state. Unload state means its content is empty.
    *
    * @param note
    * @param subject
    * @throws IOException
    */
   public void saveNote(Note note, AuthenticationInfo subject) throws IOException {
-    if (note.isLoaded()) {
+    if (note.isLoaded() || !note.isSaved()) {
       addOrUpdateNoteNode(note);
       this.notebookRepo.save(note, subject);
-      note.setLoaded(true);
+      note.setSaved(true);
     } else {
       LOGGER.warn("Try to save note: {} when it is unloaded", note.getId());
     }


### PR DESCRIPTION
### What is this PR for?

This PR is to save note only in 2 cases:
1. It is loaded. 
2. It is newly created. 

Otherwise it will throw NPE because paragraphs is null when note is in unloaded state.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5106

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
