### PR TITLE
[ZEPPELIN-5067]. Add ZSession cleanup thread

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
@@ -385,6 +385,12 @@ public class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
     SessionInfo sessionInfo = zeppelinClient.getSession("invalid_session");
     assertNull(sessionInfo);
 
-    zeppelinClient.stopSession("invalid_session");
+    try {
+      zeppelinClient.stopSession("invalid_session");
+      fail("Should fail to stop session after it is stopped");
+    } catch (Exception e) {
+      e.printStackTrace();
+      assertTrue(e.getMessage().contains("No such session"));
+    }
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -1106,7 +1106,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SEARCH_USE_DISK("zeppelin.search.use.disk", true),
     ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),
     ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", false),
-    ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false);
+    ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false),
+    ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -1107,7 +1107,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),
     ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", false),
     ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false),
-    ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10);
+    ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000);
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
@@ -53,7 +53,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
   private ExecuteWatchdog watchdog;
   private ProcessLogOutputStream processOutput;
   protected String errorMessage = null;
-  protected State state = State.NEW;
+  protected volatile State state = State.NEW;
   private boolean launchTimeout = false;
 
   public ProcessLauncher(CommandLine commandLine,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -335,6 +335,11 @@ public class Notebook {
     fireNoteRemoveEvent(note, subject);
   }
 
+  public void removeNote(String noteId, AuthenticationInfo subject) throws IOException {
+    Note note = getNote(noteId);
+    removeNote(note, subject);
+  }
+
   /**
    * Get note from NotebookRepo and also initialize it with other properties that is not
    * persistent in NotebookRepo, such as paragraphJobListener.


### PR DESCRIPTION
### What is this PR for?

This PR will create a scheduled task to check session state, if the session is stopped, it would clean the associated session resources (e.g. remove session note). 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5067

### How should this be tested?
* Unit test is added
https://travis-ci.com/github/zjffdu/zeppelin/builds/196346111

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
