### PR TITLE
[ZEPPELIN-5132] Allow job id injection for spark job url when knox is enabled

### DIFF
--- a/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
+++ b/spark/spark-shims/src/main/scala/org/apache/zeppelin/spark/SparkShims.java
@@ -108,11 +108,17 @@ public abstract class SparkShims {
                                   int jobId,
                                   Properties jobProperties,
                                   InterpreterContext context) {
-    String jobUrl = sparkWebUrl + "/jobs/job?id=" + jobId;
-    String version = VersionInfo.getVersion();
-    if (master.toLowerCase().contains("yarn") && !supportYarn6615(version)) {
-      jobUrl = sparkWebUrl + "/jobs";
+    String jobUrl = null;
+    if (sparkWebUrl.contains("{jobId}")) {
+      jobUrl = sparkWebUrl.replace("{jobId}", jobId + "");
+    } else {
+      jobUrl = sparkWebUrl + "/jobs/job?id=" + jobId;
+      String version = VersionInfo.getVersion();
+      if (master.toLowerCase().contains("yarn") && !supportYarn6615(version)) {
+        jobUrl = sparkWebUrl + "/jobs";
+      }
     }
+
     String jobGroupId = jobProperties.getProperty("spark.jobGroup.id");
 
     Map<String, String> infos = new java.util.HashMap<String, String>();


### PR DESCRIPTION

### What is this PR for?



### What type of PR is it?
[Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* First time? Setup Travis CI as described on https://zeppelin.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
