### PR TITLE
[ZEPPELIN-5338]. Add logging prefix in interpreter.sh for easy diagnose

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -310,5 +310,6 @@ else
 fi
 
 # Don't remove this echo, it is for diagnose, this line of output will be redirected to java log4j output.
-echo "Interpreter launch command: ${INTERPRETER_RUN_COMMAND[@]}"
+# Output that starts with `[INFO]` will be redirected to log4j output.
+echo "[INFO] Interpreter launch command: ${INTERPRETER_RUN_COMMAND[@]}"
 exec "${INTERPRETER_RUN_COMMAND[@]}"

--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -310,6 +310,7 @@ else
 fi
 
 # Don't remove this echo, it is for diagnose, this line of output will be redirected to java log4j output.
-# Output that starts with `[INFO]` will be redirected to log4j output.
+# Output that starts with `[INFO]` will be redirected to log4j INFO output. Other outputs from interpreter.sh
+# will be redirected to log4j DEBUG output.
 echo "[INFO] Interpreter launch command: ${INTERPRETER_RUN_COMMAND[@]}"
 exec "${INTERPRETER_RUN_COMMAND[@]}"

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/util/ProcessLauncher.java
@@ -185,7 +185,7 @@ public abstract class ProcessLauncher implements ExecuteResultHandler {
     @Override
     protected void processLine(String s, int i) {
       // print Interpreter launch command for diagnose purpose
-      if (s.startsWith("Interpreter launch command")) {
+      if (s.startsWith("[INFO]")) {
         LOGGER.info(s);
       } else {
         LOGGER.debug("Process Output: {}", s);


### PR DESCRIPTION
### What is this PR for?

Currently, we have to change log4j.properties to get more output from script `interpreter.sh` in log4j output for diagnose. This PR is to add one trick: as long as the output is start with `[INFO]` in `interpreter.sh`, it will be redirected to log4j output.  

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5338

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
