### PR TITLE
fix maven dependency convergence errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,14 @@
             <artifactId>jackson-core-asl</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-xc</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>


### PR DESCRIPTION
Hello.
I got the following Maven errors when trying to build from source (current master branch):
```
[INFO] --------------< org.apache.zeppelin:zeppelin-interpreter >--------------
[INFO] Building Zeppelin: Interpreter 0.11.0-SNAPSHOT                    [4/70]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven-version) @ zeppelin-interpreter ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-java-version) @ zeppelin-interpreter ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-dependency-convergence) @ zeppelin-interpreter ---
[WARNING] 
Dependency convergence error for org.codehaus.jackson:jackson-xc:1.9.13 paths to dependency are:
+-org.apache.zeppelin:zeppelin-interpreter:0.11.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-client:2.7.7
    +-org.apache.hadoop:hadoop-yarn-common:2.7.7
      +-org.codehaus.jackson:jackson-xc:1.9.13
and
+-org.apache.zeppelin:zeppelin-interpreter:0.11.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-client:2.7.7
    +-org.apache.hadoop:hadoop-yarn-common:2.7.7
      +-com.sun.jersey:jersey-json:1.9
        +-org.codehaus.jackson:jackson-xc:1.8.3

[WARNING] 
Dependency convergence error for org.codehaus.jackson:jackson-jaxrs:1.9.13 paths to dependency are:
+-org.apache.zeppelin:zeppelin-interpreter:0.11.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-client:2.7.7
    +-org.apache.hadoop:hadoop-yarn-common:2.7.7
      +-org.codehaus.jackson:jackson-jaxrs:1.9.13
and
+-org.apache.zeppelin:zeppelin-interpreter:0.11.0-SNAPSHOT
  +-org.apache.hadoop:hadoop-yarn-client:2.7.7
    +-org.apache.hadoop:hadoop-yarn-common:2.7.7
      +-com.sun.jersey:jersey-json:1.9
        +-org.codehaus.jackson:jackson-jaxrs:1.8.3

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Zeppelin 0.11.0-SNAPSHOT:
[INFO] 
[INFO] Zeppelin ........................................... SUCCESS [  0.961 s]
[INFO] Zeppelin: Tools .................................... SUCCESS [  0.261 s]
[INFO] Zeppelin: Common ................................... SUCCESS [  0.093 s]
[INFO] Zeppelin: Interpreter .............................. FAILURE [  0.787 s]
[INFO] Zeppelin: Interpreter Shaded ....................... SKIPPED
[INFO] Zeppelin: Interpreter Parent ....................... SKIPPED

```

### What is this PR for?

This commit fixes the following two convergence errors: 
Dependency convergence error for org.codehaus.jackson:jackson-xc:1.9.13 
Dependency convergence error for org.codehaus.jackson:jackson-jaxrs:1.9.13

### What type of PR is it?
Bug Fix

### How should this be tested?
* It should build the master branch without the aforementioned Maven convergence errors.

### Questions:
* The license files don't need to be updated.
* This PR doesn't introduce any breaking changes with older versions.
* This PR doesn't need any documentation.
