### PR TITLE
[ZEPPELIN-5729] Increase default value of zeppelin.interpreter.connect.timeout

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -417,7 +417,7 @@
 
 <property>
   <name>zeppelin.interpreter.connect.timeout</name>
-  <value>60000</value>
+  <value>600000</value>
   <description>Interpreter process connect timeout in msec.</description>
 </property>
 

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -340,8 +340,8 @@ Sources descending by priority:
   <tr>
     <td><h6 class="properties">ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT</h6></td>
     <td><h6 class="properties">zeppelin.interpreter.connect.timeout</h6></td>
-    <td>30000</td>
-    <td>Output message from interpreter exceeding the limit will be truncated</td>
+    <td>600000</td>
+    <td>Interpreter process connect timeout in msec.</td>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_DEP_LOCALREPO</h6></td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -936,7 +936,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_INTERPRETER_LOCALREPO("zeppelin.interpreter.localRepo", "local-repo"),
     ZEPPELIN_INTERPRETER_DEP_MVNREPO("zeppelin.interpreter.dep.mvnRepo",
         "https://repo1.maven.org/maven2/"),
-    ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 60000),
+    ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT("zeppelin.interpreter.connect.timeout", 600000),
     ZEPPELIN_INTERPRETER_CONNECTION_POOL_SIZE("zeppelin.interpreter.connection.poolsize", 100),
     ZEPPELIN_INTERPRETER_GROUP_DEFAULT("zeppelin.interpreter.group.default", "spark"),
     ZEPPELIN_INTERPRETER_OUTPUT_LIMIT("zeppelin.interpreter.output.limit", 1024 * 100),


### PR DESCRIPTION
### What is this PR for?
The default value of zeppelin.interpreter.connect.timeout is 60 seconds. This is too small in the case of running spark in yarn-cluster mode. 
BTY, in docs, the description for this property is wrong.


### What type of PR is it?
Improvement


### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5729

### How should this be tested?
* CI Passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
