### PR TITLE
[ZEPPELIN-5654] Implement GCSNotebookRepo Move

### DIFF
--- a/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
@@ -201,8 +201,11 @@ public class GCSNotebookRepo implements NotebookRepo {
   }
 
   @Override
-  public void move(String noteId, String notePath, String newNotePath, AuthenticationInfo subject) {
-
+  public void move(String noteId, String notePath, String newNotePath, AuthenticationInfo subject) throws IOException {
+    BlobId blobId = makeBlobId(noteId, notePath);
+    BlobId destinationBlobId = makeBlobId(noteId, newNotePath);
+    storage.get(blobId).copyTo(destinationBlobId).getResult();
+    remove(noteId, notePath, subject);
   }
 
   @Override

--- a/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
@@ -202,9 +202,14 @@ public class GCSNotebookRepo implements NotebookRepo {
 
   @Override
   public void move(String noteId, String notePath, String newNotePath, AuthenticationInfo subject) throws IOException {
-    BlobId blobId = makeBlobId(noteId, notePath);
+    Preconditions.checkArgument(StringUtils.isNotEmpty(noteId));
+    BlobId sourceBlobId = makeBlobId(noteId, notePath);
     BlobId destinationBlobId = makeBlobId(noteId, newNotePath);
-    storage.get(blobId).copyTo(destinationBlobId).getResult();
+    try {
+      storage.get(sourceBlobId).copyTo(destinationBlobId);
+    } catch (StorageException se) {
+      throw new IOException("Could not copy from " + sourceBlobId.toString() + " to " + destinationBlobId.toString() + ": " + se.getMessage(), se);
+    }
     remove(noteId, notePath, subject);
   }
 

--- a/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/main/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepo.java
@@ -207,7 +207,7 @@ public class GCSNotebookRepo implements NotebookRepo {
     BlobId destinationBlobId = makeBlobId(noteId, newNotePath);
     try {
       storage.get(sourceBlobId).copyTo(destinationBlobId);
-    } catch (StorageException se) {
+    } catch (Exception se) {
       throw new IOException("Could not copy from " + sourceBlobId.toString() + " to " + destinationBlobId.toString() + ": " + se.getMessage(), se);
     }
     remove(noteId, notePath, subject);

--- a/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
@@ -96,6 +96,8 @@ public class GCSNotebookRepoTest {
     Paragraph p = new Paragraph(note, null);
     p.setText("text");
     p.setStatus(Status.RUNNING);
+    String nullRoles = null;
+    p.setAuthenticationInfo(new AuthenticationInfo("anonymous", (String)null, "anonymous"));
     note.addParagraph(p);
     return note;
   }

--- a/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
@@ -96,7 +96,6 @@ public class GCSNotebookRepoTest {
     Paragraph p = new Paragraph(note, null);
     p.setText("text");
     p.setStatus(Status.RUNNING);
-    String nullRoles = null;
     p.setAuthenticationInfo(new AuthenticationInfo("anonymous", (String)null, "anonymous"));
     note.addParagraph(p);
     return note;

--- a/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/gcs/src/test/java/org/apache/zeppelin/notebook/repo/GCSNotebookRepoTest.java
@@ -186,6 +186,21 @@ public class GCSNotebookRepoTest {
     assertThat(storage.get(makeBlobId(runningNote.getId(), runningNote.getPath()))).isNull();
   }
 
+  @Test
+  public void testMove_nonexistent() throws Exception {
+    try {
+      notebookRepo.move("id", "/name", "/name_new", AUTH_INFO);
+      fail();
+    } catch (IOException e) {}
+  }
+
+  @Test
+  public void testMove() throws Exception {
+    create(runningNote);
+    notebookRepo.move(runningNote.getId(), runningNote.getPath(), runningNote.getPath() + "_new", AUTH_INFO);
+    assertThat(storage.get(makeBlobId(runningNote.getId(), runningNote.getPath()))).isNull();
+  }
+
   private String makeName(String relativePath) {
     if (basePath.isPresent()) {
       return basePath.get() + "/" + relativePath;


### PR DESCRIPTION
### What is this PR for?
This is to implement move function that is used for renaming notebooks and moving it to trash.
Currently it would result in a no op, making users unable to rename notebooks if using GCS as the notebook repository.

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5654

### How should this be tested?
CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No?
