### PR TITLE
[ZEPPELIN-5590] Support flink per job mode

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -790,6 +790,14 @@ In this section, we will list and explain all the supported local properties in 
   </tr>
 </table>
 
+## PerJob Mode
+
+The flink cluster launched in Zeppelin is session cluster, but you can simulate Flink's per job mode via this approach.
+* Set `zeppelin.notebook.run_all.isolated` to be `true` in `zeppelin-site.xml`
+* Run Flink note by clicking `Run all paragraphs` button in note menu.
+
+In this way, when all the paragraphs are finished, the flink interpreter will be shutdown and its associated flink cluster will be shutdown as well.
+
 ## Tutorial Notes
 
 Zeppelin is shipped with several Flink tutorial notes which may be helpful for you. You can check for more features in the tutorial notes.

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -463,6 +463,12 @@ Sources descending by priority:
     <td></td>
     <td>comma-separated list of folder, where cron is allowed</td>
   </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_NOTEBOOK_RUN_ALL_ISOLATED</h6></td>
+    <td><h6 class="properties">zeppelin.notebook.run_all.isolated</h6></td>
+    <td></td>
+    <td>Whether using isolated mode for RUN ALL action in note menu bar. In isolated mode, associated interpreters will be shutdown after RUN ALL is finished.</td>
+  </tr>
 </table>
 
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -943,6 +943,8 @@ public class ZeppelinConfiguration {
     ZEPPELIN_NOTEBOOK_RUN_SERVICE_CONTEXT("zeppelin.notebook.run.servicecontext", null), // base64 encoded serialized service context to be used ZEPPELIN_NOTEBOOK_RUN_ID.
     ZEPPELIN_NOTEBOOK_RUN_AUTOSHUTDOWN("zeppelin.notebook.run.autoshutdown", true), // after specified note (ZEPPELIN_NOTEBOOK_RUN_ID) run, shutdown zeppelin server
 
+    ZEPPELIN_NOTEBOOK_RUN_ALL_ISOLATED("zeppelin.notebook.run_all.isolated", false), // whether using isolated mode for RUN_ALL action
+
     ZEPPELIN_RECOVERY_DIR("zeppelin.recovery.dir", "recovery"),
     ZEPPELIN_RECOVERY_STORAGE_CLASS("zeppelin.recovery.storage.class",
         "org.apache.zeppelin.interpreter.recovery.NullRecoveryStorage"),

--- a/zeppelin-server/conf/notebook-authorization.json
+++ b/zeppelin-server/conf/notebook-authorization.json
@@ -1,0 +1,10 @@
+{
+  "authInfo": {
+    "2GMP1TW4Y": {
+      "readers": [],
+      "owners": [],
+      "writers": [],
+      "runners": []
+    }
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -84,8 +84,6 @@ public class NotebookServiceTest {
 
   private ServiceCallback callback = mock(ServiceCallback.class);
 
-  private Gson gson = new Gson();
-
 
   @Before
   public void setUp() throws Exception {
@@ -426,6 +424,7 @@ public class NotebookServiceTest {
     // TODO(zjffdu) Enable it after ZEPPELIN-3699
     // assertNotNull(p.getResult());
     verify(callback).onSuccess(p, context);
+
 
     // clean output
     reset(callback);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Note.java
@@ -754,6 +754,7 @@ public class Note implements JsonSerializable {
     if (isRunning()) {
       throw new Exception("Unable to run note:" + id + " because it is still in RUNNING state.");
     }
+    LOGGER.info("Run all paragraphs of note: {}, blocking: {}, isolated: {}", id, blocking, isolated);
     setIsolatedMode(isolated);
     setRunning(true);
     setStartTime(DATE_TIME_FORMATTER.format(LocalDateTime.now()));


### PR DESCRIPTION
### What is this PR for?

This PR is to support flink per job mode when user click `Run all paragraphs` button.  It introduce new property `zeppelin.notebook.run_all.isolated` to control whether run the whole note in isolated mode (use isolated mode for interpreter and close interpreter after running whole note).

### What type of PR is it?
[ Feature | Documentation ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5590

### How should this be tested?
* Manually testd

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
