### PR TITLE
[ZEPPELIN-5927]Solve the concurrency calls to `saveNoteAuth`.

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/AuthorizationService.java
@@ -99,7 +99,7 @@ public class AuthorizationService implements ClusterEventListener {
    *
    * @throws IOException
    */
-  public void saveNoteAuth() throws IOException {
+  public synchronized void saveNoteAuth() throws IOException {
     configStorage.save(new NotebookAuthorizationInfoSaving(this.notesAuth));
   }
 


### PR DESCRIPTION
### What is this PR for?
This pull request migrates solve the concurrency calls to `saveNoteAuth`.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
[ZEPPELIN-5927](https://issues.apache.org/jira/browse/ZEPPELIN-5927)

### How should this be tested?
Try to build module zeppelin-zengine by command
./mvnw -B -pl 'zeppelin-server,zeppelin-zengine,zeppelin-common,zeppelin-interpreter,zeppelin-jupyter' clean package -
DskipTests -Pbuild-distr -Pinclude-hadoop -Phadoop3 -Pweb-angular