### PR TITLE
[ZEPPELIN-5412] Unable to cancel flink job due to fail to take savepoint

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -151,7 +151,7 @@ public class JobManager {
                   jobClient.getJobID(), context.getParagraphId(), savePointPath);
         } catch (Exception e) {
           LOGGER.warn("Fail to cancel job of paragraph {} with savepoint, try to cancel it without savepoint",
-                  context.getParagraphId());
+                  context.getParagraphId(), e);
           jobClient.cancel();
         }
       }

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -141,13 +141,19 @@ public class JobManager {
       } else {
         LOGGER.info("Trying to stop job of paragraph {} with save point dir: {}",
                 context.getParagraphId(), savePointDir);
-        String savePointPath = jobClient.stopWithSavepoint(true, savePointDir).get();
-        Map<String, String> config = new HashMap<>();
-        config.put(SAVEPOINT_PATH, savePointPath);
-        context.getIntpEventClient().updateParagraphConfig(
-                context.getNoteId(), context.getParagraphId(), config);
-        LOGGER.info("Job {} of paragraph {} is stopped with save point path: {}",
-                jobClient.getJobID(), context.getParagraphId(), savePointPath);
+        try {
+          String savePointPath = jobClient.stopWithSavepoint(true, savePointDir).get();
+          Map<String, String> config = new HashMap<>();
+          config.put(SAVEPOINT_PATH, savePointPath);
+          context.getIntpEventClient().updateParagraphConfig(
+                  context.getNoteId(), context.getParagraphId(), config);
+          LOGGER.info("Job {} of paragraph {} is stopped with save point path: {}",
+                  jobClient.getJobID(), context.getParagraphId(), savePointPath);
+        } catch (Exception e) {
+          LOGGER.warn("Fail to cancel job of paragraph {} with savepoint, try to cancel it without savepoint",
+                  context.getParagraphId());
+          jobClient.cancel();
+        }
       }
       cancelled = true;
     } catch (Exception e) {


### PR DESCRIPTION
### What is this PR for?

Sometimes flink job is unable to be cancelled when savepoint is enabled. This PR would fall back to cancel job without savepoint if cancelling with savepoint is failed. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5412

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
