### PR TITLE
fix(sec): upgrade org.jetbrains.kotlin:kotlin-stdlib to 1.6.0

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <interpreter.name>kotlin</interpreter.name>
-        <kotlin.version>1.3.50</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.jetbrains.kotlin:kotlin-stdlib 1.3.50
- [CVE-2022-24329](https://www.oscs1024.com/hd/CVE-2022-24329)
- [CVE-2020-29582](https://www.oscs1024.com/hd/CVE-2020-29582)


### What did I do？
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.3.50 to 1.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS