### PR TITLE
[ZEPPELIN-5867][JDBC] Exclude hbase-server from hive-jdbc

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -166,6 +166,10 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-server</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
### What is this PR for?

This PR proposes to exclude hbase-server from hive-jdbc, because hive-jdbc does not require that, and the transitive deps of hbase-server cause issue on resolving project in IDEA

<img width="1701" alt="image" src="https://user-images.githubusercontent.com/26535726/206730829-930fbc41-f024-4b4a-81a3-28672e17e6c5.png">


### What type of PR is it?

Bug Fix

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-5867

### How should this be tested?

Existing CI.

### Screenshots (if appropriate)

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/26535726/206730982-0d8db014-62b7-4fce-af34-117c656fdf90.png">


### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
