### PR TITLE
ZEPPELIN-5536 Update protoc and grpc for Linux ARM64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,8 @@
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
     <jettison.version>1.4.0</jettison.version>
     <jsoup.version>1.13.1</jsoup.version>
+    <protoc.version>3.5.0</protoc.version>
+    <grpc.version>1.26.0</grpc.version>
 
     <!-- test library versions -->
     <junit.version>4.12</junit.version>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -35,7 +35,6 @@
     <properties>
         <interpreter.name>r</interpreter.name>
         <spark.version>2.4.5</spark.version>
-        <grpc.version>1.15.0</grpc.version>
 
         <spark.archive>spark-${spark.version}</spark.archive>
         <spark.src.download.url>

--- a/zeppelin-jupyter-interpreter/pom.xml
+++ b/zeppelin-jupyter-interpreter/pom.xml
@@ -34,7 +34,6 @@
   <properties>
     <interpreter.name>jupyter</interpreter.name>
     <python.py4j.version>0.10.7</python.py4j.version>
-    <grpc.version>1.15.0</grpc.version>
   </properties>
 
   <dependencies>
@@ -129,9 +128,9 @@
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.4.0:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>
         <executions>
           <execution>

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelClient.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelClient.java
@@ -71,7 +71,7 @@ public class JupyterKernelClient {
    * Construct client for accessing RouteGuide server at {@code host:port}.
    */
   public JupyterKernelClient(String host, int port, String kernel) {
-    this(ManagedChannelBuilder.forAddress(host, port).usePlaintext(true), new Properties(),
+    this(ManagedChannelBuilder.forAddress(host, port).usePlaintext(), new Properties(),
             kernel);
   }
 

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -137,7 +137,7 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
               32 * 1024 * 1024 + ""));
 
       jupyterKernelClient = new JupyterKernelClient(ManagedChannelBuilder.forAddress("127.0.0.1",
-              kernelPort).usePlaintext(true).maxInboundMessageSize(messageSize),
+              kernelPort).usePlaintext().maxInboundMessageSize(messageSize),
               getProperties(), kernel);
       launchJupyterKernel(kernelPort);
     } catch (Exception e) {


### PR DESCRIPTION
### What is this PR for?

Update protoc and grpc to their first versions that support Linux ARM64 architecture.
With this the build on Linux ARM64 passes!

### What type of PR is it?
Bug Fix

### What is the Jira issue?

[ZEPPELIN-5536](https://issues.apache.org/jira/browse/ZEPPELIN-5536)

### How should this be tested?

Run the build on Linux ARM64, e.g. at TravisCI or even better CircleCI on ARM64 hardware! 
Let me know if you want me to setup either of those!

### Questions:
* Does the licenses files need update? - NO
* Is there breaking changes for older versions? - Hopefully not! There is one API break in Grpc APIs (`usePlaintext()`), but there might be problems in reading serialized messages with the old versions 
* Does this needs documentation? - NO
