### PR TITLE
[ZEPPELIN-4960] Add a button to reload note from storage

### DIFF
--- a/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
+++ b/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
@@ -41,6 +41,9 @@ public class Message implements JsonSerializable {
     GET_NOTE,         // [c-s] client load note
                       // @param id note id
 
+    RELOAD_NOTE,      // [c-s] client load note
+                      // @param id note id
+
     NOTE,             // [s-c] note info
                       // @param note serialized Note object
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -116,7 +116,14 @@ public class NotebookService {
   public Note getNote(String noteId,
                       ServiceContext context,
                       ServiceCallback<Note> callback) throws IOException {
-    Note note = notebook.getNote(noteId);
+    return getNote(noteId, false, context, callback);
+  }
+
+  public Note getNote(String noteId,
+                      boolean reload,
+                      ServiceContext context,
+                      ServiceCallback<Note> callback) throws IOException {
+    Note note = notebook.getNote(noteId, reload);
     if (note == null) {
       callback.onFailure(new NoteNotFoundException(noteId), context);
       return null;

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -87,6 +87,15 @@ limitations under the License.
       </button>
 
       <button type="button"
+              class="btn btn-default btn-xs"
+              ng-hide="viewOnly"
+              ng-click="reloadNote()"
+              tooltip-placement="bottom" uib-tooltip="Reload from note file"
+              ng-disabled="revisionView">
+        <i class="fa fa-refresh"></i>
+      </button>
+
+      <button type="button"
               class="btn btn-primary btn-xs"
               ng-class="isNoteRunning() ? 'disabled' : ''"
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -280,6 +280,11 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
     websocketMsgSrv.convertNote($scope.note.id, $scope.note.name);
   };
 
+  // Export nbformat
+  $scope.reloadNote = function() {
+    websocketMsgSrv.reloadNote($scope.note.id);
+  };
+
   // Clone note
   $scope.cloneNote = function(noteId) {
     BootstrapDialog.confirm({

--- a/zeppelin-web/src/components/websocket/websocket-message.service.js
+++ b/zeppelin-web/src/components/websocket/websocket-message.service.js
@@ -81,6 +81,10 @@ function WebsocketMessageService($rootScope, websocketEvents) {
       websocketEvents.sendNewEvent({op: 'GET_NOTE', data: {id: noteId}});
     },
 
+    reloadNote: function(noteId) {
+      websocketEvents.sendNewEvent({op: 'RELOAD_NOTE', data: {id: noteId}});
+    },
+
     updateNote: function(noteId, noteName, noteConfig) {
       websocketEvents.sendNewEvent({op: 'NOTE_UPDATE', data: {id: noteId, name: noteName, config: noteConfig}});
     },

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -191,6 +191,7 @@ limitations under the License.
     <script src="bower_components/ace-builds/src-noconflict/keybinding-emacs.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/ext-language_tools.js"></script>
     <script src="bower_components/ace-builds/src-noconflict/theme-chrome.js"></script>
+    <script src="bower_components/ace-builds/src-noconflict/mode-javascript.js"></script>
     <script src="bower_components/angular-ui-ace/ui-ace.js"></script>
     <script src="bower_components/jquery.scrollTo/jquery.scrollTo.js"></script>
     <script src="bower_components/d3/d3.js"></script>


### PR DESCRIPTION
### What is this PR for?

This PR add one reload button on the tools bar of note. When click this button, note will be reloaded from NotebookRepo.

### What type of PR is it?
[Improvement | Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4960

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/106758519-8e031580-666c-11eb-9d12-25c0055a887e.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
