### PR TITLE
[Minor] Execute checkstyle during default build

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -487,4 +487,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: build without any profiles
-        run: ./mvnw clean package -DskipTests ${MAVEN_ARGS}
+        run: ./mvnw clean verify -DskipTests ${MAVEN_ARGS}


### PR DESCRIPTION
### What is this PR for?
This PR results in Checkstyle being run in the default build.
Background is my comment https://github.com/apache/zeppelin/pull/4620#issuecomment-1596241260


### What type of PR is it?
- Improvement

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
