### PR TITLE
ZEPPELIN-5342: Fixes infinite loop in zeppelin.sh

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -44,7 +44,6 @@ fi
 
 function usage() {
     echo "Usage: bin/zeppelin.sh [--config <conf-dir>] [--run <noteId>]"
-    exit 0
 }
 
 POSITIONAL=()
@@ -62,11 +61,14 @@ do
     shift # past argument
     shift # past value
     ;;
-    --help)
+    -h|--help)
         usage
+        exit 0
         ;;
-    -h)
+    *)
+        echo "Unsupported argument."
         usage
+        exit 1
         ;;
   esac
 done


### PR DESCRIPTION

### What is this PR for?
If a user is passing an invalid argument to zeppelin.sh it freezes in an infinite loop. This small change changes this behavior and outputs usage information instead of looping forever in the `while` cycle.


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5342

### How should this be tested?

Just call `zeppelin.sh` with any type of unsupported arguments