### PR TITLE
[ZEPPELIN-5169] Hive set statement doesn't work for some hive version when there's empty line ahead

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -717,6 +717,11 @@ public class JDBCInterpreter extends KerberosInterpreter {
       List<String>  sqlArray = sqlSplitter.splitSql(sql);
       for (String sqlToExecute : sqlArray) {
         LOGGER.info("Execute sql: " + sqlToExecute);
+        if (sqlToExecute.trim().toLowerCase().startsWith("set ")) {
+          // some version of hive doesn't work with set statement with empty line ahead.
+          // so we need to trim it first in this case.
+          sqlToExecute = sqlToExecute.trim();
+        }
         statement = connection.createStatement();
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)


### PR DESCRIPTION
### What is this PR for?

The current sql split logic will append empty lines before sql statement, this would cause issues for the sql statement for some hive version. This is to fix it by checking whether it is set statement, if yes, then trim the sql statement.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5169

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
