### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 4.3.29.RELEASE

### DIFF
--- a/livy/pom.xml
+++ b/livy/pom.xml
@@ -35,7 +35,7 @@
         <!--library versions-->
         <interpreter.name>livy</interpreter.name>
         <commons.exec.version>1.3</commons.exec.version>
-        <spring.web.version>4.3.0.RELEASE</spring.web.version>
+        <spring.web.version>4.3.29.RELEASE</spring.web.version>
         <spring.security.kerberosclient>1.0.1.RELEASE</spring.security.kerberosclient>
 
         <!--test library versions-->


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in org.springframework:spring-web 4.3.0.RELEASE
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)
- [CVE-2018-15756](https://www.oscs1024.com/hd/CVE-2018-15756)
- [CVE-2018-11039](https://www.oscs1024.com/hd/CVE-2018-11039)
- [CVE-2018-11040](https://www.oscs1024.com/hd/CVE-2018-11040)


### What did I do？
Upgrade org.springframework:spring-web from 4.3.0.RELEASE to 4.3.29.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS