### PR TITLE
 [ZEPPELIN-5146]. Query was cancelled incorrectly for hive on tez

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/BeelineInPlaceUpdateStream.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/BeelineInPlaceUpdateStream.java
@@ -35,6 +35,7 @@ public class BeelineInPlaceUpdateStream implements InPlaceUpdateStream {
 
   private InPlaceUpdate inPlaceUpdate;
   private EventNotifier notifier;
+  private long lastUpdateTimestamp;
 
   public BeelineInPlaceUpdateStream(PrintStream out,
                                     InPlaceUpdateStream.EventNotifier notifier) {
@@ -59,9 +60,14 @@ public class BeelineInPlaceUpdateStream implements InPlaceUpdateStream {
         etc. have to remove these notifiers when the operation logs get merged into
         GetOperationStatus
       */
+      lastUpdateTimestamp = System.currentTimeMillis();
       LOGGER.info("update progress: " + response.getProgressedPercentage());
       inPlaceUpdate.render(new ProgressMonitorWrapper(response));
     }
+  }
+
+  public long getLastUpdateTimestamp() {
+    return lastUpdateTimestamp;
   }
 
   @Override

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -101,17 +101,22 @@ public class HiveUtils {
           }
 
           if (jobLaunched) {
+            // Step 1. update jobLastActiveTime first
+            // Step 2. Check whether it is timeout.
             if (StringUtils.isNotBlank(logsOutput)) {
               jobLastActiveTime = System.currentTimeMillis();
-            } else {
-              if (((System.currentTimeMillis() - jobLastActiveTime) > timeoutThreshold)) {
-                String errorMessage = "Cancel this job as no more log is produced in the " +
-                        "last " + timeoutThreshold / 1000 + " seconds, " +
-                        "maybe it is because no yarn resources";
-                LOGGER.warn(errorMessage);
-                jdbcInterpreter.cancel(context, errorMessage);
-                break;
-              }
+            } else if (progressBar.getBeelineInPlaceUpdateStream() != null &&
+                      progressBar.getBeelineInPlaceUpdateStream().getLastUpdateTimestamp() > jobLastActiveTime) {
+              jobLastActiveTime = progressBar.getBeelineInPlaceUpdateStream().getLastUpdateTimestamp();
+            }
+
+            if (((System.currentTimeMillis() - jobLastActiveTime) > timeoutThreshold)) {
+              String errorMessage = "Cancel this job as no more log is produced in the " +
+                      "last " + timeoutThreshold / 1000 + " seconds, " +
+                      "maybe it is because no yarn resources";
+              LOGGER.warn(errorMessage);
+              jdbcInterpreter.cancel(context, errorMessage);
+              break;
             }
           }
           // refresh logs every 1 second.

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -106,8 +106,10 @@ public class HiveUtils {
             if (StringUtils.isNotBlank(logsOutput)) {
               jobLastActiveTime = System.currentTimeMillis();
             } else if (progressBar.getBeelineInPlaceUpdateStream() != null &&
-                      progressBar.getBeelineInPlaceUpdateStream().getLastUpdateTimestamp() > jobLastActiveTime) {
-              jobLastActiveTime = progressBar.getBeelineInPlaceUpdateStream().getLastUpdateTimestamp();
+                    progressBar.getBeelineInPlaceUpdateStream().getLastUpdateTimestamp()
+                            > jobLastActiveTime) {
+              jobLastActiveTime = progressBar.getBeelineInPlaceUpdateStream()
+                      .getLastUpdateTimestamp();
             }
 
             if (((System.currentTimeMillis() - jobLastActiveTime) > timeoutThreshold)) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/ProgressBar.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/ProgressBar.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
  */
 public class ProgressBar {
   private InPlaceUpdateStream.EventNotifier eventNotifier;
+  private BeelineInPlaceUpdateStream beelineInPlaceUpdateStream;
 
   public ProgressBar() {
     this.eventNotifier = new InPlaceUpdateStream.EventNotifier();
@@ -36,9 +37,14 @@ public class ProgressBar {
   }
 
   public BeelineInPlaceUpdateStream getInPlaceUpdateStream(OutputStream out) {
-    return new BeelineInPlaceUpdateStream(
+    beelineInPlaceUpdateStream = new BeelineInPlaceUpdateStream(
             new PrintStream(out),
             eventNotifier
     );
+    return beelineInPlaceUpdateStream;
+  }
+
+  public BeelineInPlaceUpdateStream getBeelineInPlaceUpdateStream() {
+    return beelineInPlaceUpdateStream;
   }
 }


### PR DESCRIPTION
### What is this PR for?

The root cause is that for hive on tez, log is updated via BeelineInPlaceUpdateStream instead of HiveStatement.getQueryLog().
This PR would check BeelineInPlaceUpdateStream to update the `jobLastActiveTime`

### What type of PR is it?
[Bug Fix |]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5146

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
