### PR TITLE
[ZEPPELIN-5773]Fix isWindowsPath Function in ZeppelinConfiguration Class

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -25,11 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -46,6 +42,7 @@ import org.apache.commons.configuration2.io.CombinedLocationStrategy;
 import org.apache.commons.configuration2.io.FileLocationStrategy;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.zeppelin.interpreter.lifecycle.NullLifecycleManager;
 import org.apache.zeppelin.util.Util;
 import org.slf4j.Logger;
@@ -327,7 +324,7 @@ public class ZeppelinConfiguration {
 
   public String getKeyStorePath() {
     String path = getString(ConfVars.ZEPPELIN_SSL_KEYSTORE_PATH);
-    if (path != null && path.startsWith("/") || isWindowsPath(path)) {
+    if (path != null && path.startsWith("/") || isWindowsCheck()) {
       return path;
     } else {
       return getAbsoluteDir(
@@ -359,7 +356,7 @@ public class ZeppelinConfiguration {
     if (path == null) {
       path = getKeyStorePath();
     }
-    if (path != null && path.startsWith("/") || isWindowsPath(path)) {
+    if (path != null && path.startsWith("/") || isWindowsCheck()) {
       return path;
     } else {
       return getAbsoluteDir(
@@ -613,7 +610,7 @@ public class ZeppelinConfiguration {
   }
 
   public String getAbsoluteDir(String path) {
-    if (path != null && (path.startsWith(File.separator) || isWindowsPath(path) || isPathWithScheme(path))) {
+    if (path != null && (path.startsWith(File.separator) || isWindowsCheck() || isPathWithScheme(path))) {
       return path;
     } else {
       return getString(ConfVars.ZEPPELIN_HOME) + File.separator + path;
@@ -636,8 +633,12 @@ public class ZeppelinConfiguration {
     return getString(ConfVars.ZEPPELIN_INTERPRETER_RPC_PORTRANGE);
   }
 
-  public boolean isWindowsPath(String path){
-    return path.matches("^[A-Za-z]:\\\\.*");
+  public boolean isWindowsCheck(){
+    Boolean wc = SystemUtils.IS_OS_WINDOWS;
+    if(Objects.isNull(wc)) {
+      return false;
+    }
+    return wc;
   }
 
   public boolean isPathWithScheme(String path){

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -67,7 +67,7 @@ public class VFSNotebookRepo implements NotebookRepo {
     URI filesystemRoot = null;
     try {
       LOGGER.info("Using notebookDir: {}", notebookDirPath);
-      if (conf.isWindowsPath(notebookDirPath)) {
+      if (conf.isWindowsCheck()) {
         filesystemRoot = new File(notebookDirPath).toURI();
       } else {
         filesystemRoot = new URI(notebookDirPath);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/conf/ZeppelinConfigurationTest.java
@@ -69,18 +69,18 @@ public class ZeppelinConfigurationTest {
   }
 
   @Test
-  public void isWindowsPathTestTrue() {
+  public void isWindowsCheckTestTrue() {
 
     ZeppelinConfiguration conf = ZeppelinConfiguration.create("zeppelin-test-site.xml");
-    Boolean isIt = conf.isWindowsPath("c:\\test\\file.txt");
+    Boolean isIt = conf.isWindowsCheck();
     Assert.assertTrue(isIt);
   }
 
   @Test
-  public void isWindowsPathTestFalse() {
+  public void isWindowsCheckTestFalse() {
 
     ZeppelinConfiguration conf = ZeppelinConfiguration.create("zeppelin-test-site.xml");
-    Boolean isIt = conf.isWindowsPath("~/test/file.xml");
+    Boolean isIt = conf.isWindowsCheck();
     Assert.assertFalse(isIt);
   }
 


### PR DESCRIPTION
### What is this PR for?
Even though the user's operating system is windows, 'isWindowsPath' function returns False and enters the else.
Therefore, I think that I need to change isWindowsPath function.

### What type of PR is it?
Bug Fix

### Todos
I replace isWindowsPath Function with isWindowsCheck function. isWindowCheck function uses SystemUtils.IS_OS_WINDOWS
to determine whether the OS is Windows or not. If the user's operating system is windows, It returns true.

### What is the Jira issue?
 https://issues.apache.org/jira/browse/ZEPPELIN-5773

### How should this be tested?
CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No
