### PR TITLE
[ZEPPELIN-5574] ConcurrentModificationException in JsonResponse.toString() when getNote with restAPI

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
@@ -172,7 +172,7 @@ public class GUI implements Serializable {
   public void convertOldInput() {
     for (Map.Entry<String, Input> entry : forms.entrySet()) {
       if (entry.getValue() instanceof OldInput) {
-        Input convertedInput = convertFromOldInput((OldInput) entry.getValue());
+        Input convertedInput = Input.convertFromOldInput((OldInput) entry.getValue());
         forms.put(entry.getKey(), convertedInput);
       }
     }
@@ -182,23 +182,5 @@ public class GUI implements Serializable {
     GUI gui = gson.fromJson(json, GUI.class);
     gui.convertOldInput();
     return gui;
-  }
-
-  private Input convertFromOldInput(OldInput oldInput) {
-    Input convertedInput = null;
-
-    if (oldInput.options == null || oldInput instanceof OldInput.OldTextBox) {
-      convertedInput = new TextBox(oldInput.name, oldInput.defaultValue.toString());
-    } else if (oldInput instanceof OldInput.OldCheckBox) {
-      convertedInput = new CheckBox(oldInput.name, (List) oldInput.defaultValue, oldInput.options);
-    } else if (oldInput instanceof OldInput && oldInput.options != null) {
-      convertedInput = new Select(oldInput.name, oldInput.defaultValue, oldInput.options);
-    } else {
-      throw new RuntimeException("Can not convert this OldInput.");
-    }
-    convertedInput.setDisplayName(oldInput.getDisplayName());
-    convertedInput.setHidden(oldInput.isHidden());
-    convertedInput.setArgument(oldInput.getArgument());
-    return convertedInput;
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/Input.java
@@ -37,6 +37,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
+ * Input is Immutable class.
  * Base class for dynamic forms. Also used as factory class of dynamic forms.
  *
  * @param <T>
@@ -81,15 +82,15 @@ public class Input<T> implements Serializable {
     return displayName;
   }
 
-  public void setDisplayName(String displayName) {
+  private void setDisplayName(String displayName) {
     this.displayName = displayName;
   }
 
-  public void setArgument(String argument) {
+  private void setArgument(String argument) {
     this.argument = argument;
   }
 
-  public void setHidden(boolean hidden) {
+  private void setHidden(boolean hidden) {
     this.hidden = hidden;
   }
 
@@ -555,5 +556,23 @@ public class Input<T> implements Serializable {
     } else {
       return false;
     }
+  }
+
+  public static Input convertFromOldInput(OldInput oldInput) {
+    Input convertedInput = null;
+
+    if (oldInput.options == null || oldInput instanceof OldInput.OldTextBox) {
+      convertedInput = new TextBox(oldInput.name, oldInput.defaultValue.toString());
+    } else if (oldInput instanceof OldInput.OldCheckBox) {
+      convertedInput = new CheckBox(oldInput.name, (List) oldInput.defaultValue, oldInput.options);
+    } else if (oldInput instanceof OldInput && oldInput.options != null) {
+      convertedInput = new Select(oldInput.name, oldInput.defaultValue, oldInput.options);
+    } else {
+      throw new RuntimeException("Can not convert this OldInput.");
+    }
+    convertedInput.setDisplayName(oldInput.getDisplayName());
+    convertedInput.setHidden(oldInput.isHidden());
+    convertedInput.setArgument(oldInput.getArgument());
+    return convertedInput;
   }
 }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -901,8 +901,8 @@ public class NotebookService {
           return null;
         }
 
-        note.getNoteForms().remove(formName);
-        note.getNoteParams().remove(formName);
+        note.removeNoteForm(formName);
+        note.removeNoteParam(formName);
         notebook.saveNote(note, context.getAutheInfo());
         callback.onSuccess(note, context);
         return null;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -724,9 +725,9 @@ public class NotebookServerTest extends AbstractTestRestApi {
         Paragraph paragraph = note.getParagraph(paragraphId);
         // check RuntimeInfos
         assertTrue(paragraph.getRuntimeInfos().containsKey("jobUrl"));
-        List<Object> list = paragraph.getRuntimeInfos().get("jobUrl").getValue();
+        Queue<Object> list = paragraph.getRuntimeInfos().get("jobUrl").getValue();
         assertEquals(1, list.size());
-        Map<String, String> map = (Map<String, String>) list.get(0);
+        Map<String, String> map = (Map<String, String>) list.poll();
         assertEquals(2, map.size());
         assertEquals(map.get("jobUrl"), "jobUrl_value");
         assertEquals(map.get("jobLabel"), "jobLabel_value");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -327,8 +328,8 @@ public class Notebook {
             newNote.setConfig(new HashMap<>(sourceNote.getConfig()));
             newNote.setInfo(new HashMap<>(sourceNote.getInfo()));
             newNote.setDefaultInterpreterGroup(sourceNote.getDefaultInterpreterGroup());
-            newNote.setNoteForms(sourceNote.getNoteForms());
-            newNote.setNoteParams(sourceNote.getNoteParams());
+            newNote.setNoteForms(new ConcurrentHashMap<>(sourceNote.getNoteForms()));
+            newNote.setNoteParams(new ConcurrentHashMap<>(sourceNote.getNoteParams()));
             newNote.setRunning(false);
             saveNote(newNote, subject);
             authorizationService.cloneNoteMeta(newNote.getId(), sourceNoteId, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -327,10 +327,9 @@ public class Notebook {
             newNote.setConfig(new HashMap<>(sourceNote.getConfig()));
             newNote.setInfo(new HashMap<>(sourceNote.getInfo()));
             newNote.setDefaultInterpreterGroup(sourceNote.getDefaultInterpreterGroup());
-            newNote.setNoteForms(new HashMap<>(sourceNote.getNoteForms()));
-            newNote.setNoteParams(new HashMap<>(sourceNote.getNoteParams()));
+            newNote.setNoteForms(sourceNote.getNoteForms());
+            newNote.setNoteParams(sourceNote.getNoteParams());
             newNote.setRunning(false);
-
             saveNote(newNote, subject);
             authorizationService.cloneNoteMeta(newNote.getId(), sourceNoteId, subject);
             return null;
@@ -376,7 +375,7 @@ public class Notebook {
    * with other properties that is not persistent in NotebookRepo, such as paragraphJobListener.
    * <p>
    * Use {@link #processNote(String, boolean, NoteProcessor)} in case you want to force
-   * a note reload from the {@link #NotebookRepo}.
+   * a note reload from the {@link NotebookRepo}.
    * </p>
    * @param noteId
    * @param noteProcessor
@@ -426,7 +425,7 @@ public class Notebook {
 
   /**
    * Checks if the notebook contains a note with the specified note ID.
-   * @param notePath
+   * @param noteId
    * @return true if a note with the specified note ID exists, otherwise false
    */
   public boolean containsNoteById(String noteId) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -619,27 +619,23 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   public ApplicationState createOrGetApplicationState(HeliumPackage pkg) {
-    synchronized (apps) {
-      for (ApplicationState as : apps) {
-        if (as.equals(pkg)) {
-          return as;
-        }
+    for (ApplicationState as : apps) {
+      if (as.equals(pkg)) {
+        return as;
       }
-
-      String appId = getApplicationId(pkg);
-      ApplicationState appState = new ApplicationState(appId, pkg);
-      apps.add(appState);
-      return appState;
     }
+
+    String appId = getApplicationId(pkg);
+    ApplicationState appState = new ApplicationState(appId, pkg);
+    apps.add(appState);
+    return appState;
   }
 
 
   public ApplicationState getApplicationState(String appId) {
-    synchronized (apps) {
-      for (ApplicationState as : apps) {
-        if (as.getId().equals(appId)) {
-          return as;
-        }
+    for (ApplicationState as : apps) {
+      if (as.getId().equals(appId)) {
+        return as;
       }
     }
 
@@ -647,9 +643,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
   }
 
   public List<ApplicationState> getAllApplicationStates() {
-    synchronized (apps) {
-      return new LinkedList<>(apps);
-    }
+    return new LinkedList<>(apps);
   }
 
   String extractVariablesFromAngularRegistry(String scriptBody, Map<String, Input> inputs,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/ParagraphRuntimeInfo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/ParagraphRuntimeInfo.java
@@ -5,21 +5,25 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Store runtime infos of each para
  *
  */
 public class ParagraphRuntimeInfo {
-  private String propertyName;  // Name of the property
-  private String label;         // Label to be used in UI
-  private String tooltip;       // Tooltip text toshow in UI
-  private String group;         // The interpretergroup from which the info was derived
+  private final String propertyName;  // Name of the property
+  private final String label;         // Label to be used in UI
+  private final String tooltip;       // Tooltip text toshow in UI
+  private final String group;         // The interpretergroup from which the info was derived
 
   // runtimeInfos job url or dropdown-menu key in
   // zeppelin-web/src/app/notebook/paragraph/paragraph-control.html
-  private List<Object> values;  // values for the key-value pair property
-  private String interpreterSettingId;
+  // Use ConcurrentLinkedQueue to make ParagraphRuntimeInfo thread-safe which is required by
+  // Note/Paragraph serialization (saving note to NotebookRepo or broadcast to frontend), see ZEPPELIN-5530.
+  private final ConcurrentLinkedQueue<Object> values;  // values for the key-value pair property
+  private final String interpreterSettingId;
   
   public ParagraphRuntimeInfo(String propertyName, String label, 
       String tooltip, String group, String intpSettingId) {
@@ -31,7 +35,7 @@ public class ParagraphRuntimeInfo {
     this.tooltip = tooltip;
     this.group = group;
     this.interpreterSettingId = intpSettingId;
-    this.values = new ArrayList<>();
+    this.values = new ConcurrentLinkedQueue();
   }
 
   public void addValue(Map<String, String> mapValue) {
@@ -39,7 +43,7 @@ public class ParagraphRuntimeInfo {
   }
 
   @VisibleForTesting
-  public List<Object> getValue() {
+  public Queue<Object> getValue() {
     return values;
   }
   


### PR DESCRIPTION

### What is this PR for?

The root cause of this issue is that when Note is serialized to json, it is being modified by another thread. This PR use thread-safe class for Note/Paragraph. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5574

### How should this be tested?
* Tested it for 2 days in customer's environment and no issue happen again. (Before this PR, this issue happens everyday)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
