### PR TITLE
[ZEPPELIN-5737] try to avoid deadlock

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/LazyOpenInterpreter.java
@@ -59,13 +59,13 @@ public class LazyOpenInterpreter
   }
 
   @Override
-  public synchronized void open() throws InterpreterException {
-    if (opened == true) {
+  public void open() throws InterpreterException {
+    if (opened) {
       return;
     }
 
     synchronized (intp) {
-      if (opened == false) {
+      if (!opened) {
         try {
           intp.open();
           opened = true;
@@ -88,7 +88,7 @@ public class LazyOpenInterpreter
   @Override
   public void close() throws InterpreterException {
     synchronized (intp) {
-      if (opened == true) {
+      if (opened) {
         intp.close();
         opened = false;
       }
@@ -96,9 +96,7 @@ public class LazyOpenInterpreter
   }
 
   public boolean isOpen() {
-    synchronized (intp) {
-      return opened;
-    }
+    return opened;
   }
 
   @Override
@@ -115,8 +113,9 @@ public class LazyOpenInterpreter
 
   @Override
   public void cancel(InterpreterContext context) throws InterpreterException {
-    open();
-    intp.cancel(context);
+    if (opened) {
+      intp.cancel(context);
+    }
   }
 
   @Override
@@ -142,8 +141,7 @@ public class LazyOpenInterpreter
   public List<InterpreterCompletion> completion(String buf, int cursor,
       InterpreterContext interpreterContext) throws InterpreterException {
     open();
-    List completion = intp.completion(buf, cursor, interpreterContext);
-    return completion;
+    return intp.completion(buf, cursor, interpreterContext);
   }
 
   @Override

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/remote/RemoteInterpreterServer.java
@@ -490,7 +490,7 @@ public class RemoteInterpreterServer extends Thread
           Iterator<Interpreter> it = interpreters.iterator();
           while (it.hasNext()) {
             Interpreter inp = it.next();
-            boolean isOpen = false;
+            boolean isOpen = true;
             if (inp instanceof LazyOpenInterpreter) {
               LazyOpenInterpreter lazy = (LazyOpenInterpreter) inp;
               isOpen = lazy.isOpen();


### PR DESCRIPTION
### What is this PR for?
This pull request is to prevent a deadlock which occurs in connection with a fast cancel in the LazyOpenInterpreter.

This PR should also correct the closing of interpreters which are not LazyOpenInterpreter.

### What type of PR is it?
* Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5737

### How should this be tested?
* CI
* manual 

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
