### PR TITLE
[ZEPPELIN-5539] UnsupportedOperationException in YarnRemoteInterpreterProcess

### DIFF
--- a/zeppelin-plugins/launcher/yarn/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/yarn/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnRemoteInterpreterProcess.java
@@ -372,7 +372,7 @@ public class YarnRemoteInterpreterProcess extends RemoteInterpreterProcess {
    * classpath specified through the Hadoop and Yarn configurations.
    */
   private void populateHadoopClasspath(Map<String, String> envs) {
-    List<String> yarnClassPath = Arrays.asList(getYarnAppClasspath());
+    List<String> yarnClassPath = new ArrayList(Arrays.asList(getYarnAppClasspath()));
     List<String> mrClassPath = Arrays.asList(getMRAppClasspath());
     yarnClassPath.addAll(mrClassPath);
     if (LOGGER.isInfoEnabled()) {


### PR DESCRIPTION

### What is this PR for?

The root cause is that `Arrays.asList` return a fixed size List, this PR use `ArrayList` instead to fix this issue.

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5539

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
