### PR TITLE
[ZEPPELIN-5754] Init Notes in background

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/ExecutorUtil.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/util/ExecutorUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.zeppelin.util;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -38,7 +39,8 @@ public class ExecutorUtil {
       // Wait a while for existing tasks to terminate
       if (!executor.awaitTermination(stopTimeoutVal, stopTimeoutUnit)) {
         LOGGER.warn("{} was not shut down in the given time {} {} - interrupting now", name, stopTimeoutVal, stopTimeoutUnit);
-        executor.shutdownNow(); // Cancel currently executing tasks
+        List<Runnable> neverExecuted = executor.shutdownNow(); // Cancel currently executing tasks
+        LOGGER.warn("{} tasks were never executed from {}.", neverExecuted.size(), name);
         // Wait a while for tasks to respond to being cancelled
         if (!executor.awaitTermination(stopTimeoutVal, stopTimeoutUnit)) {
           LOGGER.error("executor {} did not terminate", name);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -260,6 +260,8 @@ public class ZeppelinServer extends ResourceConfig {
       sharedServiceLocator, SearchService.class.getName());
     ServiceLocatorUtilities.getService(
       sharedServiceLocator, SchedulerService.class.getName());
+    // Initialization of the Notes in the notebook asynchronously
+    notebook.initNotebook();
     // Try to recover here, don't do it in constructor of Notebook, because it would cause deadlock.
     notebook.recoveryIfNecessary();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterEventTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterEventTest.java
@@ -32,7 +32,6 @@ import org.apache.zeppelin.interpreter.remote.RemoteInterpreterUtils;
 import org.apache.zeppelin.interpreter.thrift.ParagraphInfo;
 import org.apache.zeppelin.interpreter.thrift.ServiceException;
 import org.apache.zeppelin.notebook.AuthorizationService;
-import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.notebook.Paragraph;
 import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
@@ -63,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -101,7 +101,8 @@ public class ClusterEventTest extends ZeppelinServerMock {
     authorizationService = TestUtils.getInstance(AuthorizationService.class);
 
     schedulerService = new QuartzSchedulerService(zconf, notebook);
-    schedulerService.waitForFinishInit();
+    notebook.initNotebook();
+    notebook.waitForFinishInit(1, TimeUnit.MINUTES);
     notebookServer = spy(NotebookServer.getInstance());
     notebookService = new NotebookService(notebook, authorizationService, zconf, schedulerService);
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -129,7 +130,8 @@ public class NotebookServiceTest {
             null);
     searchService = new LuceneSearch(zeppelinConfiguration, notebook);
     QuartzSchedulerService schedulerService = new QuartzSchedulerService(zeppelinConfiguration, notebook);
-    schedulerService.waitForFinishInit();
+    notebook.initNotebook();
+    notebook.waitForFinishInit(1, TimeUnit.MINUTES);
     notebookService =
         new NotebookService(
             notebook, authorizationService, zeppelinConfiguration, schedulerService);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -28,7 +28,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Function;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
@@ -51,8 +56,10 @@ import org.apache.zeppelin.notebook.repo.NotebookRepoSync;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl;
 import org.apache.zeppelin.notebook.repo.NotebookRepoWithVersionControl.Revision;
 import org.apache.zeppelin.scheduler.Job;
+import org.apache.zeppelin.scheduler.SchedulerThreadFactory;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.apache.zeppelin.user.Credentials;
+import org.apache.zeppelin.util.ExecutorUtil;
 import org.quartz.SchedulerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +82,8 @@ public class Notebook {
   private NotebookRepo notebookRepo;
   private List<NoteEventListener> noteEventListeners = new CopyOnWriteArrayList<>();
   private Credentials credentials;
+  private final List<Consumer<String>> initConsumers;
+  private ExecutorService initExecutor;
 
   /**
    * Main constructor \w manual Dependency Injection
@@ -101,12 +110,67 @@ public class Notebook {
     this.interpreterSettingManager.setNotebook(this);
     this.credentials = credentials;
     addNotebookEventListener(this.interpreterSettingManager);
+    initConsumers = new LinkedList<>();
   }
 
   public void recoveryIfNecessary() {
     if (conf.isRecoveryEnabled()) {
       recoverRunningParagraphs();
     }
+  }
+
+  /**
+   * Subsystems can add a consumer, which is executed during initialization.
+   * Initialization is performed in parallel and with multiple threads.
+   *
+   * The consumer must be thread safe.
+   *
+   * @param initConsumer Consumer, which is passed the NoteId.
+   */
+  public void addInitConsumer(Consumer<String> initConsumer) {
+    this.initConsumers.add(initConsumer);
+  }
+
+  /**
+   * Asynchronous and parallel initialization of notes (during startup)
+   */
+  public void initNotebook() {
+    initExecutor = new ThreadPoolExecutor(0, Runtime.getRuntime().availableProcessors(), 1, TimeUnit.MINUTES,
+                  new LinkedBlockingQueue<>(), new SchedulerThreadFactory("NotebookInit"));
+    for (NoteInfo noteInfo : getNotesInfo()) {
+      initExecutor.execute(() -> {
+        for (Consumer<String> initConsumer : initConsumers) {
+          initConsumer.accept(noteInfo.getId());
+        }
+      });
+    }
+  }
+
+  /**
+   * Blocks until all init jobs have completed execution,
+   * or the timeout occurs, or the current thread is
+   * interrupted, whichever happens first.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the timeout argument
+   * @return {@code true} if this initJobs terminated or no initialization is active
+   *         {@code false} if the timeout elapsed before termination or the wait is interrupted
+   */
+  public boolean waitForFinishInit(long timeout, TimeUnit unit) {
+    if (initExecutor == null) {
+      return true;
+    }
+    try {
+      initExecutor.shutdown();
+      return initExecutor.awaitTermination(timeout, unit);
+    } catch (InterruptedException e) {
+      LOGGER.warn("Notebook Init-Job interrupted!", e);
+      // (Re-)Cancel if current thread also interrupted
+      initExecutor.shutdownNow();
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
+    return false;
   }
 
   private void recoverRunningParagraphs() {
@@ -683,14 +747,14 @@ public class Notebook {
         .collect(Collectors.toList());
   }
 
-  public List<NoteInfo> getNotesInfo(Function<String, Boolean> func) {
+  public List<NoteInfo> getNotesInfo(Predicate<String> func) {
     String homescreenNoteId = conf.getString(ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN);
     boolean hideHomeScreenNotebookFromList =
         conf.getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE);
 
     synchronized (noteManager.getNotesInfo()) {
       List<NoteInfo> notesInfo = noteManager.getNotesInfo().entrySet().stream().filter(entry ->
-              func.apply(entry.getKey()) &&
+              func.test(entry.getKey()) &&
               ((!hideHomeScreenNotebookFromList) ||
                   ((hideHomeScreenNotebookFromList) && !entry.getKey().equals(homescreenNoteId))))
           .map(entry -> new NoteInfo(entry.getKey(), entry.getValue()))
@@ -752,6 +816,9 @@ public class Notebook {
   }
 
   public void close() {
+    if (initExecutor != null) {
+      ExecutorUtil.softShutdown("NotebookInit", initExecutor, 1, TimeUnit.MINUTES);
+    }
     this.notebookRepo.close();
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -135,8 +135,10 @@ public class Notebook {
    * Asynchronous and parallel initialization of notes (during startup)
    */
   public void initNotebook() {
-    initExecutor = new ThreadPoolExecutor(0, Runtime.getRuntime().availableProcessors(), 1, TimeUnit.MINUTES,
-                  new LinkedBlockingQueue<>(), new SchedulerThreadFactory("NotebookInit"));
+    if (initExecutor == null || initExecutor.isShutdown() || initExecutor.isTerminated()) {
+      initExecutor = new ThreadPoolExecutor(0, Runtime.getRuntime().availableProcessors(), 1, TimeUnit.MINUTES,
+                     new LinkedBlockingQueue<>(), new SchedulerThreadFactory("NotebookInit"));
+    }
     for (NoteInfo noteInfo : getNotesInfo()) {
       initExecutor.execute(() -> {
         for (Consumer<String> initConsumer : initConsumers) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/CronJob.java
@@ -34,7 +34,6 @@ public class CronJob implements org.quartz.Job {
 
   private static final String RESULT_SUCCEEDED = "succeeded";
   private static final String RESULT_FAILED = "failed";
-  private static final String RESULT_SKIPPED = "skipped";
 
   @Override
   public void execute(JobExecutionContext context) {
@@ -47,14 +46,6 @@ public class CronJob implements org.quartz.Job {
         if (note == null) {
           LOGGER.warn("Failed to run CronJob of note: {} because there's no such note", noteId);
           context.setResult(RESULT_FAILED);
-          return null;
-        }
-        if (note.haveRunningOrPendingParagraphs()) {
-          LOGGER.warn(
-              "execution of the cron job is skipped because there is a running or pending "
-                  + "paragraph (note id: {})",
-              note.getId());
-          context.setResult(RESULT_SKIPPED);
           return null;
         }
         String cronExecutingUser = (String) note.getConfig().get("cronExecutingUser");

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/MetricCronJobListener.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/MetricCronJobListener.java
@@ -35,12 +35,12 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 
-public class CronJobListener implements JobListener {
+public class MetricCronJobListener implements JobListener {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CronJobListener.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricCronJobListener.class);
 
   // JobExecutionContext -> Timer.Sample
-  private Map<JobExecutionContext, Timer.Sample> cronJobTimerSamples = new HashMap<>();
+  private final Map<JobExecutionContext, Timer.Sample> cronJobTimerSamples = new HashMap<>();
 
   @Override
   public String getName() {
@@ -57,9 +57,7 @@ public class CronJobListener implements JobListener {
 
   @Override
   public void jobExecutionVetoed(JobExecutionContext context) {
-    JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
-    String noteId = jobDataMap.getString("noteId");
-    LOGGER.info("vetoed cron job of note: {}", noteId);
+    // do nothing
   }
 
   @Override

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/NoSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/NoSchedulerService.java
@@ -17,9 +17,6 @@
 
 package org.apache.zeppelin.notebook.scheduler;
 
-import java.util.Collections;
-import java.util.Set;
-
 public class NoSchedulerService implements SchedulerService {
   @Override
   public boolean refreshCron(String noteId) {
@@ -27,7 +24,7 @@ public class NoSchedulerService implements SchedulerService {
   }
 
   @Override
-  public Set<?> getJobs() {
-    return Collections.emptySet();
+  public int getJobsSize() {
+    return 0;
   }
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -56,7 +56,8 @@ public class QuartzSchedulerService implements SchedulerService {
     this.zeppelinConfiguration = zeppelinConfiguration;
     this.notebook = notebook;
     this.scheduler = getScheduler();
-    this.scheduler.getListenerManager().addJobListener(new CronJobListener());
+    this.scheduler.getListenerManager().addJobListener(new MetricCronJobListener());
+    this.scheduler.getListenerManager().addTriggerListener(new ZeppelinCronJobTriggerListerner());
     this.scheduler.start();
 
     // Do in a separated thread because there may be many notes,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/QuartzSchedulerService.java
@@ -18,10 +18,7 @@
 package org.apache.zeppelin.notebook.scheduler;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
-
 import javax.inject.Inject;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -162,12 +159,12 @@ public class QuartzSchedulerService implements SchedulerService {
   }
 
   @Override
-  public Set<?> getJobs() {
+  public int getJobsSize() {
     try {
-      return scheduler.getJobKeys(GroupMatcher.anyGroup());
+      return scheduler.getJobKeys(GroupMatcher.anyGroup()).size();
     } catch (SchedulerException e) {
       LOGGER.error("Error while getting jobKeys", e);
-      return Collections.emptySet();
+      return 0;
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/SchedulerService.java
@@ -17,10 +17,16 @@
 
 package org.apache.zeppelin.notebook.scheduler;
 
-import java.io.IOException;
-import java.util.Set;
-
 public interface SchedulerService {
-  boolean refreshCron(String noteId) throws IOException;
-  Set<?> getJobs();
+
+  /**
+   * @param noteId
+   * @return return true if the cron refresh was successfull
+   */
+  boolean refreshCron(String noteId);
+
+  /**
+   * @return size of queued jobs
+   */
+  int getJobsSize();
 }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/ZeppelinCronJobTriggerListerner.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/scheduler/ZeppelinCronJobTriggerListerner.java
@@ -1,0 +1,61 @@
+package org.apache.zeppelin.notebook.scheduler;
+
+import java.io.IOException;
+
+import org.apache.zeppelin.notebook.Notebook;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.Trigger;
+import org.quartz.Trigger.CompletedExecutionInstruction;
+import org.quartz.TriggerListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZeppelinCronJobTriggerListerner implements TriggerListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinCronJobTriggerListerner.class);
+
+  @Override
+  public String getName() {
+    return "ZeppelinCronJobTriggerListerner";
+  }
+
+  @Override
+  public void triggerFired(Trigger trigger, JobExecutionContext context) {
+    // Do nothing
+  }
+
+  @Override
+  public boolean vetoJobExecution(Trigger trigger, JobExecutionContext context) {
+    JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
+    String noteId = jobDataMap.getString("noteId");
+    Notebook notebook = (Notebook) jobDataMap.get("notebook");
+    try {
+        return notebook.processNote(noteId, note -> {
+            if (note.haveRunningOrPendingParagraphs()) {
+                LOGGER.warn(
+                    "execution of the cron job is skipped because there is a running or pending paragraph (noteId: {})",
+                    noteId);
+                return true;
+            }
+            return false;
+        });
+    } catch (IOException e) {
+        LOGGER.warn("Failed to check CronJob of note: {} because fail to get it", noteId ,e);
+        return true;
+    }
+  }
+
+  @Override
+  public void triggerMisfired(Trigger trigger) {
+    // Do nothing
+  }
+
+  @Override
+  public void triggerComplete(Trigger trigger, JobExecutionContext context,
+      CompletedExecutionInstruction triggerInstructionCode) {
+    // Do nothing
+  }
+
+}

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/LuceneSearch.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/search/LuceneSearch.java
@@ -104,7 +104,7 @@ public class LuceneSearch extends SearchService {
       throw new IOException("Failed to create new IndexWriter", e);
     }
     if (conf.isIndexRebuild()) {
-      startRebuildIndex();
+      notebook.addInitConsumer(this::addNoteIndex);
     }
     this.notebook.addNotebookEventListener(this);
   }
@@ -441,23 +441,5 @@ public class LuceneSearch extends SearchService {
       return;
     }
     updateDoc(noteId, noteName, null);
-  }
-
-  public void startRebuildIndex() {
-    Thread thread = new Thread(() -> {
-      LOGGER.info("Starting rebuild index");
-      notebook.getNotesInfo().forEach(noteInfo -> {
-        addNoteIndex(noteInfo.getId());
-      });
-      LOGGER.info("Finish rebuild index");
-    });
-    thread.setName("LuceneSearch-RebuildIndex-Thread");
-    thread.start();
-    try {
-      thread.join();
-    } catch (InterruptedException e) {
-      LOGGER.warn("Lucene Rebuild Index Thread interrupted!", e);
-      Thread.currentThread().interrupt();
-    }
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -104,7 +104,8 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials, null);
     notebook.setParagraphJobListener(this);
     schedulerService = new QuartzSchedulerService(conf, notebook);
-    schedulerService.waitForFinishInit();
+    notebook.initNotebook();
+    notebook.waitForFinishInit(1, TimeUnit.MINUTES);
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -991,9 +991,9 @@ public class NotebookTest extends AbstractInterpreterTest implements ParagraphJo
         note.setConfig(config);
         return null;
       });
-    final int jobsBeforeRefresh = schedulerService.getJobs().size();
+    final int jobsBeforeRefresh = schedulerService.getJobsSize();
     schedulerService.refreshCron(noteId);
-    final int jobsAfterRefresh = schedulerService.getJobs().size();
+    final int jobsAfterRefresh = schedulerService.getJobsSize();
 
     assertEquals(jobsBeforeRefresh, jobsAfterRefresh);
 


### PR DESCRIPTION
### What is this PR for?
This pull request introduces a mechanism to initialize Notes in the background.
A consumer is passed, which is then called with the NoteId.
The consumer itself is responsible for checking, for example, whether the note still exists.
The initialization runs in several threads. The consumer must therefore be thread-safe.
This approach scales well, in my opinion, because it makes effective use of NoteCache. Another approach, e.g. to initialize the Notes in the sub-module, would not utilize the NoteCache as effectively. This is true if one sub-module is faster than the other.

Changes to the CronJob behavior:
As soon as a CronJob is executed, we have checked in the execution whether it is allowed to execute the Notes at all. If not, we have skipped it. With the changes in this PR we check before execution if the CronJob is allowed to run. This is controlled by the interface `TriggerListener`, which has the possibility to give the CronJob a veto for execution.
With this change the not meaningful skip metric is avoided.

Translated with www.DeepL.com/Translator (free version)

### What type of PR is it?
 - Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5754

### How should this be tested?
* CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
