### PR TITLE
[ZEPPELIN-5426] mongodb interpreter: support mongosh

### DIFF
--- a/mongodb/src/main/resources/shell_extension.js
+++ b/mongodb/src/main/resources/shell_extension.js
@@ -97,14 +97,15 @@ function printTable(dbquery, fields, flattenArray) {
     });
 }
 
-DBQuery.prototype.table = function (fields, flattenArray) {
+(DBQuery.prototype || DBQuery).table = function (fields, flattenArray) {
     if (this._limit > tableLimit) {
         this.limit(tableLimit);
     }
     printTable(this, fields, flattenArray);
 };
 
-DBCommandCursor.prototype.table = DBQuery.prototype.table;
+if (globalThis.DBCommandCursor)
+    (DBCommandCursor.prototype || DBCommandCursor).table = (DBQuery.prototype || DBQuery).table;
 
 var userName = "USER_NAME_PLACEHOLDER";
 var password = "PASSWORD_PLACEHOLDER";


### PR DESCRIPTION
### What is this PR for?
The mongodb interpreter works by calling into the deprecated `mongo` shell (https://docs.mongodb.com/manual/reference/program/mongo/), which is going to be replaced by `mongosh` (https://docs.mongodb.com/mongodb-shell/). This is a largely backwards compatible migration, so that the interpreter works almost unchanged. Some internals have changed nevertheless, this pull request ensures the interpreter works with the new shell without breaking backwards compatibility.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5426

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? At some point... 
