### PR TITLE
Potential security vulnerability in the lz4 C library.

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <cassandra.driver.version>4.8.0</cassandra.driver.version>
         <snappy.version>1.1.7.3</snappy.version>
-        <lz4.version>1.6.0</lz4.version>
+        <lz4.version>1.7.0</lz4.version>
         <scalate.version>1.7.1</scalate.version>
 
         <!-- test library versions -->


### PR DESCRIPTION
Hi, @corneadoug, @Reamer , I'd like to report a vulnerability dependency in **org.apache.zeppelin:zeppelin-cassandra:0.10.1**.
### Issue Description
I noticed that **org.apache.zeppelin:zeppelin-cassandra:0.10.1** directly depends on **org.lz4:lz4-java:1.6.0** in the [pom](https://repo1.maven.org/maven2/org/apache/zeppelin/zeppelin-cassandra/0.10.1/zeppelin-cassandra-0.10.1.pom). However, as shown in the following dependency graph, **org.lz4:lz4-java:1.6.0** sufferes from the vulnerabilites which the C library **lz4(version:1.9.1)** exposed, containing a high severity CVE: [CVE-2019-17543](https://nvd.nist.gov/vuln/detail/CVE-2019-17543).
### Dependency Graph between Java and Shared Libraries
![image](https://user-images.githubusercontent.com/103260963/163198977-5211f6a1-075b-4e14-96ab-03eddec062a8.png)
### Suggested Vulnerability Patch Versions
**org.lz4:lz4-java:1.7.0** (**>=1.7.0**) has upgraded the vulnerable C library `lz4` to the patch version **1.9.2**. 

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr