### PR TITLE
[ZEPPELIN-5888] Upgrade sparql version to 3.17.0

### DIFF
--- a/sparql/pom.xml
+++ b/sparql/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <interpreter.name>sparql</interpreter.name>
-        <jena.version>3.12.0</jena.version>
+        <jena.version>3.17.0</jena.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What is this PR for?
Zeppelin Interpreter Support SPARQL From 3.12.0 To 3.17.0

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5888

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
