### PR TITLE
update livy archive name

### DIFF
--- a/testing/downloadLivy.sh
+++ b/testing/downloadLivy.sh
@@ -49,7 +49,7 @@ download_with_retry() {
 }
 
 LIVY_CACHE=".livy-dist"
-LIVY_ARCHIVE="livy-${LIVY_VERSION}-bin"
+LIVY_ARCHIVE="apache-livy-${LIVY_VERSION}-bin"
 export LIVY_HOME="${ZEPPELIN_HOME}/livy-server-$LIVY_VERSION"
 echo "LIVY_HOME is ${LIVY_HOME}"
 


### PR DESCRIPTION
### What is this PR for?

Fix the download script so it can correctly download with livy 0.6.0 and later

### What type of PR is it?
Bug Fix

### How should this be tested?

The `livy-0-7-with-spark-2-2-0-under-python3` GitHub Actions workflow uses this script, so we should be able to see that this doesn't fail to download livy anymore.