### PR TITLE
[ZEPPELIN-5270] Implementing a soft shutdown for K8s interpreters

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/PodPhaseWatcher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/PodPhaseWatcher.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+
+public class PodPhaseWatcher implements Watcher<Pod> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PodPhaseWatcher.class);
+  private final CountDownLatch countDownLatch;
+  private final Predicate<String> predicate;
+
+  public PodPhaseWatcher(Predicate<String> predicate) {
+    this.countDownLatch = new CountDownLatch(1);
+    this.predicate = predicate;
+  }
+
+  @Override
+  public void eventReceived(Action action, Pod pod) {
+    PodStatus status = pod.getStatus();
+    if (status != null && predicate.test(status.getPhase())) {
+      LOGGER.info("Pod {} meets phase {}", pod.getMetadata().getName(), status.getPhase());
+      countDownLatch.countDown();
+    }
+  }
+
+  @Override
+  public void onClose(KubernetesClientException cause) {
+    if (cause != null) {
+      LOGGER.error("PodWatcher exits abnormally", cause);
+    }
+    // always count down, so threads that are waiting will continue
+    countDownLatch.countDown();
+  }
+
+  public CountDownLatch getCountDownLatch() {
+    return countDownLatch;
+  }
+
+}

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/PodPhaseWatcherTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/PodPhaseWatcherTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.interpreter.launcher;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.PodStatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+
+public class PodPhaseWatcherTest {
+
+  @Rule
+  public KubernetesServer server = new KubernetesServer(true, true);
+
+  @Test
+  public void testPhase() throws InterruptedException {
+    KubernetesClient client = server.getClient();
+    // CREATE
+    client.pods().inNamespace("ns1")
+        .create(new PodBuilder().withNewMetadata().withName("pod1").endMetadata().build());
+    // READ
+    PodList podList = client.pods().inNamespace("ns1").list();
+    assertNotNull(podList);
+    assertEquals(1, podList.getItems().size());
+    Pod pod = podList.getItems().get(0);
+    // WATCH
+    PodPhaseWatcher podWatcher = new PodPhaseWatcher(
+        phase -> StringUtils.equalsAnyIgnoreCase(phase, "Succeeded", "Failed", "Running"));
+    Watch watch = client.pods().inNamespace("ns1").withName("pod1").watch(podWatcher);
+
+    // Update Pod to "pending" phase
+    pod.setStatus(new PodStatus(null, null, null, null, null, null, null, "Pending", null, null,
+        null, null, null));
+    client.pods().inNamespace("ns1").updateStatus(pod);
+
+    // Update Pod to "Running" phase
+    pod.setStatus(new PodStatusBuilder(new PodStatus(null, null, null, null, null, null, null,
+        "Running", null, null, null, null, null)).build());
+    client.pods().inNamespace("ns1").updateStatus(pod);
+
+    assertTrue(podWatcher.getCountDownLatch().await(1, TimeUnit.SECONDS));
+    watch.close();
+  }
+
+  @Test
+  public void testPhaseWithError() throws InterruptedException {
+    KubernetesClient client = server.getClient();
+    // CREATE
+    client.pods().inNamespace("ns1")
+        .create(new PodBuilder().withNewMetadata().withName("pod1").endMetadata().build());
+    // READ
+    PodList podList = client.pods().inNamespace("ns1").list();
+    assertNotNull(podList);
+    assertEquals(1, podList.getItems().size());
+    // WATCH
+    PodPhaseWatcher podWatcher = new PodPhaseWatcher(
+        phase -> StringUtils.equalsAnyIgnoreCase(phase, "Succeeded", "Failed", "Running"));
+    Watch watch = client.pods().inNamespace("ns1").withName("pod1").watch(podWatcher);
+
+    // In the case of close, we do not block thread execution
+    watch.close();
+    assertTrue(podWatcher.getCountDownLatch().await(1, TimeUnit.SECONDS));
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This PR adds a softshutdown for K8s interpreters. Also changed the implementation from multiple API calls to a watcher implementation.

### What type of PR is it?
- Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5270

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
