### PR TITLE
[ZEPPELIN-5757] Assume role in NotebookRepo S3

### DIFF
--- a/docs/setup/storage/storage.md
+++ b/docs/setup/storage/storage.md
@@ -79,6 +79,7 @@ Notebooks may be stored in S3, and optionally encrypted.  The [``DefaultAWSCrede
 
 - The ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` environment variables
 - The ``aws.accessKeyId`` and ``aws.secretKey`` Java System properties
+- Web Identity Token credentials from the environment or container
 - Credential profiles file at the default location (````~/.aws/credentials````) used by the AWS CLI
 - Instance profile credentials delivered through the Amazon EC2 metadata service
 

--- a/zeppelin-plugins/notebookrepo/s3/pom.xml
+++ b/zeppelin-plugins/notebookrepo/s3/pom.xml
@@ -34,7 +34,7 @@
     <description>NotebookRepo implementation based on S3</description>
 
     <properties>
-        <aws.sdk.s3.version>1.11.736</aws.sdk.s3.version>
+        <aws.sdk.version>1.11.736</aws.sdk.version>
         <plugin.name>NotebookRepo/S3NotebookRepo</plugin.name>
     </properties>
 
@@ -42,7 +42,20 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws.sdk.s3.version}</version>
+            <version>${aws.sdk.version}</version>
+            <exclusions>
+                <!-- jcl-over-slf4j is provided by zeppelin-interprerter -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws.sdk.version}</version>
             <exclusions>
                 <!-- jcl-over-slf4j is provided by zeppelin-interprerter -->
                 <exclusion>

--- a/zeppelin-plugins/notebookrepo/s3/pom.xml
+++ b/zeppelin-plugins/notebookrepo/s3/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
 
         <dependency>
+            <!-- STS lib needs to be on class path for the WebidentityTokenCredentialsProvider to work properly,
+             otherwise it will be skipped in DefaultAWSCredentialsProviderChain
+             https://github.com/aws/aws-sdk-java/issues/2136
+             -->
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
             <version>${aws.sdk.version}</version>

--- a/zeppelin-plugins/notebookrepo/s3/src/test/java/org/apache/zeppelin/notebook/repo/S3NotebookRepoTest.java
+++ b/zeppelin-plugins/notebookrepo/s3/src/test/java/org/apache/zeppelin/notebook/repo/S3NotebookRepoTest.java
@@ -87,6 +87,11 @@ public class S3NotebookRepoTest {
   }
 
   @Test
+  public void testAwsSTSLibraryOnClassPath() throws ClassNotFoundException {
+    Class.forName("com.amazonaws.auth.STSSessionCredentialsProvider", false, getClass().getClassLoader());
+  }
+
+  @Test
   public void testNotebookRepo() throws IOException {
     Map<String, NoteInfo> notesInfo = notebookRepo.list(anonymous);
     assertEquals(0, notesInfo.size());


### PR DESCRIPTION
### What is this PR for?
Currently NotebookRepo S3 is not able to assume role from env variables due to missing aws sts sdk
- added missing dependency
- fixed documentation


### What type of PR is it?
Bug Fix
Improvement

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5757


### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? just minor fix, docs updated with this pull request
