### PR TITLE
[ZEPPELIN-5560] spark yarn app end with failed status in yarn-cluster mode

### DIFF
--- a/zeppelin-interpreter-integration/README.md
+++ b/zeppelin-interpreter-integration/README.md
@@ -1,4 +1,6 @@
 ## How to run Zeppelin integration tests
 
-If you have hadoop installed on your machine, please make sure to unset hadoop related enviromnets:
+If you have hadoop installed on your machine, please make sure to unset hadoop related environments:
 * HADOOP_CONF_DIR
+
+If you want to run integration tests in IDE, please set `ZEPPELIN_HOME` manually.

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -98,9 +98,14 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
       sparkProperties.setProperty("spark.pyspark.python", condaEnvName + "/bin/python");
     }
 
-    if (isYarnMode() && getDeployMode().equals("cluster")) {
+    if (isYarnCluster()) {
       env.put("ZEPPELIN_SPARK_YARN_CLUSTER", "true");
       sparkProperties.setProperty("spark.yarn.submit.waitAppCompletion", "false");
+      // Need to set `zeppelin.interpreter.forceShutdown` in interpreter properties directly
+      // instead of updating sparkProperties.
+      // Because `zeppelin.interpreter.forceShutdown` is initialized in RemoteInterpreterServer
+      // before SparkInterpreter is created.
+      context.getProperties().put("zeppelin.interpreter.forceShutdown", "false");
     } else if (zConf.isOnlyYarnCluster()){
       throw new IOException("Only yarn-cluster mode is allowed, please set " +
               ZeppelinConfiguration.ConfVars.ZEPPELIN_SPARK_ONLY_YARN_CLUSTER.getVarName() +
@@ -421,9 +426,5 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
 
   private boolean isYarnCluster() {
     return isYarnMode() && "cluster".equalsIgnoreCase(getDeployMode());
-  }
-
-  private boolean isYarnClient() {
-    return isYarnMode() && "client".equalsIgnoreCase(getDeployMode());
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncherTest.java
@@ -52,7 +52,7 @@ public class SparkInterpreterLauncherTest {
       System.clearProperty(confVar.getVarName());
     }
 
-    sparkHome = DownloadUtils.downloadSpark("2.4.4", "2.7");
+    sparkHome = DownloadUtils.downloadSpark("2.4.7", "2.7");
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(),
             new File("..").getAbsolutePath());
 


### PR DESCRIPTION

### What is this PR for?

The root cause is that `RemoteInterpreterServer` would call System.exit to forceShutdown spark driver in yarn-cluster mode.
This PR would disable forceShutdown in spark's yarn-cluster mode.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5560

### How should this be tested?
* CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
