### PR TITLE
[ZEPPELIN-5475] fix zep k8s service hostname

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -393,7 +393,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
   }
 
   private String getInterpreterPodDnsName() {
-    return String.format("%s.%s.svc",
+    return String.format("%s.%s.svc.cluster.local",
         getPodName(), // service name and pod name is the same
         getNamespace());
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -90,12 +90,12 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
   }
 
   /**
-   * @return get Zeppelin service. <service-name>.<namespace>.svc
+   * @return get Zeppelin service. <service-name>.<namespace>.svc.cluster.local
    * @throws IOException if the Zeppelin service cannot be generated
    */
   private String getZeppelinService(InterpreterLaunchContext context) throws IOException {
     if (isRunningOnKubernetes()) {
-      return String.format("%s.%s.svc",
+      return String.format("%s.%s.svc.cluster.local",
               zConf.getK8sServiceName(),
               getNamespace());
     } else {


### PR DESCRIPTION
### What is this PR for?

According doc at https://kubernetes.io/docs/concepts/services-networking/service/ , service lookup must end by svc.cluster.local. This PR fix it.

### What type of PR is it?
Bug fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5475

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
