### PR TITLE
[ZEPPELIN-5413] Throw proper error message when user set execution.runtime-mode in flink sql

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -502,9 +502,9 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
 
   public abstract void callInnerSelect(String sql, InterpreterContext context) throws IOException;
 
-  public void callSet(String key, String value, InterpreterContext context) throws IOException {
+  public void callSet(String key, String value, InterpreterContext context) throws Exception {
     if (key.equals("execution.runtime-mode")) {
-      throw new IOException("execution.runtime-mode is not supported to set, " +
+      throw new UnsupportedOperationException("execution.runtime-mode is not supported to set, " +
               "you can use %flink.ssql & %flink.bsql to switch between streaming mode and batch mode");
     }
 

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -503,10 +503,16 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
   public abstract void callInnerSelect(String sql, InterpreterContext context) throws IOException;
 
   public void callSet(String key, String value, InterpreterContext context) throws IOException {
+    if (key.equals("execution.runtime-mode")) {
+      throw new IOException("execution.runtime-mode is not supported to set, " +
+              "you can use %flink.ssql & %flink.bsql to switch between streaming mode and batch mode");
+    }
+
     if (!tableConfigOptions.containsKey(key)) {
       throw new IOException(key + " is not a valid table/sql config, please check link: " +
               "https://ci.apache.org/projects/flink/flink-docs-release-1.10/dev/table/config.html");
     }
+
     LOGGER.info("Set table config: {}={}", key, value);
     this.tbenv.getConfig().getConfiguration().setString(key, value);
   }

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -503,7 +503,7 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
   public abstract void callInnerSelect(String sql, InterpreterContext context) throws IOException;
 
   public void callSet(String key, String value, InterpreterContext context) throws Exception {
-    if (key.equals("execution.runtime-mode")) {
+    if ("execution.runtime-mode".equals(key)) {
       throw new UnsupportedOperationException("execution.runtime-mode is not supported to set, " +
               "you can use %flink.ssql & %flink.bsql to switch between streaming mode and batch mode");
     }


### PR DESCRIPTION

### What is this PR for?

`execution.runtime-mode` is available in flink sql-client, but it is not available in zeppelin flink interpreter. So we need to throw proper error message when user set execution.runtime-mode in flink sql. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5413

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
