### PR TITLE
[ZEPPELIN-5290] NPE on empty dynamic form input

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -373,7 +373,11 @@ public class Input<T> implements Serializable {
         }
       } else {
         // single-selection
-        expanded = value.toString();
+        if (value == null) {
+          expanded = "";
+        } else {
+          expanded = value.toString();
+        }
       }
       replaced = match.replaceFirst(expanded);
       match = pattern.matcher(replaced);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -373,11 +373,7 @@ public class Input<T> implements Serializable {
         }
       } else {
         // single-selection
-        if (value == null) {
-          expanded = "";
-        } else {
-          expanded = value.toString();
-        }
+        expanded = StringUtils.defaultString((String) value, "");
       }
       replaced = match.replaceFirst(expanded);
       match = pattern.matcher(replaced);

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/InputTest.java
@@ -143,6 +143,12 @@ public class InputTest {
     replaced = Input.getSimpleQuery(params, script, false);
     assertEquals("INPUT=some_inputSELECTED=s_op2\nCHECKED=c_op1\n" +
         "NEW_CHECKED=nc_a and nc_c", replaced);
+
+    // textbox without param value provided
+    script = "INPUT='${input_form}'";
+    params = new HashMap<>();
+    replaced = Input.getSimpleQuery(params, script, false);
+    assertEquals("INPUT=''", replaced);
   }
 
 }


### PR DESCRIPTION
### What is this PR for?

Simple PR to address NPE on empty dynamic form input. Instead of throwing NPE, just make the form value as empty string. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5290

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
