### PR TITLE
[ZEPPELIN-5451] Fix the repository URL for downloading Pty4J

### DIFF
--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -46,9 +46,9 @@
   <!-- pty4j library not in maven central repository (http://repo.maven.apache.org/maven2) -->
   <repositories>
     <repository>
-      <id>jetbrains-pty4j</id>
+      <id>jetbrains-intellij-dependencies</id>
       <name>JetBrains Pty4j Repository</name>
-      <url>https://dl.bintray.com/jetbrains/pty4j/</url>
+      <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
     </repository>
   </repositories>
 

--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -45,9 +45,9 @@
 
   <repositories>
     <repository>
-      <id>jetbrains-pty4j</id>
+      <id>jetbrains-intellij-dependencies</id>
       <name>JetBrains Pty4j Repository</name>
-      <url>https://dl.bintray.com/jetbrains/pty4j/</url>
+      <url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
     </repository>
   </repositories>
   


### PR DESCRIPTION
### What is this PR for?
Currently, building Zeppelin fails due to the download problem of Pty4J.
This PR changes its repository URL to the officially recommended one so that we can pull it successfully.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5451

### How should this be tested?
* Ran `mvn clean package -DskipTests` locally and confirmed that the shell and submarine modules were successfully built.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
