### PR TITLE
[MINOR] Support aarch for frontend plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <!-- frontend maven plugin related versions-->
     <node.version>v12.3.1</node.version>
     <npm.version>6.9.0</npm.version>
-    <plugin.frontend.version>1.6</plugin.frontend.version>
+    <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->
     <slf4j.version>1.7.30</slf4j.version>

--- a/zeppelin-plugins/notebookrepo/s3/pom.xml
+++ b/zeppelin-plugins/notebookrepo/s3/pom.xml
@@ -34,7 +34,7 @@
     <description>NotebookRepo implementation based on S3</description>
 
     <properties>
-        <aws.sdk.version>1.12.373</aws.sdk.version>
+        <aws.sdk.version>1.12.261</aws.sdk.version>
         <plugin.name>NotebookRepo/S3NotebookRepo</plugin.name>
     </properties>
 

--- a/zeppelin-plugins/notebookrepo/s3/pom.xml
+++ b/zeppelin-plugins/notebookrepo/s3/pom.xml
@@ -34,7 +34,7 @@
     <description>NotebookRepo implementation based on S3</description>
 
     <properties>
-        <aws.sdk.version>1.12.261</aws.sdk.version>
+        <aws.sdk.version>1.12.373</aws.sdk.version>
         <plugin.name>NotebookRepo/S3NotebookRepo</plugin.name>
     </properties>
 

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -39,6 +39,7 @@
     <xml.apis.version>1.4.01</xml.apis.version>
     <commons.vfs2.version>2.6.0</commons.vfs2.version>
     <eclipse.jgit.version>4.5.4.201711221230-r</eclipse.jgit.version>
+    <eirslett.version>1.6</eirslett.version>
   </properties>
 
   <dependencies>
@@ -175,7 +176,7 @@
     <dependency>
       <groupId>com.github.eirslett</groupId>
       <artifactId>frontend-plugin-core</artifactId>
-      <version>${plugin.frontend.version}</version>
+      <version>${eirslett.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -185,6 +185,10 @@
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
### What is this PR for?
Fixing build error when using aarch jdk for mac OS. our version of node doesn't support amd64 arch but the old plugin tries to download arm version.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Update `frontend-maven-plugin`

### What is the Jira issue?
N/A

### How should this be tested?
* Pass to build with arm jdk in macOS

### Screenshots (if appropriate)
<img width="977" alt="image" src="https://user-images.githubusercontent.com/3612566/209925519-a52c9d0a-289c-48a9-91b9-0837687736c6.png">


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No 
* Does this needs documentation? No
