### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-yarn-common to 2.7.3

### DIFF
--- a/flink/flink-scala-parent/pom.xml
+++ b/flink/flink-scala-parent/pom.xml
@@ -37,7 +37,7 @@
     <!--library versions-->
     <interpreter.name>flink</interpreter.name>
     <flink.version>${flink1.12.version}</flink.version>
-    <flink.hadoop.version>2.6.5</flink.hadoop.version>
+    <flink.hadoop.version>2.7.3</flink.hadoop.version>
     <hive.version>2.3.4</hive.version>
     <hiverunner.version>4.0.0</hiverunner.version>
     <grpc.version>1.15.0</grpc.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-yarn-common 2.6.5
- [MPS-2022-12308](https://www.oscs1024.com/hd/MPS-2022-12308)


### What did I do？
Upgrade org.apache.hadoop:hadoop-yarn-common from 2.6.5 to 2.7.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS