### PR TITLE
[ZEPPELIN-5341] Apply syntax highlight for sample JSON in REST API documents

### DIFF
--- a/docs/usage/rest_api/configuration.md
+++ b/docs/usage/rest_api/configuration.md
@@ -57,7 +57,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       <td> sample JSON response
       </td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -84,7 +85,9 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     "zeppelin.server.allowed.origins":"*",
     "zeppelin.encoding": "UTF-8"
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -113,7 +116,9 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td> sample JSON response
       </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -125,7 +130,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     "zeppelin.ssl": "false",
     "zeppelin.ssl.client.auth": "false"
   }
-}</pre>
-      </td>
+}
+```
+</td>
     </tr>
   </table>

--- a/docs/usage/rest_api/credential.md
+++ b/docs/usage/rest_api/credential.md
@@ -56,7 +56,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       <td> sample JSON response
       </td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -72,7 +73,9 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
       }
     }
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -99,24 +102,26 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <pre>
+
+```json
 {
   "entity": "e1",
   "username": "user",
   "password": "password"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -145,8 +150,11 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -175,8 +183,11 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+        
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 

--- a/docs/usage/rest_api/helium.md
+++ b/docs/usage/rest_api/helium.md
@@ -55,7 +55,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -67,7 +68,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
           "type": "APPLICATION",
           "name": "zeppelin.clock",
           "description": "Clock (example)",
-          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
+          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example
+-clock-0.7.0-SNAPSHOT.jar",
           "className": "org.apache.zeppelin.example.app.clock.Clock",
           "resources": [
             [
@@ -81,8 +83,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -110,7 +112,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -122,7 +125,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
           "type": "APPLICATION",
           "name": "zeppelin.clock",
           "description": "Clock (example)",
-          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
+          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example
+-clock-0.7.0-SNAPSHOT.jar",
           "className": "org.apache.zeppelin.example.app.clock.Clock",
           "resources": [
             [
@@ -136,8 +140,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -165,7 +169,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -177,7 +182,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
           "type": "APPLICATION",
           "name": "zeppelin.clock",
           "description": "Clock (example)",
-          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
+          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example
+-clock-0.7.0-SNAPSHOT.jar",
           "className": "org.apache.zeppelin.example.app.clock.Clock",
           "resources": [
             [
@@ -191,8 +197,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -223,7 +229,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -235,7 +242,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
           "type": "APPLICATION",
           "name": "zeppelin.clock",
           "description": "Clock (example)",
-          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example-clock-0.7.0-SNAPSHOT.jar",
+          "artifact": "zeppelin-examples\/zeppelin-example-clock\/target\/zeppelin-example
+-clock-0.7.0-SNAPSHOT.jar",
           "className": "org.apache.zeppelin.example.app.clock.Clock",
           "resources": [
             [
@@ -249,8 +257,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -281,14 +289,15 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": "app_2C5FYRZ1E-20170108-040449_2068241472zeppelin_clock"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -348,10 +357,11 @@ zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNA
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {"status":"OK"}
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -379,8 +389,11 @@ zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNA
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+        
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -408,8 +421,11 @@ zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNA
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK","body":["zeppelin_horizontalbar","zeppelin-bubblechart"]}</code>
-      </td>
+        
+```json
+{"status":"OK","body":["zeppelin_horizontalbar","zeppelin-bubblechart"]}
+```
+</td>
     </tr>
   </table>
 <br/>
@@ -437,14 +453,20 @@ zeppelin-examples/zeppelin-example-clock/target/zeppelin-example-clock-0.7.0-SNA
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <code>["zeppelin-bubblechart", "zeppelin_horizontalbar"]</code>
-      </td>
+        
+```json
+["zeppelin-bubblechart", "zeppelin_horizontalbar"]
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+        
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 <br/>

--- a/docs/usage/rest_api/interpreter.md
+++ b/docs/usage/rest_api/interpreter.md
@@ -57,7 +57,8 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -104,8 +105,8 @@ The role of registered interpreters, settings and interpreters group are describ
     }
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -133,7 +134,8 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -187,8 +189,8 @@ The role of registered interpreters, settings and interpreters group are describ
     }
   ]
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
   
@@ -219,7 +221,8 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -250,8 +253,8 @@ The role of registered interpreters, settings and interpreters group are describ
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -282,7 +285,8 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <pre>
+
+```json
 {
   "name": "Markdown setting name",
   "group": "md",
@@ -307,13 +311,14 @@ The role of registered interpreters, settings and interpreters group are describ
     }
   ]
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -343,8 +348,8 @@ The role of registered interpreters, settings and interpreters group are describ
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -371,7 +376,8 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <pre>
+
+```json
 {
   "name": "Markdown setting name",
   "group": "md",
@@ -396,13 +402,14 @@ The role of registered interpreters, settings and interpreters group are describ
     }
   ]
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -432,8 +439,8 @@ The role of registered interpreters, settings and interpreters group are describ
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -461,8 +468,11 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -491,18 +501,22 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON input (Optional)</td>
       <td>
-        <pre>
+
+```json
 {
   "noteId": "2AVQJVC8N"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -530,20 +544,24 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <pre>
+
+```json
 {
   "id": "securecentral",
   "url": "https://repo1.maven.org/maven2",
   "snapshot": false
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <code>{"status":"OK"}</code>
-      </td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -593,14 +611,15 @@ The role of registered interpreters, settings and interpreters group are describ
     <tr>
       <td>Sample JSON response</td>
         <td>
-          <pre>
+
+```json
 {
   "status": "OK",
   "body": [ "textarea", "string", ...
   ]
 }            
-          </pre>
-        </td>
+```
+</td>
     </td>        
   </table>  
   

--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -55,7 +55,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -69,7 +71,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "id":"2A94M5J1Z"
     }
   ]
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -97,11 +101,18 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input (without paragraphs) </td>
-      <td><pre>{"name": "name of new note"}</pre></td>
+      <td>
+
+```json
+{"name": "name of new note"}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON input (with initial paragraphs) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "name": "name of new note",
   "paragraphs": [
@@ -126,16 +137,22 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       }
     }
   ]
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": "2AZPHY918"
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -163,7 +180,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "body": [
@@ -181,7 +200,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "started":"Tue Nov 24 14:21:40 KST 2015"
     }
   ]
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -209,14 +230,17 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": {
     "paragraphs": [
       {
-        "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age < 30 \ngroup by age \norder by age",
+        "text": "%sql \nselect age, count(1) value\nfrom bank \nwhere age < 30 \ngroup by
+ age \norder by age",
         "config": {
           "colWidth": 4,
           "graph": {
@@ -263,7 +287,8 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
           "msg": [
             {
               "type": "TABLE",
-              "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+              "data": "age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26
+\t77\n27\t94\n28\t103\n29\t97\n"
             }
           ]
         },
@@ -282,7 +307,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     },
     "info": {}
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -309,7 +336,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK","message": ""}</pre></td>
+      <td>
+
+```json
+{"status": "OK","message": ""}
+```
+</td>
     </tr>
   </table>
 
@@ -338,16 +370,25 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input </td>
-      <td><pre>{"name": "name of new note"}</pre></td>
+      <td>
+
+```json
+{"name": "name of new note"}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": "2AZPHY918"
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -378,11 +419,21 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input </td>
-      <td><pre>{"name": "new name of a note"}</pre></td>
+      <td>
+
+```json
+{"name": "new name of a note"}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status":"OK"}</pre></td>
+      <td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -409,7 +460,10 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td> 500 </td>
     </tr>
     <td> sample JSON response </td>
-      <td><pre>{
+      <td>
+
+```json
+{
   "paragraphs": [
     {
       "text": "%md This is my new paragraph in my new note",
@@ -433,7 +487,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   "angularObjects": {},
   "config": {},
   "info": {}
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -460,7 +516,10 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>sample JSON input</td>
-      <td><pre>
+      <td>
+
+
+```json
 {
   "paragraphs": [
     {
@@ -485,16 +544,22 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   "angularObjects": {},
   "config": {},
   "info": {}
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td>sample JSON response</td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": "2AZPHY918"
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -523,24 +588,33 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
     <tr>
        <td> sample JSON error response </td>
        <td>
-         <pre>
-           {
-             "status": "NOT_FOUND",
-             "message": "note not found."
-           }
-         </pre><br />
-         <pre>
-           {
-             "status": "PRECONDITION_FAILED",
-             "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter bind"
-           }
-         </pre>
-       </td>
+
+```json
+{
+  "status": "NOT_FOUND",
+  "message": "note not found."
+}
+```
+<br />
+
+```json
+{
+  "status": "PRECONDITION_FAILED",
+  "message": "paragraph_1469771130099_-278315611 Not selected or Invalid Interpreter
+ bind"
+}
+```
+</td>
     </tr>
   </table>
 
@@ -567,7 +641,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status":"OK"}</pre></td>
+      <td>
+
+```json
+{"status":"OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -602,7 +681,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>sample JSON response</td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
     </tr>
   </table>
@@ -633,24 +717,34 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input (add to the last) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "title": "Paragraph insert revised",
   "text": "%spark\nprintln(\"Paragraph insert revised\")"
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON input (add to specific index) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "title": "Paragraph insert revised",
   "text": "%spark\nprintln(\"Paragraph insert revised\")",
   "index": 0
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON input (providing paragraph config) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "title": "paragraph title2",
   "text": "paragraph text2",
@@ -666,16 +760,22 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       }
     ]
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
   "body": "20151218-100330\_1754029574"
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -703,7 +803,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -747,7 +849,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     "status": "FINISHED",
     "progressUpdateIntervalMs": 500
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -775,7 +879,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "body": {
@@ -784,7 +890,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "finished":"Tue Nov 24 14:21:40 KST 2015",
       "started":"Tue Nov 24 14:21:39 KST 2015"
     }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -824,20 +932,27 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>sample JSON input</td>
-      <td><pre>
+      <td>
+
+```json
 {
   "title": "Hello world",
   "text": "println(\"hello world\")"
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td>sample JSON response</td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "message": ""
-  }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -876,7 +991,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>sample JSON input</td>
-      <td><pre>
+      <td>
+
+```json
 {
   "colWidth": 6.0,
   "graph": {
@@ -903,16 +1020,21 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
   "editorHide": true,
   "editorMode": "ace/mode/markdown",
   "tableHide": false
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td>sample JSON response</td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status":"OK",
   "message":"",
   "body":{
-    "text":"%sql \nselect age, count(1) value\nfrom bank \nwhere age \u003c 30 \ngroup by age \norder by age",
+    "text":"%sql \nselect age, count(1) value\nfrom bank \nwhere age \u003c 30 \ngroup by
+ age \norder by age",
     "config":{
       "colWidth":6.0,
       "graph":{
@@ -952,7 +1074,8 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "msg": [
         {
           "type":"TABLE",
-          "data":"age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77\n27\t94\n28\t103\n29\t97\n"
+          "data":"age\tvalue\n19\t4\n20\t3\n21\t7\n22\t9\n23\t20\n24\t24\n25\t44\n26\t77
+\n27\t94\n28\t103\n29\t97\n"
         }
       ]
     },
@@ -962,7 +1085,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     "status":"FINISHED",
     "progressUpdateIntervalMs":500
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -989,7 +1114,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK","message": ""}</pre></td>
+      <td>
+
+```json
+{"status": "OK","message": ""}
+```
+</td>
     </tr>
   </table>
 
@@ -1016,18 +1146,27 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "name": "name of new note",
   "params": {
     "formLabel1": "value1",
     "formLabel2": "value2"
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -1054,30 +1193,44 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input (optional, only needed when if you want to update dynamic form's value) </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "name": "name of new note",
   "params": {
     "formLabel1": "value1",
     "formLabel2": "value2"
   }
-}</pre></td>
+}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>    
     <tr>
       <td> sample JSON error </td>
-      <td><pre>
+      <td>
+
+```json
 {
    "status": "INTERNAL\_SERVER\_ERROR",
    "body": {
        "code": "ERROR",
        "type": "TEXT",
-       "msg": "bash: -c: line 0: unexpected EOF while looking for matching ``'\nbash: -c: line 1: syntax error: unexpected end of file\nExitValue: 2"
+       "msg": "bash: -c: line 0: unexpected EOF while looking for matching ``'\nbash: -c:
+ line 1: syntax error: unexpected end of file\nExitValue: 2"
    }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -1104,7 +1257,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -1131,7 +1289,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK","message": ""}</pre></td>
+      <td>
+
+```json
+{"status": "OK","message": ""}
+```
+</td>
     </tr>
   </table>
 
@@ -1158,7 +1321,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td>Sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK",
   "body": [
@@ -1169,7 +1334,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       "text":""
     }
   ]
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -1198,11 +1365,21 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input </td>
-      <td><pre>{"cron": "cron expression of note", "releaseResource": "false"}</pre></td>
+      <td>
+
+```json
+{"cron": "cron expression of note", "releaseResource": "false"}
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -1230,7 +1407,12 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>{"status": "OK"}</pre></td>
+      <td>
+
+```json
+{"status": "OK"}
+```
+</td>
     </tr>
   </table>
 
@@ -1259,14 +1441,18 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
    "status": "OK", 
    "body": {
       "cron": "0 0/1 * * * ?", 
       "releaseResource": true
    }
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 
@@ -1301,7 +1487,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {  
    "status":"OK",
    "message":"",
@@ -1320,7 +1508,8 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       ]
    }
 }
-      </pre></td>
+```
+</td>
     </tr>
   </table>
 
@@ -1351,7 +1540,9 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     </tr>
     <tr>
       <td> sample JSON input </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "readers": [
     "user1"
@@ -1366,14 +1557,19 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     "user1"
   ]
 }
-</pre></td>
+```
+</td>
     </tr>
     <tr>
       <td> sample JSON response </td>
-      <td><pre>
+      <td>
+
+```json
 {
   "status": "OK"
-}</pre></td>
+}
+```
+</td>
     </tr>
   </table>
 

--- a/docs/usage/rest_api/notebook_repository.md
+++ b/docs/usage/rest_api/notebook_repository.md
@@ -55,7 +55,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -74,8 +75,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     }
   ]
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -104,13 +105,14 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": ""
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -143,20 +145,22 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>Sample JSON input</td>
       <td>
-        <pre>
+
+```json
 {
   "name":"org.apache.zeppelin.notebook.repo.GitNotebookRepo",
   "settings":{
     "Notebook Path":"/tmp/notebook/"
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>Sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "",
@@ -173,7 +177,7 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     ]
   }
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>

--- a/docs/usage/rest_api/zeppelin_server.md
+++ b/docs/usage/rest_api/zeppelin_server.md
@@ -55,7 +55,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK",
   "message": "Zeppelin version",
@@ -67,8 +68,8 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     }
   ]
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>
 
@@ -94,22 +95,24 @@ If you work with Apache Zeppelin and find a need for an additional REST API, ple
     <tr>
       <td>sample JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status": "OK"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
     <tr>
       <td>sample error JSON response</td>
       <td>
-        <pre>
+
+```json
 {
   "status":"NOT_ACCEPTABLE",
   "message":"Please check LOG level specified. Valid values: DEBUG, ERROR, FATAL, INFO, TRACE, WARN"
 }
-        </pre>
-      </td>
+```
+</td>
     </tr>
   </table>


### PR DESCRIPTION
### What is this PR for?
Apply syntax highlight for sample JSON in REST API documents


### What type of PR is it?
[Documentation]


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5341

### How should this be tested?
* Checked updated documents locally

### Screenshots (if appropriate)
Before
![image](https://user-images.githubusercontent.com/8870299/116114020-f43f8780-a6f3-11eb-8d5f-7074adc307c0.png)

After
![image](https://user-images.githubusercontent.com/8870299/116114055-fc97c280-a6f3-11eb-9270-69795da0e82b.png)

### Questions:
* Does the licenses files need update? No 
* Is there breaking changes for older versions? No
* Does this needs documentation? No
