### PR TITLE
ZEPPELIN-5231: Livy Interpreter doesn't support Japanese Character - Encoding Issue

### DIFF
--- a/docs/interpreter/livy.md
+++ b/docs/interpreter/livy.md
@@ -175,6 +175,11 @@ Example: `spark.driver.memory` to `livy.spark.driver.memory`
     <td>key_1: value_1; key_2: value_2</td>
     <td>custom http headers when calling livy rest api. Each http header is separated by `;`, and each header is one key value pair where key value is separated by `:`</td>
   </tr>
+  <tr>
+    <td>zeppelin.livy.tableWithUTFCharacters</td>
+    <td>false</td>
+    <td>If database contains UTF characters then set this as true.</td>
+  </tr>
 </table>
 
 **We remove livy.spark.master in zeppelin-0.7. Because we sugguest user to use livy 0.3 in zeppelin-0.7. And livy 0.3 don't allow to specify livy.spark.master, it enfornce yarn-cluster mode.**

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -17,6 +17,11 @@
 
 package org.apache.zeppelin.livy;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
@@ -38,6 +43,7 @@ import static org.apache.commons.lang3.StringEscapeUtils.escapeEcmaScript;
  * Livy SparkSQL Interpreter for Zeppelin.
  */
 public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
+
   public static final String ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE =
       "zeppelin.livy.spark.sql.field.truncate";
 
@@ -113,8 +119,17 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
       // use triple quote so that we don't need to do string escape.
       String sqlQuery = null;
       if (isSpark2) {
-        sqlQuery = "spark.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ", " +
-            truncate + ")";
+        if (tableWithUTFCharacter()) {
+          sqlQuery = "val df = spark.sql(\"\"\"" + line + "\"\"\")\n"
+              + "for ( col <- df.columns ) {\n"
+              + "    print(col+\"\\t\")\n"
+              + "}\n"
+              + "println\n"
+              + "df.toJSON.take(" + maxResult + ").foreach(println)";
+        } else {
+          sqlQuery = "spark.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ", " +
+              truncate + ")";
+        }
       } else {
         sqlQuery = "sqlContext.sql(\"\"\"" + line + "\"\"\").show(" + maxResult + ", " +
             truncate + ")";
@@ -127,7 +142,12 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
           // assumption is correct for now. Ideally livy should return table type. We may do it in
           // the future release of livy.
           if (message.getType() == InterpreterResult.Type.TEXT) {
-            List<String> rows = parseSQLOutput(message.getData());
+            List<String> rows;
+            if (tableWithUTFCharacter()) {
+              rows = parseSQLJsonOutput(message.getData());
+            } else {
+              rows = parseSQLOutput(message.getData());
+            }
             result2.add(InterpreterResult.Type.TABLE, StringUtils.join(rows, "\n"));
             if (rows.size() >= (maxResult + 1)) {
               result2.add(ResultMessages.getExceedsLimitRowsMessage(maxResult,
@@ -151,6 +171,28 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
   @Override
   public FormType getFormType() {
     return FormType.SIMPLE;
+  }
+
+  protected List<String> parseSQLJsonOutput(String output) {
+    List<String> rows = new ArrayList<>();
+
+    String[] rowsOutput = output.split("\n");
+    String[] header = rowsOutput[1].split("\t");
+    List<String> cells = new ArrayList<>(Arrays.asList(header));
+    rows.add(StringUtils.join(cells, "\t"));
+
+    for (int i = 2; i < rowsOutput.length; i++) {
+      Map<String, String> retMap = new Gson().fromJson(
+          rowsOutput[i], new TypeToken<HashMap<String, String>>() {
+          }.getType()
+      );
+      cells = new ArrayList<>();
+      for (String s : header) {
+        cells.add(retMap.getOrDefault(s, "null"));
+      }
+      rows.add(StringUtils.join(cells, "\t"));
+    }
+    return rows;
   }
 
   protected List<String> parseSQLOutput(String output) {
@@ -206,6 +248,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
    * Represent the start and end index of each cell.
    */
   private static class Pair {
+
     private int start;
     private int end;
 
@@ -217,6 +260,10 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
 
   public boolean concurrentSQL() {
     return Boolean.parseBoolean(getProperty("zeppelin.livy.concurrentSQL"));
+  }
+
+  public boolean tableWithUTFCharacter() {
+    return Boolean.parseBoolean(getProperty("zeppelin.livy.tableWithUTFCharacter"));
   }
 
   @Override

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -176,7 +176,7 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
   protected List<String> parseSQLJsonOutput(String output) {
     List<String> rows = new ArrayList<>();
 
-    String[] rowsOutput = output.split("\n");
+    String[] rowsOutput = output.split("(?<!\\\\)\\n");
     String[] header = rowsOutput[1].split("\t");
     List<String> cells = new ArrayList<>(Arrays.asList(header));
     rows.add(StringUtils.join(cells, "\t"));
@@ -188,7 +188,9 @@ public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
       );
       cells = new ArrayList<>();
       for (String s : header) {
-        cells.add(retMap.getOrDefault(s, "null"));
+        cells.add(retMap.getOrDefault(s, "null")
+            .replace("\n", "\\n")
+            .replace("\t", "\\t"));
       }
       rows.add(StringUtils.join(cells, "\t"));
     }

--- a/livy/src/main/resources/interpreter-setting.json
+++ b/livy/src/main/resources/interpreter-setting.json
@@ -161,6 +161,12 @@
         "defaultValue": false,
         "description": "Execute multiple SQL concurrently if set true.",
         "type": "checkbox"
+      },
+      "zeppelin.livy.tableWithUTFCharacter": {
+        "propertyName": "zeppelin.livy.tableWithUTFCharacter",
+        "defaultValue": false,
+        "description": "If database contains UTF characters then set this as true.",
+        "type": "checkbox"
       }
     },
     "option": {

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
@@ -171,4 +171,108 @@ public class LivySQLInterpreterTest {
     assertEquals("1\t\\ta", rows.get(1));
     assertEquals("2\t2b", rows.get(2));
   }
+
+  @Test
+  public void parseSQLJsonOutput() {
+    // Empty sql output
+    //    id	name
+    List<String> rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n");
+    assertEquals(1, rows.size());
+    assertEquals("id\tname", rows.get(0));
+
+
+    //  sql output with 2 rows
+    // id	name
+    // {"id":1,"name":"1a"}
+    // {"id":2,"name":"2a"}
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
+        + "{\"id\":1,\"name\":\"1a\"}\n"
+        + "{\"id\":2,\"name\":\"2a\"}");
+    assertEquals(3, rows.size());
+    assertEquals("id\tname", rows.get(0));
+    assertEquals("1\t1a", rows.get(1));
+    assertEquals("2\t2a", rows.get(2));
+
+
+    //  sql output with 3 rows and showing "only showing top 3 rows"
+    // id	name
+    // {"id":1,"name":"1a"}
+    // {"id":2,"name":"2a"}
+    // {"id":3,"name":"3a"}
+    //    only showing top 3 rows
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
+        + "{\"id\":1,\"name\":\"1a\"}\n"
+        + "{\"id\":2,\"name\":\"2a\"}\n"
+        + "{\"id\":3,\"name\":\"3a\"}");
+    assertEquals(4, rows.size());
+    assertEquals("id\tname", rows.get(0));
+    assertEquals("1\t1a", rows.get(1));
+    assertEquals("2\t2a", rows.get(2));
+    assertEquals("3\t3a", rows.get(3));
+
+
+    //  sql output with 1 rows and showing "only showing top 1 rows"
+    // id
+    // {"id":1}
+    // {"id":2}
+    // {"id":3}
+    //    only showing top 1 rows
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\n"
+        + "{\"id\":1}");
+    assertEquals(2, rows.size());
+    assertEquals("id", rows.get(0));
+    assertEquals("1", rows.get(1));
+
+
+
+    //  sql output with 3 rows, 3 columns, showing "only showing top 3 rows" with a line break in
+    //  the data
+    //    id	name	destination
+    //    {"id":1,"name":"1a","destination":"1b"}
+    //    {"id":2,"name":"2\na","destination":"2b"}
+    //    {"id":3,"name":"3a","destination":"3b"}
+    //    only showing top 3 rows
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\tdestination\n"
+        + "{\"id\":1,\"name\":\"1a\",\"destination\":\"1b\"}\n"
+        + "{\"id\":2,\"name\":\"2\\na\",\"destination\":\"2b\"}\n"
+        + "{\"id\":3,\"name\":\"3a\",\"destination\":\"3b\"}");
+    assertEquals(4, rows.size());
+    assertEquals("id\tname\tdestination", rows.get(0));
+    assertEquals("1\t1a\t1b", rows.get(1));
+    assertEquals("2\t2\\na\t2b", rows.get(2));
+    assertEquals("3\t3a\t3b", rows.get(3));
+
+
+    //  sql output with 3 rows and one containing a tab
+    // id	name
+    // {"id":1,"name":"1a"}
+    // {"id":2,"name":"2\ta"}
+    // {"id":3,"name":"3a"}
+    //    only showing top 3 rows
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
+        + "{\"id\":1,\"name\":\"1a\"}\n"
+        + "{\"id\":2,\"name\":\"2\ta\"}\n"
+        + "{\"id\":3,\"name\":\"3a\"}");
+    assertEquals(4, rows.size());
+    assertEquals("id\tname", rows.get(0));
+    assertEquals("1\t1a", rows.get(1));
+    assertEquals("2\t2\\ta", rows.get(2));
+    assertEquals("3\t3a", rows.get(3));
+
+    //  sql output with 3 rows and one containing a Japanese characters
+    // id	name
+    // {"id":1,"name":"1a"}
+    // {"id":2,"name":"みんく"}
+    // {"id":3,"name":"3a"}
+    //    only showing top 3 rows
+    rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
+        + "{\"id\":1,\"name\":\"1a\"}\n"
+        + "{\"id\":2,\"name\":\"みんく\"}\n"
+        + "{\"id\":3,\"name\":\"3a\"}");
+    assertEquals(4, rows.size());
+    assertEquals("id\tname", rows.get(0));
+    assertEquals("1\t1a", rows.get(1));
+    assertEquals("2\tみんく", rows.get(2));
+    assertEquals("3\t3a", rows.get(3));
+  }
 }

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
@@ -174,17 +174,17 @@ public class LivySQLInterpreterTest {
 
   @Test
   public void parseSQLJsonOutput() {
-    // Empty sql output
-    //    id	name
+    //  Empty sql output
+    //  id name
     List<String> rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n");
     assertEquals(1, rows.size());
     assertEquals("id\tname", rows.get(0));
 
 
     //  sql output with 2 rows
-    // id	name
-    // {"id":1,"name":"1a"}
-    // {"id":2,"name":"2a"}
+    //  id name
+    //  {"id":1,"name":"1a"}
+    //  {"id":2,"name":"2a"}
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
         + "{\"id\":1,\"name\":\"1a\"}\n"
         + "{\"id\":2,\"name\":\"2a\"}");
@@ -195,11 +195,11 @@ public class LivySQLInterpreterTest {
 
 
     //  sql output with 3 rows and showing "only showing top 3 rows"
-    // id	name
-    // {"id":1,"name":"1a"}
-    // {"id":2,"name":"2a"}
-    // {"id":3,"name":"3a"}
-    //    only showing top 3 rows
+    //  id\tname
+    //  {"id":1,"name":"1a"}
+    //  {"id":2,"name":"2a"}
+    //  {"id":3,"name":"3a"}
+    //  only showing top 3 rows
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
         + "{\"id\":1,\"name\":\"1a\"}\n"
         + "{\"id\":2,\"name\":\"2a\"}\n"
@@ -212,11 +212,11 @@ public class LivySQLInterpreterTest {
 
 
     //  sql output with 1 rows and showing "only showing top 1 rows"
-    // id
-    // {"id":1}
-    // {"id":2}
-    // {"id":3}
-    //    only showing top 1 rows
+    //  id
+    //  {"id":1}
+    //  {"id":2}
+    //  {"id":3}
+    //  only showing top 1 rows
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\n"
         + "{\"id\":1}");
     assertEquals(2, rows.size());
@@ -227,11 +227,11 @@ public class LivySQLInterpreterTest {
 
     //  sql output with 3 rows, 3 columns, showing "only showing top 3 rows" with a line break in
     //  the data
-    //    id	name	destination
-    //    {"id":1,"name":"1a","destination":"1b"}
-    //    {"id":2,"name":"2\na","destination":"2b"}
-    //    {"id":3,"name":"3a","destination":"3b"}
-    //    only showing top 3 rows
+    //  id name destination
+    //  {"id":1,"name":"1a","destination":"1b"}
+    //  {"id":2,"name":"2\na","destination":"2b"}
+    //  {"id":3,"name":"3a","destination":"3b"}
+    //  only showing top 3 rows
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\tdestination\n"
         + "{\"id\":1,\"name\":\"1a\",\"destination\":\"1b\"}\n"
         + "{\"id\":2,\"name\":\"2\\na\",\"destination\":\"2b\"}\n"
@@ -244,11 +244,11 @@ public class LivySQLInterpreterTest {
 
 
     //  sql output with 3 rows and one containing a tab
-    // id	name
-    // {"id":1,"name":"1a"}
-    // {"id":2,"name":"2\ta"}
-    // {"id":3,"name":"3a"}
-    //    only showing top 3 rows
+    //  id name
+    //  {"id":1,"name":"1a"}
+    //  {"id":2,"name":"2\ta"}
+    //  {"id":3,"name":"3a"}
+    //  only showing top 3 rows
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
         + "{\"id\":1,\"name\":\"1a\"}\n"
         + "{\"id\":2,\"name\":\"2\ta\"}\n"
@@ -260,11 +260,11 @@ public class LivySQLInterpreterTest {
     assertEquals("3\t3a", rows.get(3));
 
     //  sql output with 3 rows and one containing a Japanese characters
-    // id	name
-    // {"id":1,"name":"1a"}
-    // {"id":2,"name":"みんく"}
-    // {"id":3,"name":"3a"}
-    //    only showing top 3 rows
+    //  id name
+    //  {"id":1,"name":"1a"}
+    //  {"id":2,"name":"みんく"}
+    //  {"id":3,"name":"3a"}
+    //  only showing top 3 rows
     rows = sqlInterpreter.parseSQLJsonOutput("\nid\tname\n"
         + "{\"id\":1,\"name\":\"1a\"}\n"
         + "{\"id\":2,\"name\":\"みんく\"}\n"


### PR DESCRIPTION
### What is this PR for?
Livy Interpreter doesn't support Japanese Character - Encoding Issue


### What type of PR is it?
[Bug Fix]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5231

### How should this be tested?
On a paragraph use below to generate data set:
```
%livy.scala
spark.sql("CREATE TABLE  test ( id int, name String, destination String)")
spark.sql("INSERT INTO test VALUES ('1', 'みんく', 'みんく')")
spark.sql("INSERT INTO test VALUES ('2', 'シュレヤン', 'シュレヤン')")
spark.sql("INSERT INTO test VALUES ('3', 'サイ', 'サイ')")
spark.sql("INSERT INTO test VALUES ('4', 'ツェッペリン', 'ツェッペリン')")
spark.sql("INSERT INTO test VALUES ('5', 'テスト', 'テスト')")
spark.sql("INSERT INTO test VALUES ('6', 'チャラン', 'チャラン')")
spark.sql("select * from test").show()
```

Then in a separate paragraph use this to verify:
```
%livy.sql
select * from test
```

You would notice that on toggling (true/false) between the newly introduced `tableWithUTFCharacter` the same 2nd paragraph works.


### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update?N/A
* Is there breaking changes for older versions?N/A
* Does this needs documentation?N/A
