### PR TITLE
[ZEPPELIN-4627] Fix class loader inconsistency between driver and executor when running on Spark 3.x

### DIFF
--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -95,10 +95,7 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
     String curSql = null;
     ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
     try {
-      if (sparkInterpreter.isScala211()) {
-        // TODO(zjffdu) scala 2.12,2.13 still doesn't work for codegen (ZEPPELIN-4627)
-        Thread.currentThread().setContextClassLoader(sparkInterpreter.getScalaShellClassLoader());
-      }
+      Thread.currentThread().setContextClassLoader(sparkInterpreter.getScalaShellClassLoader());
       Method method = sqlContext.getClass().getMethod("sql", String.class);
       for (String sql : sqls) {
         curSql = sql;
@@ -142,9 +139,7 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
       }
     } finally {
       sc.clearJobGroup();
-      if (sparkInterpreter.isScala211()) {
-        Thread.currentThread().setContextClassLoader(originalClassLoader);
-      }
+      Thread.currentThread().setContextClassLoader(originalClassLoader);
     }
 
     return new InterpreterResult(Code.SUCCESS);

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/SparkInterpreterTest.java
@@ -197,7 +197,13 @@ public class SparkInterpreterTest {
     assertTrue(((String) onParaInfosReceivedArg.getValue().get("jobUrl")).startsWith("fake_spark_weburl/"
             + interpreter.getJavaSparkContext().sc().applicationId()));
 
-    // case class
+    // RDD of case class objects
+    result = interpreter.interpret(
+        "case class A(a: Integer, b: Integer)\n" +
+        "sc.parallelize(Seq(A(10, 20), A(30, 40))).collect()", getInterpreterContext());
+    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
+
+    // Dataset of case class objects
     result = interpreter.interpret("val bankText = sc.textFile(\"bank.csv\")", getInterpreterContext());
     assertEquals(InterpreterResult.Code.SUCCESS, result.code());
 

--- a/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
+++ b/spark/scala-2.12/src/main/scala/org/apache/zeppelin/spark/SparkScala212Interpreter.scala
@@ -19,7 +19,6 @@ package org.apache.zeppelin.spark
 
 import java.io.{BufferedReader, File}
 import java.net.URLClassLoader
-import java.nio.file.{Files, Paths}
 import java.util.Properties
 import org.apache.spark.SparkConf
 import org.apache.spark.repl.SparkILoop
@@ -226,7 +225,7 @@ private object SparkScala212Interpreter {
         foreach (intp quietRun _)
         )
       // classloader and power mode setup
-      intp.setContextClassLoader()
+      Thread.currentThread.setContextClassLoader(intp.classLoader)
       if (isReplPower) {
         replProps.power setValue true
         unleashAndSetPhase()

--- a/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkScala213Interpreter.scala
+++ b/spark/scala-2.13/src/main/scala/org/apache/zeppelin/spark/SparkScala213Interpreter.scala
@@ -76,6 +76,7 @@ class SparkScala213Interpreter(override val conf: SparkConf,
     sparkILoop = new SparkILoop(null, replOut)
     sparkILoop.run(settings)
     this.scalaCompletion = new ReplCompletion(sparkILoop.intp, new Accumulator)
+    Thread.currentThread.setContextClassLoader(sparkILoop.classLoader)
 
     createSparkContext()
 


### PR DESCRIPTION
### What is this PR for?
Setting thread context classloader of interpreter thread before creating SparkContext object in order to preserve correct classloader hierarchy.

We worked out this patch for fixing ZEPPELIN-4627, and it also seems to fix ZEPPELIN-5688.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-4627
* https://issues.apache.org/jira/browse/ZEPPELIN-5688

### How should this be tested?
* Manually tested cases described in ZEPPELIN-4627
* Added unit test for cases described in ZEPPELIN-5688

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
