### PR TITLE
[ZEPPELIN-5499] NPE in IPySparkInterpreter

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/IPySparkInterpreter.java
@@ -53,10 +53,12 @@ public class IPySparkInterpreter extends IPythonInterpreter {
     if (opened) {
       return;
     }
+
+    this.sparkInterpreter = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class);
     PySparkInterpreter pySparkInterpreter =
             getInterpreterInTheSameSessionByClassName(PySparkInterpreter.class, false);
-    setProperty("zeppelin.python", pySparkInterpreter.getPythonExec());
-    sparkInterpreter = getInterpreterInTheSameSessionByClassName(SparkInterpreter.class);
+    setProperty("zeppelin.python", pySparkInterpreter.getPythonExec(sparkInterpreter.getSparkContext().conf()));
+
     setProperty("zeppelin.py4j.useAuth",
             sparkInterpreter.getSparkVersion().isSecretSocketSupported() + "");
     SparkConf conf = sparkInterpreter.getSparkContext().getConf();

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -172,6 +172,10 @@ public class PySparkInterpreter extends PythonInterpreter {
   @Override
   protected String getPythonExec() {
     SparkConf sparkConf = getSparkConf();
+    return getPythonExec(sparkConf);
+  }
+
+  String getPythonExec(SparkConf sparkConf) {
     if (StringUtils.isNotBlank(sparkConf.get("spark.pyspark.driver.python", ""))) {
       return sparkConf.get("spark.pyspark.driver.python");
     }


### PR DESCRIPTION
### What is this PR for?

The root cause is the `SparkConf` in PySparkInterpreter is null when IPySparkInterpreter#open is called because SparkInterpreter is not opened yet at that time. This PR would pass `SparkConf` explicitly to avoid this issue. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5499

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
