### PR TITLE
[ZEPPELIN-5343] Zeppelin Interface becomes unresponsive

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -67,7 +67,7 @@ public class NotebookSocket extends WebSocketAdapter {
   }
 
   public synchronized void send(String serializeMessage) throws IOException {
-    connection.getRemote().sendString(serializeMessage);
+    connection.getRemote().sendStringByFuture(serializeMessage);
   }
 
   public String getUser() {


### PR DESCRIPTION
### What is this PR for?

This is experimental PR for fixing the zeppelin unresponsive issue. Regarding the jstack, it seems blocked in `NotebookSocket#send` method, this PR change it from sync call to async call. 

### What type of PR is it?
[Bug Fix ] 

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5343

### How should this be tested?
* CI 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
