### PR TITLE
[ZEPPELIN-5705] Incorrect scala version checking in SparkSqlInterpreter.java

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -142,7 +142,7 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
       }
     } finally {
       sc.clearJobGroup();
-      if (!sparkInterpreter.isScala212()) {
+      if (sparkInterpreter.isScala211()) {
         Thread.currentThread().setContextClassLoader(originalClassLoader);
       }
     }


### PR DESCRIPTION
### What is this PR for?

Trivial PR to reset the ClassLoader for the correct scala version

### What type of PR is it?
[Bug Fix ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5705

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
