### PR TITLE
[ZEPPELIN-5444] Allow users to set service account for interpreter

### DIFF
--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -248,6 +248,7 @@ The interpreter pod can also be customized through the interpreter settings. Her
 | Property Name | Default Value | Description |
 | ----- | ----- | ----- |
 | `zeppelin.k8s.namespace` | `default` | The Kubernetes namespace to use. |
+| `zeppelin.k8s.interpreter.serviceAccount` | `default` | The Kubernetes service account to use. |
 | `zeppelin.k8s.interpreter.container.image` | `apache/zeppelin:<ZEPPELIN_VERSION>` | The interpreter image to use. |
 | `zeppelin.k8s.interpreter.cores` | (optional)  | The number of cpu cores to use. |
 | `zeppelin.k8s.interpreter.memory` | (optional) | The memory to use, e.g., `1g`. |

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -33,6 +33,7 @@ metadata:
     uid: {{zeppelin.k8s.server.uid}}
   {% endif %}
 spec:
+  serviceAccountName: {{zeppelin.k8s.interpreter.serviceAccount}}
   {% if zeppelin.k8s.interpreter.group.name == "spark" %}
   automountServiceAccountToken: true
   {% else %}
@@ -169,7 +170,7 @@ metadata:
   {% endif %}
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{zeppelin.k8s.interpreter.serviceAccount}}
 roleRef:
   kind: Role
   name: {{zeppelin.k8s.interpreter.pod.name}}

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -135,6 +135,19 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     return namespace;
   }
 
+  /**
+   * Get the service account. If user does not set the service account from the interpreter settings, return default.
+   * @return the service account
+   */
+  public String getServiceAccount(){
+    if(properties.containsKey("zeppelin.k8s.interpreter.serviceAccount")){
+      return properties.getProperty("zeppelin.k8s.interpreter.serviceAccount");
+    }
+    else{
+      return "default";
+    }
+  }
+
   @Override
   public void start(String userName) throws IOException {
 
@@ -277,6 +290,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     // k8s template properties
     k8sProperties.put("zeppelin.k8s.namespace", getNamespace());
     k8sProperties.put("zeppelin.k8s.interpreter.pod.name", getPodName());
+    k8sProperties.put("zeppelin.k8s.interpreter.serviceAccount", getServiceAccount());
     k8sProperties.put("zeppelin.k8s.interpreter.container.name", interpreterGroupName.toLowerCase());
     k8sProperties.put("zeppelin.k8s.interpreter.container.image", containerImage);
     k8sProperties.put("zeppelin.k8s.interpreter.group.id", getInterpreterGroupId());


### PR DESCRIPTION
### What is this PR for?
Currently, users cannot set the service account for the interpreter pod under k8s mode. And there is no service account defined in the pod `spec` in `k8s/interpreter/100-interpreter-spec.yaml`. According to the documentation of Kubernetes (<https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/>):
> When you create a pod, if you do not specify a service account, it is automatically assigned the **default** service account in the same namespace.

, which means that currently the interpreter pod can only use the default service account.

In order to allow users to directly set the service account for the interpreter pod in the interpreter settings, this PR adds a k8s template property, named `zeppelin.k8s.interpreter.serviceAccount`.

Example usage:
```
%spark.conf
zeppelin.k8s.interpreter.serviceAccount yourServiceAccount
```

Note that the `k8s/interpreter/100-interpreter-spec.yaml` creates a **role binding** when using the spark interpreter. It was originally directly bound to the default service account. This PR makes it bind to the service account set by user.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5444>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
