### PR TITLE
[ZEPPELIN-5352] Support flink in k8s mode

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -248,7 +248,9 @@ elif [[ "${INTERPRETER_ID}" == "flink" ]]; then
 
   FLINK_PYTHON_JAR=$(find "${FLINK_HOME}/opt" -name 'flink-python_*.jar')
   ZEPPELIN_INTP_CLASSPATH+=":${FLINK_PYTHON_JAR}"
-  FLINK_APP_JAR="$(ls "${ZEPPELIN_HOME}"/interpreter/flink/zeppelin-flink-*.jar)"
+  if [[ -z "${FLINK_APP_JAR}" ]]; then
+    FLINK_APP_JAR="$(ls "${ZEPPELIN_HOME}"/interpreter/flink/zeppelin-flink-*.jar)"
+  fi
 
   if [[ -n "${HADOOP_CONF_DIR}" ]] && [[ -d "${HADOOP_CONF_DIR}" ]]; then
     ZEPPELIN_INTP_CLASSPATH+=":${HADOOP_CONF_DIR}"
@@ -300,9 +302,9 @@ if [[ -n "${SPARK_SUBMIT}" ]]; then
   else
     INTERPRETER_RUN_COMMAND+=("${SPARK_SUBMIT}" "--class" "${ZEPPELIN_SERVER}" "--driver-class-path" "${ZEPPELIN_INTP_CLASSPATH_OVERRIDES}:${ZEPPELIN_INTP_CLASSPATH}" "--driver-java-options" "${JAVA_INTP_OPTS}" "${SPARK_SUBMIT_OPTIONS_ARRAY[@]}" "${ZEPPELIN_SPARK_CONF_ARRAY[@]}" "${SPARK_APP_JAR}" "${CALLBACK_HOST}" "${PORT}" "${INTP_GROUP_ID}" "${INTP_PORT}")
   fi
-elif [[ "${ZEPPELIN_FLINK_YARN_APPLICATION}" == "true" ]]; then
-  IFS=' ' read -r -a ZEPPELIN_FLINK_YARN_APPLICATION_CONF_ARRAY <<< "${ZEPPELIN_FLINK_YARN_APPLICATION_CONF}"
-  INTERPRETER_RUN_COMMAND+=("${FLINK_HOME}/bin/flink" "run-application" "-c" "${ZEPPELIN_SERVER}" "-t" "yarn-application" "${ZEPPELIN_FLINK_YARN_APPLICATION_CONF_ARRAY[@]}" "${FLINK_APP_JAR}" "${CALLBACK_HOST}" "${PORT}" "${INTP_GROUP_ID}" "${INTP_PORT}")
+elif [[ -n "${ZEPPELIN_FLINK_APPLICATION_MODE}" ]]; then
+  IFS=' ' read -r -a ZEPPELIN_FLINK_APPLICATION_MODE_CONF_ARRAY <<< "${ZEPPELIN_FLINK_APPLICATION_MODE_CONF}"
+  INTERPRETER_RUN_COMMAND+=("${FLINK_HOME}/bin/flink" "run-application" "-c" "${ZEPPELIN_SERVER}" "-t" "${ZEPPELIN_FLINK_APPLICATION_MODE}" "${ZEPPELIN_FLINK_APPLICATION_MODE_CONF_ARRAY[@]}" "${FLINK_APP_JAR}" "${CALLBACK_HOST}" "${PORT}" "${INTP_GROUP_ID}" "${INTP_PORT}")
 else
   IFS=' ' read -r -a JAVA_INTP_OPTS_ARRAY <<< "${JAVA_INTP_OPTS}"
   IFS=' ' read -r -a ZEPPELIN_INTP_MEM_ARRAY <<< "${ZEPPELIN_INTP_MEM}"

--- a/flink/interpreter/pom.xml
+++ b/flink/interpreter/pom.xml
@@ -42,6 +42,7 @@
     <hive.version>2.3.4</hive.version>
     <hiverunner.version>4.0.0</hiverunner.version>
     <grpc.version>1.15.0</grpc.version>
+    <kubernetes.client.version>5.3.1</kubernetes.client.version>
 
     <scala.macros.version>2.0.1</scala.macros.version>
     <scala.binary.version>2.11</scala.binary.version>
@@ -93,6 +94,13 @@
       <groupId>org.apache.zeppelin</groupId>
       <artifactId>flink1.13-shims</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <version>${kubernetes.client.version}</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/ApplicationModeExecutionEnvironment.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/ApplicationModeExecutionEnvironment.java
@@ -36,15 +36,15 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 
 /**
- * ExecutionEnvironment used for yarn application mode.
+ * ExecutionEnvironment used for application mode (yarn & k8s).
  * Need to add jars of scala shell before submitting jobs.
  */
-public class YarnApplicationExecutionEnvironment extends ExecutionEnvironment {
+public class ApplicationModeExecutionEnvironment extends ExecutionEnvironment {
 
   private FlinkILoop flinkILoop;
   private FlinkScalaInterpreter flinkScalaInterpreter;
 
-  public YarnApplicationExecutionEnvironment(PipelineExecutorServiceLoader executorServiceLoader,
+  public ApplicationModeExecutionEnvironment(PipelineExecutorServiceLoader executorServiceLoader,
                                              Configuration configuration,
                                              ClassLoader userClassloader,
                                              FlinkILoop flinkILoop,

--- a/flink/interpreter/src/main/java/org/apache/zeppelin/flink/ApplicationModeStreamEnvironment.java
+++ b/flink/interpreter/src/main/java/org/apache/zeppelin/flink/ApplicationModeStreamEnvironment.java
@@ -38,17 +38,17 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 
 /**
- * StreamExecutionEnvironment used for yarn application mode.
+ * StreamExecutionEnvironment used for application mode (yarn & k8s).
  * Need to add jars of scala shell before submitting jobs.
  */
-public class YarnApplicationStreamEnvironment extends StreamExecutionEnvironment {
+public class ApplicationModeStreamEnvironment extends StreamExecutionEnvironment {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(YarnApplicationStreamEnvironment.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationModeStreamEnvironment.class);
 
   private FlinkILoop flinkILoop;
   private FlinkScalaInterpreter flinkScalaInterpreter;
 
-  public YarnApplicationStreamEnvironment(PipelineExecutorServiceLoader executorServiceLoader,
+  public ApplicationModeStreamEnvironment(PipelineExecutorServiceLoader executorServiceLoader,
                                           Configuration configuration,
                                           ClassLoader userClassloader,
                                           FlinkILoop flinkILoop,

--- a/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkILoop.scala
+++ b/flink/interpreter/src/main/scala/org/apache/zeppelin/flink/FlinkILoop.scala
@@ -70,17 +70,17 @@ class FlinkILoop(
     scalaBenv: ExecutionEnvironment,
     scalaSenv: StreamExecutionEnvironment
     ) = {
-    if (mode == ExecutionMode.YARN_APPLICATION) {
-      // For yarn application mode, ExecutionEnvironment & StreamExecutionEnvironment has already been created
+    if (ExecutionMode.isApplicationMode(mode)) {
+      // For application mode, ExecutionEnvironment & StreamExecutionEnvironment has already been created
       // by flink itself, we here just try get them via reflection and reconstruct them.
-      val scalaBenv = new ExecutionEnvironment(new YarnApplicationExecutionEnvironment(
+      val scalaBenv = new ExecutionEnvironment(new ApplicationModeExecutionEnvironment(
         getExecutionEnvironmentField(jenv, "executorServiceLoader").asInstanceOf[PipelineExecutorServiceLoader],
         getExecutionEnvironmentField(jenv, "configuration").asInstanceOf[Configuration],
         getExecutionEnvironmentField(jenv, "userClassloader").asInstanceOf[ClassLoader],
         this,
         flinkScalaInterpreter
       ))
-      val scalaSenv = new StreamExecutionEnvironment(new YarnApplicationStreamEnvironment(
+      val scalaSenv = new StreamExecutionEnvironment(new ApplicationModeStreamEnvironment(
         getStreamExecutionEnvironmentField(jsenv, "executorServiceLoader").asInstanceOf[PipelineExecutorServiceLoader],
         getStreamExecutionEnvironmentField(jsenv, "configuration").asInstanceOf[Configuration],
         getStreamExecutionEnvironmentField(jsenv, "userClassloader").asInstanceOf[ClassLoader],

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -77,7 +77,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.ByteBuffer;
@@ -142,6 +141,7 @@ public class RemoteInterpreterServer extends Thread
   private ScheduledExecutorService resultCleanService = Executors.newSingleThreadScheduledExecutor();
 
   private boolean isTest;
+  private boolean isFlinkK8sApplicationMode = false;
 
   private ZeppelinConfiguration zConf;
   // cluster manager client
@@ -321,7 +321,10 @@ public class RemoteInterpreterServer extends Thread
      * should be part of the next release and solve the problem.
      * We may have other threads that are not terminated successfully.
      */
-    System.exit(0);
+    if (!remoteInterpreterServer.isFlinkK8sApplicationMode) {
+      LOGGER.info("Force shutting down");
+      System.exit(0);
+    }
   }
 
   // Submit interpreter process metadata information to cluster metadata
@@ -385,6 +388,12 @@ public class RemoteInterpreterServer extends Thread
       interpreter.setUserName(userName);
 
       interpreterGroup.addInterpreterToSession(new LazyOpenInterpreter(interpreter), sessionId);
+      if (className.endsWith(".FlinkInterpreter")) {
+        this.isFlinkK8sApplicationMode = "kubernetes-application".equals(properties.get("flink.execution.mode"));
+        if (this.isFlinkK8sApplicationMode) {
+          LOGGER.info("Run flink interpreter in k8s application mode");
+        }
+      }
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
       throw new InterpreterRPCException("Fail to create interpreter, cause: " + e.toString());
@@ -701,8 +710,10 @@ public class RemoteInterpreterServer extends Thread
       }
 
       if (server.isServing()) {
-        LOGGER.info("Force shutting down");
-        System.exit(1);
+        if (!isFlinkK8sApplicationMode) {
+          LOGGER.info("Force shutting down");
+          System.exit(1);
+        }
       }
 
       LOGGER.info("Shutting down");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
@@ -214,9 +214,9 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
         synchronized (this) {
           notifyAll();
         }
-      } else if (isFlinkYarnApplicationMode() && exitValue == 0) {
+      } else if (isFlinkApplicationMode() && exitValue == 0) {
         // Don't update transition state when flink launcher process exist
-        // in yarn application mode.
+        // in flink application mode.
         synchronized (this) {
           notifyAll();
         }
@@ -237,9 +237,8 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
               getEnv().getOrDefault("ZEPPELIN_SPARK_YARN_CLUSTER", "false"));
     }
 
-    private boolean isFlinkYarnApplicationMode() {
-      return Boolean.parseBoolean(
-              getEnv().getOrDefault("ZEPPELIN_FLINK_YARN_APPLICATION", "false"));
+    private boolean isFlinkApplicationMode() {
+      return getEnv().containsKey("ZEPPELIN_FLINK_APPLICATION_MODE");
     }
 
     @Override


### PR DESCRIPTION
### What is this PR for?

Flink support k8s native mode from flink 1.11, this PR is to support k8s-application mode. The implementation is very similar as yarn-application mode.

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5352

### How should this be tested?
* Ci pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
