### PR TITLE
[ZEPPELIN-5191] Fix the wrong Docker image name in zeppelin-server.yaml

### DIFF
--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -97,19 +97,7 @@ zeppelin-server               0.11.0-SNAPSHOT   4f77fe989eed   3 minutes ago    
 zeppelin-distribution         latest            bd2fb4b321d2   40 minutes ago   1.27GB
 ```
 
-Now that we have the images ready, let's edit the `zeppelin-server.yaml` file with the correct names:
-
-```sh
-# from the root of the zeppelin directory
-cd ./k8s/
-vi zeppelin-server.yaml
-# we need to change ZEPPELIN_K8S_CONTAINER_IMAGE to
-# ZEPPELIN_K8S_CONTAINER_IMAGE: zeppelin-interpreter:0.11.0-SNAPSHOT
-# and then:
-#      containers:
-#      - name: zeppelin-server
-#        image: zeppelin-server:0.11.0-SNAPSHOT
-```
+Reminder: Please adjust the images in the YAML-File of `zeppelin-server.yaml`
 
 Start zeppelin on Kubernetes cluster,
 

--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -29,7 +29,7 @@ data:
   # If you have your ingress controller configured to connect to `zeppelin-server` service and have a domain name for it (with wildcard subdomain point the same address), you can replace serviceDomain field with your own domain.
   SERVICE_DOMAIN: local.zeppelin-project.org:8080
   ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE: spark:2.4.5
-  ZEPPELIN_K8S_CONTAINER_IMAGE: apache/zeppelin:0.10.1
+  ZEPPELIN_K8S_CONTAINER_IMAGE: zeppelin-interpreter:0.11.0-SNAPSHOT
   ZEPPELIN_HOME: /opt/zeppelin
   ZEPPELIN_SERVER_RPC_PORTRANGE: 12320:12320
   # default value of 'master' property for spark interpreter.
@@ -115,7 +115,7 @@ spec:
             path: nginx.conf
       containers:
       - name: zeppelin-server
-        image: apache/zeppelin:0.10.1
+        image: zeppelin-server:0.11.0-SNAPSHOT
         command: ["sh", "-c", "$(ZEPPELIN_HOME)/bin/zeppelin.sh"]
         lifecycle:
           preStop:

--- a/k8s/zeppelin-server.yaml
+++ b/k8s/zeppelin-server.yaml
@@ -29,7 +29,7 @@ data:
   # If you have your ingress controller configured to connect to `zeppelin-server` service and have a domain name for it (with wildcard subdomain point the same address), you can replace serviceDomain field with your own domain.
   SERVICE_DOMAIN: local.zeppelin-project.org:8080
   ZEPPELIN_K8S_SPARK_CONTAINER_IMAGE: spark:2.4.5
-  ZEPPELIN_K8S_CONTAINER_IMAGE: apache/zeppelin-interpreter:0.10.0
+  ZEPPELIN_K8S_CONTAINER_IMAGE: apache/zeppelin:0.10.1
   ZEPPELIN_HOME: /opt/zeppelin
   ZEPPELIN_SERVER_RPC_PORTRANGE: 12320:12320
   # default value of 'master' property for spark interpreter.
@@ -115,7 +115,7 @@ spec:
             path: nginx.conf
       containers:
       - name: zeppelin-server
-        image: apache/zeppelin-server:0.10.0
+        image: apache/zeppelin:0.10.1
         command: ["sh", "-c", "$(ZEPPELIN_HOME)/bin/zeppelin.sh"]
         lifecycle:
           preStop:


### PR DESCRIPTION
- There has never been any Docker image named `zeppelin-interpreter` or `zeppelin-server`.
- The latest version also should be 0.10.1

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

All the examples inside and outside Zeppelin website/docs point to simply using `zeppelin-server.yaml` for K8s cluster : 
```sh
curl -s -O https://raw.githubusercontent.com/apache/zeppelin/master/k8s/zeppelin-server.yaml
kubectl apply -f zeppelin-server.yaml
```

There are lots of issues on StackOverFlow and 1 on Jira that indicate the Docker images mentioned in this YAML simply don't exist on Docker Hub. 

### What type of PR is it?
Documentation
*Please leave your type of PR only*

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]
https://issues.apache.org/jira/browse/ZEPPELIN-5191

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

I have tested this on a live K8s cluster (OpenStack) and it created a Zeppelin server successfully, also creates Spark and other interpreters in the cluster upon request without any issue:

```
curl -s -O https://raw.githubusercontent.com/apache/zeppelin/master/k8s/zeppelin-server.yaml
```

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
