### PR TITLE
[ZEPPELIN-5434] Upgrade jetty version to 9.4.43.v20210629

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <flexmark.all.version>0.62.2</flexmark.all.version>
     <gson.version>2.8.6</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
-    <jetty.version>9.4.31.v20200723</jetty.version>
+    <jetty.version>9.4.43.v20210629</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -549,7 +549,6 @@ public class ZeppelinServer extends ResourceConfig {
 
     servletHolder.setInitParameter("javax.ws.rs.Application", ZeppelinServer.class.getName());
     servletHolder.setName("rest");
-    servletHolder.setForcedPath("rest");
     webapp.setSessionHandler(new SessionHandler());
     webapp.addServlet(servletHolder, "/api/*");
 

--- a/zeppelin-web/src/WEB-INF/web.xml
+++ b/zeppelin-web/src/WEB-INF/web.xml
@@ -16,29 +16,31 @@
   ~ limitations under the License.
   -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-	version="3.0">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
- <display-name>zeppelin-web</display-name>
-	<servlet>
-		<servlet-name>default</servlet-name>
+  <display-name>zeppelin-web</display-name>
+  <servlet>
+    <servlet-name>restServlet</servlet-name>
     <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
     <init-param>
       <param-name>jersey.config.server.provider.packages</param-name>
       <param-value>org.apache.zeppelin.rest</param-value>
     </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
 
-		<load-on-startup>1</load-on-startup>
-	</servlet>
-	<error-page>
-	  <error-code>404</error-code>
-	  <location>/WEB-INF/404.html</location>
-	</error-page>
-	<context-param>
-		<param-name>configuration</param-name>
-		<param-value>deployment</param-value>
-	</context-param>
+  <error-page>
+    <error-code>404</error-code>
+     <location>/WEB-INF/404.html</location>
+  </error-page>
+
+  <context-param>
+    <param-name>configuration</param-name>
+    <param-value>deployment</param-value>
+  </context-param>
 
   <session-config>
     <cookie-config>


### PR DESCRIPTION
### What is this PR for?

* Upgrade jetty version to 9.4.43.v20210629
* Change servlet settings to support jetty 9.4.43.v20210629

### What type of PR is it?

* Bug Fix

### Todos
* None

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5434

### How should this be tested?
* Locally tested, CI 

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
