### PR TITLE
[ZEPPELIN-5760] fix passing configs to spark in k8s

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -54,6 +54,16 @@ import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGet
 public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess {
   private static final Logger LOGGER = LoggerFactory.getLogger(K8sRemoteInterpreterProcess.class);
   private static final int K8S_INTERPRETER_SERVICE_PORT = 12321;
+  private static final Object SPARK_DRIVER_CLASSPATH = "";
+  private static final Object SPARK_DRIVER_DEFAULTJAVAOPTS = "";
+  private static final Object SPARK_DRIVER_EXTRALIBPATH = "";
+  private static final Object SPARK_DRIVER_EXTRAJAVAOPTS = "";
+  private static final Object SPARK_JARS = "";
+  private static final Object SPARK_JARS_PACKAGES = "";
+  private static final Object SPARK_JARS_EXCLUDES = "";
+  private static final Object SPARK_JARS_IVY = "";
+  private static final Object SPARK_JARS_IVYSETTINGS ="" ;
+  private static final Object SPARK_JARS_REPOSITORIES = "";
   private final KubernetesClient client;
   private final String interpreterNamespace;
   private final String interpreterGroupName;
@@ -423,6 +433,50 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     options.append(" --conf spark.driver.host=").append(getInterpreterPodDnsName());
     options.append(" --conf spark.driver.port=").append(getSparkDriverPort());
     options.append(" --conf spark.blockManager.port=").append(getSparkBlockManagerPort());
+
+    if (properties.containsKey(SPARK_DRIVER_MEMORY)) {
+      options.append(" --driver-memory ").append(properties.get(SPARK_DRIVER_MEMORY));
+    }
+
+    if (properties.containsKey(SPARK_DRIVER_CLASSPATH)) {
+      options.append(" --conf spark.driver.extraClassPath=").append(properties.get(SPARK_DRIVER_CLASSPATH));
+    }
+
+    if (properties.containsKey(SPARK_DRIVER_DEFAULTJAVAOPTS)) {
+      options.append(" --conf spark.driver.defaultJavaOptions=").append(properties.get(SPARK_DRIVER_DEFAULTJAVAOPTS));
+    }
+
+    if (properties.containsKey(SPARK_DRIVER_EXTRAJAVAOPTS)) {
+      options.append(" --conf spark.driver.extraJavaOptions=").append(properties.get(SPARK_DRIVER_EXTRAJAVAOPTS));
+    }
+
+    if (properties.containsKey(SPARK_DRIVER_EXTRALIBPATH)) {
+      options.append(" --conf spark.driver.extraLibraryPath=").append(properties.get(SPARK_DRIVER_EXTRALIBPATH));
+    }
+
+    if (properties.containsKey(SPARK_JARS)) {
+      options.append(" --conf spark.jars=").append(properties.get(SPARK_JARS));
+    }
+
+    if (properties.containsKey(SPARK_JARS_PACKAGES)) {
+      options.append(" --conf spark.jars.packages=").append(properties.get(SPARK_JARS_PACKAGES));
+    }
+
+    if (properties.containsKey(SPARK_JARS_EXCLUDES)) {
+      options.append(" --conf spark.jars.excludes=").append(properties.get(SPARK_JARS_EXCLUDES));
+    }
+
+    if (properties.containsKey(SPARK_JARS_IVY)) {
+      options.append(" --conf spark.jars.ivy=").append(properties.get(SPARK_JARS_IVY));
+    }
+
+    if (properties.containsKey(SPARK_JARS_IVYSETTINGS)) {
+      options.append(" --conf spark.jars.ivySettings=").append(properties.get(SPARK_JARS_IVYSETTINGS));
+    }
+
+    if (properties.containsKey(SPARK_JARS_REPOSITORIES)) {
+      options.append(" --conf spark.jars.repositories=").append(properties.get(SPARK_JARS_REPOSITORIES));
+    }
 
     return options.toString();
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -422,7 +422,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
 
   @VisibleForTesting
   String prepareZeppelinSparkConf(String userName) {
-    StringJoiner sparkConfSJ = new StringJoiner(" ");
+    StringJoiner sparkConfSJ = new StringJoiner("|");
     if (isUserImpersonated() && !StringUtils.containsIgnoreCase(userName, "anonymous")) {
       sparkConfSJ.add("--proxy-user");
       sparkConfSJ.add(userName);

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -54,16 +54,6 @@ import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGet
 public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess {
   private static final Logger LOGGER = LoggerFactory.getLogger(K8sRemoteInterpreterProcess.class);
   private static final int K8S_INTERPRETER_SERVICE_PORT = 12321;
-  private static final Object SPARK_DRIVER_CLASSPATH = "";
-  private static final Object SPARK_DRIVER_DEFAULTJAVAOPTS = "";
-  private static final Object SPARK_DRIVER_EXTRALIBPATH = "";
-  private static final Object SPARK_DRIVER_EXTRAJAVAOPTS = "";
-  private static final Object SPARK_JARS = "";
-  private static final Object SPARK_JARS_PACKAGES = "";
-  private static final Object SPARK_JARS_EXCLUDES = "";
-  private static final Object SPARK_JARS_IVY = "";
-  private static final Object SPARK_JARS_IVYSETTINGS ="" ;
-  private static final Object SPARK_JARS_REPOSITORIES = "";
   private final KubernetesClient client;
   private final String interpreterNamespace;
   private final String interpreterGroupName;
@@ -88,6 +78,16 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
   private static final String SPARK_CONTAINER_IMAGE = "zeppelin.k8s.spark.container.image";
   private static final String ENV_SERVICE_DOMAIN = "SERVICE_DOMAIN";
   private static final String ENV_ZEPPELIN_HOME = "ZEPPELIN_HOME";
+  private static final String SPARK_DRIVER_CLASSPATH = "spark.driver.extraClassPath";
+  private static final String SPARK_DRIVER_DEFAULTJAVAOPTS = "spark.driver.defaultJavaOptions";
+  private static final String SPARK_DRIVER_EXTRALIBPATH = "spark.driver.extraLibraryPath";
+  private static final String SPARK_DRIVER_EXTRAJAVAOPTS = "spark.driver.extraJavaOptions";
+  private static final String SPARK_JARS = "spark.jars";
+  private static final String SPARK_JARS_PACKAGES = "spark.jars.packages";
+  private static final String SPARK_JARS_EXCLUDES = "spark.jars.excludes";
+  private static final String SPARK_JARS_IVY = "spark.jars.ivy";
+  private static final String SPARK_JARS_IVYSETTINGS ="spark.jars.ivySettings" ;
+  private static final String SPARK_JARS_REPOSITORIES = "spark.jars.repositories";
 
   public K8sRemoteInterpreterProcess(
           KubernetesClient client,

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -325,20 +325,19 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
       // There is already initial value following --driver-java-options added in interpreter.sh
       // so we need to pass spark.driver.defaultJavaOptions and spark.driver.extraJavaOptions
       // as SPARK_DRIVER_EXTRAJAVAOPTIONS_CONF env variable to build spark-submit command correctly.
-      StringBuilder driverExtraJavaOpts = new StringBuilder();
+      StringJoiner driverExtraJavaOpts = new StringJoiner(" ");
       if (properties.containsKey(SPARK_DRIVER_DEFAULTJAVAOPTS)) {
-        driverExtraJavaOpts.append((String) properties.remove(SPARK_DRIVER_DEFAULTJAVAOPTS));
+        driverExtraJavaOpts.add((String) properties.remove(SPARK_DRIVER_DEFAULTJAVAOPTS));
       }
       if (properties.containsKey(SPARK_DRIVER_EXTRAJAVAOPTS)) {
-        driverExtraJavaOpts.append(" ");
-        driverExtraJavaOpts.append((String) properties.remove(SPARK_DRIVER_EXTRAJAVAOPTS));
+        driverExtraJavaOpts.add((String) properties.remove(SPARK_DRIVER_EXTRAJAVAOPTS));
       }
       if (driverExtraJavaOpts.length() > 0) {
         k8sEnv.put("SPARK_DRIVER_EXTRAJAVAOPTIONS_CONF", driverExtraJavaOpts.toString());
       }
 
       if (isSparkOnKubernetes(properties)) {
-        this.addSparkK8sProperties();
+        addSparkK8sProperties();
         k8sEnv.put("ZEPPELIN_SPARK_CONF", prepareZeppelinSparkConf(userName));
       }
       k8sEnv.put("SPARK_HOME", getEnv().getOrDefault("SPARK_HOME", "/spark"));

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -21,7 +21,11 @@ package org.apache.zeppelin.interpreter.launcher;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -434,10 +434,6 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     options.append(" --conf spark.driver.port=").append(getSparkDriverPort());
     options.append(" --conf spark.blockManager.port=").append(getSparkBlockManagerPort());
 
-    if (properties.containsKey(SPARK_DRIVER_MEMORY)) {
-      options.append(" --driver-memory ").append(properties.get(SPARK_DRIVER_MEMORY));
-    }
-
     if (properties.containsKey(SPARK_DRIVER_CLASSPATH)) {
       options.append(" --conf spark.driver.extraClassPath=").append(properties.get(SPARK_DRIVER_CLASSPATH));
     }

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -432,7 +432,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
       String propValue = properties.getProperty(key);
       if (isSparkConf(key, propValue)) {
         sparkConfSJ.add("--conf");
-        sparkConfSJ.add(key + "=" + propValue + "");
+        sparkConfSJ.add(key + "=" + propValue);
       }
     }
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -240,7 +240,7 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(zeppelinSparkConf.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
     assertTrue(zeppelinSparkConf.contains("spark.driver.port=" + intp.getSparkDriverPort()));
     assertTrue(zeppelinSparkConf.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
-    assertTrue(zeppelinSparkConf.contains("--proxy-user mytestUser"));
+    assertTrue(zeppelinSparkConf.contains("--proxy-user|mytestUser"));
     assertTrue(intp.isSpark());
   }
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -138,6 +138,8 @@ public class K8sRemoteInterpreterProcessTest {
     Properties properties = new Properties();
     properties.put("my.key1", "v1");
     properties.put("spark.master", "k8s://http://api");
+    properties.put("spark.jars.ivy", "my_ivy_path");
+    properties.put("spark.driver.extraJavaOptions", "-Dextra_option");
     Map<String, String> envs = new HashMap<>();
     envs.put("MY_ENV1", "V1");
     envs.put("SPARK_SUBMIT_OPTIONS", "my options");
@@ -171,6 +173,9 @@ public class K8sRemoteInterpreterProcessTest {
 
     envs = (HashMap<String, String>) p.get("zeppelin.k8s.envs");
     assertTrue( envs.containsKey("SPARK_HOME"));
+    assertTrue( envs.containsKey("SPARK_DRIVER_EXTRAJAVAOPTIONS_CONF"));
+    String driverExtraOptions = envs.get("SPARK_DRIVER_EXTRAJAVAOPTIONS_CONF");
+    assertTrue(driverExtraOptions.contains("-Dextra_option"));
 
     String sparkSubmitOptions = envs.get("SPARK_SUBMIT_OPTIONS");
     assertTrue(sparkSubmitOptions.startsWith("my options "));
@@ -180,6 +185,7 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
     assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
     assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
+    assertTrue(sparkSubmitOptions.contains("spark.jars.ivy=my_ivy_path"));
     assertFalse(sparkSubmitOptions.contains("--proxy-user"));
     assertTrue(intp.isSpark());
   }

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -178,15 +178,16 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue(driverExtraOptions.contains("-Dextra_option"));
 
     String sparkSubmitOptions = envs.get("SPARK_SUBMIT_OPTIONS");
-    assertTrue(sparkSubmitOptions.startsWith("my options "));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.namespace=default"));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.container.image=spark-container:1.0"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
-    assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
-    assertTrue(sparkSubmitOptions.contains("spark.jars.ivy=my_ivy_path"));
-    assertFalse(sparkSubmitOptions.contains("--proxy-user"));
+    assertTrue(sparkSubmitOptions.startsWith("my options"));
+    String zeppelinSparkConf = envs.get("ZEPPELIN_SPARK_CONF");
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.namespace=default"));
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.container.image=spark-container:1.0"));
+    assertTrue(zeppelinSparkConf.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
+    assertTrue(zeppelinSparkConf.contains("spark.driver.port=" + intp.getSparkDriverPort()));
+    assertTrue(zeppelinSparkConf.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
+    assertTrue(zeppelinSparkConf.contains("spark.jars.ivy=my_ivy_path"));
+    assertFalse(zeppelinSparkConf.contains("--proxy-user"));
     assertTrue(intp.isSpark());
   }
 
@@ -231,14 +232,15 @@ public class K8sRemoteInterpreterProcessTest {
     assertTrue( envs.containsKey("SPARK_HOME"));
 
     String sparkSubmitOptions = envs.get("SPARK_SUBMIT_OPTIONS");
-    assertTrue(sparkSubmitOptions.startsWith("my options "));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.namespace=default"));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
-    assertTrue(sparkSubmitOptions.contains("spark.kubernetes.container.image=spark-container:1.0"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
-    assertTrue(sparkSubmitOptions.contains("spark.driver.port=" + intp.getSparkDriverPort()));
-    assertTrue(sparkSubmitOptions.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
-    assertTrue(sparkSubmitOptions.contains("--proxy-user mytestUser"));
+    assertTrue(sparkSubmitOptions.startsWith("my options"));
+    String zeppelinSparkConf = envs.get("ZEPPELIN_SPARK_CONF");
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.namespace=default"));
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.driver.pod.name=" + intp.getPodName()));
+    assertTrue(zeppelinSparkConf.contains("spark.kubernetes.container.image=spark-container:1.0"));
+    assertTrue(zeppelinSparkConf.contains("spark.driver.host=" + intp.getPodName() + ".default.svc"));
+    assertTrue(zeppelinSparkConf.contains("spark.driver.port=" + intp.getSparkDriverPort()));
+    assertTrue(zeppelinSparkConf.contains("spark.blockManager.port=" + intp.getSparkBlockManagerPort()));
+    assertTrue(zeppelinSparkConf.contains("--proxy-user mytestUser"));
     assertTrue(intp.isSpark());
   }
 

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
@@ -98,7 +98,7 @@ public class K8sStandardInterpreterLauncherTest {
     assertTrue(client instanceof K8sRemoteInterpreterProcess);
     K8sRemoteInterpreterProcess process = (K8sRemoteInterpreterProcess) client;
     assertTrue(process.isSpark());
-    assertTrue(process.prepareZeppelinSparkConf(context.getUserName()).contains("--proxy-user user1"));
+    assertTrue(process.prepareZeppelinSparkConf(context.getUserName()).contains("--proxy-user|user1"));
   }
 
   @Test

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncherTest.java
@@ -98,7 +98,7 @@ public class K8sStandardInterpreterLauncherTest {
     assertTrue(client instanceof K8sRemoteInterpreterProcess);
     K8sRemoteInterpreterProcess process = (K8sRemoteInterpreterProcess) client;
     assertTrue(process.isSpark());
-    assertTrue(process.buildSparkSubmitOptions(context.getUserName()).contains("--proxy-user user1"));
+    assertTrue(process.prepareZeppelinSparkConf(context.getUserName()).contains("--proxy-user user1"));
   }
 
   @Test
@@ -131,6 +131,6 @@ public class K8sStandardInterpreterLauncherTest {
     assertTrue(client instanceof K8sRemoteInterpreterProcess);
     K8sRemoteInterpreterProcess process = (K8sRemoteInterpreterProcess) client;
     assertTrue(process.isSpark());
-    assertFalse(process.buildSparkSubmitOptions(context.getUserName()).contains("--proxy-user user1"));
+    assertFalse(process.prepareZeppelinSparkConf(context.getUserName()).contains("--proxy-user user1"));
   }
 }


### PR DESCRIPTION
### What is this PR for?
Some important spark configs can`t be passed via SparkConf in k8s and in client mode including spark.jars.packages and spark.driver.extraJavaOptions
This fix checks if these are set in interpreter configuration and passes them to spark-submit command 

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5760

### How should this be tested?
updated test to test this fix

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions?  No
* Does this needs documentation? No
