### PR TITLE
[ZEPPELIN-5816] [MINOR] [JDBC] JDBCInterpreterTest.testMultiTenant_* improvement

### DIFF
--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -101,6 +101,11 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
     statement.execute(
         "DROP TABLE IF EXISTS test_table; " +
         "CREATE TABLE test_table(id varchar(255), name varchar(255));");
+    statement.execute(
+        "CREATE USER IF NOT EXISTS dbuser PASSWORD 'dbpassword';" +
+        "CREATE USER IF NOT EXISTS user1Id PASSWORD 'user1Pw';" +
+        "CREATE USER IF NOT EXISTS user2Id PASSWORD 'user2Pw';"
+    );
 
     PreparedStatement insertStatement = connection.prepareStatement(
             "insert into test_table(id, name) values ('a', 'a_name'),('b', 'b_name'),('c', ?);");


### PR DESCRIPTION
### What is this PR for?
Now In test cases `JDBCInterpreterTest.testMultiTenant_1` and `JDBCInterpreterTest.testMultiTenant_1`, the jdbc interpreter would try to connect h2 databases with 3 non-existed user.  Although It does not affect the running of the entire test case, it has two consequences:


1. It would cost more time to execute these two test case. The execution time of every test case time would be reduced from over 1 second to 50 milliseconds if the users is exsited.

2. And also the interpreter would log a long message about `JdbcSQLInvalidAuthorizationSpecException` ,  which may mislead developer who is unfamiliar to JDBC module into thinking there is something wrong with the test case. I found  this problem when I develop for ticket [ZEPPELIN-5493](https://issues.apache.org/jira/browse/ZEPPELIN-5493) , it misled me at least. 😆 

```
03:41:28.204 [main] ERROR org.apache.zeppelin.jdbc.JDBCInterpreter - Fail to getConnection
org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException: Wrong user name or password [28000-206]
at org.h2.message.DbException.getJdbcSQLException(DbException.java:529) ~[h2-2.0.206.jar:2.0.206]
at org.h2.message.DbException.getJdbcSQLException(DbException.java:496) ~[h2-2.0.206.jar:2.0.206]
at org.h2.message.DbException.get(DbException.java:227) ~[h2-2.0.206.jar:2.0.206]
at org.h2.message.DbException.get(DbException.java:203) ~[h2-2.0.206.jar:2.0.206]
at org.h2.message.DbException.get(DbException.java:192) ~[h2-2.0.206.jar:2.0.206]
at org.h2.engine.Engine.validateUserAndPassword(Engine.java:393) ~[h2-2.0.206.jar:2.0.206]
at org.h2.engine.Engine.createSession(Engine.java:206) ~[h2-2.0.206.jar:2.0.206]
at org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:338) ~[h2-2.0.206.jar:2.0.206]
at org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:117) ~[h2-2.0.206.jar:2.0.206]
at org.h2.Driver.connect(Driver.java:59) ~[h2-2.0.206.jar:2.0.206]
at java.sql.DriverManager.getConnection(DriverManager.java:664) ~[?:1.8.0_345]
at java.sql.DriverManager.getConnection(DriverManager.java:208) ~[?:1.8.0_345]
```
This PR to improve the test cases by the way to create these 3 users in `setup()`.


### What type of PR is it?
Improvement


### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira [ZEPPELIN-5816](https://issues.apache.org/jira/browse/ZEPPELIN-5816)

### How should this be tested?
CI passed.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
