### PR TITLE
[ZEPPELIN-5935] Update jsoup version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
     <jettison.version>1.5.4</jettison.version>
-    <jsoup.version>1.13.1</jsoup.version>
+    <jsoup.version>1.14.2</jsoup.version>
     <protobuf.version>3.21.7</protobuf.version>
     <grpc.version>1.51.0</grpc.version>
     <google.errorprone.version>2.14.0</google.errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
     <jettison.version>1.5.4</jettison.version>
-    <jsoup.version>1.14.2</jsoup.version>
+    <jsoup.version>1.15.3</jsoup.version>
     <protobuf.version>3.21.7</protobuf.version>
     <grpc.version>1.51.0</grpc.version>
     <google.errorprone.version>2.14.0</google.errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 
     <quartz.scheduler.version>2.3.2</quartz.scheduler.version>
     <jettison.version>1.5.4</jettison.version>
-    <jsoup.version>1.15.3</jsoup.version>
+    <jsoup.version>1.16.1</jsoup.version>
     <protobuf.version>3.21.7</protobuf.version>
     <grpc.version>1.51.0</grpc.version>
     <google.errorprone.version>2.14.0</google.errorprone.version>

--- a/rlang/src/main/java/org/apache/zeppelin/r/ZeppelinRDisplay.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/ZeppelinRDisplay.java
@@ -23,7 +23,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Document.OutputSettings;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -93,7 +93,7 @@ public class ZeppelinRDisplay {
   private static RDisplay textDisplay(Element body) {
     // remove HTML tag while preserving whitespaces and newlines
     String text = Jsoup.clean(body.html(), "",
-      Whitelist.none(), new OutputSettings().prettyPrint(false));
+      Safelist.none(), new OutputSettings().prettyPrint(false));
     return new RDisplay(text, Type.TEXT, Code.SUCCESS);
   }
 

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -276,7 +276,7 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) Spire Macros 0.7.4 (org.spire-math:spire-macros:0.7.4 - https://github.com/non/spire)
     (The MIT License) Java String Similarity 0.12 (info.debatty:java-string-similarity:0.12 - https://github.com/tdebatty/java-string-similarity)
     (The MIT License) Java LSH 0.10 (info.debatty:java-lsh:0.10 - https://github.com/tdebatty/java-LSH)
-    (The MIT License) JSoup 1.12.1 (org.jsoup:jsoup:1.12.1 - https://github.com/jhy/jsoup/)
+    (The MIT License) JSoup 1.16.1 (org.jsoup:jsoup:1.16.1 - https://github.com/jhy/jsoup/)
     (The MIT License) Unirest 1.4.9 (com.mashape.unirest:unirest-java:1.4.9 - https://github.com/Mashape/unirest-java)
     (The MIT License) ngclipboard v1.1.1 (https://github.com/sachinchoolur/ngclipboard) - https://github.com/sachinchoolur/ngclipboard/blob/1.1.1/LICENSE
     (The MIT License) headroom.js 0.9.3 (https://github.com/WickyNilliams/headroom.js) - https://github.com/WickyNilliams/headroom.js/blob/master/LICENSE


### PR DESCRIPTION
### What is this PR for?
Bump jsoup version for fixing CVE-2021-37714

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5935
