### PR TITLE
[ZEPPELIN-5759] Add user to restartSetting

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/InterpreterRestApi.java
@@ -197,7 +197,7 @@ public class InterpreterRestApi {
   @Path("setting/restart/{settingId}")
   @ZeppelinApi
   public Response restartSetting(String message, @PathParam("settingId") String settingId) {
-    LOGGER.info("Restart interpreterSetting {}, msg={}", settingId, message);
+    LOGGER.info("Restart interpreterSetting {}, msg={}, user={}", settingId, message, authenticationService.getPrincipal());
 
     InterpreterSetting setting = interpreterSettingManager.get(settingId);
     try {


### PR DESCRIPTION
### What is this PR for?
This small change logs the user, which restarts Zeppelin Interpreter.


### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5759

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
