### PR TITLE
[ZEPPELIN-5567] add Logging to LdapRealm on login Error

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/LdapRealm.java
@@ -206,10 +206,10 @@ public class LdapRealm extends DefaultLdapRealm {
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
       throws org.apache.shiro.authc.AuthenticationException {
-    try{
+    try {
       return super.doGetAuthenticationInfo(token);
-    }catch (Exception e){
-      LOGGER.warn(String.format("Encountered Error while authenticating %s: %s", token.getPrincipal(), e.getMessage()));
+    } catch (org.apache.shiro.authc.AuthenticationException e){
+      LOGGER.warn("Encountered Error while authenticating {}: {}", token.getPrincipal(), e.getMessage());
       throw  e;
     }
   }


### PR DESCRIPTION
### What is this PR for?
Add a bit of Logging to LdapRealm on User Login failure to see which user was affected


### What type of PR is it?
Improvement 

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5567

### How should this be tested?
* Verify that on Login Failure with LDAP an Warning Log MEssage is printed containing the Username

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
