### PR TITLE
[ZEPPELIN-5465] SERVICE_DOMAIN may be null while Zeppelin server is running outside k8s

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -293,7 +293,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     }
     Map<String, String> k8sEnv = new HashMap<>(getEnv());
     // environment variables
-    k8sEnv.put(ENV_SERVICE_DOMAIN, getEnv().getOrDefault(ENV_SERVICE_DOMAIN, System.getenv(ENV_SERVICE_DOMAIN)));
+    k8sEnv.put(ENV_SERVICE_DOMAIN, getEnv().getOrDefault(ENV_SERVICE_DOMAIN, System.getenv(ENV_SERVICE_DOMAIN) == null ? "local.zeppelin-project.org" : System.getenv(ENV_SERVICE_DOMAIN)));
     k8sEnv.put(ENV_ZEPPELIN_HOME, getEnv().getOrDefault(ENV_ZEPPELIN_HOME, System.getenv(ENV_ZEPPELIN_HOME)));
 
     if (isSpark()) {


### PR DESCRIPTION
### What is this PR for?
The function `sparkUiWebUrlFromTemplate` needs to use the variable `SERVICE_DOMAIN` to bind the `jinjava` template, which sets the environment variable `SERVICE_DOMAIN` as the default value.
However, user may not set the environment variable when Zeppelin server is running outside of k8s, and it will get a NullPointerExcepetion:
```
NullPointerException: null value in entry: SERVICE_DOMAIN=null
```

When the user does not care about `zeppelin.spark.uiWebUrl`, he does not need to set the `SERVICE_DOMAIN` environment.

So this PR change the default value of `SERVICE_DOMAIN` to `local.zeppelin-project.org` if `System.getenv(ENV_SERVICE_DOMAIN) == null` to avoid the potential NullPointerExcepetion.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* <https://issues.apache.org/jira/browse/ZEPPELIN-5465>

### How should this be tested?
* CI pass and manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
