### PR TITLE
[ZEPPELIN-5559] Add note cache

### DIFF
--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -463,6 +463,12 @@ Sources descending by priority:
     <td></td>
     <td>comma-separated list of folder, where cron is allowed</td>
   </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTE_CACHE_THRESHOLD</h6></td>
+    <td><h6 class="properties">zeppelin.note.cache.threshold</h6></td>
+    <td>50</td>
+    <td>Threshold for the number of notes in the cache before an eviction occurs.</td>
+  </tr>
 </table>
 
 

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
@@ -28,7 +28,6 @@ import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
-import org.apache.zeppelin.interpreter.InterpreterOutput;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
@@ -36,16 +35,11 @@ import org.apache.zeppelin.interpreter.integration.DownloadUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ShellIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ShellIntegrationTest.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.integration;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
@@ -51,40 +50,45 @@ public class ShellIntegrationTest extends AbstractTestRestApi {
 
   @Test
   public void testBasicShell() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", AuthenticationInfo.ANONYMOUS);
-      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", AuthenticationInfo.ANONYMOUS);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-      // test correct shell command
-      p.setText("%sh echo 'hello world'");
-      note.run(p.getId(), true);
-      assertEquals(Job.Status.FINISHED, p.getStatus());
-      assertEquals("hello world\n", p.getReturn().message().get(0).getData());
+          // test correct shell command
+          p.setText("%sh echo 'hello world'");
+          note.run(p.getId(), true);
+          assertEquals(Job.Status.FINISHED, p.getStatus());
+          assertEquals("hello world\n", p.getReturn().message().get(0).getData());
 
-      // test invalid shell command
-      p.setText("%sh invalid_cmd");
-      note.run(p.getId(), true);
-      assertEquals(Job.Status.ERROR, p.getStatus());
-      assertTrue(p.getReturn().toString(),
-              p.getReturn().message().get(0).getData().contains("command not found"));
+          // test invalid shell command
+          p.setText("%sh invalid_cmd");
+          note.run(p.getId(), true);
+          assertEquals(Job.Status.ERROR, p.getStatus());
+          assertTrue(p.getReturn().toString(),
+                  p.getReturn().message().get(0).getData().contains("command not found"));
 
-      // test shell environment variable
-      p.setText("%sh a='hello world'\n" +
-              "echo ${a}");
-      note.run(p.getId(), true);
-      assertEquals(Job.Status.FINISHED, p.getStatus());
-      assertEquals("hello world\n", p.getReturn().message().get(0).getData());
+          // test shell environment variable
+          p.setText("%sh a='hello world'\n" +
+                  "echo ${a}");
+          note.run(p.getId(), true);
+          assertEquals(Job.Status.FINISHED, p.getStatus());
+          assertEquals("hello world\n", p.getReturn().message().get(0).getData());
 
-      // use dynamic form via local property
-      p.setText("%sh(form=simple) a='hello world'\n" +
-              "echo ${a}");
-      note.run(p.getId(), true);
-      assertEquals(Job.Status.FINISHED, p.getStatus());
-      assertEquals(0, p.getReturn().message().size());
+          // use dynamic form via local property
+          p.setText("%sh(form=simple) a='hello world'\n" +
+                  "echo ${a}");
+          note.run(p.getId(), true);
+          assertEquals(Job.Status.FINISHED, p.getStatus());
+          assertEquals(0, p.getReturn().message().size());
+          return null;
+        });
+
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, AuthenticationInfo.ANONYMOUS);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, AuthenticationInfo.ANONYMOUS);
       }
     }
   }

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -31,7 +31,6 @@ import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
-import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZSessionIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZSessionIntegrationTest.java
@@ -26,7 +26,6 @@ import org.apache.zeppelin.client.ZSession;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.integration.DownloadUtils;
 import org.apache.zeppelin.interpreter.lifecycle.TimeoutLifecycleManager;
-import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.utils.TestUtils;
@@ -89,9 +88,13 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertNull(session.getWeburl());
       assertNotNull(session.getNoteId());
 
-      Note note = notebook.getNote(session.getNoteId());
-      assertEquals(2, note.getParagraphCount());
-      assertTrue(note.getParagraph(0).getText(), note.getParagraph(0).getText().startsWith("%sh.conf"));
+      notebook.processNote(session.getNoteId(),
+        note -> {
+          assertEquals(2, note.getParagraphCount());
+          assertTrue(note.getParagraph(0).getText(), note.getParagraph(0).getText().startsWith("%sh.conf"));
+          return null;
+        });
+
 
       ExecuteResult result = session.execute("pwd");
       assertEquals(result.toString(), Status.FINISHED, result.getStatus());
@@ -106,9 +109,12 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertEquals("TEXT", result.getResults().get(1).getType());
       assertTrue(result.getResults().get(1).getData(), result.getResults().get(1).getData().contains("ExitValue"));
 
-      assertEquals(4, note.getParagraphCount());
-      assertEquals("%sh invalid_command", note.getParagraph(3).getText());
-
+      notebook.processNote(session.getNoteId(),
+        note -> {
+          assertEquals(4, note.getParagraphCount());
+          assertEquals("%sh invalid_command", note.getParagraph(3).getText());
+          return null;
+        });
     } finally {
       session.stop();
     }
@@ -126,9 +132,12 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertNull(session.getWeburl());
       assertNotNull(session.getNoteId());
 
-      Note note = notebook.getNote(session.getNoteId());
-      assertEquals(2, note.getParagraphCount());
-      assertTrue(note.getParagraph(0).getText(), note.getParagraph(0).getText().startsWith("%sh.conf"));
+      notebook.processNote(session.getNoteId(),
+        note -> {
+          assertEquals(2, note.getParagraphCount());
+          assertTrue(note.getParagraph(0).getText(), note.getParagraph(0).getText().startsWith("%sh.conf"));
+          return null;
+        });
 
       ExecuteResult result = session.submit("sleep 10\npwd");
       assertFalse("Status is: " + result.getStatus().toString(), result.getStatus().isCompleted());
@@ -146,9 +155,12 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertEquals("TEXT", result.getResults().get(1).getType());
       assertTrue(result.getResults().get(1).getData(), result.getResults().get(1).getData().contains("ExitValue"));
 
-      assertEquals(4, note.getParagraphCount());
-      assertEquals("%sh invalid_command", note.getParagraph(3).getText());
-
+      notebook.processNote(session.getNoteId(),
+        note -> {
+          assertEquals(4, note.getParagraphCount());
+          assertEquals("%sh invalid_command", note.getParagraph(3).getText());
+          return null;
+        });
     } finally {
       session.stop();
     }
@@ -456,10 +468,10 @@ public class ZSessionIntegrationTest extends AbstractTestRestApi {
       assertNull(session.getWeburl());
       assertNotNull(session.getNoteId());
 
-      assertTrue(notebook.getAllNotes().size() > 0);
+      assertTrue(notebook.getNotesInfo().size() > 0);
 
       Thread.sleep(30 * 1000);
-      assertEquals(0, notebook.getAllNotes().size());
+      assertEquals(0, notebook.getNotesInfo().size());
 
       try {
         session.execute("1/0");

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
@@ -27,7 +27,6 @@ import org.apache.zeppelin.client.ZeppelinClient;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.common.SessionInfo;
-import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.utils.TestUtils;
@@ -110,7 +109,11 @@ public class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
   @Test
   public void testNoteOperation() throws Exception {
     String noteId = zeppelinClient.createNote("/project_1/note1");
-    assertNotNull(notebook.getNote(noteId));
+    notebook.processNote(noteId,
+      note -> {
+        assertNotNull(note);
+        return null;
+      });
 
     // create duplicated note
     try {
@@ -149,34 +152,53 @@ public class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
   @Test
   public void testCloneNote() throws Exception {
     String noteId = zeppelinClient.createNote("/clone_note_test/note1");
-    Note note1 = notebook.getNote(noteId);
-    assertNotNull(note1);
-
+    notebook.processNote(noteId,
+      note1 -> {
+        assertNotNull(note1);
+        return null;
+      });
     zeppelinClient.addParagraph(noteId, "title_1", "text_1");
-    assertEquals(1, note1.getParagraphCount());
+    notebook.processNote(noteId,
+      note1 -> {
+        assertEquals(1, note1.getParagraphCount());
+        return null;
+      });
 
     String clonedNoteId = zeppelinClient.cloneNote(noteId, "/clone_note_test/cloned_note1");
-    Note clonedNote = notebook.getNote(clonedNoteId);
-    assertEquals(1, clonedNote.getParagraphCount());
-    assertEquals("title_1", clonedNote.getParagraph(0).getTitle());
-    assertEquals("text_1", clonedNote.getParagraph(0).getText());
+    notebook.processNote(clonedNoteId,
+      clonedNote -> {
+        assertEquals(1, clonedNote.getParagraphCount());
+        assertEquals("title_1", clonedNote.getParagraph(0).getTitle());
+        assertEquals("text_1", clonedNote.getParagraph(0).getText());
+        return null;
+      });
   }
 
   @Test
   public void testRenameNote() throws Exception {
     String noteId = zeppelinClient.createNote("/rename_note_test/note1");
-    Note note1 = notebook.getNote(noteId);
-    assertNotNull(note1);
+    notebook.processNote(noteId,
+      note1 -> {
+        assertNotNull(note1);
+        return null;
+      });
 
     zeppelinClient.addParagraph(noteId, "title_1", "text_1");
-    assertEquals(1, note1.getParagraphCount());
+    notebook.processNote(noteId,
+      note1 -> {
+        assertEquals(1, note1.getParagraphCount());
+        return null;
+      });
 
     zeppelinClient.renameNote(noteId, "/rename_note_test/note1_renamed");
-    Note renamedNote = notebook.getNote(noteId);
-    assertEquals("/rename_note_test/note1_renamed", renamedNote.getPath());
-    assertEquals(1, renamedNote.getParagraphCount());
-    assertEquals("title_1", renamedNote.getParagraph(0).getTitle());
-    assertEquals("text_1", renamedNote.getParagraph(0).getText());
+    notebook.processNote(noteId,
+      renamedNote -> {
+        assertEquals("/rename_note_test/note1_renamed", renamedNote.getPath());
+        assertEquals(1, renamedNote.getParagraphCount());
+        assertEquals("title_1", renamedNote.getParagraph(0).getTitle());
+        assertEquals("text_1", renamedNote.getParagraph(0).getText());
+        return null;
+      });
   }
 
   @Test

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinFlinkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinFlinkClusterTest.java
@@ -29,7 +29,6 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.utils.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +38,7 @@ import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public abstract class ZeppelinFlinkClusterTest extends AbstractTestRestApi {
 
@@ -69,56 +69,65 @@ public abstract class ZeppelinFlinkClusterTest extends AbstractTestRestApi {
   //@Test
   public void testResumeFromCheckpoint() throws Exception {
 
-    Note note = null;
+    String noteId = null;
     try {
       // create new note
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", AuthenticationInfo.ANONYMOUS);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", AuthenticationInfo.ANONYMOUS);
 
       // run p0 for %flink.conf
       String checkpointPath = Files.createTempDirectory("checkpoint").toAbsolutePath().toString();
-      Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      StringBuilder builder = new StringBuilder("%flink.conf\n");
-      builder.append("FLINK_HOME " + flinkHome + "\n");
-      builder.append("flink.execution.mode local\n");
-      builder.append("state.checkpoints.dir file://" + checkpointPath + "\n");
-      builder.append("execution.checkpointing.externalized-checkpoint-retention RETAIN_ON_CANCELLATION");
-      p0.setText(builder.toString());
-      note.run(p0.getId(), true);
-      assertEquals(Job.Status.FINISHED, p0.getStatus());
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          StringBuilder builder = new StringBuilder("%flink.conf\n");
+          builder.append("FLINK_HOME " + flinkHome + "\n");
+          builder.append("flink.execution.mode local\n");
+          builder.append("state.checkpoints.dir file://" + checkpointPath + "\n");
+          builder.append("execution.checkpointing.externalized-checkpoint-retention RETAIN_ON_CANCELLATION");
+          p0.setText(builder.toString());
+          note.run(p0.getId(), true);
+          assertEquals(Job.Status.FINISHED, p0.getStatus());
 
-      // run p1 for creating flink table via scala
-      Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p1.setText("%flink " + getInitStreamScript(2000));
-      note.run(p1.getId(), true);
-      assertEquals(Job.Status.FINISHED, p0.getStatus());
+          // run p1 for creating flink table via scala
+          Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p1.setText("%flink " + getInitStreamScript(2000));
+          note.run(p1.getId(), true);
+          assertEquals(Job.Status.FINISHED, p0.getStatus());
 
-      // run p2 for flink streaming sql
-      Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=true)\n" +
-              "select count(1) from log;");
-      note.run(p2.getId(), false);
-      p2.waitUntilRunning();
+          // run p2 for flink streaming sql
+          Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=true)\n" +
+                  "select count(1) from log;");
+          note.run(p2.getId(), false);
+          try {
+            p2.waitUntilRunning();
+            Thread.sleep(60 * 1000);
+            p2.abort();
+            // Sleep 5 seconds to ensure checkpoint info is written to note file
+            Thread.sleep(5 * 1000);
+            assertTrue(p2.getConfig().toString(), p2.getConfig().get("latest_checkpoint_path").toString().contains(checkpointPath));
+          } catch (InterruptedException e) {
+            fail();
+          }
 
-      Thread.sleep(60 * 1000);
-      p2.abort();
-
-      // Sleep 5 seconds to ensure checkpoint info is written to note file
-      Thread.sleep(5 * 1000);
-      assertTrue(p2.getConfig().toString(), p2.getConfig().get("latest_checkpoint_path").toString().contains(checkpointPath));
-
-      // run it again
-      note.run(p0.getId(), true);
-      note.run(p1.getId(), true);
-      note.run(p2.getId(), false);
-      p2.waitUntilFinished();
-      assertEquals(p2.getReturn().toString(), Job.Status.FINISHED, p2.getStatus());
-
+          // run it again
+          note.run(p0.getId(), true);
+          note.run(p1.getId(), true);
+          note.run(p2.getId(), false);
+          try {
+            p2.waitUntilFinished();
+          } catch (InterruptedException e) {
+            fail();
+          }
+          assertEquals(p2.getReturn().toString(), Job.Status.FINISHED, p2.getStatus());
+          return null;
+        });
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, AuthenticationInfo.ANONYMOUS);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, AuthenticationInfo.ANONYMOUS);
       }
     }
   }
@@ -126,50 +135,63 @@ public abstract class ZeppelinFlinkClusterTest extends AbstractTestRestApi {
   //@Test
   public void testResumeFromInvalidCheckpoint() throws Exception {
 
-    Note note = null;
+    String noteId = null;
     try {
       // create new note
-      note = TestUtils.getInstance(Notebook.class).createNote("note2", AuthenticationInfo.ANONYMOUS);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note2", AuthenticationInfo.ANONYMOUS);
 
       // run p0 for %flink.conf
       String checkpointPath = Files.createTempDirectory("checkpoint").toAbsolutePath().toString();
-      Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      StringBuilder builder = new StringBuilder("%flink.conf\n");
-      builder.append("FLINK_HOME " + flinkHome + "\n");
-      builder.append("flink.execution.mode local\n");
-      builder.append("state.checkpoints.dir file://" + checkpointPath + "\n");
-      builder.append("execution.checkpointing.externalized-checkpoint-retention RETAIN_ON_CANCELLATION");
-      p0.setText(builder.toString());
-      note.run(p0.getId(), true);
-      assertEquals(Job.Status.FINISHED, p0.getStatus());
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p0 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          StringBuilder builder = new StringBuilder("%flink.conf\n");
+          builder.append("FLINK_HOME " + flinkHome + "\n");
+          builder.append("flink.execution.mode local\n");
+          builder.append("state.checkpoints.dir file://" + checkpointPath + "\n");
+          builder.append("execution.checkpointing.externalized-checkpoint-retention RETAIN_ON_CANCELLATION");
+          p0.setText(builder.toString());
+          note.run(p0.getId(), true);
+          assertEquals(Job.Status.FINISHED, p0.getStatus());
 
-      // run p1 for creating flink table via scala
-      Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p1.setText("%flink " + getInitStreamScript(500));
-      note.run(p1.getId(), true);
-      assertEquals(Job.Status.FINISHED, p0.getStatus());
+          // run p1 for creating flink table via scala
+          Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p1.setText("%flink " + getInitStreamScript(500));
+          note.run(p1.getId(), true);
+          assertEquals(Job.Status.FINISHED, p0.getStatus());
 
-      // run p2 for flink streaming sql
-      Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=true)\n" +
-              "select count(1) from log;");
-      p2.getConfig().put("latest_checkpoint_path", "file:///invalid_checkpoint");
-      note.run(p2.getId(), false);
-      p2.waitUntilFinished();
-      assertEquals(p2.getReturn().toString(), Job.Status.ERROR, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("Cannot find checkpoint"));
+          // run p2 for flink streaming sql
+          Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=true)\n" +
+                  "select count(1) from log;");
+          p2.getConfig().put("latest_checkpoint_path", "file:///invalid_checkpoint");
+          note.run(p2.getId(), false);
+          try {
+            p2.waitUntilFinished();
+          } catch (InterruptedException e) {
+            fail();
+          }
+          assertEquals(p2.getReturn().toString(), Job.Status.ERROR, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("Cannot find checkpoint"));
 
-      p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=false)\n" +
-              "select count(1) from log;");
-      note.run(p2.getId(), false);
-      p2.waitUntilFinished();
-      assertEquals(p2.getReturn().toString(), Job.Status.FINISHED, p2.getStatus());
+          p2.setText("%flink.ssql(type=single, template=<h1>Total: {0}</h1>, resumeFromLatestCheckpoint=false)\n" +
+                  "select count(1) from log;");
+          note.run(p2.getId(), false);
+          try {
+            p2.waitUntilFinished();
+          } catch (InterruptedException e) {
+            fail();
+          }
+          assertEquals(p2.getReturn().toString(), Job.Status.FINISHED, p2.getStatus());
+          return null;
+        });
+
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, AuthenticationInfo.ANONYMOUS);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, AuthenticationInfo.ANONYMOUS);
       }
     }
   }

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinSparkClusterTest.java
@@ -59,6 +59,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test against spark cluster.
@@ -154,102 +155,114 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
   @Test
   public void scalaOutputTest() throws IOException, InterruptedException {
-    Note note = null;
+    String noteId = null;
     try {
       // create new note
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      p.setText("%spark import java.util.Date\n" +
-          "import java.net.URL\n" +
-          "println(\"hello\")\n"
-      );
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("hello\n" +
-          "import java.util.Date\n" +
-          "import java.net.URL\n",
-          p.getReturn().message().get(0).getData());
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          p.setText("%spark import java.util.Date\n" +
+              "import java.net.URL\n" +
+              "println(\"hello\")\n"
+          );
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("hello\n" +
+              "import java.util.Date\n" +
+              "import java.net.URL\n",
+              p.getReturn().message().get(0).getData());
 
-      // check spark weburl in zeppelin-server side
-      InterpreterSettingManager interpreterSettingManager = TestUtils.getInstance(InterpreterSettingManager.class);
-      InterpreterSetting sparkInterpreterSetting = interpreterSettingManager.getByName("spark");
-      assertEquals(1, sparkInterpreterSetting.getAllInterpreterGroups().size());
-      assertNotNull(sparkInterpreterSetting.getAllInterpreterGroups().get(0).getWebUrl());
+          // check spark weburl in zeppelin-server side
+          InterpreterSettingManager interpreterSettingManager = TestUtils.getInstance(InterpreterSettingManager.class);
+          InterpreterSetting sparkInterpreterSetting = interpreterSettingManager.getByName("spark");
+          assertEquals(1, sparkInterpreterSetting.getAllInterpreterGroups().size());
+          assertNotNull(sparkInterpreterSetting.getAllInterpreterGroups().get(0).getWebUrl());
 
-      p.setText("%spark invalid_code");
-      note.run(p.getId(), true);
-      assertEquals(Status.ERROR, p.getStatus());
-      assertTrue(p.getReturn().message().get(0).getData().contains("error: "));
+          p.setText("%spark invalid_code");
+          note.run(p.getId(), true);
+          assertEquals(Status.ERROR, p.getStatus());
+          assertTrue(p.getReturn().message().get(0).getData().contains("error: "));
 
-      // test local properties
-      p.setText("%spark(p1=v1,p2=v2) print(z.getInterpreterContext().getLocalProperties().size())");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("2", p.getReturn().message().get(0).getData());
+          // test local properties
+          p.setText("%spark(p1=v1,p2=v2) print(z.getInterpreterContext().getLocalProperties().size())");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("2", p.getReturn().message().get(0).getData());
 
-      // test code completion
-      List<InterpreterCompletion> completions = note.completion(p.getId(), "sc.", 2, AuthenticationInfo.ANONYMOUS);
-      assertTrue(completions.size() > 0);
+          // test code completion
+          List<InterpreterCompletion> completions = note.completion(p.getId(), "sc.", 2, AuthenticationInfo.ANONYMOUS);
+          assertTrue(completions.size() > 0);
 
-      // test cancel
-      p.setText("%spark sc.range(1,10).map(e=>{Thread.sleep(1000); e}).collect()");
-      note.run(p.getId(), false);
-      waitForRunning(p);
-      p.abort();
-      waitForFinish(p);
-      assertEquals(Status.ABORT, p.getStatus());
+          // test cancel
+          p.setText("%spark sc.range(1,10).map(e=>{Thread.sleep(1000); e}).collect()");
+          note.run(p.getId(), false);
+          waitForRunning(p);
+          p.abort();
+          waitForFinish(p);
+          assertEquals(Status.ABORT, p.getStatus());
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void basicRDDTransformationAndActionTest() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      p.setText("%spark print(sc.parallelize(1 to 10).reduce(_ + _))");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("55", p.getReturn().message().get(0).getData());
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          p.setText("%spark print(sc.parallelize(1 to 10).reduce(_ + _))");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("55", p.getReturn().message().get(0).getData());
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void sparkReadJSONTest() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      File tmpJsonFile = File.createTempFile("test", ".json");
-      FileWriter jsonFileWriter = new FileWriter(tmpJsonFile);
-      IOUtils.copy(new StringReader("{\"metadata\": { \"key\": 84896, \"value\": 54 }}\n"),
-              jsonFileWriter);
-      jsonFileWriter.close();
-      if (isSpark2() || isSpark3()) {
-        p.setText("%spark spark.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
-      } else {
-        p.setText("%spark sqlContext.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
-      }
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      if (isSpark2() || isSpark3()) {
-        assertTrue(p.getReturn().message().get(0).getData().contains(
-                "org.apache.spark.sql.DataFrame = [metadata: struct<key: bigint, value: bigint>]"));
-      } else {
-        assertTrue(p.getReturn().message().get(0).getData().contains(
-                "org.apache.spark.sql.DataFrame = [metadata: struct<key:bigint,value:bigint>]"));
-      }
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          File tmpJsonFile = File.createTempFile("test", ".json");
+          FileWriter jsonFileWriter = new FileWriter(tmpJsonFile);
+          IOUtils.copy(new StringReader("{\"metadata\": { \"key\": 84896, \"value\": 54 }}\n"),
+                  jsonFileWriter);
+          jsonFileWriter.close();
+          if (isSpark2() || isSpark3()) {
+            p.setText("%spark spark.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
+          } else {
+            p.setText("%spark sqlContext.read.json(\"file://" + tmpJsonFile.getAbsolutePath() + "\")");
+          }
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          if (isSpark2() || isSpark3()) {
+            assertTrue(p.getReturn().message().get(0).getData().contains(
+                    "org.apache.spark.sql.DataFrame = [metadata: struct<key: bigint, value: bigint>]"));
+          } else {
+            assertTrue(p.getReturn().message().get(0).getData().contains(
+                    "org.apache.spark.sql.DataFrame = [metadata: struct<key:bigint,value:bigint>]"));
+          }
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
@@ -261,152 +274,164 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
       return;
     }
 
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      File tmpCSVFile = File.createTempFile("test", ".csv");
-      FileWriter csvFileWriter = new FileWriter(tmpCSVFile);
-      IOUtils.copy(new StringReader("84896,54"), csvFileWriter);
-      csvFileWriter.close();
-      p.setText("%spark spark.read.csv(\"file://" + tmpCSVFile.getAbsolutePath() + "\")");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertTrue(p.getReturn().message().get(0).getData().contains(
-              "org.apache.spark.sql.DataFrame = [_c0: string, _c1: string]\n"));
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          File tmpCSVFile = File.createTempFile("test", ".csv");
+          FileWriter csvFileWriter = new FileWriter(tmpCSVFile);
+          IOUtils.copy(new StringReader("84896,54"), csvFileWriter);
+          csvFileWriter.close();
+          p.setText("%spark spark.read.csv(\"file://" + tmpCSVFile.getAbsolutePath() + "\")");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertTrue(p.getReturn().message().get(0).getData().contains(
+                  "org.apache.spark.sql.DataFrame = [_c0: string, _c1: string]\n"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void sparkSQLTest() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      // test basic dataframe api
-      Paragraph p = note.addNewParagraph(anonymous);
-      if (isSpark2() || isSpark3()) {
-        p.setText("%spark val df=spark.createDataFrame(Seq((\"hello\",20)))" +
-                ".toDF(\"name\", \"age\")\n" +
-                "df.collect()");
-      } else {
-        p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))" +
-                ".toDF(\"name\", \"age\")\n" +
-                "df.collect()");
-      }
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertTrue(p.getReturn().message().get(0).getData().contains(
-              "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          // test basic dataframe api
+          Paragraph p = note.addNewParagraph(anonymous);
+          if (isSpark2() || isSpark3()) {
+            p.setText("%spark val df=spark.createDataFrame(Seq((\"hello\",20)))" +
+                    ".toDF(\"name\", \"age\")\n" +
+                    "df.collect()");
+          } else {
+            p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))" +
+                    ".toDF(\"name\", \"age\")\n" +
+                    "df.collect()");
+          }
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertTrue(p.getReturn().message().get(0).getData().contains(
+                  "Array[org.apache.spark.sql.Row] = Array([hello,20])"));
 
-      // test display DataFrame
-      p = note.addNewParagraph(anonymous);
-      if (isSpark2() || isSpark3()) {
-        p.setText("%spark val df=spark.createDataFrame(Seq((\"hello\",20)))" +
-                ".toDF(\"name\", \"age\")\n" +
-                "df.createOrReplaceTempView(\"test_table\")\n" +
-                "z.show(df)");
-      } else {
-        p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))" +
-                ".toDF(\"name\", \"age\")\n" +
-                "df.registerTempTable(\"test_table\")\n" +
-                "z.show(df)");
-      }
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
+          // test display DataFrame
+          p = note.addNewParagraph(anonymous);
+          if (isSpark2() || isSpark3()) {
+            p.setText("%spark val df=spark.createDataFrame(Seq((\"hello\",20)))" +
+                    ".toDF(\"name\", \"age\")\n" +
+                    "df.createOrReplaceTempView(\"test_table\")\n" +
+                    "z.show(df)");
+          } else {
+            p.setText("%spark val df=sqlContext.createDataFrame(Seq((\"hello\",20)))" +
+                    ".toDF(\"name\", \"age\")\n" +
+                    "df.registerTempTable(\"test_table\")\n" +
+                    "z.show(df)");
+          }
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+          assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
 
-      // run sql and save it into resource pool
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark.sql(saveAs=table_result) select * from test_table");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
+          // run sql and save it into resource pool
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark.sql(saveAs=table_result) select * from test_table");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+          assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
 
-      // get resource from spark
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark val df=z.getAsDataFrame(\"table_result\")\nz.show(df)");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
+          // get resource from spark
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark val df=z.getAsDataFrame(\"table_result\")\nz.show(df)");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+          assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
 
-      // get resource from pyspark
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark.pyspark df=z.getAsDataFrame('table_result')\nz.show(df)");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
+          // get resource from pyspark
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark.pyspark df=z.getAsDataFrame('table_result')\nz.show(df)");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+          assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
 
-      // get resource from ipyspark
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark.ipyspark df=z.getAsDataFrame('table_result')\nz.show(df)");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-      assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
+          // get resource from ipyspark
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark.ipyspark df=z.getAsDataFrame('table_result')\nz.show(df)");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+          assertEquals("name\tage\nhello\t20\n", p.getReturn().message().get(0).getData());
 
-      // get resource from sparkr
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark.r df=z.getAsDataFrame('table_result')\ndf");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(InterpreterResult.Type.TEXT, p.getReturn().message().get(0).getType());
-      assertTrue(p.getReturn().toString(),
-              p.getReturn().message().get(0).getData().contains("name age\n1 hello  20"));
+          // get resource from sparkr
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark.r df=z.getAsDataFrame('table_result')\ndf");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(InterpreterResult.Type.TEXT, p.getReturn().message().get(0).getType());
+          assertTrue(p.getReturn().toString(),
+                  p.getReturn().message().get(0).getData().contains("name age\n1 hello  20"));
 
-      // test display DataSet
-      if (isSpark2() || isSpark3()) {
-        p = note.addNewParagraph(anonymous);
-        p.setText("%spark val ds=spark.createDataset(Seq((\"hello\",20)))\n" +
-            "z.show(ds)");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-        assertEquals("_1\t_2\nhello\t20\n", p.getReturn().message().get(0).getData());
-      }
+          // test display DataSet
+          if (isSpark2() || isSpark3()) {
+            p = note.addNewParagraph(anonymous);
+            p.setText("%spark val ds=spark.createDataset(Seq((\"hello\",20)))\n" +
+                "z.show(ds)");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+            assertEquals("_1\t_2\nhello\t20\n", p.getReturn().message().get(0).getData());
+          }
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void sparkRTest() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
 
-      if (isSpark3()) {
-        p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
-                "df <- createDataFrame(localDF)\n" +
-                "count(df)"
-        );
-      } else {
-        String sqlContextName = "sqlContext";
-        if (isSpark2() || isSpark3()) {
-          sqlContextName = "spark";
-        }
-        p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
-                "df <- createDataFrame(" + sqlContextName + ", localDF)\n" +
-                "count(df)"
-        );
-      }
+          if (isSpark3()) {
+            p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
+                    "df <- createDataFrame(localDF)\n" +
+                    "count(df)"
+            );
+          } else {
+            String sqlContextName = "sqlContext";
+            if (isSpark2() || isSpark3()) {
+              sqlContextName = "spark";
+            }
+            p.setText("%spark.r localDF <- data.frame(name=c(\"a\", \"b\", \"c\"), age=c(19, 23, 18))\n" +
+                    "df <- createDataFrame(" + sqlContextName + ", localDF)\n" +
+                    "count(df)"
+            );
+          }
 
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("[1] 3", p.getReturn().message().get(0).getData().trim());
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("[1] 3", p.getReturn().message().get(0).getData().trim());
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
@@ -414,309 +439,338 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
   @Test
   public void pySparkTest() throws IOException {
     // create new note
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          // run markdown paragraph, again
+          Paragraph p = note.addNewParagraph(anonymous);
+          p.setText("%spark.pyspark sc.parallelize(range(1, 11)).reduce(lambda a, b: a + b)");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("55\n", p.getReturn().message().get(0).getData());
 
-      // run markdown paragraph, again
-      Paragraph p = note.addNewParagraph(anonymous);
-      p.setText("%spark.pyspark sc.parallelize(range(1, 11)).reduce(lambda a, b: a + b)");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("55\n", p.getReturn().message().get(0).getData());
+          // simple form via local properties
+          p = note.addNewParagraph(anonymous);
+          p.setText("%spark.pyspark(form=simple) print('name_' + '${name=abc}')");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals("name_abc\n", p.getReturn().message().get(0).getData());
 
-      // simple form via local properties
-      p = note.addNewParagraph(anonymous);
-      p.setText("%spark.pyspark(form=simple) print('name_' + '${name=abc}')");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals("name_abc\n", p.getReturn().message().get(0).getData());
+          // test code completion
+          String code = "%spark.pyspark spark.";
+          List<InterpreterCompletion> completions = note.completion(p.getId(), code, code.length(), AuthenticationInfo.ANONYMOUS);
+          assertTrue(completions.size() > 0);
 
-      // test code completion
-      String code = "%spark.pyspark spark.";
-      List<InterpreterCompletion> completions = note.completion(p.getId(), code, code.length(), AuthenticationInfo.ANONYMOUS);
-      assertTrue(completions.size() > 0);
-
-      if (isSpark1()) {
-        // run sqlContext test
-        p = note.addNewParagraph(anonymous);
-        p.setText("%pyspark from pyspark.sql import Row\n" +
-            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-            "df.collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
-
-        // test display Dataframe
-        p = note.addNewParagraph(anonymous);
-        p.setText("%pyspark from pyspark.sql import Row\n" +
-            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-            "z.show(df)");
-        note.run(p.getId(), true);
-        waitForFinish(p);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
-        // TODO(zjffdu), one more \n is appended, need to investigate why.
-        assertEquals("age\tid\n20\t1\n", p.getReturn().message().get(0).getData());
-
-        // test udf
-        p = note.addNewParagraph(anonymous);
-        p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
-            "sqlContext.sql(\"select f1(\\\"abc\\\") as len\").collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
-            "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
-
-        // test exception
-        p = note.addNewParagraph(anonymous);
-        /*
-         %pyspark
-         a=1
-
-         print(a2)
-         */
-        p.setText("%pyspark a=1\n\nprint(a2)");
-        note.run(p.getId(), true);
-        assertEquals(Status.ERROR, p.getStatus());
-        assertTrue(p.getReturn().message().get(0).getData()
-            .contains("Fail to execute line 3: print(a2)"));
-        assertTrue(p.getReturn().message().get(0).getData()
-            .contains("name 'a2' is not defined"));
-      } else if (isSpark2()){
-        // run SparkSession test
-        p = note.addNewParagraph(anonymous);
-        p.setText("%pyspark from pyspark.sql import Row\n" +
-            "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
-            "df.collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
-
-        // test udf
-        p = note.addNewParagraph(anonymous);
-        // use SQLContext to register UDF but use this UDF through SparkSession
-        p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
-            "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
-            "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
-      } else {
-        // run SparkSession test
-        p = note.addNewParagraph(anonymous);
-        p.setText("%pyspark from pyspark.sql import Row\n" +
+          if (isSpark1()) {
+            // run sqlContext test
+            p = note.addNewParagraph(anonymous);
+            p.setText("%pyspark from pyspark.sql import Row\n" +
                 "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
                 "df.collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertEquals("[Row(id=1, age=20)]\n", p.getReturn().message().get(0).getData());
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
 
-        // test udf
-        p = note.addNewParagraph(anonymous);
-        // use SQLContext to register UDF but use this UDF through SparkSession
-        p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
-                "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
-        note.run(p.getId(), true);
-        assertEquals(Status.FINISHED, p.getStatus());
-        assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
+            // test display Dataframe
+            p = note.addNewParagraph(anonymous);
+            p.setText("%pyspark from pyspark.sql import Row\n" +
+                "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+                "z.show(df)");
+            note.run(p.getId(), true);
+            waitForFinish(p);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals(InterpreterResult.Type.TABLE, p.getReturn().message().get(0).getType());
+            // TODO(zjffdu), one more \n is appended, need to investigate why.
+            assertEquals("age\tid\n20\t1\n", p.getReturn().message().get(0).getData());
+
+            // test udf
+            p = note.addNewParagraph(anonymous);
+            p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
+                "sqlContext.sql(\"select f1(\\\"abc\\\") as len\").collect()");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
                 "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
-      }
+
+            // test exception
+            p = note.addNewParagraph(anonymous);
+            /*
+             %pyspark
+             a=1
+
+             print(a2)
+             */
+            p.setText("%pyspark a=1\n\nprint(a2)");
+            note.run(p.getId(), true);
+            assertEquals(Status.ERROR, p.getStatus());
+            assertTrue(p.getReturn().message().get(0).getData()
+                .contains("Fail to execute line 3: print(a2)"));
+            assertTrue(p.getReturn().message().get(0).getData()
+                .contains("name 'a2' is not defined"));
+          } else if (isSpark2()){
+            // run SparkSession test
+            p = note.addNewParagraph(anonymous);
+            p.setText("%pyspark from pyspark.sql import Row\n" +
+                "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+                "df.collect()");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals("[Row(age=20, id=1)]\n", p.getReturn().message().get(0).getData());
+
+            // test udf
+            p = note.addNewParagraph(anonymous);
+            // use SQLContext to register UDF but use this UDF through SparkSession
+            p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
+                "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
+                "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
+          } else {
+            // run SparkSession test
+            p = note.addNewParagraph(anonymous);
+            p.setText("%pyspark from pyspark.sql import Row\n" +
+                    "df=sqlContext.createDataFrame([Row(id=1, age=20)])\n" +
+                    "df.collect()");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertEquals("[Row(id=1, age=20)]\n", p.getReturn().message().get(0).getData());
+
+            // test udf
+            p = note.addNewParagraph(anonymous);
+            // use SQLContext to register UDF but use this UDF through SparkSession
+            p.setText("%pyspark sqlContext.udf.register(\"f1\", lambda x: len(x))\n" +
+                    "spark.sql(\"select f1(\\\"abc\\\") as len\").collect()");
+            note.run(p.getId(), true);
+            assertEquals(Status.FINISHED, p.getStatus());
+            assertTrue("[Row(len=u'3')]\n".equals(p.getReturn().message().get(0).getData()) ||
+                    "[Row(len='3')]\n".equals(p.getReturn().message().get(0).getData()));
+          }
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void zRunTest() throws IOException, InterruptedException {
-    Note note = null;
-    Note note2 = null;
+    String noteId = null;
+    String note2Id = null;
     try {
       // create new note
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p0 = note.addNewParagraph(anonymous);
-      // z.run(paragraphIndex)
-      p0.setText("%spark z.run(1)");
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%spark val a=10");
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%spark print(a)");
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      note2Id = TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p0 = note.addNewParagraph(anonymous);
+          // z.run(paragraphIndex)
+          p0.setText("%spark z.run(1)");
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%spark val a=10");
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%spark print(a)");
 
-      note.run(p0.getId(), true);
-      assertEquals(Status.FINISHED, p0.getStatus());
+          note.run(p0.getId(), true);
+          assertEquals(Status.FINISHED, p0.getStatus());
 
-      // z.run is not blocking call. So p1 may not be finished when p0 is done.
-      waitForFinish(p1);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertEquals("10", p2.getReturn().message().get(0).getData());
+          // z.run is not blocking call. So p1 may not be finished when p0 is done.
+          waitForFinish(p1);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertEquals("10", p2.getReturn().message().get(0).getData());
 
-      Paragraph p3 = note.addNewParagraph(anonymous);
-      p3.setText("%spark println(new java.util.Date())");
+          Paragraph p3 = note.addNewParagraph(anonymous);
+          p3.setText("%spark println(new java.util.Date())");
 
-      // run current Node, z.runNote(noteId)
-      p0.setText(String.format("%%spark z.runNote(\"%s\")", note.getId()));
-      note.run(p0.getId());
-      waitForFinish(p0);
-      waitForFinish(p1);
-      waitForFinish(p2);
-      waitForFinish(p3);
+          // run current Node, z.runNote(noteId)
+          p0.setText(String.format("%%spark z.runNote(\"%s\")", note.getId()));
+          note.run(p0.getId());
+          waitForFinish(p0);
+          waitForFinish(p1);
+          waitForFinish(p2);
+          waitForFinish(p3);
 
-      assertEquals(Status.FINISHED, p3.getStatus());
-      String p3result = p3.getReturn().message().get(0).getData();
-      assertTrue(p3result.length() > 0);
+          assertEquals(Status.FINISHED, p3.getStatus());
+          String p3result = p3.getReturn().message().get(0).getData();
+          assertTrue(p3result.length() > 0);
 
-      // z.run(noteId, paragraphId)
-      p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note.getId(), p3.getId()));
-      p3.setText("%spark println(\"END\")");
+          // z.run(noteId, paragraphId)
+          p0.setText(String.format("%%spark z.run(\"%s\", \"%s\")", note.getId(), p3.getId()));
+          p3.setText("%spark println(\"END\")");
 
-      note.run(p0.getId(), true);
-      // Sleep 1 second to ensure p3 start running
-      Thread.sleep(1000);
-      waitForFinish(p3);
-      assertEquals(Status.FINISHED, p3.getStatus());
-      assertEquals("END\n", p3.getReturn().message().get(0).getData());
+          note.run(p0.getId(), true);
+          // Sleep 1 second to ensure p3 start running
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException e) {
+            fail();
+          }
+          waitForFinish(p3);
+          assertEquals(Status.FINISHED, p3.getStatus());
+          assertEquals("END\n", p3.getReturn().message().get(0).getData());
 
-      // run paragraph in note2 via paragraph in note1
-      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
-      Paragraph p20 = note2.addNewParagraph(anonymous);
-      p20.setText("%spark val a = 1");
-      Paragraph p21 = note2.addNewParagraph(anonymous);
-      p21.setText("%spark print(a)");
+          // run paragraph in note2 via paragraph in note1
+          String noteId2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
+          TestUtils.getInstance(Notebook.class).processNote(noteId2,
+            note2 -> {
+              Paragraph p20 = note2.addNewParagraph(anonymous);
+              p20.setText("%spark val a = 1");
+              Paragraph p21 = note2.addNewParagraph(anonymous);
+              p21.setText("%spark print(a)");
 
-      // run p20 of note2 via paragraph in note1
-      p0.setText(String.format("%%spark.pyspark z.run(\"%s\", \"%s\")", note2.getId(), p20.getId()));
-      note.run(p0.getId(), true);
-      waitForFinish(p20);
-      assertEquals(Status.FINISHED, p20.getStatus());
-      assertEquals(Status.READY, p21.getStatus());
+              // run p20 of note2 via paragraph in note1
+              p0.setText(String.format("%%spark.pyspark z.run(\"%s\", \"%s\")", note2.getId(), p20.getId()));
+              note.run(p0.getId(), true);
+              waitForFinish(p20);
+              assertEquals(Status.FINISHED, p20.getStatus());
+              assertEquals(Status.READY, p21.getStatus());
 
-      p0.setText(String.format("%%spark z.runNote(\"%s\")", note2.getId()));
-      note.run(p0.getId(), true);
-      waitForFinish(p20);
-      waitForFinish(p21);
-      assertEquals(Status.FINISHED, p20.getStatus());
-      assertEquals(Status.FINISHED, p21.getStatus());
-      assertEquals("1", p21.getReturn().message().get(0).getData());
+              p0.setText(String.format("%%spark z.runNote(\"%s\")", note2.getId()));
+              note.run(p0.getId(), true);
+              waitForFinish(p20);
+              waitForFinish(p21);
+              assertEquals(Status.FINISHED, p20.getStatus());
+              assertEquals(Status.FINISHED, p21.getStatus());
+              assertEquals("1", p21.getReturn().message().get(0).getData());
+              return null;
+            });
+          return noteId2;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
-      if (null != note2) {
-        TestUtils.getInstance(Notebook.class).removeNote(note2, anonymous);
+      if (null != note2Id) {
+        TestUtils.getInstance(Notebook.class).removeNote(note2Id, anonymous);
       }
     }
   }
 
   @Test
   public void testZeppelinContextResource() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%spark z.put(\"var_1\", \"hello world\")");
 
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%spark z.put(\"var_1\", \"hello world\")");
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%spark println(z.get(\"var_1\"))");
 
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%spark println(z.get(\"var_1\"))");
+          Paragraph p3 = note.addNewParagraph(anonymous);
+          p3.setText("%spark.pyspark print(z.get(\"var_1\"))");
 
-      Paragraph p3 = note.addNewParagraph(anonymous);
-      p3.setText("%spark.pyspark print(z.get(\"var_1\"))");
+          Paragraph p4 = note.addNewParagraph(anonymous);
+          p4.setText("%spark.r z.get(\"var_1\")");
 
-      Paragraph p4 = note.addNewParagraph(anonymous);
-      p4.setText("%spark.r z.get(\"var_1\")");
+          // resources across interpreter processes (via DistributedResourcePool)
+          Paragraph p5 = note.addNewParagraph(anonymous);
+          p5.setText("%python print(z.get('var_1'))");
 
-      // resources across interpreter processes (via DistributedResourcePool)
-      Paragraph p5 = note.addNewParagraph(anonymous);
-      p5.setText("%python print(z.get('var_1'))");
+          note.run(p1.getId(), true);
+          note.run(p2.getId(), true);
+          note.run(p3.getId(), true);
+          note.run(p4.getId(), true);
+          note.run(p5.getId(), true);
 
-      note.run(p1.getId(), true);
-      note.run(p2.getId(), true);
-      note.run(p3.getId(), true);
-      note.run(p4.getId(), true);
-      note.run(p5.getId(), true);
-
-      assertEquals(Status.FINISHED, p1.getStatus());
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertEquals("hello world\n", p2.getReturn().message().get(0).getData());
-      assertEquals(Status.FINISHED, p3.getStatus());
-      assertEquals("hello world\n", p3.getReturn().message().get(0).getData());
-      assertEquals(Status.FINISHED, p4.getStatus());
-      assertTrue(p4.getReturn().toString(),
-              p4.getReturn().message().get(0).getData().contains("hello world"));
-      assertEquals(Status.FINISHED, p5.getStatus());
-      assertEquals("hello world\n", p5.getReturn().message().get(0).getData());
+          assertEquals(Status.FINISHED, p1.getStatus());
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertEquals("hello world\n", p2.getReturn().message().get(0).getData());
+          assertEquals(Status.FINISHED, p3.getStatus());
+          assertEquals("hello world\n", p3.getReturn().message().get(0).getData());
+          assertEquals(Status.FINISHED, p4.getStatus());
+          assertTrue(p4.getReturn().toString(),
+                  p4.getReturn().message().get(0).getData().contains("hello world"));
+          assertEquals(Status.FINISHED, p5.getStatus());
+          assertEquals("hello world\n", p5.getReturn().message().get(0).getData());
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testZeppelinContextHook() throws IOException {
-    Note note = null;
-    Note note2 = null;
+    String noteId = null;
+    String note2Id = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      note2Id = TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          // register global hook & note1 hook
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%python from __future__ import print_function\n" +
+              "z.registerHook('pre_exec', 'print(1)')\n" +
+              "z.registerHook('post_exec', 'print(2)')\n" +
+              "z.registerNoteHook('pre_exec', 'print(3)', '" + note.getId() + "')\n" +
+              "z.registerNoteHook('post_exec', 'print(4)', '" + note.getId() + "')\n");
 
-      // register global hook & note1 hook
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%python from __future__ import print_function\n" +
-          "z.registerHook('pre_exec', 'print(1)')\n" +
-          "z.registerHook('post_exec', 'print(2)')\n" +
-          "z.registerNoteHook('pre_exec', 'print(3)', '" + note.getId() + "')\n" +
-          "z.registerNoteHook('post_exec', 'print(4)', '" + note.getId() + "')\n");
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%python print(5)");
 
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%python print(5)");
+          note.run(p1.getId(), true);
+          note.run(p2.getId(), true);
 
-      note.run(p1.getId(), true);
-      note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertEquals("1\n3\n5\n4\n2\n", p2.getReturn().message().get(0).getData());
 
-      assertEquals(Status.FINISHED, p1.getStatus());
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertEquals("1\n3\n5\n4\n2\n", p2.getReturn().message().get(0).getData());
-
-      note2 = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
-      Paragraph p3 = note2.addNewParagraph(anonymous);
-      p3.setText("%python print(6)");
-      note2.run(p3.getId(), true);
-      assertEquals("1\n6\n2\n", p3.getReturn().message().get(0).getData());
+          String note2Tmp = TestUtils.getInstance(Notebook.class).createNote("note2", anonymous);
+          TestUtils.getInstance(Notebook.class).processNote(note2Tmp,
+            note2 -> {
+              Paragraph p3 = note2.addNewParagraph(anonymous);
+              p3.setText("%python print(6)");
+              note2.run(p3.getId(), true);
+              assertEquals("1\n6\n2\n", p3.getReturn().message().get(0).getData());
+              return null;
+            });
+          return note2Tmp;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
-      if (null != note2) {
-        TestUtils.getInstance(Notebook.class).removeNote(note2, anonymous);
+      if (null != note2Id) {
+        TestUtils.getInstance(Notebook.class).removeNote(note2Id, anonymous);
       }
     }
   }
 
   private void verifySparkVersionNumber() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
 
-      p.setText("%spark print(sc.version)");
-      note.run(p.getId());
-      waitForFinish(p);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertEquals(sparkVersion, p.getReturn().message().get(0).getData());
+          p.setText("%spark print(sc.version)");
+          note.run(p.getId());
+          waitForFinish(p);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertEquals(sparkVersion, p.getReturn().message().get(0).getData());
 
-      p.setText("%spark.pyspark sc.version");
-      note.run(p.getId());
-      waitForFinish(p);
-      assertEquals(Status.FINISHED, p.getStatus());
-      assertTrue(p.getReturn().toString(),
-              p.getReturn().message().get(0).getData().contains(sparkVersion));
+          p.setText("%spark.pyspark sc.version");
+          note.run(p.getId());
+          waitForFinish(p);
+          assertEquals(Status.FINISHED, p.getStatus());
+          assertTrue(p.getReturn().toString(),
+                  p.getReturn().message().get(0).getData().contains(sparkVersion));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
@@ -735,370 +789,442 @@ public abstract class ZeppelinSparkClusterTest extends AbstractTestRestApi {
 
   @Test
   public void testSparkZeppelinContextDynamicForms() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      String code = "%spark println(z.textbox(\"my_input\", \"default_name\"))\n" +
-          "println(z.password(\"my_pwd\"))\n" +
-          "println(z.select(\"my_select\", \"1\"," +
-          "Seq((\"1\", \"select_1\"), (\"2\", \"select_2\"))))\n" +
-          "val items=z.checkbox(\"my_checkbox\", " +
-          "Seq((\"1\", \"check_1\"), (\"2\", \"check_2\")), Seq(\"2\"))\n" +
-          "println(items(0))";
-      p.setText(code);
-      note.run(p.getId());
-      waitForFinish(p);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          String code = "%spark println(z.textbox(\"my_input\", \"default_name\"))\n" +
+              "println(z.password(\"my_pwd\"))\n" +
+              "println(z.select(\"my_select\", \"1\"," +
+              "Seq((\"1\", \"select_1\"), (\"2\", \"select_2\"))))\n" +
+              "val items=z.checkbox(\"my_checkbox\", " +
+              "Seq((\"1\", \"check_1\"), (\"2\", \"check_2\")), Seq(\"2\"))\n" +
+              "println(items(0))";
+          p.setText(code);
+          note.run(p.getId());
+          waitForFinish(p);
 
-      assertEquals(Status.FINISHED, p.getStatus());
-      Iterator<String> formIter = p.settings.getForms().keySet().iterator();
-      assertEquals("my_input", formIter.next());
-      assertEquals("my_pwd", formIter.next());
-      assertEquals("my_select", formIter.next());
-      assertEquals("my_checkbox", formIter.next());
+          assertEquals(Status.FINISHED, p.getStatus());
+          Iterator<String> formIter = p.settings.getForms().keySet().iterator();
+          assertEquals("my_input", formIter.next());
+          assertEquals("my_pwd", formIter.next());
+          assertEquals("my_select", formIter.next());
+          assertEquals("my_checkbox", formIter.next());
 
-      // check dynamic forms values
-      String[] result = p.getReturn().message().get(0).getData().split("\n");
-      assertEquals(5, result.length);
-      assertEquals("default_name", result[0]);
-      assertEquals("null", result[1]);
-      assertEquals("1", result[2]);
-      assertEquals("2", result[3]);
-      assertEquals("items: Seq[Any] = Buffer(2)", result[4]);
+          // check dynamic forms values
+          String[] result = p.getReturn().message().get(0).getData().split("\n");
+          assertEquals(5, result.length);
+          assertEquals("default_name", result[0]);
+          assertEquals("null", result[1]);
+          assertEquals("1", result[2]);
+          assertEquals("2", result[3]);
+          assertEquals("items: Seq[Any] = Buffer(2)", result[4]);
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testPySparkZeppelinContextDynamicForms() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      String code = "%spark.pyspark print(z.input('my_input', 'default_name'))\n" +
-          "print(z.password('my_pwd'))\n" +
-          "print(z.select('my_select', " +
-          "[('1', 'select_1'), ('2', 'select_2')], defaultValue='1'))\n" +
-          "items=z.checkbox('my_checkbox', " +
-          "[('1', 'check_1'), ('2', 'check_2')], defaultChecked=['2'])\n" +
-          "print(items[0])";
-      p.setText(code);
-      note.run(p.getId(), true);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          String code = "%spark.pyspark print(z.input('my_input', 'default_name'))\n" +
+              "print(z.password('my_pwd'))\n" +
+              "print(z.select('my_select', " +
+              "[('1', 'select_1'), ('2', 'select_2')], defaultValue='1'))\n" +
+              "items=z.checkbox('my_checkbox', " +
+              "[('1', 'check_1'), ('2', 'check_2')], defaultChecked=['2'])\n" +
+              "print(items[0])";
+          p.setText(code);
+          note.run(p.getId(), true);
 
-      assertEquals(Status.FINISHED, p.getStatus());
-      Iterator<String> formIter = p.settings.getForms().keySet().iterator();
-      assertEquals("my_input", formIter.next());
-      assertEquals("my_pwd", formIter.next());
-      assertEquals("my_select", formIter.next());
-      assertEquals("my_checkbox", formIter.next());
+          assertEquals(Status.FINISHED, p.getStatus());
+          Iterator<String> formIter = p.settings.getForms().keySet().iterator();
+          assertEquals("my_input", formIter.next());
+          assertEquals("my_pwd", formIter.next());
+          assertEquals("my_select", formIter.next());
+          assertEquals("my_checkbox", formIter.next());
 
-      // check dynamic forms values
-      String[] result = p.getReturn().message().get(0).getData().split("\n");
-      assertEquals(4, result.length);
-      assertEquals("default_name", result[0]);
-      assertEquals("None", result[1]);
-      assertEquals("1", result[2]);
-      assertEquals("2", result[3]);
+          // check dynamic forms values
+          String[] result = p.getReturn().message().get(0).getData().split("\n");
+          assertEquals(4, result.length);
+          assertEquals("default_name", result[0]);
+          assertEquals("None", result[1]);
+          assertEquals("1", result[2]);
+          assertEquals("2", result[3]);
+      return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testAngularObjects() throws IOException, InterpreterNotFoundException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
 
-      // add local angular object
-      p1.setText("%spark z.angularBind(\"name\", \"world\")");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      // angular object is saved to InterpreterGroup's AngularObjectRegistry
-      List<AngularObject> angularObjects = p1.getBindedInterpreter().getInterpreterGroup()
-              .getAngularObjectRegistry().getAll(note.getId(), null);
-      assertEquals(1, angularObjects.size());
-      assertEquals("name", angularObjects.get(0).getName());
-      assertEquals("world", angularObjects.get(0).get());
+          // add local angular object
+          p1.setText("%spark z.angularBind(\"name\", \"world\")");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          // angular object is saved to InterpreterGroup's AngularObjectRegistry
+          List<AngularObject> angularObjects;
+          try {
+            angularObjects = p1.getBindedInterpreter().getInterpreterGroup()
+                    .getAngularObjectRegistry().getAll(note.getId(), null);
 
-      // angular object is saved to note as well.
-      angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
-      assertEquals(1, angularObjects.size());
-      assertEquals("name", angularObjects.get(0).getName());
-      assertEquals("world", angularObjects.get(0).get());
+            assertEquals(1, angularObjects.size());
+            assertEquals("name", angularObjects.get(0).getName());
+            assertEquals("world", angularObjects.get(0).get());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
+          // angular object is saved to note as well.
+          try {
+            angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
 
-      // remove local angular object
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%spark z.angularUnbind(\"name\")");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      angularObjects = p1.getBindedInterpreter().getInterpreterGroup().getAngularObjectRegistry()
-              .getAll(note.getId(), null);
-      assertEquals(0, angularObjects.size());
+            assertEquals(1, angularObjects.size());
+            assertEquals("name", angularObjects.get(0).getName());
+            assertEquals("world", angularObjects.get(0).get());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
 
-      angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
-      assertEquals(0, angularObjects.size());
+          // remove local angular object
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%spark z.angularUnbind(\"name\")");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          try {
+            angularObjects = p1.getBindedInterpreter().getInterpreterGroup().getAngularObjectRegistry()
+                    .getAll(note.getId(), null);
+            assertEquals(0, angularObjects.size());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
 
-      // add global angular object
-      Paragraph p3 = note.addNewParagraph(anonymous);
-      p3.setText("%spark z.angularBindGlobal(\"name2\", \"world2\")");
-      note.run(p3.getId(), true);
-      assertEquals(Status.FINISHED, p3.getStatus());
-      List<AngularObject> globalAngularObjects = p3.getBindedInterpreter().getInterpreterGroup()
-              .getAngularObjectRegistry().getAll(null, null);
-      assertEquals(1, globalAngularObjects.size());
-      assertEquals("name2", globalAngularObjects.get(0).getName());
-      assertEquals("world2", globalAngularObjects.get(0).get());
 
-      // global angular object is not saved to note
-      angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
-      assertEquals(0, angularObjects.size());
+          try {
+            angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
+            assertEquals(0, angularObjects.size());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
 
-      // remove global angular object
-      Paragraph p4 = note.addNewParagraph(anonymous);
-      p4.setText("%spark z.angularUnbindGlobal(\"name2\")");
-      note.run(p4.getId(), true);
-      assertEquals(Status.FINISHED, p4.getStatus());
-      globalAngularObjects = p4.getBindedInterpreter().getInterpreterGroup()
-              .getAngularObjectRegistry().getAll(note.getId(), null);
-      assertEquals(0, globalAngularObjects.size());
 
-      // global angular object is not saved to note
-      angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
-      assertEquals(0, angularObjects.size());
+          // add global angular object
+          Paragraph p3 = note.addNewParagraph(anonymous);
+          p3.setText("%spark z.angularBindGlobal(\"name2\", \"world2\")");
+          note.run(p3.getId(), true);
+          assertEquals(Status.FINISHED, p3.getStatus());
+          List<AngularObject> globalAngularObjects;
+          try {
+            globalAngularObjects = p3.getBindedInterpreter().getInterpreterGroup()
+                    .getAngularObjectRegistry().getAll(null, null);
+            assertEquals(1, globalAngularObjects.size());
+            assertEquals("name2", globalAngularObjects.get(0).getName());
+            assertEquals("world2", globalAngularObjects.get(0).get());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
+
+
+          // global angular object is not saved to note
+          try {
+            angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
+            assertEquals(0, angularObjects.size());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
+
+
+          // remove global angular object
+          Paragraph p4 = note.addNewParagraph(anonymous);
+          p4.setText("%spark z.angularUnbindGlobal(\"name2\")");
+          note.run(p4.getId(), true);
+          assertEquals(Status.FINISHED, p4.getStatus());
+          try {
+            globalAngularObjects = p4.getBindedInterpreter().getInterpreterGroup()
+                    .getAngularObjectRegistry().getAll(note.getId(), null);
+            assertEquals(0, globalAngularObjects.size());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
+
+
+          // global angular object is not saved to note
+          try {
+            angularObjects = note.getAngularObjects(p1.getBindedInterpreter().getInterpreterGroup().getId());
+            assertEquals(0, angularObjects.size());
+          } catch (InterpreterNotFoundException e) {
+            fail();
+          }
+
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testScalaNoteDynamicForms() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
 
-      // create TextBox
-      p1.setText("%spark z.noteTextbox(\"name\", \"world\")");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      Input input = p1.getNote().getNoteForms().get("name");
-      assertTrue(input instanceof TextBox);
-      TextBox inputTextBox = (TextBox) input;
-      assertEquals("name", inputTextBox.getDisplayName());
-      assertEquals("world", inputTextBox.getDefaultValue());
-      assertEquals("world", p1.getNote().getNoteParams().get("name"));
+          // create TextBox
+          p1.setText("%spark z.noteTextbox(\"name\", \"world\")");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          Input input = p1.getNote().getNoteForms().get("name");
+          assertTrue(input instanceof TextBox);
+          TextBox inputTextBox = (TextBox) input;
+          assertEquals("name", inputTextBox.getDisplayName());
+          assertEquals("world", inputTextBox.getDefaultValue());
+          assertEquals("world", p1.getNote().getNoteParams().get("name"));
 
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${name}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${name}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
 
-      // create Select
-      p1.setText("%spark z.noteSelect(\"language\", Seq((\"java\" -> \"JAVA\"), (\"scala\" -> \"SCALA\")), \"java\")");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      input = p1.getNote().getNoteForms().get("language");
-      assertTrue(input instanceof Select);
-      Select select = (Select) input;
-      assertEquals("language", select.getDisplayName());
-      assertEquals("java", select.getDefaultValue());
-      assertEquals("java", p1.getNote().getNoteParams().get("language"));
+          // create Select
+          p1.setText("%spark z.noteSelect(\"language\", Seq((\"java\" -> \"JAVA\"), (\"scala\" -> \"SCALA\")), \"java\")");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          input = p1.getNote().getNoteForms().get("language");
+          assertTrue(input instanceof Select);
+          Select select = (Select) input;
+          assertEquals("language", select.getDisplayName());
+          assertEquals("java", select.getDefaultValue());
+          assertEquals("java", p1.getNote().getNoteParams().get("language"));
 
-      p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${language}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java"));
+          p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${language}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java"));
 
-      // create Checkbox
-      p1.setText("%spark z.noteCheckbox(\"languages\", Seq((\"java\" -> \"JAVA\"), (\"scala\" -> \"SCALA\")), Seq(\"java\", \"scala\"))");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      input = p1.getNote().getNoteForms().get("languages");
-      assertTrue(input instanceof CheckBox);
-      CheckBox checkbox = (CheckBox) input;
-      assertEquals("languages", checkbox.getDisplayName());
-      assertArrayEquals(new Object[]{"java", "scala"}, checkbox.getDefaultValue());
-      assertEquals(Arrays.asList("java", "scala"), p1.getNote().getNoteParams().get("languages"));
+          // create Checkbox
+          p1.setText("%spark z.noteCheckbox(\"languages\", Seq((\"java\" -> \"JAVA\"), (\"scala\" -> \"SCALA\")), Seq(\"java\", \"scala\"))");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          input = p1.getNote().getNoteForms().get("languages");
+          assertTrue(input instanceof CheckBox);
+          CheckBox checkbox = (CheckBox) input;
+          assertEquals("languages", checkbox.getDisplayName());
+          assertArrayEquals(new Object[]{"java", "scala"}, checkbox.getDefaultValue());
+          assertEquals(Arrays.asList("java", "scala"), p1.getNote().getNoteParams().get("languages"));
 
-      p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${checkbox:languages}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java,scala"));
+          p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${checkbox:languages}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java,scala"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testPythonNoteDynamicForms() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
 
-      // create TextBox
-      p1.setText("%spark.pyspark z.noteTextbox(\"name\", \"world\")");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      Input input = p1.getNote().getNoteForms().get("name");
-      assertTrue(input instanceof TextBox);
-      TextBox inputTextBox = (TextBox) input;
-      assertEquals("name", inputTextBox.getDisplayName());
-      assertEquals("world", inputTextBox.getDefaultValue());
-      assertEquals("world", p1.getNote().getNoteParams().get("name"));
+          // create TextBox
+          p1.setText("%spark.pyspark z.noteTextbox(\"name\", \"world\")");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          Input input = p1.getNote().getNoteForms().get("name");
+          assertTrue(input instanceof TextBox);
+          TextBox inputTextBox = (TextBox) input;
+          assertEquals("name", inputTextBox.getDisplayName());
+          assertEquals("world", inputTextBox.getDefaultValue());
+          assertEquals("world", p1.getNote().getNoteParams().get("name"));
 
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${name}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${name}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
 
-      // create Select
-      p1.setText("%spark.pyspark z.noteSelect('language', [('java', 'JAVA'), ('scala', 'SCALA')], 'java')");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      input = p1.getNote().getNoteForms().get("language");
-      assertTrue(input instanceof Select);
-      Select select = (Select) input;
-      assertEquals("language", select.getDisplayName());
-      assertEquals("java", select.getDefaultValue());
-      assertEquals("java", p1.getNote().getNoteParams().get("language"));
+          // create Select
+          p1.setText("%spark.pyspark z.noteSelect('language', [('java', 'JAVA'), ('scala', 'SCALA')], 'java')");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          input = p1.getNote().getNoteForms().get("language");
+          assertTrue(input instanceof Select);
+          Select select = (Select) input;
+          assertEquals("language", select.getDisplayName());
+          assertEquals("java", select.getDefaultValue());
+          assertEquals("java", p1.getNote().getNoteParams().get("language"));
 
-      p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${language}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java"));
+          p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${language}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java"));
 
-      // create Checkbox
-      p1.setText("%spark.pyspark z.noteCheckbox('languages', [('java', 'JAVA'), ('scala', 'SCALA')], ['java', 'scala'])");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      input = p1.getNote().getNoteForms().get("languages");
-      assertTrue(input instanceof CheckBox);
-      CheckBox checkbox = (CheckBox) input;
-      assertEquals("languages", checkbox.getDisplayName());
-      assertArrayEquals(new Object[]{"java", "scala"}, checkbox.getDefaultValue());
-      assertEquals(Arrays.asList("java", "scala"), p1.getNote().getNoteParams().get("languages"));
+          // create Checkbox
+          p1.setText("%spark.pyspark z.noteCheckbox('languages', [('java', 'JAVA'), ('scala', 'SCALA')], ['java', 'scala'])");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          input = p1.getNote().getNoteForms().get("languages");
+          assertTrue(input instanceof CheckBox);
+          CheckBox checkbox = (CheckBox) input;
+          assertEquals("languages", checkbox.getDisplayName());
+          assertArrayEquals(new Object[]{"java", "scala"}, checkbox.getDefaultValue());
+          assertEquals(Arrays.asList("java", "scala"), p1.getNote().getNoteParams().get("languages"));
 
-      p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${checkbox:languages}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java,scala"));
+          p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${checkbox:languages}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello java,scala"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testRNoteDynamicForms() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(anonymous);
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
 
-      // create TextBox
-      p1.setText("%spark.r z.noteTextbox(\"name\", \"world\")");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
-      Input input = p1.getNote().getNoteForms().get("name");
-      assertTrue(input instanceof TextBox);
-      TextBox inputTextBox = (TextBox) input;
-      assertEquals("name", inputTextBox.getDisplayName());
-      assertEquals("world", inputTextBox.getDefaultValue());
-      assertEquals("world", p1.getNote().getNoteParams().get("name"));
+          // create TextBox
+          p1.setText("%spark.r z.noteTextbox(\"name\", \"world\")");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
+          Input input = p1.getNote().getNoteForms().get("name");
+          assertTrue(input instanceof TextBox);
+          TextBox inputTextBox = (TextBox) input;
+          assertEquals("name", inputTextBox.getDisplayName());
+          assertEquals("world", inputTextBox.getDefaultValue());
+          assertEquals("world", p1.getNote().getNoteParams().get("name"));
 
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%md hello $${name}");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%md hello $${name}");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString(), p2.getReturn().toString().contains("hello world"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testConfInterpreter() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
       TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      p.setText("%spark.conf spark.jars.packages\tcom.databricks:spark-csv_2.11:1.2.0");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          p.setText("%spark.conf spark.jars.packages\tcom.databricks:spark-csv_2.11:1.2.0");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
 
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%spark\nimport com.databricks.spark.csv._");
-      note.run(p1.getId(), true);
-      assertEquals(Status.FINISHED, p1.getStatus());
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%spark\nimport com.databricks.spark.csv._");
+          note.run(p1.getId(), true);
+          assertEquals(Status.FINISHED, p1.getStatus());
 
-      // test pyspark imports path
-      Paragraph p2 = note.addNewParagraph(anonymous);
-      p2.setText("%spark.pyspark\nimport sys\nsys.path");
-      note.run(p2.getId(), true);
-      assertEquals(Status.FINISHED, p2.getStatus());
-      assertTrue(p2.getReturn().toString().contains("databricks_spark"));
+          // test pyspark imports path
+          Paragraph p2 = note.addNewParagraph(anonymous);
+          p2.setText("%spark.pyspark\nimport sys\nsys.path");
+          note.run(p2.getId(), true);
+          assertEquals(Status.FINISHED, p2.getStatus());
+          assertTrue(p2.getReturn().toString().contains("databricks_spark"));
 
-      Paragraph p3 = note.addNewParagraph(anonymous);
-      p3.setText("%spark.ipyspark\nimport sys\nsys.path");
-      note.run(p3.getId(), true);
-      assertEquals(Status.FINISHED, p3.getStatus());
-      assertTrue(p3.getReturn().toString().contains("databricks_spark"));
-
+          Paragraph p3 = note.addNewParagraph(anonymous);
+          p3.setText("%spark.ipyspark\nimport sys\nsys.path");
+          note.run(p3.getId(), true);
+          assertEquals(Status.FINISHED, p3.getStatus());
+          assertTrue(p3.getReturn().toString().contains("databricks_spark"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testFailtoLaunchSpark() throws IOException {
-    Note note = null;
+    String noteId = null;
     try {
       TestUtils.getInstance(Notebook.class).getInterpreterSettingManager().close();
-      note = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      Paragraph p = note.addNewParagraph(anonymous);
-      p.setText("%spark.conf SPARK_HOME invalid_spark_home");
-      note.run(p.getId(), true);
-      assertEquals(Status.FINISHED, p.getStatus());
+      noteId = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        note -> {
+          Paragraph p = note.addNewParagraph(anonymous);
+          p.setText("%spark.conf SPARK_HOME invalid_spark_home");
+          note.run(p.getId(), true);
+          assertEquals(Status.FINISHED, p.getStatus());
 
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%spark\nsc.version");
-      note.run(p1.getId(), true);
-      assertEquals(Status.ERROR, p1.getStatus());
-      assertTrue("Actual error message: " + p1.getReturn().message().get(0).getData(),
-              p1.getReturn().message().get(0).getData().contains("No such file or directory"));
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%spark\nsc.version");
+          note.run(p1.getId(), true);
+          assertEquals(Status.ERROR, p1.getStatus());
+          assertTrue("Actual error message: " + p1.getReturn().message().get(0).getData(),
+                  p1.getReturn().message().get(0).getData().contains("No such file or directory"));
 
-      // run it again, and get the same error
-      note.run(p1.getId(), true);
-      assertEquals(Status.ERROR, p1.getStatus());
-      assertTrue("Actual error message: " + p1.getReturn().message().get(0).getData(),
-              p1.getReturn().message().get(0).getData().contains("No such file or directory"));
+          // run it again, and get the same error
+          note.run(p1.getId(), true);
+          assertEquals(Status.ERROR, p1.getStatus());
+          assertTrue("Actual error message: " + p1.getReturn().message().get(0).getData(),
+                  p1.getReturn().message().get(0).getData().contains("No such file or directory"));
+          return null;
+        });
     } finally {
-      if (null != note) {
-        TestUtils.getInstance(Notebook.class).removeNote(note, anonymous);
+      if (null != noteId) {
+        TestUtils.getInstance(Notebook.class).removeNote(noteId, anonymous);
       }
       // reset SPARK_HOME, otherwise it will cause the following test fail
       InterpreterSetting sparkIntpSetting = TestUtils.getInstance(Notebook.class).getInterpreterSettingManager()

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -608,6 +608,10 @@ public class ZeppelinConfiguration {
     return StringUtils.split(getString(ConfVars.ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS), (","));
   }
 
+  public int getNoteCacheThreshold() {
+    return getInt(ConfVars.ZEPPELIN_NOTE_CACHE_THRESHOLD);
+  }
+
   public String getInterpreterPortRange() {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_RPC_PORTRANGE);
   }
@@ -1080,6 +1084,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_JOBMANAGER_ENABLE("zeppelin.jobmanager.enable", false),
     ZEPPELIN_SPARK_ONLY_YARN_CLUSTER("zeppelin.spark.only_yarn_cluster", false),
     ZEPPELIN_SESSION_CHECK_INTERVAL("zeppelin.session.check_interval", 60 * 10 * 1000),
+    ZEPPELIN_NOTE_CACHE_THRESHOLD("zeppelin.note.cache.threshold", 50),
     ZEPPELIN_NOTE_FILE_EXCLUDE_FIELDS("zeppelin.note.file.exclude.fields", "");
 
     private String varName;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -276,6 +276,10 @@ public class ZeppelinServer extends ResourceConfig {
     // Lazy loading will cause paragraph recovery and cron job initialization is delayed.
     Notebook notebook = ServiceLocatorUtilities.getService(
             sharedServiceLocator, Notebook.class.getName());
+    ServiceLocatorUtilities.getService(
+      sharedServiceLocator, SearchService.class.getName());
+    ServiceLocatorUtilities.getService(
+      sharedServiceLocator, SchedulerService.class.getName());
     // Try to recover here, don't do it in constructor of Notebook, because it would cause deadlock.
     notebook.recoveryIfNecessary();
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,6 +50,7 @@ import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.NoteManager;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.Notebook.NoteProcessor;
 import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.exception.CorruptedNoteException;
 import org.apache.zeppelin.notebook.exception.NotePathAlreadyExistsException;
@@ -98,50 +100,58 @@ public class NotebookService {
     this.schedulerService = schedulerService;
   }
 
-  public Note getHomeNote(ServiceContext context,
+  public String getHomeNote(ServiceContext context,
                           ServiceCallback<Note> callback) throws IOException {
     String noteId = notebook.getConf().getString(ZEPPELIN_NOTEBOOK_HOMESCREEN);
-    Note note = null;
     if (noteId != null) {
-      note = notebook.getNote(noteId);
-      if (note != null) {
-        if (!checkPermission(noteId, Permission.READER, Message.OP.GET_HOME_NOTE, context,
-                callback)) {
+      callback.onSuccess(null, context);
+    } else {
+      notebook.processNote(noteId,
+        note -> {
+          if (note != null && !checkPermission(noteId, Permission.READER, Message.OP.GET_HOME_NOTE, context,
+            callback)) {
+            return null;
+          }
+          callback.onSuccess(note, context);
           return null;
-        }
-      }
+        });
     }
-    callback.onSuccess(note, context);
-    return note;
+    return noteId;
   }
 
-  public Note getNote(String noteId,
+  public  <T> T getNote(String noteId,
                       ServiceContext context,
-                      ServiceCallback<Note> callback) throws IOException {
-    return getNote(noteId, false, context, callback);
+                      ServiceCallback<Note> callback,
+                      NoteProcessor<T> noteProcessor) throws IOException {
+    return getNote(noteId, false, context, callback, noteProcessor);
   }
 
-  public Note getNote(String noteId,
+  public <T> T getNote(String noteId,
                       boolean reload,
                       ServiceContext context,
-                      ServiceCallback<Note> callback) throws IOException {
-    Note note = notebook.getNote(noteId, reload);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return null;
-    }
-
-    if (!checkPermission(noteId, Permission.READER, Message.OP.GET_NOTE, context,
-        callback)) {
-      return null;
-    }
-    if (note.isPersonalizedMode()) {
-      note = note.getUserNote(context.getAutheInfo().getUser());
-    }
-    callback.onSuccess(note, context);
-    return note;
+                      ServiceCallback<Note> callback,
+                      NoteProcessor<T> noteProcessor) throws IOException {
+    return notebook.processNote(noteId, reload,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        if (!checkPermission(noteId, Permission.READER, Message.OP.GET_NOTE, context,
+          callback)) {
+          return null;
+        }
+        Note newNote = note;
+        if (note.isPersonalizedMode()) {
+          newNote = note.getUserNote(context.getAutheInfo().getUser());
+        }
+        callback.onSuccess(newNote, context);
+        if (noteProcessor == null) {
+          return null;
+        }
+        return noteProcessor.process(newNote);
+      });
   }
-
 
   /**
    *
@@ -150,10 +160,10 @@ public class NotebookService {
    * @param addingEmptyParagraph
    * @param context
    * @param callback
-   * @return
+   * @return noteId
    * @throws IOException
    */
-  public Note createNote(String notePath,
+  public String createNote(String notePath,
                          String defaultInterpreterGroup,
                          boolean addingEmptyParagraph,
                          ServiceContext context,
@@ -165,15 +175,20 @@ public class NotebookService {
     }
 
     try {
-      Note note = notebook.createNote(normalizeNotePath(notePath), defaultInterpreterGroup,
+      String noteId = notebook.createNote(normalizeNotePath(notePath), defaultInterpreterGroup,
           context.getAutheInfo(), false);
       // it's an empty note. so add one paragraph
-      if (addingEmptyParagraph) {
-        note.addNewParagraph(context.getAutheInfo());
-      }
-      notebook.saveNote(note, context.getAutheInfo());
-      callback.onSuccess(note, context);
-      return note;
+      notebook.processNote(noteId,
+        note -> {
+          if (addingEmptyParagraph) {
+            note.addNewParagraph(context.getAutheInfo());
+          }
+          notebook.saveNote(note, context.getAutheInfo());
+          callback.onSuccess(note, context);
+          return null;
+        });
+
+      return noteId;
     } catch (IOException e) {
       callback.onFailure(e, context);
       return null;
@@ -213,19 +228,14 @@ public class NotebookService {
     if (!checkPermission(noteId, Permission.OWNER, Message.OP.DEL_NOTE, context, callback)) {
       return;
     }
-
-    Note note = null;
-    try {
-      note = notebook.getNote(noteId);
-    } catch (CorruptedNoteException e) {
-      notebook.removeCorruptedNote(noteId, context.getAutheInfo());
-      callback.onSuccess("Delete note successfully", context);
-      return;
-    }
-
-    if (note != null) {
-      notebook.removeNote(note, context.getAutheInfo());
-      callback.onSuccess("Delete note successfully", context);
+    if (notebook.containsNoteById(noteId)) {
+      try {
+        notebook.removeNote(noteId, context.getAutheInfo());
+        callback.onSuccess("Delete note successfully", context);
+      } catch (CorruptedNoteException e) {
+        notebook.removeCorruptedNote(noteId, context.getAutheInfo());
+        callback.onSuccess("Delete note successfully", context);
+      }
     } else {
       callback.onFailure(new NoteNotFoundException(noteId), context);
     }
@@ -256,29 +266,32 @@ public class NotebookService {
     if (!checkPermission(noteId, Permission.OWNER, Message.OP.NOTE_RENAME, context, callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note != null) {
-      note.setCronSupported(notebook.getConf());
-      if (isRelative && !note.getParentPath().equals("/")) {
-        newNotePath = note.getParentPath() + "/" + newNotePath;
-      } else {
-        if (!newNotePath.startsWith("/")) {
-          newNotePath = "/" + newNotePath;
+    notebook.processNote(noteId,
+      readNote -> {
+        if (readNote == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
         }
-      }
-      try {
-        notebook.moveNote(noteId, newNotePath, context.getAutheInfo());
-        callback.onSuccess(note, context);
-      } catch (NotePathAlreadyExistsException e) {
-        callback.onFailure(e, context);
-      }
-    } else {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-    }
+        readNote.setCronSupported(notebook.getConf());
+        String newNotePathReal = newNotePath;
+        if (isRelative && !readNote.getParentPath().equals("/")) {
+          newNotePathReal = readNote.getParentPath() + "/" + newNotePath;
+        } else {
+          if (!newNotePath.startsWith("/")) {
+            newNotePathReal = "/" + newNotePath;
+          }
+        }
+        try {
+          notebook.moveNote(noteId, newNotePathReal, context.getAutheInfo());
+          callback.onSuccess(readNote, context);
+        } catch (NotePathAlreadyExistsException e) {
+          callback.onFailure(e, context);
+        }
+        return null;
+      });
 
   }
 
-  public Note cloneNote(String noteId,
+  public String cloneNote(String noteId,
                         String newNotePath,
                         ServiceContext context,
                         ServiceCallback<Note> callback) throws IOException {
@@ -287,27 +300,43 @@ public class NotebookService {
       newNotePath = "/Cloned Note_" + noteId;
     }
     try {
-      Note newNote = notebook.cloneNote(noteId, normalizeNotePath(newNotePath),
+      String newNoteId = notebook.cloneNote(noteId, normalizeNotePath(newNotePath),
           context.getAutheInfo());
-      callback.onSuccess(newNote, context);
-      return newNote;
+      return notebook.processNote(newNoteId,
+        newNote -> {
+          callback.onSuccess(newNote, context);
+          return newNote.getId();
+        });
     } catch (IOException e) {
       callback.onFailure(new IOException("Fail to clone note", e), context);
       return null;
     }
   }
 
-  public Note importNote(String notePath,
+  /**
+   *
+   * @param notePath
+   * @param noteJson
+   * @param context
+   * @param callback
+   * @return NoteId of the imported Note
+   * @throws IOException
+   */
+  public String importNote(String notePath,
                          String noteJson,
                          ServiceContext context,
                          ServiceCallback<Note> callback) throws IOException {
     try {
       // pass notePath when it is null
-      Note note = notebook.importNote(noteJson, notePath == null ?
+      String noteId = notebook.importNote(noteJson, notePath == null ?
               notePath : normalizeNotePath(notePath),
           context.getAutheInfo());
-      callback.onSuccess(note, context);
-      return note;
+      return notebook.processNote(noteId,
+        note -> {
+          callback.onSuccess(note, context);
+          return note.getId();
+        });
+
     } catch (IOException e) {
       callback.onFailure(new IOException("Fail to import note: " + e.getMessage(), e), context);
       return null;
@@ -331,7 +360,7 @@ public class NotebookService {
    * return false when paragraph execution fails due to zeppelin internal issue.
    * @throws IOException
    */
-  public boolean runParagraph(String noteId,
+  public boolean runParagraph(Note note,
                               String paragraphId,
                               String title,
                               String text,
@@ -343,16 +372,16 @@ public class NotebookService {
                               ServiceContext context,
                               ServiceCallback<Paragraph> callback) throws IOException {
 
-    LOGGER.info("Start to run paragraph: {} of note: {}", paragraphId, noteId);
-    if (!checkPermission(noteId, Permission.RUNNER, Message.OP.RUN_PARAGRAPH, context, callback)) {
+
+    if (note == null) {
+      return false;
+    }
+    LOGGER.info("Start to run paragraph: {} of note: {}", paragraphId, note.getId());
+    if (!checkPermission(note.getId(), Permission.RUNNER, Message.OP.RUN_PARAGRAPH, context, callback)) {
       return false;
     }
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return false;
-    }
+
     Paragraph p = note.getParagraph(paragraphId);
     if (p == null) {
       callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
@@ -421,61 +450,64 @@ public class NotebookService {
       return false;
     }
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return false;
-    }
+    return notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return false;
+        }
 
-    if (paragraphs != null) {
-      // run note via the data passed from frontend
-      try {
-        note.setRunning(true);
-        for (Map<String, Object> raw : paragraphs) {
-          String paragraphId = (String) raw.get("id");
-          if (paragraphId == null) {
-            LOGGER.warn("No id found in paragraph json: {}", raw);
-            continue;
-          }
+        if (paragraphs != null) {
+          // run note via the data passed from frontend
           try {
-            String text = (String) raw.get("paragraph");
-            String title = (String) raw.get("title");
-            Map<String, Object> params = (Map<String, Object>) raw.get("params");
-            Map<String, Object> config = (Map<String, Object>) raw.get("config");
+            note.setRunning(true);
+            for (Map<String, Object> raw : paragraphs) {
+              String paragraphId = (String) raw.get("id");
+              if (paragraphId == null) {
+                LOGGER.warn("No id found in paragraph json: {}", raw);
+                continue;
+              }
+              try {
+                String text = (String) raw.get("paragraph");
+                String title = (String) raw.get("title");
+                Map<String, Object> params = (Map<String, Object>) raw.get("params");
+                Map<String, Object> config = (Map<String, Object>) raw.get("config");
 
-            if (!runParagraph(noteId, paragraphId, title, text, params, config, null, false, true,
-                    context, callback)) {
-              // stop execution when one paragraph fails.
-              return false;
+                if (!runParagraph(note, paragraphId, title, text, params, config, null, false, true,
+                        context, callback)) {
+                  // stop execution when one paragraph fails.
+                  return false;
+                }
+                // also stop execution when user code in a paragraph fails
+                Paragraph p = note.getParagraph(paragraphId);
+                InterpreterResult result = p.getReturn();
+                if (result != null && result.code() == ERROR) {
+                  return false;
+                }
+                if (p.getStatus() == ABORT || p.isAborted()) {
+                  return false;
+                }
+              } catch (Exception e) {
+                throw new IOException("Fail to run paragraph json: " + raw, e);
+              }
             }
-            // also stop execution when user code in a paragraph fails
-            Paragraph p = note.getParagraph(paragraphId);
-            InterpreterResult result = p.getReturn();
-            if (result != null && result.code() == ERROR) {
-              return false;
-            }
-            if (p.getStatus() == ABORT || p.isAborted()) {
-              return false;
-            }
+          } finally {
+            note.setRunning(false);
+          }
+        } else {
+          try {
+            // run note directly when parameter `paragraphs` is null.
+            note.runAll(context.getAutheInfo(), true, false, new HashMap<>());
+            return true;
           } catch (Exception e) {
-            throw new IOException("Fail to run paragraph json: " + raw, e);
+            LOGGER.warn("Fail to run note: {}", note.getName(), e);
+            return false;
           }
         }
-      } finally {
-        note.setRunning(false);
-      }
-    } else {
-      try {
-        // run note directly when parameter `paragraphs` is null.
-        note.runAll(context.getAutheInfo(), true, false, new HashMap<>());
-        return true;
-      } catch (Exception e) {
-        LOGGER.warn("Fail to run note: {}", note.getName(), e);
-        return false;
-      }
-    }
 
-    return true;
+        return true;
+      });
+
   }
 
   public void cancelParagraph(String noteId,
@@ -486,16 +518,21 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      throw new NoteNotFoundException(noteId);
-    }
-    Paragraph p = note.getParagraph(paragraphId);
-    if (p == null) {
-      throw new ParagraphNotFoundException(paragraphId);
-    }
-    p.abort();
-    callback.onSuccess(p, context);
+
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          throw new NoteNotFoundException(noteId);
+        }
+        Paragraph p = note.getParagraph(paragraphId);
+        if (p == null) {
+          throw new ParagraphNotFoundException(paragraphId);
+        }
+        p.abort();
+        callback.onSuccess(p, context);
+        return null;
+      });
+
   }
 
   public void moveParagraph(String noteId,
@@ -507,21 +544,24 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      throw new NoteNotFoundException(noteId);
-    }
-    if (note.getParagraph(paragraphId) == null) {
-      throw new ParagraphNotFoundException(paragraphId);
-    }
-    if (newIndex >= note.getParagraphCount()) {
-      callback.onFailure(new BadRequestException("newIndex " + newIndex + " is out of bounds"),
-          context);
-      return;
-    }
-    note.moveParagraph(paragraphId, newIndex);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(note.getParagraph(newIndex), context);
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          throw new NoteNotFoundException(noteId);
+        }
+        if (note.getParagraph(paragraphId) == null) {
+          throw new ParagraphNotFoundException(paragraphId);
+        }
+        if (newIndex >= note.getParagraphCount()) {
+          callback.onFailure(new BadRequestException("newIndex " + newIndex + " is out of bounds"),
+              context);
+          return null;
+        }
+        note.moveParagraph(paragraphId, newIndex);
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(note.getParagraph(newIndex), context);
+        return null;
+      });
   }
 
   public void removeParagraph(String noteId,
@@ -532,16 +572,21 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      throw new NoteNotFoundException(noteId);
-    }
-    if (note.getParagraph(paragraphId) == null) {
-      throw new ParagraphNotFoundException(paragraphId);
-    }
-    Paragraph p = note.removeParagraph(context.getAutheInfo().getUser(), paragraphId);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(p, context);
+
+    notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            throw new NoteNotFoundException(noteId);
+          }
+          if (note.getParagraph(paragraphId) == null) {
+            throw new ParagraphNotFoundException(paragraphId);
+          }
+          Paragraph p = note.removeParagraph(context.getAutheInfo().getUser(), paragraphId);
+          notebook.saveNote(note, context.getAutheInfo());
+          callback.onSuccess(p, context);
+          return null;
+        });
+
   }
 
   public Paragraph insertParagraph(String noteId,
@@ -553,15 +598,18 @@ public class NotebookService {
         callback)) {
       return null;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      throw new NoteNotFoundException(noteId);
-    }
-    Paragraph newPara = note.insertNewParagraph(index, context.getAutheInfo());
-    newPara.mergeConfig(config);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(newPara, context);
-    return newPara;
+
+    return notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            throw new NoteNotFoundException(noteId);
+          }
+          Paragraph newPara = note.insertNewParagraph(index, context.getAutheInfo());
+          newPara.mergeConfig(config);
+          notebook.saveNote(note, context.getAutheInfo());
+          callback.onSuccess(newPara, context);
+          return newPara;
+        });
   }
 
   public void restoreNote(String noteId,
@@ -571,24 +619,28 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!note.getPath().startsWith("/" + NoteManager.TRASH_FOLDER)) {
-      callback.onFailure(new IOException("Can not restore this note " + note.getPath() +
-          " as it is not in trash folder"), context);
-      return;
-    }
-    try {
-      String destNotePath = note.getPath().replace("/" + NoteManager.TRASH_FOLDER, "");
-      notebook.moveNote(noteId, destNotePath, context.getAutheInfo());
-      callback.onSuccess(note, context);
-    } catch (IOException e) {
-      callback.onFailure(new IOException("Fail to restore note: " + noteId, e), context);
-    }
+        if (!note.getPath().startsWith("/" + NoteManager.TRASH_FOLDER)) {
+          callback.onFailure(new IOException("Can not restore this note " + note.getPath() +
+              " as it is not in trash folder"), context);
+          return null;
+        }
+        try {
+          String destNotePath = note.getPath().replace("/" + NoteManager.TRASH_FOLDER, "");
+          notebook.moveNote(noteId, destNotePath, context.getAutheInfo());
+          callback.onSuccess(note, context);
+        } catch (IOException e) {
+          callback.onFailure(new IOException("Fail to restore note: " + noteId, e), context);
+        }
+        return null;
+      });
+
 
   }
 
@@ -613,7 +665,7 @@ public class NotebookService {
 
 
   public void restoreAll(ServiceContext context,
-                         ServiceCallback<?> callback) throws IOException {
+                         ServiceCallback<Void> callback) throws IOException {
 
     try {
       notebook.restoreAll(context.getAutheInfo());
@@ -636,33 +688,45 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
-    Paragraph p = note.getParagraph(paragraphId);
-    if (p == null) {
-      callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
-      return;
-    }
 
-    p.settings.setParams(params);
-    p.mergeConfig(config);
-    p.setTitle(title);
-    p.setText(text);
-    if (note.isPersonalizedMode()) {
-      p = p.getUserParagraph(context.getAutheInfo().getUser());
-      p.settings.setParams(params);
-      p.mergeConfig(config);
-      p.setTitle(title);
-      p.setText(text);
-    }
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(p, context);
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        Paragraph p = note.getParagraph(paragraphId);
+        if (p == null) {
+          callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
+          return null;
+        }
+        p.settings.setParams(params);
+        p.mergeConfig(config);
+        p.setTitle(title);
+        p.setText(text);
+        if (note.isPersonalizedMode()) {
+          p = p.getUserParagraph(context.getAutheInfo().getUser());
+          p.settings.setParams(params);
+          p.mergeConfig(config);
+          p.setTitle(title);
+          p.setText(text);
+        }
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(p, context);
+        return null;
+      });
   }
 
-  public Paragraph getNextSessionParagraph(String noteId,
+  /**
+   *
+   * @param noteId
+   * @param maxParagraph
+   * @param context
+   * @param callback
+   * @return paragraphId
+   * @throws IOException
+   */
+  public String getNextSessionParagraphId(String noteId,
                                         int maxParagraph,
                                         ServiceContext context,
                                         ServiceCallback<Paragraph> callback) throws IOException {
@@ -670,27 +734,29 @@ public class NotebookService {
             callback)) {
       throw new IOException("No privilege to access this note");
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      throw new IOException("No such note");
-    }
-    synchronized (this) {
-      if (note.getParagraphCount() >= maxParagraph) {
-        boolean removed = false;
-        for (int i = 1; i < note.getParagraphCount(); ++i) {
-          if (note.getParagraph(i).getStatus().isCompleted()) {
-            note.removeParagraph(context.getAutheInfo().getUser(), note.getParagraph(i).getId());
-            removed = true;
-            break;
+    return notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          throw new IOException("No such note");
+        }
+        synchronized (this) {
+          if (note.getParagraphCount() >= maxParagraph) {
+            boolean removed = false;
+            for (int i = 1; i < note.getParagraphCount(); ++i) {
+              if (note.getParagraph(i).getStatus().isCompleted()) {
+                note.removeParagraph(context.getAutheInfo().getUser(), note.getParagraph(i).getId());
+                removed = true;
+                break;
+              }
+            }
+            if (!removed) {
+              throw new IOException("All the paragraphs are not completed, unable to find available paragraph");
+            }
           }
+          return note.addNewParagraph(context.getAutheInfo()).getId();
         }
-        if (!removed) {
-          throw new IOException("All the paragraphs are not completed, unable to find available paragraph");
-        }
-      }
-      return note.addNewParagraph(context.getAutheInfo());
-    }
+      });
   }
 
   public void clearParagraphOutput(String noteId,
@@ -701,25 +767,28 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
-    Paragraph p = note.getParagraph(paragraphId);
-    if (p == null) {
-      callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
-      return;
-    }
-    Paragraph returnedParagraph;
-    if (note.isPersonalizedMode()) {
-      returnedParagraph = note.clearPersonalizedParagraphOutput(paragraphId,
-          context.getAutheInfo().getUser());
-    } else {
-      note.clearParagraphOutput(paragraphId);
-      returnedParagraph = note.getParagraph(paragraphId);
-    }
-    callback.onSuccess(returnedParagraph, context);
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        Paragraph p = note.getParagraph(paragraphId);
+        if (p == null) {
+          callback.onFailure(new ParagraphNotFoundException(paragraphId), context);
+          return null;
+        }
+        Paragraph returnedParagraph;
+        if (note.isPersonalizedMode()) {
+          returnedParagraph = note.clearPersonalizedParagraphOutput(paragraphId,
+              context.getAutheInfo().getUser());
+        } else {
+          note.clearParagraphOutput(paragraphId);
+          returnedParagraph = note.getParagraph(paragraphId);
+        }
+        callback.onSuccess(returnedParagraph, context);
+        return null;
+      });
   }
 
   public void clearAllParagraphOutput(String noteId,
@@ -729,15 +798,19 @@ public class NotebookService {
         callback)) {
       return;
     }
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
 
-    note.clearAllParagraphOutput();
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(note, context);
+
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        note.clearAllParagraphOutput();
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(note, context);
+        return null;
+      });
   }
 
 
@@ -750,27 +823,30 @@ public class NotebookService {
         callback)) {
       return;
     }
+    // use write lock because config and name are overwritten
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+        if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
+          if (config.get("cron") != null) {
+            config.remove("cron");
+          }
+        }
+        boolean cronUpdated = isCronUpdated(config, note.getConfig());
+        note.setName(name);
+        note.setConfig(config);
+        if (cronUpdated) {
+          schedulerService.refreshCron(note.getId());
+        }
 
-    if (!(Boolean) note.getConfig().get("isZeppelinNotebookCronEnable")) {
-      if (config.get("cron") != null) {
-        config.remove("cron");
-      }
-    }
-    boolean cronUpdated = isCronUpdated(config, note.getConfig());
-    note.setName(name);
-    note.setConfig(config);
-    if (cronUpdated) {
-      schedulerService.refreshCron(note.getId());
-    }
-
-    notebook.updateNote(note, context.getAutheInfo());
-    callback.onSuccess(note, context);
+        notebook.updateNote(note, context.getAutheInfo());
+        callback.onSuccess(note, context);
+        return null;
+      });
   }
 
 
@@ -794,37 +870,43 @@ public class NotebookService {
         callback)) {
       return;
     }
+    // use write lock because noteParams are overwritten
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
-
-    note.setNoteParams(noteParams);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(note, context);
+        note.setNoteParams(noteParams);
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(note, context);
+        return null;
+      });
   }
 
   public void removeNoteForms(String noteId,
                               String formName,
                               ServiceContext context,
                               ServiceCallback<Note> callback) throws IOException {
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!checkPermission(noteId, Permission.WRITER, Message.OP.REMOVE_NOTE_FORMS, context,
-        callback)) {
-      return;
-    }
+        if (!checkPermission(noteId, Permission.WRITER, Message.OP.REMOVE_NOTE_FORMS, context,
+            callback)) {
+          return null;
+        }
 
-    note.getNoteForms().remove(formName);
-    note.getNoteParams().remove(formName);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(note, context);
+        note.getNoteForms().remove(formName);
+        note.getNoteParams().remove(formName);
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(note, context);
+        return null;
+      });
   }
 
   public NotebookRepoWithVersionControl.Revision checkpointNote(
@@ -833,19 +915,19 @@ public class NotebookService {
       ServiceContext context,
       ServiceCallback<NotebookRepoWithVersionControl.Revision> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return null;
-    }
+    NotebookRepoWithVersionControl.Revision revision = notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        if (!checkPermission(noteId, Permission.WRITER, Message.OP.REMOVE_NOTE_FORMS, context,
+          callback)) {
+          return null;
+        }
+        return notebook.checkpointNote(noteId, note.getPath(), commitMessage, context.getAutheInfo());
+      });
 
-    if (!checkPermission(noteId, Permission.WRITER, Message.OP.REMOVE_NOTE_FORMS, context,
-        callback)) {
-      return null;
-    }
-
-    NotebookRepoWithVersionControl.Revision revision =
-        notebook.checkpointNote(noteId, note.getPath(), commitMessage, context.getAutheInfo());
     callback.onSuccess(revision, context);
     return revision;
   }
@@ -855,49 +937,54 @@ public class NotebookService {
       ServiceContext context,
       ServiceCallback<List<NotebookRepoWithVersionControl.Revision>> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return null;
-    }
 
-    // TODO(zjffdu) Disable checking permission for now, otherwise zeppelin will send 2 AUTH_INFO
-    // message to frontend when frontend try to get note without proper privilege.
-    //    if (!checkPermission(noteId, Permission.READER, Message.OP.LIST_REVISION_HISTORY, context,
-    //        callback)) {
-    //      return null;
-    //    }
-    List<NotebookRepoWithVersionControl.Revision> revisions =
-        notebook.listRevisionHistory(noteId, note.getPath(), context.getAutheInfo());
+    List<NotebookRepoWithVersionControl.Revision> revisions = notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
+        // TODO(zjffdu) Disable checking permission for now, otherwise zeppelin will send 2 AUTH_INFO
+        // message to frontend when frontend try to get note without proper privilege.
+        //    if (!checkPermission(noteId, Permission.READER, Message.OP.LIST_REVISION_HISTORY, context,
+        //        callback)) {
+        //      return null;
+        //    }
+        return notebook.listRevisionHistory(noteId, note.getPath(), context.getAutheInfo());
+      });
+
     callback.onSuccess(revisions, context);
     return revisions;
   }
 
 
-  public Note setNoteRevision(String noteId,
+  public void setNoteRevision(String noteId,
                               String revisionId,
                               ServiceContext context,
                               ServiceCallback<Note> callback) throws IOException {
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return null;
-    }
 
-    if (!checkPermission(noteId, Permission.WRITER, Message.OP.SET_NOTE_REVISION, context,
-        callback)) {
-      return null;
-    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    try {
-      Note resultNote = notebook.setNoteRevision(noteId, note.getPath(), revisionId,
-          context.getAutheInfo());
-      callback.onSuccess(resultNote, context);
-      return resultNote;
-    } catch (Exception e) {
-      callback.onFailure(new IOException("Fail to set given note revision", e), context);
-      return null;
-    }
+        if (!checkPermission(noteId, Permission.WRITER, Message.OP.SET_NOTE_REVISION, context,
+            callback)) {
+          return null;
+        }
+
+        try {
+          Note resultNote = notebook.setNoteRevision(noteId, note.getPath(), revisionId,
+              context.getAutheInfo());
+          callback.onSuccess(resultNote, context);
+        } catch (Exception e) {
+          callback.onFailure(new IOException("Fail to set given note revision", e), context);
+        }
+        return null;
+      });
+
   }
 
   public void getNotebyRevision(String noteId,
@@ -905,19 +992,22 @@ public class NotebookService {
                                 ServiceContext context,
                                 ServiceCallback<Note> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+    notebook.processNote(noteId ,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!checkPermission(noteId, Permission.READER, Message.OP.NOTE_REVISION, context,
-        callback)) {
-      return;
-    }
-    Note revisionNote = notebook.getNoteByRevision(noteId, note.getPath(), revisionId,
-        context.getAutheInfo());
-    callback.onSuccess(revisionNote, context);
+        if (!checkPermission(noteId, Permission.READER, Message.OP.NOTE_REVISION, context,
+            callback)) {
+          return null;
+        }
+        Note revisionNote = notebook.getNoteByRevision(noteId, note.getPath(), revisionId,
+            context.getAutheInfo());
+        callback.onSuccess(revisionNote, context);
+        return null;
+      });
   }
 
   public void getNoteByRevisionForCompare(String noteId,
@@ -925,24 +1015,27 @@ public class NotebookService {
                                           ServiceContext context,
                                           ServiceCallback<Note> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+    notebook.processNote(noteId ,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!checkPermission(noteId, Permission.READER, Message.OP.NOTE_REVISION_FOR_COMPARE, context,
-        callback)) {
-      return;
-    }
-    Note revisionNote;
-    if (revisionId.equals("Head")) {
-      revisionNote = note;
-    } else {
-      revisionNote = notebook.getNoteByRevision(noteId, note.getPath(), revisionId,
-          context.getAutheInfo());
-    }
-    callback.onSuccess(revisionNote, context);
+        if (!checkPermission(noteId, Permission.READER, Message.OP.NOTE_REVISION_FOR_COMPARE, context,
+            callback)) {
+          return null;
+        }
+        Note revisionNote;
+        if (revisionId.equals("Head")) {
+          revisionNote = note;
+        } else {
+          revisionNote = notebook.getNoteByRevision(noteId, note.getPath(), revisionId,
+              context.getAutheInfo());
+        }
+        callback.onSuccess(revisionNote, context);
+        return null;
+      });
   }
 
   public List<InterpreterCompletion> completion(
@@ -953,44 +1046,49 @@ public class NotebookService {
       ServiceContext context,
       ServiceCallback<List<InterpreterCompletion>> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return null;
-    }
+    return notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!checkPermission(noteId, Permission.WRITER, Message.OP.COMPLETION, context,
-        callback)) {
-      return null;
-    }
+        if (!checkPermission(noteId, Permission.WRITER, Message.OP.COMPLETION, context,
+            callback)) {
+          return null;
+        }
 
-    try {
-      List<InterpreterCompletion> completions = note.completion(paragraphId, buffer, cursor,
-              context.getAutheInfo());
-      callback.onSuccess(completions, context);
-      return completions;
-    } catch (RuntimeException e) {
-      callback.onFailure(new IOException("Fail to get completion", e), context);
-      return null;
-    }
+        try {
+          List<InterpreterCompletion> completions = note.completion(paragraphId, buffer, cursor,
+                  context.getAutheInfo());
+          callback.onSuccess(completions, context);
+          return completions;
+        } catch (RuntimeException e) {
+          callback.onFailure(new IOException("Fail to get completion", e), context);
+          return null;
+        }
+    });
+
   }
 
   public void getEditorSetting(String noteId,
                                String paragraphText,
                                ServiceContext context,
                                ServiceCallback<Map<String, Object>> callback) throws IOException {
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
-    try {
-      Map<String, Object> settings = notebook.getInterpreterSettingManager().
-          getEditorSetting(paragraphText, noteId);
-      callback.onSuccess(settings, context);
-    } catch (Exception e) {
-      callback.onFailure(new IOException("Fail to getEditorSetting", e), context);
-    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+        }
+        try {
+          Map<String, Object> settings = notebook.getInterpreterSettingManager().
+              getEditorSetting(paragraphText, noteId);
+          callback.onSuccess(settings, context);
+        } catch (Exception e) {
+          callback.onFailure(new IOException("Fail to getEditorSetting", e), context);
+        }
+        return null;
+      });
   }
 
   public void updatePersonalizedMode(String noteId,
@@ -998,20 +1096,23 @@ public class NotebookService {
                                      ServiceContext context,
                                      ServiceCallback<Note> callback) throws IOException {
 
-    Note note = notebook.getNote(noteId);
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
+    notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          callback.onFailure(new NoteNotFoundException(noteId), context);
+          return null;
+        }
 
-    if (!checkPermission(noteId, Permission.WRITER, Message.OP.UPDATE_PERSONALIZED_MODE, context,
-        callback)) {
-      return;
-    }
+        if (!checkPermission(noteId, Permission.WRITER, Message.OP.UPDATE_PERSONALIZED_MODE, context,
+            callback)) {
+          return null;
+        }
 
-    note.setPersonalizedMode(isPersonalized);
-    notebook.saveNote(note, context.getAutheInfo());
-    callback.onSuccess(note, context);
+        note.setPersonalizedMode(isPersonalized);
+        notebook.saveNote(note, context.getAutheInfo());
+        callback.onSuccess(note, context);
+        return null;
+      });
   }
 
   public void moveNoteToTrash(String noteId,
@@ -1026,22 +1127,23 @@ public class NotebookService {
       destNotePath = destNotePath + " " + TRASH_CONFLICT_TIMESTAMP_FORMATTER.format(Instant.now());
     }
 
-    Note note = null;
+    final String finalDestNotePath = destNotePath;
+
     try {
-       note = notebook.getNote(noteId);
+      notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            callback.onFailure(new NoteNotFoundException(noteId), context);
+            return null;
+          }
+          notebook.moveNote(noteId, finalDestNotePath, context.getAutheInfo());
+          callback.onSuccess(note, context);
+          return null;
+        });
     } catch (CorruptedNoteException e) {
         LOGGER.info("Move corrupted note to trash");
         notebook.moveNote(noteId, destNotePath, context.getAutheInfo());
-        return;
     }
-
-    if (note == null) {
-      callback.onFailure(new NoteNotFoundException(noteId), context);
-      return;
-    }
-
-    notebook.moveNote(noteId, destNotePath, context.getAutheInfo());
-    callback.onSuccess(note, context);
   }
 
   public void moveFolderToTrash(String folderPath,
@@ -1129,34 +1231,36 @@ public class NotebookService {
       Job.Status status = Job.Status.valueOf((String) message.get("status"));
       Map<String, Object> params = (Map<String, Object>) message.get("params");
       Map<String, Object> config = (Map<String, Object>) message.get("config");
+      notebook.processNote(noteId,
+        note -> {
+          Paragraph p = setParagraphUsingMessage(note, message, paragraphId,
+            text, title, params, config);
+          p.setResult((InterpreterResult) message.get("results"));
+          p.setErrorMessage((String) message.get("errorMessage"));
+          p.setStatusWithoutNotification(status);
 
-      Note note = notebook.getNote(noteId);
-      Paragraph p = setParagraphUsingMessage(note, message, paragraphId,
-          text, title, params, config);
-      p.setResult((InterpreterResult) message.get("results"));
-      p.setErrorMessage((String) message.get("errorMessage"));
-      p.setStatusWithoutNotification(status);
+          // Spell uses ISO 8601 formatted string generated from moment
+          String dateStarted = (String) message.get("dateStarted");
+          String dateFinished = (String) message.get("dateFinished");
+          SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
-      // Spell uses ISO 8601 formatted string generated from moment
-      String dateStarted = (String) message.get("dateStarted");
-      String dateFinished = (String) message.get("dateFinished");
-      SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+          try {
+            p.setDateStarted(df.parse(dateStarted));
+          } catch (ParseException e) {
+            LOGGER.error("Failed parse dateStarted", e);
+          }
 
-      try {
-        p.setDateStarted(df.parse(dateStarted));
-      } catch (ParseException e) {
-        LOGGER.error("Failed parse dateStarted", e);
-      }
+          try {
+            p.setDateFinished(df.parse(dateFinished));
+          } catch (ParseException e) {
+            LOGGER.error("Failed parse dateFinished", e);
+          }
 
-      try {
-        p.setDateFinished(df.parse(dateFinished));
-      } catch (ParseException e) {
-        LOGGER.error("Failed parse dateFinished", e);
-      }
-
-      addNewParagraphIfLastParagraphIsExecuted(note, p);
-      notebook.saveNote(note, context.getAutheInfo());
-      callback.onSuccess(p, context);
+          addNewParagraphIfLastParagraphIsExecuted(note, p);
+          notebook.saveNote(note, context.getAutheInfo());
+          callback.onSuccess(p, context);
+          return null;
+        });
     } catch (IOException e) {
       callback.onFailure(new IOException("Fail to run spell", e), context);
     }
@@ -1207,45 +1311,48 @@ public class NotebookService {
     AngularObject ao = null;
     boolean global = false;
     // propagate change to (Remote) AngularObjectRegistry
-    Note note = notebook.getNote(noteId);
-    if (note != null) {
-      List<InterpreterSetting> settings =
-              note.getBindedInterpreterSettings(new ArrayList(context.getUserAndRoles()));
-      for (InterpreterSetting setting : settings) {
-        if (setting.getInterpreterGroup(user, note.getId()) == null) {
-          continue;
+    List<InterpreterSetting> settings = notebook.processNote(noteId,
+      note -> {
+        if (note == null) {
+          return Collections.emptyList();
+        } else {
+          return note.getBindedInterpreterSettings(new ArrayList<>(context.getUserAndRoles()));
         }
-        if (interpreterGroupId.equals(setting.getInterpreterGroup(user, note.getId())
-            .getId())) {
-          AngularObjectRegistry angularObjectRegistry =
-              setting.getInterpreterGroup(user, note.getId()).getAngularObjectRegistry();
+      });
+    for (InterpreterSetting setting : settings) {
+      if (setting.getInterpreterGroup(user, noteId) == null) {
+        continue;
+      }
+      if (interpreterGroupId.equals(setting.getInterpreterGroup(user, noteId)
+          .getId())) {
+        AngularObjectRegistry angularObjectRegistry =
+            setting.getInterpreterGroup(user, noteId).getAngularObjectRegistry();
 
-          // first trying to get local registry
-          ao = angularObjectRegistry.get(varName, noteId, paragraphId);
+        // first trying to get local registry
+        ao = angularObjectRegistry.get(varName, noteId, paragraphId);
+        if (ao == null) {
+          // then try notebook scope registry
+          ao = angularObjectRegistry.get(varName, noteId, null);
           if (ao == null) {
-            // then try notebook scope registry
-            ao = angularObjectRegistry.get(varName, noteId, null);
+            // then try global scope registry
+            ao = angularObjectRegistry.get(varName, null, null);
             if (ao == null) {
-              // then try global scope registry
-              ao = angularObjectRegistry.get(varName, null, null);
-              if (ao == null) {
-                LOGGER.warn("Object {} is not binded", varName);
-              } else {
-                // path from client -> server
-                ao.set(varValue, false);
-                global = true;
-              }
+              LOGGER.warn("Object {} is not binded", varName);
             } else {
               // path from client -> server
               ao.set(varValue, false);
-              global = false;
+              global = true;
             }
           } else {
+            // path from client -> server
             ao.set(varValue, false);
             global = false;
           }
-          break;
+        } else {
+          ao.set(varValue, false);
+          global = false;
         }
+        break;
       }
     }
 
@@ -1263,30 +1370,33 @@ public class NotebookService {
       }
 
 
-      Note note = notebook.getNote(noteId);
-      if (note == null) {
-        return;
-      }
-      Paragraph p = note.getParagraph(paragraphId);
-      if (p == null) {
-        return;
-      }
+      notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            return null;
+          }
+          Paragraph p = note.getParagraph(paragraphId);
+          if (p == null) {
+            return null;
+          }
 
-      DiffMatchPatch dmp = new DiffMatchPatch();
-      LinkedList<DiffMatchPatch.Patch> patches = null;
-      try {
-        patches = (LinkedList<DiffMatchPatch.Patch>) dmp.patchFromText(patchText);
-      } catch (ClassCastException e) {
-        LOGGER.error("Failed to parse patches", e);
-      }
-      if (patches == null) {
-        return;
-      }
+          DiffMatchPatch dmp = new DiffMatchPatch();
+          LinkedList<DiffMatchPatch.Patch> patches = null;
+          try {
+            patches = (LinkedList<DiffMatchPatch.Patch>) dmp.patchFromText(patchText);
+          } catch (ClassCastException e) {
+            LOGGER.error("Failed to parse patches", e);
+          }
+          if (patches == null) {
+            return null;
+          }
 
-      String paragraphText = p.getText() == null ? "" : p.getText();
-      paragraphText = (String) dmp.patchApply(patches, paragraphText)[0];
-      p.setText(paragraphText);
-      callback.onSuccess(patchText, context);
+          String paragraphText = p.getText() == null ? "" : p.getText();
+          paragraphText = (String) dmp.patchApply(patches, paragraphText)[0];
+          p.setText(paragraphText);
+          callback.onSuccess(patchText, context);
+          return null;
+      });
     } catch (IOException e) {
       callback.onFailure(new IOException("Fail to patch", e), context);
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/SessionManagerService.java
@@ -111,8 +111,8 @@ public class SessionManagerService {
       throw new Exception("Unable to generate session id");
     }
 
-    Note sessionNote = notebook.createNote(buildNotePath(interpreter, sessionId), AuthenticationInfo.ANONYMOUS);
-    SessionInfo sessionInfo = new SessionInfo(sessionId, sessionNote.getId(), interpreter);
+    String sessionNoteId = notebook.createNote(buildNotePath(interpreter, sessionId), AuthenticationInfo.ANONYMOUS);
+    SessionInfo sessionInfo = new SessionInfo(sessionId, sessionNoteId, interpreter);
     sessions.put(sessionId, sessionInfo);
     return sessionInfo;
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1982,7 +1982,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
   @Override
   public void onParagraphUpdate(Paragraph p) {
-
+    // do nothing
   }
 
   @Override
@@ -1997,7 +1997,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
   @Override
   public void onNoteUpdate(Note note, AuthenticationInfo subject) {
-
+    // do nothing
   }
 
   @Override

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookSecurityRestApiTest.java
@@ -105,8 +105,11 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     userTryRemoveNote(noteId, "user2", "password3", isForbidden());
     userTryRemoveNote(noteId, "user1", "password2", isAllowed());
 
-    Note deletedNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
-    assertNull("Deleted note should be null", deletedNote);
+    TestUtils.getInstance(Notebook.class).processNote(noteId,
+      deletedNote -> {
+        assertNull("Deleted note should be null", deletedNote);
+        return null;
+      });
   }
 
   private void userTryRemoveNote(String noteId, String user, String pwd,
@@ -142,8 +145,11 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     post.close();
     String newNoteId = (String) resp.get("body");
     Notebook notebook = TestUtils.getInstance(Notebook.class);
-    Note newNote = notebook.getNote(newNoteId);
-    assertNotNull("Can not find new note by id", newNote);
+    notebook.processNote(newNoteId,
+      newNote -> {
+        assertNotNull("Can not find new note by id", newNote);
+        return null;
+      });
     return newNoteId;
   }
 
@@ -153,8 +159,11 @@ public class NotebookSecurityRestApiTest extends AbstractTestRestApi {
     delete.close();
     // make sure note is deleted
     if (!noteId.isEmpty()) {
-      Note deletedNote = TestUtils.getInstance(Notebook.class).getNote(noteId);
-      assertNull("Deleted note should be null", deletedNote);
+      TestUtils.getInstance(Notebook.class).processNote(noteId,
+        deletedNote -> {
+          assertNull("Deleted note should be null", deletedNote);
+          return null;
+        });
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -56,16 +57,16 @@ import org.apache.zeppelin.interpreter.thrift.ParagraphInfo;
 import org.apache.zeppelin.interpreter.thrift.ServiceException;
 import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.Notebook.NoteProcessor;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
-import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
-import org.apache.zeppelin.notebook.scheduler.SchedulerService;
 import org.apache.zeppelin.common.Message;
 import org.apache.zeppelin.common.Message.OP;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.scheduler.Job;
-import org.apache.zeppelin.service.ConfigurationService;
+import org.apache.zeppelin.scheduler.Job.Status;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -74,6 +75,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 
 /** Basic REST API tests for notebookServer. */
@@ -127,19 +129,22 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
     String noteName = "Note with millis " + System.currentTimeMillis();
     notebookServer.onMessage(sock1, new Message(OP.NEW_NOTE).put("name", noteName).toJson());
-    Note createdNote = null;
-    for (Note note : notebook.getAllNotes()) {
-      if (note.getName().equals(noteName)) {
-        createdNote = note;
+    NoteInfo createdNoteInfo = null;
+    for (NoteInfo noteInfo : notebook.getNotesInfo()) {
+      if (notebook.processNote(noteInfo.getId(), Note::getName).equals(noteName)) {
+        createdNoteInfo = noteInfo;
         break;
       }
     }
 
-    Message message = new Message(OP.GET_NOTE).put("id", createdNote.getId());
+    Message message = new Message(OP.GET_NOTE).put("id", createdNoteInfo.getId());
     notebookServer.onMessage(sock1, message.toJson());
     notebookServer.onMessage(sock2, message.toJson());
 
-    Paragraph paragraph = createdNote.getParagraphs().get(0);
+    Paragraph paragraph = notebook.processNote(createdNoteInfo.getId(),
+      createdNote -> {
+        return createdNote.getParagraphs().get(0);
+      });
     String paragraphId = paragraph.getId();
 
     String[] patches = new String[]{
@@ -173,7 +178,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
     verify(sock1, times(++sock1SendCount)).send(anyString());
     verify(sock2, times(sock2SendCount)).send(anyString());
 
-    notebook.removeNote(createdNote, anonymous);
+    notebook.removeNote(createdNoteInfo.getId(), anonymous);
   }
 
   private void patchParagraph(NotebookSocket noteSocket, String paragraphId, String patch) {
@@ -186,39 +191,45 @@ public class NotebookServerTest extends AbstractTestRestApi {
   @Test
   public void testMakeSureNoAngularObjectBroadcastToWebsocketWhoFireTheEvent()
           throws IOException, InterruptedException {
-    Note note1 = null;
+    String note1Id = null;
     try {
       // create a notebook
-      note1 = notebook.createNote("note1", anonymous);
+      note1Id = notebook.createNote("note1", anonymous);
 
       // get reference to interpreterGroup
       InterpreterGroup interpreterGroup = null;
       List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
       for (InterpreterSetting setting : settings) {
         if (setting.getName().equals("md")) {
-          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1.getId());
+          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1Id);
           break;
         }
       }
 
-      // start interpreter process
-      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p1.setText("%md start remote interpreter process");
-      p1.setAuthenticationInfo(anonymous);
-      note1.run(p1.getId());
+      notebook.processNote(note1Id,
+        note1 -> {
+          // start interpreter process
+          Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p1.setText("%md start remote interpreter process");
+          p1.setAuthenticationInfo(anonymous);
+          note1.run(p1.getId());
+          return null;
+        });
 
+      Status status = notebook.processNote(note1Id, note1-> note1.getParagraph(0).getStatus());
       // wait for paragraph finished
       while (true) {
-        if (p1.getStatus() == Job.Status.FINISHED) {
+        if (status == Job.Status.FINISHED) {
           break;
         }
         Thread.sleep(100);
+        status = notebook.processNote(note1Id, note1-> note1.getParagraph(0).getStatus());
       }
       // sleep for 1 second to make sure job running thread finish to fire event. See ZEPPELIN-3277
       Thread.sleep(1000);
 
       // add angularObject
-      interpreterGroup.getAngularObjectRegistry().add("object1", "value1", note1.getId(), null);
+      interpreterGroup.getAngularObjectRegistry().add("object1", "value1", note1Id, null);
 
       // create two sockets and open it
       NotebookSocket sock1 = createWebSocket();
@@ -231,8 +242,8 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.onOpen(sock2);
       verify(sock1, times(0)).send(anyString()); // getNote, getAngularObject
       // open the same notebook from sockets
-      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1.getId()).toJson());
-      notebookServer.onMessage(sock2, new Message(OP.GET_NOTE).put("id", note1.getId()).toJson());
+      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
+      notebookServer.onMessage(sock2, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
 
       reset(sock1);
       reset(sock2);
@@ -240,7 +251,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
       // update object from sock1
       notebookServer.onMessage(sock1,
               new Message(OP.ANGULAR_OBJECT_UPDATED)
-                      .put("noteId", note1.getId())
+                      .put("noteId", note1Id)
                       .put("name", "object1")
                       .put("value", "value1")
                       .put("interpreterGroupId", interpreterGroup.getId()).toJson());
@@ -250,8 +261,8 @@ public class NotebookServerTest extends AbstractTestRestApi {
       verify(sock1, times(0)).send(anyString());
       verify(sock2, times(1)).send(anyString());
     } finally {
-      if (note1 != null) {
-        notebook.removeNote(note1, anonymous);
+      if (note1Id != null) {
+        notebook.removeNote(note1Id, anonymous);
       }
     }
   }
@@ -260,32 +271,38 @@ public class NotebookServerTest extends AbstractTestRestApi {
   public void testAngularObjectSaveToNote()
       throws IOException, InterruptedException {
     // create a notebook
-    Note note1 = null;
+    String note1Id = null;
     try {
-      note1 = notebook.createNote("note1", "angular", anonymous);
+      note1Id = notebook.createNote("note1", "angular", anonymous);
 
       // get reference to interpreterGroup
       InterpreterGroup interpreterGroup = null;
-      List<InterpreterSetting> settings = note1.getBindedInterpreterSettings(new ArrayList<>());
+      List<InterpreterSetting> settings = notebook.processNote(note1Id, note1-> note1.getBindedInterpreterSettings(new ArrayList<>()));
       for (InterpreterSetting setting : settings) {
         if (setting.getName().equals("angular")) {
-          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1.getId());
+          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1Id);
           break;
         }
       }
 
-      // start interpreter process
-      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p1.setText("%angular <h2>Bind here : {{COMMAND_TYPE}}</h2>");
-      p1.setAuthenticationInfo(anonymous);
-      note1.run(p1.getId());
+      String p1Id = notebook.processNote(note1Id,
+        note1 -> {
+          // start interpreter process
+          Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p1.setText("%angular <h2>Bind here : {{COMMAND_TYPE}}</h2>");
+          p1.setAuthenticationInfo(anonymous);
+          note1.run(p1.getId());
+          return p1.getId();
+        });
 
       // wait for paragraph finished
+      Status status = notebook.processNote(note1Id, note1-> note1.getParagraph(p1Id).getStatus());
       while (true) {
-        if (p1.getStatus() == Job.Status.FINISHED) {
+        if (status == Job.Status.FINISHED) {
           break;
         }
         Thread.sleep(100);
+        status = notebook.processNote(note1Id, note1-> note1.getParagraph(p1Id).getStatus());
       }
       // sleep for 1 second to make sure job running thread finish to fire event. See ZEPPELIN-3277
       Thread.sleep(1000);
@@ -296,67 +313,67 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.onOpen(sock1);
       verify(sock1, times(0)).send(anyString()); // getNote, getAngularObject
       // open the same notebook from sockets
-      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1.getId()).toJson());
+      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
 
       reset(sock1);
 
       // bind object from sock1
       notebookServer.onMessage(sock1,
               new Message(OP.ANGULAR_OBJECT_CLIENT_BIND)
-                      .put("noteId", note1.getId())
-                      .put("paragraphId", p1.getId())
+                      .put("noteId", note1Id)
+                      .put("paragraphId", p1Id)
                       .put("name", "COMMAND_TYPE")
                       .put("value", "COMMAND_TYPE_VALUE")
                       .put("interpreterGroupId", interpreterGroup.getId()).toJson());
-      List<AngularObject> list = note1.getAngularObjects("angular-shared_process");
-      assertEquals(list.size(), 1);
-      assertEquals(list.get(0).getNoteId(), note1.getId());
-      assertEquals(list.get(0).getParagraphId(), p1.getId());
-      assertEquals(list.get(0).getName(), "COMMAND_TYPE");
-      assertEquals(list.get(0).get(), "COMMAND_TYPE_VALUE");
+      List<AngularObject> list = notebook.processNote(note1Id, note1-> note1.getAngularObjects("angular-shared_process"));
+      assertEquals(1, list.size());
+      assertEquals(note1Id, list.get(0).getNoteId());
+      assertEquals(p1Id, list.get(0).getParagraphId());
+      assertEquals("COMMAND_TYPE", list.get(0).getName());
+      assertEquals("COMMAND_TYPE_VALUE", list.get(0).get());
       // Check if the interpreterGroup AngularObjectRegistry is updated
       Map<String, Map<String, AngularObject>> mapRegistry = interpreterGroup.getAngularObjectRegistry().getRegistry();
-      AngularObject ao = mapRegistry.get(note1.getId() + "_" + p1.getId()).get("COMMAND_TYPE");
-      assertEquals(ao.getName(), "COMMAND_TYPE");
-      assertEquals(ao.get(), "COMMAND_TYPE_VALUE");
+      AngularObject ao = mapRegistry.get(note1Id + "_" + p1Id).get("COMMAND_TYPE");
+      assertEquals("COMMAND_TYPE", ao.getName());
+      assertEquals("COMMAND_TYPE_VALUE", ao.get());
 
       // update bind object from sock1
       notebookServer.onMessage(sock1,
               new Message(OP.ANGULAR_OBJECT_UPDATED)
-                      .put("noteId", note1.getId())
-                      .put("paragraphId", p1.getId())
+                      .put("noteId", note1Id)
+                      .put("paragraphId", p1Id)
                       .put("name", "COMMAND_TYPE")
                       .put("value", "COMMAND_TYPE_VALUE_UPDATE")
                       .put("interpreterGroupId", interpreterGroup.getId()).toJson());
-      list = note1.getAngularObjects("angular-shared_process");
-      assertEquals(list.size(), 1);
-      assertEquals(list.get(0).getNoteId(), note1.getId());
-      assertEquals(list.get(0).getParagraphId(), p1.getId());
-      assertEquals(list.get(0).getName(), "COMMAND_TYPE");
-      assertEquals(list.get(0).get(), "COMMAND_TYPE_VALUE_UPDATE");
+      list = notebook.processNote(note1Id, note1-> note1.getAngularObjects("angular-shared_process"));
+      assertEquals(1, list.size());
+      assertEquals(note1Id, list.get(0).getNoteId());
+      assertEquals(p1Id, list.get(0).getParagraphId());
+      assertEquals("COMMAND_TYPE", list.get(0).getName());
+      assertEquals("COMMAND_TYPE_VALUE_UPDATE", list.get(0).get());
       // Check if the interpreterGroup AngularObjectRegistry is updated
       mapRegistry = interpreterGroup.getAngularObjectRegistry().getRegistry();
-      AngularObject ao1 = mapRegistry.get(note1.getId() + "_" + p1.getId()).get("COMMAND_TYPE");
-      assertEquals(ao1.getName(), "COMMAND_TYPE");
-      assertEquals(ao1.get(), "COMMAND_TYPE_VALUE_UPDATE");
+      AngularObject ao1 = mapRegistry.get(note1Id + "_" + p1Id).get("COMMAND_TYPE");
+      assertEquals("COMMAND_TYPE", ao1.getName());
+      assertEquals("COMMAND_TYPE_VALUE_UPDATE", ao1.get());
 
       // unbind object from sock1
       notebookServer.onMessage(sock1,
               new Message(OP.ANGULAR_OBJECT_CLIENT_UNBIND)
-                      .put("noteId", note1.getId())
-                      .put("paragraphId", p1.getId())
+                      .put("noteId", note1Id)
+                      .put("paragraphId", p1Id)
                       .put("name", "COMMAND_TYPE")
                       .put("value", "COMMAND_TYPE_VALUE")
                       .put("interpreterGroupId", interpreterGroup.getId()).toJson());
-      list = note1.getAngularObjects("angular-shared_process");
-      assertEquals(list.size(), 0);
+      list = notebook.processNote(note1Id, note1-> note1.getAngularObjects("angular-shared_process"));
+      assertEquals(0, list.size());
       // Check if the interpreterGroup AngularObjectRegistry is delete
       mapRegistry = interpreterGroup.getAngularObjectRegistry().getRegistry();
-      AngularObject ao2 = mapRegistry.get(note1.getId() + "_" + p1.getId()).get("COMMAND_TYPE");
+      AngularObject ao2 = mapRegistry.get(note1Id + "_" + p1Id).get("COMMAND_TYPE");
       assertNull(ao2);
     } finally {
-      if (note1 != null) {
-        notebook.removeNote(note1, anonymous);
+      if (note1Id != null) {
+        notebook.removeNote(note1Id, anonymous);
       }
     }
   }
@@ -364,39 +381,51 @@ public class NotebookServerTest extends AbstractTestRestApi {
   @Test
   public void testLoadAngularObjectFromNote() throws IOException, InterruptedException {
     // create a notebook
-    Note note1 = null;
+    String note1Id = null;
     try {
-      note1 = notebook.createNote("note1", anonymous);
+      note1Id = notebook.createNote("note1", anonymous);
 
       // get reference to interpreterGroup
       InterpreterGroup interpreterGroup = null;
       List<InterpreterSetting> settings = notebook.getInterpreterSettingManager().get();
       for (InterpreterSetting setting : settings) {
         if (setting.getName().equals("angular")) {
-          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1.getId());
+          interpreterGroup = setting.getOrCreateInterpreterGroup("anonymous", note1Id);
           break;
         }
       }
+      String p1Id = notebook.processNote(note1Id,
+        note1 -> {
+          // start interpreter process
+          Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          p1.setText("%angular <h2>Bind here : {{COMMAND_TYPE}}</h2>");
+          p1.setAuthenticationInfo(anonymous);
+          note1.run(p1.getId());
+          return p1.getId();
+        });
 
-      // start interpreter process
-      Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      p1.setText("%angular <h2>Bind here : {{COMMAND_TYPE}}</h2>");
-      p1.setAuthenticationInfo(anonymous);
-      note1.run(p1.getId());
 
       // wait for paragraph finished
+      Status status = notebook.processNote(note1Id, note1-> note1.getParagraph(p1Id).getStatus());
       while (true) {
-        if (p1.getStatus() == Job.Status.FINISHED) {
+        System.out.println("loop");
+        if (status == Job.Status.FINISHED) {
           break;
         }
         Thread.sleep(100);
+        status = notebook.processNote(note1Id, note1-> note1.getParagraph(p1Id).getStatus());
       }
       // sleep for 1 second to make sure job running thread finish to fire event. See ZEPPELIN-3277
       Thread.sleep(1000);
 
       // set note AngularObject
-      AngularObject ao = new AngularObject("COMMAND_TYPE", "COMMAND_TYPE_VALUE", note1.getId(), p1.getId(), null);
-      note1.addOrUpdateAngularObject("angular-shared_process", ao);
+      AngularObject ao = new AngularObject("COMMAND_TYPE", "COMMAND_TYPE_VALUE", note1Id, p1Id, null);
+      notebook.processNote(note1Id,
+        note1 -> {
+          note1.addOrUpdateAngularObject("angular-shared_process", ao);
+          return null;
+        });
+
 
       // create sockets and open it
       NotebookSocket sock1 = createWebSocket();
@@ -404,21 +433,21 @@ public class NotebookServerTest extends AbstractTestRestApi {
 
       // Check the AngularObjectRegistry of the interpreterGroup before executing GET_NOTE
       Map<String, Map<String, AngularObject>> mapRegistry1 = interpreterGroup.getAngularObjectRegistry().getRegistry();
-      assertEquals(mapRegistry1.size(), 0);
+      assertEquals(0, mapRegistry1.size());
 
       // open the notebook from sockets, AngularObjectRegistry that triggers the update of the interpreterGroup
-      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1.getId()).toJson());
+      notebookServer.onMessage(sock1, new Message(OP.GET_NOTE).put("id", note1Id).toJson());
       Thread.sleep(1000);
 
       // After executing GET_NOTE, check the AngularObjectRegistry of the interpreterGroup
       Map<String, Map<String, AngularObject>> mapRegistry2 = interpreterGroup.getAngularObjectRegistry().getRegistry();
-      assertEquals(mapRegistry1.size(), 2);
-      AngularObject ao1 = mapRegistry2.get(note1.getId() + "_" + p1.getId()).get("COMMAND_TYPE");
-      assertEquals(ao1.getName(), "COMMAND_TYPE");
-      assertEquals(ao1.get(), "COMMAND_TYPE_VALUE");
+      assertEquals(2, mapRegistry1.size());
+      AngularObject ao1 = mapRegistry2.get(note1Id + "_" + p1Id).get("COMMAND_TYPE");
+      assertEquals("COMMAND_TYPE", ao1.getName());
+      assertEquals("COMMAND_TYPE_VALUE", ao1.get());
     } finally {
-      if (note1 != null) {
-        notebook.removeNote(note1, anonymous);
+      if (note1Id != null) {
+        notebook.removeNote(note1Id, anonymous);
       }
     }
   }
@@ -432,54 +461,65 @@ public class NotebookServerTest extends AbstractTestRestApi {
         "\"name\": \"Test Zeppelin notebook import\",\"config\": " +
         "{}}}}";
     Message messageReceived = notebookServer.deserializeMessage(msg);
-    Note note = null;
+    String noteId = null;
     ServiceContext context = new ServiceContext(AuthenticationInfo.ANONYMOUS, new HashSet<>());
     try {
       try {
-        note = notebookServer.importNote(null, context, messageReceived);
+        noteId = notebookServer.importNote(null, context, messageReceived);
       } catch (NullPointerException e) {
         //broadcastNoteList(); failed nothing to worry.
         LOG.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
                 "worry ", e);
       }
 
-      assertNotEquals(null, notebook.getNote(note.getId()));
-      assertEquals("Test Zeppelin notebook import", notebook.getNote(note.getId()).getName());
-      assertEquals("Test paragraphs import", notebook.getNote(note.getId()).getParagraphs().get(0)
-              .getText());
+      notebook.processNote(noteId,
+        note -> {
+          assertNotNull(note);
+          assertEquals("Test Zeppelin notebook import", note.getName());
+          assertEquals("Test paragraphs import", note.getParagraphs().get(0)
+            .getText());
+          return null;
+        });
+
     } finally {
-      if (note != null) {
-        notebook.removeNote(note, anonymous);
+      if (noteId != null) {
+        notebook.removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testImportJupyterNote() throws IOException {
-    String jupyterNoteJson = IOUtils.toString(getClass().getResourceAsStream("/Lecture-4.ipynb"));
+    String jupyterNoteJson = IOUtils.toString(getClass().getResourceAsStream("/Lecture-4.ipynb"), StandardCharsets.UTF_8);
     String msg = "{\"op\":\"IMPORT_NOTE\",\"data\":" +
             "{\"note\": " + jupyterNoteJson + "}}";
     Message messageReceived = notebookServer.deserializeMessage(msg);
-    Note note = null;
+    String noteId = null;
     ServiceContext context = new ServiceContext(AuthenticationInfo.ANONYMOUS, new HashSet<>());
     try {
       try {
-        note = notebookServer.importNote(null, context, messageReceived);
+        noteId = notebookServer.importNote(null, context, messageReceived);
       } catch (NullPointerException e) {
         //broadcastNoteList(); failed nothing to worry.
         LOG.error("Exception in NotebookServerTest while testImportJupyterNote, failed nothing to " +
                 "worry ", e);
       }
 
-      assertNotEquals(null, notebook.getNote(note.getId()));
-      assertTrue(notebook.getNote(note.getId()).getName(),
-              notebook.getNote(note.getId()).getName().startsWith("Note converted from Jupyter_"));
-      assertEquals("md", notebook.getNote(note.getId()).getParagraphs().get(0).getIntpText());
-      assertEquals("\n# matplotlib - 2D and 3D plotting in Python",
-              notebook.getNote(note.getId()).getParagraphs().get(0).getScriptText());
+      notebook.processNote(noteId,
+        note -> {
+          assertNotNull(note);
+          assertTrue(note.getName(), note.getName().startsWith("Note converted from Jupyter_"));
+          assertEquals("md", note.getParagraphs().get(0).getIntpText());
+          assertEquals("\n# matplotlib - 2D and 3D plotting in Python",
+            note.getParagraphs().get(0).getScriptText());
+          return null;
+        });
+
+
+
     } finally {
-      if (note != null) {
-        notebook.removeNote(note, anonymous);
+      if (noteId != null) {
+        notebook.removeNote(noteId, anonymous);
       }
     }
   }
@@ -501,7 +541,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.setNotebookService(() -> notebookService);
       final Note note = mock(Note.class, RETURNS_DEEP_STUBS);
 
-      when(notebook.getNote("noteId")).thenReturn(note);
+      when(notebook.processNote(eq("noteId"), Mockito.any())).then(e -> e.getArgumentAt(1,NoteProcessor.class).process(note));
       final Paragraph paragraph = mock(Paragraph.class, RETURNS_DEEP_STUBS);
       when(note.getParagraph("paragraphId")).thenReturn(paragraph);
 
@@ -557,7 +597,7 @@ public class NotebookServerTest extends AbstractTestRestApi {
       notebookServer.setNotebook(() -> notebook);
       notebookServer.setNotebookService(() -> notebookService);
       final Note note = mock(Note.class, RETURNS_DEEP_STUBS);
-      when(notebook.getNote("noteId")).thenReturn(note);
+      when(notebook.processNote(eq("noteId"), Mockito.any())).then(e -> e.getArgumentAt(1,NoteProcessor.class).process(note));
       final Paragraph paragraph = mock(Paragraph.class, RETURNS_DEEP_STUBS);
       when(note.getParagraph("paragraphId")).thenReturn(paragraph);
 
@@ -626,19 +666,20 @@ public class NotebookServerTest extends AbstractTestRestApi {
     // expect the events are broadcasted properly
     verify(sock1, times(sendCount)).send(anyString());
 
-    Note createdNote = null;
-    for (Note note : notebook.getAllNotes()) {
-      if (note.getName().equals(noteName)) {
-        createdNote = note;
+    String createdNoteId = null;
+    for (NoteInfo noteInfo : notebook.getNotesInfo()) {
+      ;
+      if (notebook.processNote(noteInfo.getId(), Note::getName).equals(noteName)) {
+        createdNoteId = noteInfo.getId();
         break;
       }
     }
 
     if (settings.size() > 1) {
       assertEquals(notebook.getInterpreterSettingManager().getDefaultInterpreterSetting(
-              createdNote.getId()).getId(), defaultInterpreterId);
+        createdNoteId).getId(), defaultInterpreterId);
     }
-    notebook.removeNote(createdNote, anonymous);
+    notebook.removeNote(createdNoteId, anonymous);
   }
 
   @Test
@@ -651,10 +692,10 @@ public class NotebookServerTest extends AbstractTestRestApi {
         "\"name\": \"Test RuntimeInfos\",\"config\": " +
         "{}}}}";
     Message messageReceived = notebookServer.deserializeMessage(msg);
-    Note note = null;
+    String noteId = null;
     ServiceContext context = new ServiceContext(AuthenticationInfo.ANONYMOUS, new HashSet<>());
     try {
-      note = notebookServer.importNote(null, context, messageReceived);
+      noteId = notebookServer.importNote(null, context, messageReceived);
     } catch (NullPointerException e) {
       //broadcastNoteList(); failed nothing to worry.
       LOG.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
@@ -662,47 +703,52 @@ public class NotebookServerTest extends AbstractTestRestApi {
     } catch (IOException e) {
       e.printStackTrace();
     }
-
-    assertNotEquals(null, notebook.getNote(note.getId()));
-    assertNotEquals(null, note.getParagraph(0));
-
-    String nodeId = note.getId();
-    String paragraphId = note.getParagraph(0).getId();
-
     // update RuntimeInfos
     Map<String, String> infos = new java.util.HashMap<>();
-    infos.put("jobUrl", "jobUrl_value");
-    infos.put("jobLabel", "jobLabel_value");
-    infos.put("label", "SPARK JOB");
-    infos.put("tooltip", "View in Spark web UI");
-    infos.put("noteId", nodeId);
-    infos.put("paraId", paragraphId);
+    String paragraphId = notebook.processNote(noteId,
+      note -> {
+        assertNotNull(note);
+        assertNotNull(note.getParagraph(0));
+        infos.put("jobUrl", "jobUrl_value");
+        infos.put("jobLabel", "jobLabel_value");
+        infos.put("label", "SPARK JOB");
+        infos.put("tooltip", "View in Spark web UI");
+        infos.put("noteId", note.getId());
+        infos.put("paraId", note.getParagraph(0).getId());
+        return note.getParagraph(0).getId();
+      });
 
-    notebookServer.onParaInfosReceived(nodeId, paragraphId, "spark", infos);
-    Paragraph paragraph = note.getParagraph(paragraphId);
-
-    // check RuntimeInfos
-    assertTrue(paragraph.getRuntimeInfos().containsKey("jobUrl"));
-    List<Object> list = paragraph.getRuntimeInfos().get("jobUrl").getValue();
-    assertEquals(1, list.size());
-    Map<String, String> map = (Map<String, String>) list.get(0);
-    assertEquals(2, map.size());
-    assertEquals(map.get("jobUrl"), "jobUrl_value");
-    assertEquals(map.get("jobLabel"), "jobLabel_value");
+    notebookServer.onParaInfosReceived(noteId, paragraphId, "spark", infos);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph paragraph = note.getParagraph(paragraphId);
+        // check RuntimeInfos
+        assertTrue(paragraph.getRuntimeInfos().containsKey("jobUrl"));
+        List<Object> list = paragraph.getRuntimeInfos().get("jobUrl").getValue();
+        assertEquals(1, list.size());
+        Map<String, String> map = (Map<String, String>) list.get(0);
+        assertEquals(2, map.size());
+        assertEquals(map.get("jobUrl"), "jobUrl_value");
+        assertEquals(map.get("jobLabel"), "jobLabel_value");
+        return null;
+      });
   }
 
   @Test
   public void testGetParagraphList() throws IOException {
-    Note note = null;
+    String noteId = null;
 
     try {
-      note = notebook.createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(anonymous);
-      p1.setText("%md start remote interpreter process");
-      p1.setAuthenticationInfo(anonymous);
-      notebook.saveNote(note, anonymous);
+      noteId = notebook.createNote("note1", anonymous);
+      notebook.processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(anonymous);
+          p1.setText("%md start remote interpreter process");
+          p1.setAuthenticationInfo(anonymous);
+          notebook.saveNote(note, anonymous);
+          return null;
+        });
 
-      String noteId = note.getId();
       String user1Id = "user1", user2Id = "user2";
 
       // test user1 can get anonymous's note
@@ -746,44 +792,49 @@ public class NotebookServerTest extends AbstractTestRestApi {
       }
       assertNotNull(user1Id + " can get " + user2Id + "'s shared note", paragraphList2);
     } finally {
-      if (null != note) {
-        notebook.removeNote(note, anonymous);
+      if (null != noteId) {
+        notebook.removeNote(noteId, anonymous);
       }
     }
   }
 
   @Test
   public void testNoteRevision() throws IOException {
-    Note note = null;
+    String noteId = null;
 
     try {
-      note = notebook.createNote("note1", anonymous);
-      assertEquals(0, note.getParagraphCount());
-      NotebookRepoWithVersionControl.Revision firstRevision = notebook.checkpointNote(note.getId(), note.getPath(), "first commit", AuthenticationInfo.ANONYMOUS);
-      List<NotebookRepoWithVersionControl.Revision> revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
-      assertEquals(1, revisionList.size());
-      assertEquals(firstRevision.id, revisionList.get(0).id);
-      assertEquals("first commit", revisionList.get(0).message);
+      noteId = notebook.createNote("note1", anonymous);
+      notebook.processNote(noteId,
+        note -> {
+          assertEquals(0, note.getParagraphCount());
+          NotebookRepoWithVersionControl.Revision firstRevision = notebook.checkpointNote(note.getId(), note.getPath(), "first commit", AuthenticationInfo.ANONYMOUS);
+          List<NotebookRepoWithVersionControl.Revision> revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
+          assertEquals(1, revisionList.size());
+          assertEquals(firstRevision.id, revisionList.get(0).id);
+          assertEquals("first commit", revisionList.get(0).message);
 
-      // add one new paragraph and commit it
-      note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
-      assertEquals(1, note.getParagraphCount());
-      NotebookRepoWithVersionControl.Revision secondRevision = notebook.checkpointNote(note.getId(), note.getPath(), "second commit", AuthenticationInfo.ANONYMOUS);
+          // add one new paragraph and commit it
+          note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
+          assertEquals(1, note.getParagraphCount());
+          NotebookRepoWithVersionControl.Revision secondRevision = notebook.checkpointNote(note.getId(), note.getPath(), "second commit", AuthenticationInfo.ANONYMOUS);
 
-      revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
-      assertEquals(2, revisionList.size());
-      assertEquals(secondRevision.id, revisionList.get(0).id);
-      assertEquals("second commit", revisionList.get(0).message);
-      assertEquals(firstRevision.id, revisionList.get(1).id);
-      assertEquals("first commit", revisionList.get(1).message);
+          revisionList = notebook.listRevisionHistory(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
+          assertEquals(2, revisionList.size());
+          assertEquals(secondRevision.id, revisionList.get(0).id);
+          assertEquals("second commit", revisionList.get(0).message);
+          assertEquals(firstRevision.id, revisionList.get(1).id);
+          assertEquals("first commit", revisionList.get(1).message);
 
-      // checkout the first commit
-      note = notebook.getNoteByRevision(note.getId(), note.getPath(), firstRevision.id, AuthenticationInfo.ANONYMOUS);
-      assertEquals(0, note.getParagraphCount());
+          // checkout the first commit
+          note = notebook.getNoteByRevision(note.getId(), note.getPath(), firstRevision.id, AuthenticationInfo.ANONYMOUS);
+          assertEquals(0, note.getParagraphCount());
+          return null;
+        });
+
     } finally {
-      if (null != note) {
-        notebook.removeNote(note, anonymous);
+      if (null != noteId) {
+        notebook.removeNote(noteId, anonymous);
       }
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -371,28 +371,24 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
     if (notebook == null) {
       return null;
     }
-
-    Note note = null;
     try {
-      note = notebook.getNote(noteId);
-      if (note == null) {
-        logger.warn("Note " + noteId + " not found");
-        return null;
-      }
+      return notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            logger.warn("Note {} not found", noteId);
+            return null;
+          }
+          Paragraph paragraph = note.getParagraph(paragraphId);
+          if (paragraph == null) {
+            logger.error("Can't get paragraph {}", paragraphId);
+            return null;
+          }
+          return paragraph.getApplicationState(appId);
+        });
     } catch (IOException e) {
       logger.error("Can't get note {}", noteId);
       return null;
     }
-
-    Paragraph paragraph = note.getParagraph(paragraphId);
-    if (paragraph == null) {
-      logger.error("Can't get paragraph {}", paragraphId);
-      return null;
-    }
-
-    ApplicationState appFound = paragraph.getApplicationState(appId);
-
-    return appFound;
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -392,17 +392,18 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
   }
 
   @Override
-  public void onNoteRemove(Note note, AuthenticationInfo subject) throws IOException {
+  public void onNoteRemove(Note note, AuthenticationInfo subject) {
+    // do nothing
   }
 
   @Override
-  public void onNoteCreate(Note note, AuthenticationInfo subject) throws IOException {
-
+  public void onNoteCreate(Note note, AuthenticationInfo subject) {
+    // do nothing
   }
 
   @Override
-  public void onNoteUpdate(Note note, AuthenticationInfo subject) throws IOException {
-
+  public void onNoteUpdate(Note note, AuthenticationInfo subject) {
+    // do nothing
   }
 
   @Override
@@ -416,12 +417,12 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
 
   @Override
   public void onParagraphCreate(Paragraph p) {
-
+    // do nothing
   }
 
   @Override
-  public void onParagraphUpdate(Paragraph p) throws IOException {
-
+  public void onParagraphUpdate(Paragraph p) {
+    // do nothing
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -1206,16 +1206,19 @@ public class InterpreterSetting {
 
   private ExecutionContext getExecutionContext(String user, String noteId) {
     try {
-      Note note = getInterpreterSettingManager().getNotebook().getNote(noteId);
-      if (note == null) {
-        throw new RuntimeException("No such note: " + noteId);
-      } else {
-        ExecutionContext context = note.getExecutionContext();
-        context.setUser(user);
-        return context;
-      }
+      return getInterpreterSettingManager().getNotebook().processNote(noteId,
+        note -> {
+          if (note == null) {
+            throw new RuntimeException("No such note: " + noteId);
+          } else {
+            ExecutionContext context = note.getExecutionContext();
+            context.setUser(user);
+            return context;
+          }
+        });
     } catch (IOException e) {
       throw new RuntimeException("Fail to getExecutionContext", e);
     }
+
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -544,8 +544,10 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
 
   public InterpreterSetting getDefaultInterpreterSetting(String noteId) {
     try {
-      Note note = notebook.getNote(noteId);
-      InterpreterSetting interpreterSetting = interpreterSettings.get(note.getDefaultInterpreterGroup());
+      InterpreterSetting interpreterSetting = notebook.processNote(noteId,
+        note -> {
+          return interpreterSettings.get(note.getDefaultInterpreterGroup());
+        });
       if (interpreterSetting == null) {
         interpreterSetting = get().get(0);
       }
@@ -957,11 +959,13 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
   // restart in note page
   public void restart(String settingId, String user, String noteId) throws InterpreterException {
     try {
-      Note note = notebook.getNote(noteId);
-      if (note == null) {
-        throw new InterpreterException("No such note: " + noteId);
-      }
-      ExecutionContext executionContext = note.getExecutionContext();
+      ExecutionContext executionContext = notebook.processNote(noteId,
+        note -> {
+          if (note == null) {
+            throw new IOException("No such note: " + noteId);
+          }
+          return note.getExecutionContext();
+        });
       executionContext.setUser(user);
       restart(settingId, executionContext);
     } catch (IOException e) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -1120,7 +1120,7 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
   }
 
   @Override
-  public void onNoteRemove(Note note, AuthenticationInfo subject) throws IOException {
+  public void onNoteRemove(Note note, AuthenticationInfo subject) {
     // stop all associated interpreters
     if (note.getParagraphs() != null) {
       for (Paragraph paragraph : note.getParagraphs()) {
@@ -1185,40 +1185,38 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
   }
 
   @Override
-  public void onNoteCreate(Note note, AuthenticationInfo subject) throws IOException {
-
+  public void onNoteCreate(Note note, AuthenticationInfo subject) {
+    // do nothing
   }
 
   @Override
-  public void onNoteUpdate(Note note, AuthenticationInfo subject) throws IOException {
-
+  public void onNoteUpdate(Note note, AuthenticationInfo subject) {
+    // do nothing
   }
 
   @Override
-  public void onParagraphRemove(Paragraph p) throws IOException {
-
+  public void onParagraphRemove(Paragraph p) {
+    // do nothing
   }
 
   @Override
-  public void onParagraphCreate(Paragraph p) throws IOException {
-
+  public void onParagraphCreate(Paragraph p) {
+    // do nothing
   }
 
   @Override
-  public void onParagraphUpdate(Paragraph p) throws IOException {
-
+  public void onParagraphUpdate(Paragraph p) {
+    // do nothing
   }
 
   @Override
-  public void onParagraphStatusChange(Paragraph p, Job.Status status) throws IOException {
-
+  public void onParagraphStatusChange(Paragraph p, Job.Status status) {
+    // do nothing
   }
 
   @Override
   public void onClusterEvent(String msg) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("onClusterEvent : {}", msg);
-    }
+    LOGGER.debug("onClusterEvent : {}", msg);
 
     try {
       ClusterMessage message = ClusterMessage.deserializeMessage(msg);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -298,11 +298,14 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
 
     if (angularObject.getNoteId() != null) {
       try {
-        Note note = interpreterSettingManager.getNotebook().getNote(angularObject.getNoteId());
-        if (note != null) {
-          note.addOrUpdateAngularObject(intpGroupId, angularObject);
-          interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
-        }
+        interpreterSettingManager.getNotebook().processNote(angularObject.getNoteId(),
+          note -> {
+            if (note != null) {
+              note.addOrUpdateAngularObject(intpGroupId, angularObject);
+              interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
+            }
+            return null;
+          });
       } catch (IOException e) {
         LOGGER.error("Fail to get note: {}", angularObject.getNoteId());
       }
@@ -329,11 +332,14 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
 
     if (angularObject.getNoteId() != null) {
       try {
-        Note note = interpreterSettingManager.getNotebook().getNote(angularObject.getNoteId());
-        if (note != null) {
-          note.addOrUpdateAngularObject(intpGroupId, angularObject);
-          interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
-        }
+        interpreterSettingManager.getNotebook().processNote(angularObject.getNoteId(),
+            note -> {
+              if (note != null) {
+                note.addOrUpdateAngularObject(intpGroupId, angularObject);
+                interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
+              }
+              return null;
+            });
       } catch (IOException e) {
         LOGGER.error("Fail to get note: {}", angularObject.getNoteId());
       }
@@ -354,10 +360,16 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
 
     if (noteId != null) {
       try {
-        Note note = interpreterSettingManager.getNotebook().getNote(noteId);
-        note.deleteAngularObject(intpGroupId, noteId, paragraphId, name);
+        interpreterSettingManager.getNotebook().processNote(noteId,
+          note -> {
+            if (note == null) {
+              throw new IOException("Fail to get note: " + noteId);
+            }
+            note.deleteAngularObject(intpGroupId, noteId, paragraphId, name);
+            return null;
+          });
       } catch (IOException e) {
-        LOGGER.warn("Fail to get note: {}", noteId, e);
+        LOGGER.warn("Fail to removeAngularObject of note: {}", noteId, e);
       }
     }
   }
@@ -557,12 +569,16 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
           throws InterpreterRPCException, TException {
     try {
       LOGGER.info("Update paragraph config");
-      Note note = interpreterSettingManager.getNotebook().getNote(noteId);
-      note.getParagraph(paragraphId).updateConfig(config);
-      interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
+      interpreterSettingManager.getNotebook().processNote(noteId,
+          note -> {
+            note.getParagraph(paragraphId).updateConfig(config);
+            interpreterSettingManager.getNotebook().saveNote(note, AuthenticationInfo.ANONYMOUS);
+            return null;
+          });
     } catch (Exception e) {
       LOGGER.error("Fail to updateParagraphConfig", e);
     }
+
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -415,12 +415,10 @@ public class Note implements JsonSerializable {
    * Delete the note AngularObject.
    */
   public void deleteAngularObject(String intpGroupId, String noteId, String paragraphId, String name) {
-    List<AngularObject> angularObjectList;
     if (angularObjects.containsKey(intpGroupId)) {
-      angularObjectList = angularObjects.get(intpGroupId);
 
       // Delete existing AngularObject
-      Iterator<AngularObject> iter = angularObjectList.iterator();
+      Iterator<AngularObject> iter = angularObjects.get(intpGroupId).iterator();
       while(iter.hasNext()){
         String noteIdCandidate = "";
         String paragraphIdCandidate = "";
@@ -491,28 +489,24 @@ public class Note implements JsonSerializable {
 
     paragraphs.add(newParagraph);
 
-    try {
-      fireParagraphCreateEvent(newParagraph);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    fireParagraphCreateEvent(newParagraph);
 
   }
 
-  public void fireParagraphCreateEvent(Paragraph p) throws IOException {
+  public void fireParagraphCreateEvent(Paragraph p) {
     for (NoteEventListener listener : noteEventListeners) {
       listener.onParagraphCreate(p);
     }
   }
 
-  public void fireParagraphRemoveEvent(Paragraph p) throws IOException {
+  public void fireParagraphRemoveEvent(Paragraph p) {
     for (NoteEventListener listener : noteEventListeners) {
       listener.onParagraphRemove(p);
     }
   }
 
 
-  public void fireParagraphUpdateEvent(Paragraph p) throws IOException {
+  public void fireParagraphUpdateEvent(Paragraph p) {
     for (NoteEventListener listener : noteEventListeners) {
       listener.onParagraphUpdate(p);
     }
@@ -544,11 +538,7 @@ public class Note implements JsonSerializable {
 
   private void insertParagraph(Paragraph paragraph, int index) {
     paragraphs.add(index, paragraph);
-    try {
-      fireParagraphCreateEvent(paragraph);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    fireParagraphCreateEvent(paragraph);
   }
 
   /**
@@ -563,11 +553,7 @@ public class Note implements JsonSerializable {
     for (Paragraph p : paragraphs) {
       if (p.getId().equals(paragraphId)) {
         paragraphs.remove(p);
-        try {
-          fireParagraphRemoveEvent(p);
-        } catch (IOException e) {
-          LOGGER.error("Fail to fire ParagraphRemoveEvent", e);
-        }
+        fireParagraphRemoveEvent(p);
         return p;
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Represent the note of Zeppelin. All the note and its paragraph operations are done
@@ -149,8 +150,12 @@ public class Note implements JsonSerializable {
   private String path;
 
   /********************************** transient fields ******************************************/
-  private transient boolean loaded = false;
-  private transient boolean saved = false;
+  /*
+   * Do not use the fair algorithm, because it blocks read accesses when a write access is waiting.
+   * We have read accesses from different threads, which are dependent on each other.
+   * The fair behavior can therefore create a DeadLock.
+   */
+  private transient final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(false);
   private transient boolean removed = false;
   private transient InterpreterFactory interpreterFactory;
   private transient InterpreterSettingManager interpreterSettingManager;
@@ -179,11 +184,6 @@ public class Note implements JsonSerializable {
     setCronSupported(zConf);
   }
 
-  public Note(NoteInfo noteInfo) {
-    this.id = noteInfo.getId();
-    setPath(noteInfo.getPath());
-  }
-
   public String getPath() {
     return path;
   }
@@ -204,31 +204,6 @@ public class Note implements JsonSerializable {
 
   private void generateId() {
     id = IdHashes.generateId();
-  }
-
-  public boolean isLoaded() {
-    return loaded;
-  }
-
-  public void setLoaded(boolean loaded) {
-    this.loaded = loaded;
-  }
-
-  /**
-   * Release note memory
-   */
-  public void unLoad() {
-    if (isRunning() || isParagraphRunning()) {
-      LOGGER.warn("Unable to unload note because it is in RUNNING");
-    } else {
-      this.setLoaded(false);
-      this.paragraphs = null;
-      this.config = null;
-      this.info = null;
-      this.noteForms = null;
-      this.noteParams = null;
-      this.angularObjects = null;
-    }
   }
 
   public boolean isParagraphRunning() {
@@ -1226,12 +1201,8 @@ public class Note implements JsonSerializable {
     this.noteEventListeners = noteEventListeners;
   }
 
-  public void setSaved(boolean saved) {
-    this.saved = saved;
-  }
-
-  public boolean isSaved() {
-    return saved;
+  public ReentrantReadWriteLock getLock() {
+    return lock;
   }
 
   public void setRemoved(boolean removed) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventAsyncListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventAsyncListener.java
@@ -46,17 +46,17 @@ public abstract class NoteEventAsyncListener implements NoteEventListener, Close
             new LinkedBlockingQueue<>(), new SchedulerThreadFactory(name));
   }
 
-  public abstract void handleNoteCreateEvent(NoteCreateEvent noteCreateEvent) throws Exception;
+  public abstract void handleNoteCreateEvent(NoteCreateEvent noteCreateEvent);
 
-  public abstract void handleNoteRemoveEvent(NoteRemoveEvent noteRemoveEvent) throws Exception;
+  public abstract void handleNoteRemoveEvent(NoteRemoveEvent noteRemoveEvent);
 
-  public abstract void handleNoteUpdateEvent(NoteUpdateEvent noteUpdateEvent) throws Exception;
+  public abstract void handleNoteUpdateEvent(NoteUpdateEvent noteUpdateEvent);
 
-  public abstract void handleParagraphCreateEvent(ParagraphCreateEvent paragraphCreateEvent) throws Exception;
+  public abstract void handleParagraphCreateEvent(ParagraphCreateEvent paragraphCreateEvent);
 
-  public abstract void handleParagraphRemoveEvent(ParagraphRemoveEvent paragraphRemoveEvent) throws Exception;
+  public abstract void handleParagraphRemoveEvent(ParagraphRemoveEvent paragraphRemoveEvent);
 
-  public abstract void handleParagraphUpdateEvent(ParagraphUpdateEvent paragraphUpdateEvent) throws Exception;
+  public abstract void handleParagraphUpdateEvent(ParagraphUpdateEvent paragraphUpdateEvent);
 
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventAsyncListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventAsyncListener.java
@@ -66,37 +66,37 @@ public abstract class NoteEventAsyncListener implements NoteEventListener, Close
 
   @Override
   public void onNoteCreate(Note note, AuthenticationInfo subject) {
-    executor.execute(new EventHandling(new NoteCreateEvent(note)));
+    executor.execute(new EventHandling(new NoteCreateEvent(note.getId())));
   }
 
   @Override
   public void onNoteRemove(Note note, AuthenticationInfo subject) {
-    executor.execute(new EventHandling(new NoteRemoveEvent(note)));
+    executor.execute(new EventHandling(new NoteRemoveEvent(note.getId())));
   }
 
   @Override
   public void onNoteUpdate(Note note, AuthenticationInfo subject) {
-    executor.execute(new EventHandling(new NoteUpdateEvent(note)));
+    executor.execute(new EventHandling(new NoteUpdateEvent(note.getId())));
   }
 
   @Override
   public void onParagraphCreate(Paragraph p) {
-    executor.execute(new EventHandling(new ParagraphCreateEvent(p)));
+    executor.execute(new EventHandling(new ParagraphCreateEvent(p.getNote().getId(), p.getId())));
   }
 
   @Override
   public void onParagraphRemove(Paragraph p) {
-    executor.execute(new EventHandling(new ParagraphRemoveEvent(p)));
+    executor.execute(new EventHandling(new ParagraphRemoveEvent(p.getNote().getId(), p.getId())));
   }
 
   @Override
   public void onParagraphUpdate(Paragraph p) {
-    executor.execute(new EventHandling(new ParagraphUpdateEvent(p)));
+    executor.execute(new EventHandling(new ParagraphUpdateEvent(p.getNote().getId(), p.getId())));
   }
 
   @Override
   public void onParagraphStatusChange(Paragraph p, Job.Status status) {
-    executor.execute(new EventHandling(new ParagraphStatusChangeEvent(p)));
+    executor.execute(new EventHandling(new ParagraphStatusChangeEvent(p.getNote().getId(), p.getId())));
   }
 
   class EventHandling implements Runnable {
@@ -139,87 +139,111 @@ public abstract class NoteEventAsyncListener implements NoteEventListener, Close
   }
 
   public static class NoteCreateEvent implements NoteEvent {
-    private final Note note;
+    private final String noteId;
 
-    public NoteCreateEvent(Note note) {
-      this.note = note;
+    public NoteCreateEvent(String noteId) {
+      this.noteId = noteId;
     }
 
-    public Note getNote() {
-      return note;
+    public String getNoteId() {
+      return noteId;
     }
   }
 
   public static class NoteUpdateEvent implements NoteEvent {
-    private final Note note;
+    private final String noteId;
 
-    public NoteUpdateEvent(Note note) {
-      this.note = note;
+    public NoteUpdateEvent(String noteId) {
+      this.noteId = noteId;
     }
 
-    public Note getNote() {
-      return note;
+    public String getNoteId() {
+      return noteId;
     }
   }
 
 
   public static class NoteRemoveEvent implements NoteEvent {
-    private final Note note;
+    private final String noteId;
 
-    public NoteRemoveEvent(Note note) {
-      this.note = note;
+    public NoteRemoveEvent(String noteId) {
+      this.noteId = noteId;
     }
 
-    public Note getNote() {
-      return note;
+    public String getNoteId() {
+      return noteId;
     }
   }
 
   public static class ParagraphCreateEvent implements NoteEvent {
-    private final Paragraph p;
+    private final String nodeId;
+    private final String paragraphId;
 
-    public ParagraphCreateEvent(Paragraph p) {
-      this.p = p;
+    public ParagraphCreateEvent(String nodeId, String paragraphId) {
+      this.nodeId = nodeId;
+      this.paragraphId = paragraphId;
     }
 
-    public Paragraph getParagraph() {
-      return p;
+    public String getNodeId() {
+      return nodeId;
+    }
+
+    public String getParagraphId() {
+      return paragraphId;
     }
   }
 
   public static class ParagraphUpdateEvent implements NoteEvent {
-    private final Paragraph p;
+    private final String nodeId;
+    private final String paragraphId;
 
-    public ParagraphUpdateEvent(Paragraph p) {
-      this.p = p;
+    public ParagraphUpdateEvent(String nodeId, String paragraphId) {
+      this.nodeId = nodeId;
+      this.paragraphId = paragraphId;
     }
 
-    public Paragraph getParagraph() {
-      return p;
+    public String getNodeId() {
+      return nodeId;
+    }
+
+    public String getParagraphId() {
+      return paragraphId;
     }
   }
 
   public static class ParagraphRemoveEvent implements NoteEvent {
-    private final Paragraph p;
+    private final String nodeId;
+    private final String paragraphId;
 
-    public ParagraphRemoveEvent(Paragraph p) {
-      this.p = p;
+    public ParagraphRemoveEvent(String nodeId, String paragraphId) {
+      this.nodeId = nodeId;
+      this.paragraphId = paragraphId;
     }
 
-    public Paragraph getParagraph() {
-      return p;
+    public String getNodeId() {
+      return nodeId;
+    }
+
+    public String getParagraphId() {
+      return paragraphId;
     }
   }
 
   public static class ParagraphStatusChangeEvent implements NoteEvent {
-    private final Paragraph p;
+    private final String nodeId;
+    private final String paragraphId;
 
-    public ParagraphStatusChangeEvent(Paragraph p) {
-      this.p = p;
+    public ParagraphStatusChangeEvent(String nodeId, String paragraphId) {
+      this.nodeId = nodeId;
+      this.paragraphId = paragraphId;
     }
 
-    public Paragraph getParagraph() {
-      return p;
+    public String getNodeId() {
+      return nodeId;
+    }
+
+    public String getParagraphId() {
+      return paragraphId;
     }
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteEventListener.java
@@ -19,18 +19,16 @@ package org.apache.zeppelin.notebook;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.user.AuthenticationInfo;
 
-import java.io.IOException;
-
 /**
  * Notebook event
  */
 public interface NoteEventListener {
-  void onNoteRemove(Note note, AuthenticationInfo subject) throws IOException;
-  void onNoteCreate(Note note, AuthenticationInfo subject) throws IOException;
-  void onNoteUpdate(Note note, AuthenticationInfo subject) throws IOException;
+  void onNoteRemove(Note note, AuthenticationInfo subject);
+  void onNoteCreate(Note note, AuthenticationInfo subject);
+  void onNoteUpdate(Note note, AuthenticationInfo subject);
 
-  void onParagraphRemove(Paragraph p) throws IOException;
-  void onParagraphCreate(Paragraph p) throws IOException;
-  void onParagraphUpdate(Paragraph p) throws IOException;
-  void onParagraphStatusChange(Paragraph p, Job.Status status) throws IOException;
+  void onParagraphRemove(Paragraph p);
+  void onParagraphCreate(Paragraph p);
+  void onParagraphUpdate(Paragraph p);
+  void onParagraphStatusChange(Paragraph p, Job.Status status);
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -576,12 +576,12 @@ public class NoteManager {
   public static class NoteNode {
 
     private Folder parent;
-    private NoteInfo noteinfo;
+    private NoteInfo noteInfo;
     private NotebookRepo notebookRepo;
     private NoteCache noteCache;
 
-    public NoteNode(NoteInfo noteinfo, Folder parent, NotebookRepo notebookRepo, NoteCache noteCache) {
-      this.noteinfo = noteinfo;
+    public NoteNode(NoteInfo noteInfo, Folder parent, NotebookRepo notebookRepo, NoteCache noteCache) {
+      this.noteInfo = noteInfo;
       this.parent = parent;
       this.notebookRepo = notebookRepo;
       this.noteCache = noteCache;
@@ -600,12 +600,12 @@ public class NoteManager {
      */
     public <T> T loadAndProcessNote(boolean reload, NoteProcessor<T> noteProcessor)
         throws IOException {
-        // load note
+      // load note
       Note note;
       synchronized (this) {
-        note = noteCache.getNote(noteinfo.getId());
+        note = noteCache.getNote(noteInfo.getId());
         if (note == null || reload) {
-          note = notebookRepo.get(noteinfo.getId(), noteinfo.getPath(), AuthenticationInfo.ANONYMOUS);
+          note = notebookRepo.get(noteInfo.getId(), noteInfo.getPath(), AuthenticationInfo.ANONYMOUS);
           if (parent.toString().equals("/")) {
             note.setPath("/" + note.getName());
           } else {
@@ -614,9 +614,9 @@ public class NoteManager {
           note.setCronSupported(ZeppelinConfiguration.create());
           noteCache.putNote(note);
         }
-        note.getLock().readLock().lock();
       }
       try {
+        note.getLock().readLock().lock();
         // process note
         return noteProcessor.process(note);
       } finally {
@@ -625,23 +625,23 @@ public class NoteManager {
     }
 
     public String getNoteId() {
-      return this.noteinfo.getId();
+      return this.noteInfo.getId();
     }
 
     public String getNoteName() {
-      return this.noteinfo.getNoteName();
+      return this.noteInfo.getNoteName();
     }
 
     public String getNotePath() {
       if (parent.getPath().equals("/")) {
-        return parent.getPath() + noteinfo.getNoteName();
+        return parent.getPath() + noteInfo.getNoteName();
       } else {
-        return parent.getPath() + "/" + noteinfo.getNoteName();
+        return parent.getPath() + "/" + noteInfo.getNoteName();
       }
     }
 
     public NoteInfo getNoteInfo() {
-      return this.noteinfo;
+      return this.noteInfo;
     }
 
     public Folder getParent() {
@@ -658,14 +658,14 @@ public class NoteManager {
     }
 
     public void setNotePath(String notePath) {
-      this.noteinfo.setPath(notePath);
+      this.noteInfo.setPath(notePath);
     }
 
     /**
      * This is called when the ancestor folder is moved.
      */
     public void updateNotePath() {
-      this.noteinfo.setPath(getNotePath());
+      this.noteInfo.setPath(getNotePath());
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -18,24 +18,29 @@
 
 package org.apache.zeppelin.notebook;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.Notebook.NoteProcessor;
 import org.apache.zeppelin.notebook.exception.NotePathAlreadyExistsException;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tags;
 
 /**
  * Manager class for note. It handle all the note related operations, such as get, create,
@@ -48,8 +53,6 @@ import java.util.stream.Stream;
  * Note will be loaded lazily. Initially only noteId nad note name is loaded,
  * other note content is loaded until getNote is called.
  *
- * TODO(zjffdu) implement the lifecycle manager of Note
- * (release memory if note is not used for some period)
  */
 @Singleton
 public class NoteManager {
@@ -59,16 +62,19 @@ public class NoteManager {
   private Folder trash;
 
   private NotebookRepo notebookRepo;
+  private NoteCache noteCache;
   // noteId -> notePath
   private Map<String, String> notesInfo;
 
   @Inject
-  public NoteManager(NotebookRepo notebookRepo) throws IOException {
+  public NoteManager(NotebookRepo notebookRepo, ZeppelinConfiguration conf) throws IOException {
     this.notebookRepo = notebookRepo;
-    this.root = new Folder("/", notebookRepo);
+    this.noteCache = new NoteCache(conf.getNoteCacheThreshold());
+    this.root = new Folder("/", notebookRepo, noteCache);
     this.trash = this.root.getOrCreateFolder(TRASH_FOLDER);
     init();
   }
+
 
   // build the tree structure of notes
   private void init() throws IOException {
@@ -78,7 +84,7 @@ public class NoteManager {
         .forEach(entry ->
         {
           try {
-            addOrUpdateNoteNode(new Note(new NoteInfo(entry.getKey(), entry.getValue())));
+            addOrUpdateNoteNode(new NoteInfo(entry.getKey(), entry.getValue()));
           } catch (IOException e) {
             LOGGER.warn(e.getMessage());
           }
@@ -89,36 +95,27 @@ public class NoteManager {
     return notesInfo;
   }
 
-  /**
-   * Return java stream instead of List to save memory, otherwise OOM will happen
-   * when there's large amount of notes.
-   * @return
-   */
-  public Stream<Note> getNotesStream() {
-    return notesInfo.values().stream()
-            .map(notePath -> {
-              try {
-                return getNoteNode(notePath).getNote();
-              } catch (Exception e) {
-                LOGGER.warn("Fail to load note: {}", notePath, e);
-                return null;
-              }
-            })
-            .filter(Objects::nonNull);
-  }
 
   /**
    *
    * @throws IOException
    */
   public void reloadNotes() throws IOException {
-    this.root = new Folder("/", notebookRepo);
+    this.root = new Folder("/", notebookRepo, noteCache);
     this.trash = this.root.getOrCreateFolder(TRASH_FOLDER);
     init();
   }
 
-  private void addOrUpdateNoteNode(Note note, boolean checkDuplicates) throws IOException {
-    String notePath = note.getPath();
+  /**
+   *
+   * @return current cache size
+   */
+  public int getCacheSize() {
+    return this.noteCache.getSize();
+  }
+
+  private void addOrUpdateNoteNode(NoteInfo noteInfo, boolean checkDuplicates) throws IOException {
+    String notePath = noteInfo.getPath();
 
     if (checkDuplicates && !isNotePathAvailable(notePath)) {
       throw new NotePathAlreadyExistsException("Note '" + notePath + "' existed");
@@ -132,12 +129,12 @@ public class NoteManager {
       }
     }
 
-    curFolder.addNote(tokens[tokens.length -1], note);
-    this.notesInfo.put(note.getId(), note.getPath());
+    curFolder.addNote(tokens[tokens.length -1], noteInfo);
+    this.notesInfo.put(noteInfo.getId(), noteInfo.getPath());
   }
 
-  private void addOrUpdateNoteNode(Note note) throws IOException {
-    addOrUpdateNoteNode(note, false);
+  private void addOrUpdateNoteNode(NoteInfo noteInfo) throws IOException {
+    addOrUpdateNoteNode(noteInfo, false);
   }
 
   /**
@@ -172,9 +169,7 @@ public class NoteManager {
 
   /**
    * Save note to NoteManager, it won't check duplicates, this is used when updating note.
-   * Only save note in 2 cases:
-   *  1. Note is new created, isSaved is false
-   *  2. Note is in loaded state. Unload state means its content is empty.
+   * Only save note in loaded state. Unload state means its content is empty.
    *
    * @param note
    * @param subject
@@ -183,18 +178,16 @@ public class NoteManager {
   public void saveNote(Note note, AuthenticationInfo subject) throws IOException {
     if (note.isRemoved()) {
       LOGGER.warn("Try to save note: {} when it is removed", note.getId());
-    } else if (note.isLoaded() || !note.isSaved()) {
-      addOrUpdateNoteNode(note);
-      this.notebookRepo.save(note, subject);
-      note.setSaved(true);
     } else {
-      LOGGER.warn("Try to save note: {} when it is unloaded", note.getId());
+      addOrUpdateNoteNode(new NoteInfo(note));
+      noteCache.putNote(note);
+      this.notebookRepo.save(note, subject);
     }
   }
 
   public void addNote(Note note, AuthenticationInfo subject) throws IOException {
-    addOrUpdateNoteNode(note, true);
-    note.setLoaded(true);
+    addOrUpdateNoteNode(new NoteInfo(note), true);
+    noteCache.putNote(note);
   }
 
   /**
@@ -218,6 +211,7 @@ public class NoteManager {
     String notePath = this.notesInfo.remove(noteId);
     Folder folder = getOrCreateFolder(getFolderName(notePath));
     folder.removeNote(getNoteName(notePath));
+    noteCache.removeNote(noteId);
     this.notebookRepo.remove(noteId, notePath, subject);
   }
 
@@ -247,11 +241,24 @@ public class NoteManager {
     // update notebookrepo
     this.notebookRepo.move(noteId, notePath, newNotePath, subject);
 
+    // Update path of the note
+    if (!StringUtils.equalsIgnoreCase(notePath, newNotePath)) {
+      processNote(noteId,
+        note -> {
+          note.setPath(newNotePath);
+          return null;
+        });
+    }
+
     // save note if note name is changed, because we need to update the note field in note json.
     String oldNoteName = getNoteName(notePath);
     String newNoteName = getNoteName(newNotePath);
     if (!StringUtils.equalsIgnoreCase(oldNoteName, newNoteName)) {
-      this.notebookRepo.save(noteNode.note, subject);
+      processNote(noteId,
+        note -> {
+          this.notebookRepo.save(note, subject);
+          return null;
+        });
     }
   }
 
@@ -269,8 +276,8 @@ public class NoteManager {
     newFolder.getParent().addFolder(newFolder.getName(), folder);
 
     // update notesInfo
-    for (Note note : folder.getRawNotesRecursively()) {
-      notesInfo.put(note.getId(), note.getPath());
+    for (NoteInfo noteInfo : folder.getNoteInfoRecursively()) {
+      notesInfo.put(noteInfo.getId(), noteInfo.getPath());
     }
   }
 
@@ -282,53 +289,52 @@ public class NoteManager {
    * @return
    * @throws IOException
    */
-  public List<Note> removeFolder(String folderPath, AuthenticationInfo subject) throws IOException {
+  public List<NoteInfo> removeFolder(String folderPath, AuthenticationInfo subject) throws IOException {
 
     // update notebookrepo
     this.notebookRepo.remove(folderPath, subject);
 
     // update filesystem tree
     Folder folder = getFolder(folderPath);
-    List<Note> notes = folder.getParent().removeFolder(folder.getName(), subject);
+    List<NoteInfo> noteInfos = folder.getParent().removeFolder(folder.getName(), subject);
 
     // update notesInfo
-    for (Note note : notes) {
-      this.notesInfo.remove(note.getId());
+    for (NoteInfo noteInfo : noteInfos) {
+      this.notesInfo.remove(noteInfo.getId());
     }
 
-    return notes;
+    return noteInfos;
   }
 
   /**
-   * Get note from NotebookRepo.
+   * Process note from NotebookRepo in an eviction aware manner.
    *
    * @param noteId
-   * @return return null if not found on NotebookRepo.
+   * @param reload
+   * @param noteProcessor
+   * @return result of the noteProcessor
    * @throws IOException
    */
-  public Note getNote(String noteId, boolean reload) throws IOException {
+  public <T> T processNote(String noteId, boolean reload, NoteProcessor<T> noteProcessor)
+      throws IOException {
     String notePath = this.notesInfo.get(noteId);
     if (notePath == null) {
-      return null;
+      return noteProcessor.process(null);
     }
     NoteNode noteNode = getNoteNode(notePath);
-    return noteNode.getNote(reload);
+    return noteNode.loadAndProcessNote(reload, noteProcessor);
   }
 
   /**
-   * Get note from NotebookRepo.
+   * Process note from NotebookRepo in an eviction aware manner.
    *
    * @param noteId
-   * @return return null if not found on NotebookRepo.
+   * @param noteProcessor
+   * @return result of the noteProcessor
    * @throws IOException
    */
-  public Note getNote(String noteId) throws IOException {
-    String notePath = this.notesInfo.get(noteId);
-    if (notePath == null) {
-      return null;
-    }
-    NoteNode noteNode = getNoteNode(notePath);
-    return noteNode.getNote();
+  public <T> T processNote(String noteId, NoteProcessor<T> noteProcessor) throws IOException {
+    return processNote(noteId, false, noteProcessor);
   }
 
   /**
@@ -419,19 +425,21 @@ public class NoteManager {
     private String name;
     private Folder parent;
     private NotebookRepo notebookRepo;
+    private NoteCache noteCache;
 
     // noteName -> NoteNode
     private Map<String, NoteNode> notes = new HashMap<>();
     // folderName -> Folder
     private Map<String, Folder> subFolders = new HashMap<>();
 
-    public Folder(String name, NotebookRepo notebookRepo) {
+    public Folder(String name, NotebookRepo notebookRepo, NoteCache noteCache) {
       this.name = name;
       this.notebookRepo = notebookRepo;
+      this.noteCache = noteCache;
     }
 
-    public Folder(String name, Folder parent, NotebookRepo notebookRepo) {
-      this(name, notebookRepo);
+    public Folder(String name, Folder parent, NotebookRepo notebookRepo, NoteCache noteCache) {
+      this(name, notebookRepo, noteCache);
       this.parent = parent;
     }
 
@@ -440,7 +448,7 @@ public class NoteManager {
         return this;
       }
       if (!subFolders.containsKey(folderName)) {
-        subFolders.put(folderName, new Folder(folderName, this, notebookRepo));
+        subFolders.put(folderName, new Folder(folderName, this, notebookRepo, noteCache));
       }
       return subFolders.get(folderName);
     }
@@ -473,8 +481,8 @@ public class NoteManager {
       return this.notes.get(noteName);
     }
 
-    public void addNote(String noteName, Note note) {
-      notes.put(noteName, new NoteNode(note, this, notebookRepo));
+    public void addNote(String noteName, NoteInfo noteInfo) {
+      notes.put(noteName, new NoteNode(noteInfo, this, notebookRepo, noteCache));
     }
 
     /**
@@ -507,19 +515,19 @@ public class NoteManager {
       this.notes.remove(noteName);
     }
 
-    public List<Note> removeFolder(String folderName,
+    public List<NoteInfo> removeFolder(String folderName,
                                    AuthenticationInfo subject) throws IOException {
       Folder folder = this.subFolders.remove(folderName);
-      return folder.getRawNotesRecursively();
+      return folder.getNoteInfoRecursively();
     }
 
-    public List<Note> getRawNotesRecursively() {
-      List<Note> notesInfo = new ArrayList<>();
+    public List<NoteInfo> getNoteInfoRecursively() {
+      List<NoteInfo> notesInfo = new ArrayList<>();
       for (NoteNode noteNode : this.notes.values()) {
-        notesInfo.add(noteNode.getRawNote());
+        notesInfo.add(noteNode.getNoteInfo());
       }
       for (Folder folder : subFolders.values()) {
-        notesInfo.addAll(folder.getRawNotesRecursively());
+        notesInfo.addAll(folder.getNoteInfoRecursively());
       }
       return notesInfo;
     }
@@ -561,69 +569,79 @@ public class NoteManager {
    * This class has 2 usage scenarios:
    * 1. metadata of note (only noteId and note name is loaded via reading the file name)
    * 2. the note object (note content is loaded from NotebookRepo)
-   *
+   * <br>
    * It will load note from NotebookRepo lazily until method getNote is called.
+   * A NoteCache ensures to free up resources, because its size is limited.
    */
   public static class NoteNode {
 
     private Folder parent;
-    private Note note;
+    private NoteInfo noteinfo;
     private NotebookRepo notebookRepo;
+    private NoteCache noteCache;
 
-    public NoteNode(Note note, Folder parent, NotebookRepo notebookRepo) {
-      this.note = note;
+    public NoteNode(NoteInfo noteinfo, Folder parent, NotebookRepo notebookRepo, NoteCache noteCache) {
+      this.noteinfo = noteinfo;
       this.parent = parent;
       this.notebookRepo = notebookRepo;
-    }
-
-    public synchronized Note getNote() throws IOException {
-        return getNote(false);
+      this.noteCache = noteCache;
     }
 
     /**
-     * This method will load note from NotebookRepo. If you just want to get noteId, noteName or
+     * This method will process note in a eviction aware manner by loading it from NotebookRepo.
+     *
+     * If you just want to get noteId, noteName or
      * notePath, you can call method getNoteId, getNoteName & getNotePath
-     * @return
+     *
+     * @param reload force a reload from {@link NotebookRepo}
+     * @param noteProcessor callback
+     * @return result of the noteProcessor
      * @throws IOException
      */
-    public synchronized Note getNote(boolean reload) throws IOException {
-      if (!note.isLoaded() || reload) {
-        note = notebookRepo.get(note.getId(), note.getPath(), AuthenticationInfo.ANONYMOUS);
-        if (parent.toString().equals("/")) {
-          note.setPath("/" + note.getName());
-        } else {
-          note.setPath(parent.toString() + "/" + note.getName());
+    public <T> T loadAndProcessNote(boolean reload, NoteProcessor<T> noteProcessor)
+        throws IOException {
+        // load note
+      Note note;
+      synchronized (this) {
+        note = noteCache.getNote(noteinfo.getId());
+        if (note == null || reload) {
+          note = notebookRepo.get(noteinfo.getId(), noteinfo.getPath(), AuthenticationInfo.ANONYMOUS);
+          if (parent.toString().equals("/")) {
+            note.setPath("/" + note.getName());
+          } else {
+            note.setPath(parent.toString() + "/" + note.getName());
+          }
+          note.setCronSupported(ZeppelinConfiguration.create());
+          noteCache.putNote(note);
         }
-        note.setCronSupported(ZeppelinConfiguration.create());
-        note.setLoaded(true);
+        note.getLock().readLock().lock();
       }
-      return note;
+      try {
+        // process note
+        return noteProcessor.process(note);
+      } finally {
+        note.getLock().readLock().unlock();
+      }
     }
 
     public String getNoteId() {
-      return this.note.getId();
+      return this.noteinfo.getId();
     }
 
     public String getNoteName() {
-      return this.note.getName();
+      return this.noteinfo.getNoteName();
     }
 
     public String getNotePath() {
       if (parent.getPath().equals("/")) {
-        return parent.getPath() + note.getName();
+        return parent.getPath() + noteinfo.getNoteName();
       } else {
-        return parent.getPath() + "/" + note.getName();
+        return parent.getPath() + "/" + noteinfo.getNoteName();
       }
     }
 
-    /**
-     * This method will just return the note object without checking whether it is loaded
-     * from NotebookRepo.
-     *
-     * @return
-     */
-    public Note getRawNote() {
-      return this.note;
+    public NoteInfo getNoteInfo() {
+      return this.noteinfo;
     }
 
     public Folder getParent() {
@@ -640,16 +658,93 @@ public class NoteManager {
     }
 
     public void setNotePath(String notePath) {
-      this.note.setPath(notePath);
+      this.noteinfo.setPath(notePath);
     }
 
     /**
      * This is called when the ancestor folder is moved.
      */
     public void updateNotePath() {
-      this.note.setPath(getNotePath());
+      this.noteinfo.setPath(getNotePath());
     }
   }
+
+  /**
+   * Leverage a simple LRU cache for notes.
+   * Notes are not evicted in case they are currently in use (have a lock).
+   */
+  private static class NoteCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoteCache.class);
+
+    private final int threshold;
+    private final Map<String, Note> lruCache;
+    private final Counter cacheHit;
+    private final Counter cacheMiss;
+
+    public NoteCache(final int threshold) {
+      // Registering the threshold to compare the configured threshold with the actual note cache
+      this.threshold = Metrics.gauge("zeppelin_note_cache_threshold", Tags.empty(), threshold);
+      // use a synchronized map to make the NoteCache thread-safe
+      this.lruCache = Metrics.gaugeMapSize("zeppelin_note_cache", Tags.empty(), Collections.synchronizedMap(new LRUCache()));
+      this.cacheHit = Metrics.counter("zeppelin_note_cache_hit", Tags.empty());
+      this.cacheMiss = Metrics.counter("zeppelin_note_cache_miss", Tags.empty());
+    }
+
+    public int getSize() {
+      return lruCache.size();
+    }
+
+    public Note getNote(String noteId) {
+      Note note = lruCache.get(noteId);
+      if (note != null) {
+        cacheHit.increment();
+      } else {
+        cacheMiss.increment();
+      }
+      return note;
+    }
+
+    public void putNote(Note note) {
+      lruCache.put(note.getId(), note);
+    }
+
+    public Note removeNote(String noteId) {
+      return lruCache.remove(noteId);
+    }
+
+    private class LRUCache extends LinkedHashMap<String, Note> {
+
+      private static final long serialVersionUID = 1L;
+
+      public LRUCache() {
+        super(NoteCache.this.threshold, 0.5f, true /* lru by access mode */);
+      }
+
+      @Override
+      protected boolean removeEldestEntry(java.util.Map.Entry<String, Note> eldest) {
+        if (size() <= NoteCache.this.threshold) {
+          return false;
+        }
+
+        final Note eldestNote = eldest.getValue();
+        final Lock lock = eldestNote.getLock().writeLock();
+        if (lock.tryLock()) { // avoid eviction in case the note is in use
+          try {
+            return true;
+          } finally {
+            lock.unlock();
+          }
+        } else {
+          LOGGER.info("Can not evict note {}, because the write lock can not be acquired. {} notes currently loaded.",
+              eldestNote.getId(), size());
+          return false;
+        }
+      }
+    }
+
+  }
+
 
 
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -771,7 +771,7 @@ public class Notebook {
    * Functional Interface for note processing.
    */
   @FunctionalInterface
-  public static interface NoteProcessor<T> {
+  public interface NoteProcessor<T> {
 
     /**
      * Process a note.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -19,21 +19,18 @@ package org.apache.zeppelin.notebook;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.display.AngularObject;
@@ -52,7 +49,6 @@ import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl.Revision;
 import org.apache.zeppelin.scheduler.Job;
-import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.quartz.SchedulerException;
@@ -75,7 +71,6 @@ public class Notebook {
   private ZeppelinConfiguration conf;
   private ParagraphJobListener paragraphJobListener;
   private NotebookRepo notebookRepo;
-  private SearchService noteSearchService;
   private List<NoteEventListener> noteEventListeners = new ArrayList<>();
   private Credentials credentials;
 
@@ -92,9 +87,8 @@ public class Notebook {
       NoteManager noteManager,
       InterpreterFactory replFactory,
       InterpreterSettingManager interpreterSettingManager,
-      SearchService noteSearchService,
       Credentials credentials)
-      throws IOException {
+      {
     this.conf = conf;
     this.authorizationService = authorizationService;
     this.noteManager = noteManager;
@@ -103,14 +97,8 @@ public class Notebook {
     this.interpreterSettingManager = interpreterSettingManager;
     // TODO(zjffdu) cycle refer, not a good solution
     this.interpreterSettingManager.setNotebook(this);
-    this.noteSearchService = noteSearchService;
     this.credentials = credentials;
-    this.noteEventListeners.add(this.noteSearchService);
     this.noteEventListeners.add(this.interpreterSettingManager);
-
-    if (conf.isIndexRebuild()) {
-      noteSearchService.startRebuildIndex(getNoteStream());
-    }
   }
 
   public void recoveryIfNecessary() {
@@ -120,25 +108,28 @@ public class Notebook {
   }
 
   private void recoverRunningParagraphs() {
-    Thread thread = new Thread(() -> {
-      getNoteStream().forEach(note -> {
+    Thread thread = new Thread(() ->
+      getNotesInfo().forEach(noteInfo -> {
         try {
-          boolean hasRecoveredParagraph = false;
-          for (Paragraph paragraph : note.getParagraphs()) {
-            if (paragraph.getStatus() == Job.Status.RUNNING) {
-              paragraph.recover();
-              hasRecoveredParagraph = true;
-            }
-          }
-          // unload note to save memory when there's no paragraph recovering.
-          if (!hasRecoveredParagraph) {
-            note.unLoad();
+          List<Paragraph> paragraphsToRecover = new LinkedList<>();
+          processNote(noteInfo.getId(),
+            note -> {
+              for (Paragraph paragraph : note.getParagraphs()) {
+                if (paragraph.getStatus() == Job.Status.RUNNING) {
+                  paragraphsToRecover.add(paragraph);
+                }
+              }
+              return null;
+            });
+          // recover the paragraphs outside the read lock
+          for (Paragraph paragraph : paragraphsToRecover) {
+            paragraph.recover();
           }
         } catch (Exception e) {
-          LOGGER.warn("Fail to recovery note: {}", note.getPath(), e);
+          LOGGER.warn("Fail to recovery note: {}", noteInfo.getPath(), e);
         }
-      });
-    });
+      })
+    );
     thread.setName("Recovering-Thread");
     thread.start();
     LOGGER.info("Start paragraph recovering thread");
@@ -158,7 +149,6 @@ public class Notebook {
       NoteManager noteManager,
       InterpreterFactory replFactory,
       InterpreterSettingManager interpreterSettingManager,
-      SearchService noteSearchService,
       Credentials credentials,
       NoteEventListener noteEventListener)
       throws IOException {
@@ -169,10 +159,9 @@ public class Notebook {
         noteManager,
         replFactory,
         interpreterSettingManager,
-        noteSearchService,
         credentials);
     if (null != noteEventListener) {
-      this.noteEventListeners.add(noteEventListener);
+      addNotebookEventListener(noteEventListener);
     }
     this.paragraphJobListener = (ParagraphJobListener) noteEventListener;
   }
@@ -195,10 +184,10 @@ public class Notebook {
    *
    * @param notePath
    * @param subject
-   * @return
+   * @return noteId
    * @throws IOException
    */
-  public Note createNote(String notePath,
+  public String createNote(String notePath,
                          AuthenticationInfo subject) throws IOException {
     return createNote(notePath, interpreterSettingManager.getDefaultInterpreterSetting().getName(),
         subject);
@@ -211,10 +200,10 @@ public class Notebook {
    * @param notePath
    * @param subject
    * @param save
-   * @return
+   * @return noteId
    * @throws IOException
    */
-  public Note createNote(String notePath,
+  public String createNote(String notePath,
                          AuthenticationInfo subject,
                          boolean save) throws IOException {
     return createNote(notePath, interpreterSettingManager.getDefaultInterpreterSetting().getName(),
@@ -227,10 +216,10 @@ public class Notebook {
    * @param notePath
    * @param defaultInterpreterGroup
    * @param subject
-   * @return
+   * @return noteId
    * @throws IOException
    */
-  public Note createNote(String notePath,
+  public String createNote(String notePath,
                          String defaultInterpreterGroup,
                          AuthenticationInfo subject) throws IOException {
     return createNote(notePath, defaultInterpreterGroup, subject, true);
@@ -242,10 +231,10 @@ public class Notebook {
    * @param notePath
    * @param defaultInterpreterGroup
    * @param subject
-   * @return
+   * @return noteId
    * @throws IOException
    */
-  public Note createNote(String notePath,
+  public String createNote(String notePath,
                          String defaultInterpreterGroup,
                          AuthenticationInfo subject,
                          boolean save) throws IOException {
@@ -260,7 +249,7 @@ public class Notebook {
       noteManager.saveNote(note, subject);
     }
     fireNoteCreateEvent(note, subject);
-    return note;
+    return note.getId();
   }
 
   /**
@@ -272,13 +261,15 @@ public class Notebook {
    */
   public String exportNote(String noteId) throws IOException {
     try {
-      Note note = getNote(noteId);
-      if (note == null) {
-        throw new IOException("Note " + noteId + " not found");
-      }
-      return note.toJson();
+      return processNote(noteId,
+        note -> {
+          if (note == null) {
+            throw new IOException("Note " + noteId + " not found");
+          }
+          return note.toJson();
+        });
     } catch (IOException e) {
-      throw new IOException(noteId + " not found");
+      throw new IOException("Note " + noteId + " not found");
     }
   }
 
@@ -287,22 +278,26 @@ public class Notebook {
    *
    * @param sourceJson - the note JSON to import
    * @param notePath   - the path of the new note
-   * @return note ID
+   * @return noteId
    * @throws IOException
    */
-  public Note importNote(String sourceJson, String notePath, AuthenticationInfo subject)
+  public String importNote(String sourceJson, String notePath, AuthenticationInfo subject)
       throws IOException {
     Note oldNote = Note.fromJson(null, sourceJson);
     if (notePath == null) {
       notePath = oldNote.getName();
     }
-    Note newNote = createNote(notePath, subject);
-    List<Paragraph> paragraphs = oldNote.getParagraphs();
-    for (Paragraph p : paragraphs) {
-      newNote.addCloneParagraph(p, subject);
-    }
-    noteManager.saveNote(newNote, subject);
-    return newNote;
+    String newNoteId = createNote(notePath, subject);
+    processNote(newNoteId,
+      newNote -> {
+        List<Paragraph> paragraphs = oldNote.getParagraphs();
+        for (Paragraph p : paragraphs) {
+          newNote.addCloneParagraph(p, subject);
+        }
+        noteManager.saveNote(newNote, subject);
+        return null;
+      });
+    return newNoteId;
   }
 
   /**
@@ -310,34 +305,41 @@ public class Notebook {
    *
    * @param sourceNoteId - the note ID to clone
    * @param newNotePath  - the path of the new note
-   * @return noteId
+   * @return noteId from the new note
    * @throws IOException
    */
-  public Note cloneNote(String sourceNoteId, String newNotePath, AuthenticationInfo subject)
+  public String cloneNote(String sourceNoteId, String newNotePath, AuthenticationInfo subject)
       throws IOException {
-    Note sourceNote = getNote(sourceNoteId);
-    if (sourceNote == null) {
-      throw new IOException("Source note: " + sourceNoteId + " not found");
-    }
-    Note newNote = createNote(newNotePath, subject, false);
-    List<Paragraph> paragraphs = sourceNote.getParagraphs();
-    for (Paragraph p : paragraphs) {
-      newNote.addCloneParagraph(p, subject);
-    }
+    return processNote(sourceNoteId,
+      sourceNote -> {
+        if (sourceNote == null) {
+          throw new IOException("Source note: " + sourceNoteId + " not found");
+        }
+        String newNoteId = createNote(newNotePath, subject, false);
+        processNote(newNoteId,
+          newNote -> {
+            List<Paragraph> paragraphs = sourceNote.getParagraphs();
+            for (Paragraph p : paragraphs) {
+              newNote.addCloneParagraph(p, subject);
+            }
 
-    newNote.setConfig(new HashMap<>(sourceNote.getConfig()));
-    newNote.setInfo(new HashMap<>(sourceNote.getInfo()));
-    newNote.setDefaultInterpreterGroup(sourceNote.getDefaultInterpreterGroup());
-    newNote.setNoteForms(new HashMap<>(sourceNote.getNoteForms()));
-    newNote.setNoteParams(new HashMap<>(sourceNote.getNoteParams()));
-    newNote.setRunning(false);
+            newNote.setConfig(new HashMap<>(sourceNote.getConfig()));
+            newNote.setInfo(new HashMap<>(sourceNote.getInfo()));
+            newNote.setDefaultInterpreterGroup(sourceNote.getDefaultInterpreterGroup());
+            newNote.setNoteForms(new HashMap<>(sourceNote.getNoteForms()));
+            newNote.setNoteParams(new HashMap<>(sourceNote.getNoteParams()));
+            newNote.setRunning(false);
 
-    saveNote(newNote, subject);
-    authorizationService.cloneNoteMeta(newNote.getId(), sourceNoteId, subject);
-    return newNote;
+            saveNote(newNote, subject);
+            authorizationService.cloneNoteMeta(newNote.getId(), sourceNoteId, subject);
+            return null;
+          });
+
+        return newNoteId;
+      });
   }
 
-  public void removeNote(Note note, AuthenticationInfo subject) throws IOException {
+  private void removeNote(Note note, AuthenticationInfo subject) throws IOException {
     LOGGER.info("Remove note: {}", note.getId());
     // Set Remove to true to cancel saving this note
     note.setRemoved(true);
@@ -352,43 +354,64 @@ public class Notebook {
     authorizationService.removeNoteAuth(noteId);
   }
 
+  /**
+   * Removes the Note with the NoteId.
+   * @param noteId
+   * @param subject
+   * @throws IOException when fail to get it from NotebookRepo
+   */
   public void removeNote(String noteId, AuthenticationInfo subject) throws IOException {
-    Note note = getNote(noteId);
-    removeNote(note, subject);
+    processNote(noteId,
+      note -> {
+        if (note != null) {
+          removeNote(note, subject);
+        }
+        return null;
+    });
   }
 
   /**
-   * Get note from NotebookRepo and also initialize it with other properties that is not
-   * persistent in NotebookRepo, such as paragraphJobListener.
+   * Process a note in an eviction aware manner. It initializes the note
+   * with other properties that is not persistent in NotebookRepo, such as paragraphJobListener.
+   * <p>
+   * Use {@link #processNote(String, boolean, NoteProcessor)} in case you want to force
+   * a note reload from the {@link #NotebookRepo}.
+   * </p>
    * @param noteId
-   * @return null if note not found.
-   * @throws IOException when fail to get it from NotebookRepo.
+   * @param noteProcessor
+   * @return result of the noteProcessor
+   * @throws IOException when fail to get it from {@link NotebookRepo}
    */
-  public Note getNote(String noteId) throws IOException {
-    return getNote(noteId, false);
+  public <T> T processNote(String noteId, NoteProcessor<T> noteProcessor) throws IOException {
+    return processNote(noteId, false, noteProcessor);
   }
 
   /**
-   * Get note from NotebookRepo and also initialize it with other properties that is not
-   * persistent in NotebookRepo, such as paragraphJobListener.
+   * Process a note in an eviction aware manner. It initializes the note
+   * with other properties that is not persistent in NotebookRepo, such as paragraphJobListener.
+   *
    * @param noteId
-   * @return null if note not found.
-   * @throws IOException when fail to get it from NotebookRepo.
+   * @param reload
+   * @param noteProcessor
+   * @return result of the noteProcessor
+   * @throws IOException when fail to get it from {@link NotebookRepo}
    */
-  public Note getNote(String noteId, boolean reload) throws IOException {
-    Note note = noteManager.getNote(noteId, reload);
-    if (note == null) {
-      return null;
-    }
-    note.setInterpreterFactory(replFactory);
-    note.setInterpreterSettingManager(interpreterSettingManager);
-    note.setParagraphJobListener(paragraphJobListener);
-    note.setNoteEventListeners(noteEventListeners);
-    note.setCredentials(credentials);
-    for (Paragraph p : note.getParagraphs()) {
-      p.setNote(note);
-    }
-    return note;
+  public <T> T processNote(String noteId, boolean reload, NoteProcessor<T> noteProcessor) throws IOException {
+    return noteManager.processNote(noteId, reload, note -> {
+      if (note == null) {
+        return noteProcessor.process(note);
+      }
+      note.setInterpreterFactory(replFactory);
+      note.setInterpreterSettingManager(interpreterSettingManager);
+      note.setParagraphJobListener(paragraphJobListener);
+      note.setNoteEventListeners(noteEventListeners);
+      note.setCredentials(credentials);
+      for (final Paragraph p : note.getParagraphs()) {
+        p.setNote(note);
+      }
+      return noteProcessor.process(note);
+    });
+
   }
 
   public void saveNote(Note note, AuthenticationInfo subject) throws IOException {
@@ -400,10 +423,29 @@ public class Notebook {
     fireNoteUpdateEvent(note, subject);
   }
 
+  /**
+   * Checks if the notebook contains a note with the specified note ID.
+   * @param notePath
+   * @return true if a note with the specified note ID exists, otherwise false
+   */
+  public boolean containsNoteById(String noteId) {
+    return noteManager.getNotesInfo().containsKey(noteId);
+  }
+
+  /**
+   * Checks if the notebook contains a note with the given note path.
+   * @param notePath
+   * @return true if a note with the specified note path exists, otherwise false
+   */
   public boolean containsNote(String notePath) {
     return noteManager.containsNote(notePath);
   }
 
+  /**
+   * Checks if the notebook contains a folder with the given folder path
+   * @param folderPath
+   * @return true if a note with the specified folder path exists, otherwise false
+   */
   public boolean containsFolder(String folderPath) {
     return noteManager.containsFolder(folderPath);
   }
@@ -421,9 +463,9 @@ public class Notebook {
   public void removeFolder(String folderPath, AuthenticationInfo subject) throws IOException {
     LOGGER.info("Remove folder {}", folderPath);
     // TODO(zjffdu) NotebookRepo.remove is called twice here
-    List<Note> notes = noteManager.removeFolder(folderPath, subject);
-    for (Note note : notes) {
-      fireNoteRemoveEvent(note, subject);
+    List<NoteInfo> noteInfos = noteManager.removeFolder(folderPath, subject);
+    for (NoteInfo noteInfo : noteInfos) {
+      removeNote(noteInfo.getId(), subject);
     }
   }
 
@@ -496,7 +538,8 @@ public class Notebook {
   public Note loadNoteFromRepo(String id, AuthenticationInfo subject) {
     Note note = null;
     try {
-      note = noteManager.getNote(id);
+      // note can be safely returned here, because it's just broadcasted in json later on
+      note = processNote(id, n -> n);
     } catch (IOException e) {
       LOGGER.error("Fail to get note: {}", id, e);
       return null;
@@ -619,35 +662,6 @@ public class Notebook {
         .collect(Collectors.toList());
   }
 
-  public Stream<Note> getNoteStream() {
-    return noteManager.getNotesStream().map(note -> {
-      note.setInterpreterFactory(replFactory);
-      note.setInterpreterSettingManager(interpreterSettingManager);
-      note.setParagraphJobListener(paragraphJobListener);
-      note.setNoteEventListeners(noteEventListeners);
-      note.setCredentials(credentials);
-      for (Paragraph p : note.getParagraphs()) {
-        p.setNote(note);
-        p.setListener(paragraphJobListener);
-      }
-      return note;
-    });
-  }
-
-  @VisibleForTesting
-  public List<Note> getAllNotes(Function<Note, Boolean> func){
-    return getAllNotes().stream()
-        .filter(note -> func.apply(note))
-        .collect(Collectors.toList());
-  }
-
-  @VisibleForTesting
-  public List<Note> getAllNotes() {
-    List<Note> notes = getNoteStream().collect(Collectors.toList());
-    Collections.sort(notes, Comparator.comparing(Note::getPath));
-    return notes;
-  }
-
   public List<NoteInfo> getNotesInfo(Function<String, Boolean> func) {
     String homescreenNoteId = conf.getString(ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN);
     boolean hideHomeScreenNotebookFromList =
@@ -677,27 +691,31 @@ public class Notebook {
   }
 
   public List<InterpreterSetting> getBindedInterpreterSettings(String noteId) throws IOException {
-    Note note  = getNote(noteId);
-    if (note == null) {
-      return new ArrayList<>();
-    }
-    Set<InterpreterSetting> settings = new HashSet<>();
-    for (Paragraph p : note.getParagraphs()) {
-      try {
-        Interpreter intp = p.getBindedInterpreter();
-        settings.add((
-                (ManagedInterpreterGroup) intp.getInterpreterGroup()).getInterpreterSetting());
-      } catch (InterpreterNotFoundException e) {
-        // ignore this
-      }
-    }
-    // add the default interpreter group
-    InterpreterSetting defaultIntpSetting =
-            interpreterSettingManager.getByName(note.getDefaultInterpreterGroup());
-    if (defaultIntpSetting != null) {
-      settings.add(defaultIntpSetting);
-    }
-    return new ArrayList<>(settings);
+    List<InterpreterSetting> interpreterSettings = new ArrayList<>();
+    processNote(noteId,
+      note -> {
+        if (note != null) {
+          Set<InterpreterSetting> settings = new HashSet<>();
+          for (Paragraph p : note.getParagraphs()) {
+            try {
+              Interpreter intp = p.getBindedInterpreter();
+              settings.add((
+                      (ManagedInterpreterGroup) intp.getInterpreterGroup()).getInterpreterSetting());
+            } catch (InterpreterNotFoundException e) {
+              // ignore this
+            }
+          }
+          // add the default interpreter group
+          InterpreterSetting defaultIntpSetting =
+                  interpreterSettingManager.getByName(note.getDefaultInterpreterGroup());
+          if (defaultIntpSetting != null) {
+            settings.add(defaultIntpSetting);
+          }
+          interpreterSettings.addAll(settings);
+        }
+        return null;
+    });
+    return interpreterSettings;
   }
 
   public InterpreterFactory getInterpreterFactory() {
@@ -714,28 +732,35 @@ public class Notebook {
 
   public void close() {
     this.notebookRepo.close();
-    this.noteSearchService.close();
   }
 
   public void addNotebookEventListener(NoteEventListener listener) {
-    noteEventListeners.add(listener);
+    synchronized(noteEventListeners) {
+      noteEventListeners.add(listener);
+    }
   }
 
   private void fireNoteCreateEvent(Note note, AuthenticationInfo subject) throws IOException {
-    for (NoteEventListener listener : noteEventListeners) {
-      listener.onNoteCreate(note, subject);
+    synchronized(noteEventListeners) {
+      for (NoteEventListener listener : noteEventListeners) {
+        listener.onNoteCreate(note, subject);
+      }
     }
   }
 
   private void fireNoteUpdateEvent(Note note, AuthenticationInfo subject) throws IOException {
-    for (NoteEventListener listener : noteEventListeners) {
-      listener.onNoteUpdate(note, subject);
+    synchronized(noteEventListeners) {
+      for (NoteEventListener listener : noteEventListeners) {
+        listener.onNoteUpdate(note, subject);
+      }
     }
   }
 
   private void fireNoteRemoveEvent(Note note, AuthenticationInfo subject) throws IOException {
-    for (NoteEventListener listener : noteEventListeners) {
-      listener.onNoteRemove(note, subject);
+    synchronized(noteEventListeners) {
+      for (NoteEventListener listener : noteEventListeners) {
+        listener.onNoteRemove(note, subject);
+      }
     }
   }
 
@@ -747,5 +772,21 @@ public class Notebook {
     } else {
       return false;
     }
+  }
+
+  /**
+   * Functional Interface for note processing.
+   */
+  @FunctionalInterface
+  public static interface NoteProcessor<T> {
+
+    /**
+     * Process a note.
+     *
+     * @param note the current note, or null in case note does not exist.
+     * @throws IOException
+     */
+    T process(Note note) throws IOException;
+
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -719,7 +719,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   @VisibleForTesting
-  public void waitUntilFinished() throws Exception {
+  public void waitUntilFinished() throws InterruptedException {
     while(!isTerminated()) {
       LOGGER.debug("Wait for paragraph to be finished");
       Thread.sleep(1000);
@@ -727,7 +727,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   @VisibleForTesting
-  public void waitUntilRunning() throws Exception {
+  public void waitUntilRunning() throws InterruptedException {
     while(!isRunning()) {
       LOGGER.debug("Wait for paragraph to be running");
       Thread.sleep(1000);
@@ -809,14 +809,13 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
     } else if (outputBuffer.size() > index) {
       outputBuffer.set(index, interpreterResultMessage);
     } else {
-      LOGGER.warn("Get output of index: " + index + ", but there's only " +
-              outputBuffer.size() + " output in outputBuffer");
+      LOGGER.warn("Get output of index: {}, but there's only {} output in outputBuffer", index, outputBuffer.size());
     }
   }
 
   public void recover() {
     try {
-      LOGGER.info("Recovering paragraph: " + getId());
+      LOGGER.info("Recovering paragraph: {}", getId());
 
       this.interpreter = getBindedInterpreter();
       InterpreterSetting interpreterSetting = ((ManagedInterpreterGroup)

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
@@ -18,13 +18,14 @@
 package org.apache.zeppelin.notebook.scheduler;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 /** Cron task for the note. */
@@ -38,32 +39,46 @@ public class CronJob implements org.quartz.Job {
   @Override
   public void execute(JobExecutionContext context) {
     JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
-    Note note = (Note) jobDataMap.get("note");
-    if (note.haveRunningOrPendingParagraphs()) {
-      LOGGER.warn(
-          "execution of the cron job is skipped because there is a running or pending "
-              + "paragraph (note id: {})",
-          note.getId());
-      context.setResult(RESULT_SKIPPED);
-      return;
-    }
+    String noteId = jobDataMap.getString("noteId");
+    Notebook notebook = (Notebook) jobDataMap.get("notebook");
 
-    String cronExecutingUser = (String) note.getConfig().get("cronExecutingUser");
-    String cronExecutingRoles = (String) note.getConfig().get("cronExecutingRoles");
-    if (null == cronExecutingUser) {
-      cronExecutingUser = "anonymous";
-    }
-    AuthenticationInfo authenticationInfo =
-            new AuthenticationInfo(
-                    cronExecutingUser,
-                    StringUtils.isEmpty(cronExecutingRoles) ? null : cronExecutingRoles,
-                    null);
     try {
-      note.runAll(authenticationInfo, true, true, new HashMap<>());
-      context.setResult(RESULT_SUCCEEDED);
-    } catch (Exception e) {
+      notebook.processNote(noteId, note -> {
+        if (note == null) {
+          LOGGER.warn("Failed to run CronJob of note: {} because there's no such note", noteId);
+          context.setResult(RESULT_FAILED);
+          return null;
+        }
+        if (note.haveRunningOrPendingParagraphs()) {
+          LOGGER.warn(
+              "execution of the cron job is skipped because there is a running or pending "
+                  + "paragraph (note id: {})",
+              note.getId());
+          context.setResult(RESULT_SKIPPED);
+          return null;
+        }
+        String cronExecutingUser = (String) note.getConfig().get("cronExecutingUser");
+        String cronExecutingRoles = (String) note.getConfig().get("cronExecutingRoles");
+        if (null == cronExecutingUser) {
+          cronExecutingUser = "anonymous";
+        }
+        AuthenticationInfo authenticationInfo =
+                new AuthenticationInfo(
+                        cronExecutingUser,
+                        StringUtils.isEmpty(cronExecutingRoles) ? null : cronExecutingRoles,
+                        null);
+        try {
+          note.runAll(authenticationInfo, true, true, new HashMap<>());
+          context.setResult(RESULT_SUCCEEDED);
+        } catch (Exception e) {
+          context.setResult(RESULT_FAILED);
+          LOGGER.warn("Fail to run note: {}", note.getName(), e);
+        }
+        return null;
+      });
+    } catch (IOException e) {
+      LOGGER.warn("Failed to run CronJob of note: {} because fail to get it", noteId ,e);
       context.setResult(RESULT_FAILED);
-      LOGGER.warn("Fail to run note: {}", note.getName(), e);
     }
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
@@ -17,9 +17,10 @@
 
 package org.apache.zeppelin.notebook.scheduler;
 
+import java.io.IOException;
 import java.util.Set;
 
 public interface SchedulerService {
-  boolean refreshCron(String noteId);
+  boolean refreshCron(String noteId) throws IOException;
   Set<?> getJobs();
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
@@ -17,16 +17,11 @@
 
 package org.apache.zeppelin.search;
 
-import org.apache.zeppelin.conf.ZeppelinConfiguration;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.Paragraph;
-
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 public class NoSearchService extends SearchService {
 
@@ -41,38 +36,32 @@ public class NoSearchService extends SearchService {
   }
 
   @Override
-  public void updateNoteIndex(Note note) throws IOException {
+  public void updateNoteIndex(String noteId) throws IOException {
 
   }
 
   @Override
-  public void updateParagraphIndex(Paragraph paragraph) throws IOException {
+  public void updateParagraphIndex(String noteId, String paragraphId) throws IOException {
 
   }
 
   @Override
-  public void addNoteIndex(Note note) throws IOException {
+  public void addNoteIndex(String noteId) throws IOException {
 
   }
 
   @Override
-  public void addParagraphIndex(Paragraph pargaraph) throws IOException {
+  public void addParagraphIndex(String noteId, String paragraphId) throws IOException {
 
   }
 
   @Override
-  public void deleteNoteIndex(Note note) throws IOException {
+  public void deleteNoteIndex(String noteId) throws IOException {
 
   }
 
   @Override
-  public void deleteParagraphIndex(String noteId, Paragraph p) throws IOException {
-
-  }
-
-
-  @Override
-  public void startRebuildIndex(Stream<Note> notes) {
+  public void deleteParagraphIndex(String noteId, String paragraphId) throws IOException {
 
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/NoSearchService.java
@@ -18,7 +18,6 @@
 package org.apache.zeppelin.search;
 
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -36,32 +35,32 @@ public class NoSearchService extends SearchService {
   }
 
   @Override
-  public void updateNoteIndex(String noteId) throws IOException {
-
+  public void updateNoteIndex(String noteId) {
+    // do nothing
   }
 
   @Override
-  public void updateParagraphIndex(String noteId, String paragraphId) throws IOException {
-
+  public void updateParagraphIndex(String noteId, String paragraphId) {
+    // do nothing
   }
 
   @Override
-  public void addNoteIndex(String noteId) throws IOException {
-
+  public void addNoteIndex(String noteId) {
+    // do nothing
   }
 
   @Override
-  public void addParagraphIndex(String noteId, String paragraphId) throws IOException {
-
+  public void addParagraphIndex(String noteId, String paragraphId) {
+    // do nothing
   }
 
   @Override
-  public void deleteNoteIndex(String noteId) throws IOException {
-
+  public void deleteNoteIndex(String noteId) {
+    // do nothing
   }
 
   @Override
-  public void deleteParagraphIndex(String noteId, String paragraphId) throws IOException {
-
+  public void deleteParagraphIndex(String noteId, String paragraphId) {
+    // do nothing
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/SearchService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/SearchService.java
@@ -50,7 +50,7 @@ public abstract class SearchService extends NoteEventAsyncListener {
    * @param note a Note to update index for
    * @throws IOException
    */
-  public abstract void updateNoteIndex(String noteId) throws IOException;
+  public abstract void updateNoteIndex(String noteId);
 
   /**
    * Updates paragraph index for the given paragraph.
@@ -59,27 +59,27 @@ public abstract class SearchService extends NoteEventAsyncListener {
    * @throws IOException
    */
 
-  public abstract void updateParagraphIndex(String nodeId, String paragraphId) throws IOException;
+  public abstract void updateParagraphIndex(String nodeId, String paragraphId);
 
   /**
    * Indexes the given note.
    *
    * @throws IOException If there is a low-level I/O error
    */
-  public abstract void addNoteIndex(String noteId) throws IOException;
+  public abstract void addNoteIndex(String noteId);
 
   /**
    * Indexes the given paragraph.
    *
    * @throws IOException If there is a low-level I/O error
    */
-  public abstract void addParagraphIndex(String nodeId, String paragraphId) throws IOException;
+  public abstract void addParagraphIndex(String nodeId, String paragraphId);
 
 
   /**
    * Deletes all docs on given Note from index
    */
-  public abstract void deleteNoteIndex(String noteId) throws IOException;
+  public abstract void deleteNoteIndex(String noteId);
 
   /**
    * Deletes doc for a given
@@ -88,7 +88,7 @@ public abstract class SearchService extends NoteEventAsyncListener {
    * @param p
    * @throws IOException
    */
-  public abstract void deleteParagraphIndex(String noteId, String paragraphId) throws IOException;
+  public abstract void deleteParagraphIndex(String noteId, String paragraphId);
 
   /**
    * Frees the recourses used by index
@@ -100,32 +100,32 @@ public abstract class SearchService extends NoteEventAsyncListener {
   }
 
   @Override
-  public void handleNoteCreateEvent(NoteCreateEvent noteCreateEvent) throws Exception {
+  public void handleNoteCreateEvent(NoteCreateEvent noteCreateEvent) {
     addNoteIndex(noteCreateEvent.getNoteId());
   }
 
   @Override
-  public void handleNoteRemoveEvent(NoteRemoveEvent noteRemoveEvent) throws Exception {
+  public void handleNoteRemoveEvent(NoteRemoveEvent noteRemoveEvent) {
     deleteNoteIndex(noteRemoveEvent.getNoteId());
   }
 
   @Override
-  public void handleNoteUpdateEvent(NoteUpdateEvent noteUpdateEvent) throws Exception {
+  public void handleNoteUpdateEvent(NoteUpdateEvent noteUpdateEvent) {
     updateNoteIndex(noteUpdateEvent.getNoteId());
   }
 
   @Override
-  public void handleParagraphCreateEvent(ParagraphCreateEvent paragraphCreateEvent) throws Exception {
+  public void handleParagraphCreateEvent(ParagraphCreateEvent paragraphCreateEvent) {
     addParagraphIndex(paragraphCreateEvent.getNodeId(), paragraphCreateEvent.getParagraphId());
   }
 
   @Override
-  public void handleParagraphRemoveEvent(ParagraphRemoveEvent paragraphRemoveEvent) throws Exception {
+  public void handleParagraphRemoveEvent(ParagraphRemoveEvent paragraphRemoveEvent) {
     deleteParagraphIndex(paragraphRemoveEvent.getNodeId(), paragraphRemoveEvent.getParagraphId());
   }
 
   @Override
-  public void handleParagraphUpdateEvent(ParagraphUpdateEvent paragraphUpdateEvent) throws Exception {
+  public void handleParagraphUpdateEvent(ParagraphUpdateEvent paragraphUpdateEvent) {
     updateParagraphIndex(paragraphUpdateEvent.getNodeId(), paragraphUpdateEvent.getParagraphId());
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/helium/HeliumApplicationFactoryTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.AbstractInterpreterTest;
-import org.apache.zeppelin.interpreter.Interpreter;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
@@ -35,7 +35,6 @@ import org.apache.zeppelin.notebook.NoteManager;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
-import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
@@ -60,7 +59,6 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
       interpreterSetting.setAppEventListener(heliumAppFactory);
     }
 
-    SearchService search = mock(SearchService.class);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     notebookRepo = mock(NotebookRepo.class);
     notebook =
@@ -68,10 +66,9 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
             conf,
             authorizationService,
             notebookRepo,
-            new NoteManager(notebookRepo),
+            new NoteManager(notebookRepo, ZeppelinConfiguration.create()),
             interpreterFactory,
             interpreterSettingManager,
-            search,
             new Credentials());
 
     heliumAppFactory = new HeliumApplicationFactory(notebook, null);
@@ -101,14 +98,17 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
         new String[][]{},
         "", "");
 
-    Note note1 = notebook.createNote("note1", anonymous);
-
+    String note1Id = notebook.createNote("note1", anonymous);
+    Note note1 = notebook.processNote(note1Id,
+      note1Tmp -> {
+        return note1Tmp;
+      });
     Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-
     // make sure interpreter process running
     p1.setText("%mock1 job");
     p1.setAuthenticationInfo(anonymous);
     note1.run(p1.getId());
+
     while(p1.isTerminated()==false || p1.getReturn()==null) Thread.yield();
 
     assertEquals("repl1: job", p1.getReturn().message().get(0).getData());
@@ -132,7 +132,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
 
     // clean
     heliumAppFactory.unload(p1, appId);
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1.getId(), anonymous);
   }
 
   @Test
@@ -147,7 +147,11 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
         new String[][]{},
         "", "");
 
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
+    Note note1 = notebook.processNote(note1Id,
+      note1Tmp -> {
+        return note1Tmp;
+      });
     Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
     // make sure interpreter process running
@@ -170,7 +174,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
     assertEquals(ApplicationState.Status.UNLOADED, app.getStatus());
 
     // clean
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1.getId(), anonymous);
   }
 
 
@@ -186,7 +190,11 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
         new String[][]{},
         "", "");
 
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
+    Note note1 = notebook.processNote(note1Id,
+      note1Tmp -> {
+        return note1Tmp;
+      });
 
     Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
@@ -207,14 +215,18 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
     assertEquals(ApplicationState.Status.UNLOADED, app.getStatus());
 
     // clean
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1.getId(), anonymous);
   }
 
   @Test
   @Ignore
   public void testInterpreterUnbindOfNullReplParagraph() throws IOException {
     // create note
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
+    Note note1 = notebook.processNote(note1Id,
+      note1Tmp -> {
+        return note1Tmp;
+      });
 
     // add paragraph with invalid magic
     Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
@@ -229,7 +241,7 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
     }
 
     // remove note
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1.getId(), anonymous);
   }
 
 
@@ -245,7 +257,11 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
         new String[][]{},
         "", "");
 
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
+    Note note1 = notebook.processNote(note1Id,
+      note1Tmp -> {
+        return note1Tmp;
+      });
     String mock1IntpSettingId = null;
     for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
       if (setting.getName().equals("mock1")) {
@@ -280,6 +296,6 @@ public class HeliumApplicationFactoryTest extends AbstractInterpreterTest {
     assertEquals(ApplicationState.Status.UNLOADED, app.getStatus());
 
     // clean
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1.getId(), anonymous);
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -23,8 +23,15 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
+import org.apache.zeppelin.notebook.AuthorizationService;
 import org.apache.zeppelin.notebook.Note;
+import org.apache.zeppelin.notebook.NoteManager;
 import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.repo.InMemoryNotebookRepo;
+import org.apache.zeppelin.notebook.repo.NotebookRepo;
+import org.apache.zeppelin.search.LuceneSearch;
+import org.apache.zeppelin.search.SearchService;
+import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -48,7 +55,7 @@ public abstract class AbstractInterpreterTest {
 
   protected InterpreterSettingManager interpreterSettingManager;
   protected InterpreterFactory interpreterFactory;
-  protected Notebook mockNotebook;
+  protected Notebook notebook;
   protected File zeppelinHome;
   protected File interpreterDir;
   protected File confDir;
@@ -79,12 +86,15 @@ public abstract class AbstractInterpreterTest {
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_GROUP_DEFAULT.getVarName(), "test");
 
     conf = ZeppelinConfiguration.create();
+    NotebookRepo notebookRepo = new InMemoryNotebookRepo();
+    NoteManager noteManager = new NoteManager(notebookRepo, conf);
+    AuthorizationService authorizationService = new AuthorizationService(noteManager, conf);
     interpreterSettingManager = new InterpreterSettingManager(conf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class), mock(ApplicationEventListener.class));
     interpreterFactory = new InterpreterFactory(interpreterSettingManager);
-
-    mockNotebook = mock(Notebook.class);
-    interpreterSettingManager.setNotebook(mockNotebook);
+    Credentials credentials = new Credentials(conf);
+    notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials);
+    interpreterSettingManager.setNotebook(notebook);
   }
 
   @After

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/InterpreterSettingManagerTest.java
@@ -23,8 +23,7 @@ import org.apache.zeppelin.dep.Dependency;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
 import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.eclipse.aether.RepositoryException;
@@ -41,21 +40,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
 
+  private String note1Id;
+  private String note2Id;
+  private String note3Id;
+  @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
 
-    Note note1 = new Note(new NoteInfo("note1", "/note_1"));
-    Note note2 = new Note(new NoteInfo("note2", "/note_2"));
-    Note note3 = new Note(new NoteInfo("note3", "/note_3"));
-    when(mockNotebook.getNote("note1")).thenReturn(note1);
-    when(mockNotebook.getNote("note2")).thenReturn(note2);
-    when(mockNotebook.getNote("note3")).thenReturn(note3);
+    note1Id = notebook.createNote("/note_1", AuthenticationInfo.ANONYMOUS);
+    note2Id = notebook.createNote("/note_2", AuthenticationInfo.ANONYMOUS);
+    note3Id = notebook.createNote("/note_3", AuthenticationInfo.ANONYMOUS);
   }
 
   @Test
@@ -183,13 +182,13 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     // restart in note page
     // create 3 sessions as it is scoped mode
     interpreterSetting.getOption().setPerUser("scoped");
-    interpreterSetting.getDefaultInterpreter("user1", "note1");
-    interpreterSetting.getDefaultInterpreter("user2", "note2");
-    interpreterSetting.getDefaultInterpreter("user3", "note3");
-    InterpreterGroup interpreterGroup = interpreterSetting.getInterpreterGroup("user1", "note1");
+    interpreterSetting.getDefaultInterpreter("user1", note1Id);
+    interpreterSetting.getDefaultInterpreter("user2", note2Id);
+    interpreterSetting.getDefaultInterpreter("user3", note3Id);
+    InterpreterGroup interpreterGroup = interpreterSetting.getInterpreterGroup("user1", note1Id);
     assertEquals(3, interpreterGroup.getSessionNum());
     // only close user1's session
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(2, interpreterGroup.getSessionNum());
 
     // remove interpreter setting
@@ -206,10 +205,10 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
   @Test
   public void testGetEditor() {
     // get editor setting from interpreter-setting.json
-    Map<String, Object> editor = interpreterSettingManager.getEditorSetting("%test.echo", "note1");
+    Map<String, Object> editor = interpreterSettingManager.getEditorSetting("%test.echo", note1Id);
     assertEquals("java", editor.get("language"));
 
-    editor = interpreterSettingManager.getEditorSetting("%mock1", "note1");
+    editor = interpreterSettingManager.getEditorSetting("%mock1", note1Id);
     assertEquals("python", editor.get("language"));
   }
 
@@ -219,11 +218,11 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser("shared");
     interpreterSetting.getOption().setPerNote("shared");
 
-    interpreterSetting.getOrCreateSession("user1", "note1");
-    interpreterSetting.getOrCreateInterpreterGroup("user2", "note2");
+    interpreterSetting.getOrCreateSession("user1", note1Id);
+    interpreterSetting.getOrCreateInterpreterGroup("user2", note2Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(0, interpreterSetting.getAllInterpreterGroups().size());
   }
 
@@ -233,11 +232,11 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser("isolated");
     interpreterSetting.getOption().setPerNote("shared");
 
-    interpreterSetting.getOrCreateSession("user1", "note1");
-    interpreterSetting.getOrCreateSession("user2", "note2");
+    interpreterSetting.getOrCreateSession("user1", note1Id);
+    interpreterSetting.getOrCreateSession("user2", note2Id);
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
   }
 
@@ -247,11 +246,11 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser("shared");
     interpreterSetting.getOption().setPerNote("isolated");
 
-    interpreterSetting.getOrCreateSession("user1", "note1");
-    interpreterSetting.getOrCreateSession("user2", "note2");
+    interpreterSetting.getOrCreateSession("user1", note1Id);
+    interpreterSetting.getOrCreateSession("user2", note2Id);
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().size());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
   }
 
@@ -261,12 +260,12 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser("scoped");
     interpreterSetting.getOption().setPerNote("shared");
 
-    interpreterSetting.getOrCreateSession("user1", "note1");
-    interpreterSetting.getOrCreateSession("user2", "note2");
+    interpreterSetting.getOrCreateSession("user1", note1Id);
+    interpreterSetting.getOrCreateSession("user2", note2Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
   }
@@ -277,12 +276,12 @@ public class InterpreterSettingManagerTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser("shared");
     interpreterSetting.getOption().setPerNote("scoped");
 
-    interpreterSetting.getOrCreateSession("user1", "note1");
-    interpreterSetting.getOrCreateSession("user2", "note2");
+    interpreterSetting.getOrCreateSession("user1", note1Id);
+    interpreterSetting.getOrCreateSession("user2", note2Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(2, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().size());
     assertEquals(1, interpreterSetting.getAllInterpreterGroups().get(0).getSessionNum());
   }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/recovery/LocalRecoveryStorageTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/recovery/LocalRecoveryStorageTest.java
@@ -28,8 +28,7 @@ import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,11 +37,13 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
   private File recoveryDir = null;
+  private String note1Id;
+  private String note2Id;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_RECOVERY_STORAGE_CLASS.getVarName(),
@@ -51,12 +52,12 @@ public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_RECOVERY_DIR.getVarName(), recoveryDir.getAbsolutePath());
     super.setUp();
 
-    Note note1 = new Note(new NoteInfo("note1", "/note_1"));
-    Note note2 = new Note(new NoteInfo("note2", "/note_2"));
-    when(mockNotebook.getNote("note1")).thenReturn(note1);
-    when(mockNotebook.getNote("note2")).thenReturn(note2);
+    note1Id = notebook.createNote("/note_1", AuthenticationInfo.ANONYMOUS);
+    note2Id = notebook.createNote("/note_2", AuthenticationInfo.ANONYMOUS);
+
   }
 
+  @Override
   @After
   public void tearDown() throws Exception {
     super.tearDown();
@@ -69,7 +70,7 @@ public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
     InterpreterSetting interpreterSetting = interpreterSettingManager.getByName("test");
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     InterpreterContext context1 = InterpreterContext.builder()
             .setNoteId("noteId")
@@ -88,7 +89,7 @@ public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
     InterpreterSetting interpreterSetting = interpreterSettingManager.getByName("test");
     interpreterSetting.getOption().setPerUser(InterpreterOption.ISOLATED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     InterpreterContext context1 = InterpreterContext.builder()
             .setNoteId("noteId")
@@ -97,7 +98,7 @@ public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
     remoteInterpreter1.interpret("hello", context1);
     assertEquals(1, interpreterSettingManager.getRecoveryStorage().restore().size());
 
-    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note2");
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", note2Id);
     RemoteInterpreter remoteInterpreter2 = (RemoteInterpreter) interpreter2;
     InterpreterContext context2 = InterpreterContext.builder()
             .setNoteId("noteId")
@@ -107,7 +108,7 @@ public class LocalRecoveryStorageTest extends AbstractInterpreterTest {
 
     assertEquals(2, interpreterSettingManager.getRecoveryStorage().restore().size());
 
-    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", "note1");
+    interpreterSettingManager.restart(interpreterSetting.getId(), "user1", note1Id);
     assertEquals(1, interpreterSettingManager.getRecoveryStorage().restore().size());
 
     interpreterSetting.close();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectTest.java
@@ -25,16 +25,14 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.resource.LocalResourcePool;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 public class RemoteAngularObjectTest extends AbstractInterpreterTest
     implements AngularObjectRegistryListener {
@@ -48,18 +46,20 @@ public class RemoteAngularObjectTest extends AbstractInterpreterTest
   private AtomicInteger onUpdate;
   private AtomicInteger onRemove;
 
+  private String note1Id;
+
+  @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    Note note1 = new Note(new NoteInfo("note1", "/note_1"));
-    when(mockNotebook.getNote("note1")).thenReturn(note1);
+    note1Id = notebook.createNote("/note_1", AuthenticationInfo.ANONYMOUS);
 
     onAdd = new AtomicInteger(0);
     onUpdate = new AtomicInteger(0);
     onRemove = new AtomicInteger(0);
 
     interpreterSetting = interpreterSettingManager.getInterpreterSettingByName("test");
-    intp = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", "note1", "mock_ao");
+    intp = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", note1Id, "mock_ao");
     localRegistry = (RemoteAngularObjectRegistry) intp.getInterpreterGroup().getAngularObjectRegistry();
 
     context = InterpreterContext.builder()

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterTest.java
@@ -32,8 +32,7 @@ import org.apache.zeppelin.interpreter.InterpreterOption;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,19 +50,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
 
 public class RemoteInterpreterTest extends AbstractInterpreterTest {
 
   private InterpreterSetting interpreterSetting;
+  private String note1Id;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
     interpreterSetting = interpreterSettingManager.getInterpreterSettingByName("test");
-    Note note1 = new Note(new NoteInfo("note1", "/note_1"));
-    when(mockNotebook.getNote("note1")).thenReturn(note1);
+    note1Id = notebook.createNote("/note_1", AuthenticationInfo.ANONYMOUS);
   }
 
   @Override
@@ -75,8 +73,8 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testSharedMode() throws InterpreterException, IOException {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
-    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", note1Id);
     assertTrue(interpreter1 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     assertTrue(interpreter2 instanceof RemoteInterpreter);
@@ -109,8 +107,8 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testScopedMode() throws InterpreterException, IOException {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SCOPED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
-    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", note1Id);
     assertTrue(interpreter1 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     assertTrue(interpreter2 instanceof RemoteInterpreter);
@@ -153,8 +151,8 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testIsolatedMode() throws InterpreterException, IOException {
     interpreterSetting.getOption().setPerUser(InterpreterOption.ISOLATED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
-    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
+    Interpreter interpreter2 = interpreterSetting.getDefaultInterpreter("user2", note1Id);
     assertTrue(interpreter1 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
     assertTrue(interpreter2 instanceof RemoteInterpreter);
@@ -197,7 +195,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testExecuteIncorrectPrecode() throws TTransportException, IOException, InterpreterException {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
     interpreterSetting.setProperty("zeppelin.SleepInterpreter.precode", "fail test");
-    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
     InterpreterContext context1 = createDummyInterpreterContext();;
     assertEquals(Code.ERROR, interpreter1.interpret("10", context1).code());
   }
@@ -206,7 +204,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testExecuteCorrectPrecode() throws TTransportException, IOException, InterpreterException {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
     interpreterSetting.setProperty("zeppelin.SleepInterpreter.precode", "1");
-    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
     InterpreterContext context1 = createDummyInterpreterContext();
     assertEquals(Code.SUCCESS, interpreter1.interpret("10", context1).code());
   }
@@ -216,7 +214,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     interpreterSetting.setProperty("zeppelin.interpreter.echo.fail", "true");
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
 
-    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter1 = interpreterSetting.getDefaultInterpreter("user1", note1Id);
     assertTrue(interpreter1 instanceof RemoteInterpreter);
     RemoteInterpreter remoteInterpreter1 = (RemoteInterpreter) interpreter1;
 
@@ -229,7 +227,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
     // by default SleepInterpreter would use FIFOScheduler
 
-    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
     final InterpreterContext context1 = createDummyInterpreterContext();
     // run this dummy interpret method first to launch the RemoteInterpreterProcess to avoid the
     // time overhead of launching the process.
@@ -270,7 +268,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
     interpreterSetting.setProperty("zeppelin.SleepInterpreter.parallel", "true");
 
-    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
     final InterpreterContext context1 = createDummyInterpreterContext();
 
     // run this dummy interpret method first to launch the RemoteInterpreterProcess to avoid the
@@ -310,8 +308,8 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   @Test
   public void testRemoteInterpreterSharesTheSameSchedulerInstanceInTheSameGroup() {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SHARED);
-    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
-    Interpreter interpreter2 = interpreterSetting.getInterpreter("user1", "note1", "echo");
+    Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
+    Interpreter interpreter2 = interpreterSetting.getInterpreter("user1", note1Id, "echo");
     assertEquals(interpreter1.getInterpreterGroup(), interpreter2.getInterpreterGroup());
     assertEquals(interpreter1.getScheduler(), interpreter2.getScheduler());
   }
@@ -319,13 +317,13 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   @Test
   public void testMultiInterpreterSession() {
     interpreterSetting.getOption().setPerUser(InterpreterOption.SCOPED);
-    Interpreter interpreter1_user1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
-    Interpreter interpreter2_user1 = interpreterSetting.getInterpreter("user1", "note1", "echo");
+    Interpreter interpreter1_user1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
+    Interpreter interpreter2_user1 = interpreterSetting.getInterpreter("user1", note1Id, "echo");
     assertEquals(interpreter1_user1.getInterpreterGroup(), interpreter2_user1.getInterpreterGroup());
     assertEquals(interpreter1_user1.getScheduler(), interpreter2_user1.getScheduler());
 
-    Interpreter interpreter1_user2 = interpreterSetting.getInterpreter("user2", "note1", "sleep");
-    Interpreter interpreter2_user2 = interpreterSetting.getInterpreter("user2", "note1", "echo");
+    Interpreter interpreter1_user2 = interpreterSetting.getInterpreter("user2", note1Id, "sleep");
+    Interpreter interpreter2_user2 = interpreterSetting.getInterpreter("user2", note1Id, "echo");
     assertEquals(interpreter1_user2.getInterpreterGroup(), interpreter2_user2.getInterpreterGroup());
     assertEquals(interpreter1_user2.getScheduler(), interpreter2_user2.getScheduler());
 
@@ -339,7 +337,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     final AngularObjectRegistry registry = new AngularObjectRegistry("spark", null);
     registry.add("name_1", "value_1", "note_1", "paragraphId_1");
     registry.add("name_2", "value_2", "node_2", "paragraphId_2");
-    Interpreter interpreter = interpreterSetting.getInterpreter("user1", "note1", "angular_obj");
+    Interpreter interpreter = interpreterSetting.getInterpreter("user1", note1Id, "angular_obj");
     interpreter.getInterpreterGroup().setAngularObjectRegistry(registry);
 
     final InterpreterContext context = createDummyInterpreterContext();
@@ -365,7 +363,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     interpreterSetting.setProperty("ENV_1", "VALUE_1");
     interpreterSetting.setProperty("property_1", "value_1");
 
-    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "get");
+    final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "get");
     final InterpreterContext context1 = createDummyInterpreterContext();
 
     assertEquals("VALUE_1", interpreter1.interpret("getEnv ENV_1", context1).message().get(0).getData());
@@ -389,7 +387,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     gui.select("select_id", paramOptions, "default");
     gui.textbox("textbox_id");
     Map<String, Input> expected = new LinkedHashMap<>(gui.getForms());
-    Interpreter interpreter = interpreterSetting.getDefaultInterpreter("user1", "note1");
+    Interpreter interpreter = interpreterSetting.getDefaultInterpreter("user1", note1Id);
     InterpreterContext context = createDummyInterpreterContext();
 
     interpreter.interpret("text", context);
@@ -400,7 +398,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
   public void testFailToLaunchInterpreterProcess_InvalidRunner() {
     try {
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_REMOTE_RUNNER.getVarName(), "invalid_runner");
-      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
       final InterpreterContext context1 = createDummyInterpreterContext();
       // run this dummy interpret method first to launch the RemoteInterpreterProcess to avoid the
       // time overhead of launching the process.
@@ -420,7 +418,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
     try {
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_REMOTE_RUNNER.getVarName(),
                zeppelinHome.getAbsolutePath() + "/zeppelin-zengine/src/test/resources/bin/interpreter_invalid.sh");
-      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
       final InterpreterContext context1 = createDummyInterpreterContext();
       // run this dummy interpret method first to launch the RemoteInterpreterProcess to avoid the
       // time overhead of launching the process.
@@ -441,7 +439,7 @@ public class RemoteInterpreterTest extends AbstractInterpreterTest {
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_REMOTE_RUNNER.getVarName(),
               zeppelinHome.getAbsolutePath() + "/zeppelin-zengine/src/test/resources/bin/interpreter_timeout.sh");
       System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "10000");
-      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", "note1", "sleep");
+      final Interpreter interpreter1 = interpreterSetting.getInterpreter("user1", note1Id, "sleep");
       final InterpreterContext context1 = createDummyInterpreterContext();
       // run this dummy interpret method first to launch the RemoteInterpreterProcess to avoid the
       // time overhead of launching the process.

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1656,12 +1656,12 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       }
 
       @Override
-      public void onParagraphUpdate(Paragraph p) throws IOException {
+      public void onParagraphUpdate(Paragraph p) {
 
       }
 
       @Override
-      public void onParagraphStatusChange(Paragraph p, Status status) throws IOException {
+      public void onParagraphStatusChange(Paragraph p, Status status) {
 
       }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -38,7 +38,6 @@ import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
 import org.apache.zeppelin.resource.LocalResourcePool;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Job.Status;
-import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
 import org.junit.After;
@@ -53,6 +52,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,15 +95,13 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
     super.setUp();
 
-    SearchService search = mock(SearchService.class);
     notebookRepo = new VFSNotebookRepo();
     notebookRepo.init(conf);
-    noteManager = new NoteManager(notebookRepo);
+    noteManager = new NoteManager(notebookRepo, conf);
     authorizationService = new AuthorizationService(noteManager, conf);
 
     credentials = new Credentials(conf);
-    notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, search,
-            credentials, null);
+    notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials, null);
     notebook.setParagraphJobListener(this);
     schedulerService = new QuartzSchedulerService(conf, notebook);
     schedulerService.waitForFinishInit();
@@ -123,15 +121,13 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     Notebook notebook;
 
     notebookRepo = new DummyNotebookRepo();
-    notebook = new Notebook(conf, mock(AuthorizationService.class), notebookRepo, new NoteManager(notebookRepo), interpreterFactory,
-        interpreterSettingManager, null,
-        credentials, null);
+    notebook = new Notebook(conf, mock(AuthorizationService.class), notebookRepo, new NoteManager(notebookRepo, conf), interpreterFactory,
+        interpreterSettingManager, credentials, null);
     assertFalse("Revision is not supported in DummyNotebookRepo", notebook.isRevisionSupported());
 
     notebookRepo = new DummyNotebookRepoWithVersionControl();
-    notebook = new Notebook(conf, mock(AuthorizationService.class), notebookRepo, new NoteManager(notebookRepo), interpreterFactory,
-        interpreterSettingManager, null,
-        credentials, null);
+    notebook = new Notebook(conf, mock(AuthorizationService.class), notebookRepo, new NoteManager(notebookRepo, conf), interpreterFactory,
+        interpreterSettingManager, credentials, null);
     assertTrue("Revision is supported in DummyNotebookRepoWithVersionControl",
         notebook.isRevisionSupported());
   }
@@ -277,167 +273,206 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   @Test
   public void testSelectingReplImplementation() throws IOException {
-    Note note = notebook.createNote("note1", anonymous);
-    // run with default repl
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config = p1.getConfig();
-    config.put("enabled", true);
-    p1.setConfig(config);
-    p1.setText("%mock1 hello world");
-    p1.setAuthenticationInfo(anonymous);
-    note.run(p1.getId());
-    while (p1.isTerminated() == false || p1.getReturn() == null) Thread.yield();
-    assertEquals("repl1: hello world", p1.getReturn().message().get(0).getData());
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        // run with default repl
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = p1.getConfig();
+        config.put("enabled", true);
+        p1.setConfig(config);
+        p1.setText("%mock1 hello world");
+        p1.setAuthenticationInfo(anonymous);
+        note.run(p1.getId());
+        while (p1.isTerminated() == false || p1.getReturn() == null) Thread.yield();
+        assertEquals("repl1: hello world", p1.getReturn().message().get(0).getData());
 
-    // run with specific repl
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p2.setConfig(config);
-    p2.setText("%mock2 hello world");
-    p2.setAuthenticationInfo(anonymous);
-    note.run(p2.getId());
-    while (p2.isTerminated() == false || p2.getReturn() == null) Thread.yield();
-    assertEquals("repl2: hello world", p2.getReturn().message().get(0).getData());
-    notebook.removeNote(note, anonymous);
+        // run with specific repl
+        Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p2.setConfig(config);
+        p2.setText("%mock2 hello world");
+        p2.setAuthenticationInfo(anonymous);
+        note.run(p2.getId());
+        while (p2.isTerminated() == false || p2.getReturn() == null) Thread.yield();
+        assertEquals("repl2: hello world", p2.getReturn().message().get(0).getData());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testReloadAndSetInterpreter() throws IOException {
-    Note note = notebook.createNote("note1", AuthenticationInfo.ANONYMOUS);
-    Paragraph p1 = note.insertNewParagraph(0, AuthenticationInfo.ANONYMOUS);
-    p1.setText("%md hello world");
-    notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
+    String noteId = notebook.createNote("note1", AuthenticationInfo.ANONYMOUS);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p1 = note.insertNewParagraph(0, AuthenticationInfo.ANONYMOUS);
+        p1.setText("%md hello world");
+        notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
+        return null;
+      });
 
     // when load
     notebook.reloadAllNotes(anonymous);
-    assertEquals(1, notebook.getAllNotes().size());
+    assertEquals(1, notebook.getNotesInfo().size());
 
     // then interpreter factory should be injected into all the paragraphs
-    note = notebook.getNote(note.getId());
-    try {
-      note.getParagraphs().get(0).getBindedInterpreter();
-      fail("Should throw InterpreterNotFoundException");
-    } catch (InterpreterNotFoundException e) {
+    notebook.processNote(noteId,
+      newNote -> {
+        try {
+          newNote.getParagraphs().get(0).getBindedInterpreter();
+          fail("Should throw InterpreterNotFoundException");
+        } catch (InterpreterNotFoundException e) {
 
-    }
+        }
+        return null;
+      });
+
   }
 
   @Test
   public void testReloadAllNotes() throws IOException {
-    Note note1 = notebook.createNote("note1", AuthenticationInfo.ANONYMOUS);
-    Paragraph p1 = note1.insertNewParagraph(0, AuthenticationInfo.ANONYMOUS);
-    p1.setText("%md hello world");
+    String note1Id = notebook.createNote("note1", AuthenticationInfo.ANONYMOUS);
+    notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.insertNewParagraph(0, AuthenticationInfo.ANONYMOUS);
+        p1.setText("%md hello world");
+        return null;
+      });
 
-    Note note2 = notebook.cloneNote(note1.getId(), "copied note", AuthenticationInfo.ANONYMOUS);
+    String note2Id = notebook.cloneNote(note1Id, "copied note", AuthenticationInfo.ANONYMOUS);
 
     // load copied notebook on memory when reloadAllNotes() is called
-    Note copiedNote = notebookRepo.get(note2.getId(), note2.getPath(), anonymous);
+    Note copiedNote = notebookRepo.get(note2Id, "/copied note", anonymous);
     notebook.reloadAllNotes(anonymous);
-    List<Note> notes = notebook.getAllNotes();
-    assertEquals(2 , notes.size());
-    assertEquals(notes.get(0).getId(), copiedNote.getId());
-    assertEquals(notes.get(0).getName(), copiedNote.getName());
+    List<NoteInfo> notesInfo = notebook.getNotesInfo();
+    assertEquals(2 , notesInfo.size());
+    NoteInfo found = null;
+    for (NoteInfo noteInfo : notesInfo) {
+      if (noteInfo.getId().equals(copiedNote.getId())) {
+        found = noteInfo;
+        break;
+      }
+    }
+
+    assertNotNull(found);
+    assertEquals(found.getId(), copiedNote.getId());
+    assertEquals(notebook.processNote(found.getId(), Note::getName), copiedNote.getName());
     // format has make some changes due to
     // Notebook.convertFromSingleResultToMultipleResultsFormat
-    assertEquals(notes.get(0).getParagraphs().size(), copiedNote.getParagraphs().size());
-    assertEquals(notes.get(0).getParagraphs().get(0).getText(),
-        copiedNote.getParagraphs().get(0).getText());
-    assertEquals(notes.get(0).getParagraphs().get(0).settings,
-        copiedNote.getParagraphs().get(0).settings);
-    assertEquals(notes.get(0).getParagraphs().get(0).getTitle(),
-        copiedNote.getParagraphs().get(0).getTitle());
-
+    notebook.processNote(found.getId(),
+      note -> {
+        assertEquals(note.getParagraphs().size(), copiedNote.getParagraphs().size());
+        assertEquals(note.getParagraphs().get(0).getText(),
+            copiedNote.getParagraphs().get(0).getText());
+        assertEquals(note.getParagraphs().get(0).settings,
+            copiedNote.getParagraphs().get(0).settings);
+        assertEquals(note.getParagraphs().get(0).getTitle(),
+            copiedNote.getParagraphs().get(0).getTitle());
+        return null;
+      });
 
     // delete notebook from notebook list when reloadAllNotes() is called
     notebook.reloadAllNotes(anonymous);
-    notes = notebook.getAllNotes();
-    assertEquals(2, notes.size());
+    notesInfo = notebook.getNotesInfo();
+    assertEquals(2, notesInfo.size());
   }
 
   @Test
   public void testLoadAllNotes() {
-    Note note;
     try {
-      assertEquals(0, notebook.getAllNotes().size());
-      note = notebook.createNote("note1", anonymous);
-      Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      Map<String, Object> config = p1.getConfig();
-      config.put("enabled", true);
-      p1.setConfig(config);
-      p1.setText("hello world");
-      notebook.saveNote(note, anonymous);
+      assertEquals(0, notebook.getNotesInfo().size());
+      String noteId = notebook.createNote("note1", anonymous);
+      notebook.processNote(noteId,
+        note -> {
+          Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          Map<String, Object> config = p1.getConfig();
+          config.put("enabled", true);
+          p1.setConfig(config);
+          p1.setText("hello world");
+          notebook.saveNote(note, anonymous);
+          return null;
+        });
     } catch (IOException fe) {
       logger.warn("Failed to create note and paragraph. Possible problem with persisting note, safe to ignore", fe);
     }
 
-    assertEquals(1, notebook.getAllNotes().size());
+    assertEquals(1, notebook.getNotesInfo().size());
   }
 
   @Test
   public void testPersist() throws IOException, SchedulerException {
-    Note note = notebook.createNote("note1", anonymous);
-
-    // run with default repl
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config = p1.getConfig();
-    config.put("enabled", true);
-    p1.setConfig(config);
-    p1.setText("hello world");
-    notebook.saveNote(note, anonymous);
-
-//    Notebook notebook2 = new Notebook(
-//        conf, notebookRepo,
-//        new InterpreterFactory(interpreterSettingManager),
-//        interpreterSettingManager, null, null, null);
-
-    //assertEquals(1, notebook2.getAllNotes().size());
-    notebook.removeNote(note, anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        // run with default repl
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = p1.getConfig();
+        config.put("enabled", true);
+        p1.setConfig(config);
+        p1.setText("hello world");
+        notebook.saveNote(note, anonymous);
+        assertEquals(1, notebook.getNotesInfo().size());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testCreateNoteWithSubject() throws IOException, SchedulerException, RepositoryException {
     AuthenticationInfo subject = new AuthenticationInfo("user1");
-    Note note = notebook.createNote("note1", subject);
-
-    assertNotNull(authorizationService.getOwners(note.getId()));
-    assertEquals(1, authorizationService.getOwners(note.getId()).size());
+    String noteId = notebook.createNote("note1", subject);
+    assertNotNull(authorizationService.getOwners(noteId));
+    assertEquals(1, authorizationService.getOwners(noteId).size());
     Set<String> owners = new HashSet<>();
     owners.add("user1");
-    assertEquals(owners, authorizationService.getOwners(note.getId()));
-    notebook.removeNote(note, anonymous);
+    assertEquals(owners, authorizationService.getOwners(noteId));
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testClearParagraphOutput() throws IOException, SchedulerException {
-    Note note = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config = p1.getConfig();
-    config.put("enabled", true);
-    p1.setConfig(config);
-    p1.setText("%mock1 hello world");
-    p1.setAuthenticationInfo(anonymous);
-    note.run(p1.getId());
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = p1.getConfig();
+        config.put("enabled", true);
+        p1.setConfig(config);
+        p1.setText("%mock1 hello world");
+        p1.setAuthenticationInfo(anonymous);
+        note.run(p1.getId());
 
-    while (p1.isTerminated() == false || p1.getReturn() == null) Thread.yield();
-    assertEquals("repl1: hello world", p1.getReturn().message().get(0).getData());
+        while (p1.isTerminated() == false || p1.getReturn() == null) Thread.yield();
+        assertEquals("repl1: hello world", p1.getReturn().message().get(0).getData());
 
-    // clear paragraph output/result
-    note.clearParagraphOutput(p1.getId());
-    assertNull(p1.getReturn());
-    notebook.removeNote(note, anonymous);
+        // clear paragraph output/result
+        note.clearParagraphOutput(p1.getId());
+        assertNull(p1.getReturn());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testRunBlankParagraph() throws IOException, SchedulerException, InterruptedException {
-    Note note = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("");
-    p1.setAuthenticationInfo(anonymous);
-    note.run(p1.getId());
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p1.setText("");
+        p1.setAuthenticationInfo(anonymous);
+        note.run(p1.getId());
+        try {
+          Thread.sleep(2 * 1000);
+        } catch (InterruptedException e) {
+          fail("Interrupted");
+        }
+        assertEquals(Status.FINISHED, p1.getStatus());
+        assertNull(p1.getDateStarted());
+        return null;
+      });
 
-    Thread.sleep(2 * 1000);
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertNull(p1.getDateStarted());
-    notebook.removeNote(note, anonymous);
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
@@ -445,9 +480,12 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     try {
       LOGGER.info("--------------- Test testRemoveNote ---------------");
       // create a note and a paragraph
-      Note note = notebook.createNote("note1", anonymous);
+      String noteId = notebook.createNote("note1", anonymous);
       int mock1ProcessNum = interpreterSettingManager.getByName("mock1").getAllInterpreterGroups().size();
-      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+      Paragraph p = notebook.processNote(noteId,
+        note -> {
+          return note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        });
       Map<String, Object> config = new HashMap<>();
       p.setConfig(config);
       p.setText("%mock1 sleep 100000");
@@ -462,7 +500,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       }
       assertEquals(mock1ProcessNum + 1, interpreterSettingManager.getByName("mock1").getAllInterpreterGroups().size());
       LOGGER.info("--------------- Finish Test testRemoveNote ---------------");
-      notebook.removeNote(note, anonymous);
+      notebook.removeNote(noteId, anonymous);
       // stop interpreter process is async, so we wait for 5 seconds here.
       Thread.sleep(5 * 1000);
       assertEquals(mock1ProcessNum, interpreterSettingManager.getByName("mock1").getAllInterpreterGroups().size());
@@ -477,134 +515,182 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   public void testRemoveCorruptedNote() throws IOException{
       LOGGER.info("--------------- Test testRemoveCorruptedNote ---------------");
       // create a note and a paragraph
-      Note corruptedNote = notebook.createNote("note1", anonymous);
-      String corruptedNotePath = notebookDir.getAbsolutePath() + corruptedNote.getPath() + "_" + corruptedNote.getId() + ".zpln";
+      String corruptedNoteId = notebook.createNote("note1", anonymous);
+      String corruptedNotePath = notebook.processNote(corruptedNoteId,
+        corruptedNote -> {
+          return notebookDir.getAbsolutePath() + corruptedNote.getPath() + "_" + corruptedNote.getId() + ".zpln";
+        });
+
       // corrupt note
       FileWriter myWriter = new FileWriter(corruptedNotePath);
       myWriter.write("{{{I'm corrupted;;;");
       myWriter.close();
       LOGGER.info("--------------- Finish Test testRemoveCorruptedNote ---------------");
-      int numberOfNotes = notebook.getAllNotes().size();
-      notebook.removeNote(corruptedNote, anonymous);
-      assertEquals(numberOfNotes - 1, notebook.getAllNotes().size());
+      int numberOfNotes = notebook.getNotesInfo().size();
+      notebook.removeNote(corruptedNoteId, anonymous);
+      assertEquals(numberOfNotes - 1, notebook.getNotesInfo().size());
       LOGGER.info("--------------- Finish Test testRemoveCorruptedNote ---------------");
   }
 
   @Test
   public void testInvalidInterpreter() throws IOException, InterruptedException {
-    Note note = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%invalid abc");
-    p1.setAuthenticationInfo(anonymous);
-    note.run(p1.getId());
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p1.setText("%invalid abc");
+        p1.setAuthenticationInfo(anonymous);
+        note.run(p1.getId());
 
-    Thread.sleep(2 * 1000);
-    assertEquals(Status.ERROR, p1.getStatus());
-    InterpreterResult result = p1.getReturn();
-    assertEquals(InterpreterResult.Code.ERROR, result.code());
-    assertEquals("Interpreter invalid not found", result.message().get(0).getData());
-    assertNull(p1.getDateStarted());
-    notebook.removeNote(note, anonymous);
+        try {
+          Thread.sleep(2 * 1000);
+        } catch (InterruptedException e) {
+          fail("Interrupted");
+        }
+        assertEquals(Status.ERROR, p1.getStatus());
+        InterpreterResult result = p1.getReturn();
+        assertEquals(InterpreterResult.Code.ERROR, result.code());
+        assertEquals("Interpreter invalid not found", result.message().get(0).getData());
+        assertNull(p1.getDateStarted());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testRunAll() throws Exception {
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        // p1
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config1 = p1.getConfig();
+        config1.put("enabled", true);
+        p1.setConfig(config1);
+        p1.setText("%mock1 p1");
 
-    // p1
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config1 = p1.getConfig();
-    config1.put("enabled", true);
-    p1.setConfig(config1);
-    p1.setText("%mock1 p1");
+        // p2
+        Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config2 = p2.getConfig();
+        config2.put("enabled", false);
+        p2.setConfig(config2);
+        p2.setText("%mock1 p2");
 
-    // p2
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config2 = p2.getConfig();
-    config2.put("enabled", false);
-    p2.setConfig(config2);
-    p2.setText("%mock1 p2");
+        // p3
+        Paragraph p3 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p3.setText("%mock1 p3");
 
-    // p3
-    Paragraph p3 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p3.setText("%mock1 p3");
+        // when
+        try {
+          note.runAll(anonymous, true, false, new HashMap<>());
+        } catch (Exception e) {
+          fail("Exception in runAll");
+        }
 
-    // when
-    note.runAll(anonymous, true, false, new HashMap<>());
-
-    assertEquals("repl1: p1", p1.getReturn().message().get(0).getData());
-    assertNull(p2.getReturn());
-    assertEquals("repl1: p3", p3.getReturn().message().get(0).getData());
-
-    notebook.removeNote(note, anonymous);
+        assertEquals("repl1: p1", p1.getReturn().message().get(0).getData());
+        assertNull(p2.getReturn());
+        assertEquals("repl1: p3", p3.getReturn().message().get(0).getData());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testSchedule() throws InterruptedException, IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config = new HashMap<>();
-    p.setConfig(config);
-    p.setText("p1");
-    Date dateFinished = p.getDateFinished();
-    assertNull(dateFinished);
+    String noteId = notebook.createNote("note1", anonymous);
+    // use write lock, because note configuration is overwritten
+    Paragraph paragraph = notebook.processNote(noteId,
+      note -> {
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = new HashMap<>();
+        p.setConfig(config);
+        p.setText("p1");
+        Date dateFinished = p.getDateFinished();
+        assertNull(dateFinished);
 
-    // set cron scheduler, once a second
-    config = note.getConfig();
-    config.put("enabled", true);
-    config.put("cron", "* * * * * ?");
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+        // set cron scheduler, once a second
+        config = note.getConfig();
+        config.put("enabled", true);
+        config.put("cron", "* * * * * ?");
+        note.setConfig(config);
+        return p;
+      });
+    schedulerService.refreshCron(noteId);
     Thread.sleep(2 * 1000);
 
     // remove cron scheduler.
-    config.put("cron", null);
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
-    Thread.sleep(2 * 1000);
-    dateFinished = p.getDateFinished();
+    // use write lock, because note configuration is overwritten
+    notebook.processNote(noteId,
+      note -> {
+        Map<String, Object> config = note.getConfig();
+        config.put("cron", null);
+        note.setConfig(config);
+        return null;
+      });
+    schedulerService.refreshCron(noteId);
+    // wait a little until running processes are finished
+    Thread.sleep(3 * 1000);
+    Date dateFinished = paragraph.getDateFinished();
     assertNotNull(dateFinished);
+    // wait a little bit to check that no other tasks are being executed
     Thread.sleep(2 * 1000);
-    assertEquals(dateFinished, p.getDateFinished());
-    notebook.removeNote(note, anonymous);
+    assertEquals(dateFinished, paragraph.getDateFinished());
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testScheduleAgainstRunningAndPendingParagraph() throws InterruptedException, IOException {
     // create a note
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
     // append running and pending paragraphs to the note
-    for (Status status : new Status[]{Status.RUNNING, Status.PENDING}) {
-      Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-      Map<String, Object> config = new HashMap<>();
-      p.setConfig(config);
-      p.setText("p");
-      p.setStatus(status);
-      assertNull(p.getDateFinished());
-    }
+    // use write lock, because note configuration is overwritten
+    notebook.processNote(noteId,
+      note -> {
+        for (Status status : new Status[]{Status.RUNNING, Status.PENDING}) {
+          Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+          Map<String, Object> config = new HashMap<>();
+          p.setConfig(config);
+          p.setText("p");
+          p.setStatus(status);
+          assertNull(p.getDateFinished());
+        }
+        // set cron scheduler, once a second
+        Map<String, Object> config = note.getConfig();
+        config.put("enabled", true);
+        config.put("cron", "* * * * * ?");
+        note.setConfig(config);
+        return null;
+      });
 
-    // set cron scheduler, once a second
-    Map<String, Object> config = note.getConfig();
-    config.put("enabled", true);
-    config.put("cron", "* * * * * ?");
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+
+
+    schedulerService.refreshCron(noteId);
     Thread.sleep(2 * 1000);
 
     // remove cron scheduler.
-    config.put("cron", null);
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+    notebook.processNote(noteId,
+      note -> {
+        Map<String, Object> config = note.getConfig();
+        config.put("cron", null);
+        note.setConfig(config);
+        return null;
+      });
+
+    schedulerService.refreshCron(noteId);
     Thread.sleep(2 * 1000);
 
     // check if the executions of the running and pending paragraphs were skipped
-    for (Paragraph p : note.getParagraphs()) {
-      assertNull(p.getDateFinished());
-    }
+    notebook.processNote(noteId,
+      note -> {
+        for (Paragraph p : note.getParagraphs()) {
+          assertNull(p.getDateFinished());
+        }
+        return null;
+      });
 
     // remove the note
-    notebook.removeNote(note, anonymous);
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
@@ -613,9 +699,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     final String everySecondCron = "* * * * * ?";
     // each run starts a new JVM and the job takes about ~5 seconds
     final CountDownLatch jobsToExecuteCount = new CountDownLatch(5);
-    final Note note = notebook.createNote("note1", anonymous);
+    final String noteId = notebook.createNote("note1", anonymous);
 
-    executeNewParagraphByCron(note, everySecondCron);
+    executeNewParagraphByCron(noteId, everySecondCron);
     afterStatusChangedListener = new StatusChangedListener() {
       @Override
       public void onStatusChanged(Job<?> job, Status before, Status after) {
@@ -627,18 +713,22 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     assertTrue(jobsToExecuteCount.await(timeout, TimeUnit.SECONDS));
 
-    terminateScheduledNote(note);
+    terminateScheduledNote(noteId);
     afterStatusChangedListener = null;
   }
 
-  private void executeNewParagraphByCron(Note note, String cron) {
-    Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    paragraph.setText("p");
-    Map<String, Object> config = note.getConfig();
-    config.put("enabled", true);
-    config.put("cron", cron);
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+  private void executeNewParagraphByCron(String noteId, String cron) throws IOException {
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph paragraph = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        paragraph.setText("p");
+        Map<String, Object> config = note.getConfig();
+        config.put("enabled", true);
+        config.put("cron", cron);
+        note.setConfig(config);
+        return null;
+      });
+    schedulerService.refreshCron(noteId);
   }
 
   @Test
@@ -649,9 +739,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       final int timeout = 10;
       final String everySecondCron = "* * * * * ?";
       final CountDownLatch jobsToExecuteCount = new CountDownLatch(5);
-      final Note note = notebook.createNote("note1", anonymous);
+      final String noteId = notebook.createNote("note1", anonymous);
 
-      executeNewParagraphByCron(note, everySecondCron);
+      executeNewParagraphByCron(noteId, everySecondCron);
       afterStatusChangedListener = new StatusChangedListener() {
         @Override
         public void onStatusChanged(Job<?> job, Status before, Status after) {
@@ -664,7 +754,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       //This job should not run because "ZEPPELIN_NOTEBOOK_CRON_ENABLE" is set to false
       assertFalse(jobsToExecuteCount.await(timeout, TimeUnit.SECONDS));
 
-      terminateScheduledNote(note);
+      terminateScheduledNote(noteId);
       afterStatusChangedListener = null;
     } finally {
       System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_ENABLE.getVarName(), "true");
@@ -680,9 +770,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       final String everySecondCron = "* * * * * ?";
       // each run starts a new JVM and the job takes about ~5 seconds
       final CountDownLatch jobsToExecuteCount = new CountDownLatch(5);
-      final Note note = notebook.createNote("note1", anonymous);
+      final String noteId = notebook.createNote("note1", anonymous);
 
-      executeNewParagraphByCron(note, everySecondCron);
+      executeNewParagraphByCron(noteId, everySecondCron);
       afterStatusChangedListener = new StatusChangedListener() {
         @Override
         public void onStatusChanged(Job<?> job, Status before, Status after) {
@@ -695,13 +785,13 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       //This job should not run because it's path does not matches "ZEPPELIN_NOTEBOOK_CRON_FOLDERS"
       assertFalse(jobsToExecuteCount.await(timeout, TimeUnit.SECONDS));
 
-      terminateScheduledNote(note);
+      terminateScheduledNote(noteId);
       afterStatusChangedListener = null;
 
-      final Note noteNameSystem = notebook.createNote("/System/test1", anonymous);
+      final String noteNameSystemId = notebook.createNote("/System/test1", anonymous);
       final CountDownLatch jobsToExecuteCountNameSystem = new CountDownLatch(5);
 
-      executeNewParagraphByCron(noteNameSystem, everySecondCron);
+      executeNewParagraphByCron(noteNameSystemId, everySecondCron);
       afterStatusChangedListener = new StatusChangedListener() {
         @Override
         public void onStatusChanged(Job<?> job, Status before, Status after) {
@@ -714,43 +804,53 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
       //This job should run because it's path contains "System/"
       assertTrue(jobsToExecuteCountNameSystem.await(timeout, TimeUnit.SECONDS));
 
-      terminateScheduledNote(noteNameSystem);
+      terminateScheduledNote(noteNameSystemId);
       afterStatusChangedListener = null;
     } finally {
       System.clearProperty(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS.getVarName());
     }
   }
 
-  private void terminateScheduledNote(Note note) throws IOException {
-    note.getConfig().remove("cron");
-    schedulerService.refreshCron(note.getId());
-    notebook.removeNote(note, anonymous);
+  private void terminateScheduledNote(String noteId) throws IOException {
+    notebook.processNote(noteId,
+      note -> {
+        note.getConfig().remove("cron");
+        return null;
+      });
+
+    schedulerService.refreshCron(noteId);
+    notebook.removeNote(noteId, anonymous);
   }
 
 
   // @Test
   public void testAutoRestartInterpreterAfterSchedule() throws InterruptedException, IOException, InterpreterNotFoundException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
+    // use write lock, because we are overwrite the note configuration
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = new HashMap<>();
+        p.setConfig(config);
+        p.setText("%mock1 sleep 1000");
 
-    Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    Map<String, Object> config = new HashMap<>();
-    p.setConfig(config);
-    p.setText("%mock1 sleep 1000");
+        Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p2.setConfig(config);
+        p2.setText("%mock2 sleep 500");
 
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p2.setConfig(config);
-    p2.setText("%mock2 sleep 500");
+        // set cron scheduler, once a second
+        config = note.getConfig();
+        config.put("enabled", true);
+        config.put("cron", "1/3 * * * * ?");
+        config.put("releaseresource", true);
+        note.setConfig(config);
+        return null;
+      });
 
-    // set cron scheduler, once a second
-    config = note.getConfig();
-    config.put("enabled", true);
-    config.put("cron", "1/3 * * * * ?");
-    config.put("releaseresource", true);
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+    schedulerService.refreshCron(noteId);
 
-    ExecutionContext executionContext = new ExecutionContext(anonymous.getUser(), note.getId(), "test");
+    ExecutionContext executionContext = new ExecutionContext(anonymous.getUser(), noteId, "test");
     RemoteInterpreter mock1 = (RemoteInterpreter) interpreterFactory.getInterpreter("mock1", executionContext);
 
     RemoteInterpreter mock2 = (RemoteInterpreter) interpreterFactory.getInterpreter("mock2", executionContext);
@@ -766,52 +866,76 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     }
 
     // remove cron scheduler.
-    config.put("cron", null);
-    note.setConfig(config);
-    schedulerService.refreshCron(note.getId());
+    // use write lock because config is overwritten
+    notebook.processNote(noteId,
+      note -> {
+        Map<String, Object> config = note.getConfig();
+        config.put("cron", null);
+        note.setConfig(config);
+        return null;
+      });
+    schedulerService.refreshCron(noteId);
 
     // make sure all paragraph has been executed
-    assertNotNull(p.getDateFinished());
-    assertNotNull(p2.getDateFinished());
-    notebook.removeNote(note, anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        for (Paragraph p : note.getParagraphs()) {
+          assertNotNull(p);
+        }
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
 //  @Test
   public void testCronWithReleaseResourceClosesOnlySpecificInterpreters()
       throws IOException, InterruptedException, InterpreterNotFoundException {
     // create a cron scheduled note.
-    Note cronNote = notebook.createNote("note1", anonymous);
-    Map<String, Object> config = new HashMap<>();
-    config.put("cron", "1/5 * * * * ?");
-    config.put("cronExecutingUser", anonymous.getUser());
-    config.put("releaseresource", true);
-    cronNote.setConfig(config);
-
+    String cronNoteId = notebook.createNote("note1", anonymous);
+    // use write lock, because we overwrite the note configuration
+    notebook.processNote(cronNoteId,
+      cronNote -> {
+        Map<String, Object> config = new HashMap<>();
+        config.put("cron", "1/5 * * * * ?");
+        config.put("cronExecutingUser", anonymous.getUser());
+        config.put("releaseresource", true);
+        cronNote.setConfig(config);
+        return null;
+      });
     RemoteInterpreter cronNoteInterpreter =
-        (RemoteInterpreter) interpreterFactory.getInterpreter("mock1", new ExecutionContext(anonymous.getUser(), cronNote.getId(), "test"));
+        (RemoteInterpreter) interpreterFactory.getInterpreter("mock1", new ExecutionContext(anonymous.getUser(), cronNoteId, "test"));
 
     // create a paragraph of the cron scheduled note.
-    Paragraph cronNoteParagraph = cronNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    config = new HashMap<>();
-    config.put("enabled", true);
-    cronNoteParagraph.setConfig(config);
-    cronNoteParagraph.setText("%mock1 sleep 1000");
+    notebook.processNote(cronNoteId,
+      cronNote -> {
+        Paragraph cronNoteParagraph = cronNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = new HashMap<>();
+        config.put("enabled", true);
+        cronNoteParagraph.setConfig(config);
+        cronNoteParagraph.setText("%mock1 sleep 1000");
+        return null;
+      });
+
 
     // create another note
-    Note anotherNote = notebook.createNote("note1", anonymous);
+    String anotherNoteId = notebook.createNote("note1", anonymous);
 
     RemoteInterpreter anotherNoteInterpreter =
-        (RemoteInterpreter) interpreterFactory.getInterpreter("mock2", new ExecutionContext(anonymous.getUser(), anotherNote.getId(), "test"));
+        (RemoteInterpreter) interpreterFactory.getInterpreter("mock2", new ExecutionContext(anonymous.getUser(), anotherNoteId, "test"));
 
     // create a paragraph of another note
-    Paragraph anotherNoteParagraph = anotherNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    config = new HashMap<>();
-    config.put("enabled", true);
-    anotherNoteParagraph.setConfig(config);
-    anotherNoteParagraph.setText("%mock2 echo 1");
+    notebook.processNote(anotherNoteId,
+      anotherNote -> {
+        Paragraph anotherNoteParagraph = anotherNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        Map<String, Object> config = new HashMap<>();
+        config.put("enabled", true);
+        anotherNoteParagraph.setConfig(config);
+        anotherNoteParagraph.setText("%mock2 echo 1");
+        // run the paragraph of another note
+        anotherNote.run(anotherNoteParagraph.getId());
+        return null;
+      });
 
-    // run the paragraph of another note
-    anotherNote.run(anotherNoteParagraph.getId());
 
     // wait until anotherNoteInterpreter is opened
     while (!anotherNoteInterpreter.isOpened()) {
@@ -819,7 +943,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     }
 
     // refresh the cron schedule
-    schedulerService.refreshCron(cronNote.getId());
+    schedulerService.refreshCron(cronNoteId);
 
     // wait until cronNoteInterpreter is opened
     while (!cronNoteInterpreter.isOpened()) {
@@ -837,125 +961,182 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     assertTrue(anotherNoteInterpreter.isOpened());
 
     // remove cron scheduler
-    config = new HashMap<>();
-    config.put("cron", null);
-    config.put("cronExecutingUser", null);
-    config.put("releaseresource", null);
-    cronNote.setConfig(config);
-    schedulerService.refreshCron(cronNote.getId());
+    // use write lock because config is overwritten
+    notebook.processNote(cronNoteId,
+      cronNote -> {
+        Map<String, Object> config = new HashMap<>();
+        config.put("cron", null);
+        config.put("cronExecutingUser", null);
+        config.put("releaseresource", null);
+        cronNote.setConfig(config);
+        return null;
+      });
+
+    schedulerService.refreshCron(cronNoteId);
 
     // remove notebooks
-    notebook.removeNote(cronNote, anonymous);
-    notebook.removeNote(anotherNote, anonymous);
+    notebook.removeNote(cronNoteId, anonymous);
+    notebook.removeNote(anotherNoteId, anonymous);
   }
 
   @Test
   public void testCronNoteInTrash() throws InterruptedException, IOException, SchedulerException {
-    Note note = notebook.createNote("~Trash/NotCron", anonymous);
-
-    Map<String, Object> config = note.getConfig();
-    config.put("enabled", true);
-    config.put("cron", "* * * * * ?");
-    note.setConfig(config);
-
+    String noteId = notebook.createNote("~Trash/NotCron", anonymous);
+    // use write lock because we overwrite the note config
+    notebook.processNote(noteId,
+      note -> {
+        Map<String, Object> config = note.getConfig();
+        config.put("enabled", true);
+        config.put("cron", "* * * * * ?");
+        note.setConfig(config);
+        return null;
+      });
     final int jobsBeforeRefresh = schedulerService.getJobs().size();
-    schedulerService.refreshCron(note.getId());
+    schedulerService.refreshCron(noteId);
     final int jobsAfterRefresh = schedulerService.getJobs().size();
 
     assertEquals(jobsBeforeRefresh, jobsAfterRefresh);
 
     // remove cron scheduler.
-    config.remove("cron");
-    schedulerService.refreshCron(note.getId());
-    notebook.removeNote(note, anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        note.getConfig().remove("cron");
+        return null;
+      });
+    schedulerService.refreshCron(noteId);
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testExportAndImportNote() throws Exception {
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
 
-    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    String simpleText = "hello world";
-    p.setText(simpleText);
+    notebook.processNote(noteId,
+      note -> {
+        final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        String simpleText = "hello world";
+        p.setText(simpleText);
 
-    note.runAll(anonymous, true, false, new HashMap<>());
+        try {
+          note.runAll(anonymous, true, false, new HashMap<>());
+        } catch (Exception e) {
+          fail();
+        }
+        return null;
+      });
 
-    String exportedNoteJson = notebook.exportNote(note.getId());
+    String exportedNoteJson = notebook.exportNote(noteId);
 
-    Note importedNote = notebook.importNote(exportedNoteJson, "Title", anonymous);
+    String importedNoteId = notebook.importNote(exportedNoteJson, "Title", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p = note.getParagraph(0);
+        notebook.processNote(importedNoteId,
+          importedNote -> {
+            Paragraph p2 = importedNote.getParagraphs().get(0);
 
-    Paragraph p2 = importedNote.getParagraphs().get(0);
+            // Test
+            assertEquals(p.getId(), p2.getId());
+            assertEquals(p.getText(), p2.getText());
+            assertEquals(p.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            return null;
+          });
+        return null;
+      });
 
-    // Test
-    assertEquals(p.getId(), p2.getId());
-    assertEquals(p.getText(), p2.getText());
-    assertEquals(p.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
 
     // Verify import note with subject
     AuthenticationInfo subject = new AuthenticationInfo("user1");
-    Note importedNote2 = notebook.importNote(exportedNoteJson, "Title2", subject);
-    assertNotNull(authorizationService.getOwners(importedNote2.getId()));
-    assertEquals(1, authorizationService.getOwners(importedNote2.getId()).size());
+    String importedNote2Id = notebook.importNote(exportedNoteJson, "Title2", subject);
+    assertNotNull(authorizationService.getOwners(importedNote2Id));
+    assertEquals(1, authorizationService.getOwners(importedNote2Id).size());
     Set<String> owners = new HashSet<>();
     owners.add("user1");
-    assertEquals(owners, authorizationService.getOwners(importedNote2.getId()));
-    notebook.removeNote(note, anonymous);
-    notebook.removeNote(importedNote, anonymous);
-    notebook.removeNote(importedNote2, anonymous);
+    assertEquals(owners, authorizationService.getOwners(importedNote2Id));
+    notebook.removeNote(noteId, anonymous);
+    notebook.removeNote(importedNoteId, anonymous);
+    notebook.removeNote(importedNote2Id, anonymous);
   }
 
   @Test
   public void testCloneNote() throws Exception {
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p.setText("hello world");
+        try {
+          note.runAll(anonymous, true, false, new HashMap<>());
+        } catch (Exception e) {
+          fail();
+        }
 
-    final Paragraph p = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p.setText("hello world");
-    note.runAll(anonymous, true, false, new HashMap<>());
+        p.setStatus(Status.RUNNING);
+        return null;
+      });
 
-    p.setStatus(Status.RUNNING);
-    Note cloneNote = notebook.cloneNote(note.getId(), "clone note", anonymous);
-    Paragraph cp = cloneNote.getParagraph(0);
-    assertEquals(Status.READY, cp.getStatus());
+    String cloneNoteId = notebook.cloneNote(noteId, "clone note", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p = note.getParagraph(0);
+        notebook.processNote(cloneNoteId,
+          cloneNote -> {
+            Paragraph cp = cloneNote.getParagraph(0);
+            assertEquals(Status.READY, cp.getStatus());
+            // Keep same ParagraphId
+            assertEquals(cp.getId(), p.getId());
+            assertEquals(cp.getText(), p.getText());
+            assertEquals(cp.getReturn().message().get(0).getData(), p.getReturn().message().get(0).getData());
+            return null;
+          });
+        return null;
+      });
 
-    // Keep same ParagraphId
-    assertEquals(cp.getId(), p.getId());
-    assertEquals(cp.getText(), p.getText());
-    assertEquals(cp.getReturn().message().get(0).getData(), p.getReturn().message().get(0).getData());
 
     // Verify clone note with subject
     AuthenticationInfo subject = new AuthenticationInfo("user1");
-    Note cloneNote2 = notebook.cloneNote(note.getId(), "clone note2", subject);
-    assertNotNull(authorizationService.getOwners(cloneNote2.getId()));
-    assertEquals(1, authorizationService.getOwners(cloneNote2.getId()).size());
+    String cloneNote2Id = notebook.cloneNote(noteId, "clone note2", subject);
+    assertNotNull(authorizationService.getOwners(cloneNote2Id));
+    assertEquals(1, authorizationService.getOwners(cloneNote2Id).size());
     Set<String> owners = new HashSet<>();
     owners.add("user1");
-    assertEquals(owners, authorizationService.getOwners(cloneNote2.getId()));
-    notebook.removeNote(note, anonymous);
-    notebook.removeNote(cloneNote, anonymous);
-    notebook.removeNote(cloneNote2, anonymous);
+    assertEquals(owners, authorizationService.getOwners(cloneNote2Id));
+    notebook.removeNote(noteId, anonymous);
+    notebook.removeNote(cloneNoteId, anonymous);
+    notebook.removeNote(cloneNote2Id, anonymous);
   }
 
   @Test
   public void testResourceRemovealOnParagraphNoteRemove() throws Exception {
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
 
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%mock1 hello");
-    Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p2.setText("%mock2 world");
-    for (InterpreterGroup intpGroup : interpreterSettingManager.getAllInterpreterGroup()) {
-      intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
-    }
-    note.runAll(anonymous, true, false, new HashMap<>());
+    notebook.processNote(noteId,
+      note -> {
+        Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p1.setText("%mock1 hello");
+        Paragraph p2 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p2.setText("%mock2 world");
+        for (InterpreterGroup intpGroup : interpreterSettingManager.getAllInterpreterGroup()) {
+          intpGroup.setResourcePool(new LocalResourcePool(intpGroup.getId()));
+        }
+        try {
+          note.runAll(anonymous, true, false, new HashMap<>());
+        } catch (Exception e) {
+          fail();
+        }
 
-    assertEquals(2, interpreterSettingManager.getAllResources().size());
+        assertEquals(2, interpreterSettingManager.getAllResources().size());
 
-    // remove a paragraph
-    note.removeParagraph(anonymous.getUser(), p1.getId());
-    assertEquals(1, interpreterSettingManager.getAllResources().size());
+        // remove a paragraph
+        note.removeParagraph(anonymous.getUser(), p1.getId());
+        assertEquals(1, interpreterSettingManager.getAllResources().size());
+        return null;
+      });
+
+
 
     // remove note
-    notebook.removeNote(note, anonymous);
+    notebook.removeNote(noteId, anonymous);
     assertEquals(0, interpreterSettingManager.getAllResources().size());
   }
 
@@ -963,28 +1144,31 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   public void testAngularObjectRemovalOnNotebookRemove() throws InterruptedException,
       IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
-
-    AngularObjectRegistry registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
-        .getAngularObjectRegistry();
-
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-
+    String noteId = notebook.createNote("note1", anonymous);
+    AngularObjectRegistry registry = notebook.processNote(noteId,
+      note -> {
+        return note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
+          .getAngularObjectRegistry();
+      });
+    String paragraphId = notebook.processNote(noteId,
+      note -> {
+        return note.addNewParagraph(AuthenticationInfo.ANONYMOUS).getId();
+      });
     // add paragraph scope object
-    registry.add("o1", "object1", note.getId(), p1.getId());
+    registry.add("o1", "object1", noteId, paragraphId);
 
     // add notebook scope object
-    registry.add("o2", "object2", note.getId(), null);
+    registry.add("o2", "object2", noteId, null);
 
     // add global scope object
     registry.add("o3", "object3", null, null);
 
     // remove notebook
-    notebook.removeNote(note, anonymous);
+    notebook.removeNote(noteId, anonymous);
 
     // notebook scope or paragraph scope object should be removed
-    assertNull(registry.get("o1", note.getId(), null));
-    assertNull(registry.get("o2", note.getId(), p1.getId()));
+    assertNull(registry.get("o1", noteId, null));
+    assertNull(registry.get("o2", noteId, paragraphId));
 
     // global object should be remained
     assertNotNull(registry.get("o3", null, null));
@@ -994,111 +1178,129 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
   public void testAngularObjectRemovalOnParagraphRemove() throws InterruptedException,
       IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
 
-    AngularObjectRegistry registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
-        .getAngularObjectRegistry();
+    AngularObjectRegistry registry = notebook.processNote(noteId,
+      note -> {
+        return note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
+          .getAngularObjectRegistry();
+      });
 
-    Paragraph p1 = note.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    String paragraphId = notebook.processNote(noteId,
+      note -> {
+        return note.addNewParagraph(AuthenticationInfo.ANONYMOUS).getId();
+      });
 
     // add paragraph scope object
-    registry.add("o1", "object1", note.getId(), p1.getId());
+    registry.add("o1", "object1", noteId, paragraphId);
 
     // add notebook scope object
-    registry.add("o2", "object2", note.getId(), null);
+    registry.add("o2", "object2", noteId, null);
 
     // add global scope object
     registry.add("o3", "object3", null, null);
-
     // remove notebook
-    note.removeParagraph(anonymous.getUser(), p1.getId());
+    notebook.processNote(noteId,
+      note -> {
+        note.removeParagraph(anonymous.getUser(), paragraphId);
+        return null;
+      });
+
 
     // paragraph scope should be removed
-    assertNull(registry.get("o1", note.getId(), null));
+    assertNull(registry.get("o1", noteId, null));
 
     // notebook scope and global object sould be remained
-    assertNotNull(registry.get("o2", note.getId(), null));
+    assertNotNull(registry.get("o2", noteId, null));
     assertNotNull(registry.get("o3", null, null));
-    notebook.removeNote(note, anonymous);
+
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testAngularObjectRemovalOnInterpreterRestart() throws InterruptedException,
       IOException, InterpreterException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
+    notebook.processNote(noteId,
+      note -> {
+        AngularObjectRegistry registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
+            .getAngularObjectRegistry();
 
-    AngularObjectRegistry registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
-        .getAngularObjectRegistry();
+        // add local scope object
+        registry.add("o1", "object1", note.getId(), null);
+        // add global scope object
+        registry.add("o2", "object2", null, null);
 
-    // add local scope object
-    registry.add("o1", "object1", note.getId(), null);
-    // add global scope object
-    registry.add("o2", "object2", null, null);
+        // restart interpreter
+        try {
+          interpreterSettingManager.restart(note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getId());
+        } catch (InterpreterException e) {
+          fail();
+        }
+        registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0)
+            .getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
+            .getAngularObjectRegistry();
 
-    // restart interpreter
-    interpreterSettingManager.restart(note.getBindedInterpreterSettings(new ArrayList<>()).get(0).getId());
-    registry = note.getBindedInterpreterSettings(new ArrayList<>()).get(0)
-        .getOrCreateInterpreterGroup(anonymous.getUser(), note.getId())
-        .getAngularObjectRegistry();
-
-    // New InterpreterGroup will be created and its AngularObjectRegistry will be created
-    assertNull(registry.get("o1", note.getId(), null));
-    assertNull(registry.get("o2", null, null));
-    notebook.removeNote(note, anonymous);
+        // New InterpreterGroup will be created and its AngularObjectRegistry will be created
+        assertNull(registry.get("o1", note.getId(), null));
+        assertNull(registry.get("o2", null, null));
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testPermissions() throws IOException {
     // create a note and a paragraph
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
     // empty owners, readers or writers means note is public
-    assertTrue(authorizationService.isOwner(note.getId(),
+    assertTrue(authorizationService.isOwner(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isReader(note.getId(),
+    assertTrue(authorizationService.isReader(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isRunner(note.getId(),
+    assertTrue(authorizationService.isRunner(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isWriter(note.getId(),
+    assertTrue(authorizationService.isWriter(noteId,
         new HashSet<>(Arrays.asList("user2"))));
 
-    authorizationService.setOwners(note.getId(),
+    authorizationService.setOwners(noteId,
         new HashSet<>(Arrays.asList("user1")));
-    authorizationService.setReaders(note.getId(),
+    authorizationService.setReaders(noteId,
         new HashSet<>(Arrays.asList("user1", "user2")));
-    authorizationService.setRunners(note.getId(),
+    authorizationService.setRunners(noteId,
         new HashSet<>(Arrays.asList("user3")));
-    authorizationService.setWriters(note.getId(),
+    authorizationService.setWriters(noteId,
         new HashSet<>(Arrays.asList("user1")));
 
-    assertFalse(authorizationService.isOwner(note.getId(),
+    assertFalse(authorizationService.isOwner(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isOwner(note.getId(),
+    assertTrue(authorizationService.isOwner(noteId,
         new HashSet<>(Arrays.asList("user1"))));
 
-    assertFalse(authorizationService.isReader(note.getId(),
+    assertFalse(authorizationService.isReader(noteId,
         new HashSet<>(Arrays.asList("user4"))));
-    assertTrue(authorizationService.isReader(note.getId(),
+    assertTrue(authorizationService.isReader(noteId,
         new HashSet<>(Arrays.asList("user2"))));
 
-    assertTrue(authorizationService.isRunner(note.getId(),
+    assertTrue(authorizationService.isRunner(noteId,
         new HashSet<>(Arrays.asList("user3"))));
-    assertFalse(authorizationService.isRunner(note.getId(),
+    assertFalse(authorizationService.isRunner(noteId,
         new HashSet<>(Arrays.asList("user2"))));
 
-    assertFalse(authorizationService.isWriter(note.getId(),
+    assertFalse(authorizationService.isWriter(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isWriter(note.getId(),
+    assertTrue(authorizationService.isWriter(noteId,
         new HashSet<>(Arrays.asList("user1"))));
 
     // Test clearing of permissions
-    authorizationService.setReaders(note.getId(), new HashSet<>());
-    assertTrue(authorizationService.isReader(note.getId(),
+    authorizationService.setReaders(noteId, new HashSet<>());
+    assertTrue(authorizationService.isReader(noteId,
         new HashSet<>(Arrays.asList("user2"))));
-    assertTrue(authorizationService.isReader(note.getId(),
+    assertTrue(authorizationService.isReader(noteId,
         new HashSet<>(Arrays.asList("user4"))));
 
-    notebook.removeNote(note, anonymous);
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
@@ -1110,41 +1312,41 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     authorizationService.setRoles(user1, roles);
     authorizationService.setRoles(user2, roles);
 
-    Note note = notebook.createNote("note1", new AuthenticationInfo(user1));
+    String noteId = notebook.createNote("note1", new AuthenticationInfo(user1));
 
     // check that user1 is owner, reader, runner and writer
-    assertTrue(authorizationService.isOwner(note.getId(),
+    assertTrue(authorizationService.isOwner(noteId,
       new HashSet<>(Arrays.asList(user1))));
-    assertTrue(authorizationService.isReader(note.getId(),
+    assertTrue(authorizationService.isReader(noteId,
       new HashSet<>(Arrays.asList(user1))));
-    assertTrue(authorizationService.isRunner(note.getId(),
+    assertTrue(authorizationService.isRunner(noteId,
       new HashSet<>(Arrays.asList(user2))));
-    assertTrue(authorizationService.isWriter(note.getId(),
+    assertTrue(authorizationService.isWriter(noteId,
       new HashSet<>(Arrays.asList(user1))));
 
     // since user1 and user2 both have admin role, user2 will be reader and writer as well
-    assertFalse(authorizationService.isOwner(note.getId(),
+    assertFalse(authorizationService.isOwner(noteId,
       new HashSet<>(Arrays.asList(user2))));
-    assertTrue(authorizationService.isReader(note.getId(),
+    assertTrue(authorizationService.isReader(noteId,
       new HashSet<>(Arrays.asList(user2))));
-    assertTrue(authorizationService.isRunner(note.getId(),
+    assertTrue(authorizationService.isRunner(noteId,
       new HashSet<>(Arrays.asList(user2))));
-    assertTrue(authorizationService.isWriter(note.getId(),
+    assertTrue(authorizationService.isWriter(noteId,
       new HashSet<>(Arrays.asList(user2))));
 
     // check that user1 has note listed in his workbench
     Set<String> user1AndRoles = authorizationService.getRoles(user1);
     user1AndRoles.add(user1);
-    List<NoteInfo> user1Notes = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, user1AndRoles));
+    List<NoteInfo> user1Notes = notebook.getNotesInfo(noteIdTmp -> authorizationService.isReader(noteIdTmp, user1AndRoles));
     assertEquals(1, user1Notes.size());
-    assertEquals(user1Notes.get(0).getId(), note.getId());
+    assertEquals(user1Notes.get(0).getId(), noteId);
 
     // check that user2 has note listed in his workbench because of admin role
     Set<String> user2AndRoles = authorizationService.getRoles(user2);
     user2AndRoles.add(user2);
-    List<NoteInfo> user2Notes = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, user2AndRoles));
+    List<NoteInfo> user2Notes = notebook.getNotesInfo(noteIdTmp -> authorizationService.isReader(noteIdTmp, user2AndRoles));
     assertEquals(1, user2Notes.size());
-    assertEquals(user2Notes.get(0).getId(), note.getId());
+    assertEquals(user2Notes.get(0).getId(), noteId);
   }
 
   @Test
@@ -1204,168 +1406,221 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   @Test
   public void testAbortParagraphStatusOnInterpreterRestart() throws Exception {
-    Note note = notebook.createNote("note1", anonymous);
+    String noteId = notebook.createNote("note1", anonymous);
 
-    // create three paragraphs
-    Paragraph p1 = note.addNewParagraph(anonymous);
-    p1.setText("%mock1 sleep 1000");
-    Paragraph p2 = note.addNewParagraph(anonymous);
-    p2.setText("%mock1 sleep 1000");
-    Paragraph p3 = note.addNewParagraph(anonymous);
-    p3.setText("%mock1 sleep 1000");
+    notebook.processNote(noteId,
+      note -> {
+        // create three paragraphs
+        Paragraph p1 = note.addNewParagraph(anonymous);
+        p1.setText("%mock1 sleep 1000");
+        Paragraph p2 = note.addNewParagraph(anonymous);
+        p2.setText("%mock1 sleep 1000");
+        Paragraph p3 = note.addNewParagraph(anonymous);
+        p3.setText("%mock1 sleep 1000");
 
 
-    note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
+        try {
+          note.runAll(AuthenticationInfo.ANONYMOUS, false, false, new HashMap<>());
+        } catch (Exception e1) {
+          fail();
+        }
 
-    // wait until first paragraph finishes and second paragraph starts
-    while (p1.getStatus() != Status.FINISHED || p2.getStatus() != Status.RUNNING) Thread.yield();
+        // wait until first paragraph finishes and second paragraph starts
+        while (p1.getStatus() != Status.FINISHED || p2.getStatus() != Status.RUNNING) Thread.yield();
 
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertEquals(Status.RUNNING, p2.getStatus());
-    assertEquals(Status.READY, p3.getStatus());
+        assertEquals(Status.FINISHED, p1.getStatus());
+        assertEquals(Status.RUNNING, p2.getStatus());
+        assertEquals(Status.READY, p3.getStatus());
 
-    // restart interpreter
-    interpreterSettingManager.restart(interpreterSettingManager.getInterpreterSettingByName("mock1").getId());
+        // restart interpreter
+        try {
+          interpreterSettingManager.restart(interpreterSettingManager.getInterpreterSettingByName("mock1").getId());
+        } catch (InterpreterException e) {
+          fail();
+        }
 
-    // make sure three different status aborted well.
-    assertEquals(Status.FINISHED, p1.getStatus());
-    assertEquals(Status.ABORT, p2.getStatus());
-    assertEquals(Status.READY, p3.getStatus());
-
-    notebook.removeNote(note, anonymous);
+        // make sure three different status aborted well.
+        assertEquals(Status.FINISHED, p1.getStatus());
+        assertEquals(Status.ABORT, p2.getStatus());
+        assertEquals(Status.READY, p3.getStatus());
+        return null;
+      });
+    notebook.removeNote(noteId, anonymous);
   }
 
   @Test
   public void testPerSessionInterpreterCloseOnNoteRemoval() throws IOException, InterpreterException {
     // create a notes
-    Note note1 = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%mock1 getId");
-    p1.setAuthenticationInfo(anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
+    InterpreterResult result = notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p1.setText("%mock1 getId");
+        p1.setAuthenticationInfo(anonymous);
 
-    // restart interpreter with per user session enabled
-    for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
-      setting.getOption().setPerNote(InterpreterOption.SCOPED);
-      notebook.getInterpreterSettingManager().restart(setting.getId());
-    }
+        // restart interpreter with per user session enabled
+        for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
+          setting.getOption().setPerNote(InterpreterOption.SCOPED);
+          try {
+            notebook.getInterpreterSettingManager().restart(setting.getId());
+          } catch (InterpreterException e) {
+            fail();
+          }
+        }
 
-    note1.run(p1.getId());
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    InterpreterResult result = p1.getReturn();
+        note1.run(p1.getId());
+        while (p1.getStatus() != Status.FINISHED) Thread.yield();
+        return p1.getReturn();
+      });
+
 
     // remove note and recreate
-    notebook.removeNote(note1, anonymous);
-    note1 = notebook.createNote("note1", anonymous);
-    p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    p1.setText("%mock1 getId");
-    p1.setAuthenticationInfo(anonymous);
+    notebook.removeNote(note1Id, anonymous);
+    note1Id = notebook.createNote("note1", anonymous);
+    notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        p1.setText("%mock1 getId");
+        p1.setAuthenticationInfo(anonymous);
 
-    note1.run(p1.getId());
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    assertNotEquals(p1.getReturn().message(), result.message());
+        note1.run(p1.getId());
+        while (p1.getStatus() != Status.FINISHED) Thread.yield();
+        assertNotEquals(p1.getReturn().message(), result.message());
+        return null;
+      });
 
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1Id, anonymous);
   }
 
   @Test
   public void testPerSessionInterpreter() throws IOException, InterpreterException {
     // create two notes
-    Note note1 = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    String note1Id = notebook.createNote("note1", anonymous);
+    notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        String note2Id = notebook.createNote("note2", anonymous);
+        notebook.processNote(note2Id,
+          note2 -> {
+            Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Note note2 = notebook.createNote("note2", anonymous);
-    Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+            p1.setText("%mock1 getId");
+            p1.setAuthenticationInfo(anonymous);
+            p2.setText("%mock1 getId");
+            p2.setAuthenticationInfo(anonymous);
 
-    p1.setText("%mock1 getId");
-    p1.setAuthenticationInfo(anonymous);
-    p2.setText("%mock1 getId");
-    p2.setAuthenticationInfo(anonymous);
+            // run per note session disabled
+            note1.run(p1.getId());
+            note2.run(p2.getId());
 
-    // run per note session disabled
-    note1.run(p1.getId());
-    note2.run(p2.getId());
+            while (p1.getStatus() != Status.FINISHED) Thread.yield();
+            while (p2.getStatus() != Status.FINISHED) Thread.yield();
 
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    while (p2.getStatus() != Status.FINISHED) Thread.yield();
-
-    assertEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            assertEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
 
 
-    // restart interpreter with per note session enabled
-    for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
-      setting.getOption().setPerNote(InterpreterOption.SCOPED);
-      notebook.getInterpreterSettingManager().restart(setting.getId());
-    }
+            // restart interpreter with per note session enabled
+            for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
+              setting.getOption().setPerNote(InterpreterOption.SCOPED);
+              try {
+                notebook.getInterpreterSettingManager().restart(setting.getId());
+              } catch (InterpreterException e) {
+                fail();
+              }
+            }
 
-    // run per note session enabled
-    note1.run(p1.getId());
-    note2.run(p2.getId());
+            // run per note session enabled
+            note1.run(p1.getId());
+            note2.run(p2.getId());
 
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    while (p2.getStatus() != Status.FINISHED) Thread.yield();
+            while (p1.getStatus() != Status.FINISHED) Thread.yield();
+            while (p2.getStatus() != Status.FINISHED) Thread.yield();
 
-    assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            return null;
+          });
 
-    notebook.removeNote(note1, anonymous);
-    notebook.removeNote(note2, anonymous);
+        notebook.removeNote(note2Id, anonymous);
+        return null;
+      });
+
+    notebook.removeNote(note1Id, anonymous);
+
   }
 
 
   @Test
   public void testPerNoteSessionInterpreter() throws IOException, InterpreterException {
     // create two notes
-    Note note1 = notebook.createNote("note1", anonymous);
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+    String note1Id = notebook.createNote("note1", anonymous);
+    notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    Note note2 = notebook.createNote("note2", anonymous);
-    Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        String note2Id = notebook.createNote("note2", anonymous);
+        notebook.processNote(note2Id,
+          note2 -> {
+            Paragraph p2 = note2.addNewParagraph(AuthenticationInfo.ANONYMOUS);
 
-    p1.setText("%mock1 getId");
-    p1.setAuthenticationInfo(anonymous);
-    p2.setText("%mock1 getId");
-    p2.setAuthenticationInfo(anonymous);
+            p1.setText("%mock1 getId");
+            p1.setAuthenticationInfo(anonymous);
+            p2.setText("%mock1 getId");
+            p2.setAuthenticationInfo(anonymous);
 
-    // shared mode.
-    note1.run(p1.getId());
-    note2.run(p2.getId());
+            // shared mode.
+            note1.run(p1.getId());
+            note2.run(p2.getId());
 
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    while (p2.getStatus() != Status.FINISHED) Thread.yield();
+            while (p1.getStatus() != Status.FINISHED) Thread.yield();
+            while (p2.getStatus() != Status.FINISHED) Thread.yield();
 
-    assertEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            assertEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
 
-    // restart interpreter with scoped mode enabled
-    for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
-      setting.getOption().setPerNote(InterpreterOption.SCOPED);
-      notebook.getInterpreterSettingManager().restart(setting.getId());
-    }
+            // restart interpreter with scoped mode enabled
+            for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
+              setting.getOption().setPerNote(InterpreterOption.SCOPED);
+              try {
+                notebook.getInterpreterSettingManager().restart(setting.getId());
+              } catch (InterpreterException e) {
+                fail();
+              }
+            }
 
-    // run per note session enabled
-    note1.run(p1.getId());
-    note2.run(p2.getId());
+            // run per note session enabled
+            note1.run(p1.getId());
+            note2.run(p2.getId());
 
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    while (p2.getStatus() != Status.FINISHED) Thread.yield();
+            while (p1.getStatus() != Status.FINISHED) Thread.yield();
+            while (p2.getStatus() != Status.FINISHED) Thread.yield();
 
-    assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
 
-    // restart interpreter with isolated mode enabled
-    for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
-      setting.getOption().setPerNote(InterpreterOption.ISOLATED);
-      setting.getInterpreterSettingManager().restart(setting.getId());
-    }
+            // restart interpreter with isolated mode enabled
+            for (InterpreterSetting setting : note1.getBindedInterpreterSettings(new ArrayList<>())) {
+              setting.getOption().setPerNote(InterpreterOption.ISOLATED);
+              try {
+                setting.getInterpreterSettingManager().restart(setting.getId());
+              } catch (InterpreterException e) {
+                fail();
+              }
+            }
 
-    // run per note process enabled
-    note1.run(p1.getId());
-    note2.run(p2.getId());
+            // run per note process enabled
+            note1.run(p1.getId());
+            note2.run(p2.getId());
 
-    while (p1.getStatus() != Status.FINISHED) Thread.yield();
-    while (p2.getStatus() != Status.FINISHED) Thread.yield();
+            while (p1.getStatus() != Status.FINISHED) Thread.yield();
+            while (p2.getStatus() != Status.FINISHED) Thread.yield();
 
-    assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            assertNotEquals(p1.getReturn().message().get(0).getData(), p2.getReturn().message().get(0).getData());
+            return null;
+          });
+        notebook.removeNote(note2Id, anonymous);
+        return null;
+      });
 
-    notebook.removeNote(note1, anonymous);
-    notebook.removeNote(note2, anonymous);
+    notebook.removeNote(note1Id, anonymous);
+
   }
 
   public void testNotebookEventListener() throws IOException {
@@ -1412,92 +1667,96 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     });
 
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
     assertEquals(1, onNoteCreate.get());
 
-    Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    assertEquals(1, onParagraphCreate.get());
+    notebook.processNote(note1Id,
+      note1 -> {
+        Paragraph p1 = note1.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        assertEquals(1, onParagraphCreate.get());
 
-    note1.addCloneParagraph(p1, AuthenticationInfo.ANONYMOUS);
-    assertEquals(2, onParagraphCreate.get());
+        note1.addCloneParagraph(p1, AuthenticationInfo.ANONYMOUS);
+        assertEquals(2, onParagraphCreate.get());
 
-    note1.removeParagraph(anonymous.getUser(), p1.getId());
-    assertEquals(1, onParagraphRemove.get());
+        note1.removeParagraph(anonymous.getUser(), p1.getId());
+        assertEquals(1, onParagraphRemove.get());
+        return null;
+      });
 
-    notebook.removeNote(note1, anonymous);
+    notebook.removeNote(note1Id, anonymous);
     assertEquals(1, onNoteRemove.get());
     assertEquals(1, onParagraphRemove.get());
   }
 
   @Test
   public void testGetAllNotes() throws Exception {
-    Note note1 = notebook.createNote("note1", anonymous);
-    Note note2 = notebook.createNote("note2", anonymous);
-    assertEquals(2, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("anonymous")))).size());
+    String note1Id = notebook.createNote("note1", anonymous);
+    String note2Id = notebook.createNote("note2", anonymous);
+    assertEquals(2, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("anonymous")))).size());
 
-    authorizationService.setOwners(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    authorizationService.setWriters(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    authorizationService.setRunners(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    authorizationService.setReaders(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    assertEquals(1, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("anonymous")))).size());
-    assertEquals(2, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1")))).size());
+    authorizationService.setOwners(note1Id, new HashSet<>(Arrays.asList("user1")));
+    authorizationService.setWriters(note1Id, new HashSet<>(Arrays.asList("user1")));
+    authorizationService.setRunners(note1Id, new HashSet<>(Arrays.asList("user1")));
+    authorizationService.setReaders(note1Id, new HashSet<>(Arrays.asList("user1")));
+    assertEquals(1, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("anonymous")))).size());
+    assertEquals(2, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1")))).size());
 
-    authorizationService.setOwners(note2.getId(), new HashSet<>(Arrays.asList("user2")));
-    authorizationService.setWriters(note2.getId(), new HashSet<>(Arrays.asList("user2")));
-    authorizationService.setReaders(note2.getId(), new HashSet<>(Arrays.asList("user2")));
-    authorizationService.setRunners(note2.getId(), new HashSet<>(Arrays.asList("user2")));
-    assertEquals(0, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("anonymous")))).size());
-    assertEquals(1, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1")))).size());
-    assertEquals(1, notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2")))).size());
-    notebook.removeNote(note1, AuthenticationInfo.ANONYMOUS);
-    notebook.removeNote(note2, AuthenticationInfo.ANONYMOUS);
+    authorizationService.setOwners(note2Id, new HashSet<>(Arrays.asList("user2")));
+    authorizationService.setWriters(note2Id, new HashSet<>(Arrays.asList("user2")));
+    authorizationService.setReaders(note2Id, new HashSet<>(Arrays.asList("user2")));
+    authorizationService.setRunners(note2Id, new HashSet<>(Arrays.asList("user2")));
+    assertEquals(0, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("anonymous")))).size());
+    assertEquals(1, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1")))).size());
+    assertEquals(1, notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2")))).size());
+    notebook.removeNote(note1Id, AuthenticationInfo.ANONYMOUS);
+    notebook.removeNote(note2Id, AuthenticationInfo.ANONYMOUS);
   }
 
   @Test
   public void testCreateDuplicateNote() throws Exception {
-    Note note1 = notebook.createNote("note1", anonymous);
+    String note1Id = notebook.createNote("note1", anonymous);
     try {
       notebook.createNote("note1", anonymous);
       fail("Should not be able to create same note 'note1'");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Note '/note1' existed"));
     } finally {
-      notebook.removeNote(note1, anonymous);
+      notebook.removeNote(note1Id, anonymous);
     }
   }
 
   @Test
   public void testGetAllNotesWithDifferentPermissions() throws IOException {
-    List<Note> notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    List<Note> notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    List<NoteInfo> notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    List<NoteInfo> notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(0, notes1.size());
     assertEquals(0, notes2.size());
 
     //creates note and sets user1 owner
-    Note note1 = notebook.createNote("note1", new AuthenticationInfo("user1"));
+    String note1Id = notebook.createNote("note1", new AuthenticationInfo("user1"));
 
     // note is public since readers and writers empty
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(1, notes2.size());
 
-    authorizationService.setReaders(note1.getId(), new HashSet<>(Arrays.asList("user1")));
+    authorizationService.setReaders(note1Id, new HashSet<>(Arrays.asList("user1")));
     //note is public since writers empty
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(1, notes2.size());
 
-    authorizationService.setRunners(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    authorizationService.setRunners(note1Id, new HashSet<>(Arrays.asList("user1")));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(1, notes2.size());
 
-    authorizationService.setWriters(note1.getId(), new HashSet<>(Arrays.asList("user1")));
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    authorizationService.setWriters(note1Id, new HashSet<>(Arrays.asList("user1")));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(0, notes2.size());
   }
@@ -1508,27 +1767,27 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     assertTrue(conf.isNotebookPublic());
     assertTrue(authorizationService.isPublic());
 
-    List<Note> notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    List<Note> notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    List<NoteInfo> notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    List<NoteInfo> notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(0, notes1.size());
     assertEquals(0, notes2.size());
 
     // user1 creates note
-    Note notePublic = notebook.createNote("note1", new AuthenticationInfo("user1"));
+    String notePublicId = notebook.createNote("note1", new AuthenticationInfo("user1"));
 
     // both users have note
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(1, notes2.size());
-    assertEquals(notes1.get(0).getId(), notePublic.getId());
-    assertEquals(notes2.get(0).getId(), notePublic.getId());
+    assertEquals(notes1.get(0).getId(), notePublicId);
+    assertEquals(notes2.get(0).getId(), notePublicId);
 
     // user1 is only owner
-    assertEquals(1, authorizationService.getOwners(notePublic.getId()).size());
-    assertEquals(0, authorizationService.getReaders(notePublic.getId()).size());
-    assertEquals(0, authorizationService.getRunners(notePublic.getId()).size());
-    assertEquals(0, authorizationService.getWriters(notePublic.getId()).size());
+    assertEquals(1, authorizationService.getOwners(notePublicId).size());
+    assertEquals(0, authorizationService.getReaders(notePublicId).size());
+    assertEquals(0, authorizationService.getRunners(notePublicId).size());
+    assertEquals(0, authorizationService.getWriters(notePublicId).size());
 
     // case of private note
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "false");
@@ -1538,26 +1797,33 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     assertFalse(authorizationService.isPublic());
 
     // check that still 1 note per user
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(1, notes1.size());
     assertEquals(1, notes2.size());
 
     // create private note
-    Note notePrivate = notebook.createNote("note2", new AuthenticationInfo("user1"));
+    String notePrivateId = notebook.createNote("note2", new AuthenticationInfo("user1"));
 
     // only user1 have notePrivate right after creation
-    notes1 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user1"))));
-    notes2 = notebook.getAllNotes(note -> authorizationService.isReader(note.getId(), new HashSet<>(Arrays.asList("user2"))));
+    notes1 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user1"))));
+    notes2 = notebook.getNotesInfo(noteId -> authorizationService.isReader(noteId, new HashSet<>(Arrays.asList("user2"))));
     assertEquals(2, notes1.size());
     assertEquals(1, notes2.size());
-    assertEquals(true, notes1.contains(notePrivate));
+    boolean found = false;
+    for (NoteInfo info : notes1) {
+      if (info.getId() == notePrivateId) {
+        found = true;
+        break;
+      }
+    }
+    assertEquals(true, found);
 
     // user1 have all rights
-    assertEquals(1, authorizationService.getOwners(notePrivate.getId()).size());
-    assertEquals(1, authorizationService.getReaders(notePrivate.getId()).size());
-    assertEquals(1, authorizationService.getRunners(notePrivate.getId()).size());
-    assertEquals(1, authorizationService.getWriters(notePrivate.getId()).size());
+    assertEquals(1, authorizationService.getOwners(notePrivateId).size());
+    assertEquals(1, authorizationService.getReaders(notePrivateId).size());
+    assertEquals(1, authorizationService.getRunners(notePrivateId).size());
+    assertEquals(1, authorizationService.getWriters(notePrivateId).size());
 
     //set back public to true
     System.setProperty(ConfVars.ZEPPELIN_NOTEBOOK_PUBLIC.getVarName(), "true");
@@ -1566,56 +1832,57 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
   @Test
   public void testCloneImportCheck() throws IOException {
-    Note sourceNote = notebook.createNote("note1", new AuthenticationInfo("user"));
-    sourceNote.setName("TestNote");
+    String sourceNoteId = notebook.createNote("note1", new AuthenticationInfo("user"));
+    notebook.processNote(sourceNoteId,
+      sourceNote -> {
+        sourceNote.setName("TestNote");
 
-    assertEquals("TestNote",sourceNote.getName());
+        assertEquals("TestNote",sourceNote.getName());
 
-    Paragraph sourceParagraph = sourceNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
-    assertEquals("anonymous", sourceParagraph.getUser());
+        Paragraph sourceParagraph = sourceNote.addNewParagraph(AuthenticationInfo.ANONYMOUS);
+        assertEquals("anonymous", sourceParagraph.getUser());
+        String destNoteId = notebook.createNote("note2", new AuthenticationInfo("user"));
+        notebook.processNote(destNoteId,
+          destNote -> {
+            destNote.setName("ClonedNote");
+            assertEquals("ClonedNote",destNote.getName());
 
-    Note destNote = notebook.createNote("note2", new AuthenticationInfo("user"));
-    destNote.setName("ClonedNote");
-    assertEquals("ClonedNote",destNote.getName());
-
-    List<Paragraph> paragraphs = sourceNote.getParagraphs();
-    for (Paragraph p : paragraphs) {
-    	  destNote.addCloneParagraph(p, AuthenticationInfo.ANONYMOUS);
-      assertEquals("anonymous", p.getUser());
-    }
+            List<Paragraph> paragraphs = sourceNote.getParagraphs();
+            for (Paragraph p : paragraphs) {
+              destNote.addCloneParagraph(p, AuthenticationInfo.ANONYMOUS);
+              assertEquals("anonymous", p.getUser());
+            }
+            return null;
+          });
+        return null;
+      });
   }
 
   @Test
   public void testMoveNote() throws InterruptedException, IOException {
-    Note note = null;
+    String noteId = null;
     try {
-      note = notebook.createNote("note1", anonymous);
-      assertEquals("note1", note.getName());
-      assertEquals("/note1", note.getPath());
-      notebook.moveNote(note.getId(), "/tmp/note2", anonymous);
+      noteId = notebook.createNote("note1", anonymous);
+      notebook.processNote(noteId,
+        note -> {
+          assertEquals("note1", note.getName());
+          assertEquals("/note1", note.getPath());
+          return null;
+        });
+
+      notebook.moveNote(noteId, "/tmp/note2", anonymous);
 
       // read note json file to check the name field is updated
-      File noteFile = new File(conf.getNotebookDir() + "/" + notebookRepo.buildNoteFileName(note));
-      String noteJson = IOUtils.toString(new FileInputStream(noteFile));
+      File noteFile = notebook.processNote(noteId,
+        note -> {
+          return new File(conf.getNotebookDir() + "/" + notebookRepo.buildNoteFileName(note));
+        });
+      String noteJson = IOUtils.toString(new FileInputStream(noteFile), StandardCharsets.UTF_8);
       assertTrue(noteJson, noteJson.contains("note2"));
     } finally {
-      if (note != null) {
-        notebook.removeNote(note, anonymous);
+      if (noteId != null) {
+        notebook.removeNote(noteId, anonymous);
       }
-    }
-  }
-
-  private void delete(File file) {
-    if (file.isFile()) {
-      file.delete();
-    } else if (file.isDirectory()) {
-      File[] files = file.listFiles();
-      if (files != null && files.length > 0) {
-        for (File f : files) {
-          delete(f);
-        }
-      }
-      file.delete();
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -25,10 +25,9 @@ import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.interpreter.thrift.ParagraphInfo;
-import org.apache.zeppelin.notebook.Note;
-import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.resource.LocalResourcePool;
 import org.apache.zeppelin.scheduler.Job.Status;
+import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +40,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 public class RemoteSchedulerTest extends AbstractInterpreterTest
     implements RemoteInterpreterProcessListener {
@@ -50,14 +48,13 @@ public class RemoteSchedulerTest extends AbstractInterpreterTest
   private SchedulerFactory schedulerSvc;
   private static final int TICK_WAIT = 100;
   private static final int MAX_WAIT_CYCLES = 100;
+  private String note1Id;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    Note note1 = new Note(new NoteInfo("note1", "/note_1"));
-    when(mockNotebook.getNote("note1")).thenReturn(note1);
-
+    note1Id = notebook.createNote("/note_1", AuthenticationInfo.ANONYMOUS);
     schedulerSvc = SchedulerFactory.singleton();
     interpreterSetting = interpreterSettingManager.getInterpreterSettingByName("test");
   }
@@ -70,7 +67,7 @@ public class RemoteSchedulerTest extends AbstractInterpreterTest
 
   @Test
   public void test() throws Exception {
-    final RemoteInterpreter intpA = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", "note1", "mock");
+    final RemoteInterpreter intpA = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", note1Id, "mock");
 
     intpA.open();
 
@@ -140,7 +137,7 @@ public class RemoteSchedulerTest extends AbstractInterpreterTest
 
   @Test
   public void testAbortOnPending() throws Exception {
-    final RemoteInterpreter intpA = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", "note1", "mock");
+    final RemoteInterpreter intpA = (RemoteInterpreter) interpreterSetting.getInterpreter("user1", note1Id, "mock");
     intpA.open();
 
     Scheduler scheduler = intpA.getScheduler();

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/search/LuceneSearchTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
-
+import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.interpreter.InterpreterFactory;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
@@ -38,6 +38,7 @@ import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteManager;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
+import org.apache.zeppelin.notebook.repo.InMemoryNotebookRepo;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
@@ -49,6 +50,7 @@ public class LuceneSearchTest {
 
   private Notebook notebook;
   private InterpreterSettingManager interpreterSettingManager;
+  private NoteManager noteManager;
   private LuceneSearch noteSearchService;
   private File indexDir;
 
@@ -56,21 +58,24 @@ public class LuceneSearchTest {
   public void startUp() throws IOException {
     indexDir = Files.createTempDirectory("lucene").toFile();
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_SEARCH_INDEX_PATH.getVarName(), indexDir.getAbsolutePath());
-    noteSearchService = new LuceneSearch(ZeppelinConfiguration.create());
+
+    ZeppelinConfiguration conf = ZeppelinConfiguration.create();
+    noteManager = new NoteManager(new InMemoryNotebookRepo(), conf);
     interpreterSettingManager = mock(InterpreterSettingManager.class);
     InterpreterSetting defaultInterpreterSetting = mock(InterpreterSetting.class);
     when(defaultInterpreterSetting.getName()).thenReturn("test");
     when(interpreterSettingManager.getDefaultInterpreterSetting()).thenReturn(defaultInterpreterSetting);
-    notebook = new Notebook(ZeppelinConfiguration.create(), mock(AuthorizationService.class), mock(NotebookRepo.class), mock(NoteManager.class),
+    notebook = new Notebook(conf, mock(AuthorizationService.class),
+        mock(NotebookRepo.class), noteManager,
             mock(InterpreterFactory.class), interpreterSettingManager,
-            noteSearchService,
             mock(Credentials.class), null);
+    noteSearchService = new LuceneSearch(ZeppelinConfiguration.create(), notebook);
   }
 
   @After
-  public void shutDown() {
+  public void shutDown() throws IOException {
     noteSearchService.close();
-    indexDir.delete();
+    FileUtils.deleteDirectory(indexDir);
   }
 
   private void drainSearchEvents() throws InterruptedException {
@@ -83,8 +88,8 @@ public class LuceneSearchTest {
   @Test
   public void canIndexAndQuery() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
 
     // when
@@ -93,15 +98,20 @@ public class LuceneSearchTest {
     // then
     assertThat(results).isNotEmpty();
     assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0))
-        .containsEntry("id", formatId(note2.getId(), note2.getLastParagraph()));
+    notebook.processNote(note2Id,
+      note2 -> {
+        assertThat(results.get(0))
+        .containsEntry("id", formatId(note2Id, note2.getLastParagraph()));
+        return null;
+      });
+
   }
 
   @Test
   public void canIndexAndQueryByNotebookName() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
 
     // when
@@ -110,14 +120,14 @@ public class LuceneSearchTest {
     // then
     assertThat(results).isNotEmpty();
     assertThat(results.size()).isEqualTo(1);
-    assertThat(results.get(0)).containsEntry("id", note1.getId());
+    assertThat(results.get(0)).containsEntry("id", note1Id);
   }
 
   @Test
   public void canIndexAndQueryByParagraphTitle() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test", "testingTitleSearch");
-    Note note2 = newNoteWithParagraph("Notebook2", "not test", "notTestingTitleSearch");
+    String note1Id = newNoteWithParagraph("Notebook1", "test", "testingTitleSearch");
+    String note2Id = newNoteWithParagraph("Notebook2", "not test", "notTestingTitleSearch");
     drainSearchEvents();
 
     // when
@@ -138,14 +148,19 @@ public class LuceneSearchTest {
   @Test
   public void indexKeyContract() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
     drainSearchEvents();
     // when
     String id = resultForQuery("test").get(0).get("id"); // LuceneSearch.ID_FIELD
     // then
-    assertThat(id.split("/")).asList() // key structure <noteId>/paragraph/<paragraphId>
+    notebook.processNote(note1Id,
+      note1 -> {
+        assertThat(id.split("/")).asList() // key structure <noteId>/paragraph/<paragraphId>
         .containsAllOf(
-            note1.getId(), "paragraph", note1.getLastParagraph().getId()); // LuceneSearch.PARAGRAPH
+          note1Id, "paragraph", note1.getLastParagraph().getId()); // LuceneSearch.PARAGRAPH
+        return null;
+      });
+
   }
 
   @Test // (expected=IllegalStateException.class)
@@ -162,15 +177,19 @@ public class LuceneSearchTest {
   @Test
   public void canIndexAndReIndex() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
 
     // when
-    Paragraph p2 = note2.getLastParagraph();
-    p2.setText("test indeed");
-    noteSearchService.updateNoteIndex(note2);
-    noteSearchService.updateParagraphIndex(p2);
+    notebook.processNote(note2Id,
+      note2 -> {
+        Paragraph p2 = note2.getLastParagraph();
+        p2.setText("test indeed");
+        noteSearchService.updateNoteIndex(note2Id);
+        noteSearchService.updateParagraphIndex(note2Id, p2.getId());
+        return null;
+      });
 
     // then
     List<Map<String, String>> results = noteSearchService.query("all");
@@ -191,14 +210,14 @@ public class LuceneSearchTest {
   @Test
   public void canDeleteFromIndex() throws IOException, InterruptedException {
     // given
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
 
     assertThat(resultForQuery("Notebook2")).isNotEmpty();
 
     // when
-    noteSearchService.deleteNoteIndex(note2);
+    noteSearchService.deleteNoteIndex(note2Id);
 
     // then
     assertThat(noteSearchService.query("all")).isEmpty();
@@ -212,17 +231,21 @@ public class LuceneSearchTest {
   @Test
   public void indexParagraphUpdatedOnNoteSave() throws IOException, InterruptedException {
     // given: total 2 notebooks, 3 paragraphs
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
 
     assertThat(resultForQuery("test").size()).isEqualTo(3);
 
     // when
-    Paragraph p1 = note1.getLastParagraph();
-    p1.setText("no no no");
-    notebook.saveNote(note1, AuthenticationInfo.ANONYMOUS);
-    p1.getNote().fireParagraphUpdateEvent(p1);
+    notebook.processNote(note1Id,
+      note1 ->  {
+        Paragraph p1 = note1.getLastParagraph();
+        p1.setText("no no no");
+        notebook.saveNote(note1, AuthenticationInfo.ANONYMOUS);
+        p1.getNote().fireParagraphUpdateEvent(p1);
+        return null;
+      });
     drainSearchEvents();
 
     // then
@@ -234,21 +257,26 @@ public class LuceneSearchTest {
 
     // does not include Notebook1's paragraph any more
     for (Map<String, String> result : results) {
-      assertThat(result.get("id").startsWith(note1.getId())).isFalse();
+      assertThat(result.get("id").startsWith(note1Id)).isFalse();
     }
   }
 
   @Test
   public void indexNoteNameUpdatedOnNoteSave() throws IOException, InterruptedException {
     // given: total 2 notebooks, 3 paragraphs
-    Note note1 = newNoteWithParagraph("Notebook1", "test");
-    Note note2 = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
+    String note1Id = newNoteWithParagraph("Notebook1", "test");
+    String note2Id = newNoteWithParagraphs("Notebook2", "not test", "not test at all");
     drainSearchEvents();
     assertThat(resultForQuery("test").size()).isEqualTo(3);
 
     // when
-    note1.setName("NotebookN");
-    notebook.updateNote(note1, AuthenticationInfo.ANONYMOUS);
+    // use write lock, because name is overwritten
+    notebook.processNote(note1Id,
+      note1 -> {
+        note1.setName("NotebookN");
+        notebook.updateNote(note1, AuthenticationInfo.ANONYMOUS);
+        return null;
+      });
     drainSearchEvents();
     Thread.sleep(1000);
     // then
@@ -268,25 +296,37 @@ public class LuceneSearchTest {
    * @param parText text of the paragraph
    * @return Note
    */
-  private Note newNoteWithParagraph(String noteName, String parText) throws IOException {
-    Note note1 = newNote(noteName);
-    addParagraphWithText(note1, parText);
-    return note1;
+  private String newNoteWithParagraph(String noteName, String parText) throws IOException {
+    String note1Id = newNote(noteName);
+    notebook.processNote(note1Id,
+      note1 -> {
+        addParagraphWithText(note1, parText);
+        return null;
+      });
+    return note1Id;
   }
 
-  private Note newNoteWithParagraph(String noteName, String parText, String title) throws IOException {
-    Note note = newNote(noteName);
-    addParagraphWithTextAndTitle(note, parText, title);
-    return note;
+  private String newNoteWithParagraph(String noteName, String parText, String title) throws IOException {
+    String noteId = newNote(noteName);
+    notebook.processNote(noteId,
+      note -> {
+        addParagraphWithTextAndTitle(note, parText, title);
+        return null;
+      });
+    return noteId;
   }
 
   /** Creates a new Note \w given name, adds N paragraphs \w given texts */
-  private Note newNoteWithParagraphs(String noteName, String... parTexts) throws IOException {
-    Note note1 = newNote(noteName);
-    for (String parText : parTexts) {
-      addParagraphWithText(note1, parText);
-    }
-    return note1;
+  private String newNoteWithParagraphs(String noteName, String... parTexts) throws IOException {
+    String note1Id = newNote(noteName);
+    notebook.processNote(note1Id,
+      note1 -> {
+        for (String parText : parTexts) {
+          addParagraphWithText(note1, parText);
+        }
+        return null;
+      });
+    return note1Id;
   }
 
   private Paragraph addParagraphWithText(Note note, String text) {
@@ -302,7 +342,7 @@ public class LuceneSearchTest {
     return p;
   }
 
-  private Note newNote(String name) throws IOException {
+  private String newNote(String name) throws IOException {
     return notebook.createNote(name, AuthenticationInfo.ANONYMOUS);
   }
 }


### PR DESCRIPTION
### What is this PR for?
The following changes are made with this PR:
 - a note cache that holds only a certain number of notes in memory
 - a lock for each `Note`
   - No unloading of notes when in use
   - removes methods that return a Note object so that the lock is not bypassed

### What type of PR is it?
- Bug Fix/Feature

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5559

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, a new configuration option has been added
