### PR TITLE
[ZEPPELIN-5519] Show note path in the tooltip

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
@@ -51,6 +51,7 @@ export interface Note {
     paragraphs: ParagraphItem[];
     name: string;
     id: string;
+    path: string;
     defaultInterpreterGroup: string;
     noteParams: NoteParams;
     noteForms: NoteForms;

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.html
@@ -12,7 +12,9 @@
 
 <div class="bar" [class.simple]="looknfeel !== 'default'">
   <div class="title">
-    <zeppelin-elastic-input [readonly]="revisionView"
+    <zeppelin-elastic-input nz-tooltip
+                            [nzTitle]="note.path"
+                            [readonly]="revisionView"
                             [value]="note.name"
                             (valueUpdate)="updateNoteName($event)"></zeppelin-elastic-input>
   </div>

--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -22,7 +22,7 @@ limitations under the License.
       <p class="form-control-title"
          ng-class="{'reverse-ellipsis ellipsis':noteName(note).length > 45}"
          tooltip-placement="bottom"
-         uib-tooltip={{noteName(note)}}
+         uib-tooltip={{notePath(note)}}
          ng-click="input.showEditor = !revisionView; input.value = note.name"
          ng-show="!input.showEditor"><span>{{noteName(note)}}</span></p>
     </div>


### PR DESCRIPTION
### What is this PR for?
This PR adds a tooltip in zeppelin-web-angular and changes the tooltip in zeppelin-web to the note path.
Please note that I am not a front-end developer, so if you have any improvements, let me know.

### What type of PR is it?
- Improvement


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5519

### How should this be tested?
* CI

### Screenshots (if appropriate)
zeppelin-web Before:
![zeppelin-tooltip-old](https://user-images.githubusercontent.com/454320/133277486-86b4a286-2477-405d-8855-011f5122d561.png)
zeppelin-web After:
![zeppelin-tooltip-new](https://user-images.githubusercontent.com/454320/133277586-c6094826-75da-4340-897f-95fdfe8fc018.png)

zeppelin-web-angular After:
![zeppelin-tooltip-angular-new](https://user-images.githubusercontent.com/454320/133278166-a530dd16-d596-43ab-b117-ea405bffa0f7.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
