### PR TITLE
[ZEPPELIN-5130] Cleanup in ShiroAuthentication and related realms

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -96,6 +96,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   LdapContextFactory ldapContextFactory;
 
+  @Override
   protected void onInit() {
     super.onInit();
     this.getLdapContextFactory();
@@ -116,6 +117,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     return this.ldapContextFactory;
   }
 
+  @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
           throws AuthenticationException {
     try {
@@ -129,6 +131,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     }
   }
 
+  @Override
   protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
     try {
       return this.queryForAuthorizationInfo(principals,
@@ -162,6 +165,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
    * @return an {@link AuthenticationInfo} instance containing information retrieved from LDAP.
    * @throws NamingException if any LDAP errors occur during the search.
    */
+  @Override
   protected AuthenticationInfo queryForAuthenticationInfo(AuthenticationToken token,
           LdapContextFactory ldapContextFactory) throws NamingException {
     UsernamePasswordToken upToken = (UsernamePasswordToken) token;
@@ -222,6 +226,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
    * @return the AuthorizationInfo for the given Subject principal.
    * @throws NamingException if an error occurs when searching the LDAP server.
    */
+  @Override
   protected AuthorizationInfo queryForAuthorizationInfo(PrincipalCollection principals,
           LdapContextFactory ldapContextFactory) throws NamingException {
     String username = (String) getAvailablePrincipal(principals);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -61,7 +61,7 @@ import javax.naming.ldap.LdapContext;
  * @since 0.1
  */
 public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
-  private static final Logger log = LoggerFactory.getLogger(ActiveDirectoryGroupRealm.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ActiveDirectoryGroupRealm.class);
 
   private static final String ROLE_NAMES_DELIMETER = ",";
 
@@ -104,10 +104,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   public LdapContextFactory getLdapContextFactory() {
     if (this.ldapContextFactory == null) {
-      if (log.isDebugEnabled()) {
-        log.debug("No LdapContextFactory specified - creating a default instance.");
-      }
-
+      LOGGER.debug("No LdapContextFactory specified - creating a default instance.");
       DefaultLdapContextFactory defaultFactory = new DefaultLdapContextFactory();
       defaultFactory.setPrincipalSuffix(this.principalSuffix);
       defaultFactory.setSearchBase(this.searchBase);
@@ -269,9 +266,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     while (answer.hasMoreElements()) {
       SearchResult sr = (SearchResult) answer.next();
 
-      if (log.isDebugEnabled()) {
-        log.debug("Retrieving userprincipalname names for user [" + sr.getName() + "]");
-      }
+      LOGGER.debug("Retrieving userprincipalname names for user [{}]", sr.getName());
 
       Attributes attrs = sr.getAttributes();
       if (attrs != null) {
@@ -317,9 +312,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     while (answer.hasMoreElements()) {
       SearchResult sr = (SearchResult) answer.next();
 
-      if (log.isDebugEnabled()) {
-        log.debug("Retrieving group names for user [" + sr.getName() + "]");
-      }
+      LOGGER.debug("Retrieving group names for user [{}]", sr.getName());
 
       Attributes attrs = sr.getAttributes();
 
@@ -331,10 +324,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
           if (attr.getID().equals("memberOf")) {
 
             Collection<String> groupNames = LdapUtils.getAllAttributeValues(attr);
+            LOGGER.debug("Groups found for user [{}]: {}", username, groupNames);
 
-            if (log.isDebugEnabled()) {
-              log.debug("Groups found for user [" + username + "]: " + groupNames);
-            }
 
             Collection<String> rolesForGroups = getRoleNamesForGroups(groupNames);
             roleNames.addAll(rolesForGroups);
@@ -361,14 +352,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
         String strRoleNames = groupRolesMap.get(groupName);
         if (strRoleNames != null) {
           for (String roleName : strRoleNames.split(ROLE_NAMES_DELIMETER)) {
-
-            if (log.isDebugEnabled()) {
-              log.debug("User is member of group [" + groupName + "] so adding role [" +
-                  roleName + "]");
-            }
-
+            LOGGER.debug("User is member of group [{}] so adding role [{}]", groupName, roleName);
             roleNames.add(roleName);
-
           }
         }
       }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -64,7 +64,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   private static final String ROLE_NAMES_DELIMETER = ",";
 
-  final String keystorePass = "activeDirectoryRealm.systemPassword";
+  private static final String KEYSTORE_PASS = "activeDirectoryRealm.systemPassword";
 
   private String userSearchAttributeName = "sAMAccountName";
 
@@ -145,7 +145,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     if (StringUtils.isEmpty(this.hadoopSecurityCredentialPath)) {
       password = this.systemPassword;
     } else {
-      password = LdapRealm.getSystemPassword(hadoopSecurityCredentialPath, keystorePass);
+      password = LdapRealm.getSystemPassword(hadoopSecurityCredentialPath, KEYSTORE_PASS);
     }
     return password;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -284,10 +283,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   public Map<String, String> getListRoles() {
     Map<String, String> roles = new HashMap<>();
-    Iterator it = this.groupRolesMap.entrySet().iterator();
-    while (it.hasNext()) {
-      Map.Entry pair = (Map.Entry) it.next();
-      roles.put((String) pair.getValue(), "*");
+    for (Map.Entry<String, String> pair : groupRolesMap.entrySet()) {
+      roles.put(pair.getValue(), "*");
     }
     return roles;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ActiveDirectoryGroupRealm.java
@@ -119,9 +119,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
           throws AuthenticationException {
     try {
-      AuthenticationInfo info = this.queryForAuthenticationInfo(token,
+      return this.queryForAuthenticationInfo(token,
           this.getLdapContextFactory());
-      return info;
     } catch (javax.naming.AuthenticationException var5) {
       throw new AuthenticationException("LDAP authentication failed.", var5);
     } catch (NamingException var6) {
@@ -132,9 +131,8 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
 
   protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
     try {
-      AuthorizationInfo info = this.queryForAuthorizationInfo(principals,
+      return this.queryForAuthorizationInfo(principals,
           this.getLdapContextFactory());
-      return info;
     } catch (NamingException var5) {
       String msg = "LDAP naming error while attempting to " +
           "retrieve authorization for user [" + principals + "].";
@@ -187,7 +185,7 @@ public class ActiveDirectoryGroupRealm extends AbstractLdapRealm {
     return buildAuthenticationInfo(upToken.getUsername(), upToken.getPassword());
   }
 
-  private Boolean isValidPrincipalName(String userPrincipalName) {
+  private boolean isValidPrincipalName(String userPrincipalName) {
     if (userPrincipalName != null) {
       if (StringUtils.isNotEmpty(userPrincipalName) && userPrincipalName.contains("@")) {
         String userPrincipalWithoutDomain = userPrincipalName.split("@")[0].trim();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
@@ -42,6 +42,7 @@ import javax.naming.ldap.LdapContext;
 public class LdapGroupRealm extends JndiLdapRealm {
   private static final Logger LOGGER = LoggerFactory.getLogger(LdapGroupRealm.class);
 
+  @Override
   public AuthorizationInfo queryForAuthorizationInfo(PrincipalCollection principals,
           LdapContextFactory ldapContextFactory) throws NamingException {
     String username = (String) getAvailablePrincipal(principals);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
@@ -40,7 +40,7 @@ import javax.naming.ldap.LdapContext;
  * Created for org.apache.zeppelin.server.
  */
 public class LdapGroupRealm extends JndiLdapRealm {
-  private static final Logger LOG = LoggerFactory.getLogger(LdapGroupRealm.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LdapGroupRealm.class);
 
   public AuthorizationInfo queryForAuthorizationInfo(PrincipalCollection principals,
           LdapContextFactory ldapContextFactory) throws NamingException {
@@ -83,7 +83,7 @@ public class LdapGroupRealm extends JndiLdapRealm {
       return roleNames;
 
     } catch (Exception e) {
-      LOG.error("Error", e);
+      LOGGER.error("Error", e);
     }
 
     return new HashSet<>();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapGroupRealm.java
@@ -18,7 +18,7 @@ package org.apache.zeppelin.realm;
 
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
-import org.apache.shiro.realm.ldap.JndiLdapRealm;
+import org.apache.shiro.realm.ldap.DefaultLdapRealm;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.slf4j.Logger;
@@ -39,7 +39,7 @@ import javax.naming.ldap.LdapContext;
 /**
  * Created for org.apache.zeppelin.server.
  */
-public class LdapGroupRealm extends JndiLdapRealm {
+public class LdapGroupRealm extends DefaultLdapRealm {
   private static final Logger LOGGER = LoggerFactory.getLogger(LdapGroupRealm.class);
 
   @Override

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -699,7 +699,7 @@ public class LdapRealm extends JndiLdapRealm {
       return false;
     }
 
-    String searchBaseString = tokens[0].substring(tokens[0].lastIndexOf("/") + 1);
+    String searchBaseString = tokens[0].substring(tokens[0].lastIndexOf('/') + 1);
     String searchScope = tokens[2];
     String searchFilter = tokens[3];
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -59,8 +59,8 @@ import org.apache.shiro.crypto.hash.DefaultHashService;
 import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.HashRequest;
 import org.apache.shiro.crypto.hash.HashService;
+import org.apache.shiro.realm.ldap.DefaultLdapRealm;
 import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
-import org.apache.shiro.realm.ldap.JndiLdapRealm;
 import org.apache.shiro.realm.ldap.LdapContextFactory;
 import org.apache.shiro.realm.ldap.LdapUtils;
 import org.apache.shiro.session.Session;
@@ -125,7 +125,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  *   securityManager.realms = $ldapRealm
  */
-public class LdapRealm extends JndiLdapRealm {
+public class LdapRealm extends DefaultLdapRealm {
 
   private static final SearchControls SUBTREE_SCOPE = new SearchControls();
   private static final SearchControls ONELEVEL_SCOPE = new SearchControls();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -141,7 +141,6 @@ public class LdapRealm extends JndiLdapRealm {
   private static final String MATCHING_RULE_IN_CHAIN_FORMAT =
       "(&(objectClass=%s)(%s:1.2.840.113556.1.4.1941:=%s))";
 
-  private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{(\\d+?)\\}");
   private static final String DEFAULT_PRINCIPAL_REGEX = "(.*)";
   private static final String MEMBER_SUBSTITUTION_TOKEN = "{0}";
   private static final String HASHING_ALGORITHM = "SHA-1";

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -183,7 +183,7 @@ public class LdapRealm extends JndiLdapRealm {
   private final Map<String, List<String>> permissionsByRole = new LinkedHashMap<>();
 
   private String hadoopSecurityCredentialPath;
-  final String keystorePass = "ldapRealm.systemPassword";
+  private static final String KEYSTORE_PASS = "ldapRealm.systemPassword";
 
   private boolean authorizationEnabled;
 
@@ -218,7 +218,7 @@ public class LdapRealm extends JndiLdapRealm {
     if (!org.apache.commons.lang3.StringUtils.isEmpty(this.hadoopSecurityCredentialPath)
         && getContextFactory() != null) {
       ((JndiLdapContextFactory) getContextFactory()).setSystemPassword(
-          getSystemPassword(this.hadoopSecurityCredentialPath, keystorePass));
+          getSystemPassword(this.hadoopSecurityCredentialPath, KEYSTORE_PASS));
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -213,6 +213,7 @@ public class LdapRealm extends JndiLdapRealm {
     }
   }
 
+  @Override
   protected void onInit() {
     super.onInit();
     if (!org.apache.commons.lang3.StringUtils.isEmpty(this.hadoopSecurityCredentialPath)

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -666,7 +666,7 @@ public class LdapRealm extends JndiLdapRealm {
   }
 
   private Map<String, List<String>> parsePermissionByRoleString(String permissionsByRoleStr) {
-    Map<String, List<String>> perms = new HashMap<String, List<String>>();
+    Map<String, List<String>> perms = new HashMap<>();
 
     // split by semicolon ; then by eq = then by comma ,
     StringTokenizer stSem = new StringTokenizer(permissionsByRoleStr, ";");
@@ -679,7 +679,7 @@ public class LdapRealm extends JndiLdapRealm {
       String role = stEq.nextToken().trim();
       String perm = stEq.nextToken().trim();
       StringTokenizer stCom = new StringTokenizer(perm, ",");
-      List<String> permList = new ArrayList<String>();
+      List<String> permList = new ArrayList<>();
       while (stCom.hasMoreTokens()) {
         permList.add(stCom.nextToken().trim());
       }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/PamRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/PamRealm.java
@@ -28,9 +28,6 @@ import org.apache.shiro.subject.PrincipalCollection;
 import org.jvnet.libpam.PAM;
 import org.jvnet.libpam.PAMException;
 import org.jvnet.libpam.UnixUser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -38,7 +35,6 @@ import java.util.Set;
  * An {@code AuthorizingRealm} based on libpam4j.
  */
 public class PamRealm extends AuthorizingRealm {
-  private static final Logger LOG = LoggerFactory.getLogger(PamRealm.class);
 
   private String service;
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ZeppelinHubRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/ZeppelinHubRealm.java
@@ -16,7 +16,6 @@
  */
 package org.apache.zeppelin.realm;
 
-import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import java.io.IOException;
@@ -131,7 +130,7 @@ public class ZeppelinHubRealm extends AuthorizingRealm {
   protected User authenticateUser(String requestBody) {
     String responseBody;
     String userSession;
-    HttpPut put = new HttpPut(Joiner.on("/").join(zeppelinhubUrl, USER_LOGIN_API_ENDPOINT));
+    HttpPut put = new HttpPut(String.join("/", zeppelinhubUrl, USER_LOGIN_API_ENDPOINT));
     put.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
     try (CloseableHttpResponse response = httpClient.execute(put)){
       if (HttpStatus.SC_OK != response.getStatusLine().getStatusCode()) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -74,7 +74,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
             ((DefaultWebSecurityManager) org.apache.shiro.SecurityUtils.getSecurityManager())
                 .getRealms();
         if (realms.size() > 1) {
-          Boolean isIniRealmEnabled = false;
+          boolean isIniRealmEnabled = false;
           for (Realm realm : realms) {
             if (realm instanceof IniRealm && ((IniRealm) realm).getIni().get("users") != null) {
               isIniRealmEnabled = true;
@@ -287,7 +287,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
   private List<String> getUserList(JndiLdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     String userDnTemplate = r.getUserDnTemplate();
-    String userDn[] = userDnTemplate.split(",", 2);
+    String[] userDn = userDnTemplate.split(",", 2);
     String userDnPrefix = userDn[0].split("=")[0];
     String userDnSuffix = userDn[1];
     JndiLdapContextFactory cf = (JndiLdapContextFactory) r.getContextFactory();
@@ -399,7 +399,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
     ResultSet rs = null;
     DataSource dataSource = null;
     String authQuery = "";
-    String retval[];
+    String[] retval;
     String tablename = "";
     String username = "";
     String userquery;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -215,7 +215,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
   public Set<String> getAssociatedRoles() {
     Subject subject = org.apache.shiro.SecurityUtils.getSubject();
     HashSet<String> roles = new HashSet<>();
-    Map allRoles = null;
+    Map<String, String> allRoles = null;
 
     if (subject.isAuthenticated()) {
       Collection<Realm> realmsList = getRealmsList();
@@ -298,10 +298,10 @@ public class ShiroAuthenticationService implements AuthenticationService {
       constraints.setSearchScope(SearchControls.SUBTREE_SCOPE);
       String[] attrIDs = {userDnPrefix};
       constraints.setReturningAttributes(attrIDs);
-      NamingEnumeration result =
+      NamingEnumeration<SearchResult> result =
           ctx.search(userDnSuffix, "(" + userDnPrefix + "=*" + searchText + "*)", constraints);
       while (result.hasMore()) {
-        Attributes attrs = ((SearchResult) result.next()).getAttributes();
+        Attributes attrs = result.next().getAttributes();
         if (attrs.get(userDnPrefix) != null) {
           String currentUser = attrs.get(userDnPrefix).toString();
           userList.add(currentUser.split(":")[1].trim());
@@ -329,7 +329,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
       constraints.setCountLimit(numUsersToFetch);
       String[] attrIDs = {userAttribute};
       constraints.setReturningAttributes(attrIDs);
-      NamingEnumeration result =
+      NamingEnumeration<SearchResult> result =
           ctx.search(
               userSearchRealm,
               "(&(objectclass="
@@ -341,7 +341,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
                   + "*))",
               constraints);
       while (result.hasMore()) {
-        Attributes attrs = ((SearchResult) result.next()).getAttributes();
+        Attributes attrs = result.next().getAttributes();
         if (attrs.get(userAttribute) != null) {
           String currentUser;
           if (r.getUserLowerCase()) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ShiroAuthenticationService implements AuthenticationService {
 
-  private final Logger LOGGER = LoggerFactory.getLogger(ShiroAuthenticationService.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ShiroAuthenticationService.class);
 
   private final ZeppelinConfiguration conf;
 
@@ -107,8 +107,9 @@ public class ShiroAuthenticationService implements AuthenticationService {
     if (subject.isAuthenticated()) {
       principal = extractPrincipal(subject);
       if (conf.isUsernameForceLowerCase()) {
-        LOGGER.debug("Converting principal name " + principal
-            + " to lower case:" + principal.toLowerCase());
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Converting principal name {} to lower case: {}", principal, principal.toLowerCase());
+        }
         principal = principal.toLowerCase();
       }
     } else {
@@ -157,7 +158,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
       if (realmsList != null) {
         for (Realm realm : realmsList) {
           String realClassName = realm.getClass().getName();
-          LOGGER.debug("RealmClass.getName: " + realClassName);
+          LOGGER.debug("RealmClass.getName: {}", realClassName);
           if (realClassName.equals("org.apache.shiro.realm.text.IniRealm")) {
             usersList.addAll(getUserList((IniRealm) realm));
           } else if (realClassName.equals("org.apache.zeppelin.realm.LdapGroupRealm")) {
@@ -191,7 +192,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
       if (realmsList != null) {
         for (Realm realm : realmsList) {
           String name = realm.getClass().getName();
-          LOGGER.debug("RealmClass.getName: " + name);
+          LOGGER.debug("RealmClass.getName: {}", name);
           if (name.equals("org.apache.shiro.realm.text.IniRealm")) {
             rolesList.addAll(getRolesList((IniRealm) realm));
           } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
@@ -316,14 +317,14 @@ public class ShiroAuthenticationService implements AuthenticationService {
     } catch (Exception e) {
       LOGGER.error("Error retrieving User list from Ldap Realm", e);
     }
-    LOGGER.info("UserList: " + userList);
+    LOGGER.info("UserList: {}", userList);
     return userList;
   }
 
   /** Function to extract users from Zeppelin LdapRealm. */
   private List<String> getUserList(LdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
-    LOGGER.debug("SearchText: " + searchText);
+    LOGGER.debug("SearchText: {}", searchText);
     String userAttribute = r.getUserSearchAttributeName();
     String userSearchRealm = r.getUserSearchBase();
     String userObjectClass = r.getUserObjectClass();
@@ -357,7 +358,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
             LOGGER.debug("userLowerCase false");
             currentUser = (String) attrs.get(userAttribute).get();
           }
-          LOGGER.debug("CurrentUser: " + currentUser);
+          LOGGER.debug("CurrentUser: {}", currentUser);
           userList.add(currentUser.trim());
         }
       }
@@ -380,8 +381,8 @@ public class ShiroAuthenticationService implements AuthenticationService {
       Iterator it = roles.entrySet().iterator();
       while (it.hasNext()) {
         Map.Entry pair = (Map.Entry) it.next();
-        LOGGER.debug("RoleKeyValue: " + pair.getKey() + " = " + pair.getValue());
         roleList.add((String) pair.getKey());
+        LOGGER.debug("RoleKeyValue: {} = {}", pair.getKey(), pair.getValue());
       }
     }
     return roleList;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -41,8 +41,8 @@ import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.authz.AuthorizationInfo;
 import org.apache.shiro.realm.Realm;
 import org.apache.shiro.realm.jdbc.JdbcRealm;
+import org.apache.shiro.realm.ldap.DefaultLdapRealm;
 import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
-import org.apache.shiro.realm.ldap.JndiLdapRealm;
 import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
@@ -167,7 +167,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
           if (INI_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((IniRealm) realm));
           } else if (LDAP_GROUP_REALM.equals(realClassName)) {
-            usersList.addAll(getUserList((JndiLdapRealm) realm, searchText, numUsersToFetch));
+            usersList.addAll(getUserList((DefaultLdapRealm) realm, searchText, numUsersToFetch));
           } else if (LDAP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((LdapRealm) realm, searchText, numUsersToFetch));
           } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(realClassName)) {
@@ -290,7 +290,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
   }
 
   /** Function to extract users from LDAP. */
-  private List<String> getUserList(JndiLdapRealm r, String searchText, int numUsersToFetch) {
+  private List<String> getUserList(DefaultLdapRealm r, String searchText, int numUsersToFetch) {
     List<String> userList = new ArrayList<>();
     String userDnTemplate = r.getUserDnTemplate();
     String[] userDn = userDnTemplate.split(",", 2);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -24,7 +24,6 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -245,11 +244,9 @@ public class ShiroAuthenticationService implements AuthenticationService {
         }
       }
       if (allRoles != null) {
-        Iterator it = allRoles.entrySet().iterator();
-        while (it.hasNext()) {
-          Map.Entry pair = (Map.Entry) it.next();
-          if (subject.hasRole((String) pair.getKey())) {
-            roles.add((String) pair.getKey());
+        for (Map.Entry<String, String> pair : allRoles.entrySet()) {
+          if (subject.hasRole(pair.getKey())) {
+            roles.add(pair.getKey());
           }
         }
       }
@@ -260,12 +257,10 @@ public class ShiroAuthenticationService implements AuthenticationService {
   /** Function to extract users from shiro.ini. */
   private List<String> getUserList(IniRealm r) {
     List<String> userList = new ArrayList<>();
-    Map getIniUser = r.getIni().get("users");
+    Map<String, String> getIniUser = r.getIni().get(IniRealm.USERS_SECTION_NAME);
     if (getIniUser != null) {
-      Iterator it = getIniUser.entrySet().iterator();
-      while (it.hasNext()) {
-        Map.Entry pair = (Map.Entry) it.next();
-        userList.add(pair.getKey().toString().trim());
+      for (Map.Entry<String, String> pair : getIniUser.entrySet()) {
+        userList.add(pair.getKey().trim());
       }
     }
     return userList;
@@ -279,12 +274,10 @@ public class ShiroAuthenticationService implements AuthenticationService {
    */
   private List<String> getRolesList(IniRealm r) {
     List<String> roleList = new ArrayList<>();
-    Map getIniRoles = r.getIni().get("roles");
+    Map<String, String> getIniRoles = r.getIni().get(IniRealm.ROLES_SECTION_NAME);
     if (getIniRoles != null) {
-      Iterator it = getIniRoles.entrySet().iterator();
-      while (it.hasNext()) {
-        Map.Entry pair = (Map.Entry) it.next();
-        roleList.add(pair.getKey().toString().trim());
+      for (Map.Entry<String, String> pair : getIniRoles.entrySet()) {
+        roleList.add(pair.getKey().trim());
       }
     }
     return roleList;
@@ -378,11 +371,9 @@ public class ShiroAuthenticationService implements AuthenticationService {
     List<String> roleList = new ArrayList<>();
     Map<String, String> roles = r.getListRoles();
     if (roles != null) {
-      Iterator it = roles.entrySet().iterator();
-      while (it.hasNext()) {
-        Map.Entry pair = (Map.Entry) it.next();
-        roleList.add((String) pair.getKey());
+      for (Map.Entry<String, String> pair : roles.entrySet()) {
         LOGGER.debug("RoleKeyValue: {} = {}", pair.getKey(), pair.getValue());
+        roleList.add(pair.getKey());
       }
     }
     return roleList;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -62,6 +62,12 @@ public class ShiroAuthenticationService implements AuthenticationService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ShiroAuthenticationService.class);
 
+  private static final String INI_REALM = "org.apache.shiro.realm.text.IniRealm";
+  private static final String LDAP_REALM = "org.apache.zeppelin.realm.LdapRealm";
+  private static final String LDAP_GROUP_REALM = "org.apache.zeppelin.realm.LdapGroupRealm";
+  private static final String ACTIVE_DIRECTORY_GROUP_REALM = "org.apache.zeppelin.realm.ActiveDirectoryGroupRealm";
+  private static final String JDBC_REALM = "org.apache.shiro.realm.jdbc.JdbcRealm";
+
   private final ZeppelinConfiguration conf;
 
   @Inject
@@ -158,16 +164,16 @@ public class ShiroAuthenticationService implements AuthenticationService {
         for (Realm realm : realmsList) {
           String realClassName = realm.getClass().getName();
           LOGGER.debug("RealmClass.getName: {}", realClassName);
-          if (realClassName.equals("org.apache.shiro.realm.text.IniRealm")) {
+          if (INI_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((IniRealm) realm));
-          } else if (realClassName.equals("org.apache.zeppelin.realm.LdapGroupRealm")) {
+          } else if (LDAP_GROUP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((JndiLdapRealm) realm, searchText, numUsersToFetch));
-          } else if (realClassName.equals("org.apache.zeppelin.realm.LdapRealm")) {
+          } else if (LDAP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((LdapRealm) realm, searchText, numUsersToFetch));
-          } else if (realClassName.equals("org.apache.zeppelin.realm.ActiveDirectoryGroupRealm")) {
+          } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(realClassName)) {
             usersList.addAll(
                 getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
-          } else if (realClassName.equals("org.apache.shiro.realm.jdbc.JdbcRealm")) {
+          } else if (JDBC_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((JdbcRealm) realm));
           }
         }
@@ -192,9 +198,9 @@ public class ShiroAuthenticationService implements AuthenticationService {
         for (Realm realm : realmsList) {
           String name = realm.getClass().getName();
           LOGGER.debug("RealmClass.getName: {}", name);
-          if (name.equals("org.apache.shiro.realm.text.IniRealm")) {
+          if (INI_REALM.equals(name)) {
             rolesList.addAll(getRolesList((IniRealm) realm));
-          } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
+          } else if (LDAP_REALM.equals(name)) {
             rolesList.addAll(getRolesList((LdapRealm) realm));
           }
         }
@@ -221,10 +227,10 @@ public class ShiroAuthenticationService implements AuthenticationService {
       Collection<Realm> realmsList = getRealmsList();
       for (Realm realm : realmsList) {
         String name = realm.getClass().getName();
-        if (name.equals("org.apache.shiro.realm.text.IniRealm")) {
+        if (INI_REALM.equals(name)) {
           allRoles = ((IniRealm) realm).getIni().get("roles");
           break;
-        } else if (name.equals("org.apache.zeppelin.realm.LdapRealm")) {
+        } else if (LDAP_REALM.equals(name)) {
           try {
             AuthorizationInfo auth =
                 ((LdapRealm) realm)
@@ -238,7 +244,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
             LOGGER.error("Can't fetch roles", e);
           }
           break;
-        } else if (name.equals("org.apache.zeppelin.realm.ActiveDirectoryGroupRealm")) {
+        } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(name)) {
           allRoles = ((ActiveDirectoryGroupRealm) realm).getListRoles();
           break;
         }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
@@ -17,13 +17,9 @@
 package org.apache.zeppelin.service;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.security.Principal;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -86,14 +82,6 @@ public class ShiroAuthenticationServiceTest {
     }
   }
 
-  private void setFinalStatic(Field field, Object newValue)
-      throws NoSuchFieldException, IllegalAccessException {
-    field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
-    modifiersField.setAccessible(true);
-    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-    field.set(null, newValue);
-  }
   public class TestPrincipal implements Principal {
 
     private String username;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -124,6 +125,6 @@ public class VFSNotebookRepoTest {
 
   private void createNewNote(String content, String noteId, String noteName) throws IOException {
     FileUtils.writeStringToFile(
-        new File(notebookDir + "/" + noteName + "_" + noteId + ".zpln"), content);
+        new File(notebookDir + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
### What is this PR for?
During #4021 I hit some files, which can be improved in readability, performance and stability. This PR requires #4021.
This PR includes:
  - improve Logging performance 
  - use Java generics to avoid casting.
  - remove dead code
  - use DefaultLdapRealm instead of JndiLdapRealm (see [JavaDoc](https://shiro.apache.org/static/1.7.0/apidocs/org/apache/shiro/realm/ldap/JndiLdapRealm.html))

### What type of PR is it?
 - Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5130

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
