### PR TITLE
[ZEPPELIN-5211] Fix authType in JDBCInterpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -513,7 +513,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     String url = properties.getProperty(URL_KEY);
     String connectionUrl = appendProxyUserToURL(url, user, dbPrefix);
 
-    String authType = properties.getProperty("zeppelin.jdbc.auth.type", "SIMPLE")
+    String authType = getProperty("zeppelin.jdbc.auth.type", "SIMPLE")
             .trim().toUpperCase();
     switch (authType) {
       case "SIMPLE":

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -513,7 +513,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     String url = properties.getProperty(URL_KEY);
     String connectionUrl = appendProxyUserToURL(url, user, dbPrefix);
 
-    String authType = getProperty("zeppelin.jdbc.auth.type", "SIMPLE")
+    String authType = StringUtils.defaultIfEmpty(getProperty("zeppelin.jdbc.auth.type"), "SIMPLE")
             .trim().toUpperCase();
     switch (authType) {
       case "SIMPLE":

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -513,7 +513,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     String url = properties.getProperty(URL_KEY);
     String connectionUrl = appendProxyUserToURL(url, user, dbPrefix);
 
-    String authType = StringUtils.defaultIfEmpty(getProperty("zeppelin.jdbc.auth.type"), "SIMPLE")
+    String authType = getProperty("zeppelin.jdbc.auth.type", "SIMPLE")
             .trim().toUpperCase();
     switch (authType) {
       case "SIMPLE":

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -627,7 +627,7 @@ public class InterpreterSetting {
     Properties jProperties = new Properties();
     Map<String, InterpreterProperty> iProperties = (Map<String, InterpreterProperty>) properties;
     for (Map.Entry<String, InterpreterProperty> entry : iProperties.entrySet()) {
-      if (entry.getValue().getValue() != null) {
+      if (entry.getValue().getValue() != null && StringUtils.isNotBlank(entry.getValue().getValue().toString())) {
         jProperties.setProperty(entry.getKey().trim(),
             entry.getValue().getValue().toString().trim());
       }


### PR DESCRIPTION
### What is this PR for?

Bug Fix: get `authType` using `getProperty` instead of `jdbcUserConfigurations.getPropertyMap(dbPrefix).getProperty`.

According to the JDBC Interpreter document (https://github.com/apache/zeppelin/blob/master/docs/interpreter/jdbc.md), we should use `zeppelin.jdbc.auth.type`, but It is observed in the JDBC Interpreter that:
- Setting `zeppelin.jdbc.auth.type`  to `KERBEROS` didn't work
- Setting `default.zeppelin.jdbc.auth.type`  to `KERBEROS` works

In `protected boolean isKerboseEnabled()`, we use `getProperty("zeppelin.jdbc.auth.type")`, but in `public Connection getConnection(String dbPrefix, InterpreterContext context)`, `jdbcUserConfigurations.getPropertyMap(dbPrefix).getProperty("zeppelin.jdbc.auth.type", "SIMPLE")` was used. 


### What type of PR is it?
Bug Fix

### Todos
* [x] - Make jdbcIntegrationTest happy

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5211

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
