### PR TITLE
[ZEPPELIN-5549] Shiro authentication doc improvements

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -253,7 +253,9 @@ authc = org.apache.zeppelin.realm.kerberos.KerberosAuthenticationFilter
 ```
 For above configuration to work, user need to do some more configurations outside Zeppelin.
 
-1). A valid SPNEGO keytab should be available on the Zeppelin node and should be readable by 'zeppelin' user. If there is a SPNEGO keytab already available (because of other Hadoop service), it can be reused here and no need to generate a new keytab. An example of working SPNEGO keytab could be:
+1. A valid SPNEGO keytab should be available on the Zeppelin node and should be readable by 'zeppelin' user. If there is a SPNEGO keytab already available (because of another Hadoop service), it can be reused here without generating a new keytab.
+An example of working SPNEGO keytab could be:
+
 ```
 $ klist -kt /etc/security/keytabs/spnego.service.keytab
 Keytab name: FILE:/etc/security/keytabs/spnego.service.keytab
@@ -264,16 +266,19 @@ KVNO Timestamp           Principal
    2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
    2 11/26/2018 16:58:38 HTTP/zeppelin.fqdn.domain.com@EXAMPLE.COM
 ```
-and the keytab permission should be: (VERY IMPORTANT to not to set this to 777 or readable by all !!!):
+
+Ensure that the keytab premissions are sufficiently strict while still readable by the 'zeppelin' user:
+
 ```
 $ ls -l /etc/security/keytabs/spnego.service.keytab
 -r--r-----. 1 root hadoop 346 Nov 26 16:58 /etc/security/keytabs/spnego.service.keytab
 ```
-Above 'zeppelin' user happens to be member of 'hadoop' group.
 
-2). A secret signature file must be present on Zeppelin node (readable to 'zeppelin' user). This file contains the random binary numbers which is used to sign 'hadoop.auth' cookie, generated during SPNEGO exchange. If such a file is already generated and available on the Zeppelin node, it should be used rather than generating a new file.
+Note that for the above example, the 'zeppelin' user can read the keytab because they are a member of the 'hadoop' group.
 
+2. A secret signature file must be present on Zeppelin node, readable by 'zeppelin' user. This file contains the random binary numbers which is used to sign 'hadoop.auth' cookie, generated during SPNEGO exchange. If such a file is already generated and available on the Zeppelin node, it should be used rather than generating a new file.
 Commands to generate a secret signature file (if required):
+
 ```
 dd if=/dev/urandom of=/etc/security/http_secret bs=1024 count=1
 chown hdfs:hadoop /etc/security/http_secret

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -213,7 +213,7 @@ either reuse one of these services or create your own for Zeppelin. Activating P
 ### Knox SSO
 [KnoxSSO](https://knox.apache.org/books/knox-0-13-0/dev-guide.html#KnoxSSO+Integration) provides an abstraction for integrating any number of authentication systems and SSO solutions and enables participating web applications to scale to those solutions more easily. Without the token exchange capabilities offered by KnoxSSO each component UI would need to integrate with each desired solution on its own.
 
-When Knox SSO is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine group membership of user who is trying to log in. Role-based access permission can be set based on groups as seen by Hadoop.
+When Knox SSO is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine the group memberships of the user who is trying to log in. Role-based access permission can be set based on groups as seen by Hadoop.
 
 To enable this, apply the following change in `conf/shiro.ini` under `[main]` section.
 
@@ -236,7 +236,7 @@ authc = org.apache.zeppelin.realm.jwt.KnoxAuthenticationFilter
 ### HTTP SPNEGO Authentication
 HTTP SPNEGO (Simple and Protected GSS-API NEGOtiation) is the standard way to support Kerberos Ticket based user authentication for Web Services. Based on [Apache Hadoop Auth](https://hadoop.apache.org/docs/current/hadoop-auth/index.html), Zeppelin supports ability to authenticate users by accepting and validating their Kerberos Ticket.
 
-When HTTP SPNEGO Authentication is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine group membership of user who is trying to log in. Role-based access permission can be set based on groups as seen by Hadoop.
+When HTTP SPNEGO Authentication is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine the group memberships of the user who is trying to log in. Role-based access permission can be set based on groups as seen by Hadoop.
 
 To enable this, apply the following change in `conf/shiro.ini` under `[main]` section.
 

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -213,6 +213,8 @@ either reuse one of these services or create your own for Zeppelin. Activiting P
 ### Knox SSO
 [KnoxSSO](https://knox.apache.org/books/knox-0-13-0/dev-guide.html#KnoxSSO+Integration) provides an abstraction for integrating any number of authentication systems and SSO solutions and enables participating web applications to scale to those solutions more easily. Without the token exchange capabilities offered by KnoxSSO each component UI would need to integrate with each desired solution on its own.
 
+When Knox SSO is enabled for Zeppelin, the [Apache Hadoop Groups Mapping](https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/GroupsMapping.html) configuration will used internally to determine group membership of user who is trying to log in. Role-based access permission can be set based on groups as seen by Hadoop.
+
 To enable this, apply the following change in `conf/shiro.ini` under `[main]` section.
 
 ```

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -199,8 +199,8 @@ ldapRealm.hadoopSecurityCredentialPath = jceks://file/user/zeppelin/conf/zeppeli
 
 ### PAM
 [PAM](https://en.wikipedia.org/wiki/Pluggable_authentication_module) authentication support allows the reuse of existing authentication
-moduls on the host where Zeppelin is running. On a typical system modules are configured per service for example sshd, passwd, etc. under `/etc/pam.d/`. You can
-either reuse one of these services or create your own for Zeppelin. Activiting PAM authentication requires two parameters:
+modules on the host where Zeppelin is running. On a typical system modules are configured per service for example sshd, passwd, etc. under `/etc/pam.d/`. You can
+either reuse one of these services or create your own for Zeppelin. Activating PAM authentication requires two parameters:
  1. realm: The Shiro realm being used
  2. service: The service configured under `/etc/pam.d/` to be used. The name here needs to be the same as the file name under `/etc/pam.d/`
 


### PR DESCRIPTION
### What is this PR for?
- Adds note about Knox SSO using Hadoop Groups for group mappings (copied and modified from SPNEGO).
- Corrects markdown formatting issues in SPNEGO section.
- Modified the wording of some SPNEGO instructions for clarity.
- Fixes a few minor typos and grammar issues.

### What type of PR is it?
Documentation

### How should this be tested?
* Verify that markdown changes render correctly, especially those under the SPNEGO heading.

### Questions:
* If this PR looks good, could you kindly apply the 'hacktoberfest-accepted' label? 😅
