### PR TITLE
[ZEPPELIN-5717] Fix incorrect editor value gotten by Runner

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -1230,7 +1230,7 @@ function ParagraphCtrl($scope, $rootScope, $route, $window, $routeParams, $locat
   };
 
   $scope.getEditorValue = function() {
-    return !$scope.editor ? $scope.paragraph.text : $scope.editor.getValue();
+    return !$scope.editor || $scope.viewOnly ? $scope.paragraph.text : $scope.editor.getValue();
   };
 
   $scope.getProgress = function() {


### PR DESCRIPTION
### What is this PR for?
For user under runner role, the editor is hidden, so the **$scope.editor object** is not empty and the **$scope.editor.getValue()** function may return a null value.

So there should be one more condition to judge: if user cannot view editor, it's also expected to get editor value from **$scope.paragraph.text** as well.

The **$scope.viewOnly** in notebook.controller.js determines whether the editor is editable for user, and when user is under role of owner or writer, the value will become true. This value can be referred in the adjacent js files. 

So it's used as a new judgement condition when get editor value.

### What type of PR is it?
Bug Fix 

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5717

### How should this be tested?
* Create paragraph with input box in notebook;
* Grant one user with only runner role;
* Login and run the paragraph by pressing the enter key on input box(can try multiple times);
* See if the paragraph content will be overwritten and lost (become empty);
* If no, means success.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
