### PR TITLE
[ZEPPELIN-5661] Support clone a specific revision of a note

### DIFF
--- a/docs/usage/rest_api/notebook.md
+++ b/docs/usage/rest_api/notebook.md
@@ -352,7 +352,8 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
     <tr>
       <td>Description</td>
       <td>This ```POST``` method clones a note by the given id and create a new note using the given name
-          or default name if none given.
+          or default name if none given. If what you want to copy is a certain version of note, you need 
+          to specify the revisionId.
           The body field of the returned JSON contains the new note id.
       </td>
     </tr>
@@ -373,7 +374,10 @@ Notebooks REST API supports the following operations: List, Create, Get, Delete,
       <td>
 
 ```json
-{"name": "name of new note"}
+{
+  "name": "name of new note",
+  "revisionId": "revisionId of note to be copied (optional)"
+}
 ```
 </td>
     </tr>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -469,11 +469,13 @@ public class NotebookRestApi extends AbstractRestApi {
     checkIfUserCanWrite(noteId, "Insufficient privileges you cannot clone this note");
     NewNoteRequest request = NewNoteRequest.fromJson(message);
     String newNoteName = null;
+    String revisionId = null;
     if (request != null) {
       newNoteName = request.getName();
+      revisionId = request.getRevisionId();
     }
     AuthenticationInfo subject = new AuthenticationInfo(authenticationService.getPrincipal());
-    String newNoteId = notebookService.cloneNote(noteId, newNoteName, getServiceContext(),
+    String newNoteId = notebookService.cloneNote(noteId, revisionId, newNoteName, getServiceContext(),
             new RestServiceCallback<Note>() {
               @Override
               public void onSuccess(Note newNote, ServiceContext context) throws IOException {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/message/NewNoteRequest.java
@@ -33,6 +33,7 @@ public class NewNoteRequest implements JsonSerializable {
   private String defaultInterpreterGroup;
   private boolean addingEmptyParagraph = false;
   private List<NewParagraphRequest> paragraphs;
+  private String revisionId;
 
   public NewNoteRequest (){
   }
@@ -51,6 +52,10 @@ public class NewNoteRequest implements JsonSerializable {
 
   public List<NewParagraphRequest> getParagraphs() {
     return paragraphs;
+  }
+
+  public String getRevisionId() {
+    return revisionId;
   }
 
   public String toJson() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -317,15 +317,30 @@ public class NotebookService {
   }
 
   public String cloneNote(String noteId,
-                        String newNotePath,
-                        ServiceContext context,
-                        ServiceCallback<Note> callback) throws IOException {
+                          String newNotePath,
+                          ServiceContext context,
+                          ServiceCallback<Note> callback) throws IOException {
+    return cloneNote(noteId, "", newNotePath, context, callback);
+  }
+
+
+  public String cloneNote(String noteId,
+                          String revisionId,
+                          String newNotePath,
+                          ServiceContext context,
+                          ServiceCallback<Note> callback) throws IOException {
     //TODO(zjffdu) move these to Notebook
     if (StringUtils.isBlank(newNotePath)) {
       newNotePath = "/Cloned Note_" + noteId;
+      if(StringUtils.isNotEmpty(revisionId)) {
+        // If cloning a revision of the note,
+        // append the short commit id of revision to newNoteName
+        // to distinguish which commit to be copied.
+        newNotePath += "_" + revisionId.substring(0, 7);
+      }
     }
     try {
-      String newNoteId = notebook.cloneNote(noteId, normalizeNotePath(newNotePath),
+      String newNoteId = notebook.cloneNote(noteId, revisionId, normalizeNotePath(newNotePath),
           context.getAutheInfo());
       return notebook.processNote(newNoteId,
         newNote -> {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -30,6 +30,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.rest.message.ParametersRequest;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.utils.TestUtils;
@@ -42,10 +43,7 @@ import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -695,33 +693,69 @@ public class NotebookRestApiTest extends AbstractTestRestApi {
   public void testCloneNote() throws IOException {
     LOG.info("Running testCloneNote");
     String note1Id = null;
-    String clonedNoteId = null;
+    List<String> clonedNoteIds = new ArrayList<>();
+    String text1 = "%text clone note";
+    String text2 = "%text clone revision of note";
     try {
-      note1Id = TestUtils.getInstance(Notebook.class).createNote("note1", anonymous);
-      CloseableHttpResponse post = httpPost("/notebook/" + note1Id, "");
-      String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testCloneNote response\n" + postResponse);
-      assertThat(post, isAllowed());
-      Map<String, Object> resp = gson.fromJson(postResponse,
-              new TypeToken<Map<String, Object>>() {}.getType());
-      clonedNoteId = (String) resp.get("body");
-      post.close();
+      Notebook notebook = TestUtils.getInstance(Notebook.class);
+      note1Id = notebook.createNote("note1", anonymous);
 
-      CloseableHttpResponse get = httpGet("/notebook/" + clonedNoteId);
-      assertThat(get, isAllowed());
-      Map<String, Object> resp2 = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
-              new TypeToken<Map<String, Object>>() {}.getType());
-      Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
+      // add text and commit note
+      NotebookRepoWithVersionControl.Revision first_commit =
+              notebook.processNote(note1Id, note -> {
+                Paragraph p1 = note.addNewParagraph(anonymous);
+                p1.setText(text2);
+                notebook.saveNote(note, AuthenticationInfo.ANONYMOUS);
+                return notebook.checkpointNote(note.getId(), note.getPath(), "first commit", anonymous);
+              });
 
-      //    assertEquals(resp2Body.get("name"), "Note " + clonedNoteId);
-      get.close();
+      // change the text of note
+      notebook.processNote(note1Id, note -> {
+        note.getParagraph(0).setText(text1);
+        return null;
+      });
+
+      // Clone a note
+      CloseableHttpResponse post1 = httpPost("/notebook/" + note1Id, "");
+      // Clone a revision of note
+      CloseableHttpResponse post2 =
+              httpPost("/notebook/" + note1Id, "{ revisionId: " + first_commit.id + "}");
+
+      // Verify the responses
+      for (int i = 0; i < 2; i++) {
+        CloseableHttpResponse post = Arrays.asList(post1, post2).get(i);
+        String text = Arrays.asList(text1, text2).get(i);
+
+        String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
+        LOG.info("testCloneNote response: {}", postResponse);
+        assertThat(post, isAllowed());
+        Map<String, Object> resp = gson.fromJson(postResponse,
+                new TypeToken<Map<String, Object>>() {
+                }.getType());
+        clonedNoteIds.add((String) resp.get("body"));
+        post.close();
+
+        CloseableHttpResponse get = httpGet("/notebook/" + clonedNoteIds.get(clonedNoteIds.size() - 1));
+        assertThat(get, isAllowed());
+        Map<String, Object> resp2 = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
+                new TypeToken<Map<String, Object>>() {
+                }.getType());
+        Map<String, Object> resp2Body = (Map<String, Object>) resp2.get("body");
+        List<Map<String, String>> paragraphs = (List<Map<String, String>>) resp2Body.get("paragraphs");
+        // Verify that the original and copied text are consistent
+        assertEquals(text, paragraphs.get(0).get("text"));
+        //    assertEquals(resp2Body.get("name"), "Note " + clonedNoteId);
+        get.close();
+      }
     } finally {
       // cleanup
       if (null != note1Id) {
         TestUtils.getInstance(Notebook.class).removeNote(note1Id, anonymous);
       }
-      if (null != clonedNoteId) {
-        TestUtils.getInstance(Notebook.class).removeNote(clonedNoteId, anonymous);
+      if (null != clonedNoteIds) {
+        for (String clonedNoteId : clonedNoteIds) {
+          TestUtils.getInstance(Notebook.class).removeNote(clonedNoteId, anonymous);
+        }
       }
     }
   }


### PR DESCRIPTION
### What is this PR for?
This PR is to provide restful API to clone a specific revision of a note.

Here is one of usage scenarios:
Some time we need to run multiple version of a note independently.  
The easiest to copy the version of the note to a new note then run it.
It's helpful if there is a restful api to copy specific version of note.


### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-5661

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes