### PR TITLE
Reflect ZEPPELIN-5352 changes in docs

### DIFF
--- a/docs/interpreter/flink.md
+++ b/docs/interpreter/flink.md
@@ -194,7 +194,7 @@ You can also add and set other Flink properties which are not listed in the tabl
   <tr>
     <td>flink.execution.mode</td>
     <td>local</td>
-    <td>Execution mode of Flink, e.g. local | remote | yarn | yarn-application</td>
+    <td>Execution mode of Flink, e.g. local | remote | yarn | yarn-application | kubernetes-application</td>
   </tr>
   <tr>
     <td>flink.execution.remote.host</td>


### PR DESCRIPTION
### What is this PR for?
https://issues.apache.org/jira/browse/ZEPPELIN-5352
Changes made to add support for Flink in k8s mode were not reflected in the interpreter documentation.


### What type of PR is it?
Documentation

### Todos
* [ ] - Review change

### What is the Jira issue?
Not provided because public signup is disabled

### How should this be tested?
Manual review

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? Yes, support for 'kubernetes-application' >= 0.10.1
* Does this needs documentation? No
