### PR TITLE
[ZEPPELIN-5832] Use protoc-jar-maven-plugin, which has a good IDE support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
     <plugin.jdeb.version>1.8</plugin.jdeb.version>
     <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
-    <plugin.protobuf.version>0.6.1</plugin.protobuf.version>
+    <plugin.protobuf.version>3.11.4</plugin.protobuf.version>
     <plugin.rat.version>0.13</plugin.rat.version>
     <plugin.remote.resource.version>1.7.0</plugin.remote.resource.version>
     <plugin.resource.version>3.1.0</plugin.resource.version>
@@ -1765,8 +1765,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
         <version>${plugin.protobuf.version}</version>
       </plugin>
 

--- a/zeppelin-jupyter-interpreter/pom.xml
+++ b/zeppelin-jupyter-interpreter/pom.xml
@@ -123,25 +123,35 @@
     </extensions>
 
     <plugins>
-
       <plugin>
-        <groupId>org.xolstice.maven.plugins</groupId>
-        <artifactId>protobuf-maven-plugin</artifactId>
-        <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
-          <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-        </configuration>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
         <executions>
           <execution>
+            <phase>generate-sources</phase>
             <goals>
-              <goal>compile</goal>
-              <goal>compile-custom</goal>
+              <goal>run</goal>
             </goals>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:${protoc.version}</protocArtifact>
+              <inputDirectories>
+                <include>src/main/proto</include>
+              </inputDirectories>
+              <outputTargets>
+                <outputTarget>
+                  <type>java</type>
+                  <outputDirectorySuffix>protobuf</outputDirectorySuffix>
+                </outputTarget>
+                <outputTarget>
+                  <type>grpc-java</type>
+                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</pluginArtifact>
+                  <outputDirectorySuffix>protobuf</outputDirectorySuffix>
+                </outputTarget>
+              </outputTargets>
+            </configuration>
           </execution>
         </executions>
       </plugin>
-
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>


### PR DESCRIPTION
### What is this PR for?
This PR changes the plugin to compile the proto files. The Eclipse IDE support is very good and it works immediately after integration.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5832

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
