### PR TITLE
[ZEPPELIN-5433] Update Action setup-java to v2

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -79,8 +80,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -111,8 +113,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -151,8 +154,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -184,8 +188,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -223,8 +228,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -260,8 +266,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -296,8 +303,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -332,8 +340,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -366,8 +375,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -54,8 +55,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -80,8 +82,9 @@ jobs:
       - name: Tune Runner VM
         uses: ./.github/actions/tune-runner-vm
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
       - name: Check Rat
         run: mvn apache-rat:check -Prat -B


### PR DESCRIPTION
### What is this PR for?
This PR updates setup-java action to v2.
I decided to use the binaries from adoptopenjdk because it is a community project with many [sponsors](https://adoptopenjdk.net/sponsors.html). Azul, which provides the other OpenJDK variant ( Zulu ), is also on board.

### What type of PR is it?
- Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5433

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
