### PR TITLE
[MINOR] Disable depeanabot branches for AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,10 @@ version: '0.11.0.{build}'
 
 shallow_clone: true
 
+branches:
+  except:
+    - /dependabot/
+
 platform:
   - x64
 


### PR DESCRIPTION
### What is this PR for?
Disabling to execute AppVeyor jobs for branches for `dependabot`.

### What type of PR is it?
Improvement

### Todos
* [x] - Add `except` settings for `.appveyor.yml`

### What is the Jira issue?
* N/A

### How should this be tested?
* Open `dependabot` issue
* @dependabot rebase
* Check only one appveyor job

### Screenshots (if appropriate)
<img width="873" alt="image" src="https://user-images.githubusercontent.com/3612566/212478964-25146031-40e0-40ce-9e72-1e8e1626fbc2.png">


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
