### PR TITLE
[ZEPPELIN-5613] zeppelin-interpreter-parent: Add dependencyManagement for log4j2 in pom.xml

### DIFF
--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -33,6 +33,35 @@
   <version>0.9.0-SNAPSHOT</version>
   <name>Zeppelin: Interpreter Parent</name>
 
+  <properties>
+    <log4j2.version>2.17.1</log4j2.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-web</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
### What is this PR for?
I found that geode-interpreter using log4j2 so I added dependencyManagement for log4j2.

I think that this PR prevent potential log4jShell through future interpreter.


### What type of PR is it?
[Bug Fix]

### Todos
* Nothing

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5613

### How should this be tested?
```
mvn dependency:tree
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
    * No
* Is there breaking changes for older versions?
    * No
* Does this needs documentation?
    * No
