### PR TITLE
[ZEPPELIN-5830] Zeppelin Security page header styling

### DIFF
--- a/assets/themes/zeppelin/css/style.css
+++ b/assets/themes/zeppelin/css/style.css
@@ -1117,6 +1117,10 @@ and (max-width: 768px) {
     font-size: 15px;
   }
 
+  .docs .dropdown-menu li.title a {
+    color: white !important;
+  }
+
   .navbar-collapse.in {
     overflow-y: auto;
   }
@@ -1214,6 +1218,10 @@ and (max-width: 996px) {
     font-size: 15px;
   }
 
+  .docs .dropdown-menu li.title a {
+    color: white !important;
+  }
+
   .navbar-inverse .navbar-nav > li > a {
     margin-left: -12px;
     font-size: 15px;
@@ -1298,6 +1306,11 @@ and (max-width: 1024px) {
 
 .docs .dropdown-menu li a {
   padding-left: 30px;
+}
+
+.docs .dropdown-menu li.title a {
+  padding-left: 0px;
+  color: #3071a9;
 }
 
 /*

--- a/security.md
+++ b/security.md
@@ -1,3 +1,24 @@
+---
+layout: page
+title: "Security"
+description: "This page explains what security characteristics can be expected from Zeppelin, what measures operators of a Zeppelin instance will have to take, and how to report any security issues found in the Zeppelin software."
+group:
+---
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+{% include JB/setup %}
+
 # Zeppelin Security
 
 This page explains what security characteristics can be expected from


### PR DESCRIPTION
### What is this PR for?
When creating #4478 I ran into trouble running jekyll so I couldn't test the output.

I have since tested the output and made some updates accordingly. I have also pushed the generated site to https://github.com/raboof/zeppelin-docs.

### What type of PR is it?
Bug Fix
Documentation

### What is the Jira issue?
[ZEPPELIN-5830](https://issues.apache.org/jira/browse/ZEPPELIN-5830)

### How should this be tested?
Use jekyll 3.x to test the documentation generation.

### Screenshots (if appropriate)
![zeppelin-desktop](https://user-images.githubusercontent.com/131856/203592823-63ff8da1-21ae-4b4a-a92f-cffa32c9f38c.png)
![zeppelin-mobile](https://user-images.githubusercontent.com/131856/203592860-07c376b9-55ee-4f9f-ba8f-174581b607a9.png)

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? N/A
