### PR TITLE
[ZEPPELIN-5223] - K8s+docker document format is not correct

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ xcode-select --install
 ```
 
 ## Run website locally
-If you don't want to encounter uglily rendered pages, run the documentation site in your local first.
+If you don't want to encounter ugly rendered pages, run the documentation site in your local environment first.
 
 In `$ZEPPELIN_HOME/docs`,
 

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -205,5 +205,5 @@ Zeppelin can run locally (such as inside your IDE in debug mode) and able to run
 
 | Configuration variable | Value | Description |
 | ----- | ----- | ----- |
-| ZEPPELIN_RUN_MODE | docker | Make Zeppelin run interpreter on Docker |
-| ZEPPELIN_DOCKER_CONTAINER_IMAGE | <image>:<version> | Zeppelin interpreter docker image to use |
+| `ZEPPELIN_RUN_MODE` | `docker` | Make Zeppelin run interpreter on Docker |
+| `ZEPPELIN_DOCKER_CONTAINER_IMAGE` | `<image>:<version>` | Zeppelin interpreter docker image to use |

--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -260,10 +260,10 @@ Zeppelin can run locally (such as inside your IDE in debug mode) and able to run
 
 | Environment variable | Value | Description |
 | ----- | ----- | ----- |
-| ZEPPELIN_RUN_MODE | k8s | Make Zeppelin run interpreter on Kubernetes |
-| ZEPPELIN_K8S_PORTFORWARD | true | Enable port forwarding from local Zeppelin instance to Interpreters running on Kubernetes |
-| ZEPPELIN_K8S_CONTAINER_IMAGE | <image>:<version> | Zeppelin interpreter docker image to use |
-| ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE | <image>:<version> | Spark docker image to use |
-| ZEPPELIN_K8S_NAMESPACE | <k8s namespace> | Kubernetes namespace  to use |
-| KUBERNETES_AUTH_TOKEN | <token> | Kubernetes auth token to create resources |
+| `ZEPPELIN_RUN_MODE` | `k8s` | Make Zeppelin run interpreter on Kubernetes |
+| `ZEPPELIN_K8S_PORTFORWARD` | `true` | Enable port forwarding from local Zeppelin instance to Interpreters running on Kubernetes |
+| `ZEPPELIN_K8S_CONTAINER_IMAGE` | `<image>:<version>` | Zeppelin interpreter docker image to use |
+| `ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE` | `<image>:<version>` | Spark docker image to use |
+| `ZEPPELIN_K8S_NAMESPACE` | `<k8s namespace>` | Kubernetes namespace  to use |
+| `KUBERNETES_AUTH_TOKEN` | `<token>` | Kubernetes auth token to create resources |
 


### PR DESCRIPTION
Added formatting (to avoid escaping each `_` occurrence, I couldn't find a style guide for documentation or other examples that would suggest another method.
I noticed this also happens in the `docker.md` so I fixed that as well