### PR TITLE
 [ZEPPELIN-5682] SQL keywords are not highlighted in paragraph

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
@@ -102,7 +102,7 @@ export interface SaveInterpreterBindings {
 
 export interface EditorSettingSend {
   paragraphId: string;
-  magic: string;
+  paragraphText: string;
 }
 
 export interface EditorSettingReceived {

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -160,7 +160,8 @@ export enum OP {
   /**
    * [c-s]
    * ask paragraph editor setting
-   * @param magic magic keyword written in paragraph
+   * @param paragraphId paragraph id
+   * @param paragraphText text of the paragraph
    * ex) spark.spark or spark
    */
   EDITOR_SETTING = 'EDITOR_SETTING',

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -498,10 +498,10 @@ export class Message {
     });
   }
 
-  editorSetting(paragraphId: string, replName: string): void {
+  editorSetting(paragraphId: string, paragraphText: string): void {
     this.send<OP.EDITOR_SETTING>(OP.EDITOR_SETTING, {
       paragraphId: paragraphId,
-      magic: replName
+      paragraphText: paragraphText
     });
   }
 

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -179,13 +179,13 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
       const interpreterName = this.getInterpreterName(this.text);
       if (this.interpreterName !== interpreterName) {
         this.interpreterName = interpreterName;
-        this.getEditorSetting(interpreterName);
+        this.getEditorSetting();
       }
     }
   }
 
-  getEditorSetting(interpreterName: string) {
-    this.messageService.editorSetting(this.pid, interpreterName);
+  getEditorSetting() {
+    this.messageService.editorSetting(this.pid, this.text);
   }
 
   layout() {


### PR DESCRIPTION
### What is this PR for?

When use the SQL statement in paragraph, some keywords are not highlighted.
The reason is new web ui code bug(zeppeline-web-angular), front-end send the parameter is 'magic', but back-end 
receive the parameter is  paragraphText, or else catch,  don't return editsetting, front-end need the setting that language is sql in paragraph implement highlight.
This PR modify the correct parameter

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5682

### How should this be tested?
* CI passed

### Screenshots (if appropriate)
 
![image](https://user-images.githubusercontent.com/44150070/163777618-98ec3566-a2c0-40b8-8d66-45785bc738e8.png)
the back-end code is
![image](https://user-images.githubusercontent.com/44150070/163778600-f21faf02-b311-4a7a-b772-273272395818.png)

### Questions:
* Does the licenses files need to update?  no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
