### PR TITLE
[ZEPPELIN-5621] add configuration of tmp_path to store compiled files like scala_shell_tmp-xxx.jar

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -288,7 +288,7 @@ You can also add and set other Flink properties which are not listed in the tabl
   <tr>
     <td>zeppelin.flink.scala.shell.tmp_dir</td>
     <td></td>
-    <td>emp folder for storing scala shell compiled jar</td>
+    <td>Temp folder for storing scala shell compiled jar</td>
   </tr>
   <tr>
     <td>zeppelin.flink.enableHive</td>

--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -285,7 +285,11 @@ You can also add and set other Flink properties which are not listed in the tabl
     <td>true</td>
     <td>Whether display Scala shell output in colorful format</td>
   </tr>
-
+  <tr>
+    <td>zeppelin.flink.scala.shell.tmp_dir</td>
+    <td></td>
+    <td>emp folder for storing scala shell compiled jar</td>
+  </tr>
   <tr>
     <td>zeppelin.flink.enableHive</td>
     <td>false</td>

--- a/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
+++ b/flink/flink-scala-parent/src/main/resources/interpreter-setting.json
@@ -138,6 +138,13 @@
         "description": "Whether display scala shell output in colorful format",
         "type": "checkbox"
       },
+      "zeppelin.flink.scala.shell.tmp_dir": {
+        "envName": "zeppelin.flink.scala.shell.tmp_dir",
+        "propertyName": "zeppelin.flink.scala.shell.tmp_dir",
+        "defaultValue": "",
+        "description": "Temp folder for storing scala shell compiled jar",
+        "type": "string"
+      },
       "zeppelin.flink.enableHive": {
         "envName": null,
         "propertyName": null,

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkILoop.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkILoop.scala
@@ -111,7 +111,9 @@ class FlinkILoop(
     val tmpDir: File = new File(scalaShellTmpParentFolder, "scala_shell_tmp-" + abstractID)
     LOGGER.info("Folder for scala shell compiled jar: {}", tmpDir.getAbsolutePath)
     if (!tmpDir.exists) {
-      tmpDir.mkdir
+      if (!tmpDir.mkdirs()) {
+        throw new IOException("Unable to make tmp dir for scala shell", e)
+      }
     }
     tmpDir
   }

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkILoop.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/internal/FlinkILoop.scala
@@ -112,7 +112,7 @@ class FlinkILoop(
     LOGGER.info("Folder for scala shell compiled jar: {}", tmpDir.getAbsolutePath)
     if (!tmpDir.exists) {
       if (!tmpDir.mkdirs()) {
-        throw new IOException("Unable to make tmp dir for scala shell", e)
+        throw new IOException(s"Unable to make tmp dir ${tmpDir.getAbsolutePath} for scala shell")
       }
     }
     tmpDir


### PR DESCRIPTION

### What is this PR for?

Add one configuration `flink.scala_shell.tmp_dir` for configuring the tmp folder for flink scala shell compiled jars.

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5621

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
