### PR TITLE
[MINOR] Add github autolink to ZEPPELIN

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,5 +39,8 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
+  autolink_jira:
+    - ZEPPELIN
+
 notifications:
   jira_options: link label comment


### PR DESCRIPTION
### What is this PR for?
Enable auto link feature to connect with issues.a.o/ZEPPELIN.


### What type of PR is it?
Improvement

### Todos
* [x] - Add `autolink_jira` field to .asf.yaml

### What is the Jira issue?
N/A

### How should this be tested?
Ppl can click the issue number like ZEPPELIN-XXXX

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
