### PR TITLE
[ZEPPELIN-5423] Running %spark.conf cell seem to break placeholder #{user} from config

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -118,6 +118,10 @@ public abstract class SparkIntegrationTest {
     assertEquals(interpreterResult.toString(), InterpreterResult.Code.SUCCESS, interpreterResult.code());
     assertTrue(interpreterResult.toString(), interpreterResult.message().get(0).getData().contains("45"));
 
+    interpreterResult = sparkInterpreter.interpret("sc.getConf.get(\"spark.user.name\")", context);
+    assertEquals(interpreterResult.toString(), InterpreterResult.Code.SUCCESS, interpreterResult.code());
+    assertTrue(interpreterResult.toString(), interpreterResult.message().get(0).getData().contains("user1"));
+
     // test jars & packages can be loaded correctly
     interpreterResult = sparkInterpreter.interpret("import org.apache.zeppelin.interpreter.integration.DummyClass\n" +
             "import com.maxmind.geoip2._", context);
@@ -162,6 +166,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("zeppelin.pyspark.useIPython", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");
+    sparkInterpreterSetting.setProperty("spark.user.name", "#{user}");
 
     try {
       setUpSparkInterpreterSetting(sparkInterpreterSetting);
@@ -189,6 +194,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");
+    sparkInterpreterSetting.setProperty("spark.user.name", "#{user}");
 
     try {
       setUpSparkInterpreterSetting(sparkInterpreterSetting);
@@ -237,6 +243,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");
+    sparkInterpreterSetting.setProperty("spark.user.name", "#{user}");
 
     try {
       setUpSparkInterpreterSetting(sparkInterpreterSetting);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -159,7 +159,7 @@ public class RemoteInterpreter extends Interpreter {
         interpreterProcess.callRemoteFunction(client -> {
           LOGGER.info("Create RemoteInterpreter {}", getClassName());
           client.createInterpreter(getInterpreterGroup().getId(), sessionId,
-              className, (Map) getProperties(), getUserName());
+              className, (Map) properties, getUserName());
           return null;
         });
         isCreated = true;


### PR DESCRIPTION

### What is this PR for?

The root cause is that we do context parameter replacement in zeppelin server side (RemoteInterpreter). Actually we should do it in interpreter process side. Also add tests for this. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5423

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
