### PR TITLE
[ZEPPELIN-5920] Fix deprecation warnings

### DIFF
--- a/python/src/main/resources/python/zeppelin_context.py
+++ b/python/src/main/resources/python/zeppelin_context.py
@@ -221,7 +221,7 @@ class PyZeppelinContext(object):
                 body_buf.write(self.normalizeColumn(str(cell)))
             # don't print '\n' after the last row
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
+                warnings.simplefilter("ignore", category=DeprecationWarning)
                 if idx != (rowNumber - 1):
                     body_buf.write("\n")
         body_buf.seek(0)

--- a/python/src/main/resources/python/zeppelin_context.py
+++ b/python/src/main/resources/python/zeppelin_context.py
@@ -220,10 +220,9 @@ class PyZeppelinContext(object):
                 body_buf.write("\t")
                 body_buf.write(self.normalizeColumn(str(cell)))
             # don't print '\n' after the last row
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", category=DeprecationWarning)
-                if idx != (rowNumber - 1):
-                    body_buf.write("\n")
+            rowNumber -=1
+            if rowNumber != 0:
+                body_buf.write("\n")
         body_buf.seek(0)
         header_buf.seek(0)
         print("%table " + header_buf.read() + body_buf.read())

--- a/python/src/main/resources/python/zeppelin_context.py
+++ b/python/src/main/resources/python/zeppelin_context.py
@@ -220,8 +220,10 @@ class PyZeppelinContext(object):
                 body_buf.write("\t")
                 body_buf.write(self.normalizeColumn(str(cell)))
             # don't print '\n' after the last row
-            if idx != (rowNumber - 1):
-                body_buf.write("\n")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                if idx != (rowNumber - 1):
+                    body_buf.write("\n")
         body_buf.seek(0)
         header_buf.seek(0)
         print("%table " + header_buf.read() + body_buf.read())

--- a/python/src/test/java/org/apache/zeppelin/python/BasePythonInterpreterTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/BasePythonInterpreterTest.java
@@ -339,6 +339,25 @@ public abstract class BasePythonInterpreterTest extends ConcurrentTestCase {
             "%html <strong>1</strong>\t2\tb\n" +
             "%html <strong>2</strong>\t3\tc\n", interpreterResultMessages.get(0).getData());
 
+    // z.show(df, show_index=True), index is timestamp
+    context = getInterpreterContext();
+    result = interpreter.interpret("import pandas as pd\n" +
+                    "idx = pd.date_range('20230530', periods=3, freq='D')\n" +
+                    "df = pd.DataFrame({'name':['a','b','c']}, index= idx)\n" +
+                    "z.show(df, show_index=True)",
+            context);
+    assertEquals(context.out.toInterpreterResultMessage().toString(),
+            InterpreterResult.Code.SUCCESS, result.code());
+    interpreterResultMessages = context.out.toInterpreterResultMessage();
+    assertEquals(1, interpreterResultMessages.size());
+    assertEquals(InterpreterResult.Type.TABLE, interpreterResultMessages.get(0).getType());
+    assertEquals("\tname\n" +
+            "%html <strong>2023-05-30T00:00:00.000000000</strong>\ta\n" +
+            "%html <strong>2023-05-31T00:00:00.000000000</strong>\tb\n" +
+            "%html <strong>2023-06-01T00:00:00.000000000</strong>\tc\n",
+            interpreterResultMessages.get(0).getData());
+
+
     // z.show(matplotlib)
     context = getInterpreterContext();
     result = interpreter.interpret("import matplotlib.pyplot as plt\n" +


### PR DESCRIPTION
### What is this PR for?
If z.show is used with a Panda DataFrame that has a timestamp as index, then a DeprecationWarning appears for every row in the data frame.
This issue was fixed.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5920

### How should this be tested?
* A new unit test was added

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
