### PR TITLE
[ZEPPELIN-5522] Remove unnecessary maven-dependency-plugin maven plugin calls

### DIFF
--- a/alluxio/pom.xml
+++ b/alluxio/pom.xml
@@ -108,9 +108,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/angular/pom.xml
+++ b/angular/pom.xml
@@ -41,9 +41,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -252,9 +252,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -86,9 +86,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -235,9 +235,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -89,9 +89,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -72,9 +72,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/flink-cmd/pom.xml
+++ b/flink-cmd/pom.xml
@@ -63,9 +63,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -63,9 +63,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -51,9 +51,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/hazelcastjet/pom.xml
+++ b/hazelcastjet/pom.xml
@@ -56,9 +56,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -104,9 +104,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -121,9 +121,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/influxdb/pom.xml
+++ b/influxdb/pom.xml
@@ -65,9 +65,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -52,9 +52,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -196,9 +196,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -103,9 +103,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/ksql/pom.xml
+++ b/ksql/pom.xml
@@ -70,9 +70,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/kylin/pom.xml
+++ b/kylin/pom.xml
@@ -62,9 +62,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/lens/pom.xml
+++ b/lens/pom.xml
@@ -146,9 +146,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -304,9 +304,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/markdown/pom.xml
+++ b/markdown/pom.xml
@@ -83,9 +83,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -52,9 +52,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -78,9 +78,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -147,9 +147,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -134,9 +134,6 @@
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
 
             <!-- include sparkr by default -->
             <plugin>

--- a/sap/pom.xml
+++ b/sap/pom.xml
@@ -62,9 +62,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -143,9 +143,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/scio/pom.xml
+++ b/scio/pom.xml
@@ -111,9 +111,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -121,9 +121,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/spark-submit/pom.xml
+++ b/spark-submit/pom.xml
@@ -49,9 +49,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/spark/spark-dependencies/pom.xml
+++ b/spark/spark-dependencies/pom.xml
@@ -203,24 +203,6 @@
         </executions>
       </plugin>
 
-      <!-- Deploy datanucleus jars to the interpreter/spark directory -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-interpreter-dependencies</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>

--- a/sparql/pom.xml
+++ b/sparql/pom.xml
@@ -58,9 +58,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>

--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -157,9 +157,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
       </plugin>
       <plugin>

--- a/zeppelin-common/pom.xml
+++ b/zeppelin-common/pom.xml
@@ -69,12 +69,6 @@
         <filtering>true</filtering>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
 
 </project>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -118,14 +118,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <!--assembly does all the job here-->
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -160,21 +160,6 @@
           </configuration>
         </plugin>
 
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>copy-dependencies</id>
-              <phase>process-test-resources</phase>
-              <goals>
-                <goal>copy-dependencies</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/zeppelin-jupyter-interpreter/pom.xml
+++ b/zeppelin-jupyter-interpreter/pom.xml
@@ -169,10 +169,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
 

--- a/zeppelin-plugins/launcher/k8s-standard/pom.xml
+++ b/zeppelin-plugins/launcher/k8s-standard/pom.xml
@@ -118,13 +118,15 @@
                     </filters>
                 </configuration>
             </plugin>
-            <!--  disable maven-dependency-plugin with execution copy-plugin-dependencies because we shade the whole dependency -->
+            <!--  skip maven-dependency-plugin with execution copy-plugin-dependencies because we shade the whole dependency -->
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>copy-plugin-dependencies</id>
-                        <phase>none</phase>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### What is this PR for?
This PR removes unnecessary maven-dependency-plugin maven plugin calls


### What type of PR is it?
 - Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5522

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
