### PR TITLE
[ZEPPELIN-5497] Memory leak of GenericObjectPool

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/PooledRemoteClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/PooledRemoteClient.java
@@ -60,6 +60,11 @@ public class PooledRemoteClient<T extends TServiceClient> {
     // Close client socket connection
     if (remoteClientFactory != null) {
       remoteClientFactory.close();
+      this.remoteClientFactory = null;
+    }
+    if (this.clientPool != null) {
+      this.clientPool.close();
+      this.clientPool = null;
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

Should close `clientPool` explicitly, otherwise it won't be garbage collected. 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5497?filter=-2

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
