### PR TITLE
[ZEPPELIN-5170]. Support spark-submit in spark interpreter

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -112,6 +112,12 @@
 
     <dependency>
       <groupId>org.apache.zeppelin</groupId>
+      <artifactId>zeppelin-shell</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-python</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSubmitInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSubmitInterpreter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zeppelin.spark;
+
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.apache.zeppelin.interpreter.InterpreterOutputListener;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterResultMessageOutput;
+import org.apache.zeppelin.shell.ShellInterpreter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Properties;
+
+
+/**
+ * Support %spark.submit which run spark-submit command. Internally,
+ * it would run shell command via ShellInterpreter.
+ *
+ */
+public class SparkSubmitInterpreter extends ShellInterpreter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkSubmitInterpreter.class);
+
+  private String sparkHome;
+
+  public SparkSubmitInterpreter(Properties property) {
+    super(property);
+    // Set time to be max integer so that the shell process won't timeout.
+    setProperty("shell.command.timeout.millisecs", Integer.MAX_VALUE + "");
+    this.sparkHome = properties.getProperty("SPARK_HOME");
+    LOGGER.info("SPARK_HOME: " + sparkHome);
+  }
+
+  @Override
+  public InterpreterResult internalInterpret(String cmd, InterpreterContext context) {
+    String sparkSubmitCommand = sparkHome + "/bin/spark-submit " + cmd.trim();
+    LOGGER.info("Run spark command: " + sparkSubmitCommand);
+    context.out.addInterpreterOutListener(new SparkSubmitOutputListener(context));
+    return super.internalInterpret(sparkSubmitCommand, context);
+  }
+
+  /**
+   * InterpreterOutputListener which extract spark ui link from logs.
+   */
+  private static class SparkSubmitOutputListener implements InterpreterOutputListener  {
+
+    private InterpreterContext context;
+    private boolean isSparkUrlSent = false;
+
+    public SparkSubmitOutputListener(InterpreterContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public void onUpdateAll(InterpreterOutput out) {
+
+    }
+
+    @Override
+    public void onAppend(int index, InterpreterResultMessageOutput out, byte[] line) {
+      String text = new String(line);
+      if (isSparkUrlSent) {
+        return;
+      }
+      if (text.contains("tracking URL:")) {
+        // yarn mode, extract yarn proxy url as spark ui link
+        buildSparkUIInfo(text, context);
+        isSparkUrlSent = true;
+      } else if (text.contains("Bound SparkUI to")) {
+        // other mode, extract the spark ui link
+        buildSparkUIInfo(text, context);
+        isSparkUrlSent = true;
+      }
+    }
+
+    private void buildSparkUIInfo(String log, InterpreterContext context) {
+      int pos = log.lastIndexOf(" ");
+      if (pos != -1) {
+        String sparkUI = log.substring(pos + 1);
+        Map<String, String> infos = new java.util.HashMap<String, String>();
+        infos.put("jobUrl", sparkUI);
+        infos.put("label", "Spark UI");
+        infos.put("tooltip", "View in Spark web UI");
+        infos.put("noteId", context.getNoteId());
+        infos.put("paraId", context.getParagraphId());
+        context.getIntpEventClient().onParaInfosReceived(infos);
+      } else {
+        LOGGER.error("Unable to extract spark url from this log: " + log);
+      }
+    }
+
+    @Override
+    public void onUpdate(int index, InterpreterResultMessageOutput out) {
+
+    }
+  }
+}

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -349,5 +349,18 @@
       "completionKey": "TAB",
       "completionSupport": false
     }
+  },
+
+  {
+    "group": "spark",
+    "name": "submit",
+    "className": "org.apache.zeppelin.spark.SparkSubmitInterpreter",
+    "properties": {
+    },
+    "editor": {
+      "language": "sh",
+      "editOnDblClick": false,
+      "completionSupport": false
+    }
   }
 ]

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -145,6 +145,13 @@ public abstract class SparkIntegrationTest {
     assertEquals(interpreterResult.toString(), InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertEquals(interpreterResult.toString(), InterpreterResult.Type.TEXT, interpreterResult.message().get(0).getType());
     assertTrue(interpreterResult.toString(), interpreterResult.message().get(0).getData().contains("eruptions waiting"));
+
+    // test SparkSubmitInterpreter
+    context = new InterpreterContext.Builder().setNoteId("note1").setParagraphId("paragraph_1").build();
+    Interpreter sparkSubmitInterpreter = interpreterFactory.getInterpreter("spark.submit", new ExecutionContextBuilder().setUser("user1").setNoteId("note1").setDefaultInterpreterGroup("test").createExecutionContext());
+    interpreterResult = sparkSubmitInterpreter.interpret("--class org.apache.spark.examples.SparkPi " + sparkHome + "/examples/jars/spark-examples*.jar ", context);
+
+    assertEquals(interpreterResult.toString(), InterpreterResult.Code.SUCCESS, interpreterResult.code());
   }
 
   @Test

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
@@ -85,7 +85,7 @@ public class InterpreterResult implements Serializable, JsonSerializable {
    * @param msg
    */
   public void add(String msg) {
-    InterpreterOutput out = new InterpreterOutput(null);
+    InterpreterOutput out = new InterpreterOutput();
     try {
       out.write(msg);
       out.flush();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -359,7 +359,7 @@ public class RemoteInterpreterServer extends Thread
 
         String localRepoPath = properties.get("zeppelin.interpreter.localRepo");
         if (properties.containsKey("zeppelin.interpreter.output.limit")) {
-          InterpreterOutput.limit = Integer.parseInt(
+          InterpreterOutput.LIMIT = Integer.parseInt(
                   properties.get("zeppelin.interpreter.output.limit"));
         }
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/InterpreterOutputTest.java
@@ -166,7 +166,7 @@ public class InterpreterOutputTest implements InterpreterOutputListener {
   @Test
   public void testTruncate() throws IOException {
     // output is truncated after the new line
-    InterpreterOutput.limit = 3;
+    InterpreterOutput.LIMIT = 3;
     out = new InterpreterOutput(this);
 
     // truncate text
@@ -189,7 +189,7 @@ public class InterpreterOutputTest implements InterpreterOutputListener {
     assertEquals("hello\nworld\n", new String(out.getOutputAt(0).toByteArray()));
 
     // restore default
-    InterpreterOutput.limit = Constants.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT;
+    InterpreterOutput.LIMIT = Constants.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT;
   }
 
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -49,8 +49,6 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.EnumSet;
-import java.util.Objects;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.management.remote.JMXServiceURL;
@@ -149,7 +147,7 @@ public class ZeppelinServer extends ResourceConfig {
 
   @Inject
   public ZeppelinServer() {
-    InterpreterOutput.limit = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT);
+    InterpreterOutput.LIMIT = conf.getInt(ConfVars.ZEPPELIN_INTERPRETER_OUTPUT_LIMIT);
 
     packages("org.apache.zeppelin.rest");
   }


### PR DESCRIPTION
### What is this PR for?

This PR is to support `%spark.submit` to spark-submit command so that user can run spark jar jobs in zeppelin. This is a sub interpreter of spark. Internally it runs shell interpreter for spark-submit command.


### What type of PR is it?
[Feature ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5170

### How should this be tested?
* Manually tested and integration test is added

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/102894878-b9f08000-449e-11eb-99ce-6eb2cc6ca80d.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
