### PR TITLE
docs: update maven url to download redshift jdbc dependencies on migrated repo

### DIFF
--- a/docs/interpreter/jdbc.md
+++ b/docs/interpreter/jdbc.md
@@ -599,12 +599,12 @@ Here are some examples you can refer to. Including the below connectors, you can
     <th>Excludes</th>
   </tr>
   <tr>
-    <td>com.amazonaws:aws-java-sdk-redshift:1.11.51</td>
+    <td>com.amazon.redshift:redshift-jdbc42:2.1.0.18</td>
     <td></td>
   </tr>
 </table>
 
-[Maven Repository: com.amazonaws:aws-java-sdk-redshift](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-redshift)
+[Maven Repository: com.amazon.redshift:redshift-jdbc42](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42)
 
 ### Apache Hive
 


### PR DESCRIPTION
### What is this PR for?
- update maven url to download redshift jdbc dependencies on migrated repo

### What type of PR is it?
Documentation

### How should this be tested?
[as-is]
```
java.lang.ClassNotFoundException: com.amazon.redshift.jdbc42.Driver
```

- update docs to download redshift jdbc driver package from migrated repository
- maven: https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42
- git: https://github.com/aws/amazon-redshift-jdbc-driver