### PR TITLE
[MINOR] Remove warnning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1697,60 +1697,7 @@
           <version>${plugin.antrun.version}</version>
         </plugin>
 
-        <!--This plugin's configuration is used to store Eclipse m2e settings
-          only. It has no influence on the Maven build itself. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>${plugin.lifecycle.mapping.version}</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>
-                      org.apache.maven.plugins
-                    </groupId>
-                    <artifactId>
-                      maven-dependency-plugin
-                    </artifactId>
-                    <versionRange>
-                      [2.8,)
-                    </versionRange>
-                    <goals>
-                      <goal>copy-dependencies</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore/>
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>
-                      org.apache.maven.plugins
-                    </groupId>
-                    <artifactId>
-                      maven-checkstyle-plugin
-                    </artifactId>
-                    <versionRange>
-                      [2.13,)
-                    </versionRange>
-                    <goals>
-                      <goal>checkstyle</goal>
-                      <goal>check</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore></ignore>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-
-        <plugin>
+       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-eclipse-plugin</artifactId>
           <version>${plugin.eclipse.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1697,7 +1697,7 @@
           <version>${plugin.antrun.version}</version>
         </plugin>
 
-       <plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-eclipse-plugin</artifactId>
           <version>${plugin.eclipse.version}</version>


### PR DESCRIPTION
### What is this PR for?
Remove outdated maven plugin setting.

I saw some warnings when I check some maven logs.
```
[WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
[WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of central has elapsed or updates are forced
```

I tried to find the package in maven central but couldn't find it and reached a description of https://www.eclipse.org/m2e/documentation/m2e-making-maven-plugins-compat.html. This link shows that the setting is only for maven plugin developers. I don't know the initial motivation for the plugin because it's added in 2013 and I didn't contribute to Zeppelin at that time. I, however, feel like we don't need it for now because the description indicates it's only for plugin developers.

### What type of PR is it?
Improvement

### Todos
* [x] - Remvoe plugin

### What is the Jira issue?
N/A

### How should this be tested?
Nothing should change

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
