### PR TITLE
[ZEPPELIN-5176] Kerberos ticket renewal fix in JDBC Interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -182,6 +182,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   @Override
   protected boolean runKerberosLogin() {
+    // Initialize UGI before using
+    Configuration conf = new org.apache.hadoop.conf.Configuration();
+    conf.set("hadoop.security.authentication", KERBEROS.toString());
+    UserGroupInformation.setConfiguration(conf);
     try {
       if (UserGroupInformation.isLoginKeytabBased()) {
         UserGroupInformation.getLoginUser().reloginFromKeytab();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/KerberosInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/KerberosInterpreter.java
@@ -146,7 +146,8 @@ public abstract class KerberosInterpreter extends AbstractInterpreter {
             logger.error("runKerberosLogin failed for  max attempts, calling close interpreter.");
             close();
           } else {
-            scheduledExecutorService.submit(this);
+            // wait for 1 second before calling runKerberosLogin() again
+            scheduledExecutorService.schedule(this, 1, TimeUnit.SECONDS);
           }
         }
         return null;


### PR DESCRIPTION
### What is this PR for?
This PR addresses a problem in JDBC Interpreter where the Kerberos ticket renewal thread and the interpret() function vies for Kerberos ticket during Interpreter initialization and later on, during the ticket renewal, which can lead to an expired ticket intermittently.
This PR fixes Kerberos ticket renewal logic in JDBC interpreter:
1. Initialize UGI before using it in runKerberosLogin()
2. Wait 1 second between every call to runKerberosLogin()

### What type of PR is it?
[Bug Fix]

### Todos
* none

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5176


### How should this be tested?
* Manual testing on a cluster. Configure JDBC interpreter with Kerberos enabled and make sure that the ticket is valid after the expiration time

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
