### PR TITLE
[ZEPPELIN-5447] Spark driver pod cannot create resource configmaps under k8s mode

### DIFF
--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -136,7 +136,7 @@ metadata:
   {% endif %}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services"]
+  resources: ["pods", "services", "configmaps"]
   verbs: ["create", "get", "update", "list", "delete", "watch" ]
 ---
 kind: RoleBinding


### PR DESCRIPTION


### What is this PR for?
When zeppelin is running under k8s mode, make the pod of spark driver obtain the permission to create the resource "configmaps". 

According to the [Apache Spark Documentation: Running Spark on Kubernetes](https://spark.apache.org/docs/3.1.2/running-on-kubernetes.html), the service account credentials used by the driver pods must be allowed to create pods, services and configmaps.


### What type of PR is it?
[Bug fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5447>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
