### PR TITLE
[ZEPPELIN-5405] ClassNotFoundException in YarnAppMonitor when hadoop client is not installed

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
@@ -100,9 +100,20 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
       Matcher m = YARN_APP_PATTER.matcher(launchOutput);
       if (m.find()) {
         String appId = m.group(1);
-        LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", appId);
-        YarnAppMonitor.get().addYarnApp(ConverterUtils.toApplicationId(appId), this);
+        if (isHadoopClientAvailable()) {
+          LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", appId);
+          YarnAppMonitor.get().addYarnApp(ConverterUtils.toApplicationId(appId), this);
+        }
       }
+    }
+  }
+
+  private boolean isHadoopClientAvailable() {
+    try {
+      Class.forName("org.apache.hadoop.yarn.conf.YarnConfiguration");
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
@@ -95,15 +95,15 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
 
     if (!interpreterProcessLauncher.isRunning()) {
       throw new IOException("Fail to launch interpreter process:\n" + interpreterProcessLauncher.getErrorMessage());
-    } else {
+    }
+
+    if (isHadoopClientAvailable()) {
       String launchOutput = interpreterProcessLauncher.getProcessLaunchOutput();
       Matcher m = YARN_APP_PATTER.matcher(launchOutput);
       if (m.find()) {
         String appId = m.group(1);
-        if (isHadoopClientAvailable()) {
-          LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", appId);
-          YarnAppMonitor.get().addYarnApp(ConverterUtils.toApplicationId(appId), this);
-        }
+        LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", appId);
+        YarnAppMonitor.get().addYarnApp(ConverterUtils.toApplicationId(appId), this);
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?

Minor PR to only use YarnAppMonitor when hadoop client is installed, otherwise ClassNotFoundException will be thrown

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5405

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
