### PR TITLE
[ZEPPELIN-5442] Allow users to set a separate namespace for the interpreter

### DIFF
--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -248,7 +248,7 @@ The interpreter pod can also be customized through the interpreter settings. Her
 
 | Property Name | Default Value | Description |
 | ----- | ----- | ----- |
-| `zeppelin.k8s.namespace` | `default` | The Kubernetes namespace to use. |
+| `zeppelin.k8s.interpreter.namespace` | `default` | Specify the namespace of the current interpreter. Users can set different namespaces for different interpreters. In order to minimize permissions, the interpreter pod can only be created in the `default` namespace by default. If users need to create an interpreter pod in other namespaces, they need to add the corresponding `rolebinding` in `k8s/zeppelin-server.yaml`.|
 | `zeppelin.k8s.interpreter.serviceAccount` | `default` | The Kubernetes service account to use. |
 | `zeppelin.k8s.interpreter.container.image` | `apache/zeppelin:<ZEPPELIN_VERSION>` | The interpreter image to use. |
 | `zeppelin.k8s.interpreter.cores` | (optional)  | The number of cpu cores to use. |

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -17,7 +17,7 @@
 kind: Pod
 apiVersion: v1
 metadata:
-  namespace: {{zeppelin.k8s.namespace}}
+  namespace: {{zeppelin.k8s.interpreter.namespace}}
   name: {{zeppelin.k8s.interpreter.pod.name}}
   labels:
     app: {{zeppelin.k8s.interpreter.pod.name}}
@@ -114,7 +114,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  namespace: {{zeppelin.k8s.namespace}}
+  namespace: {{zeppelin.k8s.interpreter.namespace}}
   name: {{zeppelin.k8s.interpreter.pod.name}}             # keep Service name the same to Pod name.
   {% if zeppelin.k8s.server.uid is defined %}
   ownerReferences:
@@ -146,7 +146,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{zeppelin.k8s.interpreter.pod.name}}
-  namespace: {{zeppelin.k8s.namespace}}
+  namespace: {{zeppelin.k8s.interpreter.namespace}}
   {% if zeppelin.k8s.server.uid is defined %}
   ownerReferences:
   - apiVersion: v1

--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -201,7 +201,7 @@ kind: ServiceAccount
 metadata:
   name: zeppelin-server
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: zeppelin-server-role
@@ -217,10 +217,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: zeppelin-server-role-binding
+  namespace: default
 subjects:
 - kind: ServiceAccount
   name: zeppelin-server
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: zeppelin-server-role
   apiGroup: rbac.authorization.k8s.io

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -112,7 +112,7 @@ public class K8sRemoteInterpreterProcessTest {
     Properties p = intp.getTemplateBindings(null);
 
     // then
-    assertEquals("default", p.get("zeppelin.k8s.namespace"));
+    assertEquals("default", p.get("zeppelin.k8s.interpreter.namespace"));
     assertEquals(intp.getPodName(), p.get("zeppelin.k8s.interpreter.pod.name"));
     assertEquals("sh", p.get("zeppelin.k8s.interpreter.container.name"));
     assertEquals("interpreter-container:1.0", p.get("zeppelin.k8s.interpreter.container.image"));
@@ -424,7 +424,7 @@ public class K8sRemoteInterpreterProcessTest {
         true);
     ExecutorService service = Executors.newFixedThreadPool(1);
     service
-        .submit(new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp));
+        .submit(new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp));
     intp.start("TestUser");
     // then
     assertEquals("Running", intp.getPodPhase());
@@ -458,7 +458,7 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         false,
         true);
-    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp);
+    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp);
     podStatusSimulator.setSecondPhase("Failed");
     podStatusSimulator.setSuccessfulStart(false);
     ExecutorService service = Executors.newFixedThreadPool(1);
@@ -472,7 +472,7 @@ public class K8sRemoteInterpreterProcessTest {
       assertNotNull(e);
       // Check that the Pod is deleted
       assertNull(
-          server.getClient().pods().inNamespace(intp.getNamespace()).withName(intp.getPodName())
+          server.getClient().pods().inNamespace(intp.getInterpreterNamespace()).withName(intp.getPodName())
               .get());
     }
   }
@@ -505,7 +505,7 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         false,
         false);
-    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getNamespace(), intp.getPodName(), intp);
+    PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp);
     podStatusSimulator.setFirstPhase("Pending");
     podStatusSimulator.setSecondPhase("Pending");
     podStatusSimulator.setSuccessfulStart(false);
@@ -526,7 +526,7 @@ public class K8sRemoteInterpreterProcessTest {
     // wait for a shutdown
     service.awaitTermination(10, TimeUnit.SECONDS);
     // Check that the Pod is deleted
-    assertNull(server.getClient().pods().inNamespace(intp.getNamespace())
+    assertNull(server.getClient().pods().inNamespace(intp.getInterpreterNamespace())
         .withName(intp.getPodName()).get());
 
   }


### PR DESCRIPTION
### What is this PR for?
Currently, if zeppelin is running under k8s mode and the zeppelin server is running inside the k8s cluster, it will start the interpreter pod under the namespace specified in `/var/run/secrets/kubernetes.io/serviceaccount/namespace`. But if zeppelin-server is running **outside of kubernetes cluster**, it will use the config `zeppelin.k8s.namespace` to start the interpreter pod under the given namespace. However, this approach will cause users to only set a **global namespace**.

Hence, this PR allows user to set a set **separate namespace** for the interpreter in the interpreter settings:

Example usage:
```
%spark.conf
zeppelin.k8s.interpreter.namespace spark
```
The spark interpreter pod will be created under the namespace: `spark`.

```
%python.conf
zeppelin.k8s.interpreter.namespace python
```
The python interpreter pod will be created under the namespace: `python`.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5442>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
