### PR TITLE
Sanitize user labels for k8s

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sRemoteInterpreterProcess.java
@@ -297,7 +297,7 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     Properties k8sProperties = new Properties();
 
     // k8s template properties
-    k8sProperties.put("zeppelin.k8s.interpreter.user", String.valueOf(userName).trim());
+    k8sProperties.put("zeppelin.k8s.interpreter.user", sanitize(userName));
     k8sProperties.put("zeppelin.k8s.interpreter.namespace", getInterpreterNamespace());
     k8sProperties.put("zeppelin.k8s.interpreter.pod.name", getPodName());
     k8sProperties.put("zeppelin.k8s.interpreter.serviceAccount", getServiceAccount());
@@ -395,6 +395,22 @@ public class K8sRemoteInterpreterProcess extends RemoteInterpreterManagedProcess
     // interpreter properties overrides the values
     k8sProperties.putAll(Maps.fromProperties(properties));
     return k8sProperties;
+  }
+
+  private static String sanitize(String userName) {
+    String sanitized = "";
+    if (StringUtils.isEmpty(userName)) {
+      return sanitized;
+    }
+
+
+    if (userName.length() >= 63) {
+      sanitized = userName.substring(0, 62);
+    }
+
+    sanitized.replaceAll("[^a-zA-Z0-9]", "");
+
+    return sanitized;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
K8S labels has specific requirement to name labels  which can be found here
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

if Using external auth like Shiro with OIDC or JWT where principal is name / or username or email it can have special chars which then does not allow pod to launch.

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://172.20.0.1/api/v1/namespaces/dbdwf06018702/pods. Message: Pod "jdbc-nrgtbo" is invalid: metadata.labels: Invalid value: "Firstname Lastname": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character ...
```



### What type of PR is it?
Bug Fix




### What is the Jira issue?
* NA

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.



### Questions:
* Does the license files need to update? -NO
* Is there breaking changes for older versions? -NO
* Does this needs documentation? - NO
