### PR TITLE
[ZEPPELIN-5549] GCS Notebook storage documentation corrections

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -98,7 +98,7 @@
   <value></value>
   <description>
     A GCS path in the form gs://bucketname/path/to/dir.
-    Notes are stored at {zeppelin.notebook.gcs.dir}/{notebook-id}/note.json
+    Notes are stored at {zeppelin.notebook.gcs.dir}/{notebook-name}_{notebook-id}.zpln
  </description>
 </property>
 

--- a/docs/_includes/themes/zeppelin/_navigation.html
+++ b/docs/_includes/themes/zeppelin/_navigation.html
@@ -114,6 +114,7 @@
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-local-git-repository">Git Storage</a></li>
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-s3">S3 Storage</a></li>
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-azure">Azure Storage</a></li>
+                <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-google-cloud-storage">Google Cloud Storage</a></li>
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-oss">OSS Storage</a></li>
                 <li><a href="{{BASE_PATH}}/setup/storage/storage.html#notebook-storage-in-mongodb">MongoDB Storage</a></li>
                 <li role="separator" class="divider"></li>

--- a/docs/setup/storage/storage.md
+++ b/docs/setup/storage/storage.md
@@ -326,13 +326,13 @@ First, choose a GCS path under which to store notebooks.
 </property>
 ```
 
-Then, initialize the `GCSNotebookRepo` class in the file **zeppelin-site.xml** by commenting the next property:
+Then, initialize the `GCSNotebookRepo` class in the file **zeppelin-site.xml** by uncommenting:
 
 ```xml
 <property>
   <name>zeppelin.notebook.storage</name>
-  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo</value>
-  <description>versioned notebook persistence layer implementation</description>
+  <value>org.apache.zeppelin.notebook.repo.GCSNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
 </property>
 ```
 
@@ -341,8 +341,8 @@ and commenting out:
 ```xml
 <property>
   <name>zeppelin.notebook.storage</name>
-  <value>org.apache.zeppelin.notebook.repo.GCSNotebookRepo</value>
-  <description>notebook persistence layer implementation</description>
+  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo</value>
+  <description>versioned notebook persistence layer implementation</description>
 </property>
 ```
 

--- a/docs/setup/storage/storage.md
+++ b/docs/setup/storage/storage.md
@@ -321,7 +321,7 @@ First, choose a GCS path under which to store notebooks.
   <value></value>
   <description>
     A GCS path in the form gs://bucketname/path/to/dir.
-    Notes are stored at {zeppelin.notebook.gcs.dir}/{notebook-id}/note.json
+    Notes are stored at {zeppelin.notebook.gcs.dir}/{notebook-name}_{notebook-id}.zpln
  </description>
 </property>
 ```

--- a/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
@@ -111,7 +111,7 @@ public class GCSNotebookRepo implements NotebookRepo {
       this.basePath = Optional.empty();
     }
 
-    // Notes are stored at gs://bucketName/basePath/<note-id>/note.json
+    // Notes are stored at gs://bucketName/basePath/<note-name>_<note-id>.zpln
     if (basePath.isPresent()) {
       this.notePathPattern = Pattern.compile(
           "^" + Pattern.quote(basePath.get() + "/") + "(.+\\.zpln)$");


### PR DESCRIPTION
### What is this PR for?
The documentation surrounding notebook storage using Google Cloud Storage contains a number of small inaccuracies.  Additionally, the GCS notebook storage documentation link was missing from the main navigation bar.

### What type of PR is it?
Documentation

### How should this be tested?
* Ensure that new Google Cloud Storage entry appears in navigation menu and works correctly.

### Questions:
* I noticed that the S3 storage documentation has similar inaccuracies regarding the notebook storage paths.  Should I go ahead and update those as well, or should those be handled as a separate issue?
* If this PR looks good, could you kindly apply the 'hacktoberfest-accepted' label? 😅
