### PR TITLE
[ZEPPELIN-5815] Frontend CI jobs improvement

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -46,7 +46,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: Install application
-        run: ./mvnw -B install -DskipTests -DskipRat -pl ${INTERPRETERS} -Phadoop2 -Pscala-2.11
+        run: |
+          ./mvnw -B install -DskipTests -DskipRat -DskipZeppelinPlugins -pl ${INTERPRETERS} -Phadoop2 -Pscala-2.11
+          ./mvnw clean package -pl zeppelin-plugins -amd -B
       - name: Run headless test
         run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" ./mvnw verify -DskipRat -pl zeppelin-web -Pscala-2.11 -Pweb-e2e -B
       - name: Print zeppelin logs
@@ -121,7 +123,7 @@ jobs:
           R -e "IRkernel::installspec()"
       - name: install environment
         run: |
-          ./mvnw clean install -DskipTests -DskipRat -pl ${INTERPRETERS} -Pspark-2.4 -Phadoop2 -Phelium-dev -Pexamples -Pintegration -Pspark-scala-2.11 -B
+          ./mvnw clean install -DskipTests -DskipRat -DskipZeppelinPlugins -pl ${INTERPRETERS} -Pspark-2.4 -Phadoop2 -Phelium-dev -Pexamples -Pintegration -Pspark-scala-2.11 -B
           ./mvnw clean package -pl zeppelin-plugins -amd -B
       - name: run tests
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -1923,7 +1923,7 @@
 
     <profile>
       <id>include-plugins</id>
-      <!-- It would be always activated if you don't add -DskipZeppelinPlugins     -->
+      <!-- It would be always activated if you don't add -DskipZeppelinPlugins -->
       <activation>
         <property>
           <name>!skipZeppelinPlugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
     <module>zeppelin-web</module>
     <module>zeppelin-server</module>
     <module>zeppelin-jupyter</module>
-    <module>zeppelin-plugins</module>
     <module>zeppelin-distribution</module>
   </modules>
 
@@ -1920,6 +1919,19 @@
         <scala.version>${scala.2.11.version}</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
       </properties>
+    </profile>
+
+    <profile>
+      <id>include-plugins</id>
+      <!-- It would be always activated if you don't add -DskipZeppelinPlugins     -->
+      <activation>
+        <property>
+          <name>!skipZeppelinPlugins</name>
+        </property>
+      </activation>
+      <modules>
+        <module>zeppelin-plugins</module>
+      </modules>
     </profile>
 
     <profile>


### PR DESCRIPTION
### What is this PR for?

This PR is to improve a some step in Frontend CI jobs.

There are two command in this step in file `frontend.yml`  as follow:
https://github.com/apache/zeppelin/blob/f42943c6d5bc04498b7fc9ca518dc433091a9c9c/.github/workflows/frontend.yml#L123-L125

The first command would `mvn install` many modules including the submodule of  `zeppelin-plugins`.
The second command would `mvn package`  `zeppelin-plugins`.

Actually, we only need to `mvn package` module  `zeppelin-plugins` one time instead of to install then to package it, which would save running time of CI.
And there is no need to `mvn install` module  `zeppelin-plugins` , which may bring something unexpected. `mvn package` is enough.


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira [ZEPPELIN-5815](https://issues.apache.org/jira/browse/ZEPPELIN-5815)

### How should this be tested?
CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
