### PR TITLE
[ZEPPELIN-5359] The names of the two methods do not fit.

### DIFF
--- a/flink/interpreter/pom.xml
+++ b/flink/interpreter/pom.xml
@@ -50,6 +50,14 @@
     <flink.bin.download.url>https://archive.apache.org/dist/flink/flink-${flink.version}/flink-${flink.version}-bin-scala_${scala.binary.version}.tgz</flink.bin.download.url>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>conjars repo</id>
+      <name>conjars repo</name>
+      <url>https://conjars.org/repo/</url>
+    </repository>
+  </repositories>
+  
   <dependencies>
 
     <dependency>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -313,7 +313,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     return completer;
   }
 
-  private void initStatementMap() {
+  private void clearStatementMap() {
     for (JDBCUserConfigurations configurations : jdbcUserConfigurationsMap.values()) {
       try {
         configurations.initStatementMap();
@@ -323,7 +323,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     }
   }
 
-  private void initConnectionPoolMap() {
+  private void clearConnectionPoolMap() {
     for (String key : jdbcUserConfigurationsMap.keySet()) {
       try {
         closeDBPool(key, DEFAULT_KEY);
@@ -343,8 +343,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
   public void close() {
     super.close();
     try {
-      initStatementMap();
-      initConnectionPoolMap();
+      clearStatementMap();
+      clearConnectionPoolMap();
     } catch (Exception e) {
       LOGGER.error("Error while closing...", e);
     }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -316,7 +316,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private void clearStatementMap() {
     for (JDBCUserConfigurations configurations : jdbcUserConfigurationsMap.values()) {
       try {
-        configurations.initStatementMap();
+        configurations.clearStatementMap();
       } catch (Exception e) {
         LOGGER.error("Error while closing paragraphIdStatementMap statement...", e);
       }
@@ -332,9 +332,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
       }
       try {
         JDBCUserConfigurations configurations = jdbcUserConfigurationsMap.get(key);
-        configurations.initConnectionPoolMap();
+        configurations.clearConnectionPoolMap();
       } catch (SQLException e) {
-        LOGGER.error("Error while closing initConnectionPoolMap.", e);
+        LOGGER.error("Error while clearing connection pool map.", e);
       }
     }
   }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
@@ -43,14 +43,14 @@ public class JDBCUserConfigurations {
     isSuccessful = new HashMap<>();
   }
 
-  public void initStatementMap() throws SQLException {
+  public void clearStatementMap() throws SQLException {
     for (Statement statement : paragraphIdStatementMap.values()) {
       statement.close();
     }
     paragraphIdStatementMap.clear();
   }
 
-  public void initConnectionPoolMap() throws SQLException {
+  public void clearConnectionPoolMap() throws SQLException {
     poolingDriverMap.clear();
     isSuccessful.clear();
   }


### PR DESCRIPTION
The names of the two methods do not fit.

### What is this PR for?
"initStatementMap" and "initConnectionPoolMap" the names of the two methods do not fit.The  two metheds is not use for init but clear.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5359
