### PR TITLE
[ZEPPELIN-5819] Update to newer geoip jar

### DIFF
--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -110,7 +110,7 @@ public abstract class SparkIntegrationTest {
   private void testInterpreterBasics() throws IOException, InterpreterException, XmlPullParserException {
     // add jars & packages for testing
     InterpreterSetting sparkInterpreterSetting = interpreterSettingManager.getInterpreterSettingByName("spark");
-    sparkInterpreterSetting.setProperty("spark.jars.packages", "com.maxmind.geoip2:geoip2:2.5.0");
+    sparkInterpreterSetting.setProperty("spark.jars.packages", "com.maxmind.geoip2:geoip2:2.16.1");
     sparkInterpreterSetting.setProperty("SPARK_PRINT_LAUNCH_COMMAND", "true");
     sparkInterpreterSetting.setProperty("zeppelin.python.gatewayserver_address", "127.0.0.1");
 


### PR DESCRIPTION
### What is this PR for?
Unfortunately, the main reason of the error could not be found.
I have cleared the GitHub CI cache, unfortunately the problem was still present.
Following comment is very helpful to further understand the artifact resolution. https://github.com/databricks/spark-redshift/issues/244#issuecomment-347082455

This PR is mainly a workaround, so there is no reference to the library jackson-annotations;2.6.0.

### What type of PR is it?
- Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5819

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
