### PR TITLE
[ZEPPELIN-5337] Spark scope mode is broken

### DIFF
--- a/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
+++ b/spark/scala-2.10/src/main/scala/org/apache/zeppelin/spark/SparkScala210Interpreter.scala
@@ -40,7 +40,8 @@ class SparkScala210Interpreter(override val conf: SparkConf,
                                override val depFiles: java.util.List[String],
                                override val properties: Properties,
                                override val interpreterGroup: InterpreterGroup,
-                               override val sparkInterpreterClassLoader: URLClassLoader)
+                               override val sparkInterpreterClassLoader: URLClassLoader,
+                               val outputDir: File)
   extends BaseSparkScalaInterpreter(conf, depFiles, properties, interpreterGroup, sparkInterpreterClassLoader) {
 
   lazy override val LOGGER: Logger = LoggerFactory.getLogger(getClass)
@@ -57,9 +58,7 @@ class SparkScala210Interpreter(override val conf: SparkConf,
     if (InterpreterContext.get() != null) {
       interpreterOutput.setInterpreterOutput(InterpreterContext.get().out)
     }
-    val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
-    this.outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
-    outputDir.deleteOnExit()
+
     LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
     // Only Spark1 requires to create http server, Spark2 removes HttpServer class.

--- a/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
+++ b/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
@@ -40,7 +40,8 @@ class SparkScala211Interpreter(override val conf: SparkConf,
                                override val depFiles: java.util.List[String],
                                override val properties: Properties,
                                override val interpreterGroup: InterpreterGroup,
-                               override val sparkInterpreterClassLoader: URLClassLoader)
+                               override val sparkInterpreterClassLoader: URLClassLoader,
+                               val outputDir: File)
   extends BaseSparkScalaInterpreter(conf, depFiles, properties, interpreterGroup, sparkInterpreterClassLoader) {
 
   import SparkScala211Interpreter._
@@ -56,12 +57,10 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     if (sparkMaster == "yarn-client") {
       System.setProperty("SPARK_YARN_MODE", "true")
     }
-    // Only Spark1 requires to create http server, Spark2 removes HttpServer class.
-    val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
-    this.outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+
     LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
-    outputDir.deleteOnExit()
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
+    // Only Spark1 requires to create http server, Spark2 removes HttpServer class.
     startHttpServer(outputDir).foreach { case (server, uri) =>
       sparkHttpServer = server
       conf.set("spark.repl.class.uri", uri)

--- a/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
+++ b/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
@@ -40,7 +40,8 @@ class SparkScala212Interpreter(override val conf: SparkConf,
                                override val depFiles: java.util.List[String],
                                override val properties: Properties,
                                override val interpreterGroup: InterpreterGroup,
-                               override val sparkInterpreterClassLoader: URLClassLoader)
+                               override val sparkInterpreterClassLoader: URLClassLoader,
+                               val outputDir: File)
   extends BaseSparkScalaInterpreter(conf, depFiles, properties, interpreterGroup, sparkInterpreterClassLoader) {
 
   lazy override val LOGGER: Logger = LoggerFactory.getLogger(getClass)
@@ -54,11 +55,8 @@ class SparkScala212Interpreter(override val conf: SparkConf,
     if (sparkMaster == "yarn-client") {
       System.setProperty("SPARK_YARN_MODE", "true")
     }
-    // Only Spark1 requires to create http server, Spark2 removes HttpServer class.
-    val rootDir = conf.get("spark.repl.classdir", System.getProperty("java.io.tmpdir"))
-    this.outputDir = Files.createTempDirectory(Paths.get(rootDir), "spark").toFile
+
     LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
-    outputDir.deleteOnExit()
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
 
     val settings = new Settings()

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -63,8 +63,6 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
 
   protected var sparkSession: Object = _
 
-  protected var outputDir: File = _
-
   protected var userJars: Seq[String] = _
 
   protected var sparkHttpServer: Object = _


### PR DESCRIPTION
### What is this PR for?

Spark scope mode is broken because we use different scala shell output dir for each spark scala shell. This PR fix this issue by using a shared output folder for all the scala shell instances.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5337

### How should this be tested?
* UT is added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
