### PR TITLE
[ZEPPELIN-5078] Make it possible to cancel "run all paragraphs" operation

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -79,6 +79,10 @@ abstract public class AbstractZeppelinIT {
     clickAndWait(by);
   }
 
+  protected void cancelParagraph(int paragraphNo) {
+    By by = By.xpath(getParagraphXPath(paragraphNo) + "//span[@class='icon-control-pause']");
+    clickAndWait(by);
+  }
 
   protected String getParagraphXPath(int paragraphNo) {
     return "(//div[@ng-controller=\"ParagraphCtrl\"])[" + paragraphNo + "]";

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ParagraphActionsIT.java
@@ -276,6 +276,46 @@ public class ParagraphActionsIT extends AbstractZeppelinIT {
     }
   }
 
+  @Test
+  public void testRunAllCancel() throws Exception {
+    try {
+      createNewNote();
+      waitForParagraph(1, "READY");
+      setTextOfParagraph(1, "%sh\\n\\nfor i in {1..30}; do\\n  sleep 1\\ndone");
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//span[@class='icon-settings']")).click();
+      driver.findElement(By.xpath(getParagraphXPath(1) + "//ul/li/a[@ng-click=\"insertNew('below')\"]"))
+              .click();
+      waitForParagraph(2, "READY");
+      setTextOfParagraph(2, "%sh\\n echo \"Hello World!\"");
+
+
+      driver.findElement(By.xpath(".//*[@id='main']//button[contains(@ng-click, 'runAllParagraphs')]")).sendKeys(Keys.ENTER);
+      ZeppelinITUtils.sleep(1000, false);
+      driver.findElement(By.xpath("//div[@class='modal-dialog'][contains(.,'Run all paragraphs?')]" +
+              "//div[@class='modal-footer']//button[contains(.,'OK')]")).click();
+      waitForParagraph(1, "RUNNING");
+
+      ZeppelinITUtils.sleep(2000, false);
+      cancelParagraph(1);
+      waitForParagraph(1, "ABORT");
+      
+      collector.checkThat("First paragraph status is ",
+              getParagraphStatus(1), CoreMatchers.equalTo("ABORT")
+      );
+      collector.checkThat("Second paragraph status is ",
+              getParagraphStatus(2), CoreMatchers.equalTo("READY")
+      );
+
+
+      driver.navigate().refresh();
+      ZeppelinITUtils.sleep(3000, false);
+      deleteTestNotebook(driver);
+      
+    } catch (Exception e) {
+      handleException("Exception in ParagraphActionsIT while testRunAllCancel", e);
+    }
+  }
+
 //  @Test
   public void testRunOnSelectionChange() throws Exception {
     try {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -21,6 +21,7 @@ package org.apache.zeppelin.service;
 
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN;
 import static org.apache.zeppelin.interpreter.InterpreterResult.Code.ERROR;
+import static org.apache.zeppelin.scheduler.Job.Status.ABORT;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -430,6 +431,9 @@ public class NotebookService {
             Paragraph p = note.getParagraph(paragraphId);
             InterpreterResult result = p.getReturn();
             if (result != null && result.code() == ERROR) {
+              return false;
+            }
+            if (p.getStatus() == ABORT || p.isAborted()) {
               return false;
             }
           } catch (Exception e) {

--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -316,8 +316,6 @@ export abstract class ParagraphBase extends MessageListenersManager {
   }
 
   cancelParagraph() {
-    if (!this.isEntireNoteRunning) {
-      this.messageService.cancelParagraph(this.paragraph.id);
-    }
+    this.messageService.cancelParagraph(this.paragraph.id);
   }
 }

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
@@ -53,7 +53,7 @@ limitations under the License.
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C"
           tooltip-placement="top" uib-tooltip="Cancel (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+C)"
           ng-click="cancelParagraph(paragraph)"
-          ng-class="{'item-disable' : isNoteRunning}"
+          ng-class="{'item-disable' : paragraph.status!='RUNNING'}"
           ng-show="paragraph.status=='RUNNING' || paragraph.status=='PENDING'"></span>
     <span class="{{paragraph.config.editorHide ? 'icon-size-fullscreen' : 'icon-size-actual'}}" style="cursor:pointer" tooltip-placement="top"
           uib-tooltip="{{(paragraph.config.editorHide ? 'Show' : 'Hide')}} editor (Ctrl+{{ (isMac ? 'Option' : 'Alt') }}+E)"

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -276,9 +276,6 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.cancelParagraph = function(paragraph) {
-    if ($scope.isNoteRunning) {
-      return;
-    }
     console.log('Cancel %o', paragraph.id);
     websocketMsgSrv.cancelParagraphRun(paragraph.id);
   };


### PR DESCRIPTION
### What is this PR for?

Make it possible to cancel "run all paragraphs" operation. Currently, Cancel is blocked by UI as well as blocking "run all" operation on server. This PR will unblock cancel from UI and do "run all" operation in separate thread and so avoid blocking the websocket.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5078

### How should this be tested?
Two automatic tests in zeppelin-integration package.
I have problems with CI, but I am able to run them successfully locally.
