### PR TITLE
[ZEPPELIN-5459] Unable to change graph setting when paragraph is in RUNNING

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js
@@ -815,7 +815,7 @@ function ResultCtrl($scope, $rootScope, $route, $window, $routeParams, $location
   };
 
   const commitVizConfigChange = function(config, vizId) {
-    if ([ParagraphStatus.RUNNING, ParagraphStatus.PENDING].indexOf(paragraph.status) < 0) {
+    if (ParagraphStatus.PENDING !== paragraph.status) {
       let newConfig = angular.copy($scope.config);
       if (!newConfig.graph) {
         newConfig.graph = {};


### PR DESCRIPTION

### What is this PR for?

The issue happens in Flink streaming visualization. If I change the graph setting when paragraph is in RUNNING, it would be revert back to its original setting when backend send data to frontend. The root cause is that zeppelin didn't save paragraph setting change when paragraph is in RUNNING.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5459

### How should this be tested?
*  manually tested

### Screenshots (if appropriate)

Before

![before](https://user-images.githubusercontent.com/164491/125650746-193c1a03-0c0a-44d3-8f26-57fbfda5eed7.gif)

After
![after](https://user-images.githubusercontent.com/164491/125650760-284b232a-ce4a-4d5f-b637-c2cf1e9bb3e1.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
