### PR TITLE
[ZEPPELIN-5918] Use Classloader class for flink creation

### DIFF
--- a/flink/flink-scala-2.11/src/main/scala/org/apache/zeppelin/flink/FlinkScala211Interpreter.scala
+++ b/flink/flink-scala-2.11/src/main/scala/org/apache/zeppelin/flink/FlinkScala211Interpreter.scala
@@ -30,7 +30,7 @@ import scala.tools.nsc.interpreter.{IMain, JPrintWriter}
 
 
 class FlinkScala211Interpreter(override val properties: Properties,
-                               override val flinkScalaClassLoader: URLClassLoader)
+                               override val flinkScalaClassLoader: ClassLoader)
   extends FlinkScalaInterpreter(properties, flinkScalaClassLoader) {
 
   override def completion(buf: String,

--- a/flink/flink-scala-2.12/src/main/scala/org/apache/zeppelin/flink/FlinkScala212Interpreter.scala
+++ b/flink/flink-scala-2.12/src/main/scala/org/apache/zeppelin/flink/FlinkScala212Interpreter.scala
@@ -29,7 +29,7 @@ import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.{IMain, JPrintWriter}
 
 class FlinkScala212Interpreter(override val properties: Properties,
-                               override val flinkScalaClassLoader: URLClassLoader)
+                               override val flinkScalaClassLoader: ClassLoader)
   extends FlinkScalaInterpreter(properties, flinkScalaClassLoader) {
 
   override def completion(buf: String,

--- a/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
+++ b/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java
@@ -90,7 +90,7 @@ public class FlinkInterpreter extends Interpreter {
     Class<?> clazz = Class.forName(innerIntpClassName);
 
     return (FlinkScalaInterpreter)
-            clazz.getConstructor(Properties.class, URLClassLoader.class)
+            clazz.getConstructor(Properties.class, ClassLoader.class)
                     .newInstance(getProperties(), flinkScalaClassLoader);
   }
 

--- a/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
+++ b/flink/flink-scala-parent/src/main/scala/org/apache/zeppelin/flink/FlinkScalaInterpreter.scala
@@ -65,7 +65,7 @@ import scala.tools.nsc.interpreter.{Completion, IMain, IR, JPrintWriter, Results
  * @param properties
  */
 abstract class FlinkScalaInterpreter(val properties: Properties,
-                                     val flinkScalaClassLoader: URLClassLoader) {
+                                     val flinkScalaClassLoader: ClassLoader) {
 
   private lazy val LOGGER: Logger = LoggerFactory.getLogger(getClass)
 


### PR DESCRIPTION
### What is this PR for?
JDK 11 is more strict about creation by reflection.

At this point we have only a Classloader and no URLClassloader.

https://github.com/apache/zeppelin/blob/3fd026616efb6c7257b4eed09581d16ca7f71f78/flink/flink-scala-parent/src/main/java/org/apache/zeppelin/flink/FlinkInterpreter.java#L86-L96

### What type of PR is it?
Improvement

### What is the Jira issue?
 * https://issues.apache.org/jira/browse/ZEPPELIN-5918

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
