### PR TITLE
[ZEPPELIN-5619] Fix 'import ipynb/json notebook' button bug

### DIFF
--- a/zeppelin-web/src/components/note-import/note-import.controller.js
+++ b/zeppelin-web/src/components/note-import/note-import.controller.js
@@ -43,6 +43,10 @@ function NoteImportCtrl($scope, $timeout, websocketMsgSrv) {
     angular.element('#noteImportFile').click();
   };
 
+  $scope.resetFile = function(element) {
+    element.value = '';
+  };
+
   $scope.importFile = function(element) {
     $scope.note.errorText = '';
     $scope.note.importFile = element.files[0];

--- a/zeppelin-web/src/components/note-import/note-import.html
+++ b/zeppelin-web/src/components/note-import/note-import.html
@@ -47,6 +47,7 @@ limitations under the License.
             <div style="display: none">
               <input class="form-control note-name-input" id="noteImportFile"
                      placeholder="Note name" type="file"
+                     onclick="angular.element(this).scope().resetFile(this)"
                      ng-model="note.importFile" onchange="angular.element(this).scope().importFile(this)" />
             </div>
           </div>


### PR DESCRIPTION
### What is this PR for?
Fixed 'import note - select json/ipynb file' button bug
This is my first contribution to open source, so if there is any problem please let me know

### What type of PR is it?
Bug Fix

### Todos
No

### What is the Jira issue?
[[ZEPPELIN-5619]](https://issues.apache.org/jira/browse/ZEPPELIN-5619)


### How should this be tested?
1. Import some local ipynb file(notebook1.ipynb) via ‘Import New Note’

2. Import another ipynb file(notebook2.ipynb) with the same note name(notebook1). This will make some error message because there exists a zeppelin notebook with the same name(notebook1) in the path

3. Again, import the same ipynb file(notebook2.ipynb) used at step2 without changing note name. Importing notebook process is successfully triggered.


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
