### PR TITLE
[ZEPPELIN-5756] able to pass base image as docker build arg

### DIFF
--- a/scripts/docker/zeppelin-interpreter/Dockerfile
+++ b/scripts/docker/zeppelin-interpreter/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM zeppelin-distribution:latest AS zeppelin-distribution
+ARG ZEPPELIN_DISTRIBUTION_IMAGE=zeppelin-distribution:latest
+FROM $ZEPPELIN_DISTRIBUTION_IMAGE AS zeppelin-distribution
 
 FROM ubuntu:20.04
 

--- a/scripts/docker/zeppelin-server/Dockerfile
+++ b/scripts/docker/zeppelin-server/Dockerfile
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM zeppelin-distribution:latest AS zeppelin-distribution
+ARG ZEPPELIN_DISTRIBUTION_IMAGE=zeppelin-distribution:latest
+FROM $ZEPPELIN_DISTRIBUTION_IMAGE AS zeppelin-distribution
 
 # Prepare all interpreter settings for Zeppelin server
 # This steps are not needed, if you you add only specific interpreters settings to your image


### PR DESCRIPTION
### What is this PR for?
when building zeppelin-interpreter or zeppelin-server, it`s sometimes useful to pass base image as build argument


### What type of PR is it?
Improvement


### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5756

### How should this be tested?
None

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
