### PR TITLE
[ZEPPELIN-5232]. Default value of zeppelin server memory & interpreter memory should be 1024m

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -138,11 +138,11 @@ if [[ -z "${ZEPPELIN_ENCODING}" ]]; then
 fi
 
 if [[ -z "${ZEPPELIN_MEM}" ]]; then
-  export ZEPPELIN_MEM="-Xms1024m -Xmx1024m"
+  export ZEPPELIN_MEM="-Xmx1024m"
 fi
 
 if [[ ( -z "${ZEPPELIN_INTP_MEM}" ) && ( "${ZEPPELIN_INTERPRETER_LAUNCHER}" != "yarn" ) ]]; then
-  export ZEPPELIN_INTP_MEM="-Xms1024m -Xmx2048m"
+  export ZEPPELIN_INTP_MEM="-Xmx1024m"
 fi
 
 JAVA_OPTS+=" ${ZEPPELIN_JAVA_OPTS} -Dfile.encoding=${ZEPPELIN_ENCODING} ${ZEPPELIN_MEM}"


### PR DESCRIPTION

### What is this PR for?

Trivial PR to change the default memory size to be 1024m for both zeppelin server & interpreter. And also remove `-Xms`, because for some interpreters, memory usage is very small, so just remove `-Xms` to save memory.   

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5232

### How should this be tested?
* No test

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
