### PR TITLE
[ZEPPELIN-5365] displayedJMWebUrl of flink interpreter is not correctly initialized

### DIFF
--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -321,7 +321,7 @@ class FlinkScalaInterpreter(val properties: Properties) {
           }
       }
 
-      if (this.displayedJMWebUrl != null) {
+      if (this.displayedJMWebUrl == null) {
         // use jmWebUrl as displayedJMWebUrl if it is not set
         this.displayedJMWebUrl = this.jmWebUrl
       }


### PR DESCRIPTION


### What is this PR for?

Trivial PR fix the displayedJMWebUrl initialization.

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5365

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
