### PR TITLE
[ZEPPELIN-5237]. ConcurrentModificationException in Notebook.getNotesInfo

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -71,8 +71,9 @@ public class NoteManager {
 
   // build the tree structure of notes
   private void init() throws IOException {
+    // use ConcurrentMap because it may be used in multiple threads.
     this.notesInfo = notebookRepo.list(AuthenticationInfo.ANONYMOUS).values().stream()
-        .collect(Collectors.toMap(NoteInfo::getId, NoteInfo::getPath));
+        .collect(Collectors.toConcurrentMap(NoteInfo::getId, NoteInfo::getPath));
     this.notesInfo.entrySet().stream()
         .forEach(entry ->
         {


### PR DESCRIPTION

### What is this PR for?

Trivial PR to resolve the ConcurrentModificationException by using ConcurrentMap instead of Map

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5237

### How should this be tested?
* No test

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
