### PR TITLE
[ZEPPELIN-5417] Unable to set conda env in pyspark

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -80,16 +80,24 @@ public class PythonInterpreter extends Interpreter {
   public void open() throws InterpreterException {
     // try IPythonInterpreter first
     iPythonInterpreter = getIPythonInterpreter();
-    if (getProperty("zeppelin.python.useIPython", "true").equals("true") &&
-        StringUtils.isEmpty(
-            iPythonInterpreter.checkKernelPrerequisite(getPythonExec()))) {
-      try {
-        iPythonInterpreter.open();
-        LOGGER.info("IPython is available, Use IPythonInterpreter to replace PythonInterpreter");
-        return;
-      } catch (Exception e) {
-        iPythonInterpreter = null;
-        LOGGER.warn("Fail to open IPythonInterpreter", e);
+    boolean useIPython = Boolean.parseBoolean(getProperty("zeppelin.python.useIPython", "true"));
+
+    LOGGER.info("zeppelin.python.useIPython: {}", useIPython);
+    if (useIPython) {
+      String checkKernelPrerequisiteResult = iPythonInterpreter.checkKernelPrerequisite(
+              getPythonExec());
+      if (StringUtils.isEmpty(checkKernelPrerequisiteResult)) {
+        try {
+          iPythonInterpreter.open();
+          LOGGER.info("IPython is available, Use IPythonInterpreter to replace PythonInterpreter");
+          return;
+        } catch (Exception e) {
+          iPythonInterpreter = null;
+          LOGGER.warn("Fail to open IPythonInterpreter", e);
+        }
+      } else {
+        LOGGER.info("IPython requirement is not met, checkKernelPrerequisiteResult: {}",
+                checkKernelPrerequisiteResult);
       }
     }
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -178,12 +178,13 @@ public class PySparkInterpreter extends PythonInterpreter {
     if (StringUtils.isNotBlank(sparkConf.get("spark.pyspark.python", ""))) {
       return sparkConf.get("spark.pyspark.python");
     }
-    if (System.getenv("PYSPARK_PYTHON") != null) {
-      return System.getenv("PYSPARK_PYTHON");
-    }
     if (System.getenv("PYSPARK_DRIVER_PYTHON") != null) {
       return System.getenv("PYSPARK_DRIVER_PYTHON");
     }
+    if (System.getenv("PYSPARK_PYTHON") != null) {
+      return System.getenv("PYSPARK_PYTHON");
+    }
+
     return "python";
   }
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -171,11 +171,12 @@ public class PySparkInterpreter extends PythonInterpreter {
   // spark.pyspark.driver.python > spark.pyspark.python > PYSPARK_DRIVER_PYTHON > PYSPARK_PYTHON
   @Override
   protected String getPythonExec() {
-    if (!StringUtils.isBlank(getProperty("spark.pyspark.driver.python", ""))) {
-      return properties.getProperty("spark.pyspark.driver.python");
+    SparkConf sparkConf = getSparkConf();
+    if (StringUtils.isNotBlank(sparkConf.get("spark.pyspark.driver.python", ""))) {
+      return sparkConf.get("spark.pyspark.driver.python");
     }
-    if (!StringUtils.isBlank(getProperty("spark.pyspark.python", ""))) {
-      return properties.getProperty("spark.pyspark.python");
+    if (StringUtils.isNotBlank(sparkConf.get("spark.pyspark.python", ""))) {
+      return sparkConf.get("spark.pyspark.python");
     }
     if (System.getenv("PYSPARK_PYTHON") != null) {
       return System.getenv("PYSPARK_PYTHON");

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/IPySparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/IPySparkInterpreterTest.java
@@ -90,6 +90,7 @@ public class IPySparkInterpreterTest extends IPythonInterpreterTest {
     intpGroup.get("session_1").add(interpreter);
     interpreter.setInterpreterGroup(intpGroup);
 
+    pySparkInterpreter.open();
     interpreter.open();
   }
 

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -153,6 +153,7 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
    * @return check result of checking kernel prerequisite.
    */
   public String checkKernelPrerequisite(String pythonExec) {
+    LOGGER.info("checkKernelPrerequisite using python executable: {}", pythonExec);
     ProcessBuilder processBuilder = new ProcessBuilder(pythonExec, "-m", "pip", "freeze");
     File stderrFile = null;
     File stdoutFile = null;


### PR DESCRIPTION
### What is this PR for?

2 changes here in this PR:
* Use SparkConf instead of properties, because the spark configuration may be in spark side (e.g. spark-defaults.conf instead of zeppelin side), `properties` mean the configuration in zeppelin side, `SparkConf` is the complete configuration of spark.
* Code improvement on the logics of detecting availability of IPython.

### What type of PR is it?
[Bug Fix | Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5417

### How should this be tested?
* Manually tested
* 
![image](https://user-images.githubusercontent.com/164491/122939982-a9b25280-d3a6-11eb-9f66-6300223ca19d.png)


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
