### PR TITLE
[ZEPPELIN-5233]. Clear output before running paragraph

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -350,6 +350,11 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
               = interpreterSetting.getConfig(interpreter.getClassName());
       mergeConfig(config);
 
+      // clear output
+      setResult(null);
+      cleanOutputBuffer();
+      cleanRuntimeInfos();
+
       setStatus(Status.PENDING);
 
       if (shouldSkipRunParagraph()) {


### PR DESCRIPTION
### What is this PR for?

Trivial PR to clean output before running paragraph. setStatus will broadcast paragraph to frontend. That means the output in frontend will be cleaned before running

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5233

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
