### PR TITLE
[ZEPPELIN-5762] Modify activeByDefault value of hadoop3 profile to true for successful build.

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -448,3 +448,30 @@ jobs:
           R -e "IRkernel::installspec()"
       - name: run tests
         run: ./mvnw verify -DskipRat -pl livy -am  -B
+
+  default-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Tune Runner VM
+        uses: ./.github/actions/tune-runner-vm
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/zeppelin/
+            ~/.spark-dist
+            ~/.cache
+          key: ${{ runner.os }}-zeppelin-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-zeppelin-
+      - name: build without any profiles
+        run: ./mvnw clean package -DskipTests
+        

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -497,7 +497,9 @@
     </profile>
     <profile>
       <id>hadoop3</id>
-
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <hadoop.version>${hadoop3.2.version}</hadoop.version>
         <hadoop-client-runtime.artifact>hadoop-client-runtime</hadoop-client-runtime.artifact>


### PR DESCRIPTION
### What is this PR for?
When building from the source code, the default profile activation option of the zeppelin-server module is "using-source-tree", so I got the error as in the screenshot. So I modified activeByDefault value of hadoop3 profile in the "zeppelin-server module" to true for successful build.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Documentation?

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5762

### How should this be tested?
I tested with Travis CI, which is set by default. And after modifying the source code, I tried to build again.

### Screenshots (if appropriate)
* ```./mvnw clean package -DskipTests ``` before modifying the profile with 'hadoop2'
![image](https://user-images.githubusercontent.com/10491931/178147192-85d224b4-e4ae-4d08-a96e-3c2a8df43000.png)

* ```./mvnw clean package -DskipTests ``` after modifying the profile with 'hadoop2'
![image](https://user-images.githubusercontent.com/10491931/178148159-51912fae-47e5-4ffb-af4c-a1a54d5a8b69.png)


### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
