### PR TITLE
[ZEPPELIN-5644] Reduce redundancy during the interpreter execution process

### DIFF
--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -544,7 +544,7 @@ public class SparkInterpreterTest {
   }
 
   @Test
-  public void testScopedMode() throws InterpreterException {
+  public void testScopedMode() throws Exception {
     Properties properties = new Properties();
     properties.setProperty(SparkStringConstants.MASTER_PROP_NAME, "local");
     properties.setProperty(SparkStringConstants.APP_NAME_PROP_NAME, "test");
@@ -566,6 +566,9 @@ public class SparkInterpreterTest {
     InterpreterContext.set(getInterpreterContext());
     interpreter1.open();
     interpreter2.open();
+
+    // check if there is any duplicated loaded class
+    assertEquals(true, interpreter1.getInnerInterpreter().getClass()==interpreter2.getInnerInterpreter().getClass());
 
     InterpreterContext context = getInterpreterContext();
 

--- a/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
+++ b/spark/scala-2.11/src/main/scala/org/apache/zeppelin/spark/SparkScala211Interpreter.scala
@@ -120,6 +120,7 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     super.close()
     if (sparkILoop != null) {
       sparkILoop.closeInterpreter()
+      sparkILoop = null
     }
   }
 

--- a/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
+++ b/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
@@ -111,6 +111,7 @@ class SparkScala212Interpreter(override val conf: SparkConf,
     super.close()
     if (sparkILoop != null) {
       sparkILoop.closeInterpreter()
+      sparkILoop = null
     }
   }
 

--- a/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
+++ b/spark/spark-scala-parent/src/main/scala/org/apache/zeppelin/spark/BaseSparkScalaInterpreter.scala
@@ -202,13 +202,14 @@ abstract class BaseSparkScalaInterpreter(val conf: SparkConf,
     }
     if (sc != null) {
       sc.stop()
+      sc = null
     }
-    sc = null
     if (sparkSession != null) {
       sparkSession.getClass.getMethod("stop").invoke(sparkSession)
       sparkSession = null
     }
     sqlContext = null
+    z = null
   }
 
   private def cleanupStagingDirInternal(stagingDirPath: Path, hadoopConf: Configuration): Unit = {


### PR DESCRIPTION
### What is this PR for?
Optimize the interpreter execution process from the following aspects:
1. Close the interpreter executor thread when restart interpreter;
2. Only close opened interpreter when restart interpreter and create non-existent interpreter when create Interpreter;
3. For spark interpreter, reuse the static innerScalaInterpreter class, in the context of multi sub threads, which is only loaded by the first interpreter;
4. When close spark interpreter, set the inner objects (SparkZeppelinContext and sparkILoop) to empty.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5644

### How should this be tested?
* Covered by existing unit test

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
