### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -25,6 +25,9 @@ defaults:
   run:
     shell: bash -l {0}
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   # test on core-modules (zeppelin-interpreter,zeppelin-zengine,zeppelin-server),
   # some interpreters are included, because zeppelin-server test depends on them: spark, shell & markdown

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,6 +21,9 @@ env:
   ZEPPELIN_LOCAL_IP: 127.0.0.1
   INTERPRETERS: '!hbase,!jdbc,!file,!flink,!cassandra,!elasticsearch,!bigquery,!alluxio,!livy,!groovy,!java,!neo4j,!submarine,!sparql,!mongodb'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   run-e2e-tests-in-zeppelin-web:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.