### PR TITLE
[ZEPPELIN-5299] Comment at end of query causes query to be ignored

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
@@ -93,6 +93,10 @@ public class SqlSplitter {
       if (singleLineComment && (character == '\n')) {
         singleLineComment = false;
         query.append(character);
+        if (index == (text.length() - 1) && !query.toString().trim().isEmpty()) {
+          // add query when it is the end of sql.
+          queries.add(query.toString());
+        }
         continue;
       }
 

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/util/SqlSplitterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/util/SqlSplitterTest.java
@@ -354,4 +354,19 @@ public class SqlSplitterTest {
     assertEquals("show tables", sqls.get(0));
     assertEquals("\ndescribe table_1", sqls.get(1));
   }
+
+  @Test
+  public void testCommentAtEnd() {
+    String sql = "\n" +
+            "select\n" +
+            "  'one'\n" +
+            "  , 'two' -- comment\n";
+    SqlSplitter sqlSplitter = new SqlSplitter();
+    List<String> sqls = sqlSplitter.splitSql(sql);
+    assertEquals(1, sqls.size());
+    assertEquals("\n" +
+            "select\n" +
+            "  'one'\n" +
+            "  , 'two' \n", sqls.get(0));
+  }
 }


### PR DESCRIPTION
### What is this PR for?

This is to fix the corner case that when the comment is at the end of query, the query will be skipped due to bug in SqlSplitter.
This PR fix the bug in SqlSplitter and also add UT

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5299

### How should this be tested?
* UT is added

### Screenshots (if appropriate)

### Questions: 
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
