### PR TITLE
[ZEPPELIN-5926] Remove map entries if Collection is empty

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ConnectionManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ConnectionManagerTest.java
@@ -1,0 +1,42 @@
+package org.apache.zeppelin.socket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import org.apache.zeppelin.notebook.AuthorizationService;
+import org.junit.jupiter.api.Test;
+
+class ConnectionManagerTest {
+
+  @Test
+  void checkMapGrow() {
+    AuthorizationService authService = mock(AuthorizationService.class);
+
+    ConnectionManager manager = new ConnectionManager(authService);
+    NotebookSocket socket = mock(NotebookSocket.class);
+    manager.addNoteConnection("test", socket);
+    assertEquals(1, manager.noteSocketMap.size());
+    // Remove Connection from wrong note
+    manager.removeNoteConnection("test1", socket);
+    assertEquals(1, manager.noteSocketMap.size());
+    // Remove Connection from right note
+    manager.removeNoteConnection("test", socket);
+    assertEquals(0, manager.noteSocketMap.size());
+
+    manager.addUserConnection("TestUser", socket);
+    assertEquals(1, manager.userSocketMap.size());
+    manager.removeUserConnection("TestUser", socket);
+    assertEquals(0, manager.userSocketMap.size());
+  }
+
+  @Test
+  void checkMapGrowRemoveAll() {
+    AuthorizationService authService = mock(AuthorizationService.class);
+
+    ConnectionManager manager = new ConnectionManager(authService);
+    NotebookSocket socket = mock(NotebookSocket.class);
+    manager.addNoteConnection("test", socket);
+    assertEquals(1, manager.noteSocketMap.size());
+    manager.removeConnectionFromAllNote(socket);
+    assertEquals(0, manager.noteSocketMap.size());
+  }
+}

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ConnectionManagerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/ConnectionManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.zeppelin.socket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.zeppelin.socket;
 
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -42,6 +41,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -566,7 +566,10 @@ class NotebookServerTest extends AbstractTestRestApi {
               .put("noteId", "noteId")
               .put("paragraphId", "paragraphId"));
 
-      notebookServer.getConnectionManager().noteSocketMap.put("noteId", asList(conn, otherConn));
+      Set<NotebookSocket> sockets = new HashSet<>();
+      sockets.add(otherConn);
+      sockets.add(conn);
+      notebookServer.getConnectionManager().noteSocketMap.put("noteId", sockets);
 
       // When
       notebookServer.angularObjectClientBind(conn, messageReceived);
@@ -619,7 +622,10 @@ class NotebookServerTest extends AbstractTestRestApi {
               .put("noteId", "noteId")
               .put("paragraphId", "paragraphId"));
 
-      notebookServer.getConnectionManager().noteSocketMap.put("noteId", asList(conn, otherConn));
+      Set<NotebookSocket> sockets = new HashSet<>();
+      sockets.add(otherConn);
+      sockets.add(conn);
+      notebookServer.getConnectionManager().noteSocketMap.put("noteId", sockets);
 
       // When
       notebookServer.angularObjectClientUnbind(conn, messageReceived);


### PR DESCRIPTION
### What is this PR for?
This PR deletes a map element if the collection behind the map key is empty, so that the map size can decrease.


### What type of PR is it?
Bug Fix


### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5926

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
