### PR TITLE
[ZEPPELIN-5800] upgrade version of apache commons configuration2 to 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <commons.compress.version>1.21</commons.compress.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <commons.text.version>1.8</commons.text.version>
-    <commons.configuration2.version>2.7</commons.configuration2.version>
+    <commons.configuration2.version>2.8.0</commons.configuration2.version>
     <commons.exec.version>1.3</commons.exec.version>
     <commons.codec.version>1.14</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -8,7 +8,7 @@ The following components are provided under Apache License.
     (Apache 2.0) Apache Commons Codec (commons-codec:commons-codec:1.5 - http://commons.apache.org/proper/commons-codec/)
     (Apache 2.0) Apache Commons Collections (commons-collections:commons-collections:3.2.2 - http://commons.apache.org/proper/commons-configuration/)
     (Apache 2.0) Apache Commons Compress (org.apache.commons:commons-compress:1.21 - http://commons.apache.org/proper/commons-compress/)
-    (Apache 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.7 - http://commons.apache.org/configuration/)
+    (Apache 2.0) Apache Commons Configuration (org.apache.commons:commons-configuration2:2.8.0 - http://commons.apache.org/configuration/)
     (Apache 2.0) Apache Commons CLI (commons-cli:commons-cli:1.2 - http://commons.apache.org/cli/)
     (Apache 2.0) Apache Commons Exec (commons-exec:commons-exec:1.3 - http://commons.apache.org/exec/)
     (Apache 2.0) Http Components (org.apache.httpcomponents:httpcore:4.3.3 - https://github.com/apache/httpclient)


### PR DESCRIPTION
### What is this PR for?
This PR is to upgrade version of commons-configuration from 2.7 to 2.8 due to [CVE-2022-33980](https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2/2.7).


### What type of PR is it?
Bug Fix


### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5800
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
