### PR TITLE
[ZEPPELIN-5173] Fix the entity name according to the convention

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -100,6 +100,7 @@ import org.apache.zeppelin.user.UsernamePassword;
 public class JDBCInterpreter extends KerberosInterpreter {
   private static final Logger LOGGER = LoggerFactory.getLogger(JDBCInterpreter.class);
 
+  static final String INTERPRETER_NAME = "jdbc";
   static final String COMMON_KEY = "common";
   static final String MAX_LINE_KEY = "max_count";
   static final int MAX_LINE_DEFAULT = 1000;
@@ -343,10 +344,10 @@ public class JDBCInterpreter extends KerberosInterpreter {
   }
 
   private String getEntityName(String replName, String propertyKey) {
-    if ("jdbc".equals(replName)) {
-      return propertyKey;
+    if (INTERPRETER_NAME.equals(replName)) {
+      return INTERPRETER_NAME + "." + propertyKey;
     } else {
-      return replName;
+      return INTERPRETER_NAME + "." + replName;
     }
   }
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -540,7 +540,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
 
     JDBCInterpreter jdbc = new JDBCInterpreter(properties);
     AuthenticationInfo user1Credential = getUserAuth("user1", null, null, null);
-    AuthenticationInfo user2Credential = getUserAuth("user2", "hive", "user2Id", "user2Pw");
+    AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.hive", "user2Id", "user2Pw");
     jdbc.open();
 
     // user1 runs default
@@ -574,7 +574,7 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
             .setAuthenticationInfo(user2Credential)
             .setInterpreterOut(new InterpreterOutput(null))
             .setLocalProperties(localProperties)
-            .setReplName("jdbc")
+            .setReplName("hive")
             .build();
     jdbc.interpret("", context);
 
@@ -591,8 +591,8 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     // user2 %hive  select from default db
     Properties properties = getDBProperty("default", "", "");
     JDBCInterpreter jdbc = new JDBCInterpreter(properties);
-    AuthenticationInfo user1Credential = getUserAuth("user1", "hive", "user1Id", "user1Pw");
-    AuthenticationInfo user2Credential = getUserAuth("user2", "hive", "user2Id", "user2Pw");
+    AuthenticationInfo user1Credential = getUserAuth("user1", "jdbc.hive", "user1Id", "user1Pw");
+    AuthenticationInfo user2Credential = getUserAuth("user2", "jdbc.hive", "user2Id", "user2Pw");
     jdbc.open();
 
     // user1 runs default


### PR DESCRIPTION
### What is this PR for?
JDBC interpreter cannot get the username and password from the credential page.
The reason is that the org.apache.zeppelin.jdbc.JDBCInterpreter#getEntityName method returns "hive" instead of "jdbc.hive".
According to the convention of the entity([interpreter group].[Interpreter name]), fixed the function to return "jdbc.hive".

### What type of PR is it?
Hot Fix

### Todos
* [ ] - Task

### What is the Jira issue?
*  https://issues.apache.org/jira/browse/ZEPPELIN-5173

### How should this be tested?
* Run unit tests.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
