### PR TITLE
[HOTFIX] Fix CI failure due to sqlalchemy api change

### DIFF
--- a/testing/env_python_3.8_with_R.yml
+++ b/testing/env_python_3.8_with_R.yml
@@ -9,6 +9,7 @@ dependencies:
   - grpcio
   - protobuf
   - pandasql
+  - sqlalchemy=1.4.46
   - ipython
   - ipython_genutils
   - ipykernel


### PR DESCRIPTION
### What is this PR for?

Recently CI is failed due to sqlalchemy api change. This PR enforce the sqlalchemy version to make the CI pass.

### What type of PR is it?

Hot Fix


### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* CI pass

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
