### PR TITLE
[ZEPPELIN-5763] NoClassDefFoundError in spark interpreter: org/apache/commons/lang/StringUtils

### DIFF
--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -217,6 +217,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/AbstractSparkScalaInterpreter.java
@@ -18,7 +18,7 @@
 package org.apache.zeppelin.spark;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/spark/spark2-shims/src/main/java/org/apache/zeppelin/spark/Spark2Shims.java
+++ b/spark/spark2-shims/src/main/java/org/apache/zeppelin/spark/Spark2Shims.java
@@ -18,7 +18,7 @@
 
 package org.apache.zeppelin.spark;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListener;
 import org.apache.spark.scheduler.SparkListenerJobStart;

--- a/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
+++ b/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
@@ -18,7 +18,7 @@
 
 package org.apache.zeppelin.spark;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.SparkContext;
 import org.apache.spark.scheduler.SparkListener;
 import org.apache.spark.scheduler.SparkListenerJobStart;


### PR DESCRIPTION
### What is this PR for?

Fix it by using `commons-lang3` instead of `commons-lang`

### What type of PR is it?
Bug Fix


### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5763

### How should this be tested?
* Manually tested

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? NO
