### PR TITLE
[ZEPPELIN-5728] Absence of cancelNote method in Zeppelin Client Api

### DIFF
--- a/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/ZeppelinClientExample.java
+++ b/zeppelin-client-examples/src/main/java/org/apache/zeppelin/client/examples/ZeppelinClientExample.java
@@ -56,6 +56,8 @@ public class ZeppelinClientExample {
               "%python\nimport time\ntime.sleep(5)\nprint('done')");
       zClient.submitParagraph(noteId, paragraphId2);
       zClient.waitUtilParagraphRunning(noteId, paragraphId2);
+      // It's also ok here to call zClient.cancelNote(noteId);
+      // CancelNote() would cancel all paragraphs in the note.
       zClient.cancelParagraph(noteId, paragraphId2);
       paragraphResult = zClient.waitUtilParagraphFinish(noteId, paragraphId2);
       System.out.println("Added new paragraph, submit it then cancel it");

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ZeppelinClient.java
@@ -502,6 +502,21 @@ public class ZeppelinClient {
     return queryNoteResult(noteId);
   }
 
+  /**
+   * Cancel a running note.
+   *
+   * @param noteId
+   * @throws Exception
+   */
+  public void cancelNote(String noteId) throws Exception {
+    HttpResponse<JsonNode> response = Unirest
+            .delete("/notebook/job/{noteId}")
+            .routeParam("noteId", noteId)
+            .asJson();
+    checkResponse(response);
+    JsonNode jsonNode = response.getBody();
+    checkJsonNodeStatus(jsonNode);
+  }
 
   /**
    * Import note with given note json content to the specified notePath.


### PR DESCRIPTION
### What is this PR for?
Currently there's a cancelParagraph method in zeppelin client api, however, there's no cancelNote method.
PR is to add a cancelNote method  in zeppelin client api.


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5728

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
