### PR TITLE
[ZEPPELIN-5441] Check no jobs running before kill interpreter job in TimeoutLifecycleManager

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManager.java
@@ -57,6 +57,9 @@ public class TimeoutLifecycleManager extends LifecycleManager {
     ScheduledExecutorService checkScheduler = ExecutorFactory.singleton()
         .createOrGetScheduled("TimeoutLifecycleManager", 1);
     checkScheduler.scheduleAtFixedRate(() -> {
+      // check both lastBusyTimeInMillis & noJobsRunnings
+      // In one corner case, lastBusyTimeInMilli won't be updated, that is when zeppelin server is dead
+      // then RemoteInterpreterServer#getProgress and RemoteInterpreterServer#getStatus won't be called.
       if ((System.currentTimeMillis() - lastBusyTimeInMillis) > timeoutThreshold &&
               noJobsRunning()) {
         LOGGER.info("Interpreter process idle time exceed threshold, try to stop it");

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -402,7 +402,7 @@ public class RemoteInterpreterServer extends Thread
     }
   }
 
-  protected InterpreterGroup getInterpreterGroup() {
+  public InterpreterGroup getInterpreterGroup() {
     return interpreterGroup;
   }
 


### PR DESCRIPTION
### What is this PR for?

Minor PR to check no jobs running before kill interpreter job in `TimeoutLifecycleManager`, otherwise it is possible to kill interpreter process that still has jobs running.

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5441

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
