### PR TITLE
[ZEPPELIN-5267]. Use environment variable FLINK_HOME if it is not specified

### DIFF
--- a/zeppelin-plugins/launcher/flink/src/main/java/org/apache/zeppelin/interpreter/launcher/FlinkInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/flink/src/main/java/org/apache/zeppelin/interpreter/launcher/FlinkInterpreterLauncher.java
@@ -35,7 +35,10 @@ public class FlinkInterpreterLauncher extends StandardInterpreterLauncher {
   public Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context)
           throws IOException {
     Map<String, String> envs = super.buildEnvFromProperties(context);
-    String flinkHome = context.getProperties().getProperty("FLINK_HOME", envs.get("FLINK_HOME"));
+    String flinkHome = context.getProperties().getProperty("FLINK_HOME");
+    if (StringUtils.isBlank(flinkHome)) {
+      flinkHome = System.getenv("FLINK_HOME");
+    }
     if (StringUtils.isBlank(flinkHome)) {
       throw new IOException("FLINK_HOME is not specified");
     }


### PR DESCRIPTION

### What is this PR for?

When `FLINK_HOME` is not in flink interpreter setting, we should use the current environment variable `FLINK_HOME`. 
2 possible use scenario that use `FLINK_HOME` environment variable:
* Specify `FLINK_HOME` in `zeppelin-env.sh`
* Mount flink distribution and pass `FLINK_HOME` via docker command

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5267

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
