### PR TITLE
[ZEPPELIN-5919] Compile scala only where scala code is present

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -71,57 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <configuration combine.self="override"></configuration>
             </plugin>
-
-            <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>eclipse-add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>scala-compile-first</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>scala-test-compile-first</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <args>
-                        <arg>-unchecked</arg>
-                        <arg>-deprecation</arg>
-                        <arg>-feature</arg>
-                    </args>
-                    <jvmArgs>
-                        <jvmArg>-Xms1024m</jvmArg>
-                        <jvmArg>-Xmx1024m</jvmArg>
-                        <jvmArg>-XX:MaxMetaspaceSize=${MaxMetaspace}</jvmArg>
-                    </jvmArgs>
-                    <javacArgs>
-                        <javacArg>-source</javacArg>
-                        <javacArg>${java.version}</javacArg>
-                        <javacArg>-target</javacArg>
-                        <javacArg>${java.version}</javacArg>
-                        <javacArg>-Xlint:all,-serial,-path,-options</javacArg>
-                    </javacArgs>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
-
-
 </project>


### PR DESCRIPTION
### What is this PR for?
This PR removes an unnecessary executions of the Scala Maven plugin in the `spark-parent` pom project.
The `spark-scala-parent` project configures the Scala Maven plugin for the Spark Scala submodules. 

Unnecessary executions:
```
2023-05-26T11:41:01.8159846Z [INFO] --- scala-maven-plugin:4.6.3:add-source (eclipse-add-source) @ spark-parent ---
2023-05-26T11:41:01.8172148Z [INFO] Add Source directory: /home/runner/work/zeppelin/zeppelin/spark/src/main/scala
2023-05-26T11:41:01.8180408Z [INFO] Add Test Source directory: /home/runner/work/zeppelin/zeppelin/spark/src/test/scala
2023-05-26T11:41:01.8184308Z [INFO] 
2023-05-26T11:41:01.8196734Z [INFO] --- maven-remote-resources-plugin:1.7.0:process (process-resource-bundles) @ spark-parent ---
2023-05-26T11:41:01.8216849Z [INFO] Preparing remote bundle org.apache:apache-jar-resource-bundle:1.4
2023-05-26T11:41:01.8337513Z [INFO] Copying 3 resources from 1 bundle.
2023-05-26T11:41:02.0178362Z [INFO] 
2023-05-26T11:41:02.0179540Z [INFO] --- scala-maven-plugin:4.6.3:compile (scala-compile-first) @ spark-parent ---
2023-05-26T11:41:02.0238274Z [INFO] No sources to compile
2023-05-26T11:41:02.0239237Z [INFO] 
2023-05-26T11:41:02.0240044Z [INFO] --- scala-maven-plugin:4.6.3:testCompile (scala-test-compile-first) @ spark-parent ---
2023-05-26T11:41:02.0299840Z [INFO] No sources to compile
```

### What type of PR is it?
Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5919

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
