### PR TITLE
[ZEPPELIN-5551] add support for trino driver for recent versions

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -473,10 +473,14 @@ public class JDBCInterpreter extends KerberosInterpreter {
     LOGGER.info("Creating connection pool for url: {}, user: {}, dbPrefix: {}, properties: {}",
             url, user, dbPrefix, properties);
 
+    /* Remove properties that is not valid properties for presto/trino by checking driver key.
+     * - Presto: com.facebook.presto.jdbc.PrestoDriver
+     * - Trino(ex. PrestoSQL): io.trino.jdbc.TrinoDriver / io.prestosql.jdbc.PrestoDriver
+     */
     String driverClass = properties.getProperty(DRIVER_KEY);
     if (driverClass != null && (driverClass.equals("com.facebook.presto.jdbc.PrestoDriver")
-            || driverClass.equals("io.prestosql.jdbc.PrestoDriver"))) {
-      // Only add valid properties otherwise presto won't work.
+            || driverClass.equals("io.prestosql.jdbc.PrestoDriver")
+            || driverClass.equals("io.trino.jdbc.TrinoDriver"))) {
       for (String key : properties.stringPropertyNames()) {
         if (!PRESTO_PROPERTIES.contains(key)) {
           properties.remove(key);


### PR DESCRIPTION
### What is this PR for?

- Prestosql has changed its name to Trino in 2020.12 and Trino no longer supports the name `io.prestosql.jdbc.PrestoDriver` and has been removed in v358.
- Adds support for trino drivers for v358 and above 
- Users can now use trino named driver for driver name.

### What type of PR is it?

- Bug Fix


### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-5551

### How should this be tested?
* Test if JDBC Interpreter works for trino/presto

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/25147023/137051013-c3a65d30-9b52-4212-8c13-b7b54a7cbe3a.png)
![image](https://user-images.githubusercontent.com/25147023/137051018-6f2c656c-4b16-410b-963c-d6ec292e01b0.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
