### PR TITLE
[ZEPPELIN-5150]. Allow option to allow exclude paragraph result when saving note to NotebookRepo

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -815,4 +815,10 @@
   <description>Whether only allow yarn cluster mode</description>
 </property>
 
+<property>
+  <name>zeppelin.note.file.exclude.fields</name>
+  <value></value>
+  <description>fields to be excluded from being saved in note files, with Paragraph prefix mean the fields in Paragraph, e.g. Paragraph.results</description>
+</property>
+
 </configuration>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -645,6 +645,10 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     return getString(ConfVars.ZEPPELIN_SERVER_RPC_PORTRANGE);
   }
 
+  public String[] getNoteFileExcludedFields() {
+    return StringUtils.split(getString(ConfVars.ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS), (","));
+  }
+
   public String getInterpreterPortRange() {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_RPC_PORTRANGE);
   }
@@ -1128,7 +1132,8 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),
     ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", false),
     ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false),
-    ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000);
+    ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000),
+    ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", "");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
@@ -173,13 +173,13 @@ public class SessionManagerService {
         } else {
           // if it is running before, but interpreterGroup is not running now, that means the session is stopped.
           // e.g. InterpreterProcess is terminated for whatever unexpected reason.
-          if (sessionInfo.getState().equals(SessionState.RUNNING.name())) {
+          if (SessionState.RUNNING.name().equalsIgnoreCase(sessionInfo.getState())) {
             sessionInfo.setState(SessionState.STOPPED.name());
           }
         }
       }
     } else {
-      if (sessionInfo.getState().equals(SessionState.RUNNING.name())) {
+      if (SessionState.RUNNING.name().equalsIgnoreCase(sessionInfo.getState())) {
         // if it is running before, but interpreterGroup is null now, that means the session is stopped.
         // e.g. InterpreterProcess is killed if it exceed idle timeout threshold.
         sessionInfo.setState(SessionState.STOPPED.name());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -18,6 +18,7 @@ package org.apache.zeppelin.conf;
 
 
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.junit.Assert;
 import org.junit.Before;
@@ -136,4 +137,5 @@ public class ZeppelinConfigurationTest {
     System.setProperty(ConfVars.ZEPPELIN_CONFIG_STORAGE_CLASS.getVarName(), "org.apache.zeppelin.storage.FileSystemConfigStorage");
     assertEquals("conf", conf.getConfigFSDir(false));
   }
+
 }


### PR DESCRIPTION

### What is this PR for?

When using zeppelin as job server instead of interactive notebook, it is not necessary to save paragraph results (sometimes it is pretty large) into NotebookRepo which may cause high pressure on IO when many jobs are running. It doesn't affect current behavior, because by default we still store paragraph results in NotebookRepo

### What type of PR is it?
[Improvement | Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5150

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
