### PR TITLE
[ZEPPELIN-5456] Allow users to set the config 'imagePullPolicy' under k8s mode

### DIFF
--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -255,6 +255,7 @@ The interpreter pod can also be customized through the interpreter settings. Her
 | `zeppelin.k8s.interpreter.gpu.nums` | (optional) | Tne number of gpu to use. |
 | `zeppelin.k8s.interpreter.imagePullSecrets` | (optional) | Set the comma-separated list of Kubernetes secrets while pulling images, e.g., `mysecret1,mysecret2` |
 | `zeppelin.k8s.interpreter.container.imagePullPolicy` | (optional) | Set the pull policy of the interpreter image, e.g., `Always` |
+| `zeppelin.k8s.spark.container.imagePullPolicy` | (optional) | Set the pull policy of the spark image, e.g., `Always` |
 
 ## Future work
 

--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -254,7 +254,7 @@ The interpreter pod can also be customized through the interpreter settings. Her
 | `zeppelin.k8s.interpreter.gpu.type` | (optional) | Set the type of gpu to request when the interpreter pod is required to schedule gpu resources, e.g., `nvidia.com/gpu`. |
 | `zeppelin.k8s.interpreter.gpu.nums` | (optional) | Tne number of gpu to use. |
 | `zeppelin.k8s.interpreter.imagePullSecrets` | (optional) | Set the comma-separated list of Kubernetes secrets while pulling images, e.g., `mysecret1,mysecret2` |
-
+| `zeppelin.k8s.interpreter.container.imagePullPolicy` | (optional) | Set the pull policy of the interpreter image, e.g., `Always` |
 
 ## Future work
 

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -43,6 +43,9 @@ spec:
   containers:
   - name: {{zeppelin.k8s.interpreter.container.name}}
     image: {{zeppelin.k8s.interpreter.container.image}}
+    {% if zeppelin.k8s.interpreter.container.imagePullPolicy is defined %}
+    imagePullPolicy: {{zeppelin.k8s.interpreter.container.imagePullPolicy}}
+    {% endif %}
     args:
       - "$(ZEPPELIN_HOME)/bin/interpreter.sh"
       - "-d"
@@ -89,6 +92,9 @@ spec:
   initContainers:
   - name: spark-home-init
     image: {{zeppelin.k8s.spark.container.image}}
+    {% if zeppelin.k8s.spark.container.imagePullPolicy is defined %}
+    imagePullPolicy: {{zeppelin.k8s.spark.container.imagePullPolicy}}
+    {% endif %}
     command: ["sh", "-c", "cp -r /opt/spark/* /spark/"]
     volumeMounts:
     - name: spark-home


### PR DESCRIPTION

### What is this PR for?
Currently, the interpreter pod created by `k8s/interpreter/100-interpreter-spec.yaml` cannot set the `imagePullPolicy` for both the zeppelin image and the spark image (When using the spark interpreter, the spark image needs to be set for the init container).

So this PR adds two properties:
* `zeppelin.k8s.interpreter.container.imagePullPolicy`, to set the pull policy of the zeppelin image.
* `zeppelin.k8s.spark.container.imagePullPolicy`, to set the pull policy of the spark image.

Users can set these two properties directly in the interpreter settings, such as:
```
%spark.conf
zeppelin.k8s.interpreter.container.imagePullPolicy Always
zeppelin.k8s.spark.container.imagePullPolicy Always
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5456>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
