### PR TITLE
[ZEPPELIN-5572] resolve the websocket deadlock problem 

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -40,7 +40,7 @@ public class NotebookSocket {
     return String.valueOf(headers.get(key));
   }
 
-  public synchronized void send(String serializeMessage) throws IOException {
+  public void send(String serializeMessage) throws IOException {
     session.getBasicRemote().sendText(serializeMessage);
   }
 


### PR DESCRIPTION
### What is this PR for?
- The org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint#blockingWrite method has been to ensure that the websocket sends messages serially by `ReentrantLock` and `WriteBlocket`, so the NotebookSocket.send method does not need to be locked.
- If we lock the NotebookSocket.send method, the NotebookServer#onClose method will be triggered when the NotebookSocket.send method sends a message abnormally. At this time, if there are other threads that need to send messages through the current Websocket Session to preempt the noteSocketMap lock in the ConnectionManager,  It will trigger a deadlock.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-5572](https://issues.apache.org/jira/browse/ZEPPELIN-5572)

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
