### PR TITLE
[ZEPPELIN-5893] NPE in ParagraphResult when getting progress from paragraphJson

### DIFF
--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
@@ -45,7 +45,9 @@ public class ParagraphResult {
   public ParagraphResult(JSONObject paragraphJson) {
     this.paragraphId = paragraphJson.getString("id");
     this.status = Status.valueOf(paragraphJson.getString("status"));
-    this.progress = paragraphJson.getInt("progress");
+    if (paragraphJson.has("progress")) {
+			this.progress = paragraphJson.getInt("progress");
+		}
     this.results = new ArrayList<>();
     if (paragraphJson.has("results")) {
       JSONObject resultJson = paragraphJson.getJSONObject("results");

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
@@ -46,8 +46,8 @@ public class ParagraphResult {
     this.paragraphId = paragraphJson.getString("id");
     this.status = Status.valueOf(paragraphJson.getString("status"));
     if (paragraphJson.has("progress")) {
-			this.progress = paragraphJson.getInt("progress");
-		}
+    this.progress = paragraphJson.getInt("progress");
+    }
     this.results = new ArrayList<>();
     if (paragraphJson.has("results")) {
       JSONObject resultJson = paragraphJson.getJSONObject("results");

--- a/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
+++ b/zeppelin-client/src/main/java/org/apache/zeppelin/client/ParagraphResult.java
@@ -46,7 +46,7 @@ public class ParagraphResult {
     this.paragraphId = paragraphJson.getString("id");
     this.status = Status.valueOf(paragraphJson.getString("status"));
     if (paragraphJson.has("progress")) {
-    this.progress = paragraphJson.getInt("progress");
+      this.progress = paragraphJson.getInt("progress");
     }
     this.results = new ArrayList<>();
     if (paragraphJson.has("results")) {


### PR DESCRIPTION
### What is this PR for?

use ZeppelinClient  Example:
 ```
public class ZeppelinTest {
	public static void main(String[] args) throws Exception {
		ClientConfig clientConfig = new ClientConfig("http://ip:8080");
		ZeppelinClient zClient = new ZeppelinClient(clientConfig);
		String zeppelinVersion = zClient.getVersion();
		System.out.println("Zeppelin version: " + zeppelinVersion);
		// execute note 2A94M5J1Z paragraph by paragraph
		try {
			//ParagraphResult paragraphResult = zClient.executeParagraph("2HXQ8YRYN", "20230330-101251_25695257");
			ParagraphResult paragraphResult = zClient.executeParagraph("2HXQ8YRYN","20230330-101251_25695257");
			System.out.println("Execute the 1st spark tutorial paragraph, paragraph result: " + paragraphResult);
			System.out.println("Execute the 4th spark tutorial paragraph, paragraph result: " + paragraphResult);
		} finally {
			// you need to stop interpreter explicitly if you are running paragraph
			// separately.
			//zClient.stopInterpreter("2A94M5J1Z", "spark");
		}
	}
}
 ```
exception:
 ```
kong.unirest.json.JSONException: JSONObject["progress"] not found.
	at kong.unirest.json.JSONObject.getProperty(JSONObject.java:954)
	at kong.unirest.json.JSONObject.lambda$getInt$11(JSONObject.java:485)
	at kong.unirest.json.JSONObject.tryNumber(JSONObject.java:961)
	at kong.unirest.json.JSONObject.getInt(JSONObject.java:485)
	at org.apache.zeppelin.client.ParagraphResult.<init>(ParagraphResult.java:48)
	at org.apache.zeppelin.client.ZeppelinClient.queryParagraphResult(ZeppelinClient.java:782)
	at org.apache.zeppelin.client.ZeppelinClient.submitParagraph(ZeppelinClient.java:676)
	at org.apache.zeppelin.client.ZeppelinClient.executeParagraph(ZeppelinClient.java:602)
	at org.apache.zeppelin.client.ZeppelinClient.executeParagraph(ZeppelinClient.java:618)
	at org.apache.dolphinscheduler.plugin.task.zeppelin.ZeppelinTask.handle(ZeppelinTask.java:131)
	at org.apache.dolphinscheduler.server.worker.runner.DefaultWorkerDelayTaskExecuteRunnable.executeTask(DefaultWorkerDelayTaskExecuteRunnable.java:49)
 ```
paragraphJson.getInt("progress");  May occur ong.unirest.json.JSONException: JSONObject["progress"] not found.

### What type of PR is it?
Improvement
### Todos
* [ ] - Task
### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5893

### How should this be tested?
* CI passed

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
