### PR TITLE
[ZEPPELIN-5141]. Solve the incompatibility issue of hive below 2.3

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/ProgressBar.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/ProgressBar.java
@@ -16,6 +16,7 @@
 
 package org.apache.zeppelin.jdbc.hive;
 
+import org.apache.hive.jdbc.HiveStatement;
 import org.apache.hive.jdbc.logs.InPlaceUpdateStream;
 
 import java.io.OutputStream;
@@ -40,5 +41,9 @@ public class ProgressBar {
             new PrintStream(out),
             eventNotifier
     );
+  }
+
+  public void setInPlaceUpdateStream(HiveStatement hiveStmt, OutputStream out){
+    hiveStmt.setInPlaceUpdateStream(this.getInPlaceUpdateStream(out));
   }
 }


### PR DESCRIPTION
### What is this PR for?
The current hive interpreter (jdbc) cannot work with hive below 2.3.  The code "hiveStmt.setInPlaceUpdateStream(InPlaceUpdateStream stream)" in HiveUtils uses InPlaceUpdateStream class which is only available in version 2.3 or above, which leads to runtime NoClassDefFoundError.  Move the code into ProgressBar to delay NoClassDefFoundError of InPlaceUpdateStream until ProgressBar instanced. When hive < 2.3, ProgressBar will not be instanced, so it works well.


### What type of PR is it?
[Bug Fix | Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5141

### How should this be tested?
* Test the hive interpreter(jdbc) with version both above 2.3 and below 2.3 to check whether it can work well.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
