### PR TITLE
ZEPPELIN-5746: Add support for escaping html in markdown

### DIFF
--- a/markdown/src/main/java/org/apache/zeppelin/markdown/FlexmarkParser.java
+++ b/markdown/src/main/java/org/apache/zeppelin/markdown/FlexmarkParser.java
@@ -28,6 +28,7 @@ import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.data.MutableDataSet;
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,7 @@ public class FlexmarkParser implements MarkdownParser {
   private HtmlRenderer renderer;
 
   public FlexmarkParser() {
+    ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
     MutableDataSet options = new MutableDataSet();
     options.set(Parser.EXTENSIONS, Arrays.asList(StrikethroughExtension.create(),
             TablesExtension.create(),
@@ -54,6 +56,7 @@ public class FlexmarkParser implements MarkdownParser {
             EmojiExtension.create()));
     options.set(HtmlRenderer.SOFT_BREAK, "<br />\n");
     options.set(EmojiExtension.USE_IMAGE_TYPE, UNICODE_ONLY);
+    options.set(HtmlRenderer.ESCAPE_HTML, zConf.isZeppelinNotebookMarkdownEscapeHtml());
     parser = Parser.builder(options).build();
     renderer = HtmlRenderer.builder(options).build();
   }

--- a/markdown/src/test/java/org/apache/zeppelin/markdown/FlexmarkParserTest.java
+++ b/markdown/src/test/java/org/apache/zeppelin/markdown/FlexmarkParserTest.java
@@ -223,5 +223,26 @@ public class FlexmarkParserTest {
     // Do not activate, because this test depends on www.websequencediagrams.com
     //assertTrue(containsImg);
   }
+
+  @Test
+  public void testEscapeHtml() {
+    String input =
+            new StringBuilder()
+                    .append("This is\n")
+                    .append("<script type=\"text/javascript\">alert(1);</script>\n")
+                    .append("<div onclick='alert(2)'>this is div</div>\n")
+                    .toString();
+
+    String expected =
+            new StringBuilder()
+                    .append("<p>This is</p>\n")
+                    .append("<p>&lt;script type=&quot;text/javascript&quot;&gt;" +
+                            "alert(1);&lt;/script&gt;</p>\n")
+                    .append("<p>&lt;div &gt;this is div&lt;/div&gt;</p>\n")
+                    .toString();
+
+    InterpreterResult result = md.interpret(input, null);
+    assertEquals(wrapWithMarkdownClassDiv(expected), result.message().get(0).getData());
+  }
 }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -761,6 +761,10 @@ public class ZeppelinConfiguration {
     return getString(ConfVars.ZEPPELIN_NOTEBOOK_CRON_FOLDERS);
   }
 
+  public boolean isZeppelinNotebookMarkdownEscapeHtml() {
+    return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_MARKDOWN_ESCAPE_HTML);
+  }
+
   public Boolean isZeppelinNotebookCollaborativeModeEnable() {
     return getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_COLLABORATIVE_MODE_ENABLE);
   }
@@ -1079,6 +1083,7 @@ public class ZeppelinConfiguration {
             true),
     ZEPPELIN_NOTEBOOK_CRON_ENABLE("zeppelin.notebook.cron.enable", false),
     ZEPPELIN_NOTEBOOK_CRON_FOLDERS("zeppelin.notebook.cron.folders", null),
+    ZEPPELIN_NOTEBOOK_MARKDOWN_ESCAPE_HTML("zeppelin.notebook.markdown.escape.html", true),
     ZEPPELIN_PROXY_URL("zeppelin.proxy.url", null),
     ZEPPELIN_PROXY_USER("zeppelin.proxy.user", null),
     ZEPPELIN_PROXY_PASSWORD("zeppelin.proxy.password", null),


### PR DESCRIPTION
This is implemented by flexmark. A new configuration is also added, and
this configuration is turned on by default.

### What is this PR for?
Zeppelin should support escaping html in markdown.

### What type of PR is it?
* Bug Fix

### What is the Jira issue?
* [ZEPPELIN-5746](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-5746)

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

I also noticed there is another call of flexmark in `org.apache.zeppelin.jupyter.parser.MarkdownParser`. But it seems the package `jupyter` can not read from configuration. I am not sure if this occurrence should be fixed or not. Feel free to tell me if this need to be fixed. :)
