### PR TITLE
[ZEPPELIN-5580] Pass scala version from SparkInterpreterLauncher instead of detect it at runtime

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -123,6 +123,14 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     }
 
 
+    String scalaVersion = null;
+    try {
+      scalaVersion = detectSparkScalaVersion(getEnv("SPARK_HOME"), env);
+      context.getProperties().put("zeppelin.spark.scala.version", scalaVersion);
+    } catch (Exception e) {
+      throw new IOException("Fail to detect scala version, the reason is:"+ e.getMessage());
+    }
+
     if (isYarnMode()
         && getDeployMode().equals("cluster")) {
       try {
@@ -138,7 +146,6 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
           }
         }
 
-        String scalaVersion = detectSparkScalaVersion(getEnv("SPARK_HOME"), env);
         Path scalaFolder =  Paths.get(zConf.getZeppelinHome(), "/interpreter/spark/scala-" + scalaVersion);
         if (!scalaFolder.toFile().exists()) {
           throw new IOException("spark scala folder " + scalaFolder.toFile() + " doesn't exist");


### PR DESCRIPTION
### What is this PR for?
Currently we detect scala version via scala.util.Properties.versionString(); 
but it depends on the resource file library.version on classpath, sometimes user may package this resource of scala-2.11 into his jar which cause we detect the wrong scala version.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5580

### How should this be tested?
CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
