### PR TITLE
[ZEPPELIN-5614] A JDBC interpreter property for disable setting tag for application of hive engines

### DIFF
--- a/docs/interpreter/hive.md
+++ b/docs/interpreter/hive.md
@@ -127,6 +127,21 @@ See the example below of settings and dependencies.
     <td></td>
     <td><b>( Optional ) </b>Other properties used by the driver of <code>%hive(${prefix})</code> </td>
   </tr>
+  <tr>
+    <td>zeppelin.jdbc.hive.timeout.threshold</td>
+    <td>60000</td>
+    <td>Timeout for hive job timeout</td>
+  </tr>
+  <tr>
+    <td>zeppelin.jdbc.hive.monitor.query_interval</td>
+    <td>1000</td>
+    <td>Query interval for hive statement</td>
+  </tr>
+  <tr>
+    <td>zeppelin.jdbc.hive.engines.tag.enable</td>
+    <td>true</td>
+    <td>Set application tag for applications started by hive engines</td>
+  </tr>
 </table>
 
 This interpreter provides multiple configuration with `${prefix}`. User can set a multiple connection properties by this prefix. It can be used like `%hive(${prefix})`.

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -739,6 +739,8 @@ See [User Impersonation in interpreter](../usage/interpreter/user_impersonation.
   </tr>
 </table>
 
+See [Hive Interpreter](../interpreter/hive.html) for more properties about Hive interpreter.
+
 ### Presto/Trino
 
 Properties

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -604,14 +604,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   // only add tags for hive jdbc
   private String appendTagsToURL(String url, InterpreterContext context) {
-    // To deal engines which don't need to set application tag
-    String disabledAppTypeStr = getProperty("zeppelin.jdbc.hive.tagged.engines.exclude");
-    HashSet<String> disabledAppType = new HashSet<>();
-    if (StringUtils.isNotEmpty(disabledAppTypeStr)) {
-      disabledAppType = new HashSet<>(Arrays.asList(disabledAppTypeStr.split(",")));
-      if ((disabledAppType.contains("MAPREDUCE") && disabledAppType.contains("TEZ"))) {
-        return url;
-      }
+    if (!Boolean.parseBoolean(getProperty("zeppelin.jdbc.hive.engines.tag.enable"))) {
+      return url;
     }
 
     StringBuilder builder = new StringBuilder(url);
@@ -623,12 +617,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
       } else {
         lastIndexOfQMark++;
       }
-      if (!disabledAppType.contains("MAPREDUCE")) {
-        builder.insert(lastIndexOfQMark, "mapreduce.job.tags=" + context.getParagraphId() + ";");
-      }
-      if (!disabledAppType.contains("TEZ")) {
-        builder.insert(lastIndexOfQMark, "tez.application.tags=" + context.getParagraphId() + ";");
-      }
+      builder.insert(lastIndexOfQMark, "mapreduce.job.tags=" + context.getParagraphId() + ";");
+      builder.insert(lastIndexOfQMark, "tez.application.tags=" + context.getParagraphId() + ";");
     }
     return builder.toString();
   }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -604,7 +604,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   // only add tags for hive jdbc
   private String appendTagsToURL(String url, InterpreterContext context) {
-    if (!Boolean.parseBoolean(getProperty("zeppelin.jdbc.hive.engines.tag.enable"))) {
+    if (!Boolean.parseBoolean(getProperty("zeppelin.jdbc.hive.engines.tag.enable", "true"))) {
       return url;
     }
 

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -143,6 +143,13 @@
         "defaultValue": "1000",
         "description": "Query interval for hive statement",
         "type": "number"
+      },
+      "zeppelin.jdbc.hive.tagged.engines.exclude": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.hive.tagged.engines.exclude",
+        "defaultValue": "",
+        "description": "hive engines which don't need to set yarn application tag. Example: TEZ,MAPREDUCE",
+        "type": "string"
       }
     },
     "editor": {

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -77,7 +77,7 @@
       "zeppelin.jdbc.auth.kerberos.proxy.enable": {
         "envName": null,
         "propertyName": "zeppelin.jdbc.auth.kerberos.proxy.enable",
-        "defaultValue": "true",
+        "defaultValue": true,
         "description": "When auth type is Kerberos, enable/disable Kerberos proxy with the login user to get the connection. Default value is true.",
         "type": "checkbox"
       },
@@ -144,12 +144,12 @@
         "description": "Query interval for hive statement",
         "type": "number"
       },
-      "zeppelin.jdbc.hive.tagged.engines.exclude": {
+      "zeppelin.jdbc.hive.engines.tag.enable": {
         "envName": null,
-        "propertyName": "zeppelin.jdbc.hive.tagged.engines.exclude",
-        "defaultValue": "",
-        "description": "hive engines which don't need to set yarn application tag. Example: TEZ,MAPREDUCE",
-        "type": "string"
+        "propertyName": "zeppelin.jdbc.hive.engines.tag.enable",
+        "defaultValue": true,
+        "description": "Set application tag for applications started by hive engines",
+        "type": "checkbox"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
This PR introduce a JDBC interpreter property for disable setting tag for application of hive engines.

Some users disabled tez.* property in hive  and hence unable to use hive in zeppelin. The reason is Zeppelin jdbc interpreter always set both tez and MR tags property when connect to hive.   This PR provide a property to disable setting tag for tez and MR application in hive.


### What type of PR is it?
Improvement


### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5614

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
