### PR TITLE
[ZEPPELIN-4871] Fix livy interpreter 0.7.1 donwload link 

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -431,7 +431,7 @@ jobs:
         run: |
           ./mvnw install -DskipTests -DskipRat -pl livy -am  -B
           ./testing/downloadSpark.sh "2.2.0" "2.6"
-          ./testing/downloadLivy.sh "0.5.0-incubating"
+          ./testing/downloadLivy.sh "0.7.1-incubating"
       - name: Setup conda environment with python 3.7 and R
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -404,7 +404,7 @@ jobs:
           rm -rf spark/interpreter/metastore_db
           ./mvnw test -DskipRat -pl spark-submit,spark/interpreter -Pspark-3.3 -Pspark-scala-2.13 -Phadoop3 -Pintegration -B -DfailIfNoTests=false
 
-  livy-0-5-with-spark-2-2-0-under-python3:
+  livy-0-7-with-spark-2-2-0-under-python3:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -39,7 +39,7 @@
         <spring.security.kerberosclient>1.0.1.RELEASE</spring.security.kerberosclient>
 
         <!--test library versions-->
-        <livy.version>0.5.0-incubating</livy.version>
+        <livy.version>0.7.1-incubating</livy.version>
         <spark.version>2.1.0</spark.version>
         <hadoop.version>${hadoop2.6.version}</hadoop.version>
     </properties>

--- a/testing/downloadLivy.sh
+++ b/testing/downloadLivy.sh
@@ -49,7 +49,7 @@ download_with_retry() {
 }
 
 LIVY_CACHE=".livy-dist"
-LIVY_ARCHIVE="livy-${LIVY_VERSION}-bin"
+LIVY_ARCHIVE="apache-livy-${LIVY_VERSION}-bin"
 export LIVY_HOME="${ZEPPELIN_HOME}/livy-server-$LIVY_VERSION"
 echo "LIVY_HOME is ${LIVY_HOME}"
 


### PR DESCRIPTION
### What is this PR for?
During a previous [PR](https://github.com/apache/zeppelin/pull/4433) related to livy interpreter version upgrade, CI is not working because of unvalid download link of livy interpreter 0.7.1.  then, I create a new PR for fixing a download link of livy interpreter zip file.


@jongyoul 
[previous comment](https://github.com/apache/zeppelin/pull/4433#issuecomment-1200735324)

### What type of PR is it?
bug

### What is the Jira issue?
(https://issues.apache.org/jira/browse/ZEPPELIN-4871)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

AS IT
https://dist.apache.org/repos/dist/release/incubator/livy/0.7.1-incubating/livy-0.7.1-incubating-bin.zip
TO BE
https://dist.apache.org/repos/dist/release/incubator/livy/0.7.1-incubating/apache-livy-0.7.1-incubating-bin.zip

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
