### PR TITLE
[ZEPPELIN-5571] Return empty list instead of null

### DIFF
--- a/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/FileSystemNotebookRepo.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +129,7 @@ public class FileSystemNotebookRepo implements NotebookRepo {
   @Override
   public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
     LOGGER.warn("getSettings is not implemented for FileSystemNotebookRepo");
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/OldFileSystemNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/filesystem/src/main/java/org/apache/zeppelin/notebook/repo/OldFileSystemNotebookRepo.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -81,7 +82,7 @@ public class OldFileSystemNotebookRepo implements OldNotebookRepo {
   @Override
   public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
     LOGGER.warn("getSettings is not implemented for HdfsNotebookRepo");
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/InMemoryNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/InMemoryNotebookRepo.java
@@ -24,6 +24,7 @@ import org.apache.zeppelin.notebook.NoteInfo;
 import org.apache.zeppelin.user.AuthenticationInfo;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class InMemoryNotebookRepo implements NotebookRepo {
 
   @Override
   public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -55,6 +55,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -184,7 +185,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     @Override
     public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-      return null;
+      return Collections.emptyList();
     }
 
     @Override
@@ -265,7 +266,7 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
 
     @Override
     public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-      return null;
+      return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
### What is this PR for?
This pull request sends an empty list to the zeppelin-web-angular frontend and the variable `settings` is defined with it.


### What type of PR is it?
 - Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5571

### How should this be tested?
* Ci

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
