### PR TITLE
[HOTFIX] [ZEPPELIN-3945] Remove blank in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* .js text eol=lf
+*.js text eol=lf


### PR DESCRIPTION
### What is this PR for?
The eof setting of gitattributes was applied to all files including `.js`, so there was a problem that the file was changed in the Windows environment.
So, I removed the space in the eof setting of gitattributes to apply only to `.js`.

### What type of PR is it?
Hot Fix

### Todos
* [x] - Remove blank in .gitattributes

### What is the Jira issue?
[ZEPPELIN-3945](https://issues.apache.org/jira/browse/ZEPPELIN-3945)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
