### PR TITLE
[ZEPPELIN-5697] Remove old planner support of flink

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -385,21 +385,13 @@ Here are the builtin variables created in Flink Scala shell.
 
 * senv (StreamExecutionEnvironment),
 * benv (ExecutionEnvironment)
-* stenv (StreamTableEnvironment for blink planner)
-* btenv (BatchTableEnvironment for blink planner)
-* stenv_2 (StreamTableEnvironment for flink planner)
-* btenv_2 (BatchTableEnvironment for flink planner)
+* stenv (StreamTableEnvironment for blink planner (aka. new planner))
+* btenv (BatchTableEnvironment for blink planner (aka. new planner))
 * z  (ZeppelinContext)
 
 ### Blink/Flink Planner
 
-There are 2 planners supported by Flink SQL: `flink` & `blink`.
-
-* If you want to use DataSet api, and convert it to Flink table then please use `flink` planner (`btenv_2` and `stenv_2`).
-* In other cases, we would always recommend you to use `blink` planner. This is also what Flink batch/streaming sql interpreter use (`%flink.bsql` & `%flink.ssql`)
-
-Check this [page](https://ci.apache.org/projects/flink/flink-docs-release-1.10/dev/table/common.html#main-differences-between-the-two-planners) for the difference between flink planner and blink planner.
-
+After Zeppelin 0.11, we remove the support of flink planner (aka. old planner) which is also removed after Flink 1.14.
 
 ### Stream WordCount Example
 
@@ -537,10 +529,8 @@ These are variables created in Python shell.
 
 * `s_env`    (StreamExecutionEnvironment),
 * `b_env`     (ExecutionEnvironment)
-* `st_env`   (StreamTableEnvironment for blink planner)
-* `bt_env`   (BatchTableEnvironment for blink planner)
-* `st_env_2`   (StreamTableEnvironment for flink planner)
-* `bt_env_2`   (BatchTableEnvironment for flink planner)
+* `st_env`   (StreamTableEnvironment for blink planner (aka. new planner))
+* `bt_env`   (BatchTableEnvironment for blink planner (aka. new planner))
 
 
 ### Configure PyFlink

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkBatchSqlInterpreter.java
@@ -38,7 +38,7 @@ public class FlinkBatchSqlInterpreter extends FlinkSqlInterpreter {
             flinkInterpreter.getExecutionEnvironment().getJavaEnv(),
             flinkInterpreter.getStreamExecutionEnvironment().getJavaEnv(),
             flinkInterpreter.getJavaBatchTableEnvironment("blink"),
-            flinkInterpreter.getJavaStreamTableEnvironment("blink"),
+            flinkInterpreter.getJavaStreamTableEnvironment(),
             flinkInterpreter.getZeppelinContext(),
             null);
     flinkInterpreter.getFlinkShims().initInnerBatchSqlInterpreter(flinkSqlContext);

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -155,15 +155,15 @@ public class FlinkInterpreter extends Interpreter {
   }
 
   TableEnvironment getStreamTableEnvironment() {
-    return this.innerIntp.getStreamTableEnvironment("blink");
+    return this.innerIntp.getStreamTableEnvironment();
   }
 
   org.apache.flink.table.api.TableEnvironment getJavaBatchTableEnvironment(String planner) {
     return this.innerIntp.getJavaBatchTableEnvironment(planner);
   }
 
-  TableEnvironment getJavaStreamTableEnvironment(String planner) {
-    return this.innerIntp.getJavaStreamTableEnvironment(planner);
+  TableEnvironment getJavaStreamTableEnvironment() {
+    return this.innerIntp.getJavaStreamTableEnvironment();
   }
 
   TableEnvironment getBatchTableEnvironment() {

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreter.java
@@ -43,7 +43,7 @@ public class FlinkStreamSqlInterpreter extends FlinkSqlInterpreter {
             flinkInterpreter.getExecutionEnvironment().getJavaEnv(),
             flinkInterpreter.getStreamExecutionEnvironment().getJavaEnv(),
             flinkInterpreter.getJavaBatchTableEnvironment("blink"),
-            flinkInterpreter.getJavaStreamTableEnvironment("blink"),
+            flinkInterpreter.getJavaStreamTableEnvironment(),
             flinkInterpreter.getZeppelinContext(),
             sql -> callInnerSelect(sql));
 
@@ -56,7 +56,7 @@ public class FlinkStreamSqlInterpreter extends FlinkSqlInterpreter {
     if (streamType.equalsIgnoreCase("single")) {
       SingleRowStreamSqlJob streamJob = new SingleRowStreamSqlJob(
               flinkInterpreter.getStreamExecutionEnvironment(),
-              flinkInterpreter.getJavaStreamTableEnvironment("blink"),
+              flinkInterpreter.getJavaStreamTableEnvironment(),
               flinkInterpreter.getJobManager(),
               context,
               flinkInterpreter.getDefaultParallelism(),

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/IPyFlinkInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/IPyFlinkInterpreter.java
@@ -150,7 +150,7 @@ public class IPyFlinkInterpreter extends IPythonInterpreter {
     return flinkInterpreter.getJavaBatchTableEnvironment(planner);
   }
 
-  public TableEnvironment getJavaStreamTableEnvironment(String planner) {
-    return flinkInterpreter.getJavaStreamTableEnvironment(planner);
+  public TableEnvironment getJavaStreamTableEnvironment() {
+    return flinkInterpreter.getJavaStreamTableEnvironment();
   }
 }

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/PyFlinkInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/PyFlinkInterpreter.java
@@ -199,7 +199,7 @@ public class PyFlinkInterpreter extends PythonInterpreter {
     return flinkInterpreter.getJavaBatchTableEnvironment(planner);
   }
 
-  public TableEnvironment getJavaStreamTableEnvironment(String planner) {
-    return flinkInterpreter.getJavaStreamTableEnvironment(planner);
+  public TableEnvironment getJavaStreamTableEnvironment() {
+    return flinkInterpreter.getJavaStreamTableEnvironment();
   }
 }

--- a/flink/flink-scala-parent/src/main/resources/python/zeppelin_ipyflink.py
+++ b/flink/flink-scala-parent/src/main/resources/python/zeppelin_ipyflink.py
@@ -50,11 +50,9 @@ if not intp.isAfterFlink114():
     from pyflink.dataset import *
     b_env = pyflink.dataset.ExecutionEnvironment(intp.getJavaExecutionEnvironment())
     bt_env = BatchTableEnvironment(intp.getJavaBatchTableEnvironment("blink"))
-    st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("blink"))
-    bt_env_2 = BatchTableEnvironment(intp.getJavaBatchTableEnvironment("flink"))
-    st_env_2 = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("flink"))
+    st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment())
 else:
-    st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("blink"))
+    st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment())
 
 class IPyFlinkZeppelinContext(PyZeppelinContext):
 

--- a/flink/flink-scala-parent/src/main/resources/python/zeppelin_pyflink.py
+++ b/flink/flink-scala-parent/src/main/resources/python/zeppelin_pyflink.py
@@ -39,11 +39,9 @@ if not intp.isAfterFlink114():
   from pyflink.dataset import *
   b_env = pyflink.dataset.ExecutionEnvironment(intp.getJavaExecutionEnvironment())
   bt_env = BatchTableEnvironment(intp.getJavaBatchTableEnvironment("blink"))
-  st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("blink"))
-  bt_env_2 = BatchTableEnvironment(intp.getJavaBatchTableEnvironment("flink"))
-  st_env_2 = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("flink"))
+  st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment())
 else:
-  st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment("blink"))
+  st_env = StreamTableEnvironment(intp.getJavaStreamTableEnvironment())
 
 
 from zeppelin_context import PyZeppelinContext


### PR DESCRIPTION
### What is this PR for?

The old planner is removed starting from Flink 1.14. It is only used by a few users in some uncommon scenarios. This PR is to remove it from Flink interpreter to reduce maintenance effort.

### What type of PR is it?
[ Improvement ]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5697

### How should this be tested?
* CI 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
