### PR TITLE
[ZEPPELIN-5228]. IPySpark unsupported environment would cause other spark interpreter fail

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -148,9 +148,6 @@ public class IPySparkInterpreter extends IPythonInterpreter {
   public void close() throws InterpreterException {
     LOGGER.info("Close IPySparkInterpreter");
     super.close();
-    if (sparkInterpreter != null) {
-      sparkInterpreter.close();
-    }
   }
 
   @Override

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -109,10 +109,8 @@ public class PySparkInterpreter extends PythonInterpreter {
 
   @Override
   public void close() throws InterpreterException {
+    LOGGER.info("Close PySparkInterpreter");
     super.close();
-    if (sparkInterpreter != null) {
-      sparkInterpreter.close();
-    }
   }
 
   @Override

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -207,7 +207,7 @@ public class SparkInterpreter extends AbstractInterpreter {
 
   public ZeppelinContext getZeppelinContext() {
     if (this.innerInterpreter == null) {
-      LOGGER.error("innerInterpreter is null!");
+      throw new RuntimeException("innerInterpreterContext is null");
     }
     return this.innerInterpreter.getZeppelinContext();
   }

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkRInterpreter.java
@@ -123,10 +123,6 @@ public class SparkRInterpreter extends RInterpreter {
   @Override
   public void close() throws InterpreterException {
     super.close();
-    if (this.sparkInterpreter != null) {
-      this.sparkInterpreter.close();
-      this.sparkInterpreter = null;
-    }
   }
 
   @Override


### PR DESCRIPTION

### What is this PR for?

The root cause is that if ipyspark interpreter fail to open due to environment issue, it would close SparkInterpreter which close SparkContext. This PR won't do that in ipyspark interpreter's close method. This is fine, because when user click restarting interpreter button, all the sub interpreters will be closed. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5228

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
