### PR TITLE
[ZEPPELIN-5192]: Don't try to decrypt a non-existent credentials file

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -137,7 +137,7 @@ public class Credentials {
   private void loadFromFile() throws IOException {
     try {
       String json = storage.loadCredentials();
-      if (encryptor != null) {
+      if (json != null && encryptor != null) {
         json = encryptor.decrypt(json);
       }
 


### PR DESCRIPTION
### What is this PR for?

This is a very simple fix for the issue described in [ZEPPELIN-5192](https://issues.apache.org/jira/browse/ZEPPELIN-5192): Zeppelin will currently fail to start if a credentials encryption key is configured but no `credentials.json` file exists currently. This is due to an NPE inside the decryption code path. The fix is to only attempt the decryption if the file could be loaded.

### What type of PR is it?

[Bug Fix]

### What is the Jira issue?

* [ZEPPELIN-5192](https://issues.apache.org/jira/browse/ZEPPELIN-5192)


### How should this be tested?

Booting a fresh Zeppelin server with ZEPPELIN_CREDENTIALS_ENCRYPT_KEY set is sufficient to reproduce the issue and validate the fix.

