### PR TITLE
[ZEPPELIN-5968] Bump Jetty 9.4.52.v20230823

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <flexmark.all.version>0.62.2</flexmark.all.version>
     <gson.version>2.8.9</gson.version>
     <gson-extras.version>0.2.2</gson-extras.version>
-    <jetty.version>9.4.51.v20230217</jetty.version>
+    <jetty.version>9.4.52.v20230823</jetty.version>
     <httpcomponents.core.version>4.4.1</httpcomponents.core.version>
     <httpcomponents.client.version>4.5.13</httpcomponents.client.version>
     <httpcomponents.asyncclient.version>4.0.2</httpcomponents.asyncclient.version>


### PR DESCRIPTION
### What is this PR for?

Jetty 9.x is EOL but still gets Security / Vulnerability triggered releases

https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.52.v20230823

### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?

ZEPPELIN-5968

### How should this be tested?

Pass GA.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
