### PR TITLE
[ZEPPELIN-5524] Some configuration of flink interpreter are incorrect

### DIFF
--- a/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
+++ b/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
@@ -52,14 +52,14 @@
         "propertyName": null,
         "defaultValue": "1024m",
         "description": "Memory for JobManager, e.g. 1024m",
-        "type": "number"
+        "type": "text"
       },
       "taskmanager.memory.process.size": {
         "envName": null,
         "propertyName": null,
         "defaultValue": "1024m",
         "description": "Memory for TaskManager, e.g. 1024m",
-        "type": "number"
+        "type": "text"
       },
       "taskmanager.numberOfTaskSlots": {
         "envName": null,
@@ -92,7 +92,7 @@
       "zeppelin.flink.uiWebUrl": {
         "envName": null,
         "propertyName": null,
-        "defaultValue": false,
+        "defaultValue": "",
         "description": "User specified Flink JobManager url, it could be used in remote mode where Flink cluster is already started, or could be used as url template, e.g. https://knox-server:8443/gateway/cluster-topo/yarn/proxy/{{applicationId}}/ where {{applicationId}} would be replaced with yarn app id",
         "type": "string"
       },


### PR DESCRIPTION
### What is this PR for?
Type of `taskmanager.memory.process.size` & `jobmanager.memory.process.size` should be text.

Default value of `zeppelin.flink.uiWebUrl` should be empty string.


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5524

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
