### PR TITLE
[ZEPPELIN-4794] Add comment about changing localhost when running Zeppelin on WSL or Windows

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -22,7 +22,7 @@
 <property>
   <name>zeppelin.server.addr</name>
   <value>127.0.0.1</value>
-  <description>Server binding address</description>
+  <description>Server binding address. If you cannot connect to your web browser on WSL or Windows, change 127.0.0.1 to 0.0.0.0.</description>
 </property>
 
 <property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -22,7 +22,7 @@
 <property>
   <name>zeppelin.server.addr</name>
   <value>127.0.0.1</value>
-  <description>Server binding address. If you cannot connect to your web browser on WSL or Windows, change 127.0.0.1 to 0.0.0.0.</description>
+  <description>Server binding address. If you cannot connect to your web browser on WSL or Windows, change 127.0.0.1 to 0.0.0.0. It, however, causes security issues when you open your machine to the public</description>
 </property>
 
 <property>


### PR DESCRIPTION
### What is this PR for?
When trying to run Zeppelin on Windows WSL linux, server property in Zeppelin-site.xml should be set to 0.0.0.0.
But, we don't change from 127.0.0.0 to 0.0.0.0 because of security issue. I think that we should at least write a comment.

### What type of PR is it?
Documentation

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-4794

### How should this be tested?

CI

### Questions:
* Does the licenses files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
