### PR TITLE
 [ZEPPELIN-5530] Support scala-2.13 for spark interpreter

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: install application with some interpreter
-        run: ./mvnw install -Pbuild-distr -DskipRat -DskipTests -pl zeppelin-server,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,markdown,angular,shell -am -Phelium-dev -Pexamples -P${{ matrix.hadoop }} -B
+        run: ./mvnw install -Pbuild-distr -DskipRat -DskipTests -pl zeppelin-server,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,spark/scala-2.13,markdown,angular,shell -am -Phelium-dev -Pexamples -P${{ matrix.hadoop }} -B
       - name: install and test plugins
         run: ./mvnw package -DskipRat -pl zeppelin-plugins -amd -B
       - name: Setup conda environment with python 3.7 and R
@@ -74,7 +74,7 @@ jobs:
           conda list
           conda info
       - name: run tests with ${{ matrix.hadoop }} # skip spark test because we would run them in other CI
-        run: ./mvnw verify -Pusing-packaged-distr -DskipRat -pl zeppelin-server,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,markdown,angular,shell -am -Phelium-dev -Pexamples -P${{ matrix.hadoop }} -Dtests.to.exclude=**/org/apache/zeppelin/spark/* -DfailIfNoTests=false
+        run: ./mvnw verify -Pusing-packaged-distr -DskipRat -pl zeppelin-server,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,spark/scala-2.13,markdown,angular,shell -am -Phelium-dev -Pexamples -P${{ matrix.hadoop }} -Dtests.to.exclude=**/org/apache/zeppelin/spark/* -DfailIfNoTests=false
 
   # test interpreter modules except spark, flink, python, rlang, jupyter
   interpreter-test-non-core:
@@ -190,7 +190,7 @@ jobs:
             ${{ runner.os }}-zeppelin-
       - name: install environment
         run: |
-          ./mvnw install -DskipTests -DskipRat -Phadoop2 -Pintegration -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,markdown,flink-cmd,flink/flink-scala-2.11,flink/flink-scala-2.12,jdbc,shell -am
+          ./mvnw install -DskipTests -DskipRat -Phadoop2 -Pintegration -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,spark/scala-2.13,markdown,flink-cmd,flink/flink-scala-2.11,flink/flink-scala-2.12,jdbc,shell -am
           ./mvnw package -DskipRat -pl zeppelin-plugins -amd -DskipTests -B
       - name: Setup conda environment with python 3.7 and R
         uses: conda-incubator/setup-miniconda@v2
@@ -279,7 +279,7 @@ jobs:
             ${{ runner.os }}-zeppelin-
       - name: install environment
         run: |
-          ./mvnw install -DskipTests -DskipRat -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,markdown -am -Phadoop2 -Pintegration -B
+          ./mvnw install -DskipTests -DskipRat -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.11,spark/scala-2.12,spark/scala-2.13,markdown -am -Phadoop2 -Pintegration -B
           ./mvnw clean package -pl zeppelin-plugins -amd -DskipTests -B
       - name: Setup conda environment with python 3.7 and R
         uses: conda-incubator/setup-miniconda@v2
@@ -325,7 +325,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: install environment
-        run: ./mvnw install -DskipTests -DskipRat -pl spark-submit,spark/scala-2.11,spark/scala-2.12 -am -Phadoop2 -B
+        run: ./mvnw install -DskipTests -DskipRat -pl spark-submit,spark/scala-2.11,spark/scala-2.12,spark/scala-2.13 -am -Phadoop2 -B
       - name: Setup conda environment with python ${{ matrix.python }} and R
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -359,7 +359,11 @@ jobs:
       - name: run spark-3.2 tests with scala-2.12 and python-${{ matrix.python }}
         run: |
           rm -rf spark/interpreter/metastore_db
-          ./mvnw test -DskipRat -pl spark-submit,spark/interpreter -Pspark-3.1 -Pspark-scala-2.12 -Phadoop2 -Pintegration -B -DfailIfNoTests=false
+          ./mvnw test -DskipRat -pl spark-submit,spark/interpreter -Pspark-3.2 -Pspark-scala-2.12 -Phadoop2 -Pintegration -B -DfailIfNoTests=false
+      - name: run spark-3.2 tests with scala-2.13 and python-${{ matrix.python }}
+        run: |
+          rm -rf spark/interpreter/metastore_db
+          ./mvnw test -DskipRat -pl spark-submit,spark/interpreter -Pspark-3.2 -Pspark-scala-2.13 -Phadoop2 -Pintegration -B -DfailIfNoTests=false
 
   livy-0-5-with-spark-2-2-0-under-python3:
     runs-on: ubuntu-20.04

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -40,6 +40,25 @@
     <maven.aeither.provider.version>3.0.3</maven.aeither.provider.version>
     <wagon.version>2.7</wagon.version>
 
+    <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
+    <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
+    <datanucleus.core.version>3.2.10</datanucleus.core.version>
+
+    <!-- spark versions -->
+    <spark.version>3.1.2</spark.version>
+    <protobuf.version>2.5.0</protobuf.version>
+    <py4j.version>0.10.9</py4j.version>
+    <spark.scala.version>2.12.7</spark.scala.version>
+    <spark.scala.binary.version>2.12</spark.scala.binary.version>
+
+    <spark.archive>spark-${spark.version}</spark.archive>
+    <spark.src.download.url>
+      https://archive.apache.org/dist/spark/${spark.archive}/${spark.archive}.tgz
+    </spark.src.download.url>
+    <spark.bin.download.url>
+      https://archive.apache.org/dist/spark/${spark.archive}/${spark.archive}-bin-without-hadoop.tgz
+    </spark.bin.download.url>
+
     <scala.compile.version>${spark.scala.version}</scala.compile.version>
     <!-- settings -->
     <pyspark.test.exclude>**/PySparkInterpreterMatplotlibTest.java</pyspark.test.exclude>
@@ -269,13 +288,6 @@
     </dependency>
 
     <!--test libraries-->
-    <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${spark.scala.binary.version}</artifactId>
-      <version>${scalatest.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-core</artifactId>
@@ -525,4 +537,88 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+
+    <!-- profile spark-scala-x only affect the unit test in spark/interpreter module -->
+
+    <profile>
+      <id>spark-scala-2.13</id>
+      <properties>
+        <spark.scala.version>2.13.4</spark.scala.version>
+        <spark.scala.binary.version>2.13</spark.scala.binary.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-scala-2.12</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.scala.version>2.12.7</spark.scala.version>
+        <spark.scala.binary.version>2.12</spark.scala.binary.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-scala-2.11</id>
+      <properties>
+        <spark.scala.version>2.11.12</spark.scala.version>
+        <spark.scala.binary.version>2.11</spark.scala.binary.version>
+      </properties>
+    </profile>
+
+    <!-- profile spark-x only affect spark version used in test -->
+
+    <profile>
+      <id>spark-3.2</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <datanucleus.core.version>4.1.17</datanucleus.core.version>
+        <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
+        <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
+        <spark.version>3.2.0</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.9.2</py4j.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-3.1</id>
+      <properties>
+        <datanucleus.core.version>4.1.17</datanucleus.core.version>
+        <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
+        <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
+        <spark.version>3.1.2</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.9</py4j.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-3.0</id>
+      <properties>
+        <datanucleus.core.version>4.1.17</datanucleus.core.version>
+        <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
+        <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
+        <spark.version>3.0.3</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.9</py4j.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-2.4</id>
+      <properties>
+        <spark.version>2.4.5</spark.version>
+        <protobuf.version>2.5.0</protobuf.version>
+        <py4j.version>0.10.7</py4j.version>
+      </properties>
+    </profile>
+
+  </profiles>
+
 </project>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -25,6 +25,7 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
+import org.apache.zeppelin.kotlin.KotlinInterpreter;
 
 import java.util.List;
 
@@ -64,6 +65,10 @@ public abstract class AbstractSparkScalaInterpreter {
   public abstract void close();
 
   public abstract InterpreterResult interpret(String st, InterpreterContext context);
+
+  public abstract InterpreterResult delegateInterpret(KotlinInterpreter kotlinInterpreter,
+                                                      String st,
+                                                      InterpreterContext context);
 
   public abstract List<InterpreterCompletion> completion(String buf,
                                                          int cursor,

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -29,6 +29,7 @@ import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterGroup;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
+import org.apache.zeppelin.kotlin.KotlinInterpreter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,10 +85,12 @@ public class SparkInterpreter extends AbstractInterpreter {
     if (Boolean.parseBoolean(properties.getProperty("zeppelin.spark.scala.color", "true"))) {
       System.setProperty("scala.color", "true");
     }
+
     this.enableSupportedVersionCheck = java.lang.Boolean.parseBoolean(
         properties.getProperty("zeppelin.spark.enableSupportedVersionCheck", "true"));
     innerInterpreterClassMap.put("2.11", "org.apache.zeppelin.spark.SparkScala211Interpreter");
     innerInterpreterClassMap.put("2.12", "org.apache.zeppelin.spark.SparkScala212Interpreter");
+    innerInterpreterClassMap.put("2.13", "org.apache.zeppelin.spark.SparkScala213Interpreter");
   }
 
   @Override
@@ -145,6 +148,7 @@ public class SparkInterpreter extends AbstractInterpreter {
    *
    * SparkScala211Interpreter   ZEPPELIN_HOME/interpreter/spark/scala-2.11
    * SparkScala212Interpreter   ZEPPELIN_HOME/interpreter/spark/scala-2.12
+   * SparkScala213Interpreter   ZEPPELIN_HOME/interpreter/spark/scala-2.13
    *
    * @param conf
    * @return AbstractSparkScalaInterpreter
@@ -234,6 +238,12 @@ public class SparkInterpreter extends AbstractInterpreter {
     return this.innerInterpreter.getZeppelinContext();
   }
 
+  public InterpreterResult delegateInterpret(KotlinInterpreter kotlinInterpreter,
+                                             String code,
+                                             InterpreterContext context) {
+    return innerInterpreter.delegateInterpret(kotlinInterpreter, code, context);
+  }
+
   public SparkContext getSparkContext() {
     return this.sc;
   }
@@ -280,13 +290,23 @@ public class SparkInterpreter extends AbstractInterpreter {
       return "2.11";
     } else if (scalaVersionString.contains("2.12")) {
       return "2.12";
+    } else if (scalaVersionString.contains("2.13")) {
+      return "2.13";
     } else {
       throw new InterpreterException("Unsupported scala version: " + scalaVersionString);
     }
   }
 
+  public boolean isScala211() throws InterpreterException {
+    return scalaVersion.equals("2.11");
+  }
+
   public boolean isScala212() throws InterpreterException {
     return scalaVersion.equals("2.12");
+  }
+
+  public boolean isScala213() {
+    return scalaVersion.equals("2.13");
   }
 
   private List<String> getDependencyFiles() throws InterpreterException {

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -95,9 +95,9 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
     String curSql = null;
     ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
     try {
-      if (!sparkInterpreter.isScala212()) {
-        // TODO(zjffdu) scala 2.12 still doesn't work for codegen (ZEPPELIN-4627)
-      Thread.currentThread().setContextClassLoader(sparkInterpreter.getScalaShellClassLoader());
+      if (sparkInterpreter.isScala211()) {
+        // TODO(zjffdu) scala 2.12,2.13 still doesn't work for codegen (ZEPPELIN-4627)
+        Thread.currentThread().setContextClassLoader(sparkInterpreter.getScalaShellClassLoader());
       }
       Method method = sqlContext.getClass().getMethod("sql", String.class);
       for (String sql : sqls) {

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -33,7 +33,6 @@
     <description>Zeppelin Spark Support</description>
 
     <properties>
-        <!--library versions-->
         <datanucleus.rdbms.version>3.2.9</datanucleus.rdbms.version>
         <datanucleus.apijdo.version>3.2.6</datanucleus.apijdo.version>
         <datanucleus.core.version>3.2.10</datanucleus.core.version>
@@ -44,6 +43,8 @@
         <py4j.version>0.10.9</py4j.version>
         <spark.scala.version>2.12.7</spark.scala.version>
         <spark.scala.binary.version>2.12</spark.scala.binary.version>
+
+        <scala.compile.version>${spark.scala.version}</scala.compile.version>
 
         <spark.archive>spark-${spark.version}</spark.archive>
         <spark.src.download.url>
@@ -59,6 +60,7 @@
         <module>spark-scala-parent</module>
         <module>scala-2.11</module>
         <module>scala-2.12</module>
+        <module>scala-2.13</module>
         <module>spark-shims</module>
         <module>spark2-shims</module>
         <module>spark3-shims</module>
@@ -131,78 +133,5 @@
         </plugins>
     </build>
 
-    <profiles>
 
-        <!-- profile spark-scala-x only affect the unit test in spark/interpreter module -->
-
-        <profile>
-            <id>spark-scala-2.12</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <spark.scala.version>2.12.7</spark.scala.version>
-                <spark.scala.binary.version>2.12</spark.scala.binary.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spark-scala-2.11</id>
-            <properties>
-                <spark.scala.version>2.11.12</spark.scala.version>
-                <spark.scala.binary.version>2.11</spark.scala.binary.version>
-            </properties>
-        </profile>
-
-        <!-- profile spark-x only affect the embedded spark version in zeppelin distribution -->
-
-        <profile>
-            <id>spark-3.2</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <datanucleus.core.version>4.1.17</datanucleus.core.version>
-                <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
-                <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
-                <spark.version>3.2.0</spark.version>
-                <protobuf.version>2.5.0</protobuf.version>
-                <py4j.version>0.10.9.2</py4j.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spark-3.1</id>
-            <properties>
-                <datanucleus.core.version>4.1.17</datanucleus.core.version>
-                <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
-                <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
-                <spark.version>3.1.2</spark.version>
-                <protobuf.version>2.5.0</protobuf.version>
-                <py4j.version>0.10.9</py4j.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spark-3.0</id>
-            <properties>
-                <datanucleus.core.version>4.1.17</datanucleus.core.version>
-                <datanucleus.rdbms.version>4.1.19</datanucleus.rdbms.version>
-                <datanucleus.apijdo.version>4.2.4</datanucleus.apijdo.version>
-                <spark.version>3.0.3</spark.version>
-                <protobuf.version>2.5.0</protobuf.version>
-                <py4j.version>0.10.9</py4j.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>spark-2.4</id>
-            <properties>
-                <spark.version>2.4.5</spark.version>
-                <protobuf.version>2.5.0</protobuf.version>
-                <py4j.version>0.10.7</py4j.version>
-            </properties>
-        </profile>
-
-    </profiles>
 </project>

--- a/spark/scala-2.13/pom.xml
+++ b/spark/scala-2.13/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.zeppelin</groupId>
+    <artifactId>spark-scala-parent</artifactId>
+    <version>0.11.0-SNAPSHOT</version>
+    <relativePath>../spark-scala-parent/pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>spark-scala-2.13</artifactId>
+  <packaging>jar</packaging>
+  <name>Zeppelin: Spark Interpreter Scala_2.13</name>
+
+  <properties>
+    <spark.version>3.2.0</spark.version>
+    <spark.scala.version>2.13.4</spark.scala.version>
+    <spark.scala.binary.version>2.13</spark.scala.binary.version>
+    <spark.scala.compile.version>${spark.scala.version}</spark.scala.compile.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spark/scala-2.13/spark-scala-parent
+++ b/spark/scala-2.13/spark-scala-parent
@@ -1,0 +1,1 @@
+../spark-scala-parent

--- a/spark/scala-2.13/src/main/resources/log4j.properties
+++ b/spark/scala-2.13/src/main/resources/log4j.properties
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c:%L - %m%n
+#log4j.appender.stdout.layout.ConversionPattern=
+#%5p [%t] (%F:%L) - %m%n
+#%-4r [%t] %-5p %c %x - %m%n
+#
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+ 
+#mute some noisy guys
+log4j.logger.org.apache.hadoop.mapred=WARN
+log4j.logger.org.apache.hadoop.hive.ql=WARN
+log4j.logger.org.apache.hadoop.hive.metastore=WARN
+log4j.logger.org.apache.haadoop.hive.service.HiveServer=WARN
+log4j.logger.org.apache.zeppelin.scheduler=WARN
+
+log4j.logger.org.quartz=WARN
+log4j.logger.DataNucleus=WARN
+log4j.logger.DataNucleus.MetaData=ERROR
+log4j.logger.DataNucleus.Datastore=ERROR
+
+# Log all JDBC parameters
+log4j.logger.org.hibernate.type=ALL
+
+log4j.logger.org.apache.zeppelin.interpreter=DEBUG
+log4j.logger.org.apache.zeppelin.spark=DEBUG
+
+
+log4j.logger.org.apache.spark.repl.Main=INFO

--- a/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkILoop.scala
+++ b/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkILoop.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.spark
+
+import java.io.{BufferedReader, PrintWriter}
+
+import scala.Predef.{println => _, _}
+import scala.tools.nsc.GenericRunnerSettings
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.shell.{ILoop, ShellConfig}
+import scala.tools.nsc.util.stringFromStream
+import scala.util.Properties.{javaVersion, javaVmName, versionString}
+
+/**
+ *  Copy from spark project with minor modification (Remove the SparkContext initialization)
+ */
+class SparkILoop(in0: BufferedReader, out: PrintWriter)
+  extends ILoop(ShellConfig(new GenericRunnerSettings(_ => ())), in0, out) {
+  def this() = this(null, new PrintWriter(Console.out, true))
+
+  override protected def internalReplAutorunCode(): Seq[String] = Seq.empty
+
+  /** Print a welcome message */
+  override def printWelcome(): Unit = {
+    import org.apache.spark.SPARK_VERSION
+    echo("""Welcome to
+      ____              __
+     / __/__  ___ _____/ /__
+    _\ \/ _ \/ _ `/ __/  '_/
+   /___/ .__/\_,_/_/ /_/\_\   version %s
+      /_/
+         """.format(SPARK_VERSION))
+    val welcomeMsg = "Using Scala %s (%s, Java %s)".format(
+      versionString,
+      javaVmName,
+      javaVersion
+    )
+    echo(welcomeMsg)
+    echo("Type in expressions to have them evaluated.")
+    echo("Type :help for more information.")
+  }
+
+  /** Available commands */
+  override def commands: List[LoopCommand] = standardCommands
+
+  override def resetCommand(line: String): Unit = {
+    super.resetCommand(line)
+    echo(
+      "Note that after :reset, state of SparkSession and SparkContext is unchanged."
+    )
+  }
+
+  override def replay(): Unit = {
+    super.replay()
+  }
+
+  /** Start an interpreter with the given settings.
+   *  @return true if successful
+   */
+  override def run(interpreterSettings: Settings): Boolean = {
+    createInterpreter(interpreterSettings)
+    intp.reporter.withoutPrintingResults(intp.withSuppressedSettings {
+      intp.initializeCompiler()
+      if (intp.reporter.hasErrors) {
+        echo("Interpreter encountered errors during initialization!")
+        throw new InterruptedException
+      }
+    })
+    true
+  }
+}
+

--- a/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkScala213Interpreter.scala
+++ b/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkScala213Interpreter.scala
@@ -17,33 +17,30 @@
 
 package org.apache.zeppelin.spark
 
-import java.io.{BufferedReader, File}
-import java.net.URLClassLoader
-import java.nio.file.{Files, Paths}
-import java.util.Properties
+
 import org.apache.spark.SparkConf
-import org.apache.spark.repl.SparkILoop
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion
 import org.apache.zeppelin.interpreter.util.InterpreterOutputStream
 import org.apache.zeppelin.interpreter.{InterpreterContext, InterpreterGroup, InterpreterResult}
-import org.slf4j.LoggerFactory
-import org.slf4j.Logger
+import org.slf4j.{Logger, LoggerFactory}
 
+import java.io.{File, PrintWriter}
+import java.net.URLClassLoader
+import java.util.Properties
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._
+import scala.tools.nsc.interpreter.shell.{Accumulator, Completion, ReplCompletion}
 
 /**
-  * SparkInterpreter for scala-2.11
+  * SparkInterpreter for scala-2.13
   */
-class SparkScala211Interpreter(override val conf: SparkConf,
+class SparkScala213Interpreter(override val conf: SparkConf,
                                override val depFiles: java.util.List[String],
                                override val properties: Properties,
                                override val interpreterGroup: InterpreterGroup,
                                override val sparkInterpreterClassLoader: URLClassLoader,
                                val outputDir: File)
   extends BaseSparkScalaInterpreter(conf, depFiles, properties, interpreterGroup, sparkInterpreterClassLoader) {
-
-  import SparkScala211Interpreter._
 
   lazy override val LOGGER: Logger = LoggerFactory.getLogger(getClass)
 
@@ -58,40 +55,30 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     if (sparkMaster == "yarn-client") {
       System.setProperty("SPARK_YARN_MODE", "true")
     }
-
     LOGGER.info("Scala shell repl output dir: " + outputDir.getAbsolutePath)
     conf.set("spark.repl.class.outputDir", outputDir.getAbsolutePath)
-    val target = conf.get("spark.repl.target", "jvm-1.6")
+
     val settings = new Settings()
     settings.processArguments(List("-Yrepl-class-based",
       "-Yrepl-outdir", s"${outputDir.getAbsolutePath}"), true)
     settings.embeddedDefaults(sparkInterpreterClassLoader)
     settings.usejavacp.value = true
-    settings.target.value = target
-
     this.userJars = getUserJars()
     LOGGER.info("UserJars: " + userJars.mkString(File.pathSeparator))
     settings.classpath.value = userJars.mkString(File.pathSeparator)
 
     val printReplOutput = properties.getProperty("zeppelin.spark.printREPLOutput", "true").toBoolean
     val replOut = if (printReplOutput) {
-      new JPrintWriter(interpreterOutput, true)
+      new PrintWriter(interpreterOutput, true)
     } else {
-      new JPrintWriter(Console.out, true)
+      new PrintWriter(Console.out, true)
     }
-    sparkILoop = new SparkILoop(None, replOut)
-    sparkILoop.settings = settings
-    sparkILoop.createInterpreter()
-
-    val in0 = getField(sparkILoop, "scala$tools$nsc$interpreter$ILoop$$in0").asInstanceOf[Option[BufferedReader]]
-    val reader = in0.fold(sparkILoop.chooseReader(settings))(r => SimpleReader(r, replOut, interactive = true))
-
-    sparkILoop.in = reader
-    sparkILoop.initializeSynchronous()
-    loopPostInit(this)
-    this.scalaCompletion = reader.completion
+    sparkILoop = new SparkILoop(null, replOut)
+    sparkILoop.run(settings)
+    this.scalaCompletion = new ReplCompletion(sparkILoop.intp, new Accumulator)
 
     createSparkContext()
+
     scalaInterpret("import org.apache.spark.SparkContext._")
     scalaInterpret("import spark.implicits._")
     scalaInterpret("import spark.sql")
@@ -99,6 +86,7 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     // print empty string otherwise the last statement's output of this method
     // (aka. import org.apache.spark.sql.functions._) will mix with the output of user code
     scalaInterpret("print(\"\")")
+
     createZeppelinContext()
   }
 
@@ -118,9 +106,9 @@ class SparkScala211Interpreter(override val conf: SparkConf,
         interpreterOutput.ignoreLeadingNewLinesFromScalaReporter()
 
         val status = scalaInterpret(code) match {
-          case success@scala.tools.nsc.interpreter.IR.Success =>
+          case success@scala.tools.nsc.interpreter.Results.Success =>
             success
-          case scala.tools.nsc.interpreter.IR.Error =>
+          case scala.tools.nsc.interpreter.Results.Error =>
             val errorMsg = new String(interpreterOutput.getInterpreterOutput.toByteArray)
             if (errorMsg.contains("value toDF is not a member of org.apache.spark.rdd.RDD") ||
               errorMsg.contains("value toDS is not a member of org.apache.spark.rdd.RDD")) {
@@ -129,9 +117,9 @@ class SparkScala211Interpreter(override val conf: SparkConf,
               context.out.clear()
               scalaInterpret("import sqlContext.implicits._\n" + code)
             } else {
-              scala.tools.nsc.interpreter.IR.Error
+              scala.tools.nsc.interpreter.Results.Error
             }
-          case scala.tools.nsc.interpreter.IR.Incomplete =>
+          case scala.tools.nsc.interpreter.Results.Incomplete =>
             // add print("") at the end in case the last line is comment which lead to INCOMPLETE
             scalaInterpret(code + "\nprint(\"\")")
         }
@@ -144,11 +132,11 @@ class SparkScala211Interpreter(override val conf: SparkConf,
 
     context.out.write("")
     val lastStatus = _interpret(code) match {
-      case scala.tools.nsc.interpreter.IR.Success =>
+      case scala.tools.nsc.interpreter.Results.Success =>
         InterpreterResult.Code.SUCCESS
-      case scala.tools.nsc.interpreter.IR.Error =>
+      case scala.tools.nsc.interpreter.Results.Error =>
         InterpreterResult.Code.ERROR
-      case scala.tools.nsc.interpreter.IR.Incomplete =>
+      case scala.tools.nsc.interpreter.Results.Incomplete =>
         InterpreterResult.Code.INCOMPLETE
     }
 
@@ -158,18 +146,21 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     }
   }
 
+  def scalaInterpret(code: String): scala.tools.nsc.interpreter.Results.Result =
+    sparkILoop.interpret(code)
+
   protected override def completion(buf: String,
                                     cursor: Int,
                                     context: InterpreterContext): java.util.List[InterpreterCompletion] = {
-    val completions = scalaCompletion.completer().complete(buf.substring(0, cursor), cursor).candidates
-      .map(e => new InterpreterCompletion(e, e, null))
-    scala.collection.JavaConversions.seqAsJavaList(completions)
+    val completions = scalaCompletion.complete(buf.substring(0, cursor), cursor).candidates
+      .map(e => new InterpreterCompletion(e.defString, e.defString, null))
+    scala.collection.JavaConverters.asJava(completions)
   }
 
   protected def bind(name: String, tpe: String, value: Object, modifier: List[String]): Unit = {
     sparkILoop.beQuietDuring {
       val result = sparkILoop.bind(name, tpe, value, modifier)
-      if (result != IR.Success) {
+      if (result != Results.Success) {
         throw new RuntimeException("Fail to bind variable: " + name)
       }
     }
@@ -179,84 +170,10 @@ class SparkScala211Interpreter(override val conf: SparkConf,
     super.close()
     if (sparkILoop != null) {
       sparkILoop.closeInterpreter()
-      sparkILoop = null
     }
   }
-
-  def scalaInterpret(code: String): scala.tools.nsc.interpreter.IR.Result =
-    sparkILoop.interpret(code)
 
   override def getScalaShellClassLoader: ClassLoader = {
     sparkILoop.classLoader
   }
-}
-
-private object SparkScala211Interpreter {
-
-  /**
-    * This is a hack to call `loopPostInit` at `ILoop`. At higher version of Scala such
-    * as 2.11.12, `loopPostInit` became a nested function which is inaccessible. Here,
-    * we redefine `loopPostInit` at Scala's 2.11.8 side and ignore `loadInitFiles` being called at
-    * Scala 2.11.12 since here we do not have to load files.
-    *
-    * Both methods `loopPostInit` and `unleashAndSetPhase` are redefined, and `phaseCommand` and
-    * `asyncMessage` are being called via reflection since both exist in Scala 2.11.8 and 2.11.12.
-    *
-    * Please see the codes below:
-    * https://github.com/scala/scala/blob/v2.11.8/src/repl/scala/tools/nsc/interpreter/ILoop.scala
-    * https://github.com/scala/scala/blob/v2.11.12/src/repl/scala/tools/nsc/interpreter/ILoop.scala
-    *
-    * See also ZEPPELIN-3810.
-    */
-  private def loopPostInit(interpreter: SparkScala211Interpreter): Unit = {
-    import StdReplTags._
-    import scala.reflect.classTag
-    import scala.reflect.io
-
-    val sparkILoop = interpreter.sparkILoop
-    val intp = sparkILoop.intp
-    val power = sparkILoop.power
-    val in = sparkILoop.in
-
-    def loopPostInit() {
-      // Bind intp somewhere out of the regular namespace where
-      // we can get at it in generated code.
-      intp.quietBind(NamedParam[IMain]("$intp", intp)(tagOfIMain, classTag[IMain]))
-      // Auto-run code via some setting.
-      (replProps.replAutorunCode.option
-        flatMap (f => io.File(f).safeSlurp())
-        foreach (intp quietRun _)
-        )
-      // classloader and power mode setup
-      intp.setContextClassLoader()
-      if (isReplPower) {
-        replProps.power setValue true
-        unleashAndSetPhase()
-        asyncMessage(power.banner)
-      }
-      // SI-7418 Now, and only now, can we enable TAB completion.
-      in.postInit()
-    }
-
-    def unleashAndSetPhase() = if (isReplPower) {
-      power.unleash()
-      intp beSilentDuring phaseCommand("typer") // Set the phase to "typer"
-    }
-
-    def phaseCommand(name: String): Results.Result = {
-      interpreter.callMethod(
-        sparkILoop,
-        "scala$tools$nsc$interpreter$ILoop$$phaseCommand",
-        Array(classOf[String]),
-        Array(name)).asInstanceOf[Results.Result]
-    }
-
-    def asyncMessage(msg: String): Unit = {
-      interpreter.callMethod(
-        sparkILoop, "asyncMessage", Array(classOf[String]), Array(msg))
-    }
-
-    loopPostInit()
-  }
-
 }

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -39,10 +39,20 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.apache.zeppelin</groupId>
       <artifactId>zeppelin-interpreter</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.atomix</groupId>
+          <artifactId>atomix</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/zeppelin-jupyter-interpreter-shaded/pom.xml
+++ b/zeppelin-jupyter-interpreter-shaded/pom.xml
@@ -79,6 +79,14 @@
               <pattern>com.google</pattern>
               <shadedPattern>org.apache.zeppelin.jupyter.com.google</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>io</pattern>
+              <shadedPattern>org.apache.zeppelin.jupyter.io</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.esotericsoftware</pattern>
+              <shadedPattern>org.apache.zeppelin.jupyter.com.esotericsoftware</shadedPattern>
+            </relocation>
           </relocations>
 
         </configuration>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/launcher/SparkInterpreterLauncher.java
@@ -132,6 +132,7 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
       String sparkHome = getEnv("SPARK_HOME");
       LOGGER.info("SPARK_HOME: {}", sparkHome);
       scalaVersion = detectSparkScalaVersion(sparkHome, env);
+      LOGGER.info("Scala version for Spark: {}", scalaVersion);
       context.getProperties().put("zeppelin.spark.scala.version", scalaVersion);
     } catch (Exception e) {
       throw new IOException("Fail to detect scala version, the reason is:"+ e.getMessage());
@@ -277,12 +278,12 @@ public class SparkInterpreterLauncher extends StandardInterpreterLauncher {
     Matcher matcher = pattern.matcher(processOutput);
     if (matcher.find()) {
       String scalaVersion = matcher.group(1);
-      if (scalaVersion.startsWith("2.10")) {
-        return "2.10";
-      } else if (scalaVersion.startsWith("2.11")) {
+      if (scalaVersion.startsWith("2.11")) {
         return "2.11";
       } else if (scalaVersion.startsWith("2.12")) {
         return "2.12";
+      } else if (scalaVersion.startsWith("2.13")) {
+        return "2.13";
       } else {
         throw new Exception("Unsupported scala version: " + scalaVersion);
       }


### PR DESCRIPTION
### What is this PR for?

Spark 3.2 starts to support scala-2.13, this PR is to support scala-2.13 on the zeppelin side. A new module `scala-2.13` is introduced in this PR. `SparkILoop` is copied from the spark project with minor modification. 

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5530

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
