### PR TITLE
[ZEPPELIN-5620] Staging directory is not deleted in Flink's yarn-application

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/HadoopUtils.java
@@ -79,11 +79,10 @@ public class HadoopUtils {
     return yarnClient.getApplicationReport(yarnAppId);
   }
 
-  public static void cleanupStagingDirInternal(ClusterClient clusterClient) {
+  public static void cleanupStagingDirInternal(String yarnAppId) {
     try {
-      ApplicationId appId = (ApplicationId) clusterClient.getClusterId();
       FileSystem fs = FileSystem.get(new Configuration());
-      Path stagingDirPath = new Path(fs.getHomeDirectory(), ".flink/" + appId.toString());
+      Path stagingDirPath = new Path(fs.getHomeDirectory(), ".flink/" + yarnAppId);
       if (fs.delete(stagingDirPath, true)) {
         LOGGER.info("Deleted staging directory " + stagingDirPath);
       }

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -107,6 +107,8 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
   private var jmWebUrl: String = _
   // used for displaying on zeppelin ui
   private var displayedJMWebUrl: String = _
+  // used only for yarn or yarn-application mode
+  private var yarnAppId: String = _
   private var jobManager: JobManager = _
   private var defaultParallelism = 1
   private var defaultSqlParallelism = 1
@@ -186,7 +188,8 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
       properties.getProperty("flink.execution.mode", "LOCAL")
         .replace("-", "_")
         .toUpperCase)
-    if (ExecutionMode.isYarnAppicationMode(mode)) {
+
+    if (ExecutionMode.isYarnApplicationMode(mode)) {
       // use current yarn container working directory as FLINK_HOME, FLINK_CONF_DIR and HIVE_CONF_DIR
       val workingDirectory = new File(".").getAbsolutePath
       flinkHome = workingDirectory
@@ -296,7 +299,7 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
     }
 
     val (iLoop, cluster) = {
-      // workaround of checking hadoop jars in yarn  mode
+      // workaround of checking hadoop jars in yarn mode
       if (mode == ExecutionMode.YARN) {
         try {
           Class.forName(classOf[FlinkYarnSessionCli].getName)
@@ -320,16 +323,16 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
           } else if (mode == ExecutionMode.YARN) {
             LOGGER.info("Starting FlinkCluster in yarn mode")
             this.jmWebUrl = clusterClient.getWebInterfaceURL
-            val yarnAppId = HadoopUtils.getYarnAppId(clusterClient)
+            this.yarnAppId = HadoopUtils.getYarnAppId(clusterClient)
             this.displayedJMWebUrl = getDisplayedJMWebUrl(yarnAppId)
           } else {
             throw new Exception("Starting FlinkCluster in invalid mode: " + mode)
           }
         case None =>
           // yarn-application mode
-          if (mode == ExecutionMode.YARN_APPLICATION) {
+          if (ExecutionMode.isYarnApplicationMode(mode)) {
             // get yarnAppId from env `_APP_ID`
-            val yarnAppId = System.getenv("_APP_ID")
+            this.yarnAppId = System.getenv("_APP_ID")
             LOGGER.info("Use FlinkCluster in yarn application mode, appId: {}", yarnAppId)
             this.jmWebUrl = "http://localhost:" + HadoopUtils.getFlinkRestPort(yarnAppId)
             this.displayedJMWebUrl = getDisplayedJMWebUrl(yarnAppId)
@@ -750,16 +753,18 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
             LOGGER.info("Shutdown FlinkCluster")
             clusterClient.shutDownCluster()
             clusterClient.close()
-            // delete staging dir
-            if (mode == ExecutionMode.YARN) {
-              HadoopUtils.cleanupStagingDirInternal(clusterClient)
-            }
           case None =>
             LOGGER.info("Don't close the Remote FlinkCluster")
         }
       }
     } else {
       LOGGER.info("Keep cluster alive when closing interpreter")
+    }
+
+    if (ExecutionMode.isOnYarn(mode) && StringUtils.isNotBlank(yarnAppId)) {
+      // delete staging dir
+      LOGGER.info("Deleting flink staging directory for app: {}", yarnAppId)
+      HadoopUtils.cleanupStagingDirInternal(yarnAppId)
     }
 
     if (flinkILoop != null) {

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkShell.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkShell.scala
@@ -42,8 +42,16 @@ object FlinkShell {
   object ExecutionMode extends Enumeration {
     val UNDEFINED, LOCAL, REMOTE, YARN, YARN_APPLICATION, KUBERNETES_APPLICATION = Value
 
-    def isYarnAppicationMode(mode: ExecutionMode.Value): Boolean = {
+    def isYarnApplicationMode(mode: ExecutionMode.Value): Boolean = {
       mode == ExecutionMode.YARN_APPLICATION
+    }
+
+    def isYarnMode(mode: ExecutionMode.Value): Boolean = {
+      mode == ExecutionMode.YARN
+    }
+
+    def isOnYarn(mode: ExecutionMode.Value): Boolean = {
+      isYarnApplicationMode(mode) || isYarnMode(mode)
     }
 
     def isK8sApplicationMode(mode: ExecutionMode.Value): Boolean = {
@@ -51,7 +59,7 @@ object FlinkShell {
     }
 
     def isApplicationMode(mode: ExecutionMode.Value): Boolean = {
-      isYarnAppicationMode(mode) || isK8sApplicationMode(mode)
+      isYarnApplicationMode(mode) || isK8sApplicationMode(mode)
     }
   }
 


### PR DESCRIPTION

### What is this PR for?

This PR is to delete the staging directory on hdfs for flink's yarn-application mode.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5620

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
