### PR TITLE
[ZEPPELIN-5678] Remove the wordcount init job in Flink yarn-application mode

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/ApplicationModeExecutionEnvironment.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/ApplicationModeExecutionEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.zeppelin.flink.internal.FlinkILoop;
 
 import java.io.File;
@@ -65,6 +66,12 @@ public class ApplicationModeExecutionEnvironment extends ExecutionEnvironment {
   public JobExecutionResult execute() throws Exception {
     updateDependencies();
     return super.execute();
+  }
+
+  @Override
+  public JobExecutionResult execute(String jobName) throws Exception {
+    updateDependencies();
+    return super.execute(jobName);
   }
 
   private void updateDependencies() throws Exception {

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/ApplicationModeStreamEnvironment.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/ApplicationModeStreamEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.zeppelin.flink.internal.FlinkILoop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,18 @@ public class ApplicationModeStreamEnvironment extends StreamExecutionEnvironment
   public JobClient executeAsync(String jobName) throws Exception {
     updateDependencies();
     return super.executeAsync(jobName);
+  }
+
+  @Override
+  public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+    updateDependencies();
+    return super.execute(streamGraph);
+  }
+
+  @Override
+  public JobClient executeAsync(StreamGraph streamGraph) throws Exception {
+    updateDependencies();
+    return super.executeAsync(streamGraph);
   }
 
   private void updateDependencies() throws Exception {

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -145,25 +145,6 @@ abstract class FlinkScalaInterpreter(val properties: Properties,
 
     // load udf jar
     this.userUdfJars.foreach(jar => loadUDFJar(jar))
-
-    if (ExecutionMode.isApplicationMode(mode)) {
-      // have to call senv.execute method before running any user code, otherwise yarn application mode
-      // will cause ClassNotFound issue. Needs to do more investigation. TODO(zjffdu)
-      val initCode =
-        """
-          |val data = senv.fromElements("hello world", "hello flink", "hello hadoop")
-          |data.flatMap(line => line.split("\\s"))
-          |  .map(w => (w, 1))
-          |  .keyBy(0)
-          |  .sum(1)
-          |  .print
-          |
-          |senv.execute()
-          |""".stripMargin
-
-      interpret(initCode, InterpreterContext.get())
-      InterpreterContext.get().out.clear()
-    }
   }
 
   def createIMain(settings: Settings, out: JPrintWriter): IMain


### PR DESCRIPTION

### What is this PR for?

The cause is that in the `yarn-application`, `StreamExecutionEnvironment#execute(StreamGrpah)` is invoked when calling `TableEnvironment#execute.` But we didn't override it before this PR, so the scala shell jar is not added into the flink job. 
This PR fix this issue by overriding the method `StreamExecutionEnvironment#execute(StreamGrpah)`

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5678

### How should this be tested?
* Ci pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? NO
* Does this needs documentation? No
