### PR TITLE
[ZEPPELIN-5470] set statement may not work when key value around quotes

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterrpeter.java
@@ -502,7 +502,21 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
 
   public abstract void callInnerSelect(String sql, InterpreterContext context) throws IOException;
 
+  private String removeSingleQuote(String value) {
+    value = value.trim();
+    if (value.startsWith("'")) {
+      value = value.substring(1);
+    }
+    if (value.endsWith("'")) {
+      value = value.substring(0, value.length() - 1);
+    }
+    return value;
+  }
+
   public void callSet(String key, String value, InterpreterContext context) throws Exception {
+    key = removeSingleQuote(key);
+    value = removeSingleQuote(value);
+
     if ("execution.runtime-mode".equals(key)) {
       throw new UnsupportedOperationException("execution.runtime-mode is not supported to set, " +
               "you can use %flink.ssql & %flink.bsql to switch between streaming mode and batch mode");

--- a/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -551,6 +551,15 @@ public abstract class SqlInterpreterTest {
       InterpreterResult result = sqlInterpreter.interpret(
               "set table.sql-dialect=hive", context);
       assertEquals(context.out.toString(), Code.ERROR, result.code());
+      assertTrue(context.out.toString(),
+              context.out.toString().contains("table.sql-dialect is not a valid table/sql config"));
+    }
+
+    // table.local-time-zone is only available from 1.12
+    if (flinkVersion.newerThanOrEqual(FlinkVersion.fromVersionString("1.12.0"))) {
+      InterpreterContext context = getInterpreterContext();
+      InterpreterResult result = sqlInterpreter.interpret("SET 'table.local-time-zone' = 'UTC'", context);
+      assertEquals(context.out.toString(), InterpreterResult.Code.SUCCESS, result.code());
     }
   }
 

--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkVersion.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkVersion.java
@@ -63,6 +63,10 @@ public class FlinkVersion {
     return this.version < versionToCompare.version;
   }
 
+  public boolean newerThanOrEqual(FlinkVersion versionToCompare) {
+    return this.version >= versionToCompare.version;
+  }
+
   public int getMinorVersion() {
     return minorVersion;
   }


### PR DESCRIPTION
### What is this PR for?

Set statement will fail when key value is around quotes, this PR fix this issue by removing the quote, and unit test is added.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5470

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/164491/127421024-7c511d6f-6830-48aa-a30a-ef3712962c58.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
