### PR TITLE
[ZEPPELIN-5489] Fix NullPointerException, if the InterpreterResult is null

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/ParagraphJobStatus.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/ParagraphJobStatus.java
@@ -46,7 +46,7 @@ public class ParagraphJobStatus {
         if (!StringUtils.isBlank(p.getErrorMessage())) {
           this.errorMessage = p.getErrorMessage();
         } else {
-          this.errorMessage = p.getReturn().toString();
+          this.errorMessage = String.valueOf(p.getReturn());
         }
       }
     } else {


### PR DESCRIPTION
### What is this PR for?
This PR fixes a NullPointerException if the InterpreterResult is `null`.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5489

### How should this be tested?
* via CI


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
