### PR TITLE
[ZEPPELIN-5789] Update Dockerfile to use JDK instead of JRE

### DIFF
--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -29,7 +29,7 @@ ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
 
 RUN echo "$LOG_TAG install basic packages" && \
     apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-8-jre-headless wget unzip && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-8-jdk-headless wget unzip && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -29,6 +29,7 @@ ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
 
 RUN echo "$LOG_TAG install basic packages" && \
     apt-get -y update && \
+    # Switch back to install JRE instead of JDK when moving to JDK9 or later.
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-8-jdk-headless wget unzip && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
### What is this PR for?
Fixes issues such as trying to add a new interpreter belonging to "jdbc" group having hive-jdbc conf results in missing dependencies (tools.jar) and such.

### What type of PR is it?
Bug Fix

### Todos
(none)

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5789

### How should this be tested?
Build, publish and run the image via Dockerfile `docker run -d -p 80:8080 --name test imagename`

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
