### PR TITLE
[ZEPPELIN-5307] Ignore the single quote and double quote in sql comment

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
@@ -102,7 +102,7 @@ public class SqlSplitter {
         multiLineComment = false;
       }
 
-      if (character == '\'') {
+      if (character == '\'' && (!singleLineComment && !multiLineComment)) {
         if (singleQuoteString) {
           singleQuoteString = false;
         } else if (!doubleQuoteString) {
@@ -110,7 +110,7 @@ public class SqlSplitter {
         }
       }
 
-      if (character == '"') {
+      if (character == '"' && (!singleLineComment && !multiLineComment)) {
         if (doubleQuoteString && index > 0) {
           doubleQuoteString = false;
         } else if (!singleQuoteString) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/SqlSplitter.java
@@ -102,7 +102,7 @@ public class SqlSplitter {
         multiLineComment = false;
       }
 
-      if (character == '\'' && (!singleLineComment && !multiLineComment)) {
+      if (character == '\'' && !(singleLineComment || multiLineComment)) {
         if (singleQuoteString) {
           singleQuoteString = false;
         } else if (!doubleQuoteString) {
@@ -110,7 +110,7 @@ public class SqlSplitter {
         }
       }
 
-      if (character == '"' && (!singleLineComment && !multiLineComment)) {
+      if (character == '"' && !(singleLineComment || multiLineComment)) {
         if (doubleQuoteString && index > 0) {
           doubleQuoteString = false;
         } else if (!singleQuoteString) {

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/util/SqlSplitterTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/interpreter/util/SqlSplitterTest.java
@@ -330,4 +330,28 @@ public class SqlSplitterTest {
     assertEquals(1, sqls.size());
     assertEquals("select a \n from table_1", sqls.get(0));
   }
+
+  @Test
+  public void testQuoteInComment() {
+    SqlSplitter sqlSplitter = new SqlSplitter();
+    List<String> sqls = sqlSplitter.splitSql("show tables;-- comment_1'\ndescribe table_1");
+    assertEquals(2, sqls.size());
+    assertEquals("show tables", sqls.get(0));
+    assertEquals("\ndescribe table_1", sqls.get(1));
+
+    sqls = sqlSplitter.splitSql("show tables;-- comment_1\"\ndescribe table_1");
+    assertEquals(2, sqls.size());
+    assertEquals("show tables", sqls.get(0));
+    assertEquals("\ndescribe table_1", sqls.get(1));
+
+    sqls = sqlSplitter.splitSql("show tables;/* comment_1' */\ndescribe table_1");
+    assertEquals(2, sqls.size());
+    assertEquals("show tables", sqls.get(0));
+    assertEquals("\ndescribe table_1", sqls.get(1));
+
+    sqls = sqlSplitter.splitSql("show tables;/* comment_1\" */\ndescribe table_1");
+    assertEquals(2, sqls.size());
+    assertEquals("show tables", sqls.get(0));
+    assertEquals("\ndescribe table_1", sqls.get(1));
+  }
 }


### PR DESCRIPTION
### What is this PR for?

This PR is to fix the bug of SqlSplitter when single/double quote in sql comment. UT is added. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5307

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
