### PR TITLE
[Ci-Hotfix] Install holoview 1.16, 1.17 drops python 3.7 support

### DIFF
--- a/testing/env_python_3.7_with_R.yml
+++ b/testing/env_python_3.7_with_R.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3.8_with_R.yml
+++ b/testing/env_python_3.8_with_R.yml
@@ -15,6 +15,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3_with_R.yml
+++ b/testing/env_python_3_with_R.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - bokeh

--- a/testing/env_python_3_with_R_and_tensorflow.yml
+++ b/testing/env_python_3_with_R_and_tensorflow.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - bokeh

--- a/testing/env_python_3_with_flink_112.yml
+++ b/testing/env_python_3_with_flink_112.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3_with_flink_113.yml
+++ b/testing/env_python_3_with_flink_113.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3_with_flink_114.yml
+++ b/testing/env_python_3_with_flink_114.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3_with_flink_115.yml
+++ b/testing/env_python_3_with_flink_115.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake

--- a/testing/env_python_3_with_flink_116.yml
+++ b/testing/env_python_3_with_flink_116.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake


### PR DESCRIPTION

### What is this PR for?
Install holoview 1.16, 1.17 drops python 3.7 support see https://github.com/holoviz/holoviews/pull/5695

### What type of PR is it?
Hot Fix

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
