### PR TITLE
[ZEPPELIN-5392] Timezone is not applied in the timestamp field in flink interpreter

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
@@ -105,7 +105,8 @@ public abstract class AbstractStreamSqlJob {
 
   public String run(String st) throws IOException {
     this.table = stenv.sqlQuery(st);
-    String tableName = "UnnamedTable_" + SQL_INDEX.getAndIncrement();
+    String tableName = "UnnamedTable_" +
+            "_" + SQL_INDEX.getAndIncrement();
     return run(table, tableName);
   }
 
@@ -201,12 +202,13 @@ public abstract class AbstractStreamSqlJob {
 
   protected abstract String buildResult();
 
-  protected String table2String(List<Row> rows) {
+  protected String tableToString(List<Row> rows) {
     StringBuilder builder = new StringBuilder();
     for (Row row : rows) {
-      String[] fields = flinkShims.row2String(row, table, stenv.getConfig());
-      String rowString =
-              Arrays.stream(fields).map(TableDataUtils::normalizeColumn).collect(Collectors.joining("\t"));
+      String[] fields = flinkShims.rowToString(row, table, stenv.getConfig());
+      String rowString = Arrays.stream(fields)
+              .map(TableDataUtils::normalizeColumn)
+              .collect(Collectors.joining("\t"));
       builder.append(rowString);
       builder.append("\n");
     }

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
@@ -112,6 +112,7 @@ public abstract class AbstractStreamSqlJob {
 
   public String run(Table table, String tableName) throws IOException {
     try {
+      this.table = table;
       int parallelism = Integer.parseInt(context.getLocalProperties()
               .getOrDefault("parallelism", defaultParallelism + ""));
       this.schema = removeTimeAttributes(table.getSchema());

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -107,16 +107,7 @@ public class AppendStreamSqlJob extends AbstractStreamSqlJob {
                       maxTimestamp - tsWindowThreshold)
               .collect(Collectors.toList());
 
-      for (Row row : materializedTable) {
-        for (int i = 0; i < row.getArity(); ++i) {
-          Object field = row.getField(i);
-          builder.append(TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(field)));
-          if (i != (row.getArity() - 1)) {
-            builder.append("\t");
-          }
-        }
-        builder.append("\n");
-      }
+      builder.append(table2String(materializedTable));
     }
     builder.append("\n%text ");
     return builder.toString();

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -107,7 +107,7 @@ public class AppendStreamSqlJob extends AbstractStreamSqlJob {
                       maxTimestamp - tsWindowThreshold)
               .collect(Collectors.toList());
 
-      builder.append(table2String(materializedTable));
+      builder.append(tableToString(materializedTable));
     }
     builder.append("\n%text ");
     return builder.toString();

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
@@ -91,16 +91,7 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
       String f2 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r2.getField(0)));
       return f1.compareTo(f2);
     });
-    for (Row row : materializedTable) {
-      for (int i = 0; i < row.getArity(); ++i) {
-        Object field = row.getField(i);
-        builder.append(TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(field)));
-        if (i != (row.getArity() - 1)) {
-          builder.append("\t");
-        }
-      }
-      builder.append("\n");
-    }
+    builder.append(table2String(materializedTable));
     builder.append("\n%text\n");
     return builder.toString();
   }

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/sql/UpdateStreamSqlJob.java
@@ -91,7 +91,7 @@ public class UpdateStreamSqlJob extends AbstractStreamSqlJob {
       String f2 = TableDataUtils.normalizeColumn(StringUtils.arrayAwareToString(r2.getField(0)));
       return f1.compareTo(f2);
     });
-    builder.append(table2String(materializedTable));
+    builder.append(tableToString(materializedTable));
     builder.append("\n%text\n");
     return builder.toString();
   }

--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
@@ -158,5 +158,5 @@ public abstract class FlinkShims {
     // only needed after flink 1.13
   }
 
-  public abstract String[] row2String(Object row, Object tableSchema, Object tableConfig);
+  public abstract String[] rowToString(Object row, Object table, Object tableConfig);
 }

--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkShims.java
@@ -157,4 +157,6 @@ public abstract class FlinkShims {
   public void setOldPlanner(Object tableConfig) {
     // only needed after flink 1.13
   }
+
+  public abstract String[] row2String(Object row, Object tableSchema, Object tableConfig);
 }

--- a/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
+++ b/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
@@ -321,7 +321,7 @@ public class Flink110Shims extends FlinkShims {
   }
 
   @Override
-  public String[] row2String(Object row, Object table, Object tableConfig) {
+  public String[] rowToString(Object row, Object table, Object tableConfig) {
     return rowToString((Row) row);
   }
 

--- a/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
+++ b/flink/flink1.10-shims/src/main/java/org/apache/zeppelin/flink/Flink110Shims.java
@@ -44,8 +44,8 @@ import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
-import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FlinkException;
 import org.apache.zeppelin.flink.shims110.CollectStreamTableSink;
@@ -318,5 +318,23 @@ public class Flink110Shims extends FlinkShims {
       }
     }
     return configOptions;
+  }
+
+  @Override
+  public String[] row2String(Object row, Object table, Object tableConfig) {
+    return rowToString((Row) row);
+  }
+
+  private String[] rowToString(Row row) {
+    final String[] fields = new String[row.getArity()];
+    for (int i = 0; i < row.getArity(); i++) {
+      final Object field = row.getField(i);
+      if (field == null) {
+        fields[i] = "(NULL)";
+      } else {
+        fields[i] = EncodingUtils.objectToString(field);
+      }
+    }
+    return fields;
   }
 }

--- a/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
+++ b/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
@@ -79,6 +79,7 @@ import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropViewOperation;
 import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.utils.PrintUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.FlinkException;
@@ -466,5 +467,10 @@ public class Flink111Shims extends FlinkShims {
       }
     }
     return configOptions;
+  }
+
+  @Override
+  public String[] row2String(Object row, Object table, Object tableConfig) {
+    return PrintUtils.rowToString((Row) row);
   }
 }

--- a/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
+++ b/flink/flink1.11-shims/src/main/java/org/apache/zeppelin/flink/Flink111Shims.java
@@ -470,7 +470,7 @@ public class Flink111Shims extends FlinkShims {
   }
 
   @Override
-  public String[] row2String(Object row, Object table, Object tableConfig) {
+  public String[] rowToString(Object row, Object table, Object tableConfig) {
     return PrintUtils.rowToString((Row) row);
   }
 }

--- a/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
+++ b/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
@@ -80,6 +80,7 @@ import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.operations.ddl.DropViewOperation;
 import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.utils.PrintUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.FlinkException;
@@ -479,5 +480,10 @@ public class Flink112Shims extends FlinkShims {
       }
     }
     return configOptions;
+  }
+
+  @Override
+  public String[] row2String(Object row, Object table, Object tableConfig) {
+    return PrintUtils.rowToString((Row) row);
   }
 }

--- a/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
+++ b/flink/flink1.12-shims/src/main/java/org/apache/zeppelin/flink/Flink112Shims.java
@@ -483,7 +483,7 @@ public class Flink112Shims extends FlinkShims {
   }
 
   @Override
-  public String[] row2String(Object row, Object table, Object tableConfig) {
+  public String[] rowToString(Object row, Object table, Object tableConfig) {
     return PrintUtils.rowToString((Row) row);
   }
 }

--- a/flink/flink1.13-shims/src/main/java/org/apache/zeppelin/flink/Flink113Shims.java
+++ b/flink/flink1.13-shims/src/main/java/org/apache/zeppelin/flink/Flink113Shims.java
@@ -498,7 +498,7 @@ public class Flink113Shims extends FlinkShims {
   }
 
   @Override
-  public String[] row2String(Object row, Object table, Object tableConfig) {
+  public String[] rowToString(Object row, Object table, Object tableConfig) {
     final String zone = ((TableConfig) tableConfig).getConfiguration()
             .get(TableConfigOptions.LOCAL_TIME_ZONE);
     ZoneId zoneId = TableConfigOptions.LOCAL_TIME_ZONE.defaultValue().equals(zone)


### PR DESCRIPTION

### What is this PR for?

Add timezone support for flink interpreter, It is only available for flink 1.13, previous version are not supported.


### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5392

### How should this be tested?
* Manually tested.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/121799463-d8ba1d00-cc5e-11eb-8a45-776b94496bd1.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
