### PR TITLE
[ZEPPELIN-5135]. Keep default.splitQueries in jdbc

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -19,6 +19,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 
+import com.beust.jcommander.internal.Lists;
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
@@ -108,6 +109,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   static final String DRIVER_KEY = "driver";
   static final String URL_KEY = "url";
   static final String USER_KEY = "user";
+  static final String SPLIT_QURIES_KEY = "splitQueries";
   static final String PASSWORD_KEY = "password";
   static final String PRECODE_KEY = "precode";
   static final String STATEMENT_PRECODE_KEY = "statementPrecode";
@@ -709,7 +711,15 @@ public class JDBCInterpreter extends KerberosInterpreter {
     }
 
     try {
-      List<String> sqlArray = sqlSplitter.splitSql(sql);
+      boolean splitSql = Boolean.parseBoolean(
+              getJDBCConfiguration(user).getPropertyMap(dbPrefix).getProperty(SPLIT_QURIES_KEY, "true"));
+      List<String> sqlArray = null;
+      if (splitSql) {
+        sqlArray = sqlSplitter.splitSql(sql);
+      } else {
+        sqlArray = Lists.newArrayList(sql);
+      }
+
       for (String sqlToExecute : sqlArray) {
         statement = connection.createStatement();
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -19,7 +19,6 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
 
-import com.beust.jcommander.internal.Lists;
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
@@ -51,6 +50,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -711,13 +711,14 @@ public class JDBCInterpreter extends KerberosInterpreter {
     }
 
     try {
-      boolean splitSql = Boolean.parseBoolean(
-              getJDBCConfiguration(user).getPropertyMap(dbPrefix).getProperty(SPLIT_QURIES_KEY, "true"));
+      boolean splitSql = Boolean.parseBoolean(getJDBCConfiguration(user)
+              .getPropertyMap(dbPrefix)
+              .getProperty(SPLIT_QURIES_KEY, "true"));
       List<String> sqlArray = null;
       if (splitSql) {
         sqlArray = sqlSplitter.splitSql(sql);
       } else {
-        sqlArray = Lists.newArrayList(sql);
+        sqlArray = Collections.singletonList(sql);
       }
 
       for (String sqlToExecute : sqlArray) {

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -32,6 +32,13 @@
         "description": "JDBC Driver Name",
         "type": "string"
       },
+      "default.splitQueries": {
+        "envName": null,
+        "propertyName": "default.splitQueries",
+        "defaultValue": "true",
+        "description": "Whether split the whole text into multiple sql statements",
+        "type": "checkbox"
+      },
       "default.completer.ttlInSeconds": {
         "envName": null,
         "propertyName": "default.completer.ttlInSeconds",

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -852,7 +852,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     resultMessages = context.out.toInterpreterResultMessage();
     assertEquals(1, resultMessages.size());
     assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
-    assertTrue(resultMessages.get(0).getData(), resultMessages.get(0).getData().startsWith("ID\tNAME"));
+    assertTrue(resultMessages.get(0).getData(),
+            resultMessages.get(0).getData().startsWith("ID\tNAME"));
   }
   private InterpreterContext getInterpreterContext() {
     return InterpreterContext.builder()

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -818,6 +818,42 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     assertEquals(3, resultMessages.size());
   }
 
+  @Test
+  public void testSqlWithoutSplit() throws IOException,
+          InterpreterException {
+    Properties properties = new Properties();
+    properties.setProperty("common.max_count", "1000");
+    properties.setProperty("common.max_retry", "3");
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection());
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    properties.setProperty("default.splitQueries", "false");
+    JDBCInterpreter t = new JDBCInterpreter(properties);
+    t.open();
+
+    String sqlQuery = "-- comment\n" +
+            "--select * from test_table\n" +
+            "select * from test_table;";
+
+    InterpreterResult interpreterResult = t.interpret(sqlQuery, context);
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    List<InterpreterResultMessage> resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(1, resultMessages.size());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+
+
+    // the second sql is skipped.
+    context = getInterpreterContext();
+    sqlQuery = "select * from test_table;" +
+            "select name from test_table";
+    interpreterResult = t.interpret(sqlQuery, context);
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(1, resultMessages.size());
+    assertEquals(InterpreterResult.Type.TABLE, resultMessages.get(0).getType());
+    assertTrue(resultMessages.get(0).getData(), resultMessages.get(0).getData().startsWith("ID\tNAME"));
+  }
   private InterpreterContext getInterpreterContext() {
     return InterpreterContext.builder()
             .setAuthenticationInfo(new AuthenticationInfo("testUser"))


### PR DESCRIPTION
### What is this PR for?

This PR is to bring back `default.splitQueries` in jdbc, so that user can choose whether split sql. But by default, we still enable it.

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5135

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
