### PR TITLE
[ZEPPELIN-5540] fix the unexpected NPE when use hive with Flink

### DIFF
--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -489,7 +489,7 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
 
   private def registerHiveCatalog(): Unit = {
     val hiveConfDir =
-      properties.getOrDefault("HIVE_CONF_DIR", System.getenv("HIVE_CONF_DIR")).toString
+      properties.getOrDefault("HIVE_CONF_DIR", System.getenv("HIVE_CONF_DIR"))
     if (hiveConfDir == null) {
       throw new InterpreterException("HIVE_CONF_DIR is not specified");
     }

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -495,7 +495,7 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
     }
     val database = properties.getProperty("zeppelin.flink.hive.database", "default")
     val hiveVersion = properties.getProperty("zeppelin.flink.hive.version", "2.3.4")
-    val hiveCatalog = new HiveCatalog("hive", database, hiveConfDir, hiveVersion)
+    val hiveCatalog = new HiveCatalog("hive", database, hiveConfDir.toString, hiveVersion)
     this.btenv.registerCatalog("hive", hiveCatalog)
     this.btenv.useCatalog("hive")
     this.btenv.useDatabase(database)


### PR DESCRIPTION
### What is this PR for?
When we enable hive in Flink interpreter, we encounter the unexpected NPE. The root cause is the value `properties.getOrDefault("HIVE_CONF_DIR", System.getenv("HIVE_CONF_DIR"))` is null. It will throw NPE when apply the `toString()` method.


### What type of PR is it?
[Bug Fix ]

### Todos
None

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5540

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
