### PR TITLE
[ZEPPELIN-5834] Remove last references to Hadoop 2.6 as JDK11 is not supported.

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -34,7 +34,7 @@
     <!--library versions-->
     <interpreter.name>hbase</interpreter.name>
     <hbase.hbase.version>2.4.12</hbase.hbase.version>
-    <hbase.hadoop.version>${hadoop2.6.version}</hbase.hadoop.version>
+    <hbase.hadoop.version>${hadoop2.7.version}</hbase.hadoop.version>
     <jruby.version>1.6.8</jruby.version>
     <protobuf.version>2.5.0</protobuf.version>
     <jline.version>2.12.1</jline.version>

--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -41,7 +41,7 @@
         <!--test library versions-->
         <livy.version>0.7.1-incubating</livy.version>
         <spark.version>2.1.0</spark.version>
-        <hadoop.version>${hadoop2.6.version}</hadoop.version>
+        <hadoop.version>${hadoop2.7.version}</hadoop.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
     <micrometer.version>1.6.0</micrometer.version>
 
     <hadoop2.7.version>2.7.7</hadoop2.7.version>
-    <hadoop2.6.version>2.6.5</hadoop2.6.version>
     <hadoop3.0.version>3.0.3</hadoop3.0.version>
     <hadoop3.1.version>3.1.3</hadoop3.1.version>
     <hadoop3.2.version>3.2.0</hadoop3.2.version>


### PR DESCRIPTION
### What is this PR for?
This PR updates Hadoop 2.6 dependencies to 2.7.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5834

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
