### PR TITLE
[ZEPPELIN-5964] Fix renaming bug

### DIFF
--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -227,6 +227,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -247,7 +247,7 @@ public class NoteManager {
     this.notebookRepo.move(noteId, notePath, newNotePath, subject);
 
     // Update path of the note
-    if (!notePath.equals(newNotePath)) {
+    if (!StringUtils.equals(notePath, newNotePath)) {
       processNote(noteId,
         note -> {
           note.setPath(newNotePath);
@@ -258,7 +258,7 @@ public class NoteManager {
     // save note if note name is changed, because we need to update the note field in note json.
     String oldNoteName = getNoteName(notePath);
     String newNoteName = getNoteName(newNotePath);
-    if (!oldNoteName.equals(newNoteName)) {
+    if (!StringUtils.equals(oldNoteName, newNoteName)) {
       processNote(noteId,
         note -> {
           this.notebookRepo.save(note, subject);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/NoteManager.java
@@ -247,7 +247,7 @@ public class NoteManager {
     this.notebookRepo.move(noteId, notePath, newNotePath, subject);
 
     // Update path of the note
-    if (!StringUtils.equalsIgnoreCase(notePath, newNotePath)) {
+    if (!notePath.equals(newNotePath)) {
       processNote(noteId,
         note -> {
           note.setPath(newNotePath);
@@ -258,7 +258,7 @@ public class NoteManager {
     // save note if note name is changed, because we need to update the note field in note json.
     String oldNoteName = getNoteName(notePath);
     String newNoteName = getNoteName(newNotePath);
-    if (!StringUtils.equalsIgnoreCase(oldNoteName, newNoteName)) {
+    if (!oldNoteName.equals(newNoteName)) {
       processNote(noteId,
         note -> {
           this.notebookRepo.save(note, subject);


### PR DESCRIPTION
### What is this PR for?
If a note is renamed by changing only the capitalization, the note is copied at the file system level when it is executed again.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-5964

### How should this be tested?
* New unit test were added

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
