### PR TITLE
[ZEPPELIN-5155]. Add option to disable search

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -1128,6 +1128,7 @@ public class ZeppelinConfiguration extends XMLConfiguration {
     ZEPPELIN_PROXY_URL("zeppelin.proxy.url", null),
     ZEPPELIN_PROXY_USER("zeppelin.proxy.user", null),
     ZEPPELIN_PROXY_PASSWORD("zeppelin.proxy.password", null),
+    ZEPPELIN_SEARCH_ENABLE("zeppelin.search.enable", true),
     ZEPPELIN_SEARCH_INDEX_REBUILD("zeppelin.search.index.rebuild", false),
     ZEPPELIN_SEARCH_USE_DISK("zeppelin.search.use.disk", true),
     ZEPPELIN_SEARCH_INDEX_PATH("zeppelin.search.index.path", "/tmp/zeppelin-index"),

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -90,6 +90,7 @@ import org.apache.zeppelin.notebook.scheduler.SchedulerService;
 import org.apache.zeppelin.plugin.PluginManager;
 import org.apache.zeppelin.rest.exception.WebApplicationExceptionMapper;
 import org.apache.zeppelin.search.LuceneSearch;
+import org.apache.zeppelin.search.NoSearchService;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.service.*;
 import org.apache.zeppelin.service.AuthenticationService;
@@ -181,7 +182,6 @@ public class ZeppelinServer extends ResourceConfig {
             Credentials credentials = new Credentials(conf);
             bindAsContract(InterpreterFactory.class).in(Singleton.class);
             bindAsContract(NotebookRepoSync.class).to(NotebookRepo.class).in(Immediate.class);
-            bind(LuceneSearch.class).to(SearchService.class).in(Singleton.class);
             bindAsContract(Helium.class).in(Singleton.class);
             bind(conf).to(ZeppelinConfiguration.class);
             bindAsContract(InterpreterSettingManager.class).in(Singleton.class);
@@ -217,6 +217,11 @@ public class ZeppelinServer extends ResourceConfig {
               bind(QuartzSchedulerService.class).to(SchedulerService.class).in(Singleton.class);
             } else {
               bind(NoSchedulerService.class).to(SchedulerService.class).in(Singleton.class);
+            }
+            if (conf.getBoolean(ConfVars.ZEPPELIN_SEARCH_ENABLE)) {
+              bind(LuceneSearch.class).to(SearchService.class).in(Singleton.class);
+            } else {
+              bind(NoSearchService.class).to(SearchService.class).in(Singleton.class);
             }
           }
         });

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
@@ -23,6 +23,7 @@ import org.apache.zeppelin.notebook.Paragraph;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -30,13 +31,13 @@ import java.util.stream.Stream;
 public class NoSearchService extends SearchService {
 
   @Inject
-  public NoSearchService(ZeppelinConfiguration conf) {
+  public NoSearchService() {
     super("NoSearchService-Thread");
   }
 
   @Override
   public List<Map<String, String>> query(String queryStr) {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.search;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Paragraph;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class NoSearchService extends SearchService {
+
+  @Inject
+  public NoSearchService(ZeppelinConfiguration conf) {
+    super("NoSearchService-Thread");
+  }
+
+  @Override
+  public List<Map<String, String>> query(String queryStr) {
+    return null;
+  }
+
+  @Override
+  public void updateNoteIndex(Note note) throws IOException {
+
+  }
+
+  @Override
+  public void updateParagraphIndex(Paragraph paragraph) throws IOException {
+
+  }
+
+  @Override
+  public void addNoteIndex(Note note) throws IOException {
+
+  }
+
+  @Override
+  public void addParagraphIndex(Paragraph pargaraph) throws IOException {
+
+  }
+
+  @Override
+  public void deleteNoteIndex(Note note) throws IOException {
+
+  }
+
+  @Override
+  public void deleteParagraphIndex(String noteId, Paragraph p) throws IOException {
+
+  }
+
+
+  @Override
+  public void startRebuildIndex(Stream<Note> notes) {
+
+  }
+}


### PR DESCRIPTION
### What is this PR for?

This introduce property `zeppelin.search.enable` so that user can disable search in some case (e.g. use zeppelin as job server). 

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5155

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
