### PR TITLE
[ZEPPELIN-5227] User can choose whether add empty paragraph when calling create note http api

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -392,7 +392,7 @@ public class NotebookRestApi extends AbstractRestApi {
     Note note = notebookService.createNote(
             request.getName(),
             defaultInterpreterGroup,
-            false,
+            request.getAddingEmptyParagraph(),
             getServiceContext(),
             new RestServiceCallback<>());
     AuthenticationInfo subject = new AuthenticationInfo(authenticationService.getPrincipal());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
@@ -31,9 +31,14 @@ public class NewNoteRequest implements JsonSerializable {
   //TODO(zjffdu) rename it to be notePath instead of name
   private String name;
   private String defaultInterpreterGroup;
+  private boolean addingEmptyParagraph = false;
   private List<NewParagraphRequest> paragraphs;
 
   public NewNoteRequest (){
+  }
+
+  public boolean getAddingEmptyParagraph() {
+    return addingEmptyParagraph;
   }
 
   public String getName() {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -202,6 +202,38 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   }
 
   @Test
+  public void testCreateNote() throws Exception {
+    LOG.info("Running testCreateNote");
+    String message1 = "{\n\t\"name\" : \"test1\",\n\t\"addingEmptyParagraph\" : true\n}";
+    CloseableHttpResponse post1 = httpPost("/notebook/", message1);
+    assertThat(post1, isAllowed());
+
+    Map<String, Object> resp1 = gson.fromJson(EntityUtils.toString(post1.getEntity(), StandardCharsets.UTF_8),
+            new TypeToken<Map<String, Object>>() {}.getType());
+    assertEquals("OK", resp1.get("status"));
+
+    String noteId1 = (String) resp1.get("body");
+    Note note1 = TestUtils.getInstance(Notebook.class).getNote(noteId1);
+    assertEquals("test1", note1.getName());
+    assertEquals(1, note1.getParagraphCount());
+    assertNull(note1.getParagraph(0).getText());
+    assertNull(note1.getParagraph(0).getTitle());
+
+    String message2 = "{\n\t\"name\" : \"test2\"\n}";
+    CloseableHttpResponse post2 = httpPost("/notebook/", message2);
+    assertThat(post2, isAllowed());
+
+    Map<String, Object> resp2 = gson.fromJson(EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8),
+            new TypeToken<Map<String, Object>>() {}.getType());
+    assertEquals("OK", resp2.get("status"));
+
+    String noteId2 = (String) resp2.get("body");
+    Note note2 = TestUtils.getInstance(Notebook.class).getNote(noteId2);
+    assertEquals("test2", note2.getName());
+    assertEquals(0, note2.getParagraphCount());
+  }
+
+  @Test
   public void testRunNoteBlocking() throws IOException {
     LOG.info("Running testRunNoteBlocking");
     Note note1 = null;


### PR DESCRIPTION
### What is this PR for?

When I call create note http api on zeppelin-0.9.0, a empty note without any paragraph was created, but I can't add paragraph on the note with zeppelin ui(https://issues.apache.org/jira/browse/ZEPPELIN-5227), so I put the "addingEmptyParagraph" parameter to the api message, user can add a empty paragraph when call create note http api, and won't add a empty paragraph for default.


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5227

### How should this be tested?
CI
Unit Test

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
