### PR TITLE
[ZEPPELIN-5316] Incorrect markdown at '/quickstart/docker.html'

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -133,9 +133,9 @@ Zeppelin service runs on local server, it auto configure itself to use `DockerIn
  - ${ZEPPELIN_HOME}/interpreter/${interpreterGroupName}
  - ${ZEPPELIN_HOME}/conf/zeppelin-site.xml
  - ${ZEPPELIN_HOME}/conf/log4j.properties
- - ${ZEPPELIN_HOME}/conf/log4j_yarn_cluster.properties
- - HADOOP_CONF_DIR
- - SPARK_CONF_DIR
+ - ${ZEPPELIN\_HOME}/conf/log4j\_yarn_cluster.properties
+ - HADOOP\_CONF_DIR
+ - SPARK\_CONF_DIR
  - /etc/krb5.conf
  - Keytab file configured in the interpreter properties
    - zeppelin.shell.keytab.location
@@ -151,12 +151,12 @@ All file paths uploaded to the container, Keep the same path as the local one. T
 When interpreter group is `spark`, Zeppelin sets necessary spark configuration automatically to use Spark on Docker.
 Supports all running modes of `local[*]`, `yarn-client`, and `yarn-cluster` of zeppelin spark interpreter.
 
-#### SPARK_CONF_DIR
+#### SPARK\_CONF_DIR
 
 1. Configuring in the zeppelin-env.sh
 
   Because there are only spark binary files in the interpreter image, no spark conf files are included.
-  The configuration file in the `spark-<version>/conf/` local to the zeppelin service needs to be uploaded to the ``/spark/conf/` directory in the spark interpreter container.
+  The configuration file in the `spark-<version>/conf/` local to the zeppelin service needs to be uploaded to the `/spark/conf/` directory in the spark interpreter container.
   So you need to setting `export SPARK_CONF_DIR=/spark-<version>-path/conf/` in the `zeppelin-env.sh` file.
 
 2. Configuring in the spark Properties
@@ -165,10 +165,10 @@ Supports all running modes of `local[*]`, `yarn-client`, and `yarn-cluster` of z
 
   | properties name | Value | Description |
   | ----- | ----- | ----- |
-  | SPARK_CONF_DIR | /spark-<version>-path.../conf/ | Spark-<version>-path/conf/ path local on the zeppelin service |
+  | SPARK\_CONF_DIR | /spark-<version>-path.../conf/ | Spark-<version>-path/conf/ path local on the zeppelin service |
 
 
-#### HADOOP_CONF_DIR
+#### HADOOP\_CONF_DIR
 
 1. Configuring in the zeppelin-env.sh
 
@@ -182,7 +182,7 @@ Supports all running modes of `local[*]`, `yarn-client`, and `yarn-cluster` of z
 
   | properties name | Value | Description |
   | ----- | ----- | ----- |
-  | HADOOP_CONF_DIR | hadoop-<version>-path/etc/hadoop | hadoop-<version>-path/etc/hadoop path local on the zeppelin service |
+  | HADOOP\_CONF_DIR | hadoop-<version>-path/etc/hadoop | hadoop-<version>-path/etc/hadoop path local on the zeppelin service |
 
 
 #### Accessing Spark UI (or Service running in interpreter container)


### PR DESCRIPTION
### What is this PR for?
Fix incorrect markdown at /quickstart/docker.md

### What type of PR is it?
[Documentation]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5316

### How should this be tested?
* Checked update document locally

### Screenshots (if appropriate)
**Before**
![image](https://issues.apache.org/jira/secure/attachment/13023566/image-2021-04-08-23-15-29-553.png)
**After**
![image](https://user-images.githubusercontent.com/8870299/114047424-a38ef880-98c4-11eb-8a74-26e03336d22f.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
