### PR TITLE
[ZEPPELIN-5855] Refactor docker plugin and remove powermock

### DIFF
--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -88,7 +88,7 @@ access to this port.
  Set to the same time zone as the zeppelin server, keeping the time zone in the interpreter docker container the same as the server. E.g, `"America/New_York"` or `"Asia/Shanghai"`
 
  ```bash
- export DOCKER_TIME_ZONE="America/New_York"
+ export ZEPPELIN_DOCKER_TIME_ZONE="America/New_York"
  ```
 
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -1086,7 +1087,13 @@ public class ZeppelinConfiguration {
     ZEPPELIN_K8S_SERVICE_NAME("zeppelin.k8s.service.name", "zeppelin-server"),
     ZEPPELIN_K8S_TIMEOUT_DURING_PENDING("zeppelin.k8s.timeout.during.pending", true),
 
+    // Used by K8s and Docker plugin
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
+
+    ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME("zeppelin.docker.container.spark.home", "/spark"),
+    ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER("zeppelin.docker.upload.local.lib.to.container", true),
+    ZEPPELIN_DOCKER_HOST("zeppelin.docker.host", "http://0.0.0.0:2375"),
+    ZEPPELIN_DOCKER_TIME_ZONE("zeppelin.docker.time.zone", TimeZone.getDefault().getID()),
 
     ZEPPELIN_METRIC_ENABLE_PROMETHEUS("zeppelin.metric.enable.prometheus", false),
 

--- a/zeppelin-plugins/launcher/docker/pom.xml
+++ b/zeppelin-plugins/launcher/docker/pom.xml
@@ -61,14 +61,6 @@
       <artifactId>commons-compress</artifactId>
       <version>${commons.compress.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -24,12 +24,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketException;
 import java.net.URI;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -37,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.spotify.docker.client.DefaultDockerClient;
@@ -56,6 +54,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.interpreter.launcher.utils.TarFileEntry;
 import org.apache.zeppelin.interpreter.launcher.utils.TarUtils;
 import org.apache.zeppelin.interpreter.remote.RemoteInterpreterProcess;
@@ -67,7 +66,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars.ZEPPELIN_SERVER_KERBEROS_KEYTAB;
 
 public class DockerInterpreterProcess extends RemoteInterpreterProcess {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DockerInterpreterLauncher.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DockerInterpreterProcess.class);
 
   private String dockerIntpServicePort = "0";
 
@@ -99,13 +98,12 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   private String zeppelinHome;
 
   @VisibleForTesting
-  final String CONTAINER_SPARK_HOME;
+  final String containerSparkHome;
 
   @VisibleForTesting
-  final String DOCKER_HOST;
+  final String dockerHost;
 
-  private String containerId;
-  final String CONTAINER_UPLOAD_TAR_DIR = "/tmp/zeppelin-tar";
+  private static final String CONTAINER_UPLOAD_TAR_DIR = "/tmp/zeppelin-tar";
 
   public DockerInterpreterProcess(
       ZeppelinConfiguration zconf,
@@ -127,27 +125,20 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     this.interpreterGroupName = interpreterGroupName;
     this.interpreterSettingName = interpreterSettingName;
     this.properties = properties;
-    this.envs = new HashMap(envs);
+    this.envs = new HashMap<>(envs);
 
     this.zconf = zconf;
     this.containerName = interpreterGroupId.toLowerCase();
 
-    String sparkHome = System.getenv("CONTAINER_SPARK_HOME");
-    CONTAINER_SPARK_HOME = (sparkHome == null) ?  "/spark" : sparkHome;
-
-    String uploadLocalLib = System.getenv("UPLOAD_LOCAL_LIB_TO_CONTAINTER");
-    if (null != uploadLocalLib && StringUtils.equals(uploadLocalLib, "false")) {
-      uploadLocalLibToContainter = false;
-    }
+    containerSparkHome = zconf.getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME);
+    uploadLocalLibToContainter = zconf.getBoolean(ConfVars.ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER);
 
     try {
       this.zeppelinHome = getZeppelinHome();
     } catch (IOException e) {
       LOGGER.error(e.getMessage(), e);
     }
-    String defDockerHost = "http://0.0.0.0:2375";
-    String dockerHost = System.getenv("DOCKER_HOST");
-    DOCKER_HOST = (dockerHost == null) ?  defDockerHost : dockerHost;
+    dockerHost = zconf.getString(ConfVars.ZEPPELIN_DOCKER_HOST);
   }
 
   @Override
@@ -162,7 +153,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
   @Override
   public void start(String userName) throws IOException {
-    docker = DefaultDockerClient.builder().uri(URI.create(DOCKER_HOST)).build();
+    docker = DefaultDockerClient.builder().uri(URI.create(dockerHost)).build();
 
     removeExistContainer(containerName);
 
@@ -229,7 +220,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
       final ContainerCreation containerCreation
           = docker.createContainer(containerConfig, containerName);
-      this.containerId = containerCreation.id();
+      String containerId = containerCreation.id();
 
       // Start container
       docker.startContainer(containerId);
@@ -242,6 +233,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       throw new IOException(e.getMessage());
     } catch (InterruptedException e) {
       LOGGER.error(e.getMessage(), e);
+      // Restore interrupted state...
+      Thread.currentThread().interrupt();
       throw new IOException(e.getMessage());
     }
 
@@ -249,11 +242,13 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
     // wait until interpreter send dockerStarted message through thrift rpc
     synchronized (dockerStarted) {
-      if (!dockerStarted.get()) {
+      while (!dockerStarted.get()) {
         try {
           dockerStarted.wait(getConnectTimeout());
         } catch (InterruptedException e) {
           LOGGER.error("Remote interpreter is not accessible");
+          // Restore interrupted state...
+          Thread.currentThread().interrupt();
           throw new IOException(e.getMessage());
         }
       }
@@ -273,6 +268,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
           Thread.sleep(1000);
         } catch (InterruptedException e) {
           LOGGER.error(e.getMessage(), e);
+          // Restore interrupted state...
+          Thread.currentThread().interrupt();
         }
       }
     }
@@ -285,12 +282,12 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     LOGGER.info("Interpreter container created {}:{}", containerHost, containerPort);
     synchronized (dockerStarted) {
       dockerStarted.set(true);
-      dockerStarted.notify();
+      dockerStarted.notifyAll();
     }
   }
 
   @VisibleForTesting
-  Properties getTemplateBindings() throws IOException {
+  Properties getTemplateBindings() {
     Properties dockerProperties = new Properties();
 
     // docker template properties
@@ -312,19 +309,15 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   }
 
   @VisibleForTesting
-  List<String> getListEnvs() throws SocketException, UnknownHostException {
+  List<String> getListEnvs() {
     // environment variables
     envs.put("ZEPPELIN_HOME", zeppelinHome);
     envs.put("ZEPPELIN_CONF_DIR", zeppelinHome + "/conf");
     envs.put("ZEPPELIN_FORCE_STOP", "true");
-    envs.put("SPARK_HOME", this.CONTAINER_SPARK_HOME);
+    envs.put("SPARK_HOME", this.containerSparkHome);
 
     // set container time zone
-    String dockerTimeZone = System.getenv("DOCKER_TIME_ZONE");
-    if (StringUtils.isBlank(dockerTimeZone)) {
-      dockerTimeZone = TimeZone.getDefault().getID();
-    }
-    envs.put("TZ", dockerTimeZone);
+    envs.put("TZ", zconf.getString(ConfVars.ZEPPELIN_DOCKER_TIME_ZONE));
 
     List<String> listEnv = new ArrayList<>();
     for (Map.Entry<String, String> entry : this.envs.entrySet()) {
@@ -353,7 +346,11 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
 
       // Remove container
       docker.removeContainer(containerName);
-    } catch (DockerException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      LOGGER.error(e.getMessage(), e);
+      // Restore interrupted state...
+      Thread.currentThread().interrupt();
+    } catch (DockerException e) {
       LOGGER.error(e.getMessage(), e);
     }
 
@@ -379,18 +376,26 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
         }
       }
 
-      if (isExist == true) {
+      if (isExist) {
         LOGGER.info("kill exist container {}", containerName);
         docker.killContainer(containerName);
       }
-    } catch (DockerException | InterruptedException e) {
+    } catch (InterruptedException e) {
+      LOGGER.error(e.getMessage(), e);
+      // Restore interrupted state...
+      Thread.currentThread().interrupt();
+    } catch (DockerException e) {
       LOGGER.error(e.getMessage(), e);
     } finally {
       try {
-        if (isExist == true) {
+        if (isExist) {
           docker.removeContainer(containerName);
         }
-      } catch (DockerException | InterruptedException e) {
+      } catch (InterruptedException e) {
+        LOGGER.error(e.getMessage(), e);
+        // Restore interrupted state...
+        Thread.currentThread().interrupt();
+      } catch (DockerException e) {
         LOGGER.error(e.getMessage(), e);
       }
     }
@@ -479,15 +484,14 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       // 3.5) jdbc interpreter properties keytab file
       intpKeytab = properties.getProperty("zeppelin.jdbc.keytab.location", "");
     }
-    if (!StringUtils.isBlank(intpKeytab) && !copyFiles.containsKey(intpKeytab)) {
+    if (!StringUtils.isBlank(intpKeytab)) {
       LOGGER.info("intpKeytab : {}", intpKeytab);
-      copyFiles.put(intpKeytab, intpKeytab);
+      copyFiles.putIfAbsent(intpKeytab, intpKeytab);
     }
     // 3.6) zeppelin server keytab file
     String zeppelinServerKeytab = zconf.getString(ZEPPELIN_SERVER_KERBEROS_KEYTAB);
-    if (!StringUtils.isBlank(zeppelinServerKeytab)
-        && !copyFiles.containsKey(zeppelinServerKeytab)) {
-      copyFiles.put(zeppelinServerKeytab, zeppelinServerKeytab);
+    if (!StringUtils.isBlank(zeppelinServerKeytab)) {
+      copyFiles.putIfAbsent(zeppelinServerKeytab, zeppelinServerKeytab);
     }
 
     // 4) hadoop conf dir
@@ -499,10 +503,10 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     // 5) spark conf dir
     if (envs.containsKey("SPARK_CONF_DIR")) {
       String sparkConfDir = envs.get("SPARK_CONF_DIR");
-      rmInContainer(containerId, CONTAINER_SPARK_HOME + "/conf");
-      mkdirInContainer(containerId, CONTAINER_SPARK_HOME + "/conf");
-      copyFiles.put(sparkConfDir, CONTAINER_SPARK_HOME + "/conf");
-      envs.put("SPARK_CONF_DIR", CONTAINER_SPARK_HOME + "/conf");
+      rmInContainer(containerId, containerSparkHome + "/conf");
+      mkdirInContainer(containerId, containerSparkHome + "/conf");
+      copyFiles.put(sparkConfDir, containerSparkHome + "/conf");
+      envs.put("SPARK_CONF_DIR", containerSparkHome + "/conf");
     }
 
     if (uploadLocalLibToContainter){
@@ -528,9 +532,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
           FileFilterUtils.suffixFileFilter("jar"), null);
       for (File jarfile : listFiles) {
         String jarfilePath = jarfile.getAbsolutePath();
-        if (!StringUtils.isBlank(jarfilePath)
-            && !copyFiles.containsKey(jarfilePath)) {
-          copyFiles.put(jarfilePath, jarfilePath);
+        if (!StringUtils.isBlank(jarfilePath)) {
+          copyFiles.putIfAbsent(jarfilePath, jarfilePath);
         }
       }
     }
@@ -558,8 +561,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     cpdirInContainer(containerId, CONTAINER_UPLOAD_TAR_DIR + "/*", "/");
 
     // delete tar file in the local
-    File fileTar = new File(tarFile);
-    fileTar.delete();
+    Files.delete(Paths.get(tarFile));
   }
 
   private void mkdirInContainer(String containerId, String path)
@@ -583,7 +585,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   private void execInContainer(String containerId, String execCommand, boolean logout)
       throws DockerException, InterruptedException {
 
-    LOGGER.info("exec container commmand: " + execCommand);
+    LOGGER.info("exec container commmand: {}");
 
     final String[] command = {"sh", "-c", execCommand};
     final ExecCreation execCreation = docker.execCreate(
@@ -622,15 +624,10 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   }
 
   private String getZeppelinHome() throws IOException {
-    String zeppelinHome = zconf.getZeppelinHome();
-    if (System.getenv("ZEPPELIN_HOME") != null) {
-      zeppelinHome = System.getenv("ZEPPELIN_HOME");
-    }
-
     // check zeppelinHome is exist
-    File fileZeppelinHome = new File(zeppelinHome);
+    File fileZeppelinHome = new File(zconf.getZeppelinHome());
     if (fileZeppelinHome.exists() && fileZeppelinHome.isDirectory()) {
-      return zeppelinHome;
+      return zconf.getZeppelinHome();
     }
 
     throw new IOException("Can't find zeppelin home path!");

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -17,36 +17,29 @@
 package org.apache.zeppelin.interpreter.launcher;
 
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.interpreter.InterpreterOption;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({System.class, DockerInterpreterProcess.class})
-@PowerMockIgnore( {"javax.management.*"})
-public class DockerInterpreterProcessTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DockerInterpreterProcessTest.class);
+class DockerInterpreterProcessTest {
 
-  protected static ZeppelinConfiguration zconf = ZeppelinConfiguration.create();
+  protected static ZeppelinConfiguration zconf = spy(ZeppelinConfiguration.create());
 
   @Test
-  public void testCreateIntpProcess() throws IOException {
+  void testCreateIntpProcess() throws IOException {
     DockerInterpreterLauncher launcher
         = new DockerInterpreterLauncher(zconf, null);
     Properties properties = new Properties();
@@ -62,44 +55,42 @@ public class DockerInterpreterProcessTest {
     DockerInterpreterProcess interpreterProcess = (DockerInterpreterProcess) client;
     assertEquals("name", interpreterProcess.getInterpreterSettingName());
 
-    assertEquals(interpreterProcess.CONTAINER_SPARK_HOME, "/spark");
-    assertEquals(interpreterProcess.uploadLocalLibToContainter, true);
-    assertNotEquals(interpreterProcess.DOCKER_HOST, "http://my-docker-host:2375");
+    assertEquals("/spark", interpreterProcess.containerSparkHome);
+    assertTrue(interpreterProcess.uploadLocalLibToContainter);
+    assertNotEquals("http://my-docker-host:2375", interpreterProcess.dockerHost);
   }
 
   @Test
-  public void testEnv() throws IOException {
-    PowerMockito.mockStatic(System.class);
-    PowerMockito.when(System.getenv("CONTAINER_SPARK_HOME")).thenReturn("my-spark-home");
-    PowerMockito.when(System.getenv("UPLOAD_LOCAL_LIB_TO_CONTAINTER")).thenReturn("false");
-    PowerMockito.when(System.getenv("DOCKER_HOST")).thenReturn("http://my-docker-host:2375");
+  void testEnv() throws IOException {
+    when(zconf.getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME)).thenReturn("my-spark-home");
+    when(zconf.getBoolean(ConfVars.ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER)).thenReturn(false);
+    when(zconf.getString(ConfVars.ZEPPELIN_DOCKER_HOST)).thenReturn("http://my-docker-host:2375");
 
     Properties properties = new Properties();
     properties.setProperty(
-        ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
-
+      ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
     HashMap<String, String> envs = new HashMap<String, String>();
     envs.put("MY_ENV1", "V1");
 
-    DockerInterpreterProcess intp = new DockerInterpreterProcess(
-        zconf,
-        "interpreter-container:1.0",
-        "shared_process",
-        "sh",
-        "shell",
-        properties,
-        envs,
-        "zeppelin.server.hostname",
-        12320,
-        5000, 10);
+    DockerInterpreterProcess intp = spy(new DockerInterpreterProcess(
+      zconf,
+      "interpreter-container:1.0",
+      "shared_process",
+      "sh",
+      "shell",
+      properties,
+      envs,
+      "zeppelin.server.hostname",
+      12320,
+      5000, 10));
 
-    assertEquals(intp.CONTAINER_SPARK_HOME, "my-spark-home");
-    assertEquals(intp.uploadLocalLibToContainter, false);
-    assertEquals(intp.DOCKER_HOST, "http://my-docker-host:2375");
+    assertEquals("my-spark-home", intp.containerSparkHome);
+    assertFalse(intp.uploadLocalLibToContainter);
+    assertEquals("http://my-docker-host:2375", intp.dockerHost);
   }
 
   @Test
-  public void testTemplateBindings() throws IOException {
+  void testTemplateBindings() throws IOException {
     Properties properties = new Properties();
     properties.setProperty(
         ZeppelinConfiguration.ConfVars.ZEPPELIN_INTERPRETER_CONNECT_TIMEOUT.getVarName(), "5000");
@@ -120,28 +111,28 @@ public class DockerInterpreterProcessTest {
         5000, 10);
 
     Properties dockerProperties = intp.getTemplateBindings();
-    assertEquals(dockerProperties.size(), 10);
+    assertEquals(10, dockerProperties.size());
 
-    assertTrue(null != dockerProperties.get("CONTAINER_ZEPPELIN_HOME"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.container.image"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.group.id"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.group.name"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.setting.name"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.localRepo"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.rpc.portRange"));
-    assertTrue(null != dockerProperties.get("zeppelin.server.rpc.host"));
-    assertTrue(null != dockerProperties.get("zeppelin.server.rpc.portRange"));
-    assertTrue(null != dockerProperties.get("zeppelin.interpreter.connect.timeout"));
+    assertNotNull(dockerProperties.get("CONTAINER_ZEPPELIN_HOME"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.container.image"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.group.id"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.group.name"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.setting.name"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.localRepo"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.rpc.portRange"));
+    assertNotNull(dockerProperties.get("zeppelin.server.rpc.host"));
+    assertNotNull(dockerProperties.get("zeppelin.server.rpc.portRange"));
+    assertNotNull(dockerProperties.get("zeppelin.interpreter.connect.timeout"));
 
     List<String> listEnvs = intp.getListEnvs();
-    assertEquals(listEnvs.size(), 6);
+    assertEquals(6, listEnvs.size());
     Map<String, String> mapEnv = new HashMap<>();
     for (int i = 0; i < listEnvs.size(); i++) {
       String env = listEnvs.get(i);
       String kv[] = env.split("=");
       mapEnv.put(kv[0], kv[1]);
     }
-    assertEquals(mapEnv.size(), 6);
+    assertEquals(6, mapEnv.size());
     assertTrue(mapEnv.containsKey("ZEPPELIN_HOME"));
     assertTrue(mapEnv.containsKey("ZEPPELIN_CONF_DIR"));
     assertTrue(mapEnv.containsKey("ZEPPELIN_FORCE_STOP"));


### PR DESCRIPTION
### What is this PR for?
[Powermock](https://github.com/powermock/powermock/issues/929) is not supported in JUnit5. We should not be dependent on Powermock. This PR removes the Powermock dependency from the Docker plugin. It also makes some refactoring.

Instead of using environment variables directly, this possibility of configuration is moved to ZeppelinConfiguration. In order not to break the naming scheme in ZeppelinConfiguration, the environment variables that were previously accessed must be changed.

`CONTAINER_SPARK_HOME` -> `ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME`
`UPLOAD_LOCAL_LIB_TO_CONTAINTER` -> `ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER`
`DOCKER_HOST` -> `ZEPPELIN_DOCKER_HOST`
`DOCKER_TIME_ZONE` -> `ZEPPELIN_DOCKER_TIME_ZONE`

Except for DOCKER_TIME_ZONE, I have not found any references in the documentation or other files.

### What type of PR is it?

Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5855

### How should this be tested?
* CI

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No
