### PR TITLE
fix(sec): upgrade org.codehaus.jettison:jettison to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <hadoop-client-minicluster.artifact>hadoop-client</hadoop-client-minicluster.artifact>
 
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
-    <jettison.version>1.4.0</jettison.version>
+    <jettison.version>1.5.2</jettison.version>
     <jsoup.version>1.13.1</jsoup.version>
     <protoc.version>3.5.0</protoc.version>
     <grpc.version>1.26.0</grpc.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.codehaus.jettison:jettison 1.4.0
- [CVE-2022-40149](https://www.oscs1024.com/hd/CVE-2022-40149)


### What did I do？
Upgrade org.codehaus.jettison:jettison from 1.4.0 to 1.5.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS