### PR TITLE
ZEPPELIN-5197: Livy.sql interpreter fails to execute

### DIFF
--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -229,7 +229,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
       if (sparkInterpreter != null) {
         return sparkInterpreter.getScheduler();
       } else {
-        return null;
+        return super.getScheduler();
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
If `zeppelin.livy.concurrentSQL` is set to `false` then livy-interpreter fails with following exception:

```
java.lang.RuntimeException: Fail to callRemoteFunction, because connection is broken
	at org.apache.zeppelin.interpreter.remote.PooledRemoteClient.callRemoteFunction(PooledRemoteClient.java:108)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess.callRemoteFunction(RemoteInterpreterProcess.java:98)
	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.interpret(RemoteInterpreter.java:208)
	at org.apache.zeppelin.notebook.Paragraph.jobRun(Paragraph.java:490)
	at org.apache.zeppelin.notebook.Paragraph.jobRun(Paragraph.java:72)
	at org.apache.zeppelin.scheduler.Job.run(Job.java:172)
	at org.apache.zeppelin.scheduler.AbstractScheduler.runJob(AbstractScheduler.java:132)
	at org.apache.zeppelin.scheduler.RemoteScheduler$JobRunner.run(RemoteScheduler.java:182)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5197

### How should this be tested?
* Set `zeppelin.livy.concurrentSQL` as `false` and try executing below
```
%livy.sql
show tables
```

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? N/A
* Is there breaking changes for older versions? N/A
* Does this needs documentation? N/A
