### PR TITLE
[ZEPPELIN-5477] Change the wrong class name

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
@@ -27,7 +27,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import java.io.IOException;
 import java.util.Properties;
 
-public class FlinkBatchSqlInterpreter extends FlinkSqlInterrpeter {
+public class FlinkBatchSqlInterpreter extends FlinkSqlInterpreter {
 
   private ZeppelinContext z;
 

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterpreter.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.table.api.TableEnvironment;
@@ -51,9 +50,9 @@ import java.util.Properties;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
+public abstract class FlinkSqlInterpreter extends AbstractInterpreter {
 
-  protected static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterrpeter.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterpreter.class);
 
   protected FlinkInterpreter flinkInterpreter;
   protected TableEnvironment tbenv;
@@ -65,7 +64,7 @@ public abstract class FlinkSqlInterrpeter extends AbstractInterpreter {
   // https://ci.apache.org/projects/flink/flink-docs-release-1.10/dev/table/config.html
   private Map<String, ConfigOption> tableConfigOptions;
 
-  public FlinkSqlInterrpeter(Properties properties) {
+  public FlinkSqlInterpreter(Properties properties) {
     super(properties);
   }
 

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
@@ -30,7 +30,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
 import java.io.IOException;
 import java.util.Properties;
 
-public class FlinkStreamSqlInterpreter extends FlinkSqlInterrpeter {
+public class FlinkStreamSqlInterpreter extends FlinkSqlInterpreter {
 
   public FlinkStreamSqlInterpreter(Properties properties) {
     super(properties);

--- a/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
+++ b/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreterTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 public class FlinkBatchSqlInterpreterTest extends SqlInterpreterTest {
 
   @Override
-  protected FlinkSqlInterrpeter createFlinkSqlInterpreter(Properties properties) {
+  protected FlinkSqlInterpreter createFlinkSqlInterpreter(Properties properties) {
     return new FlinkBatchSqlInterpreter(properties);
   }
 

--- a/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
+++ b/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
@@ -27,7 +27,6 @@ import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
@@ -40,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 public class FlinkStreamSqlInterpreterTest extends SqlInterpreterTest {
 
   @Override
-  protected FlinkSqlInterrpeter createFlinkSqlInterpreter(Properties properties) {
+  protected FlinkSqlInterpreter createFlinkSqlInterpreter(Properties properties) {
     return new FlinkStreamSqlInterpreter(properties);
   }
 

--- a/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
+++ b/flink/flink-scala-parent/src/test/java/org/apache/zeppelin/flink/SqlInterpreterTest.java
@@ -77,7 +77,7 @@ public abstract class SqlInterpreterTest {
   protected FlinkInterpreter flinkInterpreter;
   protected IPyFlinkInterpreter iPyFlinkInterpreter;
   protected PyFlinkInterpreter pyFlinkInterpreter;
-  protected FlinkSqlInterrpeter sqlInterpreter;
+  protected FlinkSqlInterpreter sqlInterpreter;
 
   private AngularObjectRegistry angularObjectRegistry;
 
@@ -150,7 +150,7 @@ public abstract class SqlInterpreterTest {
     }
   }
 
-  protected abstract FlinkSqlInterrpeter createFlinkSqlInterpreter(Properties properties);
+  protected abstract FlinkSqlInterpreter createFlinkSqlInterpreter(Properties properties);
 
   @Test
   public void testDatabases() throws InterpreterException, IOException {


### PR DESCRIPTION
### What is this PR for?
FlinkSqlInterrpeter the class name is misspelled.Should be changed to FlinkSqlInterpreter.


### What type of PR is it?
[Improvement]


### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5477