### PR TITLE
[ZEPPELIN-5460] Handling of hidden files while applying files under k8s mode

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -241,6 +241,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
   void apply(File path, boolean delete, Properties templateProperties) throws IOException {
     if (path.getName().startsWith(".") || path.isHidden() || path.getName().endsWith("~")) {
       LOGGER.info("Skip {}", path.getAbsolutePath());
+      return;
     }
 
     if (path.isDirectory()) {


### PR DESCRIPTION
### What is this PR for?
Currently, if there are some hidden files in the directory `k8s/interpreter`, zeppelin just outputs some logs `Skip {...}` but does not actually skip those hidden files. So if there are some odd files (e.g., `.DS_Store`), there will be some errors while applying them to k8s.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5460>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
