### PR TITLE
[ZEPPELIN-5140]Close RemoteInterpreter when RemoteInterpreterServer already timeout.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -188,6 +188,10 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
               intpGroupId);
       return;
     }
+    // Close RemoteInterpreter when RemoteInterpreterServer already timeout.
+    // Otherwise the ProgressBar will be missing when rerun after the RemoteInterpreterServer timeout
+    // and old RemoteInterpreterGroups will always alive after GC.
+    interpreterGroup.close();
     interpreterSettingManager.removeInterpreterGroup(intpGroupId);
   }
 


### PR DESCRIPTION
### What is this PR for?
This PR is to fix ZEPPELIN-5135. 
Close RemoteInterpreter when RemoteInterpreterServer already timeout.
Otherwise the ProgressBar will be missing when rerun after the RemoteInterpreterServer timeout and old RemoteInterpreterGroup will always alive after GC.


### What type of PR is it?
[Bug Fix | Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-5140

### How should this be tested?
* First, run a paragraph using spark interpreter
* Then, wait the TimeoutLifecycleManager to expire
* Rerun the above paragraph, and the progress bar is missing.

After the bug fixed, the above issue is solved

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
