### PR TITLE
[ZEPPELIN-5259] Use RemoteInterpreterManagedProcess for K8sRemoteInterpreterProcess

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -234,27 +234,21 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
 
   @Override
   public boolean isRunning() {
+    return RemoteInterpreterUtils.checkIfRemoteEndpointAccessible(getHost(), getPort())
+        && "Running".equalsIgnoreCase(getPodPhase()) && started.get();
+  }
+
+  public String getPodPhase() {
     try {
-      if (RemoteInterpreterUtils.checkIfRemoteEndpointAccessible(getHost(), getPort())) {
-        return true;
-      }
       Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
       if (pod != null) {
         PodStatus status = pod.getStatus();
         if (status != null) {
-          return "Running".equals(status.getPhase()) && started.get();
+          return status.getPhase();
         }
       }
     } catch (Exception e) {
-      LOGGER.error("Can't get pod status", e);
-    }
-    return false;
-  }
-
-  public String getPodPhase() {
-    Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
-    if (pod != null) {
-      return pod.getStatus().getPhase();
+      LOGGER.error("Can't get pod phase", e);
     }
     return "Unknown";
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.IOUtils;
@@ -72,7 +71,6 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
   private final boolean timeoutDuringPending;
 
   private AtomicBoolean started = new AtomicBoolean(false);
-  private Random rand = new Random();
 
   private static final String SPARK_DRIVER_MEMORY = "spark.driver.memory";
   private static final String SPARK_DRIVER_MEMORY_OVERHEAD = "spark.driver.memoryOverhead";
@@ -111,7 +109,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
     this.envs = new HashMap<>(envs);
     this.portForward = portForward;
     this.sparkImage = sparkImage;
-    this.podName = interpreterGroupName.toLowerCase() + "-" + getRandomString(6);
+    this.podName = interpreterGroupName.toLowerCase() + "-" + K8sUtils.getRandomPodSuffix(6);
     this.isUserImpersonatedForSpark = isUserImpersonatedForSpark;
     this.timeoutDuringPending = timeoutDuringPending;
   }
@@ -461,17 +459,6 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterProcess {
 
   private String ownerName() {
     return System.getenv("POD_NAME");
-  }
-
-  private String getRandomString(int length) {
-    char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length; i++) {
-      char c = chars[rand.nextInt(chars.length)];
-      sb.append(c);
-    }
-    return sb.toString();
   }
 
   @Override

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -43,7 +43,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(K8sStandardInterpreterLauncher.class);
-  private InterpreterLaunchContext context;
   private final KubernetesClient client;
 
   public K8sStandardInterpreterLauncher(ZeppelinConfiguration zConf, RecoveryStorage recoveryStorage) throws IOException {
@@ -95,7 +94,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
    * return <service-name>.<namespace>.svc
    * @throws IOException
    */
-  private String getZeppelinService() throws IOException {
+  private String getZeppelinService(InterpreterLaunchContext context) throws IOException {
     if (isRunningOnKubernetes()) {
       return String.format("%s.%s.svc",
               zConf.getK8sServiceName(),
@@ -109,7 +108,7 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
    * get Zeppelin server rpc port
    * Read env variable "<HOSTNAME>_SERVICE_PORT_RPC"
    */
-  private int getZeppelinServiceRpcPort() {
+  private int getZeppelinServiceRpcPort(InterpreterLaunchContext context) {
     String envServicePort = System.getenv(
             String.format("%s_SERVICE_PORT_RPC", getHostname().replaceAll("[-.]", "_").toUpperCase()));
     if (envServicePort != null) {
@@ -134,7 +133,6 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
   @Override
   public InterpreterClient launchDirectly(InterpreterLaunchContext context) throws IOException {
     LOGGER.info("Launching Interpreter: {}", context.getInterpreterSettingGroup());
-    this.context = context;
     this.properties = context.getProperties();
 
     return new K8sRemoteInterpreterProcess(
@@ -147,8 +145,8 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
             context.getInterpreterSettingName(),
             properties,
             buildEnvFromProperties(context),
-            getZeppelinService(),
-            getZeppelinServiceRpcPort(),
+            getZeppelinService(context),
+            getZeppelinServiceRpcPort(context),
             zConf.getK8sPortForward(),
             zConf.getK8sSparkContainerImage(),
             getConnectTimeout(),

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.zeppelin.interpreter.launcher;
 
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,6 +31,8 @@ public class K8sUtils {
   private static final long G = M * K;
   private static final long T = G * K;
   private static final long MINIMUM_OVERHEAD = 384;
+
+  private static final Random rand = new Random();
 
   private K8sUtils() {
     // do nothing
@@ -73,5 +76,16 @@ public class K8sUtils {
       throw new NumberFormatException("Conversion of " + memory + " exceeds Long.MAX_VALUE");
     }
     return memoryAmountBytes;
+  }
+
+  public static String getRandomPodSuffix(int length) {
+    char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      char c = chars[rand.nextInt(chars.length)];
+      sb.append(c);
+    }
+    return sb.toString();
   }
 }

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -19,16 +19,27 @@ package org.apache.zeppelin.interpreter.launcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.zeppelin.interpreter.remote.RemoteInterpreterManagedProcess;
 import org.junit.Rule;
 import org.junit.Test;
-
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
 public class K8sRemoteInterpreterProcessTest {
@@ -382,4 +393,204 @@ public class K8sRemoteInterpreterProcessTest {
     assertEquals("1280Mi", p.get("zeppelin.k8s.interpreter.memory"));
   }
 
+  @Test
+  public void testK8sStartSuccessful() throws IOException, InterruptedException {
+    // given
+    Properties properties = new Properties();
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("SERVICE_DOMAIN", "mydomain");
+    URL url = Thread.currentThread().getContextClassLoader()
+        .getResource("k8s-specs/interpreter-spec.yaml");
+    File file = new File(url.getPath());
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+        server.getClient(),
+        "default",
+        file,
+        "interpreter-container:1.0",
+        "shared_process",
+        "spark",
+        "myspark",
+        properties,
+        envs,
+        "zeppelin.server.service",
+        12320,
+        false,
+        "spark-container:1.0",
+        10000,
+        10,
+        false,
+        true);
+    ExecutorService service = Executors.newFixedThreadPool(1);
+    service
+        .submit(new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp));
+    intp.start("TestUser");
+    // then
+    assertEquals("Running", intp.getPodPhase());
+  }
+
+  @Test
+  public void testK8sStartFailed() throws IOException, InterruptedException {
+    // given
+    Properties properties = new Properties();
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("SERVICE_DOMAIN", "mydomain");
+    URL url = Thread.currentThread().getContextClassLoader()
+        .getResource("k8s-specs/interpreter-spec.yaml");
+    File file = new File(url.getPath());
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+        server.getClient(),
+        "default",
+        file,
+        "interpreter-container:1.0",
+        "shared_process",
+        "spark",
+        "myspark",
+        properties,
+        envs,
+        "zeppelin.server.service",
+        12320,
+        false,
+        "spark-container:1.0",
+        3000,
+        10,
+        false,
+        true);
+    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp);
+    podStatusSimulator.setSecondPhase("Failed");
+    podStatusSimulator.setSuccessfullStart(false);
+    ExecutorService service = Executors.newFixedThreadPool(1);
+    service
+        .submit(podStatusSimulator);
+    // should throw an IOException
+    try {
+      intp.start("TestUser");
+      fail("We excepting an IOException");
+    } catch (IOException e) {
+      assertNotNull(e);
+      // Check that the Pod is deleted
+      assertNull(
+          server.getClient().pods().inNamespace(intp.getNamespace()).withName(intp.getPodName())
+              .get());
+    }
+  }
+
+  @Test
+  public void testK8sStartTimeoutPending() throws IOException, InterruptedException {
+    // given
+    Properties properties = new Properties();
+    HashMap<String, String> envs = new HashMap<String, String>();
+    envs.put("SERVICE_DOMAIN", "mydomain");
+    URL url = Thread.currentThread().getContextClassLoader()
+        .getResource("k8s-specs/interpreter-spec.yaml");
+    File file = new File(url.getPath());
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+        server.getClient(),
+        "default",
+        file,
+        "interpreter-container:1.0",
+        "shared_process",
+        "spark",
+        "myspark",
+        properties,
+        envs,
+        "zeppelin.server.service",
+        12320,
+        false,
+        "spark-container:1.0",
+        3000,
+        10,
+        false,
+        true);
+    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp);
+    podStatusSimulator.setFirstPhase("Pending");
+    podStatusSimulator.setSecondPhase("Pending");
+    podStatusSimulator.setSuccessfullStart(false);
+    ExecutorService service = Executors.newFixedThreadPool(2);
+    service
+        .submit(podStatusSimulator);
+    service.submit(() -> {
+      try {
+        intp.start("TestUser");
+        fail("We interrupt, this line of code should not be executed.");
+      } catch (IOException e) {
+        fail("We interrupt, this line of code should not be executed.");
+      }
+    });
+    // wait a little bit
+    TimeUnit.SECONDS.sleep(5);
+    service.shutdownNow();
+    // wait for a shutdown
+    service.awaitTermination(10, TimeUnit.SECONDS);
+    // Check that the Pod is deleted
+    assertNull(server.getClient().pods().inNamespace(intp.getNamespace())
+        .withName(intp.getPodName()).get());
+
+  }
+
+  class PodStatusSimulator implements Runnable {
+
+    private final KubernetesClient client;
+    private final String namespace;
+    private final String podName;
+    private final RemoteInterpreterManagedProcess process;
+
+    private String firstPhase = "Pending";
+    private String secondPhase = "Running";
+    private boolean successfulStart = true;
+
+    public PodStatusSimulator(
+        KubernetesClient client,
+        String namespace,
+        String podName,
+        RemoteInterpreterManagedProcess process) {
+      this.client = client;
+      this.namespace = namespace;
+      this.podName = podName;
+      this.process = process;
+    }
+
+    public void setFirstPhase(String phase) {
+      this.firstPhase = phase;
+    }
+    public void setSecondPhase(String phase) {
+      this.secondPhase = phase;
+    }
+    public void setSuccessfullStart(boolean successful) {
+      this.successfulStart = successful;
+    }
+
+    @Override
+    public void run() {
+      try {
+        Instant timeoutTime = Instant.now().plusSeconds(10);
+        while (timeoutTime.isAfter(Instant.now())) {
+          Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
+          if (pod != null) {
+            TimeUnit.SECONDS.sleep(1);
+            // Update Pod to "pending" phase
+            pod.setStatus(new PodStatus(null, null, null, null, null, null, null, firstPhase,
+                null,
+                null, null, null, null));
+            client.pods().inNamespace(namespace).updateStatus(pod);
+            // Update Pod to "Running" phase
+            pod.setStatus(new PodStatus(null, null, null, null, null, null, null, secondPhase,
+                null,
+                null, null, null, null));
+            client.pods().inNamespace(namespace).updateStatus(pod);
+            TimeUnit.SECONDS.sleep(1);
+            if (successfulStart) {
+              process.processStarted(12320, "testing");
+            }
+            break;
+          } else {
+            TimeUnit.MILLISECONDS.sleep(100);
+          }
+        }
+      } catch (InterruptedException e) {
+      }
+    }
+  }
 }

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -37,36 +37,6 @@ public class K8sRemoteInterpreterProcessTest {
   public KubernetesServer server = new KubernetesServer(true, true);
 
   @Test
-  public void testGetHostPort() {
-    // given
-    Properties properties = new Properties();
-    HashMap<String, String> envs = new HashMap<String, String>();
-
-    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
-        server.getClient(),
-        "default",
-        new File(".skip"),
-        "interpreter-container:1.0",
-        "shared_process",
-        "sh",
-        "shell",
-        properties,
-        envs,
-        "zeppelin.server.hostname",
-        12320,
-        false,
-        "spark-container:1.0",
-        10,
-        10,
-        false,
-        false);
-
-    // then
-    assertEquals(String.format("%s.%s.svc", intp.getPodName(), "default"), intp.getHost());
-    assertEquals(12321, intp.getPort());
-  }
-
-  @Test
   public void testPredefinedPortNumbers() {
     // given
     Properties properties = new Properties();
@@ -94,7 +64,7 @@ public class K8sRemoteInterpreterProcessTest {
 
     // following values are hardcoded in k8s/interpreter/100-interpreter.yaml.
     // when change those values, update the yaml file as well.
-    assertEquals(12321, intp.getPort());
+    assertEquals("12321:12321", intp.getInterpreterPortRange());
     assertEquals(22321, intp.getSparkDriverPort());
     assertEquals(22322, intp.getSparkBlockmanagerPort());
   }
@@ -194,7 +164,7 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.namespace=default"));
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.container.image=spark-container:1.0"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getHost()));
+    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
     assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
     assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockmanagerPort()));
     assertFalse(sparkSubmitOptions.contains("--proxy-user"));
@@ -245,7 +215,7 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.namespace=default"));
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
     assertTrue(sparkSubmitOptions.contains("spark.kubernetes.container.image=spark-container:1.0"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getHost()));
+    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
     assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
     assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockmanagerPort()));
     assertTrue(sparkSubmitOptions.contains("--proxy-user mytestUser"));

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/resources/k8s-specs/interpreter-spec.yaml
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/resources/k8s-specs/interpreter-spec.yaml
@@ -1,0 +1,162 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+kind: Pod
+apiVersion: v1
+metadata:
+  namespace: {{zeppelin.k8s.namespace}}
+  name: {{zeppelin.k8s.interpreter.pod.name}}
+  labels:
+    app: {{zeppelin.k8s.interpreter.pod.name}}
+    interpreterGroupId: {{zeppelin.k8s.interpreter.group.id}}
+    interpreterSettingName: {{zeppelin.k8s.interpreter.setting.name}}
+  {% if zeppelin.k8s.server.uid is defined %}
+  ownerReferences:
+  - apiVersion: v1
+    controller: false
+    blockOwnerDeletion: false
+    kind: Pod
+    name: {{zeppelin.k8s.server.pod.name}}
+    uid: {{zeppelin.k8s.server.uid}}
+  {% endif %}
+spec:
+  {% if zeppelin.k8s.interpreter.group.name == "spark" %}
+  automountServiceAccountToken: true
+  {% else %}
+  automountServiceAccountToken: false
+  {% endif %}
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 30
+  containers:
+  - name: {{zeppelin.k8s.interpreter.container.name}}
+    image: {{zeppelin.k8s.interpreter.container.image}}
+    args:
+      - "$(ZEPPELIN_HOME)/bin/interpreter.sh"
+      - "-d"
+      - "$(ZEPPELIN_HOME)/interpreter/{{zeppelin.k8s.interpreter.group.name}}"
+      - "-r"
+      - "{{zeppelin.k8s.interpreter.rpc.portRange}}"
+      - "-c"
+      - "{{zeppelin.k8s.server.rpc.service}}"
+      - "-p"
+      - "{{zeppelin.k8s.server.rpc.portRange}}"
+      - "-i"
+      - "{{zeppelin.k8s.interpreter.group.id}}"
+      - "-l"
+      - "{{zeppelin.k8s.interpreter.localRepo}}/{{zeppelin.k8s.interpreter.setting.name}}"
+      - "-g"
+      - "{{zeppelin.k8s.interpreter.setting.name}}"
+    env:
+  {% for key, value in zeppelin.k8s.envs.items() %}
+    - name: {{key}}
+      value: {{value}}
+  {% endfor %}
+  {% if zeppelin.k8s.interpreter.cores is defined and zeppelin.k8s.interpreter.memory is defined %}
+    resources:
+      requests:
+        memory: "{{zeppelin.k8s.interpreter.memory}}"
+        cpu: "{{zeppelin.k8s.interpreter.cores}}"
+{# limits.memory is not set because of a potential OOM-Killer. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits #}
+      limits:
+        cpu: "{{zeppelin.k8s.interpreter.cores}}"
+  {% endif %}
+  {% if zeppelin.k8s.interpreter.group.name == "spark" %}
+    volumeMounts:
+    - name: spark-home
+      mountPath: /spark
+  initContainers:
+  - name: spark-home-init
+    image: {{zeppelin.k8s.spark.container.image}}
+    command: ["sh", "-c", "cp -r /opt/spark/* /spark/"]
+    volumeMounts:
+    - name: spark-home
+      mountPath: /spark
+  volumes:
+  - name: spark-home
+    emptyDir: {}
+  {% endif %}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: {{zeppelin.k8s.namespace}}
+  name: {{zeppelin.k8s.interpreter.pod.name}}             # keep Service name the same to Pod name.
+  {% if zeppelin.k8s.server.uid is defined %}
+  ownerReferences:
+  - apiVersion: v1
+    controller: false
+    blockOwnerDeletion: false
+    kind: Pod
+    name: {{zeppelin.k8s.server.pod.name}}
+    uid: {{zeppelin.k8s.server.uid}}
+  {% endif %}
+spec:
+  clusterIP: None
+  ports:
+    - name: intp
+      port: 12321
+    {% if zeppelin.k8s.interpreter.group.name == "spark" %}
+    - name: spark-driver
+      port: 22321
+    - name: spark-blockmanager
+      port: 22322
+    - name: spark-ui
+      port: 4040
+    {% endif %}
+  selector:
+    app: {{zeppelin.k8s.interpreter.pod.name}}
+{% if zeppelin.k8s.interpreter.group.name == "spark" %}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{zeppelin.k8s.interpreter.pod.name}}
+  namespace: {{zeppelin.k8s.namespace}}
+  {% if zeppelin.k8s.server.uid is defined %}
+  ownerReferences:
+  - apiVersion: v1
+    controller: false
+    blockOwnerDeletion: false
+    kind: Pod
+    name: {{zeppelin.k8s.server.pod.name}}
+    uid: {{zeppelin.k8s.server.uid}}
+  {% endif %}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["create", "get", "update", "list", "delete", "watch" ]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{zeppelin.k8s.interpreter.pod.name}}
+  {% if zeppelin.k8s.server.uid is defined %}
+  ownerReferences:
+  - apiVersion: v1
+    controller: false
+    blockOwnerDeletion: false
+    kind: Pod
+    name: {{zeppelin.k8s.server.pod.name}}
+    uid: {{zeppelin.k8s.server.uid}}
+  {% endif %}
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: {{zeppelin.k8s.interpreter.pod.name}}
+  apiGroup: rbac.authorization.k8s.io
+{% endif %}


### PR DESCRIPTION
### What is this PR for?
This PR changes the parent class for K8sRemoteInterpreterProcess to RemoteInterpreterManagedProcess.
It also contains some bug fixes.

I removed the static method `RemoteInterpreterUtils.checkIfRemoteEndpointAccessible`, because this function is unnecessary and it also blocks testing. It is sufficient to listen for `processStarted`. This signals a successful start of the interpreter.


### What type of PR is it?
Improvement and Bugfixing


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5259

### How should this be tested?
* CI
* Port forwarding was tested locally

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
