### PR TITLE
[ZEPPELIN-5810] Allow both package names jupyter_client and jupyter-client

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -27,6 +27,7 @@ import org.apache.zeppelin.interpreter.jupyter.proto.ExecuteResponse;
 import org.apache.zeppelin.interpreter.jupyter.proto.ExecuteStatus;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterUtils;
 import org.apache.zeppelin.jupyter.JupyterKernelInterpreter;
+import org.apache.zeppelin.jupyter.PythonPackagePredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import py4j.GatewayServer;
@@ -67,10 +68,16 @@ public class IPythonInterpreter extends JupyterKernelInterpreter {
   }
 
   @Override
-  public List<String> getRequiredPackages() {
-    List<String> requiredPackages = super.getRequiredPackages();
-    requiredPackages.add("ipython");
-    requiredPackages.add("ipykernel");
+  public List<PythonPackagePredicate<String>> getRequiredPackagesPredicates() {
+    List<PythonPackagePredicate<String>> requiredPackages = super.getRequiredPackagesPredicates();
+    requiredPackages.add(
+        new PythonPackagePredicate<>("ipython",
+            packages -> packages.contains("ipython ") ||
+                        packages.contains("ipython=")));
+    requiredPackages.add(
+        new PythonPackagePredicate<>("ipykernel",
+            packages -> packages.contains("ipykernel ") ||
+                        packages.contains("ipykernel=")));
     return requiredPackages;
   }
 

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/PythonPackagePredicate.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/PythonPackagePredicate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.jupyter;
+
+import java.util.function.Predicate;
+
+public class PythonPackagePredicate<T> implements Predicate<T> {
+  private final String name;
+  private final Predicate<T> predicate;
+
+  public PythonPackagePredicate(String name, Predicate<T> predicate) {
+    this.name = name;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public boolean test(T t) {
+    return predicate.test(t);
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This pull request changes the Python dependency check minimally to get high flexibility for the package check.

### What type of PR is it?
- Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5810

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
