### PR TITLE
[ZEPPELIN-5936] Update jetty to latest 9.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <flexmark.all.version>0.62.2</flexmark.all.version>
     <gson.version>2.8.9</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
-    <jetty.version>9.4.43.v20210629</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>


### PR DESCRIPTION
### What is this PR for?
This PullRequest updates the used Jetty version to the currently latest 9.4.x version.
Please note that Jetty 9.4.x is end of life. https://github.com/eclipse/jetty.project/issues/7958

For Jetty 10 or 11 at least JDK 11 is required.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5936

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
