### PR TITLE
[ZEPPELIN-5693] IPythonInterpreterTest.testIPythonPlotting fails due to jinjia2 version upgrade

### DIFF
--- a/testing/env_python_3.7_with_R.yml
+++ b/testing/env_python_3.7_with_R.yml
@@ -22,6 +22,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - r-base=3
   - r-data.table

--- a/testing/env_python_3.8_with_R.yml
+++ b/testing/env_python_3.8_with_R.yml
@@ -22,6 +22,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - r-base=3
   - r-data.table

--- a/testing/env_python_3.yml
+++ b/testing/env_python_3.yml
@@ -18,6 +18,7 @@ dependencies:
   - bokeh=1.3.4
   - panel=0.6.0
   - holoviews=1.12.3
+  - jinja2=3.0.3
   - pip
   - pip:
     - bkzep==0.6.1

--- a/testing/env_python_3_with_R.yml
+++ b/testing/env_python_3_with_R.yml
@@ -23,6 +23,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - r-base=3
   - r-data.table

--- a/testing/env_python_3_with_R_and_tensorflow.yml
+++ b/testing/env_python_3_with_R_and_tensorflow.yml
@@ -23,6 +23,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - r-base=3
   - r-data.table

--- a/testing/env_python_3_with_flink_112.yml
+++ b/testing/env_python_3_with_flink_112.yml
@@ -22,6 +22,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - pip:
       - apache-flink==1.12.2

--- a/testing/env_python_3_with_flink_113.yml
+++ b/testing/env_python_3_with_flink_113.yml
@@ -22,6 +22,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - pip:
       - apache-flink==1.13.1

--- a/testing/env_python_3_with_flink_114.yml
+++ b/testing/env_python_3_with_flink_114.yml
@@ -22,6 +22,7 @@ dependencies:
   - altair
   - vega_datasets
   - plotly
+  - jinja2=3.0.3
   - pip
   - pip:
       - apache-flink==1.14.0


### PR DESCRIPTION

### What is this PR for?

Specify the jinjia2 version explicitly so that we won't get the error described in the jira. 

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5693

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
