### PR TITLE
[ZEPPELIN-5981] Check binded interpreter inside Paragraph.jobAbort()

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java
@@ -502,12 +502,19 @@ public class Paragraph extends JobWithProgressPoller<InterpreterResult> implemen
 
   @Override
   protected boolean jobAbort() {
-    try {
-      this.interpreter = getBindedInterpreter();
-    } catch (InterpreterNotFoundException e) {
-      LOGGER.debug("Unable to abort because there's no interpreter bind to it", e);
-      setInterpreterNotFound(e);
+    if (isAborted()) {
+      LOGGER.debug("Paragraph is already aborted.");
       return true;
+    }
+    if (isRunning() && this.interpreter == null) {
+      try {
+        LOGGER.debug("Trying to get the binded interpreter to cancel.");
+        this.interpreter = getBindedInterpreter();
+      } catch (InterpreterNotFoundException e) {
+        LOGGER.debug("Unable to abort because there's no interpreter bind to it", e);
+        setInterpreterNotFound(e);
+        return true;
+      }
     }
     if (interpreter == null) {
       LOGGER.debug("Unable to abort because interpreter is null");


### PR DESCRIPTION
### What is this PR for?
Inside an open zeppelin notebook, after running a paragraph by clicking the play icon button, canceling the running paragraph by clicking the pause icon button (or the Ctrl+Option+C shortcut) does not interrupt the running process and cancel the paragraph.

I've checked that `CANCEL_PARAGRAPH` message gets well passed through the websocket connection but server was somehow completely ignoring the message.

After some more investigation, I've found that the reason for that was the `Paragraph`'s `jobAbort()` method, which does nothing due to the null interpreter member.

https://github.com/apache/zeppelin/blob/73e1aa37d403626d23138b3b346aec5ef2c12813/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java#L505

I've checked some other methods of `Paragraph` such as `completion()`, `execute()`, `jobRun()`, `recover()` and they were initializing interpreter before doing something by calling `getBindedInterpreter()`, so I've changed the `jobAbort()` method to do the same.

https://github.com/apache/zeppelin/blob/73e1aa37d403626d23138b3b346aec5ef2c12813/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java#L258

https://github.com/apache/zeppelin/blob/73e1aa37d403626d23138b3b346aec5ef2c12813/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java#L333

https://github.com/apache/zeppelin/blob/73e1aa37d403626d23138b3b346aec5ef2c12813/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java#L399

https://github.com/apache/zeppelin/blob/73e1aa37d403626d23138b3b346aec5ef2c12813/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Paragraph.java#L810

Other than that, I have some doubts on whether it's right thing to return true on failing what was requested.

But after all, I just sticked to the original behavior (returning true for every case) to prevent some unexpected side effects.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-5981

### How should this be tested?
* Run a paragraph that can be canceled, like a python interpreter paragraph with `for i in range(10): time.sleep(1)`
* Click the cancel button and check if it gets canceled .

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
