### PR TITLE
[ZEPPELIN-5664] Change from adopt to temurin

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -89,7 +89,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -131,7 +131,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -177,7 +177,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -223,7 +223,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -262,7 +262,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -313,7 +313,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -371,7 +371,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -61,7 +61,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2
@@ -88,7 +88,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Check Rat
         run: ./mvnw apache-rat:check -Prat -B
@@ -48,7 +48,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Run Maven Validate
         run: ./mvnw validate -DskipRat -P${{ matrix.hadoop }} -Pinclude-hadoop -B


### PR DESCRIPTION
### What is this PR for?
This PR migrates the JDK from adoptopenjdk to temurin, the successor.
https://github.com/actions/setup-java#supported-distributions

### What type of PR is it?
Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5664

### How should this be tested?
* CI

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
