### PR TITLE
[ZEPPELIN-5979] Support and use Python 3.9 in default

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -68,12 +68,12 @@ jobs:
         run: ./mvnw install -Pbuild-distr -DskipTests -pl zeppelin-server,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown,angular,shell -am -Phelium-dev -Pexamples -P${{ matrix.hadoop }} ${MAVEN_ARGS}
       - name: install and test plugins
         run: ./mvnw package -pl zeppelin-plugins -amd ${MAVEN_ARGS}
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R
-          environment-file: testing/env_python_3.7_with_R.yml
-          python-version: 3.7
+          environment-file: testing/env_python_3.9_with_R.yml
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
@@ -119,12 +119,12 @@ jobs:
             ${{ runner.os }}-zeppelin-
       - name: install environment
         run: ./mvnw install -DskipTests -am -pl ${INTERPRETERS} -Pscala-2.11 ${MAVEN_ARGS}
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R_and_tensorflow
           environment-file: testing/env_python_3_with_R_and_tensorflow.yml
-          python-version: 3.7
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
@@ -139,8 +139,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ 3.7, 3.8 ]
+        python: [ 3.9 ]
         java: [ 8, 11 ]
+        include:
+          - python: 3.7
+            java: 8
+          - python: 3.8
+            java: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -218,12 +223,12 @@ jobs:
         run: |
           ./mvnw install -DskipTests -Phadoop2 -Pintegration -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown,flink-cmd,flink/flink-scala-2.12,jdbc,shell -am -Pflink-117 ${MAVEN_ARGS}
           ./mvnw package -pl zeppelin-plugins -amd -DskipTests ${MAVEN_ARGS}
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
-          python-version: 3.7
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
@@ -243,7 +248,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flink: [115, 116, 117]
+        python: [ 3.9 ]
+        flink: [116, 117]
+        include:
+          # Flink 1.15 supports Python 3.6, 3.7, and 3.8
+          # https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/python/installation/
+          - python: 3.8
+            flink: 115
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -269,12 +280,12 @@ jobs:
         run: |
           ./mvnw install -DskipTests -am -pl flink/flink-scala-2.12,flink-cmd,zeppelin-interpreter-integration -Pflink-${{ matrix.flink }} -Phadoop2 -Pintegration ${MAVEN_ARGS}
           ./mvnw clean package -pl zeppelin-plugins -amd -DskipTests ${MAVEN_ARGS}
-      - name: Setup conda environment with python 3.7 and
+      - name: Setup conda environment with python ${{ matrix.python }} and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_flink
           environment-file: testing/env_python_3_with_flink_${{ matrix.flink }}.yml
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
@@ -319,12 +330,12 @@ jobs:
         run: |
           ./mvnw install -DskipTests -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown -am -Phadoop2 -Pintegration ${MAVEN_ARGS}
           ./mvnw clean package -pl zeppelin-plugins -amd -DskipTests ${MAVEN_ARGS}
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
-          python-version: 3.7
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
@@ -342,8 +353,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ 3.7, 3.8 ]
+        python: [ 3.9 ]
         java: [ 8, 11 ]
+        include:
+          - python: 3.7
+            java: 8
+          - python: 3.8
+            java: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -435,12 +451,12 @@ jobs:
           ./mvnw install -DskipTests -pl livy -am  ${MAVEN_ARGS}
           ./testing/downloadSpark.sh "3.4.1" "3"
           ./testing/downloadLivy.sh "0.7.1-incubating"
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
-          python-version: 3.7
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -112,12 +112,12 @@ jobs:
           key: ${{ runner.os }}-zeppelin-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-zeppelin-
-      - name: Setup conda environment with python 3.7 and R
+      - name: Setup conda environment with python 3.9 and R
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
-          python-version: 3.7
+          python-version: 3.9
           miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true

--- a/docs/interpreter/python.md
+++ b/docs/interpreter/python.md
@@ -443,7 +443,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7 
+  - python=3.9
   - jupyter
   - grpcio
   - protobuf

--- a/docs/interpreter/r.md
+++ b/docs/interpreter/r.md
@@ -361,7 +361,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7 
+  - python=3.9 
   - jupyter
   - grpcio
   - protobuf

--- a/testing/env_python_3.9_with_R.yml
+++ b/testing/env_python_3.9_with_R.yml
@@ -1,4 +1,4 @@
-name: python_3_with_R_and_tensorflow
+name: python_3_with_R
 channels:
   - conda-forge
   - defaults
@@ -18,7 +18,6 @@ dependencies:
   - holoviews=1.16
   - plotnine
   - seaborn
-  - bokeh=2.4
   - intake
   - intake-parquet
   - intake-xarray
@@ -36,4 +35,3 @@ dependencies:
   - r-irkernel
   - r-shiny
   - r-googlevis
-  - tensorflow

--- a/testing/env_python_3.yml
+++ b/testing/env_python_3.yml
@@ -3,21 +3,21 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pycodestyle=2.5.0
-  - numpy=1.17.3
-  - pandas=0.25.0
-  - scipy=1.3.1
-  - grpcio=1.22.0
-  - hvplot=0.5.2
-  - protobuf=3.10.0
-  - pandasql=0.7.3
-  - ipython=7.8.0
-  - matplotlib=3.0.3
-  - ipykernel=5.1.2
-  - jupyter_client=5.3.4
-  - bokeh=1.3.4
+  - pycodestyle
+  - numpy=1.19.5
+  - pandas=1.4.4
+  - scipy
+  - grpcio
+  - hvplot
+  - protobuf
+  - pandasql
+  - ipython
+  - matplotlib
+  - ipykernel
+  - jupyter_client=5
+  - bokeh=2.4
   - panel=0.6.0
-  - holoviews=1.12.3
+  - holoviews=1.16
   - jinja2=3.0.3
   - pip
   - pip:

--- a/testing/env_python_3_with_R.yml
+++ b/testing/env_python_3_with_R.yml
@@ -9,6 +9,7 @@ dependencies:
   - grpcio
   - protobuf
   - pandasql
+  - sqlalchemy=1.4.46
   - ipython
   - ipython_genutils
   - ipykernel
@@ -17,7 +18,7 @@ dependencies:
   - holoviews=1.16
   - plotnine
   - seaborn
-  - bokeh
+  - bokeh=2.4
   - intake
   - intake-parquet
   - intake-xarray

--- a/testing/env_python_3_with_flink_117.yml
+++ b/testing/env_python_3_with_flink_117.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipykernel
   - jupyter_client=5
   - hvplot
+  - holoviews=1.16
   - plotnine
   - seaborn
   - intake


### PR DESCRIPTION
### What is this PR for?

Currently, Zeppelin only tests with Python 3.7(default) and 3.8.

According to https://endoflife.date/, Python 3.7 is EOL. This PR adds the Python 3.9 test with minimal tunes. Although Python 3.12 is available, I conservatively just moved to Python 3.9 for safety (I'm not a Python expert), also Python 3.9 is the first version officially supporting Apple Sillicon.


### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?

ZEPPELIN-5979

### How should this be tested?

Pass GA.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
