### PR TITLE
[ZEPPELIN-5625] Potentially misleading error message when sparkR backend is not available

### DIFF
--- a/rlang/src/main/java/org/apache/zeppelin/r/RInterpreter.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/RInterpreter.java
@@ -131,7 +131,7 @@ public class RInterpreter extends AbstractInterpreter {
       // render output with knitr
       if (rbackendDead.get()) {
         return new InterpreterResult(InterpreterResult.Code.ERROR,
-            "sparkR backend is dead, please try to increase spark.r.backendConnectionTimeout");
+            "sparkR backend is dead");
       }
       if (useKnitr) {
         zeppelinR.setInterpreterOutput(null);


### PR DESCRIPTION
### What is this PR for?
Removing potentially misleading message about cause of R interpreter's not being available


### What type of PR is it?
Documentation

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5625

### How should this be tested?
* Let sparkR backend die, run a cell with %r interpreter

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
