### PR TITLE
fix conjars repository url

### DIFF
--- a/scalding/pom.xml
+++ b/scalding/pom.xml
@@ -43,9 +43,8 @@
 
   <repositories>
     <repository>
-      <id>conjars</id>
-      <name>Concurrent Maven Repo</name>
-      <url>https://conjars.org/repo</url>
+      <id>conjars.org</id>
+      <url>https://conjars.wensel.net/repo</url>
     </repository>
     <repository>
       <id>twitter</id>


### PR DESCRIPTION
### What is this PR for?
Fix broken url of conjars repository.
The old link: https://conjars.org/repo is deprecated, changed to https://conjars.wensel.net/repo


### What type of PR is it?
Bug Fix

### What is the Jira issue?

### How should this be tested?
* CI

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
