### PR TITLE
[ZEPPELIN-5464] Zeppelin server needs to obtain the permission to create configmaps under k8s mode

### DIFF
--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -207,7 +207,7 @@ metadata:
   name: zeppelin-server-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services"]
+  resources: ["pods", "services", "configmaps"]
   verbs: ["create", "get", "update", "patch", "list", "delete", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]


### PR DESCRIPTION
### What is this PR for?
Since the spark interpreter pod need to create the resource "configmaps" (please refer to <https://github.com/apache/zeppelin/pull/4165> for more information), Zeppelin Server also needs to obtain relative permissions when it is running inside k8s cluster. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5464>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
