### PR TITLE
[ZEPPELIN-5218]. Don't exit shell interpreter if there's more logging produced

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/ShellInterpreter.java
@@ -106,6 +106,10 @@ public class ShellInterpreter extends KerberosInterpreter {
         }
       }
     }
+
+    if (shellOutputCheckExecutor != null) {
+      shellOutputCheckExecutor.shutdownNow();
+    }
   }
 
   @Override

--- a/shell/src/main/resources/interpreter-setting.json
+++ b/shell/src/main/resources/interpreter-setting.json
@@ -12,6 +12,13 @@
         "description": "Shell command time out in millisecs. Default = 60000",
         "type": "number"
       },
+      "shell.command.timeout.check.interval": {
+        "envName": "",
+        "propertyName": "shell.command.timeout.check.interval",
+        "defaultValue": "60000",
+        "description": "Shell command output check interval in millisecs. Default = 10000",
+        "type": "number"
+      },
       "shell.working.directory.user.home": {
         "envName": "SHELL_WORKING_DIRECTORY_USER_HOME",
         "propertyName": "shell.working.directory.user.home",

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -44,7 +44,9 @@ public class ShellInterpreterTest {
     p.setProperty("shell.command.timeout.millisecs", "5000");
     p.setProperty("shell.command.timeout.check.interval", "1000");
     shell = new ShellInterpreter(p);
-    context = InterpreterContext.builder().setParagraphId("paragraphId").build();
+    context = InterpreterContext.builder()
+            .setInterpreterOut(new InterpreterOutput())
+            .setParagraphId("paragraphId").build();
     shell.open();
   }
 
@@ -93,7 +95,7 @@ public class ShellInterpreterTest {
   public void testShellTimeout2() throws InterpreterException {
     context = InterpreterContext.builder()
             .setParagraphId("paragraphId")
-            .setInterpreterOut(new InterpreterOutput(null))
+            .setInterpreterOut(new InterpreterOutput())
             .build();
     result = shell.interpret("for i in {1..10}\ndo\n\tsleep 1\n\techo $i\ndone", context);
     // won't exit shell because the continues output is produced

--- a/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/ShellInterpreterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,9 +41,9 @@ public class ShellInterpreterTest {
   @Before
   public void setUp() throws Exception {
     Properties p = new Properties();
-    p.setProperty("shell.command.timeout.millisecs", "2000");
+    p.setProperty("shell.command.timeout.millisecs", "5000");
+    p.setProperty("shell.command.timeout.check.interval", "1000");
     shell = new ShellInterpreter(p);
-
     context = InterpreterContext.builder().setParagraphId("paragraphId").build();
     shell.open();
   }
@@ -59,10 +60,10 @@ public class ShellInterpreterTest {
       result = shell.interpret("ls", context);
     }
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    assertTrue(shell.executors.isEmpty());
+    assertTrue(shell.getExecutorMap().isEmpty());
     // it should be fine to cancel a statement that has been completed.
     shell.cancel(context);
-    assertTrue(shell.executors.isEmpty());
+    assertTrue(shell.getExecutorMap().isEmpty());
   }
 
   @Test
@@ -73,18 +74,30 @@ public class ShellInterpreterTest {
       result = shell.interpret("invalid_command\nls", context);
     }
     assertEquals(Code.SUCCESS, result.code());
-    assertTrue(shell.executors.isEmpty());
+    assertTrue(shell.getExecutorMap().isEmpty());
   }
 
   @Test
   public void testShellTimeout() throws InterpreterException {
     if (System.getProperty("os.name").startsWith("Windows")) {
-      result = shell.interpret("timeout 4", context);
+      result = shell.interpret("timeout 8", context);
     } else {
-      result = shell.interpret("sleep 4", context);
+      result = shell.interpret("sleep 8", context);
     }
-
+    // exit shell process because no output is produced during the timeout threshold
     assertEquals(Code.INCOMPLETE, result.code());
     assertTrue(result.message().get(0).getData().contains("Paragraph received a SIGTERM"));
+  }
+
+  @Test
+  public void testShellTimeout2() throws InterpreterException {
+    context = InterpreterContext.builder()
+            .setParagraphId("paragraphId")
+            .setInterpreterOut(new InterpreterOutput(null))
+            .build();
+    result = shell.interpret("for i in {1..10}\ndo\n\tsleep 1\n\techo $i\ndone", context);
+    // won't exit shell because the continues output is produced
+    assertEquals(Code.SUCCESS, result.code());
+    assertEquals("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n", context.out.toString());
   }
 }


### PR DESCRIPTION

### What is this PR for?

This PR change the timeout behavior of shell interpreter. Shell command would only timeout after there're no output produced. If there's continue output, then the shell command would continue to execute.

### What type of PR is it?
[ Improvement | Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5218

### How should this be tested?
* Test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
