### PR TITLE
[ZEPPELIN-5671] Split spark-integration-test to hadoop2 and hadoop3

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -254,6 +254,10 @@ jobs:
 
   spark-integration-test:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        hadoop: [ 2, 3 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -291,12 +295,8 @@ jobs:
       - name: Make IRkernel available to Jupyter
         run: |
           R -e "IRkernel::installspec()"
-      - name: run tests on hadoop2
-        run: ./mvnw test -DskipRat -pl zeppelin-interpreter-integration -Phadoop2 -Pintegration -B -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest24,SparkIntegrationTest24,ZeppelinSparkClusterTest30,SparkIntegrationTest30,ZeppelinSparkClusterTest31,SparkIntegrationTest31,ZeppelinSparkClusterTest32,SparkIntegrationTest32 -DfailIfNoTests=false
-      - name: run tests on hadoop3
-        run: |
-          rm -rf spark/interpreter/metastore_db
-          ./mvnw test -DskipRat -pl zeppelin-interpreter-integration -Phadoop3 -Pintegration -B -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest24,SparkIntegrationTest24,ZeppelinSparkClusterTest30,SparkIntegrationTest30,ZeppelinSparkClusterTest31,SparkIntegrationTest31,ZeppelinSparkClusterTest32,SparkIntegrationTest32 -DfailIfNoTests=false
+      - name: run tests on hadoop${{ matrix.hadoop }}
+        run: ./mvnw test -DskipRat -pl zeppelin-interpreter-integration -Phadoop${{ matrix.hadoop }} -Pintegration -B -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest24,SparkIntegrationTest24,ZeppelinSparkClusterTest30,SparkIntegrationTest30,ZeppelinSparkClusterTest31,SparkIntegrationTest31,ZeppelinSparkClusterTest32,SparkIntegrationTest32 -DfailIfNoTests=false
 
   # test on spark for each spark version & scala version
   spark-test:


### PR DESCRIPTION
### What is this PR for?

Trivial PR to split spark-integration-test to hadoop2 and hadoop3

### What type of PR is it?
[Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5671

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
