### PR TITLE
[ZEPPELIN-5422] Add test for quoted local property in ZSession

### DIFF
--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZSession.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZSession.java
@@ -205,6 +205,18 @@ public class ZSession {
    * Run code in non-blocking way.
    *
    * @param code
+   * @param localProperties
+   * @return
+   * @throws Exception
+   */
+  public ExecuteResult execute(String code, Map<String, String> localProperties) throws Exception {
+    return execute("", localProperties, code);
+  }
+
+  /**
+   * Run code in non-blocking way.
+   *
+   * @param code
    * @param messageHandler
    * @return
    * @throws Exception
@@ -270,7 +282,7 @@ public class ZSession {
     if (localProperties != null && !localProperties.isEmpty()) {
       builder.append("(");
       List<String> propertyString = localProperties.entrySet().stream()
-              .map(entry -> (entry.getKey() + "=\"" + entry.getValue() + "\""))
+              .map(entry -> ("\"" + entry.getKey() + "\"=\"" + entry.getValue() + "\""))
               .collect(Collectors.toList());
       builder.append(StringUtils.join(propertyString, ","));
       builder.append(")");

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZSessionIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZSessionIntegrationTest.java
@@ -427,6 +427,14 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertEquals(result.toString(), Status.FINISHED, result.getStatus());
       assertEquals(1, result.getResults().size());
       assertEquals("TEXT", result.getResults().get(0).getType());
+
+      Map<String, String> localProperties = new HashMap<>();
+      localProperties.put("key 1", "hello world"); // contains whitespace
+      localProperties.put("key,2", "a,b"); // contains comma
+      result = session.execute("1+1", localProperties);
+      assertEquals(result.toString(), Status.FINISHED, result.getStatus());
+      assertEquals(1, result.getResults().size());
+      assertEquals("TEXT", result.getResults().get(0).getType());
     } finally {
       session.stop();
     }


### PR DESCRIPTION
### What is this PR for?

This PR add test for quoted local property in ZSession. Besides that it also add method `execute(code, localProperties)` which is missing in the execute api.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5422

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
