### PR TITLE
[ZEPPELIN-5204]. NPE when runAsOne is true in flink interpreter

### DIFF
--- a/flink/interpreter/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
+++ b/flink/interpreter/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
@@ -443,6 +443,15 @@ public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
             context);
 
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    // runAsOne won't affect the select statement.
+    context = getInterpreterContext();
+    context.getLocalProperties().put("runAsOne", "true");
+    context.getLocalProperties().put("type", "update");
+    result = sqlInterpreter.interpret(
+            "select 1",
+            context);
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
   }
 
   @Test


### PR DESCRIPTION
### What is this PR for?

This PR is to fix the NPE when `runAsOne` is true in flink interpreter. The root cause is that runAsOne should only take effect when there's at least one insert statement.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5204

### How should this be tested?
* Test is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
