### PR TITLE
Update protobuf-maven-plugin from 0.5.0 to 0.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
     <plugin.jdeb.version>1.8</plugin.jdeb.version>
     <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
-    <plugin.protobuf.version>0.5.0</plugin.protobuf.version>
+    <plugin.protobuf.version>0.6.1</plugin.protobuf.version>
     <plugin.rat.version>0.13</plugin.rat.version>
     <plugin.remote.resource.version>1.7.0</plugin.remote.resource.version>
     <plugin.resource.version>3.1.0</plugin.resource.version>


### PR DESCRIPTION
### What is this PR for?

Update the protobuf plugin to a version that, among other things, no longer overwrites the protoc compiler executable each time the project is built, which is convenient on systems where it needs some post-processing (current NixOS).

### What type of PR is it?
Improvement
