### PR TITLE
[ZEPPELIN-5133]. Warning message of SessionRestApi for empty path annotation

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SessionRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SessionRestApi.java
@@ -66,7 +66,6 @@ public class SessionRestApi {
    * @throws Exception
    */
   @GET
-  @Path("/")
   public Response listSessions(@QueryParam("interpreter") String interpreter) throws Exception {
     if (StringUtils.isBlank(interpreter)) {
       LOGGER.info("List all sessions of all interpreters");
@@ -90,7 +89,6 @@ public class SessionRestApi {
    * @throws Exception
    */
   @POST
-  @Path("/")
   public Response createSession(@QueryParam("interpreter") String interpreter) throws Exception {
     LOGGER.info("Create new session for interpreter: {}", interpreter);
     SessionInfo sessionInfo = sessionManagerService.createSession(interpreter);


### PR DESCRIPTION

### What is this PR for?

Very trivial PR to fix the issue of warning message of SessionRestApi for empty path annotation

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5133

### How should this be tested?
* Manually tested. (warning message is gone after this PR)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? NO
* Does this needs documentation? No
