### PR TITLE
[ZEPPELIN-5116] Accessing zeppelin via knox after knox logout should be redirected to  knox login page

### DIFF
--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -80,6 +80,7 @@ user3 = password4, role2
 # krbRealm.cookieDomain = domain.com
 # krbRealm.cookiePath = /
 # krbRealm.logout = /logout
+# krbRealm.logoutAPI = true
 # krbRealm.providerUrl = https://domain.example.com/
 # krbRealm.redirectParam = originalUrl
 # authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter

--- a/conf/shiro.ini.template
+++ b/conf/shiro.ini.template
@@ -70,6 +70,20 @@ user3 = password4, role2
 #knoxJwtRealm.principalMapping = principal.mapping
 #authc = org.apache.zeppelin.realm.jwt.KnoxAuthenticationFilter
 
+### A sample for configuring Kerberos Realm
+# krbRealm = org.apache.zeppelin.realm.kerberos.KerberosRealm
+# krbRealm.principal = HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+# krbRealm.keytab = /etc/security/keytabs/spnego.service.keytab
+# krbRealm.nameRules = DEFAULT
+# krbRealm.signatureSecretFile = /etc/security/http_secret
+# krbRealm.tokenValidity = 36000
+# krbRealm.cookieDomain = domain.com
+# krbRealm.cookiePath = /
+# krbRealm.logout = /logout
+# krbRealm.providerUrl = https://domain.example.com/
+# krbRealm.redirectParam = originalUrl
+# authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
+
 sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
 
 ### If caching of user is required then uncomment below lines

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -67,14 +67,15 @@ import java.util.regex.Pattern;
  * The Shiro configuration section should be configured as:
  * [main]
  * krbRealm = org.apache.zeppelin.realm.kerberos.KerberosRealm
- * krbRealm.principal=HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
- * krbRealm.keytab=/etc/security/keytabs/spnego.service.keytab
- * krbRealm.nameRules=DEFAULT
- * krbRealm.signatureSecretFile=/etc/security/http_secret
- * krbRealm.tokenValidity=36000
- * krbRealm.cookieDomain=domain.com
- * krbRealm.cookiePath=/
- * krbRealm.logout=/logout
+ * krbRealm.principal = HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
+ * krbRealm.keytab = /etc/security/keytabs/spnego.service.keytab
+ * krbRealm.nameRules = DEFAULT
+ * krbRealm.signatureSecretFile = /etc/security/http_secret
+ * krbRealm.tokenValidity = 36000
+ * krbRealm.cookieDomain = domain.com
+ * krbRealm.cookiePath = /
+ * krbRealm.logout = logout
+ * krbRealm.logoutAPI = true
  * krbRealm.providerUrl = https://domain.example.com/
  * krbRealm.redirectParam = originalUrl
  * authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
@@ -94,7 +95,8 @@ public class KerberosRealm extends AuthorizingRealm {
   private boolean isCookiePersistent = false;
   private String signatureSecretFile = null;
   private String signatureSecretProvider = "file";
-  private String logout = "/logout";
+  private String logout = "logout";
+  private Boolean logoutAPI = true;
   private String providerUrl = "https://domain.example.com/";
   private String redirectParam = "originalUrl";
 
@@ -1000,6 +1002,14 @@ public class KerberosRealm extends AuthorizingRealm {
 
   public void setLogout(String logout) {
     this.logout = logout;
+  }
+
+  public Boolean getLogoutAPI() {
+    return logoutAPI;
+  }
+
+  public void setLogoutAPI(Boolean logoutAPI) {
+    this.logoutAPI = logoutAPI;
   }
 
   public String getProviderUrl() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -74,6 +74,9 @@ import java.util.regex.Pattern;
  * krbRealm.tokenValidity=36000
  * krbRealm.cookieDomain=domain.com
  * krbRealm.cookiePath=/
+ * krbRealm.logout=/logout
+ * krbRealm.providerUrl = https://domain.example.com/
+ * krbRealm.redirectParam = originalUrl
  * authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
  *
  */
@@ -91,6 +94,9 @@ public class KerberosRealm extends AuthorizingRealm {
   private boolean isCookiePersistent = false;
   private String signatureSecretFile = null;
   private String signatureSecretProvider = "file";
+  private String logout = "/logout";
+  private String providerUrl = "https://domain.example.com/";
+  private String redirectParam = "originalUrl";
 
   /**
    * Constant for the property that specifies the authentication handler to use.
@@ -167,6 +173,11 @@ public class KerberosRealm extends AuthorizingRealm {
    * implementation will be used.
    */
   private static final String SIGNER_SECRET_PROVIDER = "signer.secret.provider";
+  /**
+   * Constant for the configuration property that indicates the path to use to logout
+   */
+  private static final String LOGOUT = "logout";
+
 
   private static Signer signer = null;
   private SignerSecretProvider secretProvider = null;
@@ -878,6 +889,7 @@ public class KerberosRealm extends AuthorizingRealm {
     props.put(PRINCIPAL, principal);
     props.put(KEYTAB, keytab);
     props.put(NAME_RULES, nameRules);
+    props.put(LOGOUT, logout);
     return props;
   }
 
@@ -980,6 +992,30 @@ public class KerberosRealm extends AuthorizingRealm {
 
   public void setSignatureSecretProvider(String signatureSecretProvider) {
     this.signatureSecretProvider = signatureSecretProvider;
+  }
+
+  public String getLogout() {
+    return logout;
+  }
+
+  public void setLogout(String logout) {
+    this.logout = logout;
+  }
+
+  public String getProviderUrl() {
+    return providerUrl;
+  }
+
+  public void setProviderUrl(String providerUrl) {
+    this.providerUrl = providerUrl;
+  }
+
+  public String getRedirectParam() {
+    return redirectParam;
+  }
+
+  public void setRedirectParam(String redirectParam) {
+    this.redirectParam = redirectParam;
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -99,9 +99,9 @@ public class LoginRestApi {
       }
       if (response == null) {
         Map<String, String> data = new HashMap<>();
-        String redirect = knoxJwtRealm.getRedirectParam();
-        StringBuilder redirectURL = new StringBuilder(knoxJwtRealm.getProviderUrl());
-        data.put("redirectURL", constructUrl(redirectURL, redirect, knoxJwtRealm.getLogin()));
+        data.put("redirectURL",
+            constructUrl(knoxJwtRealm.getProviderUrl(), knoxJwtRealm.getRedirectParam(),
+                knoxJwtRealm.getLogin()));
         response = new JsonResponse(Status.OK, "", data);
       }
       return response.build();
@@ -265,27 +265,28 @@ public class LoginRestApi {
     }
     if (isKnoxSSOEnabled()) {
       KnoxJwtRealm knoxJwtRealm = getJTWRealm();
-      StringBuilder redirectURL = new StringBuilder(knoxJwtRealm.getProviderUrl());
-      String redirect = knoxJwtRealm.getRedirectParam();
-      data.put("redirectURL", constructUrl(redirectURL, redirect,
-          knoxJwtRealm.getLogout()));
+      data.put("redirectURL",
+          constructUrl(knoxJwtRealm.getProviderUrl(), knoxJwtRealm.getRedirectParam(),
+              knoxJwtRealm.getLogout()));
       data.put("isLogoutAPI", knoxJwtRealm.getLogoutAPI().toString());
     } else if (isKerberosRealmEnabled()) {
       KerberosRealm kerberosRealm = getKerberosRealm();
-      StringBuilder redirectURL = new StringBuilder(kerberosRealm.getProviderUrl());
-      String redirect = kerberosRealm.getRedirectParam();
-      data.put("redirectURL", constructUrl(redirectURL, redirect, kerberosRealm.getLogout()));
+      data.put("redirectURL",
+          constructUrl(kerberosRealm.getProviderUrl(), kerberosRealm.getRedirectParam(),
+              kerberosRealm.getLogout()));
+      data.put("isLogoutAPI", kerberosRealm.getLogoutAPI().toString());
     }
     JsonResponse<Map<String, String>> response = new JsonResponse<>(status, "", data);
     LOG.info(response.toString());
     return response.build();
   }
 
-  private String constructUrl(StringBuilder redirectURL, String redirect,
+  private String constructUrl(String providerURL, String redirectParam,
       String path) {
+    StringBuilder redirectURL = new StringBuilder(providerURL);
     redirectURL.append(path);
-    if (redirect != null) {
-      redirectURL.append("?").append(redirect).append("=");
+    if (redirectParam != null) {
+      redirectURL.append("?").append(redirectParam).append("=");
     }
     return redirectURL.toString();
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -99,8 +99,10 @@ public class LoginRestApi {
       }
       if (response == null) {
         Map<String, String> data = new HashMap<>();
-        data.put("redirectURL", constructKnoxUrl(knoxJwtRealm, knoxJwtRealm.getLogin()));
-        response = new JsonResponse<>(Status.OK, "", data);
+        String redirect = knoxJwtRealm.getRedirectParam();
+        StringBuilder redirectURL = new StringBuilder(knoxJwtRealm.getProviderUrl());
+        data.put("redirectURL", constructUrl(redirectURL, redirect, knoxJwtRealm.getLogin()));
+        response = new JsonResponse(Status.OK, "", data);
       }
       return response.build();
     }
@@ -162,6 +164,18 @@ public class LoginRestApi {
     if (realmsList != null) {
       for (Realm realm : realmsList) {
         if (realm instanceof KnoxJwtRealm) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private boolean isKerberosRealmEnabled() {
+    Collection<Realm> realmsList = authenticationService.getRealmsList();
+    if (realmsList != null) {
+      for (Realm realm : realmsList) {
+        if (realm instanceof KerberosRealm) {
           return true;
         }
       }
@@ -251,19 +265,27 @@ public class LoginRestApi {
     }
     if (isKnoxSSOEnabled()) {
       KnoxJwtRealm knoxJwtRealm = getJTWRealm();
-      data.put("redirectURL", constructKnoxUrl(knoxJwtRealm, knoxJwtRealm.getLogout()));
+      StringBuilder redirectURL = new StringBuilder(knoxJwtRealm.getProviderUrl());
+      String redirect = knoxJwtRealm.getRedirectParam();
+      data.put("redirectURL", constructUrl(redirectURL, redirect,
+          knoxJwtRealm.getLogout()));
       data.put("isLogoutAPI", knoxJwtRealm.getLogoutAPI().toString());
+    } else if (isKerberosRealmEnabled()) {
+      KerberosRealm kerberosRealm = getKerberosRealm();
+      StringBuilder redirectURL = new StringBuilder(kerberosRealm.getProviderUrl());
+      String redirect = kerberosRealm.getRedirectParam();
+      data.put("redirectURL", constructUrl(redirectURL, redirect, kerberosRealm.getLogout()));
     }
     JsonResponse<Map<String, String>> response = new JsonResponse<>(status, "", data);
     LOG.info(response.toString());
     return response.build();
   }
 
-  private String constructKnoxUrl(KnoxJwtRealm knoxJwtRealm, String path) {
-    StringBuilder redirectURL = new StringBuilder(knoxJwtRealm.getProviderUrl());
+  private String constructUrl(StringBuilder redirectURL, String redirect,
+      String path) {
     redirectURL.append(path);
-    if (knoxJwtRealm.getRedirectParam() != null) {
-      redirectURL.append("?").append(knoxJwtRealm.getRedirectParam()).append("=");
+    if (redirect != null) {
+      redirectURL.append("?").append(redirect).append("=");
     }
     return redirectURL.toString();
   }

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -107,8 +107,7 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
         let res = angular.fromJson(response.data).body;
         if (res['redirectURL']) {
           if (res['isLogoutAPI'] === 'true') {
-            $http.get(res['redirectURL']).then(function() {
-            }, function() {
+            $http.get(res['redirectURL']).finally(function() {
               window.location = baseUrlSrv.getBase();
             });
           } else {


### PR DESCRIPTION
### What is this PR for?
When zeppelin is running under kerberosRealm the logout doesn't work, it should be redirected to knox login page. With this PR, a fix for this is provided.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-5116

### How should this be tested?
1. Created a cluster
2. Deploy the changes to the cluster
3. Added respective entries in shiro.ini
4. Performed logout and tested


