### PR TITLE
[ZEPPELIN-5636] Improvement:  Automatically clean old version for /interpreter/zeppelin-interpreter-shaded-*.jar

### DIFF
--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -155,6 +155,10 @@
             </goals>
             <configuration>
               <target>
+                <echo>ANT TASK - clean files....</echo>
+                <delete failonerror="false">
+                  <fileset dir="${project.basedir}/../interpreter" includes="zeppelin-interpreter-shaded-*.jar" />
+                </delete>
                 <echo>ANT TASK - copying files....</echo>
                 <copy todir="${project.basedir}/../interpreter" overwrite="true" flatten="true">
                   <fileset dir="${project.build.directory}" includes="zeppelin-interpreter-shaded-*.jar" >


### PR DESCRIPTION
### What is this PR for?
This PR is to automatically clean old version for /interpreter/zeppelin-interpreter-shaded-*.jar.

If there are more than one version of /interpreter/zeppelin-interpreter-shaded-*.jar, all version of them would be added into javapath when Zeppelin interpreter starts, which would cause  a lot of unexpected problems. And this situation is easy to be ignored when developing.


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-5636

### How should this be tested?
CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
