### PR TITLE
[ZEPPELIN-5360] K8S interpreter create spark pods, should support the 'imagePullSecrets' config

### DIFF
--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -245,15 +245,15 @@ to customize,
   4. Run a paragraph will create an interpreter using modified yaml files.
 
 The interpreter pod can also be customized through the interpreter settings. Here are some of the properties:
-| Property | Value | Description |
+| Property Name | Default Value | Description |
 | ----- | ----- | ----- |
-| `zeppelin.k8s.namespace` | `<k8s namespace>` | The Kubernetes namespace to use. |
-| `zeppelin.k8s.interpreter.container.image` | `<image>:<version>` | The interpreter image to use. |
-| `zeppelin.k8s.interpreter.cores` | `<cpu cores>` | The number of cpu cores to use. |
-| `zeppelin.k8s.interpreter.memory` | `<memory>` | The memory to use, e.g., `1g`. |
-| `zeppelin.k8s.interpreter.gpu.type` | `<gpu type>` | Set the type of gpu to request when the interpreter pod is required to schedule gpu resources, e.g., `nvidia.com/gpu`. |
-| `zeppelin.k8s.interpreter.gpu.nums` | `<gpu nums>` | Tne number of gpu to use. |
-| `zeppelin.k8s.interpreter.imagePullSecrets` | `<k8s secret1>,<k8s secret2>` | Set the comma-separated list of Kubernetes secrets while pulling images. |
+| `zeppelin.k8s.namespace` | `default` | The Kubernetes namespace to use. |
+| `zeppelin.k8s.interpreter.container.image` | `apache/zeppelin:<ZEPPELIN_VERSION>` | The interpreter image to use. |
+| `zeppelin.k8s.interpreter.cores` | (optional)  | The number of cpu cores to use. |
+| `zeppelin.k8s.interpreter.memory` | (optional) | The memory to use, e.g., `1g`. |
+| `zeppelin.k8s.interpreter.gpu.type` | (optional) | Set the type of gpu to request when the interpreter pod is required to schedule gpu resources, e.g., `nvidia.com/gpu`. |
+| `zeppelin.k8s.interpreter.gpu.nums` | (optional) | Tne number of gpu to use. |
+| `zeppelin.k8s.interpreter.imagePullSecrets` | (optional) | Set the comma-separated list of Kubernetes secrets while pulling images, e.g., `mysecret1,mysecret2` |
 
 
 ## Future work

--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -244,6 +244,17 @@ to customize,
   3. Apply modified `k8s/zeppelin-server.yaml`.
   4. Run a paragraph will create an interpreter using modified yaml files.
 
+The interpreter pod can also be customized through the interpreter settings. Here are some of the properties:
+| Property | Value | Description |
+| ----- | ----- | ----- |
+| `zeppelin.k8s.namespace` | `<k8s namespace>` | The Kubernetes namespace to use. |
+| `zeppelin.k8s.interpreter.container.image` | `<image>:<version>` | The interpreter image to use. |
+| `zeppelin.k8s.interpreter.cores` | `<cpu cores>` | The number of cpu cores to use. |
+| `zeppelin.k8s.interpreter.memory` | `<memory>` | The memory to use, e.g., `1g`. |
+| `zeppelin.k8s.interpreter.gpu.type` | `<gpu type>` | Set the type of gpu to request when the interpreter pod is required to schedule gpu resources, e.g., `nvidia.com/gpu`. |
+| `zeppelin.k8s.interpreter.gpu.nums` | `<gpu nums>` | Tne number of gpu to use. |
+| `zeppelin.k8s.interpreter.imagePullSecrets` | `<k8s secret1>,<k8s secret2>` | Set the comma-separated list of Kubernetes secrets while pulling images. |
+
 
 ## Future work
 

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -93,6 +93,12 @@ spec:
     volumeMounts:
     - name: spark-home
       mountPath: /spark
+  {% if zeppelin.k8s.interpreter.imagePullSecrets is defined %}
+  imagePullSecrets:
+  {% for secret in zeppelin.k8s.interpreter.imagePullSecrets.split(',') %}
+  - name: {{secret}}
+  {% endfor %}
+  {% endif %}
   volumes:
   - name: spark-home
     emptyDir: {}


### PR DESCRIPTION

### What is this PR for?
When Zeppelin is creating the interpreter pod, it may need to pull the image from the **private repository**. However, the current `k8s/interpreter/100-interpreter-spec.yaml` file does not support setting the config `imagePullSecrets`. 

So this PR adds a property named: `zeppelin.k8s.interpreter.imagePullSecrets`, which allows users to set the **comma-separated list of Kubernetes secrets**. So that the interpreter pod can pull the image from the private repository.

For example:
```
%spark.conf
zeppelin.k8s.interpreter.imagePullSecrets mysecret1,mysecret2,mysecret3
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5360>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No 
* Is there breaking changes for older versions? No
* Does this needs documentation? No
