### PR TITLE
[ZEPPELIN-5109]. Support knox in zeppelin-client

### DIFF
--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ClientConfig.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ClientConfig.java
@@ -17,6 +17,8 @@
 
 package org.apache.zeppelin.client;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Configuration of Zeppelin client, such as zeppelin server rest url and
  * query interval of polling note/paragraph result.
@@ -24,20 +26,20 @@ package org.apache.zeppelin.client;
 public class ClientConfig {
   private String zeppelinRestUrl;
   private long queryInterval ;
-  private boolean useKnox = false;
+  private String knoxSSOUrl;
 
   public ClientConfig(String zeppelinRestUrl) {
     this(zeppelinRestUrl, 1000);
   }
 
   public ClientConfig(String zeppelinRestUrl, long queryInterval) {
-    this(zeppelinRestUrl, queryInterval, false);
+    this(zeppelinRestUrl, queryInterval, null);
   }
 
-  public ClientConfig(String zeppelinRestUrl, long queryInterval, boolean useKnox) {
+  public ClientConfig(String zeppelinRestUrl, long queryInterval, String knoxSSOUrl) {
     this.zeppelinRestUrl = removeTrailingSlash(zeppelinRestUrl);
     this.queryInterval = queryInterval;
-    this.useKnox = useKnox;
+    this.knoxSSOUrl = knoxSSOUrl;
   }
 
   private String removeTrailingSlash(String zeppelinRestUrl) {
@@ -57,6 +59,10 @@ public class ClientConfig {
   }
 
   public boolean isUseKnox() {
-    return useKnox;
+    return StringUtils.isNotBlank(knoxSSOUrl);
+  }
+
+  public String getKnoxSSOUrl() {
+    return knoxSSOUrl;
   }
 }

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
@@ -125,7 +125,7 @@ public class ZeppelinClient {
     checkJsonNodeStatus(jsonNode);
     return jsonNode.getObject().getJSONObject("body").getString("version");
   }
-
+  
   /**
    * Request a new session id. It doesn't create session (interpreter process) in zeppelin server side, but just
    * create an unique session id.
@@ -257,20 +257,20 @@ public class ZeppelinClient {
    */
   public void login(String userName, String password) throws Exception {
     if (clientConfig.isUseKnox()) {
-      HttpResponse<String> response = Unirest.get("/")
+      HttpResponse<String> response = Unirest.get(clientConfig.getKnoxSSOUrl() +
+              "?originalUrl=" + clientConfig.getZeppelinRestUrl())
               .basicAuth(userName, password)
               .asString();
       if (response.getStatus() != 200) {
-        throw new Exception(String.format("Login failed, status: %s, statusText: %s",
+        throw new Exception(String.format("Knox SSO login failed, status: %s, statusText: %s",
                 response.getStatus(),
                 response.getStatusText()));
       }
     } else {
-      HttpResponse<JsonNode> response = Unirest
-              .post("/login")
-              .field("userName", userName)
-              .field("password", password)
-              .asJson();
+      HttpResponse<String> response = Unirest
+              .get("/")
+              .basicAuth(userName, password)
+              .asString();
       if (response.getStatus() != 200) {
         throw new Exception(String.format("Login failed, status: %s, statusText: %s",
                 response.getStatus(),

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
@@ -266,11 +266,19 @@ public class ZeppelinClient {
                 response.getStatus(),
                 response.getStatusText()));
       }
-    } else {
-      HttpResponse<String> response = Unirest
-              .get("/")
-              .basicAuth(userName, password)
+      response = Unirest.get("/security/ticket")
               .asString();
+      if (response.getStatus() != 200) {
+        throw new Exception(String.format("Fail to get ticket after Knox SSO, status: %s, statusText: %s",
+                response.getStatus(),
+                response.getStatusText()));
+      }
+    } else {
+      HttpResponse<JsonNode> response = Unirest
+              .post("/login")
+              .field("userName", userName)
+              .field("password", password)
+              .asJson();
       if (response.getStatus() != 200) {
         throw new Exception(String.format("Login failed, status: %s, statusText: %s",
                 response.getStatus(),


### PR DESCRIPTION
### What is this PR for?

This PR add support of knox in zeppelin-client. I tested it in a real environment. What user need to provide is the knos sso url

### What type of PR is it?
[ Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5109

### How should this be tested?
* CI Pass.
https://travis-ci.com/github/zjffdu/zeppelin/builds/196564937

Sample code
```
    ClientConfig clientConfig = new ClientConfig("https://xxx:8443/gateway/cluster-topo/zeppelin",
            1000, "https://xxx:8443/gateway/knoxsso/api/v1/websso");
    ZeppelinClient zeppelinClient = new ZeppelinClient(clientConfig);
    zeppelinClient.login("username", "password");
    String version = zeppelinClient.getVersion();
    System.out.println(version);
```
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
