### PR TITLE
[ZEPPELIN-5577] No meaningful log when interpreter process is down

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/PooledRemoteClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/PooledRemoteClient.java
@@ -89,9 +89,10 @@ public class PooledRemoteClient<T extends TServiceClient> implements AutoCloseab
     }
   }
 
-  public <R> R callRemoteFunction(RemoteFunction<R, T> func) {
+  public <R> R callRemoteFunction(RemoteFunction<R, T> func) throws RemoteCallException {
     boolean broken = false;
     String errorCause = null;
+    Exception errorException = null;
     for (int i = 0;i < RETRY_COUNT; ++ i) {
       T client = null;
       broken = false;
@@ -100,14 +101,16 @@ public class PooledRemoteClient<T extends TServiceClient> implements AutoCloseab
         if (client != null) {
           return func.call(client);
         }
-      } catch (InterpreterRPCException e) {
+      } catch (InterpreterRPCException e1) {
         // zeppelin side exception, no need to retry
         broken = true;
-        errorCause = e.getErrorMessage();
+        errorCause = e1.getErrorMessage();
+        errorException = e1;
         break;
-      } catch (Exception e1) {
+      } catch (Exception e2) {
         // thrift framework exception (maybe due to network issue), need to retry
         broken = true;
+        errorException = e2;
         continue;
       } finally {
         if (client != null) {
@@ -116,9 +119,10 @@ public class PooledRemoteClient<T extends TServiceClient> implements AutoCloseab
       }
     }
     if (broken) {
-      throw new RuntimeException(errorCause);
+      throw new RemoteCallException(errorCause, errorException);
+    } else {
+      throw new RuntimeException("No result returned");
     }
-    return null;
   }
 
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteCallException.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteCallException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.zeppelin.interpreter.remote;
+
+public class RemoteCallException extends Exception {
+
+  public RemoteCallException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterDownloader.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterDownloader.java
@@ -60,7 +60,12 @@ public class RemoteInterpreterDownloader {
 
       RemoteInterpreterDownloader downloader = new RemoteInterpreterDownloader(interpreter,
           intpEventClient, new File(localRepoPath));
-      downloader.syncAllLibraries();
+      try {
+        downloader.syncAllLibraries();
+      } catch (RemoteCallException e) {
+        LOGGER.error("Fail to sync libraries", e);
+        System.exit(-1);
+      }
     } else {
       LOGGER.error(
           "Wrong amount of Arguments. Expected: [ZeppelinHostname] [ZeppelinPort] [InterpreterName] [LocalRepoPath]");
@@ -69,7 +74,7 @@ public class RemoteInterpreterDownloader {
     }
   }
 
-  private void syncAllLibraries() {
+  private void syncAllLibraries() throws RemoteCallException {
     LOGGER.info("Loading all libraries for interpreter {} to {}", interpreter, localRepoDir);
     List<LibraryMetadata> metadatas = client.getAllLibraryMetadatas(interpreter);
     if (!localRepoDir.isDirectory()) {
@@ -141,7 +146,7 @@ public class RemoteInterpreterDownloader {
       } else {
         LOGGER.error("Unable to create a new library file {}", library);
       }
-    } catch (IOException e) {
+    } catch (IOException | RemoteCallException e) {
       LOGGER.error("Unable to download Library {}", metadata.getName(), e);
     }
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterEventClient.java
@@ -76,7 +76,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
     }, connectionPoolSize);
   }
 
-  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, RemoteInterpreterEventService.Client> func) {
+  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, RemoteInterpreterEventService.Client> func) throws RemoteCallException {
     return remoteClient.callRemoteFunction(func);
   }
 
@@ -84,21 +84,21 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
     this.intpGroupId = intpGroupId;
   }
 
-  public void registerInterpreterProcess(RegisterInfo registerInfo) {
+  public void registerInterpreterProcess(RegisterInfo registerInfo) throws RemoteCallException {
     callRemoteFunction(client -> {
       client.registerInterpreterProcess(registerInfo);
       return null;
     });
   }
 
-  public void unRegisterInterpreterProcess() {
+  public void unRegisterInterpreterProcess() throws RemoteCallException {
     callRemoteFunction(client -> {
       client.unRegisterInterpreterProcess(intpGroupId);
       return null;
     });
   }
 
-  public void sendWebUrlInfo(String webUrl) {
+  public void sendWebUrlInfo(String webUrl) throws RemoteCallException {
     callRemoteFunction(client -> {
       client.sendWebUrl(new WebUrlInfo(intpGroupId, webUrl));
       return null;
@@ -127,15 +127,15 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
     }
   }
 
-  public List<ParagraphInfo> getParagraphList(String user, String noteId) {
+  public List<ParagraphInfo> getParagraphList(String user, String noteId) throws RemoteCallException {
     return callRemoteFunction(client -> client.getParagraphList(user, noteId));
   }
 
-  public List<LibraryMetadata> getAllLibraryMetadatas(String interpreter) {
+  public List<LibraryMetadata> getAllLibraryMetadatas(String interpreter) throws RemoteCallException {
     return callRemoteFunction(client -> client.getAllLibraryMetadatas(interpreter));
   }
 
-  public ByteBuffer getLibrary(String interpreter, String libraryName) {
+  public ByteBuffer getLibrary(String interpreter, String libraryName) throws RemoteCallException {
     return callRemoteFunction(client -> client.getLibrary(interpreter, libraryName));
   }
 
@@ -144,7 +144,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
     try {
       ByteBuffer buffer = callRemoteFunction(client -> client.getResource(resourceId.toJson()));
       return Resource.deserializeObject(buffer);
-    } catch (IOException | ClassNotFoundException e) {
+    } catch (IOException | ClassNotFoundException | RemoteCallException e) {
       LOGGER.warn("Fail to readResource: {}", resourceId, e);
       return null;
     }
@@ -176,7 +176,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
     try {
       ByteBuffer buffer = callRemoteFunction(client -> client.invokeMethod(intpGroupId, invokeMethod.toJson()));
       return Resource.deserializeObject(buffer);
-    } catch (IOException | ClassNotFoundException e) {
+    } catch (IOException | ClassNotFoundException | RemoteCallException e) {
       LOGGER.error("Failed to invoke method", e);
       return null;
     }
@@ -215,7 +215,7 @@ public class RemoteInterpreterEventClient implements ResourcePoolConnector,
       remoteResource.setResourcePoolConnector(this);
 
       return remoteResource;
-    } catch (IOException | ClassNotFoundException e) {
+    } catch (IOException | ClassNotFoundException | RemoteCallException e) {
       LOGGER.error("Failed to invoke method", e);
       return null;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -548,15 +548,11 @@ public class Helium {
           resourceSet.addAll(localPool.getAll());
         }
       } else if (remoteInterpreterProcess.isRunning()) {
-        try {
-          List<String> resourceList = remoteInterpreterProcess.callRemoteFunction(client ->
-                  client.resourcePoolGetAll());
-          Gson gson = new Gson();
-          for (String res : resourceList) {
-            resourceSet.add(gson.fromJson(res, Resource.class));
-          }
-        } catch (RemoteCallException e) {
-          LOGGER.warn("Fail to call resourcePoolGetAll", e);
+        List<String> resourceList = remoteInterpreterProcess.callRemoteFunction(client ->
+                client.resourcePoolGetAll());
+        Gson gson = new Gson();
+        for (String res : resourceList) {
+          resourceSet.add(gson.fromJson(res, Resource.class));
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -223,13 +223,8 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
           throw new ApplicationException("Target interpreter process is not running");
         }
 
-        RemoteApplicationResult ret = null;
-        try {
-          ret = intpProcess.callRemoteFunction(client ->
+        RemoteApplicationResult ret = intpProcess.callRemoteFunction(client ->
                   client.unloadApplication(appsToUnload.getId()));
-        } catch (RemoteCallException e) {
-          throw new ApplicationException(e);
-        }
         if (ret.isSuccess()) {
           appStatusChange(paragraph, appsToUnload.getId(), ApplicationState.Status.UNLOADED);
         } else {
@@ -302,13 +297,8 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         if (intpProcess == null) {
           throw new ApplicationException("Target interpreter process is not running");
         }
-        RemoteApplicationResult ret = null;
-        try {
-          ret = intpProcess.callRemoteFunction(client ->
-                  client.runApplication(app.getId()));
-        } catch (RemoteCallException e) {
-          throw new ApplicationException(e);
-        }
+        RemoteApplicationResult ret = intpProcess.callRemoteFunction(client ->
+                client.runApplication(app.getId()));
         if (ret.isSuccess()) {
           // success
         } else {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -26,6 +26,7 @@ import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
+import org.apache.zeppelin.interpreter.remote.RemoteCallException;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.interpreter.thrift.RemoteApplicationResult;
 import org.apache.zeppelin.notebook.ApplicationState;
@@ -222,8 +223,13 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
           throw new ApplicationException("Target interpreter process is not running");
         }
 
-        RemoteApplicationResult ret = intpProcess.callRemoteFunction(client ->
-                client.unloadApplication(appsToUnload.getId()));
+        RemoteApplicationResult ret = null;
+        try {
+          ret = intpProcess.callRemoteFunction(client ->
+                  client.unloadApplication(appsToUnload.getId()));
+        } catch (RemoteCallException e) {
+          throw new ApplicationException(e);
+        }
         if (ret.isSuccess()) {
           appStatusChange(paragraph, appsToUnload.getId(), ApplicationState.Status.UNLOADED);
         } else {
@@ -296,8 +302,13 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         if (intpProcess == null) {
           throw new ApplicationException("Target interpreter process is not running");
         }
-        RemoteApplicationResult ret = intpProcess.callRemoteFunction(client ->
-                client.runApplication(app.getId()));
+        RemoteApplicationResult ret = null;
+        try {
+          ret = intpProcess.callRemoteFunction(client ->
+                  client.runApplication(app.getId()));
+        } catch (RemoteCallException e) {
+          throw new ApplicationException(e);
+        }
         if (ret.isSuccess()) {
           // success
         } else {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -53,6 +53,7 @@ import org.apache.zeppelin.helium.ApplicationEventListener;
 import org.apache.zeppelin.interpreter.Interpreter.RegisteredInterpreter;
 import org.apache.zeppelin.interpreter.recovery.RecoveryStorage;
 import org.apache.zeppelin.interpreter.remote.RemoteAngularObjectRegistry;
+import org.apache.zeppelin.interpreter.remote.RemoteCallException;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcessListener;
 import org.apache.zeppelin.notebook.ApplicationState;
@@ -682,11 +683,11 @@ public class InterpreterSettingManager implements NoteEventListener, ClusterEven
   }
 
   //TODO(zjffdu) move Resource related api to ResourceManager
-  public ResourceSet getAllResources() {
+  public ResourceSet getAllResources() throws RemoteCallException {
     return getAllResourcesExcept(null);
   }
 
-  private ResourceSet getAllResourcesExcept(String interpreterGroupExcludsion) {
+  private ResourceSet getAllResourcesExcept(String interpreterGroupExcludsion) throws RemoteCallException {
     ResourceSet resourceSet = new ResourceSet();
     for (ManagedInterpreterGroup intpGroup : getAllInterpreterGroup()) {
       if (interpreterGroupExcludsion != null &&

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/ManagedInterpreterGroup.java
@@ -19,6 +19,7 @@
 package org.apache.zeppelin.interpreter;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.interpreter.remote.RemoteCallException;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
 import org.apache.zeppelin.scheduler.Job;
 import org.apache.zeppelin.scheduler.Scheduler;
@@ -66,7 +67,11 @@ public class ManagedInterpreterGroup extends InterpreterGroup {
         remoteInterpreterProcess = interpreterSetting.createInterpreterProcess(id, userName,
                 properties);
         remoteInterpreterProcess.start(userName);
-        remoteInterpreterProcess.init(ZeppelinConfiguration.create());
+        try {
+          remoteInterpreterProcess.init(ZeppelinConfiguration.create());
+        } catch (RemoteCallException e) {
+          throw new IOException("Fail to init remote interpreter process", e);
+        }
         getInterpreterSetting().getRecoveryStorage()
                 .onInterpreterClientStart(remoteInterpreterProcess);
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -545,15 +545,10 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
           resourceSet.addAll(localPool.getAll());
         }
       } else if (remoteInterpreterProcess.isRunning()) {
-        List<String> resourceList = null;
-        try {
-          resourceList = remoteInterpreterProcess.callRemoteFunction(
-                  client -> client.resourcePoolGetAll());
-          for (String res : resourceList) {
-            resourceSet.add(RemoteResource.fromJson(res));
-          }
-        } catch (RemoteCallException e) {
-          LOGGER.error(e.getMessage(), e);
+        List<String> resourceList = remoteInterpreterProcess.callRemoteFunction(
+                client -> client.resourcePoolGetAll());
+        for (String res : resourceList) {
+          resourceSet.add(RemoteResource.fromJson(res));
         }
       }
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/YarnAppMonitor.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/YarnAppMonitor.java
@@ -120,7 +120,7 @@ public class YarnAppMonitor {
     }
     if (yarnClient != null) {
       try {
-        ApplicationReport appReport = yarnClient.getApplicationReport(ApplicationId.fromString(yarnAppId));
+        ApplicationReport appReport = yarnClient.getApplicationReport(ConverterUtils.toApplicationId(yarnAppId));
         if (appReport.getYarnApplicationState() == YarnApplicationState.FAILED ||
                 appReport.getYarnApplicationState() == YarnApplicationState.KILLED) {
           return appReport.getDiagnostics();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
@@ -157,6 +157,13 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
 
   @Override
   public String getErrorMessage() {
+    if (isHadoopClientAvailable() && yarnAppId != null) {
+      String yarnDiagnostics = YarnAppMonitor.get().getDiagnostics(yarnAppId);
+      if (StringUtils.isNotBlank(yarnDiagnostics)) {
+        return yarnDiagnostics;
+      }
+    }
+
     if (this.interpreterProcessLauncher != null) {
       if (StringUtils.isNotBlank(this.interpreterProcessLauncher.getErrorMessage())) {
         return this.interpreterProcessLauncher.getErrorMessage();

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/ExecRemoteInterpreterProcess.java
@@ -24,6 +24,9 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.zeppelin.interpreter.YarnAppMonitor;
 import org.apache.zeppelin.interpreter.util.ProcessLauncher;
@@ -39,6 +42,7 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
   private static final Pattern YARN_APP_PATTER = Pattern.compile("Submitted application (\\w+)");
 
   private final String interpreterRunner;
+  private String yarnAppId;
   private InterpreterProcessLauncher interpreterProcessLauncher;
 
   public ExecRemoteInterpreterProcess(
@@ -101,9 +105,9 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
       String launchOutput = interpreterProcessLauncher.getProcessLaunchOutput();
       Matcher m = YARN_APP_PATTER.matcher(launchOutput);
       if (m.find()) {
-        String appId = m.group(1);
-        LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", appId);
-        YarnAppMonitor.get().addYarnApp(ConverterUtils.toApplicationId(appId), this);
+        this.yarnAppId = m.group(1);
+        LOGGER.info("Detected yarn app: {}, add it to YarnAppMonitor", yarnAppId);
+        YarnAppMonitor.get().addYarnApp(yarnAppId, this);
       }
     }
   }
@@ -153,9 +157,13 @@ public class ExecRemoteInterpreterProcess extends RemoteInterpreterManagedProces
 
   @Override
   public String getErrorMessage() {
-    return this.interpreterProcessLauncher != null
-        ? this.interpreterProcessLauncher.getErrorMessage()
-        : "";
+    if (this.interpreterProcessLauncher != null) {
+      if (StringUtils.isNotBlank(this.interpreterProcessLauncher.getErrorMessage())) {
+        return this.interpreterProcessLauncher.getErrorMessage();
+      }
+    }
+
+    return super.getErrorMessage();
   }
 
   private class InterpreterProcessLauncher extends ProcessLauncher {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObject.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObject.java
@@ -21,11 +21,14 @@ import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectListener;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Proxy for AngularObject that exists in remote interpreter process
  */
 public class RemoteAngularObject extends AngularObject {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteAngularObject.class);
 
   private transient ManagedInterpreterGroup interpreterGroup;
 
@@ -45,10 +48,14 @@ public class RemoteAngularObject extends AngularObject {
     super.set(o, emitWeb);
 
     if (emitRemoteProcess) {
-      // send updated value to remote interpreter
-      interpreterGroup.getRemoteInterpreterProcess().
-          updateRemoteAngularObject(
-              getName(), getNoteId(), getParagraphId(), o);
+      try {
+        // send updated value to remote interpreter
+        interpreterGroup.getRemoteInterpreterProcess().
+                updateRemoteAngularObject(
+                        getName(), getNoteId(), getParagraphId(), o);
+      } catch (RemoteCallException e) {
+        LOGGER.warn("Fail to remote set", e);
+      }
     }
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectRegistry.java
@@ -22,12 +22,16 @@ import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
 import org.apache.zeppelin.display.AngularObjectRegistryListener;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 
 /**
  * Proxy for AngularObjectRegistry that exists in remote interpreter process
  */
 public class RemoteAngularObjectRegistry extends AngularObjectRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteAngularObjectRegistry.class);
   private static final Gson GSON = new Gson();
 
   private ManagedInterpreterGroup interpreterGroup;
@@ -61,13 +65,16 @@ public class RemoteAngularObjectRegistry extends AngularObjectRegistry {
       return super.add(name, o, noteId, paragraphId, true);
     }
 
-    remoteInterpreterProcess.callRemoteFunction(client -> {
-      client.angularObjectAdd(name, noteId, paragraphId, GSON.toJson(o));
-      return null;
-    });
+    try {
+      remoteInterpreterProcess.callRemoteFunction(client -> {
+        client.angularObjectAdd(name, noteId, paragraphId, GSON.toJson(o));
+        return null;
+      });
+    } catch (RemoteCallException e) {
+      LOGGER.warn("Fail to call remote angularObjectAdd", e);
+    }
 
     return super.add(name, o, noteId, paragraphId, true);
-
   }
 
   /**
@@ -85,10 +92,14 @@ public class RemoteAngularObjectRegistry extends AngularObjectRegistry {
     if (remoteInterpreterProcess == null || !remoteInterpreterProcess.isRunning()) {
       return super.remove(name, noteId, paragraphId);
     }
-    remoteInterpreterProcess.callRemoteFunction(client -> {
-      client.angularObjectRemove(name, noteId, paragraphId);
-      return null;
-    });
+    try {
+      remoteInterpreterProcess.callRemoteFunction(client -> {
+        client.angularObjectRemove(name, noteId, paragraphId);
+        return null;
+      });
+    } catch (RemoteCallException e) {
+      LOGGER.warn("Fail to call remote angularObjectRemove", e);
+    }
 
     return super.remove(name, noteId, paragraphId);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteAngularObjectRegistry.java
@@ -65,14 +65,10 @@ public class RemoteAngularObjectRegistry extends AngularObjectRegistry {
       return super.add(name, o, noteId, paragraphId, true);
     }
 
-    try {
-      remoteInterpreterProcess.callRemoteFunction(client -> {
-        client.angularObjectAdd(name, noteId, paragraphId, GSON.toJson(o));
-        return null;
-      });
-    } catch (RemoteCallException e) {
-      LOGGER.warn("Fail to call remote angularObjectAdd", e);
-    }
+    remoteInterpreterProcess.callRemoteFunction(client -> {
+      client.angularObjectAdd(name, noteId, paragraphId, GSON.toJson(o));
+      return null;
+    });
 
     return super.add(name, o, noteId, paragraphId, true);
   }
@@ -92,14 +88,11 @@ public class RemoteAngularObjectRegistry extends AngularObjectRegistry {
     if (remoteInterpreterProcess == null || !remoteInterpreterProcess.isRunning()) {
       return super.remove(name, noteId, paragraphId);
     }
-    try {
-      remoteInterpreterProcess.callRemoteFunction(client -> {
-        client.angularObjectRemove(name, noteId, paragraphId);
-        return null;
-      });
-    } catch (RemoteCallException e) {
-      LOGGER.warn("Fail to call remote angularObjectRemove", e);
-    }
+
+    remoteInterpreterProcess.callRemoteFunction(client -> {
+      client.angularObjectRemove(name, noteId, paragraphId);
+      return null;
+    });
 
     return super.remove(name, noteId, paragraphId);
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.interpreter.remote;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.apache.zeppelin.display.AngularObject;
 import org.apache.zeppelin.display.AngularObjectRegistry;
@@ -252,6 +253,9 @@ public class RemoteInterpreter extends Interpreter {
           }
       );
     } catch (RemoteCallException e) {
+      if (StringUtils.isNotBlank(interpreterProcess.getErrorMessage())) {
+        return new InterpreterResult(InterpreterResult.Code.ERROR, interpreterProcess.getErrorMessage());
+      }
       throw new InterpreterException(e);
     }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreter.java
@@ -131,23 +131,20 @@ public class RemoteInterpreter extends Interpreter {
           }
         }
 
-        try {
-          interpreterProcess.callRemoteFunction(client -> {
-            LOGGER.info("Open RemoteInterpreter {}", getClassName());
-            // open interpreter here instead of in the jobRun method in RemoteInterpreterServer
-            // client.open(sessionId, className);
-            // Push angular object loaded from JSON file to remote interpreter
-            synchronized (getInterpreterGroup()) {
-              if (!getInterpreterGroup().isAngularRegistryPushed()) {
-                pushAngularObjectRegistryToRemote(client);
-                getInterpreterGroup().setAngularRegistryPushed(true);
-              }
+        interpreterProcess.callRemoteFunction(client -> {
+          LOGGER.info("Open RemoteInterpreter {}", getClassName());
+          // open interpreter here instead of in the jobRun method in RemoteInterpreterServer
+          // client.open(sessionId, className);
+          // Push angular object loaded from JSON file to remote interpreter
+          synchronized (getInterpreterGroup()) {
+            if (!getInterpreterGroup().isAngularRegistryPushed()) {
+              pushAngularObjectRegistryToRemote(client);
+              getInterpreterGroup().setAngularRegistryPushed(true);
             }
-            return null;
-          });
-        } catch (RemoteCallException e) {
-          throw new InterpreterException(e);
-        }
+          }
+          return null;
+        });
+
         isOpened = true;
       }
     }
@@ -161,16 +158,13 @@ public class RemoteInterpreter extends Interpreter {
           throw new IOException("Interpreter process is not running\n" +
                   interpreterProcess.getErrorMessage());
         }
-        try {
-          interpreterProcess.callRemoteFunction(client -> {
-            LOGGER.info("Create RemoteInterpreter {}", getClassName());
-            client.createInterpreter(getInterpreterGroup().getId(), sessionId,
-                className, (Map) properties, getUserName());
-            return null;
-          });
-        } catch (RemoteCallException e) {
-          throw new IOException(e);
-        }
+
+        interpreterProcess.callRemoteFunction(client -> {
+          LOGGER.info("Create RemoteInterpreter {}", getClassName());
+          client.createInterpreter(getInterpreterGroup().getId(), sessionId,
+              className, (Map) properties, getUserName());
+          return null;
+        });
         isCreated = true;
       }
     }
@@ -186,14 +180,10 @@ public class RemoteInterpreter extends Interpreter {
       } catch (IOException e) {
         throw new InterpreterException(e);
       }
-      try {
-        interpreterProcess.callRemoteFunction(client -> {
-          client.close(sessionId, className);
-          return null;
-        });
-      } catch (RemoteCallException e) {
-        throw new InterpreterException(e);
-      }
+      interpreterProcess.callRemoteFunction(client -> {
+        client.close(sessionId, className);
+        return null;
+      });
       isOpened = false;
     } else {
       LOGGER.warn("close is called when RemoterInterpreter is not opened for {}", className);
@@ -218,47 +208,40 @@ public class RemoteInterpreter extends Interpreter {
       return new InterpreterResult(InterpreterResult.Code.ERROR,
               "Interpreter process is not running\n" + interpreterProcess.getErrorMessage());
     }
-    try {
-      return interpreterProcess.callRemoteFunction(client -> {
-            RemoteInterpreterResult remoteResult = client.interpret(
-                sessionId, className, st, convert(context));
-            Map<String, Object> remoteConfig = (Map<String, Object>) GSON.fromJson(
-                remoteResult.getConfig(), new TypeToken<Map<String, Object>>() {
-                }.getType());
-            context.getConfig().clear();
-            if (remoteConfig != null) {
-              context.getConfig().putAll(remoteConfig);
-            }
-            GUI currentGUI = context.getGui();
-            GUI currentNoteGUI = context.getNoteGui();
-            if (form == FormType.NATIVE) {
-              GUI remoteGui = GUI.fromJson(remoteResult.getGui());
-              GUI remoteNoteGui = GUI.fromJson(remoteResult.getNoteGui());
-              currentGUI.clear();
-              currentGUI.setParams(remoteGui.getParams());
-              currentGUI.setForms(remoteGui.getForms());
-              currentNoteGUI.setParams(remoteNoteGui.getParams());
-              currentNoteGUI.setForms(remoteNoteGui.getForms());
-            } else if (form == FormType.SIMPLE) {
-              final Map<String, Input> currentForms = currentGUI.getForms();
-              final Map<String, Object> currentParams = currentGUI.getParams();
-              final GUI remoteGUI = GUI.fromJson(remoteResult.getGui());
-              final Map<String, Input> remoteForms = remoteGUI.getForms();
-              final Map<String, Object> remoteParams = remoteGUI.getParams();
-              currentForms.putAll(remoteForms);
-              currentParams.putAll(remoteParams);
-            }
 
-            return convert(remoteResult);
+    return interpreterProcess.callRemoteFunction(client -> {
+          RemoteInterpreterResult remoteResult = client.interpret(
+              sessionId, className, st, convert(context));
+          Map<String, Object> remoteConfig = (Map<String, Object>) GSON.fromJson(
+              remoteResult.getConfig(), new TypeToken<Map<String, Object>>() {
+              }.getType());
+          context.getConfig().clear();
+          if (remoteConfig != null) {
+            context.getConfig().putAll(remoteConfig);
           }
-      );
-    } catch (RemoteCallException e) {
-      if (StringUtils.isNotBlank(interpreterProcess.getErrorMessage())) {
-        return new InterpreterResult(InterpreterResult.Code.ERROR, interpreterProcess.getErrorMessage());
-      }
-      throw new InterpreterException(e);
-    }
+          GUI currentGUI = context.getGui();
+          GUI currentNoteGUI = context.getNoteGui();
+          if (form == FormType.NATIVE) {
+            GUI remoteGui = GUI.fromJson(remoteResult.getGui());
+            GUI remoteNoteGui = GUI.fromJson(remoteResult.getNoteGui());
+            currentGUI.clear();
+            currentGUI.setParams(remoteGui.getParams());
+            currentGUI.setForms(remoteGui.getForms());
+            currentNoteGUI.setParams(remoteNoteGui.getParams());
+            currentNoteGUI.setForms(remoteNoteGui.getForms());
+          } else if (form == FormType.SIMPLE) {
+            final Map<String, Input> currentForms = currentGUI.getForms();
+            final Map<String, Object> currentParams = currentGUI.getParams();
+            final GUI remoteGUI = GUI.fromJson(remoteResult.getGui());
+            final Map<String, Input> remoteForms = remoteGUI.getForms();
+            final Map<String, Object> remoteParams = remoteGUI.getParams();
+            currentForms.putAll(remoteForms);
+            currentParams.putAll(remoteParams);
+          }
 
+          return convert(remoteResult);
+        }
+    );
   }
 
   @Override
@@ -274,7 +257,7 @@ public class RemoteInterpreter extends Interpreter {
         client.cancel(sessionId, className, convert(context));
         return null;
       });
-    } catch (IOException | RemoteCallException e) {
+    } catch (IOException e) {
       throw new InterpreterException(e);
     }
   }
@@ -298,7 +281,7 @@ public class RemoteInterpreter extends Interpreter {
         formType = FormType.valueOf(client.getFormType(sessionId, className));
         return formType;
       });
-    } catch (IOException | RemoteCallException e) {
+    } catch (IOException e) {
       throw new InterpreterException(e);
     }
   }
@@ -314,7 +297,7 @@ public class RemoteInterpreter extends Interpreter {
       interpreterProcess = getOrCreateInterpreterProcess();
       return interpreterProcess.callRemoteFunction(client ->
               client.getProgress(sessionId, className, convert(context)));
-    } catch (IOException | RemoteCallException e) {
+    } catch (IOException e) {
       throw new InterpreterException(e);
     }
   }
@@ -332,12 +315,8 @@ public class RemoteInterpreter extends Interpreter {
     } catch (IOException e) {
       throw new InterpreterException(e);
     }
-    try {
-      return interpreterProcess.callRemoteFunction(client ->
-              client.completion(sessionId, className, buf, cursor, convert(interpreterContext)));
-    } catch (RemoteCallException e) {
-      throw new InterpreterException(e);
-    }
+    return interpreterProcess.callRemoteFunction(client ->
+            client.completion(sessionId, className, buf, cursor, convert(interpreterContext)));
   }
 
   public String getStatus(final String jobId) {
@@ -351,7 +330,7 @@ public class RemoteInterpreter extends Interpreter {
       return interpreterProcess.callRemoteFunction(client -> {
         return client.getStatus(sessionId, jobId);
       });
-    } catch (IOException | RemoteCallException e) {
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -89,18 +89,18 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient, Aut
   public void updateRemoteAngularObject(String name,
                                         String noteId,
                                         String paragraphId,
-                                        Object o) {
+                                        Object o) throws RemoteCallException {
     remoteClient.callRemoteFunction(client -> {
        client.angularObjectUpdate(name, noteId, paragraphId, GSON.toJson(o));
        return null;
     });
   }
 
-  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, Client> func) {
+  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, Client> func) throws RemoteCallException {
     return remoteClient.callRemoteFunction(func);
   }
 
-  public void init(ZeppelinConfiguration zConf) {
+  public void init(ZeppelinConfiguration zConf) throws RemoteCallException {
     callRemoteFunction(client -> {
       client.init(zConf.getCompleteConfiguration());
       return null;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterProcess.java
@@ -17,6 +17,7 @@
 package org.apache.zeppelin.interpreter.remote;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
@@ -96,8 +97,17 @@ public abstract class RemoteInterpreterProcess implements InterpreterClient, Aut
     });
   }
 
-  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, Client> func) throws RemoteCallException {
-    return remoteClient.callRemoteFunction(func);
+  public <R> R callRemoteFunction(PooledRemoteClient.RemoteFunction<R, Client> func) {
+    try {
+      return remoteClient.callRemoteFunction(func);
+    } catch (RemoteCallException e) {
+      String processErrorMessage = getErrorMessage();
+      if (StringUtils.isNotBlank(processErrorMessage)) {
+        throw new RuntimeException(String.format("Interpreter process is failed, cause: %s", processErrorMessage));
+      } else {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   public void init(ZeppelinConfiguration zConf) throws RemoteCallException {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -44,6 +44,7 @@ import org.apache.zeppelin.interpreter.InterpreterNotFoundException;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
 import org.apache.zeppelin.interpreter.InterpreterSettingManager;
 import org.apache.zeppelin.interpreter.ManagedInterpreterGroup;
+import org.apache.zeppelin.interpreter.remote.RemoteCallException;
 import org.apache.zeppelin.notebook.NoteManager.Folder;
 import org.apache.zeppelin.notebook.NoteManager.NoteNode;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -1121,15 +1121,13 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
         }
         try {
           note.runAll(anonymous, true, false, new HashMap<>());
+          assertEquals(2, interpreterSettingManager.getAllResources().size());
+          // remove a paragraph
+          note.removeParagraph(anonymous.getUser(), p1.getId());
+          assertEquals(1, interpreterSettingManager.getAllResources().size());
         } catch (Exception e) {
           fail();
         }
-
-        assertEquals(2, interpreterSettingManager.getAllResources().size());
-
-        // remove a paragraph
-        note.removeParagraph(anonymous.getUser(), p1.getId());
-        assertEquals(1, interpreterSettingManager.getAllResources().size());
         return null;
       });
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/resource/DistributedResourcePoolTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/resource/DistributedResourcePoolTest.java
@@ -22,6 +22,7 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.remote.RemoteCallException;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreter;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.After;
@@ -155,7 +156,7 @@ public class DistributedResourcePoolTest extends AbstractInterpreterTest {
   }
 
   @Test
-  public void testResourcePoolUtils() throws InterpreterException {
+  public void testResourcePoolUtils() throws InterpreterException, RemoteCallException {
     Gson gson = new Gson();
 
     // when create some resources


### PR DESCRIPTION
### What is this PR for?

The issue is that when interpreter process is shut down abnormally, zeppelin-server doesn't know that, and still try to call thrift api. This introduce `RemoteCallException` to indicate the calling thrift api exception, and would try to get yarn app diagnoiss when this kind of exception happens ([RemoteInterpreterProcess.java](https://github.com/apache/zeppelin/compare/master...zjffdu:ZEPPELIN-5577?expand=1#diff-691ce8c1996fd0d40223563731591cd289eefdc187145a58f11310369ce99fb4))

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5577

### How should this be tested?
* Integration test is added in `SparkIntegrationTest`

### Screenshots (if appropriate)
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/164491/158723214-e66ced42-20a3-43a6-819b-7e29e94102f8.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
