### PR TITLE
[ZEPPELIN-5934] Check notebook folder permissions before allowing to rename, remove or restore it

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -33,6 +33,7 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Notebook.NoteProcessor;
+import org.apache.zeppelin.notebook.exception.FolderPathAlreadyExistsException;
 import org.apache.zeppelin.notebook.exception.NotePathAlreadyExistsException;
 import org.apache.zeppelin.notebook.repo.NotebookRepo;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -270,6 +271,10 @@ public class NoteManager {
   public void moveFolder(String folderPath,
                          String newFolderPath,
                          AuthenticationInfo subject) throws IOException {
+
+    if (containsFolder(newFolderPath)) {
+      throw new FolderPathAlreadyExistsException("Folder '" + newFolderPath + "' existed");
+    }
 
     // update notebookrepo
     this.notebookRepo.move(folderPath, newFolderPath, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -376,7 +376,7 @@ public class NoteManager {
     return noteNode;
   }
 
-  private Folder getFolder(String folderPath) throws IOException {
+  public Folder getFolder(String folderPath) throws IOException {
     String[] tokens = folderPath.split("/");
     Folder curFolder = root;
     for (int i = 0; i < tokens.length; ++i) {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -537,6 +537,10 @@ public class Notebook {
     return noteManager.containsFolder(folderPath);
   }
 
+  public NoteManager.Folder getFolder(String folderPath) throws IOException {
+    return noteManager.getFolder(folderPath);
+  }
+
   public void moveNote(String noteId, String newNotePath, AuthenticationInfo subject) throws IOException {
     LOGGER.info("Move note {} to {}", noteId, newNotePath);
     noteManager.moveNote(noteId, newNotePath, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/exception/FolderPathAlreadyExistsException.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/exception/FolderPathAlreadyExistsException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.notebook.exception;
+
+import java.io.IOException;
+
+public class FolderPathAlreadyExistsException extends IOException {
+    public FolderPathAlreadyExistsException(final String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
### What is this PR for?
Users who are able to see notes in some directory can rename, move to trash and remove from trash that directory without being owner or having write permissions for notes in that directory.
This is resolved in first commit.

Secondly, after renaming directory to the name of already existing directory, old notes in target directory become unaccessible (in fact those notes are removed in file system, but still visible in UI as they are present in NoteManager registry).
This addresses 2nd point in ZEPPELIN-5333.
Fixed in 2nd commit.

### What type of PR is it?
Improvement

### What is the Jira issue?
* [ZEPPELIN-5934](https://issues.apache.org/jira/browse/ZEPPELIN-5934)
* [ZEPPELIN-5333.](https://issues.apache.org/jira/browse/ZEPPELIN-5333.)

### How should this be tested?
* I've tested this manually by creating some note in directory, giving read permission to it for some other user, and checking whether that user can move to trash, remove, rename or restore directory with that note.
* I've checked and it does not seem like there are available infrastructure in `NotebookServiceTest` or in `NoteManagerTest` to cover multi-user scenarios.
