### PR TITLE
[ZEPPELIN-5439] Improve the logic of extract hive job url in JdbcInterpreter

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -35,7 +35,7 @@
     <!--library versions-->
     <interpreter.name>jdbc</interpreter.name>
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
-    <hadoop.common.version>${hadoop2.7.version}</hadoop.common.version>
+    <hadoop.version>${hadoop2.7.version}</hadoop.version>
     <h2.version>1.4.190</h2.version>
     <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
     <hive2.version>2.3.4</hive2.version>
@@ -85,8 +85,15 @@
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.common.version}</version>
+      <version>${hadoop.version}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/YarnUtil.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/hive/YarnUtil.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.zeppelin.jdbc.hive;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class YarnUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(YarnUtil.class);
+
+  private static YarnClient yarnClient;
+
+  static {
+    try {
+      yarnClient = YarnClient.createYarnClient();
+      YarnConfiguration yarnConf = new YarnConfiguration();
+      // disable timeline service as we only query yarn app here.
+      // Otherwise we may hit this kind of ERROR:
+      // java.lang.ClassNotFoundException: com.sun.jersey.api.client.config.ClientConfig
+      yarnConf.set("yarn.timeline-service.enabled", "false");
+      yarnClient.init(yarnConf);
+      yarnClient.start();
+    } catch (Exception e) {
+      LOGGER.warn("Fail to start yarnClient", e);
+    }
+  }
+
+
+  public static String getYarnAppIdByTag(String paragraphId) {
+    if (yarnClient == null) {
+      return null;
+    }
+    Set<String> applicationTypes = Sets.newHashSet("MAPREDUCE", "TEZ");
+    EnumSet<YarnApplicationState> yarnStates =
+            Sets.newEnumSet(Lists.newArrayList(YarnApplicationState.RUNNING),
+            YarnApplicationState.class);
+
+    try {
+      List<ApplicationReport> apps =
+              yarnClient.getApplications(applicationTypes, yarnStates);
+      for (ApplicationReport appReport : apps) {
+        if (appReport.getApplicationTags().contains(paragraphId)) {
+          return appReport.getApplicationId().toString();
+        }
+      }
+      return null;
+    } catch (YarnException | IOException e) {
+      LOGGER.warn("Fail to get yarn apps", e);
+      return null;
+    }
+  }
+}

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/hive/HiveUtilsTest.java
@@ -38,4 +38,16 @@ public class HiveUtilsTest {
     assertTrue(jobURL.isPresent());
     assertEquals("http://localhost:8088/proxy/application_1591195707498_0064/", jobURL.get());
   }
+
+  @Test
+  public void testTezAppId() {
+    Optional<String> appId = HiveUtils.extractTezAppId(
+            "Query ID = hadoop_20210514105011_6f620c39-f557-4fc6-a899-ecd892be2652\n" +
+                    "Total jobs = 1\n" +
+                    "Launching Job 1 out of 1\n" +
+                    "Status: Running " +
+                    "(Executing on YARN cluster with App id application_1612885840821_260263)");
+    assertTrue(appId.isPresent());
+    assertEquals("application_1612885840821_260263", appId.get());
+  }
 }


### PR DESCRIPTION

### What is this PR for?

Previously we extract hive job url from hive jdbc job log, but it seems the in the latest hive, there's no job url info in log. 
This PR is use another approach to do that, we use the paragraphId as the hive job yarn tag, after hive sql execution is started, we look at the yarn app that has this tag. 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5439

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
