### PR TITLE
[ZEPPELIN-5881] Missing dependency when package zeppelin-server module

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -531,6 +531,7 @@
       </activation>
       <properties>
         <hadoop.version>${hadoop3.2.version}</hadoop.version>
+        <hadoop-client-api.artifact>hadoop-client-api</hadoop-client-api.artifact>
         <hadoop-client-runtime.artifact>hadoop-client-runtime</hadoop-client-runtime.artifact>
       </properties>
 


### PR DESCRIPTION
### What is this PR for?
Fixed maven build failed on module `zeppelin-server` with profile `hadoop3`.

### What type of PR is it?
Bug Fix

### Todos
* [ ] Run maven build after fixed

### What is the Jira issue?
* ZEPPELIN-5881

### How should this be tested?
* Try to build module zeppelin-server by command
`./mvnw -B -pl 'zeppelin-server,zeppelin-zengine,zeppelin-common,zeppelin-interpreter,zeppelin-jupyter' clean package -DskipTests -Pbuild-distr -Pinclude-hadoop -Phadoop3 -Pweb-angular`
