### PR TITLE
[ZEPPELIN-5547] Rename note doesn't change the name field in file json

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -246,6 +246,13 @@ public class NoteManager {
 
     // update notebookrepo
     this.notebookRepo.move(noteId, notePath, newNotePath, subject);
+
+    // save note if note name is changed, because we need to update the note field in note json.
+    String oldNoteName = getNoteName(notePath);
+    String newNoteName = getNoteName(newNotePath);
+    if (!oldNoteName.equalsIgnoreCase(newNoteName)) {
+      this.notebookRepo.save(noteNode.note, subject);
+    }
   }
 
   public void moveFolder(String folderPath,

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.notebook;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.aether.RepositoryException;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -78,7 +80,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   private Notebook notebook;
   private NoteManager noteManager;
-  private NotebookRepo notebookRepo;
+  private VFSNotebookRepo notebookRepo;
   private AuthorizationService authorizationService;
   private Credentials credentials;
   private AuthenticationInfo anonymous = AuthenticationInfo.ANONYMOUS;
@@ -1579,6 +1581,26 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     for (Paragraph p : paragraphs) {
     	  destNote.addCloneParagraph(p, AuthenticationInfo.ANONYMOUS);
       assertEquals("anonymous", p.getUser());
+    }
+  }
+
+  @Test
+  public void testMoveNote() throws InterruptedException, IOException {
+    Note note = null;
+    try {
+      note = notebook.createNote("note1", anonymous);
+      assertEquals("note1", note.getName());
+      assertEquals("/note1", note.getPath());
+      notebook.moveNote(note.getId(), "/tmp/note2", anonymous);
+
+      // read note json file to check the name field is updated
+      File noteFile = new File(conf.getNotebookDir() + "/" + notebookRepo.buildNoteFileName(note));
+      String noteJson = IOUtils.toString(new FileInputStream(noteFile));
+      assertTrue(noteJson, noteJson.contains("note2"));
+    } finally {
+      if (note != null) {
+        notebook.removeNote(note, anonymous);
+      }
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

This PR would update note file if the file name is changed. Otherwise the `name` field in note json would be inconsistent with note file name. They would become consistent when user do save note operation afterwards. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5547

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
