### PR TITLE
ZEPPELIN-5690: use jinjava 2.5.4 due to cves

### DIFF
--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -47,6 +47,8 @@
       <name>Concurrent Maven Repo</name>
       <url>https://conjars.org/repo</url>
     </repository>
+
+    <!-- the twitter repo is unreliable (https://github.com/twitter/hadoop-lzo/issues/148) -->
     <repository>
       <id>twitter</id>
       <name>Twitter Maven Repo</name>

--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -34,7 +34,7 @@
     <!--library versions-->
     <interpreter.name>submarine</interpreter.name>
     <hadoop.version>${hadoop2.7.version}</hadoop.version>
-    <jinjava.version>2.4.0</jinjava.version>
+    <jinjava.version>2.5.4</jinjava.version>
     <squirrel.version>0.3.8</squirrel.version>
     <guava.version>24.1.1-jre</guava.version>
     <!--test library versions-->

--- a/zeppelin-plugins/launcher/docker/pom.xml
+++ b/zeppelin-plugins/launcher/docker/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
-      <version>2.4.12</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>


### PR DESCRIPTION
### What is this PR for?

use jinjava 2.5.4 due to cves

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-5690

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update?
* Is there breaking changes for older versions?
* Does this needs documentation?
