### PR TITLE
[ZEPPELIN-5121]. Improve the support of hive on kerbose

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -503,11 +503,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
     final Properties properties = jdbcUserConfigurations.getPropertyMap(dbPrefix);
     String url = properties.getProperty(URL_KEY);
-    String principal = getProperty("zeppelin.jdbc.principal");
-    if (!StringUtils.isBlank(principal) && !url.contains("principal=")) {
-      url = url + ";principal=" + principal;
-    }
-
+    
     if (isEmpty(getProperty("zeppelin.jdbc.auth.type"))) {
       connection = getConnectionFromPool(url, user, dbPrefix, properties);
     } else {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -97,12 +97,12 @@ public class HiveUtils {
           LOGGER.warn("Fail to write output", e);
         }
       }
-      LOGGER.debug("Hive monitor thread is finished");
+      LOGGER.info("HiveMonitor-Thread is finished");
     });
     thread.setName("HiveMonitor-Thread");
     thread.setDaemon(true);
     thread.start();
-    LOGGER.info("Start HiveMonitor-Thread for sql: " + stmt);
+    LOGGER.info("Start HiveMonitor-Thread for sql: " + hiveStmt);
 
     if (progressBar != null) {
       hiveStmt.setInPlaceUpdateStream(progressBar.getInPlaceUpdateStream(context.out));

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
@@ -53,9 +53,10 @@ public class JDBCSecurityImpl {
           if (!UserGroupInformation.isSecurityEnabled()
               || UserGroupInformation.getCurrentUser().getAuthenticationMethod() != KERBEROS
               || !UserGroupInformation.isLoginKeytabBased()) {
-            UserGroupInformation.loginUserFromKeytab(
-                properties.getProperty("zeppelin.jdbc.principal"),
-                properties.getProperty("zeppelin.jdbc.keytab.location"));
+            String keytab = properties.getProperty("zeppelin.jdbc.keytab.location");
+            String principal = properties.getProperty("zeppelin.jdbc.principal");
+            UserGroupInformation.loginUserFromKeytab(principal, keytab);
+            LOGGER.info("Login successfully via keytab: {} and principal: {}", keytab, principal);
           } else {
             LOGGER.info("The user has already logged in using Keytab and principal, " +
                 "no action required");
@@ -67,7 +68,7 @@ public class JDBCSecurityImpl {
     }
   }
 
-  public static AuthenticationMethod getAuthtype(Properties properties) {
+  public static AuthenticationMethod getAuthType(Properties properties) {
     AuthenticationMethod authType;
     try {
       authType = AuthenticationMethod.valueOf(properties.getProperty("zeppelin.jdbc.auth.type")


### PR DESCRIPTION
### What is this PR for?

Several improvements of hive on kerbors support
1. Remove ·`zeppelin.jdbc.auth.kerberos.proxy.enable`, it is never documented, use `prefix.proxy.user.property` is enough.
2. Append principal to url automatically for users. 
3. Remove the doAs code block, it looks like is not necessary.

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5121

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
