### PR TITLE
[ZEPPELIN-5454] Explain output should be in text format

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -102,6 +102,9 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
       Method method = sqlContext.getClass().getMethod("sql", String.class);
       for (String sql : sqls) {
         curSql = sql;
+        // Put sql into InterpreterContext's local properties, so that ZeppelinContext#show
+        // can use this context info
+        context.getLocalProperties().put("sql", curSql);
         String result = sparkInterpreter.getZeppelinContext()
                 .showData(method.invoke(sqlContext, sql), maxResult);
         context.out.write(result);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkSqlInterpreterTest.java
@@ -198,6 +198,12 @@ public class SparkSqlInterpreterTest {
     assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
     assertEquals(Type.HTML, context.out.toInterpreterResultMessage().get(0).getType());
     assertEquals("Total count: <h1>10</h1>, Total age: <h1>55</h1>", context.out.toInterpreterResultMessage().get(0).getData());
+
+    // test Explain statement
+    ret = sqlInterpreter.interpret("explain select count(1), sum(age) from gr", context);
+    assertEquals(InterpreterResult.Code.SUCCESS, ret.code());
+    assertEquals(Type.TEXT, context.out.toInterpreterResultMessage().get(0).getType());
+    assertTrue(context.out.toString(), context.out.toInterpreterResultMessage().get(0).getData().contains("Physical Plan"));
   }
 
   @Test

--- a/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
+++ b/spark/spark1-shims/src/main/scala/org/apache/zeppelin/spark/Spark1Shims.java
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.ui.jobs.JobProgressListener;
 import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.ResultMessages;
 import org.apache.zeppelin.interpreter.SingleRowInterpreterResult;
 import org.apache.zeppelin.tabledata.TableDataUtils;
@@ -81,9 +82,16 @@ public class Spark1Shims extends SparkShims {
         }
       }
 
+      InterpreterResult.Type outputType = InterpreterResult.Type.TABLE;
+      String sql = context.getLocalProperties().get("sql");
+      if (StringUtils.isNotBlank(sql) && sql.trim().toLowerCase().startsWith("explain")) {
+        outputType = InterpreterResult.Type.TEXT;
+      }
+
       StringBuilder msg = new StringBuilder();
-      msg.append("\n%table ");
+      msg.append("\n%" + outputType.toString().toLowerCase() + " ");
       msg.append(StringUtils.join(TableDataUtils.normalizeColumns(columns), "\t"));
+
       msg.append("\n");
       boolean isLargerThanMaxResult = rows.size() > maxResult;
       if (isLargerThanMaxResult) {
@@ -91,7 +99,11 @@ public class Spark1Shims extends SparkShims {
       }
       for (Row row : rows) {
         for (int i = 0; i < row.size(); ++i) {
-          msg.append(TableDataUtils.normalizeColumn(row.get(i)));
+          if (outputType == InterpreterResult.Type.TABLE) {
+            msg.append(TableDataUtils.normalizeColumn(row.get(i)));
+          } else {
+            msg.append(row.get(i));
+          }
           if (i != row.size() - 1) {
             msg.append("\t");
           }

--- a/spark/spark3-shims/src/main/scala/org/apache/zeppelin/spark/Spark3Shims.java
+++ b/spark/spark3-shims/src/main/scala/org/apache/zeppelin/spark/Spark3Shims.java
@@ -28,6 +28,8 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterOutput;
+import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.ResultMessages;
 import org.apache.zeppelin.interpreter.SingleRowInterpreterResult;
 import org.apache.zeppelin.tabledata.TableDataUtils;
@@ -80,10 +82,16 @@ public class Spark3Shims extends SparkShims {
           return "";
         }
       }
+      InterpreterResult.Type outputType = InterpreterResult.Type.TABLE;
+      String sql = context.getLocalProperties().get("sql");
+      if (StringUtils.isNotBlank(sql) && sql.trim().toLowerCase().startsWith("explain")) {
+        outputType = InterpreterResult.Type.TEXT;
+      }
 
       StringBuilder msg = new StringBuilder();
-      msg.append("%table ");
+      msg.append("\n%" + outputType.toString().toLowerCase() + " ");
       msg.append(StringUtils.join(TableDataUtils.normalizeColumns(columns), "\t"));
+
       msg.append("\n");
       boolean isLargerThanMaxResult = rows.size() > maxResult;
       if (isLargerThanMaxResult) {
@@ -91,7 +99,11 @@ public class Spark3Shims extends SparkShims {
       }
       for (Row row : rows) {
         for (int i = 0; i < row.size(); ++i) {
-          msg.append(TableDataUtils.normalizeColumn(row.get(i)));
+          if (outputType == InterpreterResult.Type.TABLE) {
+            msg.append(TableDataUtils.normalizeColumn(row.get(i)));
+          } else {
+            msg.append(row.get(i));
+          }
           if (i != row.size() -1) {
             msg.append("\t");
           }


### PR DESCRIPTION
### What is this PR for?

Use text format instead of table format for the spark sql explain statement. Because the table format is not readable. See the following screenshot. 

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5454

### How should this be tested?
* UT is added and Manually tested

### Screenshots (if appropriate)

Before
![image](https://user-images.githubusercontent.com/164491/125060927-6a427080-e0df-11eb-9639-d60bb0130238.png)

After
![image](https://user-images.githubusercontent.com/164491/125060582-1899e600-e0df-11eb-8ff4-0ef3a5da7c0b.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
