### PR TITLE
[ZEPPELIN-5255] Exported note name should included the note id

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -266,12 +266,12 @@ function NotebookCtrl($scope, $route, $routeParams, $location, $rootScope,
         message: 'Do you still want to export this note?',
         callback: function(result) {
           if (result) {
-            saveAsService.saveAs(jsonContent, $scope.note.name, 'zpln');
+            saveAsService.saveAs(jsonContent, $scope.note.name + '_' + $scope.note.id, 'zpln');
           }
         },
       });
     } else {
-      saveAsService.saveAs(jsonContent, $scope.note.name, 'zpln');
+      saveAsService.saveAs(jsonContent, $scope.note.name + '_' + $scope.note.id, 'zpln');
     }
   };
 


### PR DESCRIPTION
### What is this PR for?

Trivial PR to include note id into the exported note name so that the exported note name is consistent with the note name we stored in notebook repo.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5255

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
