### PR TITLE
fix(sec): upgrade org.apache.jena:jena-arq to 4.2.0

### DIFF
--- a/sparql/pom.xml
+++ b/sparql/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <interpreter.name>sparql</interpreter.name>
-        <jena.version>3.12.0</jena.version>
+        <jena.version>4.2.0</jena.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.jena:jena-arq 3.12.0
- [CVE-2021-39239](https://www.oscs1024.com/hd/CVE-2021-39239)


### What did I do？
Upgrade org.apache.jena:jena-arq from 3.12.0 to 4.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS