### PR TITLE
[ZEPPELIN-5403] Update kubernetes client to 5.4.1 and fix unit tests

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/pom.xml
+++ b/zeppelin-plugins/launcher/k8s-standard/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <plugin.name>Launcher/K8sStandardInterpreterLauncher</plugin.name>
-        <kubernetes.client.version>5.3.2</kubernetes.client.version>
+        <kubernetes.client.version>5.4.1</kubernetes.client.version>
         <jinjava.version>2.5.4</jinjava.version>
     </properties>
 


### PR DESCRIPTION
### What is this PR for?
This PR re-enables the unit tests in K8's launcher.

### What type of PR is it?
 - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5403

### How should this be tested?
* CI, with several runs

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
