### PR TITLE
[ZEPPELIN-5409] Zeppelin server fails to start due to java.lang.ClassNotFoundException: org.apache.commons.vfs2.provider.webdav.WebdavFileProvider

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -37,7 +37,6 @@
 
   <properties>
     <!--library versions-->
-    <jackrabbit.webdav.version>1.5.2</jackrabbit.webdav.version>
     <lucene.version>5.3.1</lucene.version>
     <org.reflections.version>0.9.8</org.reflections.version>
     <xml.apis.version>1.4.01</xml.apis.version>
@@ -103,11 +102,10 @@
       <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
 
-
     <dependency>
-      <groupId>org.apache.jackrabbit</groupId>
-      <artifactId>jackrabbit-webdav</artifactId>
-      <version>${jackrabbit.webdav.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2-jackrabbit1</artifactId>
+      <version>${commons.vfs2.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-httpclient</groupId>


### PR DESCRIPTION

### What is this PR for?

This is a regression issue caused by ZEPPELIN-5303, we should upgrade `commons-vfs2-jackrabbit1` as well

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5409

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
