### PR TITLE
[ZEPPELIN-5165]. fix bug in interpreter.cmd-0.9.0 Windows

### DIFF
--- a/bin/interpreter.cmd
+++ b/bin/interpreter.cmd
@@ -29,6 +29,9 @@ if /I "%~1"=="-d" (
 if /I "%~1"=="-p" set PORT=%~2
 if /I "%~1"=="-c" set CALLBACK_HOST=%~2
 if /I "%~1"=="-l" set LOCAL_INTERPRETER_REPO=%~2
+if /I "%~1"=="-i" set INTP_GROUP_ID=%~2
+if /I "%~1"=="-r" set INTP_PORT=%~2
+if /I "%~1"=="-g" set INTERPRETER_SETTING_NAME=%~2
 shift
 goto loop
 :cont
@@ -132,7 +135,7 @@ if defined SPARK_SUBMIT (
 ) else (
     set JAVA_INTP_OPTS=%JAVA_INTP_OPTS% -Dzeppelin.log.file="%ZEPPELIN_LOGFILE%"
 
-    "%ZEPPELIN_RUNNER%" !JAVA_INTP_OPTS! %ZEPPELIN_INTP_MEM% -cp '%ZEPPELIN_CLASSPATH_OVERRIDES%;%CLASSPATH%' %ZEPPELIN_SERVER% "%CALLBACK_HOST%" %PORT%
+    "%ZEPPELIN_RUNNER%" !JAVA_INTP_OPTS! %ZEPPELIN_INTP_MEM% -cp '%ZEPPELIN_CLASSPATH_OVERRIDES%;%CLASSPATH%' %ZEPPELIN_SERVER% "%CALLBACK_HOST%" %PORT% %INTP_GROUP_ID% %INTP_PORT%
 )
 
 exit /b


### PR DESCRIPTION
### What is this PR for?
* For `zeppelin-0.9.0`,  Windows, `bin\interpreter.cmd` calls `RemoteInterpreterServer` but misses `groupId` paramters, resulting in `ArrayIndexOutOfBoundsException` when any paragraphs are executed.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - change `bin\interpreter.cmd`

### What is the Jira issue?
* Open an issue on Jira [ZEPPELIN-5165](https://issues.apache.org/jira/browse/ZEPPELIN-5165)

### How should this be tested?
* Running zeppelin 0.9.0 on Windows.

### Screenshots (if appropriate)
The bug snapshot:
![image](https://user-images.githubusercontent.com/5548915/102581648-f2f5c100-413b-11eb-8cb7-23cefd3b9dab.png)

