### PR TITLE
[ZEPPELIN-5802][MINOR] fix rimraf version

### DIFF
--- a/zeppelin-web/package-lock.json
+++ b/zeppelin-web/package-lock.json
@@ -13230,9 +13230,9 @@
           }
         },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"

--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -93,7 +93,7 @@
     "postcss-loader": "^3.0.0",
     "protractor": "^5.4.1",
     "raw-loader": "^0.5.1",
-    "rimraf": "^2.5.4",
+    "rimraf": "^3.0.2",
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.13.1",
     "time-grunt": "^0.3.1",


### PR DESCRIPTION
### What is this PR for?
In the [ZEPPELIN-5786] Remove sap interpreter  pr, the rimraf version overrided from 3.0.2 to 2.5.4 unintentionally.
Therefore it needs to be fixed back to 3.0.2 version.


### What type of PR is it?
Bug Fix

### Todos
* [ ] - fix rimraf version to 3.0.2

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5802


### How should this be tested?
* CI

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
