### PR TITLE
[ZEPPELIN-5638] Add flink job interval check

### DIFF
--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/JobManager.java
@@ -72,6 +72,10 @@ public class JobManager {
       return;
     }
     long checkInterval = Long.parseLong(properties.getProperty("zeppelin.flink.job.check_interval", "1000"));
+    if (checkInterval < 0) {
+      LOGGER.warn("The value of checkInterval must be positive {}", checkInterval);
+      return;
+    }
     FlinkJobProgressPoller thread = new FlinkJobProgressPoller(flinkWebUrl, jobClient.getJobID(), context, checkInterval);
     thread.setName("JobProgressPoller-Thread-" + paragraphId);
     thread.start();


### PR DESCRIPTION
### What is this PR for?
zeppelin-interpreter-flink-yarn produce a lot of logs, caused disk space to run out


### What type of PR is it?
Improvement

### Todos
* [x] - Add validation the value of zeppelin.flink.job.check_interval

### Need Help
I think negative value is invalid input, so I make it just return and not to add job
But, the issuer suggest that set default value 1000. Is it better?

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5638

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
