### PR TITLE
[MINOR] Specify branch names for Github action

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -2,9 +2,8 @@ name: core
 
 on:
   push:
-    branches:
-      - master
-      - branch-*
+    ignore-branches:
+      - dependabot/**
   pull_request:
     branches:
       - master

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,11 +1,16 @@
 name: core
+
 on:
   push:
+    branches:
+      - master
+      - branch-*
   pull_request:
     branches:
       - master
       - branch-*
-    types: [opened, synchronize]
+    paths:
+      - !**.md # Ignore documentation contribution
 
 env:
   # Disable keepAlive and pool

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - master
       - branch-*
-    paths:
-      - !**.md # Ignore documentation contribution
 
 env:
   # Disable keepAlive and pool

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,9 +2,8 @@ name: frontend
 
 on:
   push:
-    branches:
-      - master
-      - branch-*
+    ignore-branches:
+      - dependabot/**
   pull_request:
     branches:
       - master

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,11 +1,16 @@
 name: frontend
+
 on:
   push:
+    branches:
+      - master
+      - branch-*
   pull_request:
     branches:
       - master
       - branch-*
-    types: [opened, synchronize]
+    paths:
+      - !**.md # Ignore documentation contribution
 
 env:
   # Disable keepAlive and pool

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - master
       - branch-*
-    paths:
-      - !**.md # Ignore documentation contribution
 
 env:
   # Disable keepAlive and pool

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - master
       - branch-*
-    paths:
-      - !**.md # Ignore documentation contribution
 
 permissions:
   contents: read

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -1,11 +1,16 @@
 name: quick
+
 on:
   push:
+    branches:
+      - master
+      - branch-*
   pull_request:
     branches:
       - master
       - branch-*
-    types: [opened, synchronize]
+    paths:
+      - !**.md # Ignore documentation contribution
 
 permissions:
   contents: read

--- a/.github/workflows/quick.yml
+++ b/.github/workflows/quick.yml
@@ -2,9 +2,8 @@ name: quick
 
 on:
   push:
-    branches:
-      - master
-      - branch-*
+    ignore-branches:
+      - dependabot/**
   pull_request:
     branches:
       - master


### PR DESCRIPTION
### What is this PR for?
Specify the condition to trigger GitHub action when pushing commits. E.g. dependabot's PRs run twice for GitHub action as we allow to run it for all branches in the repository.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add `branches:` information for `push:`

### What is the Jira issue?
N/A

### How should this be tested?
* Check dependabot's PR so that it runs only once for each Github actions

### Questions:
* Does the licenses files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
