### PR TITLE
[ZEPPELIN-5379] LIST_CONFIGURATIONS command cannot return the default…

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -871,6 +871,10 @@ public class ZeppelinConfiguration {
         completeConfiguration.put(c.getVarName(), sysConfig.getString(c.getVarName()));
       } else if (envConfig.containsKey(c.name())) {
         completeConfiguration.put(c.getVarName(), envConfig.getString(c.name()));
+      }else {
+        if (getString(c)!=null){
+          completeConfiguration.put(c.getVarName(),getString(c));
+        }
       }
     }
     return completeConfiguration;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -864,17 +864,10 @@ public class ZeppelinConfiguration {
    * @return
    */
   public Map<String, String> getCompleteConfiguration() {
-    Map<String, String> completeConfiguration = new HashMap<>(properties);
-    // Is it possible that we overwrite properties
+    Map<String, String> completeConfiguration = new HashMap<>();
     for (ConfVars c : ConfVars.values()) {
-      if (sysConfig.containsKey(c.getVarName())) {
-        completeConfiguration.put(c.getVarName(), sysConfig.getString(c.getVarName()));
-      } else if (envConfig.containsKey(c.name())) {
-        completeConfiguration.put(c.getVarName(), envConfig.getString(c.name()));
-      }else {
-        if (getString(c)!=null){
-          completeConfiguration.put(c.getVarName(),getString(c));
-        }
+      if (getString(c) != null){
+        completeConfiguration.put(c.getVarName(), getString(c));
       }
     }
     return completeConfiguration;


### PR DESCRIPTION

### What is this PR for?

when download distirbution package ,  run zeppelin server ,do not config zeppelin-site.xml ,i found LIST_CONFIGURATIONS command cannot return the default configuration in the ZeppelinConfiguration class code,so the web  lack some configuration 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
*  [ZEPPELIN-5379] https://issues.apache.org/jira/browse/ZEPPELIN-5379

### How should this be tested?
* Ci pass and manually tested



### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/7891811/118913595-58a0e000-b95c-11eb-9fd6-4385d9a19d6a.png)


### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
