### PR TITLE
[ZEPPELIN-5493] Remove prefix in jdbc interpreter

### DIFF
--- a/docs/interpreter/hive.md
+++ b/docs/interpreter/hive.md
@@ -25,7 +25,7 @@ limitations under the License.
 
 ## Important Notice
 
-Hive Interpreter will be deprecated and merged into JDBC Interpreter. 
+Hive Interpreter has been deprecated and merged into JDBC Interpreter. 
 You can use Hive Interpreter by using JDBC Interpreter with same functionality. 
 See the example below of settings and dependencies.
 
@@ -36,19 +36,19 @@ See the example below of settings and dependencies.
     <th>Value</th>
   </tr>
   <tr>
-    <td>hive.driver</td>
+    <td>default.driver</td>
     <td>org.apache.hive.jdbc.HiveDriver</td>
   </tr>
   <tr>
-    <td>hive.url</td>
+    <td>default.url</td>
     <td>jdbc:hive2://localhost:10000</td>
   </tr>
   <tr>
-    <td>hive.user</td>
+    <td>default.user</td>
     <td>hiveUser</td>
   </tr>
   <tr>
-    <td>hive.password</td>
+    <td>default.password</td>
     <td>hivePassword</td>
   </tr>
 </table>
@@ -103,31 +103,6 @@ See the example below of settings and dependencies.
     <td><b>( Optional ) </b>Other properties used by the driver</td>
   </tr>
   <tr>
-    <td>${prefix}.driver</td>
-    <td></td>
-    <td>Driver class path of <code>%hive(${prefix})</code> </td>
-  </tr>
-  <tr>
-    <td>${prefix}.url</td>
-    <td></td>
-    <td>Url of <code>%hive(${prefix})</code> </td>
-  </tr>
-  <tr>
-    <td>${prefix}.user</td>
-    <td></td>
-    <td><b>( Optional ) </b>Username of the connection of <code>%hive(${prefix})</code> </td>
-  </tr>
-  <tr>
-    <td>${prefix}.password</td>
-    <td></td>
-    <td><b>( Optional ) </b>Password of the connection of <code>%hive(${prefix})</code> </td>
-  </tr>
-  <tr>
-    <td>${prefix}.xxx</td>
-    <td></td>
-    <td><b>( Optional ) </b>Other properties used by the driver of <code>%hive(${prefix})</code> </td>
-  </tr>
-  <tr>
     <td>zeppelin.jdbc.hive.timeout.threshold</td>
     <td>60000</td>
     <td>Timeout for hive job timeout</td>
@@ -144,8 +119,6 @@ See the example below of settings and dependencies.
   </tr>
 </table>
 
-This interpreter provides multiple configuration with `${prefix}`. User can set a multiple connection properties by this prefix. It can be used like `%hive(${prefix})`.
-
 ## Overview
 
 The [Apache Hive](https://hive.apache.org/) ™ data warehouse software facilitates querying and managing large datasets 
@@ -159,14 +132,6 @@ Basically, you can use
 
 ```sql
 %hive
-select * from my_table;
-```
-
-or
-
-```sql
-%hive(etl)
--- 'etl' is a ${prefix}
 select * from my_table;
 ```
 

--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -722,16 +722,16 @@ See [User Impersonation in interpreter](../usage/interpreter/user_impersonation.
     <th>Value</th>
   </tr>
   <tr>
-    <td>hive.driver</td>
+    <td>default.driver</td>
     <td>org.apache.hive.jdbc.HiveDriver</td>
   </tr>
   <tr>
-    <td>hive.url</td>
+    <td>default.url</td>
     <td>jdbc:hive2://hive-server-host:2181/;serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2</td>
   </tr>
   <tr>
-    <td>hive.proxy.user.property</td>
-    <td>hive.server2.proxy.user</td>
+    <td>default.proxy.user.property</td>
+    <td>default.server2.proxy.user</td>
   </tr>
   <tr>
     <td>zeppelin.jdbc.auth.type</td>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCUserConfigurations.java
@@ -15,6 +15,7 @@
 package org.apache.zeppelin.jdbc;
 
 import org.apache.commons.dbcp2.PoolingDriver;
+import org.apache.zeppelin.user.UsernamePassword;
 
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -22,25 +23,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.zeppelin.user.UsernamePassword;
-
 /**
  * UserConfigurations for JDBC impersonation.
  */
 public class JDBCUserConfigurations {
   private final Map<String, Statement> paragraphIdStatementMap;
-  // dbPrefix --> PoolingDriver
-  private final Map<String, PoolingDriver> poolingDriverMap;
-  // dbPrefix --> Properties
-  private final HashMap<String, Properties> propertiesMap;
-  // dbPrefix --> Boolean
-  private HashMap<String, Boolean> isSuccessful;
+  private PoolingDriver poolingDriver;
+  private Properties properties;
+  private Boolean isSuccessful;
 
   public JDBCUserConfigurations() {
     paragraphIdStatementMap = new HashMap<>();
-    poolingDriverMap = new HashMap<>();
-    propertiesMap = new HashMap<>();
-    isSuccessful = new HashMap<>();
   }
 
   public void initStatementMap() throws SQLException {
@@ -51,27 +44,26 @@ public class JDBCUserConfigurations {
   }
 
   public void initConnectionPoolMap() throws SQLException {
-    poolingDriverMap.clear();
-    isSuccessful.clear();
+    this.poolingDriver = null;
+    this.isSuccessful = null;
   }
 
-  public void setPropertyMap(String dbPrefix, Properties properties) {
-    Properties p = (Properties) properties.clone();
-    propertiesMap.put(dbPrefix, p);
+  public void setProperty(Properties properties) {
+    this.properties = (Properties) properties.clone();
   }
 
-  public Properties getPropertyMap(String key) {
-    return propertiesMap.get(key);
+  public Properties getProperty() {
+    return this.properties;
   }
 
-  public void cleanUserProperty(String dfPrefix) {
-    propertiesMap.get(dfPrefix).remove("user");
-    propertiesMap.get(dfPrefix).remove("password");
+  public void cleanUserProperty() {
+    this.properties.remove("user");
+    this.properties.remove("password");
   }
 
-  public void setUserProperty(String dbPrefix, UsernamePassword usernamePassword) {
-    propertiesMap.get(dbPrefix).setProperty("user", usernamePassword.getUsername());
-    propertiesMap.get(dbPrefix).setProperty("password", usernamePassword.getPassword());
+  public void setUserProperty(UsernamePassword usernamePassword) {
+    this.properties.setProperty("user", usernamePassword.getUsername());
+    this.properties.setProperty("password", usernamePassword.getPassword());
   }
 
   public void saveStatement(String paragraphId, Statement statement) throws SQLException {
@@ -86,20 +78,23 @@ public class JDBCUserConfigurations {
     paragraphIdStatementMap.remove(paragraphId);
   }
 
-  public void saveDBDriverPool(String dbPrefix, PoolingDriver driver) throws SQLException {
-    poolingDriverMap.put(dbPrefix, driver);
-    isSuccessful.put(dbPrefix, false);
-  }
-  public PoolingDriver removeDBDriverPool(String key) throws SQLException {
-    isSuccessful.remove(key);
-    return poolingDriverMap.remove(key);
+  public void saveDBDriverPool(PoolingDriver driver) throws SQLException {
+    this.poolingDriver = driver;
+    this.isSuccessful = false;
   }
 
-  public boolean isConnectionInDBDriverPool(String key) {
-    return poolingDriverMap.containsKey(key);
+  public PoolingDriver removeDBDriverPool() throws SQLException {
+    this.isSuccessful = null;
+    PoolingDriver tmp = poolingDriver;
+    this.poolingDriver = null;
+    return tmp;
   }
 
-  public void setConnectionInDBDriverPoolSuccessful(String dbPrefix) {
-    isSuccessful.put(dbPrefix, true);
+  public boolean isConnectionInDBDriverPool() {
+    return this.poolingDriver != null;
+  }
+
+  public void setConnectionInDBDriverPoolSuccessful() {
+    this.isSuccessful = true;
   }
 }


### PR DESCRIPTION
### What is this PR for?
Currently, zeppelin allow user to run multiple kinds of sql in one interpreter, e.g.
```
%jdbc(db=mysql)
%jdbc(db=hive){code}
```
 
But this would make jdbc interpreter very complicated, and hard to maintain.
 
This PR is to proposal to remove this feature, so that user need to create separated interpreter for each database.

```
%mysql
%hive
```

### What type of PR is it?
Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira [ZEPPELIN-5493](https://issues.apache.org/jira/browse/ZEPPELIN-5493)

### How should this be tested?
CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
