### PR TITLE
[ZEPPELIN-5185]. HiveMonitor thread is never finished sometimes

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -71,11 +71,14 @@ public class HiveUtils {
     final ProgressBar progressBar = progressBarTemp;
     final long timeoutThreshold = Long.parseLong(
             jdbcInterpreter.getProperty("zeppelin.jdbc.hive.timeout.threshold", "" + 60 * 1000));
+    final long queryInterval = Long.parseLong(jdbcInterpreter.getProperty("zeppelin.jdbc.hive.monitor.query_interval",
+            DEFAULT_QUERY_PROGRESS_INTERVAL + ""));
     Thread thread = new Thread(() -> {
       boolean jobLaunched = false;
       long jobLastActiveTime = System.currentTimeMillis();
       while (hiveStmt.hasMoreLogs() && !Thread.interrupted()) {
         try {
+          Thread.sleep(queryInterval);
           List<String> logs = hiveStmt.getQueryLog();
           String logsOutput = StringUtils.join(logs, System.lineSeparator());
           LOGGER.debug("Hive job output: " + logsOutput);
@@ -122,10 +125,9 @@ public class HiveUtils {
               break;
             }
           }
-          // refresh logs every 1 second.
-          Thread.sleep(DEFAULT_QUERY_PROGRESS_INTERVAL);
         } catch (Exception e) {
-          LOGGER.warn("Fail to write output", e);
+          LOGGER.warn("Fail to monitor hive statement", e);
+          break;
         } finally {
           try {
             // Sometimes, maybe hiveStmt was closed unnormally, hiveStmt.hasMoreLogs() will be true,

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -77,7 +77,7 @@ public class HiveUtils {
       boolean jobLaunched = false;
       long jobLastActiveTime = System.currentTimeMillis();
       try {
-        while (hiveStmt.hasMoreLogs() && !Thread.interrupted()) {
+        while (hiveStmt.hasMoreLogs() && !hiveStmt.isClosed() && !Thread.interrupted()) {
           Thread.sleep(queryInterval);
           List<String> logs = hiveStmt.getQueryLog();
           String logsOutput = StringUtils.join(logs, System.lineSeparator());

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/HiveUtils.java
@@ -125,6 +125,9 @@ public class HiveUtils {
               break;
             }
           }
+        } catch (InterruptedException e) {
+          LOGGER.warn("Hive monitor thread is interrupted", e);
+          break;
         } catch (Exception e) {
           LOGGER.warn("Fail to monitor hive statement", e);
           break;

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -136,6 +136,13 @@
         "defaultValue": "60000",
         "description": "Timeout for hive job timeout",
         "type": "number"
+      },
+      "zeppelin.jdbc.hive.monitor.query_interval": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.hive.monitor.query_interval",
+        "defaultValue": "1000",
+        "description": "Query interval for hive statement",
+        "type": "number"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?

Sometimes, hive monitor thread will never exit when getting the following exception (see screenshot) 
![image](https://user-images.githubusercontent.com/164491/103433552-b216a580-4c2d-11eb-9bd9-abb61d93c21a.png)

This PR would exit the monitor thread when any exception happens and also introduce property `zeppelin.jdbc.hive.monitor.query_interval` to control the query interval. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5185

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
