### PR TITLE
fix(sec): upgrade org.elasticsearch:elasticsearch to 6.8.17

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <interpreter.name>elasticsearch</interpreter.name>
-    <elasticsearch.version>2.4.3</elasticsearch.version>
+    <elasticsearch.version>8.2.1</elasticsearch.version>
     <httpasyncclient.version>4.0.2</httpasyncclient.version>
     <guava.version>18.0</guava.version>
     <json-flattener.version>0.1.6</json-flattener.version>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in org.elasticsearch:elasticsearch 2.4.3
- [CVE-2020-7020](https://www.oscs1024.com/hd/CVE-2020-7020)
- [CVE-2021-22144](https://www.oscs1024.com/hd/CVE-2021-22144)
- [CVE-2020-7021](https://www.oscs1024.com/hd/CVE-2020-7021)
- [CVE-2021-22137](https://www.oscs1024.com/hd/CVE-2021-22137)
- [CVE-2021-22135](https://www.oscs1024.com/hd/CVE-2021-22135)
- [CVE-2019-7614](https://www.oscs1024.com/hd/CVE-2019-7614)


### What did I do？
Upgrade org.elasticsearch:elasticsearch from 2.4.3 to 6.8.17 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS