### PR TITLE
[MINOR] Remove `maven-eclipse-plugin`

### DIFF
--- a/flink/flink-scala-parent/pom.xml
+++ b/flink/flink-scala-parent/pom.xml
@@ -821,30 +821,6 @@
         <artifactId>scalatest-maven-plugin</artifactId>
       </plugin>
 
-      <!-- Eclipse Integration -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <configuration>
-          <downloadSources>true</downloadSources>
-          <projectnatures>
-            <projectnature>org.scala-ide.sdt.core.scalanature</projectnature>
-            <projectnature>org.eclipse.jdt.core.javanature</projectnature>
-          </projectnatures>
-          <buildcommands>
-            <buildcommand>org.scala-ide.sdt.core.scalabuilder</buildcommand>
-          </buildcommands>
-          <classpathContainers>
-            <classpathContainer>org.scala-ide.sdt.launching.SCALA_CONTAINER</classpathContainer>
-            <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER</classpathContainer>
-          </classpathContainers>
-          <sourceIncludes>
-            <sourceInclude>**/*.scala</sourceInclude>
-            <sourceInclude>**/*.java</sourceInclude>
-          </sourceIncludes>
-        </configuration>
-      </plugin>
-
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,6 @@
     <plugin.dependency.version>3.1.2</plugin.dependency.version>
     <plugin.deploy.version>2.8.2</plugin.deploy.version>
     <plugin.download.version>1.6.0</plugin.download.version>
-    <plugin.eclipse.version>2.8</plugin.eclipse.version>
     <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
     <plugin.exec.version>1.6.0</plugin.exec.version>
     <plugin.failsafe.version>2.17</plugin.failsafe.version>
@@ -1635,12 +1634,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>${plugin.antrun.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-eclipse-plugin</artifactId>
-          <version>${plugin.eclipse.version}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
### What is this PR for?
Remove the elicpse-related maven plugin which was retired 7 years ago.


### What type of PR is it?
Improvement

### Todos
* [x] - Remove `maven-eclipse-plugin`

### What is the Jira issue?
N/A

### How should this be tested?
Already been tested by some contributors
<img width="1614" alt="image" src="https://user-images.githubusercontent.com/3612566/204132002-ba8a1e56-fade-4d12-b119-cbc15ec7bb7b.png">
<img width="766" alt="image" src="https://user-images.githubusercontent.com/3612566/204132011-c56ef46b-531d-4b62-a47b-87ade799bfdc.png">

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
