### PR TITLE
[ZEPPELIN-5458] fix that zeppelin can not parse columns  which contains chinese character

### DIFF
--- a/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivySQLInterpreterTest.java
@@ -76,12 +76,12 @@ public class LivySQLInterpreterTest {
     rows = sqlInterpreter.parseSQLOutput("+---+---+\n" +
         "|  a|  b|\n" +
         "+---+---+\n" +
-        "|  1| 1a|\n" +
+        "|  1| 你|\n" +
         "|  2| 2b|\n" +
         "+---+---+");
     assertEquals(3, rows.size());
     assertEquals("a\tb", rows.get(0));
-    assertEquals("1\t1a", rows.get(1));
+    assertEquals("1\t你", rows.get(1));
     assertEquals("2\t2b", rows.get(2));
 
 


### PR DESCRIPTION
### What is this PR for?
fix that zeppelin can not parse columns  which contains chinese character

this PR do two things

the first one thing insert a special character (/u0001) which nerver use after every chinese character,
so zeppeline can split string correctly, replace /u0001 with empty string, before add record to rows

the second thing avoid that chinese character is escaped.
### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5458

### How should this be tested?
already added test case in test units

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47968604/125909542-6db4d111-ed61-4086-9446-84ff117bceaa.png)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
