### PR TITLE
[ZEPPELIN-5193] Describe table using full table name in FlinkSQL can  not work

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -469,7 +469,7 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
   }
 
   private void callDescribe(String name, InterpreterContext context) throws IOException {
-    TableSchema schema = tbenv.scan(name).getSchema();
+    TableSchema schema = tbenv.scan(name.split("\\.")).getSchema();
     StringBuilder builder = new StringBuilder();
     builder.append("Column\tType\n");
     for (int i = 0; i < schema.getFieldCount(); ++i) {

--- a/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -195,6 +195,15 @@ public abstract class SqlInterpreterTest {
     assertEquals("table\nsource\n", resultMessages.get(0).getData());
 
     context = getInterpreterContext();
+    result = sqlInterpreter.interpret("describe db1.source", context);
+    assertEquals(Code.SUCCESS, result.code());
+    resultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(Type.TABLE, resultMessages.get(0).getType());
+    assertEquals("Column\tType\n" +
+                    "msg\tINT\n"
+            , resultMessages.get(0).getData());
+
+    context = getInterpreterContext();
     result = sqlInterpreter.interpret("use default", context);
     assertEquals(Code.SUCCESS, result.code());
 


### PR DESCRIPTION

### What is this PR for?

Simple PR to make describing table via full table name in flink sql work. Just split full table name via `dot` separator. So that flink api can recognize it correctly. See unit test for more details. 


### What type of PR is it?
[ Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5193

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
