### PR TITLE
[ZEPPELIN-5474] Add configuration to specify the port range of shiny app

### DIFF
--- a/rlang/src/main/java/org/apache/zeppelin/r/IRInterpreter.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/IRInterpreter.java
@@ -53,6 +53,7 @@ public class IRInterpreter extends JupyterKernelInterpreter {
   // only one shiny app can be hosted in one R session.
   private File shinyAppFolder;
   private SparkRBackend sparkRBackend;
+  private String shinyPortRange;
 
   public IRInterpreter(Properties properties) {
     super("ir", properties);
@@ -113,6 +114,7 @@ public class IRInterpreter extends JupyterKernelInterpreter {
     try {
       this.shinyAppFolder = Files.createTempDirectory("zeppelin-shiny").toFile();
       this.shinyAppFolder.deleteOnExit();
+      this.shinyPortRange = properties.getProperty("zeppelin.R.shiny.portRange", ":");
     } catch (IOException e) {
       throw new InterpreterException(e);
     }
@@ -185,11 +187,11 @@ public class IRInterpreter extends JupyterKernelInterpreter {
     try {
       StringBuilder builder = new StringBuilder("library(shiny)\n");
       String host = RemoteInterpreterUtils.findAvailableHostAddress();
-      int port = RemoteInterpreterUtils.findRandomAvailablePortOnAllLocalInterfaces();
+      int port = RemoteInterpreterUtils.findAvailablePort(shinyPortRange);
       builder.append("runApp(appDir='" + shinyAppFolder.getAbsolutePath() + "', " +
               "port=" + port + ", host='" + host + "', launch.browser=FALSE)");
       // shiny app will launch and block there until user cancel the paragraph.
-      LOGGER.info("Run shiny app code: {}", builder);
+      LOGGER.info("Run shiny app code: {}", builder.toString());
       return internalInterpret(builder.toString(), context);
     } finally {
       getKernelProcessLauncher().setRedirectedContext(null);

--- a/rlang/src/main/resources/interpreter-setting.json
+++ b/rlang/src/main/resources/interpreter-setting.json
@@ -31,6 +31,13 @@
         "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F, fig.retina = 2",
         "description": "",
         "type": "textarea"
+      },
+      "zeppelin.R.shiny.portRange": {
+        "envName": "",
+        "propertyName": "zeppelin.R.shiny.portRange",
+        "defaultValue": ":",
+        "description": "Shiny app would launch a web app at some port, this property is to specify the portRange via format '<start>:<end>', e.g. '5000:5001'. By default it is ':' which means any port",
+        "type": "string"
       }
     },
     "editor": {

--- a/spark/interpreter/src/main/resources/interpreter-setting.json
+++ b/spark/interpreter/src/main/resources/interpreter-setting.json
@@ -289,6 +289,13 @@
         "defaultValue": "out.format = 'html', comment = NA, echo = FALSE, results = 'asis', message = F, warning = F, fig.retina = 2",
         "description": "",
         "type": "textarea"
+      },
+      "zeppelin.R.shiny.portRange": {
+        "envName": "",
+        "propertyName": "zeppelin.R.shiny.portRange",
+        "defaultValue": ":",
+        "description": "Shiny app would launch a web app at some port, this property is to specify the portRange via format '<start>:<end>', e.g. '5000:5001'. By default it is ':' which means any port",
+        "type": "string"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?

Add configuration `zeppelin.R.shiny.portRange` for both R interpreter and SparkR, so that user can specify the portRange of shiny app. This would be useful when user has port usage constraint due to security reason. 

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5474

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
