### PR TITLE
ZEPPELIN-5534 Fix Maven warnings

### DIFF
--- a/flink/flink-scala-2.11/pom.xml
+++ b/flink/flink-scala-2.11/pom.xml
@@ -43,16 +43,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
-
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-
+      
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>

--- a/flink/flink-scala-2.12/pom.xml
+++ b/flink/flink-scala-2.12/pom.xml
@@ -45,15 +45,6 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
       </plugin>

--- a/flink/flink-scala-parent/pom.xml
+++ b/flink/flink-scala-parent/pom.xml
@@ -232,21 +232,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-hive_${flink.scala.binary.version}</artifactId>
-      <version>${flink.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-connector-hive_${flink.scala.binary.version}</artifactId>
-      <version>${flink.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-
     <!-- hadoop compatibility dependency -->
     <dependency>
       <groupId>org.apache.flink</groupId>
@@ -644,11 +629,37 @@
 
   <build>
     <pluginManagement>
-      <plugins>
+    <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+            <source>src/main/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+          <!-- Add src/test/scala to eclipse build path -->
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+            <source>src/test/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+
           <execution>
             <id>add-java-sources</id>
             <phase>generate-sources</phase>
@@ -846,40 +857,6 @@
             <sourceInclude>**/*.java</sourceInclude>
           </sourceIncludes>
         </configuration>
-      </plugin>
-
-      <!-- Adding scala source directories to build path -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <!-- Add src/main/scala to eclipse build path -->
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-            <source>src/main/scala</source>
-              </sources>
-            </configuration>
-          </execution>
-          <!-- Add src/test/scala to eclipse build path -->
-          <execution>
-            <id>add-test-source</id>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-            <source>src/test/scala</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
### What is this PR for?

There are Maven warnings caused by duplicate declarations of Maven plugins.

### What type of PR is it?
[Improvement]

### Todos

None

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5534

### How should this be tested?
* Execute any Maven goal, e.g. `mvn clean`
* Make sure there are no warnings

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - NO
* Does this needs documentation? - NO
