### PR TITLE
[ZEPPELIN-5781]Add cross datasource query support to Spark SQL interpreter

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -341,6 +341,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mongodb.spark</groupId>
+      <artifactId>mongo-spark-connector_${spark.scala.binary.version}</artifactId>
+      <version>2.4.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -35,7 +35,6 @@ import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResult.Code;
-import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.apache.zeppelin.interpreter.util.SqlSplitter;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
@@ -45,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -100,10 +98,10 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
     SparkContext sc = sparkInterpreter.getSparkContext();
 
     try {
-      st = enableCrossEngineQuerySupport(st,context);
+      st = enableCrossDatabaseQuerySupport(st,context);
     } catch (Exception e) {
       try{
-        LOGGER.error("Can not enable cross-engine query support:",e);
+        LOGGER.error("Can not enable cross datasource query support:",e);
         context.out.write(e.toString());
         e.printStackTrace();
         context.out.flush();
@@ -175,15 +173,13 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
 
 
   /**
-   * inject mysql/mongodb table to spark sql session
-   * the table that need to inject should be declared like : %interpreterName%.dbName.tableName
-   * table will be fully load into spark session without any filter
+   * inject jdbc/mongodb table to spark sql session
+   * table should be declared in format : interpreterName.dbName.tableName
    * @param st query string
    * @param context zeppelin context
    * @return new query string
-   * @throws IOException
    */
-  public String enableCrossEngineQuerySupport(String st,InterpreterContext context) throws IOException, InvalidCredentialsException {
+  public String enableCrossDatabaseQuerySupport(String st, InterpreterContext context) throws IOException, InvalidCredentialsException {
     AuthenticationInfo authenticationInfo = context.getAuthenticationInfo();
     HashSet<String> usersAndRoles = new HashSet<>(authenticationInfo.getUsersAndRoles());
     Gson gson = new Gson();
@@ -192,7 +188,7 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
     String interSettingsStr = context.getLocalProperties().get("interpreterSettings");
 
     if(interSettingsStr == null || interSettingsStr.isEmpty()){
-      context.out.write("\ncannot perform cross engine query , reason : can not load interpreter settings" );
+      context.out.write("\ncannot perform cross datasource query , reason : can not load interpreter settings" );
     }
 
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkSqlInterpreter.java
@@ -103,13 +103,13 @@ public class SparkSqlInterpreter extends AbstractInterpreter {
       st = enableCrossEngineQuerySupport(st,context);
     } catch (Exception e) {
       try{
-        LOGGER.error("inject DB error",e);
-        context.out.write(e.getMessage());
+        LOGGER.error("Can not enable cross-engine query support:",e);
+        context.out.write(e.toString());
         e.printStackTrace();
         context.out.flush();
         return new InterpreterResult(Code.ERROR);
       }catch(IOException ex) {
-        LOGGER.error("Fail to write output", ex);
+        LOGGER.error("Fail to write output:", ex);
         return new InterpreterResult(Code.ERROR);
       }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -461,7 +461,7 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
         InterpreterContext context = getInterpreterContext();
 
         // inject interpreter settings for spark interpreter
-        // spark sql cross-engine query depends on other interpreter settings
+        // spark sql cross-datasource query depends on other interpreter settings
         // it is necessary to inject here inorder to get all interpreter settings in yarn-cluster mode
         ZeppelinConfiguration zConf = ZeppelinConfiguration.create();
         InterpreterSettingManager interpreterSettingManager =


### PR DESCRIPTION
### What is this PR for?
Add **cross datasource query** support to Spark SQL interpreter, currently support cross datasource query with these datasources:

- hive
- jdbc
- mongodb

#### How to Use
1. User should declare a cross datasource table in format: `interpreterName.databaseName.tableName`.
2. `interpreterName` should exists in zeppelin interpreter configuration.
3. For JDBC datasource, jdbc driver jars should be included in dependencies.

### What type of PR is it?
Feature

### TODO

- [ ] Implement cross datasource query with catalog for spark 3.x

### Need Help
#### 1. Is there a better way to load all interpreter settings:

Currently inplement by reading interpreter settings list inside zengine module and pass this list to Spark SQL interpreter. So this pull request include 2 modules:

1. `zeppelin-zengine`: read and pass all interpreter settings to Spark SQL interpreter
2. `spark-interpreter`: add Spark SQL cross datasource query


When spark is launch with `local` or `yarn-client` mode, it is easy to load interpreter settings list inside `spark-interpreter` and we do not need to make a change to `zeppelin-zengine`, but when you luanch spark interpreter in `yarn-cluster` mode, `interpreter.json` do not exists in yarn-cluster driver node, so you can not get interpreter settings. So I made a change to `zeppelin-zengine` to read and pass all interpreter settings to Spark SQL interpreter, and this works in `yarn-cluster` mode.

I think it is not good to make change to zengine, is there a better way to get all interpreter settings in `yarn-cluster` mode without make change to `zengine` ?

#### 2. How to distinguish between user and role in `option.owners` field of interpreter setting?

I cannot distinguish user and role inside `option.owners` field of interpreter setting and datasource authorization check is implemented with these code:
```java
HashSet<String> usersAndRoles = new HashSet<>(authenticationInfo.getUsersAndRoles());
HashSet<String> owners = new HashSet<>(iSetting.option.owners);
// if owners is empty, means all users can access
if(!owners.isEmpty()){
  int size1 = owners.size();
  owners.retainAll(usersAndRoles);
  int size2 = owners.size();
  if(size1 == size2){
    // no user or role match
    throw new InvalidCredentialsException(String.format(String.format("user %s has not privilege to access interpreter %s",authenticationInfo.getUser(), interpreterId)));
  }
} 
```

If there is any security concern, how can I make a better authentication check ?

### What is the Jira issue?
[ZEPPELIN-5781]

### How should this be tested?
1. make sure sparkSQL-interepreter(`%sql`) works 
2. config a jdbc / mongodb interpreter with name `interpreter-nameX`
3. test query jdbc/mongodb in %sql:
```sql
%sql
select * from interpreter-nameX.databaseName.tableName;
```

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/30063898/180590511-231d7a69-1be4-4157-9cc9-13dfc04d4654.png)


### Questions:
* Does the licenses files need to update? no
* Is there breaking changes for older versions? yes
* Does this needs documentation? yes
