### PR TITLE
[ZEPPELIN-5272] Row return type FunctionHint doesn't work in flink interpreter

### DIFF
--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
@@ -121,6 +121,8 @@ public abstract class FlinkShims {
 
   public abstract Object toDataSet(Object btenv, Object table);
 
+  public abstract void registerScalarFunction(Object btenv, String name, Object scalarFunction);
+
   public abstract void registerTableFunction(Object btenv, String name, Object tableFunction);
 
   public abstract void registerAggregateFunction(Object btenv, String name, Object aggregateFunction);

--- a/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
+++ b/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
@@ -41,8 +41,10 @@ import org.apache.flink.table.api.scala.BatchTableEnvironment;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FlinkException;
@@ -192,6 +194,11 @@ public class Flink110Shims extends FlinkShims {
   @Override
   public void registerTableSink(Object stenv, String tableName, Object collectTableSink) {
     ((TableEnvironment) stenv).registerTableSink(tableName, (TableSink) collectTableSink);
+  }
+
+  @Override
+  public void registerScalarFunction(Object btenv, String name, Object scalarFunction) {
+    ((StreamTableEnvironmentImpl)(btenv)).registerFunction(name, (ScalarFunction) scalarFunction);
   }
 
   @Override

--- a/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
+++ b/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
@@ -49,6 +49,7 @@ import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
@@ -244,6 +245,11 @@ public class Flink111Shims extends FlinkShims {
   public void registerTableSink(Object stenv, String tableName, Object collectTableSink) {
     ((org.apache.flink.table.api.internal.TableEnvironmentInternal) stenv)
             .registerTableSinkInternal(tableName, (TableSink) collectTableSink);
+  }
+
+  @Override
+  public void registerScalarFunction(Object btenv, String name, Object scalarFunction) {
+    ((StreamTableEnvironmentImpl)(btenv)).createTemporarySystemFunction(name, (ScalarFunction) scalarFunction);
   }
 
   @Override

--- a/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
+++ b/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
@@ -50,6 +50,7 @@ import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
@@ -245,6 +246,11 @@ public class Flink112Shims extends FlinkShims {
   public void registerTableSink(Object stenv, String tableName, Object collectTableSink) {
     ((org.apache.flink.table.api.internal.TableEnvironmentInternal) stenv)
             .registerTableSinkInternal(tableName, (TableSink) collectTableSink);
+  }
+
+  @Override
+  public void registerScalarFunction(Object btenv, String name, Object scalarFunction) {
+    ((StreamTableEnvironmentImpl)(btenv)).createTemporarySystemFunction(name, (ScalarFunction) scalarFunction);
   }
 
   @Override

--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -487,7 +487,7 @@ class FlinkScalaInterpreter(val properties: Properties) {
             val udf = c.newInstance()
             if (udf.isInstanceOf[ScalarFunction]) {
               val scalarUDF = udf.asInstanceOf[ScalarFunction]
-              btenv.registerFunction(c.getSimpleName, scalarUDF)
+              flinkShims.registerScalarFunction(btenv, c.getSimpleName, scalarUDF)
             } else if (udf.isInstanceOf[TableFunction[_]]) {
               val tableUDF = udf.asInstanceOf[TableFunction[_]]
               flinkShims.registerTableFunction(btenv, c.getSimpleName, tableUDF)


### PR DESCRIPTION

### What is this PR for?

The root cause is in flink side. And flink 1.11 fix this issue via introducing a new api `createTemporarySystemFunction`. In this PR, I will this method for `flink1.11-shim` and `flink1.12-shim`. Unit test is added as well.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5272

### How should this be tested?
* UT is added

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/109663552-34c4ce00-7ba7-11eb-9f17-56091d669bc6.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
