### PR TITLE
[ZEPPELIN-5908]JDBCSecurityImpl should relogin when authType='kerberos' to void kerberos ticket expired

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/security/JDBCSecurityImpl.java
@@ -58,8 +58,9 @@ public class JDBCSecurityImpl {
             UserGroupInformation.loginUserFromKeytab(principal, keytab);
             LOGGER.info("Login successfully via keytab: {} and principal: {}", keytab, principal);
           } else {
+            UserGroupInformation.getCurrentUser().checkTGTAndReloginFromKeytab();
             LOGGER.info("The user has already logged in using Keytab and principal, " +
-                "no action required");
+                "will check tgt and whether to re-login");
           }
         } catch (IOException e) {
           LOGGER.error("Failed to get either keytab location or principal name in the " +


### PR DESCRIPTION

### What is this PR for?
for  jdbc interpreter. in some situation,  'zeppelin.jdbc.auth.type'= 'KERBEROS', such as hive
if interprete open for long time(more than 12h),  and execyte sql, kerberos ticket will expired, and throw exception.
We should relogin in JDBCSecurityImpl  when authType='kerberos' to void kerberos ticket expired.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5908

### How should this be tested?
test locally

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
 no
* Is there breaking changes for older versions?
no
* Does this needs documentation?
no