### PR TITLE
[MINOR] Change notification emails

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,4 +43,7 @@ github:
     - ZEPPELIN
 
 notifications:
-  jira_options: link label comment
+  commits: commits@zeppelin.apache.org
+  issues: reviews@zeppelin.apache.org
+  pullrequests: reviews@zeppelin.apache.org
+  jira_options: link label


### PR DESCRIPTION
### What is this PR for?
Changing Github's notification email addresses in order to use `reviews@zeppelin.apache.org`


### What type of PR is it?
Improvement

### Todos
* [x] - Change target emails

### What is the Jira issue?
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
