### PR TITLE
[ZEPPELIN-5380] Add scripts folder to zeppelin-distribution

### DIFF
--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -93,6 +93,9 @@
       <directory>../k8s</directory>
     </fileSet>
     <fileSet>
+      <directory>../scripts</directory>
+    </fileSet>
+    <fileSet>
       <outputDirectory>/lib/node_modules/zeppelin-vis</outputDirectory>
       <directory>../zeppelin-web/src/app/visualization</directory>
     </fileSet>


### PR DESCRIPTION
### What is this PR for?

This PR add scripts folder in the binary distribution, so that user can build images via these scripts

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5380

### How should this be tested?
* No test needed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
