### PR TITLE
[hotfix] Install R version 3.x

### DIFF
--- a/testing/install_external_dependencies.sh
+++ b/testing/install_external_dependencies.sh
@@ -59,7 +59,7 @@ fi
 
 # Install R dependencies if R is true
 if [[ "$R" == "true" ]] ; then
-  conda install -y --quiet r-base r-evaluate r-base64enc r-knitr r-ggplot2 r-irkernel r-shiny r-googlevis
+  conda install -y --quiet r-base=3 r-evaluate r-base64enc r-knitr r-ggplot2 r-irkernel r-shiny r-googlevis
   R -e "IRkernel::installspec()"
   echo "R_LIBS=~/miniconda/lib/R/library" > ~/.Renviron
   echo "export R_LIBS=~/miniconda/lib/R/library" >> ~/.environ


### PR DESCRIPTION
### What is this PR for?
This PR ensures that a 3.x version of R is installed
R 4.x breaks our CI tests

### What type of PR is it?
- Hotfix

### How should this be tested?
* Travis-CI: https://travis-ci.com/github/Reamer/zeppelin/builds/203034613

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
