### PR TITLE
[ZEPPELIN-5601]Make the page update after excuse the clear output paragraph action

### DIFF
--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -103,6 +103,12 @@ export abstract class ParagraphBase extends MessageListenersManager {
   paragraphData(data: MessageReceiveDataTypeMap[OP.PARAGRAPH]) {
     const oldPara = this.paragraph;
     const newPara = data.paragraph;
+    if (!newPara.results) {
+      newPara.results = {};
+    }
+    if (!newPara.results.msg) {
+      newPara.results.msg = [];
+    }
     if (this.isUpdateRequired(oldPara, newPara)) {
       this.updateParagraph(oldPara, newPara, () => {
         if (newPara.results && newPara.results.msg) {

--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -106,9 +106,6 @@ export abstract class ParagraphBase extends MessageListenersManager {
     if (!newPara.results) {
       newPara.results = {};
     }
-    if (!newPara.results.msg) {
-      newPara.results.msg = [];
-    }
     if (this.isUpdateRequired(oldPara, newPara)) {
       this.updateParagraph(oldPara, newPara, () => {
         if (newPara.results && newPara.results.msg) {


### PR DESCRIPTION
### What is this PR for?
The page is not updated after excuse action of clear output paragraph, because the backend don't responese  the column of results when frented send the websocket command PARAGRAPH_CLEAR_OUTPUT. So add the initial value  make sure enter reload logical

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5601

### How should this be tested?
I have problems with CI, but I am able to run them successfully locally.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/44150070/144569383-43cea4c0-6356-4d4b-b858-553dd01de65c.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
