### PR TITLE
[ZEPPELIN-5526] interpreter setting still in error status when remove the invalid dependency

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -667,6 +667,11 @@ public class InterpreterSetting {
     this.dependencies = dependencies;
     if (!this.dependencies.isEmpty()) {
       loadInterpreterDependencies();
+    } else {
+      // Interpreter setting may be in ERROR due to download fail,
+      // reset status to be READY when dependency is cleaned.
+      setStatus(Status.READY);
+      setErrorReason(null);
     }
   }
 


### PR DESCRIPTION

### What is this PR for?

The root cause is that the status and errorReason is not reset after invalid dependency is removed. This PR just reset them and also add unit test for that. 


### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5526

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
