### PR TITLE
[ZEPPELIN-5349] fix multithread  simultaneously   run saveToFile method   s…

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -871,6 +871,10 @@ public class ZeppelinConfiguration {
         completeConfiguration.put(c.getVarName(), sysConfig.getString(c.getVarName()));
       } else if (envConfig.containsKey(c.name())) {
         completeConfiguration.put(c.getVarName(), envConfig.getString(c.name()));
+      }else {
+        if (getString(c)!=null){
+          completeConfiguration.put(c.getVarName(),getString(c));
+        }
       }
     }
     return completeConfiguration;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -343,7 +343,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
     }
   }
 
-  public void saveToFile() throws IOException {
+  public synchronized void saveToFile() throws IOException {
     InterpreterInfoSaving info = new InterpreterInfoSaving();
     info.interpreterSettings = Maps.newHashMap(interpreterSettings);
     info.interpreterRepositories = interpreterRepositories;


### PR DESCRIPTION
ZEPPELIN-5349.: fix  InterpreterSettingManager init error  then init again 
### What is this PR for?

This problem is because
   The loadFromFile() method of the InterpreterSettingManager class during initialization
    (This method is mainly to load all interpreters and dependency processing) It is found that newly added  interpreter is configured with dependent jar packages ,The InterpreterSetting class will start the thread to do interpreter dependency processing, and then trigger the` interpreterSettingManager.saveToFile()` operation. Save the interpreter.json file. This operation is time-consuming. At the same time, the main thread then executes saveToFile();  this time there is a thread synchronization problem
      There is a high probability that the main thread exception  and after this happened 

  ```  
  Notebook notebook = ServiceLocatorUtilities.getService( 
                 sharedServiceLocator, Notebook.class.getName()); 
   ```
will be executed again, causing   InterpreterSettingManager init again，Thrift Server start twice 


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-5349

### How should this be tested?
  add a new Interpreter  include dependency jar 


### Screenshots (if appropriate)


