### PR TITLE
[ZEPPELIN-5244] Docker build in dockerhub fails

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -48,13 +48,14 @@ RUN set -ex && \
     export PATH=/opt/conda/bin:$PATH && \
     conda config --set always_yes yes --set changeps1 no && \
     conda info -a && \
-    conda env update -f /env_python_3_with_R.yml --prune && \
+    conda install mamba -c conda-forge && \
+    mamba env update -f /env_python_3_with_R.yml --prune && \
     # Cleanup
     rm -v miniconda.sh anaconda.sha256  && \
     # Cleanup based on https://github.com/ContinuumIO/docker-images/commit/cac3352bf21a26fa0b97925b578fb24a0fe8c383
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    conda clean -ay
+    mamba clean -ay
     # Allow to modify conda packages. This allows malicious code to be injected into other interpreter sessions, therefore it is disabled by default
     # chmod -R ug+rwX /opt/conda
 ENV PATH /opt/conda/bin:$PATH


### PR DESCRIPTION
### What is this PR for?
This PR switches to mamba to set up the Python and R environment. [mamba](https://github.com/mamba-org/mamba) is much faster than conda and could solve the build at Dockerhub.

### What type of PR is it?
 - Bug Fix

### Todos
* [x] - Testing

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5244

### How should this be tested?
* manual

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
