### PR TITLE
[ZEPPELIN-5243] Get HIVE_CONF_DIR from enviroment in flink interpreter

### DIFF
--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -450,9 +450,9 @@ class FlinkScalaInterpreter(val properties: Properties) {
   }
 
   private def registerHiveCatalog(): Unit = {
-    val hiveConfDir =
-      properties.getOrDefault("HIVE_CONF_DIR", System.getenv("HIVE_CONF_DIR")).toString
-    if (hiveConfDir == null) {
+    val hiveConfDir = sys.env.getOrElse("HIVE_CONF_DIR",
+      properties.getProperty("HIVE_CONF_DIR", "")).toString
+    if (StringUtils.isBlank(hiveConfDir)) {
       throw new InterpreterException("HIVE_CONF_DIR is not specified");
     }
     val database = properties.getProperty("zeppelin.flink.hive.database", "default")


### PR DESCRIPTION
### What is this PR for?

Trivial PR to get HIVE_CONF_DIR from environment variable in flink interpreter

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5243

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
