### PR TITLE
[ZEPPELIN-5206] JDK 11 Support

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -214,7 +214,6 @@
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-nobootcp</arg>
-<!--                        <arg>-target:jvm-1.8</arg>-->
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -31,14 +31,18 @@
     <description>Zeppelin cassandra support</description>
 
     <properties>
-        <cassandra.driver.version>4.8.0</cassandra.driver.version>
-        <snappy.version>1.1.7.3</snappy.version>
-        <lz4.version>1.7.0</lz4.version>
-        <scalate.version>1.7.1</scalate.version>
+        <cassandra.driver.version>4.14.1</cassandra.driver.version>
+        <snappy.version>1.1.8.4</snappy.version>
+        <lz4.version>1.8.0</lz4.version>
+        <scalate.version>1.9.8</scalate.version>
 
         <!-- test library versions -->
-        <jna.version>4.2.0</jna.version>
+        <jna.version>5.12.1</jna.version>
         <cassandra.unit.version>4.3.1.0</cassandra.unit.version>
+
+        <scala.version>2.12.16</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <cassandra.scalatest.version>3.2.0-SNAP10</cassandra.scalatest.version>
 
         <interpreter.name>cassandra</interpreter.name>
     </properties>
@@ -122,7 +126,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${cassandra.scalatest.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -158,6 +162,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+            <version>1.1.2</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -174,30 +184,51 @@
         <plugins>
             <!-- Plugin to compile Scala code -->
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>compile</id>
+                        <id>eclipse-add-source</id>
                         <goals>
-                            <goal>compile</goal>
+                            <goal>add-source</goal>
                         </goals>
-                        <phase>compile</phase>
                     </execution>
                     <execution>
-                        <id>test-compile</id>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <phase>test-compile</phase>
-                    </execution>
-                    <execution>
+                        <id>scala-compile-first</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>scala-test-compile-first</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
                 </executions>
+                <configuration>
+                    <args>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                        <arg>-nobootcp</arg>
+<!--                        <arg>-target:jvm-1.8</arg>-->
+                    </args>
+                    <jvmArgs>
+                        <jvmArg>-Xms1024m</jvmArg>
+                        <jvmArg>-Xmx1024m</jvmArg>
+                        <jvmArg>-XX:MaxMetaspaceSize=${MaxMetaspace}</jvmArg>
+                    </jvmArgs>
+                    <javacArgs>
+                        <javacArg>-source</javacArg>
+                        <javacArg>${java.version}</javacArg>
+                        <javacArg>-target</javacArg>
+                        <javacArg>${java.version}</javacArg>
+                        <javacArg>-Xlint:all,-serial,-path,-options</javacArg>
+                    </javacArgs>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -209,24 +240,6 @@
                         <goals>
                             <goal>test</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.scalatra.scalate</groupId>
-                <artifactId>maven-scalate-plugin_${scala.binary.version}</artifactId>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>precompile</goal>
-                        </goals>
-                        <configuration>
-                            <resourcesSourceDirectory>${basedir}/src/main/resources/scalate</resourcesSourceDirectory>
-                            <contextClass>org.fusesource.scalate.DefaultRenderContext</contextClass>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/flink/flink-scala-parent/pom.xml
+++ b/flink/flink-scala-parent/pom.xml
@@ -751,6 +751,7 @@
             <arg>-unchecked</arg>
             <arg>-deprecation</arg>
             <arg>-feature</arg>
+            <arg>-nobootcp</arg>
           </args>
           <jvmArgs>
             <jvmArg>-Xms1024m</jvmArg>

--- a/flink/flink-scala-parent/pom.xml
+++ b/flink/flink-scala-parent/pom.xml
@@ -405,6 +405,10 @@
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/flink/flink1.12-shims/pom.xml
+++ b/flink/flink1.12-shims/pom.xml
@@ -176,7 +176,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
-                        <arg>-target:jvm-1.8</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/flink/flink1.13-shims/pom.xml
+++ b/flink/flink1.13-shims/pom.xml
@@ -178,7 +178,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
-                        <arg>-target:jvm-1.8</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/flink/flink1.14-shims/pom.xml
+++ b/flink/flink1.14-shims/pom.xml
@@ -171,7 +171,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
-                        <arg>-target:jvm-1.8</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/flink/flink1.15-shims/pom.xml
+++ b/flink/flink1.15-shims/pom.xml
@@ -165,7 +165,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
-                        <arg>-target:jvm-1.8</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -166,6 +166,10 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 
   <properties>
     <!-- language versions -->
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <scala.2.10.version>2.10.7</scala.2.10.version>
     <scala.version>${scala.2.10.version}</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
@@ -107,7 +107,7 @@
     <!-- frontend maven plugin related versions-->
     <node.version>v12.3.1</node.version>
     <npm.version>6.9.0</npm.version>
-    <plugin.frontend.version>1.6</plugin.frontend.version>
+    <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->
     <slf4j.version>1.7.30</slf4j.version>
@@ -1903,16 +1903,16 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>scala-2.10</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <scala.version>${scala.2.10.version}</scala.version>
-        <scala.binary.version>2.10</scala.binary.version>
-      </properties>
-    </profile>
+<!--    <profile>-->
+<!--      <id>scala-2.10</id>-->
+<!--      <activation>-->
+<!--        <activeByDefault>true</activeByDefault>-->
+<!--      </activation>-->
+<!--      <properties>-->
+<!--        <scala.version>${scala.2.10.version}</scala.version>-->
+<!--        <scala.binary.version>2.10</scala.binary.version>-->
+<!--      </properties>-->
+<!--    </profile>-->
 
     <profile>
       <id>scala-2.11</id>

--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,10 @@
   <properties>
     <!-- language versions -->
     <java.version>1.8</java.version>
-    <scala.2.10.version>2.10.5</scala.2.10.version>
+    <scala.2.10.version>2.10.7</scala.2.10.version>
     <scala.version>${scala.2.10.version}</scala.version>
     <scala.binary.version>2.10</scala.binary.version>
-    <scala.2.11.version>2.11.8</scala.2.11.version>
+    <scala.2.11.version>2.11.12</scala.2.11.version>
     <scalatest.version>3.0.7</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -114,6 +114,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -180,6 +180,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>

--- a/spark/spark-shims/pom.xml
+++ b/spark/spark-shims/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <scala.version>${spark.2.11.version}</scala.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
### What is this PR for?

Upgrade java version to 11. 
Recently, lots of newest languages and framework decide not to support JDK 8. 
This is a draft PR. If you build Zeppelin using $ ./mvnw clean package -DskipTests -Phadoop2, you can see that build is success, but if you try to run Zeppelin, there's some error in process and dead.

error message
`Exception in thread "main" MultiException stack 1 of 2
java.io.IOException: Failed to create new IndexWriter
	at org.apache.zeppelin.search.LuceneSearch.<init>(LuceneSearch.java:104)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.glassfish.hk2.utilities.reflection.ReflectionHelper.makeMe(ReflectionHelper.java:1356)
	at org.jvnet.hk2.internal.ClazzCreator.createMe(ClazzCreator.java:248)
	at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:342)
	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:463)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:59)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:47)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture$1.call(Cache.java:74)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture.run(Cache.java:131)
	at org.glassfish.hk2.utilities.cache.Cache.compute(Cache.java:176)
	at org.jvnet.hk2.internal.SingletonContext.findOrCreate(SingletonContext.java:98)
	at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2102)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:93)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:67)
	at org.glassfish.hk2.utilities.ServiceLocatorUtilities.getService(ServiceLocatorUtilities.java:669)
	at org.apache.zeppelin.server.ZeppelinServer.main(ZeppelinServer.java:259)
Caused by: org.apache.lucene.store.LockObtainFailedException: Lock held by another program: /private/tmp/zeppelin-index/write.lock
	at org.apache.lucene.store.NativeFSLockFactory.obtainFSLock(NativeFSLockFactory.java:130)
	at org.apache.lucene.store.FSLockFactory.obtainLock(FSLockFactory.java:41)
	at org.apache.lucene.store.BaseDirectory.obtainLock(BaseDirectory.java:45)
	at org.apache.lucene.index.IndexWriter.<init>(IndexWriter.java:923)
	at org.apache.zeppelin.search.LuceneSearch.<init>(LuceneSearch.java:102)
	... 20 more
MultiException stack 2 of 2
java.lang.IllegalStateException: Unable to perform operation: create on org.apache.zeppelin.search.LuceneSearch
	at org.jvnet.hk2.internal.ClazzCreator.create(ClazzCreator.java:369)
	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:463)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:59)
	at org.jvnet.hk2.internal.SingletonContext$1.compute(SingletonContext.java:47)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture$1.call(Cache.java:74)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.glassfish.hk2.utilities.cache.Cache$OriginThreadAwareFuture.run(Cache.java:131)
	at org.glassfish.hk2.utilities.cache.Cache.compute(Cache.java:176)
	at org.jvnet.hk2.internal.SingletonContext.findOrCreate(SingletonContext.java:98)
	at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2102)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:93)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:67)
	at org.glassfish.hk2.utilities.ServiceLocatorUtilities.getService(ServiceLocatorUtilities.java:669)
	at org.apache.zeppelin.server.ZeppelinServer.main(ZeppelinServer.java:259)`

`ZEPPELIN_CLASSPATH: :/Users/will/Develop/zeppelin_11/zeppelin/zeppelin-server/target/lib/*:/Users/will/Develop/zeppelin_11/zeppelin/zeppelin-zengine/target/lib/*:/Users/will/Develop/zeppelin_11/zeppelin/*::/Users/will/Develop/zeppelin_11/zeppelin/conf:/Users/will/Develop/zeppelin_11/zeppelin/zeppelin-interpreter/target/classes:/Users/will/Develop/zeppelin_11/zeppelin/zeppelin-zengine/target/classes:/Users/will/Develop/zeppelin_11/zeppelin/zeppelin-server/target/classes
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/apache/zeppelin/server/ZeppelinServer has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)`

### What type of PR is it?
Improvement

### Todos
* [x] - Change/Remove/Add Dependency which supports Java 11
* [ ] - Fix the error during running Zeppelin. 

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5821

### How should this be tested?
CI and maybe we have to add more CI

### Questions:
* Does the licenses files need to update? Yes
* Is there breaking changes for older versions? Yes
* Does this needs documentation? Yes
