### PR TITLE
[ZEPPELIN-5367] Run flink job as the login user in yarn mode

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -146,6 +146,11 @@ You can also add and set other flink properties which are not listed in the tabl
     <td>Set this value only when your yarn address is mapped to some other address, e.g. some cloud vender will map `http://resource-manager:8088` to `https://xxx-yarn.yy.cn/gateway/kkk/yarn`</td>
   </tr>
   <tr>
+    <td>zeppelin.flink.run.asLoginUser</td>
+    <td>true</td>
+    <td>Whether run flink job as the zeppelin login user, it is only applied when running flink job in hadoop yarn cluster and shiro is enabled</td>
+  </tr> 
+  <tr>
     <td>flink.udf.jars</td>
     <td></td>
     <td>Flink udf jars (comma separated), zeppelin will register udf in this jar automatically for user. These udf jars could be either local files or hdfs files if you have hadoop installed. The udf name is the class name.</td>

--- a/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
+++ b/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
@@ -103,6 +103,13 @@
         "description": "Set this value only when your yarn address is mapped to some other address, e.g. some cloud vender will map `http://resource-manager:8088` to `https://xxx-yarn.yy.cn/gateway/kkk/yarn`",
         "type": "string"
       },
+      "zeppelin.flink.run.asLoginUser": {
+        "envName": null,
+        "propertyName": null,
+        "defaultValue": true,
+        "description": "Whether run flink job as the zeppelin login user, it is only applied when running flink job in hadoop yarn cluster and shiro is enabled",
+        "type": "checkbox"
+      },
       "flink.udf.jars": {
         "envName": null,
         "propertyName": null,

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
@@ -154,6 +154,8 @@ public abstract class FlinkIntegrationTest {
     flinkInterpreterSetting.setProperty("PATH", hadoopHome + "/bin:" + System.getenv("PATH"));
     flinkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     flinkInterpreterSetting.setProperty("flink.execution.mode", "YARN");
+    flinkInterpreterSetting.setProperty("zeppelin.flink.run.asLoginUser", "false");
+
     testInterpreterBasics();
 
     // 1 yarn application launched
@@ -176,6 +178,8 @@ public abstract class FlinkIntegrationTest {
     flinkInterpreterSetting.setProperty("PATH", hadoopHome + "/bin:" + System.getenv("PATH"));
     flinkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     flinkInterpreterSetting.setProperty("flink.execution.mode", "yarn-application");
+    flinkInterpreterSetting.setProperty("zeppelin.flink.run.asLoginUser", "false");
+
     testInterpreterBasics();
 
     // 1 yarn application launched


### PR DESCRIPTION
### What is this PR for?

Introduce new flink configuration `zeppelin.flink.run.asLoginUser` to control whether run the flink job as the login user in yarn mode. 

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5367

### How should this be tested?
* CI pass

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/164491/124083533-8ceddd00-da80-11eb-849e-96e93ec9a12f.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
