### PR TITLE
fix(sec): upgrade org.codehaus.groovy:groovy-all to 2.4.8

### DIFF
--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -14,10 +14,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -40,7 +37,7 @@
     <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.4.7</version>
+        <version>2.4.8</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.codehaus.groovy:groovy-all 2.4.7
- [CVE-2016-6814](https://www.oscs1024.com/hd/CVE-2016-6814)


### What did I do？
Upgrade org.codehaus.groovy:groovy-all from 2.4.7 to 2.4.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS