### PR TITLE
Add custom labels to k8s interpreter

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -776,6 +776,12 @@
 </property>
 
 <property>
+  <name>zeppelin.k8s.interpreter.customLabels</name>
+  <value></value>
+  <description>A comma-separated list of Key, Value pair of k8s pods labels ex) k1:v1, k2:v2 </description>
+</property>
+
+<property>
   <name>zeppelin.docker.container.image</name>
   <value>apache/zeppelin:0.8.0</value>
   <description>Docker image for interpreters</description>

--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -24,6 +24,9 @@ metadata:
     interpreterGroupId: {{zeppelin.k8s.interpreter.group.id}}
     interpreterSettingName: {{zeppelin.k8s.interpreter.setting.name}}
     user: {{ zeppelin.k8s.interpreter.user }}
+    {% for k, v in zeppelin.k8s.interpreter.customLabels.items() %}
+    {{k}} : {{v}}
+    {% endfor %}
   {% if zeppelin.k8s.server.uid is defined %}
   ownerReferences:
   - apiVersion: v1

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -879,6 +879,10 @@ public class ZeppelinConfiguration {
     return getBoolean(ConfVars.ZEPPELIN_K8S_TIMEOUT_DURING_PENDING);
   }
 
+  public String getK8sCustomLabels(){
+    return getString(ConfVars.ZEPPELIN_K8S_INTERPRETER_CUSTOM_LABELS);
+  }
+
   public String getDockerContainerImage() {
     return getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_IMAGE);
   }
@@ -1085,11 +1089,9 @@ public class ZeppelinConfiguration {
     ZEPPELIN_K8S_TEMPLATE_DIR("zeppelin.k8s.template.dir", "k8s"),
     ZEPPELIN_K8S_SERVICE_NAME("zeppelin.k8s.service.name", "zeppelin-server"),
     ZEPPELIN_K8S_TIMEOUT_DURING_PENDING("zeppelin.k8s.timeout.during.pending", true),
-
+    ZEPPELIN_K8S_INTERPRETER_CUSTOM_LABELS("zeppelin.k8s.interpreter.customLabels", ""),
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
-
     ZEPPELIN_METRIC_ENABLE_PROMETHEUS("zeppelin.metric.enable.prometheus", false),
-
     ZEPPELIN_IMPERSONATE_SPARK_PROXY_USER("zeppelin.impersonate.spark.proxy.user", true),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_URL("zeppelin.notebook.git.remote.url", ""),
     ZEPPELIN_NOTEBOOK_GIT_REMOTE_USERNAME("zeppelin.notebook.git.remote.username", "token"),

--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sStandardInterpreterLauncher.java
@@ -123,7 +123,8 @@ public class K8sStandardInterpreterLauncher extends InterpreterLauncher {
             getConnectTimeout(),
             getConnectPoolSize(),
             isUserImpersonateForSparkInterpreter(context),
-            zConf.getK8sTimeoutDuringPending());
+            zConf.getK8sTimeoutDuringPending(),
+            zConf.getK8sCustomLabels());
   }
 
   protected Map<String, String> buildEnvFromProperties(InterpreterLaunchContext context) {

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -541,7 +541,41 @@ public class K8sRemoteInterpreterProcessTest {
     // Check that the Pod is deleted
     assertNull(server.getClient().pods().inNamespace(intp.getInterpreterNamespace())
         .withName(intp.getPodName()).get());
+  }
 
+  @Test
+  public void testK8sPodsLabels() throws InterruptedException {
+    // given
+    Properties properties = new Properties();
+    Map<String, String> envs = new HashMap<>();
+    envs.put("SERVICE_DOMAIN", "mydomain");
+    URL url = Thread.currentThread().getContextClassLoader()
+            .getResource("k8s-specs/interpreter-spec.yaml");
+    File file = new File(url.getPath());
+
+    K8sRemoteInterpreterProcess intp = new K8sRemoteInterpreterProcess(
+            server.getClient(),
+            "default",
+            file,
+            "interpreter-container:1.0",
+            "shared_process",
+            "spark",
+            "myspark",
+            properties,
+            envs,
+            "zeppelin.server.service",
+            12320,
+            false,
+            "spark-container:1.0",
+            3000,
+            10,
+            false,
+            false,
+            "k1:v1");
+
+    Map<String, String> m = new HashMap<>();
+    m.put("k1", "v1");
+    assertEquals(m, intp.getCustomLables());
   }
 
   class PodStatusSimulator implements Runnable {

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcessTest.java
@@ -71,7 +71,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
 
     // following values are hardcoded in k8s/interpreter/100-interpreter.yaml.
@@ -106,7 +107,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings(null);
@@ -160,7 +162,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings("mytestUser");
@@ -212,7 +215,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         true,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings("mytestUser");
@@ -264,7 +268,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         true,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings("anonymous");
@@ -304,7 +309,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
     // when non template url
     assertEquals("static.url",
@@ -349,7 +355,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings(null);
@@ -386,7 +393,8 @@ public class K8sRemoteInterpreterProcessTest {
         10,
         10,
         false,
-        false);
+        false,
+        "");
 
     // when
     Properties p = intp.getTemplateBindings(null);
@@ -423,7 +431,8 @@ public class K8sRemoteInterpreterProcessTest {
         10000,
         10,
         false,
-        true);
+        true,
+        "");
     ExecutorService service = Executors.newFixedThreadPool(1);
     service
         .submit(new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp));
@@ -459,7 +468,8 @@ public class K8sRemoteInterpreterProcessTest {
         3000,
         10,
         false,
-        true);
+        true,
+        "");
     PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp);
     podStatusSimulator.setSecondPhase("Failed");
     podStatusSimulator.setSuccessfulStart(false);
@@ -506,7 +516,8 @@ public class K8sRemoteInterpreterProcessTest {
         3000,
         10,
         false,
-        false);
+        false,
+        "");
     PodStatusSimulator podStatusSimulator = new PodStatusSimulator(server.getClient(), intp.getInterpreterNamespace(), intp.getPodName(), intp);
     podStatusSimulator.setFirstPhase("Pending");
     podStatusSimulator.setSecondPhase("Pending");

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/resources/k8s-specs/interpreter-spec.yaml
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/resources/k8s-specs/interpreter-spec.yaml
@@ -24,6 +24,9 @@ metadata:
     interpreterGroupId: {{zeppelin.k8s.interpreter.group.id}}
     interpreterSettingName: {{zeppelin.k8s.interpreter.setting.name}}
     user: {{ zeppelin.k8s.interpreter.user }}
+    {% for k, v in zeppelin.k8s.interpreter.customLabels.items() %}
+    {{k}} : {{v}}
+    {% endfor %}
   {% if zeppelin.k8s.server.uid is defined %}
   ownerReferences:
   - apiVersion: v1


### PR DESCRIPTION
### What type of PR is it?
to run interpreter on eks fargate, add custom labels to k8s interpreter 
here is eks with fargate [doc](https://www.stacksimplify.com/aws-eks/aws-fargate/learn-to-run-kubernetes-workloads-on-aws-eks-and-aws-fargate-serverless-part-2/)

### How should this be tested?
add zeppelin.k8s.interpreter.customLabels to zeppelin-site.xml and deploy on eks 

### Screenshots (if appropriate)
custom label k1:v1 is attached
![스크린샷 2022-09-01 오후 10 55 06](https://user-images.githubusercontent.com/90180644/187931803-fed0a954-dde1-4231-8ba0-c83998ebda6e.png)
