### PR TITLE
[ZEPPELIN-5762] Fix default profile activation option to build succes…

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -458,7 +458,7 @@
     <profile>
       <id>using-source-tree</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
         <zeppelin.daemon.package.base>
@@ -481,7 +481,9 @@
 
     <profile>
       <id>hadoop2</id>
-
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <hadoop.version>${hadoop2.7.version}</hadoop.version>
       </properties>


### PR DESCRIPTION
### What is this PR for?
When building from source code, if the Profile option is not given to the maven command by default, an error like Screenshot occurs. So I changed the default profile activation option in the "zeppelin-server module" to hadoop2.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Documentation?

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5762

### How should this be tested?
I tested with Travis CI, which is set by default.

### Screenshots (if appropriate)
* ```./mvnw clean package -DskipTests ``` before modifying the profile with 'hadoop2'
![image](https://user-images.githubusercontent.com/10491931/178147192-85d224b4-e4ae-4d08-a96e-3c2a8df43000.png)

* ```./mvnw clean package -DskipTests ``` after modifying the profile with 'hadoop2'
![image](https://user-images.githubusercontent.com/10491931/178148159-51912fae-47e5-4ffb-af4c-a1a54d5a8b69.png)


### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
