### PR TITLE
Upgrade gson to 2.8.9 due to CVE-2022-25647

### DIFF
--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -39,7 +39,6 @@
 
     <!-- library versions -->
     <bigquery.api.version>v2-rev20190917-1.30.3</bigquery.api.version>
-    <gson.version>2.8.9</gson.version>
     <guava.version>24.1.1-jre</guava.version>
 
     <interpreter.name>bigquery</interpreter.name>

--- a/influxdb/pom.xml
+++ b/influxdb/pom.xml
@@ -37,7 +37,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <influxdb.client.version>1.7.0</influxdb.client.version>
         <dependency.okhttp3.version>3.13.1</dependency.okhttp3.version>
-        <dependency.gson.version>2.8.9</dependency.gson.version>
     </properties>
 
     <dependencies>
@@ -49,7 +48,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>${dependency.gson.version}</version>
+            <version>${gson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <log4j.version>1.2.17</log4j.version>
     <libthrift.version>0.13.0</libthrift.version>
     <flexmark.all.version>0.62.2</flexmark.all.version>
-    <gson.version>2.8.6</gson.version>
+    <gson.version>2.8.9</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -38,7 +38,6 @@
     <pty4j.version>0.9.3</pty4j.version>
     <jinjava.version>2.4.0</jinjava.version>
     <guava.version>24.1.1-jre</guava.version>
-    <gson.version>2.8.9</gson.version>
   </properties>
 
   <!-- pty4j library not in maven central repository (http://repo.maven.apache.org/maven2) -->

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -1,7 +1,7 @@
 The following components are provided under Apache License.
 
     (Apache 2.0) nvd3.js v1.7.1 (http://nvd3.org/) - https://github.com/novus/nvd3/blob/v1.7.1/LICENSE.md
-    (Apache 2.0) gson v2.2 (com.google.code.gson:gson:jar:2.2 - https://github.com/google/gson) - https://github.com/google/gson/blob/gson-2.2/LICENSE
+    (Apache 2.0) gson v2.8.9 (com.google.code.gson:gson:jar:2.8.9 - https://github.com/google/gson) - https://github.com/google/gson/blob/gson-parent-2.8.9/LICENSE
     (Apache 2.0) Amazon Web Services SDK for Java v1.11.736 (https://aws.amazon.com/sdk-for-java/) - https://raw.githubusercontent.com/aws/aws-sdk-java/1.11.736/LICENSE.txt
     (Apache 2.0) JavaEWAH v0.7.9 (https://github.com/lemire/javaewah) - https://github.com/lemire/javaewah/blob/master/LICENSE-2.0.txt
     (Apache 2.0) Apache Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/proper/commons-logging/)

--- a/zeppelin-distribution/src/bin_license/licenses/LICENSE-gson-2.8.9
+++ b/zeppelin-distribution/src/bin_license/licenses/LICENSE-gson-2.8.9
@@ -1,4 +1,3 @@
-Google Gson
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +187,7 @@ Google Gson
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2008-2011 Google Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/zeppelin-integration/pom.xml
+++ b/zeppelin-integration/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.9</version>
+      <version>${gson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
### What is this PR for?
Upgrade gson to 2.8.9 due to CVE-2022-25647
The version of gson  is 2.8.6 in parent POM. And the LICENESE should be updated too.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-5829

### How should this be tested?
CI passed

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
