### PR TITLE
[ZEPPELIN-5986] Re-enable Junit 5 integration tests by upgrading maven plugins

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -342,9 +342,11 @@ jobs:
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
+        shell: bash -el {0}
         run: |
           R -e "IRkernel::installspec()"
       - name: run tests on hadoop${{ matrix.hadoop }}
+        shell: bash -el {0}
         run: |
           conda activate python_3_with_R
           export PYSPARK_PYTHON=`which python`

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -341,6 +341,10 @@ jobs:
           channel-priority: true
           auto-activate-base: false
           use-mamba: true
+      - name: Install R
+        run: |
+          apt-get update -y
+          apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
       - name: Make IRkernel available to Jupyter
         shell: bash -el {0}
         run: |

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -331,7 +331,7 @@ jobs:
           ./mvnw install -DskipTests -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown -am -Phadoop2 -Pintegration ${MAVEN_ARGS}
           ./mvnw clean package -pl zeppelin-plugins -amd -DskipTests ${MAVEN_ARGS}
       - name: Setup conda environment with python 3.9 and R
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -329,6 +329,7 @@ jobs:
       - name: Install R
         shell: bash
         run: |
+          whoami
           apt-get update -y
           apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
       - name: install environment

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -347,6 +347,8 @@ jobs:
       - name: run tests on hadoop${{ matrix.hadoop }}
         run: |
           export PYSPARK_PYTHON=`which python`
+          echo "PYSPARK_PYTHON=$PYSPARK_PYTHON"
+          echo "PATH=$PATH"
           ./mvnw test -pl zeppelin-interpreter-integration -Phadoop${{ matrix.hadoop }} -Pintegration -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest32,SparkIntegrationTest32,ZeppelinSparkClusterTest33,SparkIntegrationTest33 -DfailIfNoTests=false ${MAVEN_ARGS}
 
   # test on spark for each spark version & scala version

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -299,7 +299,7 @@ jobs:
 
 
   spark-integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -327,6 +327,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: Install R
+        shell: bash
         run: |
           apt-get update -y
           apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -330,8 +330,8 @@ jobs:
         shell: bash
         run: |
           whoami
-          apt-get update -y
-          apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
+          sudo apt-get update -y
+          sudo apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
       - name: install environment
         run: |
           ./mvnw install -DskipTests -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown -am -Phadoop2 -Pintegration ${MAVEN_ARGS}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -345,7 +345,7 @@ jobs:
         run: |
           R -e "IRkernel::installspec()"
       - name: run tests on hadoop${{ matrix.hadoop }}
-        run: ｜
+        run: |
           export PYSPARK_PYTHON=`which python`
           ./mvnw test -pl zeppelin-interpreter-integration -Phadoop${{ matrix.hadoop }} -Pintegration -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest32,SparkIntegrationTest32,ZeppelinSparkClusterTest33,SparkIntegrationTest33 -DfailIfNoTests=false ${MAVEN_ARGS}
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -345,7 +345,9 @@ jobs:
         run: |
           R -e "IRkernel::installspec()"
       - name: run tests on hadoop${{ matrix.hadoop }}
-        run: ./mvnw test -pl zeppelin-interpreter-integration -Phadoop${{ matrix.hadoop }} -Pintegration -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest32,SparkIntegrationTest32,ZeppelinSparkClusterTest33,SparkIntegrationTest33 -DfailIfNoTests=false ${MAVEN_ARGS}
+        run: ｜
+          export PYSPARK_PYTHON=`which python`
+          ./mvnw test -pl zeppelin-interpreter-integration -Phadoop${{ matrix.hadoop }} -Pintegration -Dtest=SparkSubmitIntegrationTest,ZeppelinSparkClusterTest32,SparkIntegrationTest32,ZeppelinSparkClusterTest33,SparkIntegrationTest33 -DfailIfNoTests=false ${MAVEN_ARGS}
 
   # test on spark for each spark version & scala version
   spark-test:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -326,6 +326,10 @@ jobs:
           key: ${{ runner.os }}-zeppelin-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-zeppelin-
+      - name: Install R
+        run: |
+          apt-get update -y
+          apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
       - name: install environment
         run: |
           ./mvnw install -DskipTests -pl zeppelin-interpreter-integration,zeppelin-web,spark-submit,spark/scala-2.12,spark/scala-2.13,markdown -am -Phadoop2 -Pintegration ${MAVEN_ARGS}
@@ -341,10 +345,6 @@ jobs:
           channel-priority: true
           auto-activate-base: false
           use-mamba: true
-      - name: Install R
-        run: |
-          apt-get update -y
-          apt-get install -y r-base r-cran-data.table r-cran-evaluate r-cran-base64enc r-cran-knitr r-cran-ggplot2 r-cran-irkernel r-cran-shiny r-cran-googlevis
       - name: Make IRkernel available to Jupyter
         shell: bash -el {0}
         run: |

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -346,6 +346,7 @@ jobs:
           R -e "IRkernel::installspec()"
       - name: run tests on hadoop${{ matrix.hadoop }}
         run: |
+          conda activate python_3_with_R
           export PYSPARK_PYTHON=`which python`
           echo "PYSPARK_PYTHON=$PYSPARK_PYTHON"
           echo "PATH=$PATH"

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,6 @@
     <plugin.download.version>1.6.0</plugin.download.version>
     <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
     <plugin.exec.version>1.6.0</plugin.exec.version>
-    <plugin.failsafe.version>2.17</plugin.failsafe.version>
     <plugin.git.commit.id.version>4.0.0</plugin.git.commit.id.version>
     <plugin.gpg.version>1.6</plugin.gpg.version>
     <plugin.jar.version>3.2.0</plugin.jar.version>
@@ -193,7 +192,7 @@
     <plugin.scalatest.version>2.0.0</plugin.scalatest.version>
     <plugin.scm.version>1.11.2</plugin.scm.version>
     <plugin.source.version>3.2.1</plugin.source.version>
-    <plugin.surefire.version>2.22.2</plugin.surefire.version>
+    <plugin.surefire.version>3.2.2</plugin.surefire.version>
     <plugin.os.version>1.4.1.Final</plugin.os.version>
 
     <testcontainers.version>1.19.0</testcontainers.version>
@@ -1646,7 +1645,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${plugin.failsafe.version}</version>
+          <version>${plugin.surefire.version}</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1556,6 +1556,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.surefire.version}</version>
           <configuration combine.children="append">
+            <failIfNoTests>false</failIfNoTests>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
             <environmentVariables>
               <IS_ZEPPELIN_TEST>true</IS_ZEPPELIN_TEST>
@@ -1646,6 +1648,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${plugin.surefire.version}</version>
+          <configuration>
+            <failIfNoTests>false</failIfNoTests>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -234,7 +234,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     sparkInterpreterSetting.setProperty("zeppelin.spark.useHiveContext", "false");
     sparkInterpreterSetting.setProperty("zeppelin.pyspark.useIPython", "false");
-    sparkInterpreterSetting.setProperty("PYSPARK_PYTHON", getPythonExec());
+    sparkInterpreterSetting.setProperty("spark.pyspark.python", getPythonExec());
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");
@@ -287,8 +287,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     sparkInterpreterSetting.setProperty("zeppelin.spark.useHiveContext", "false");
     sparkInterpreterSetting.setProperty("zeppelin.pyspark.useIPython", "false");
-    sparkInterpreterSetting.setProperty("zeppelin.python", getPythonExec());
-    sparkInterpreterSetting.setProperty("PYSPARK_PYTHON", getPythonExec());
+    sparkInterpreterSetting.setProperty("spark.pyspark.python", getPythonExec());
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -234,7 +234,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     sparkInterpreterSetting.setProperty("zeppelin.spark.useHiveContext", "false");
     sparkInterpreterSetting.setProperty("zeppelin.pyspark.useIPython", "false");
-    sparkInterpreterSetting.setProperty("spark.pyspark.python", getPythonExec());
+    sparkInterpreterSetting.setProperty("spark.pyspark.python", PYTHON_EXEC);
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");
@@ -287,7 +287,7 @@ public abstract class SparkIntegrationTest {
     sparkInterpreterSetting.setProperty("ZEPPELIN_CONF_DIR", zeppelin.getZeppelinConfDir().getAbsolutePath());
     sparkInterpreterSetting.setProperty("zeppelin.spark.useHiveContext", "false");
     sparkInterpreterSetting.setProperty("zeppelin.pyspark.useIPython", "false");
-    sparkInterpreterSetting.setProperty("spark.pyspark.python", getPythonExec());
+    sparkInterpreterSetting.setProperty("spark.pyspark.python", PYTHON_EXEC);
     sparkInterpreterSetting.setProperty("spark.driver.memory", "512m");
     sparkInterpreterSetting.setProperty("zeppelin.spark.scala.color", "false");
     sparkInterpreterSetting.setProperty("zeppelin.spark.deprecatedMsg.show", "false");

--- a/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
+++ b/zeppelin-jupyter-interpreter/src/main/java/org/apache/zeppelin/jupyter/JupyterKernelInterpreter.java
@@ -191,7 +191,9 @@ public class JupyterKernelInterpreter extends AbstractInterpreter {
         String freezeOutput = IOUtils.toString(in, StandardCharsets.UTF_8);
         for (PythonPackagePredicate<String> packagePredicate : getRequiredPackagesPredicates()) {
           if (!packagePredicate.test(freezeOutput)) {
-            return packagePredicate + " is not installed, installed packages:\n" + freezeOutput;
+            return packagePredicate + " is not installed, python: " + pythonExec +
+                    ", conda_env=" + getProperty("zeppelin.interpreter.conda.env.name") +
+                    ", installed packages:\n" + freezeOutput;
           }
         }
         LOGGER.info("Prerequisite for kernel {} is met", getKernelName());


### PR DESCRIPTION
### What is this PR for?

I found that we can not trigger the Livy integration tests while tackling the Livy Hadoop3 upgrading, I finally found it was caused by the low version of `maven-failsafe-plugin` not supporting JUnit5 annotations.

Actually, `maven-surefire-plugin`(for UT) and `maven-failsafe-plugin`(for IT) are developed in the same project[1] and they share the same release cycle thus have same versions.

This PR upgrades these two plugins to the latest 3.2.2 to recover the IT written in Junit5.

[1] https://github.com/apache/maven-surefire

### What type of PR is it?

Fix test cases can not run.

### Todos
* [ ] - Task

### What is the Jira issue?

ZEPPELIN-5986

### How should this be tested?

Pass CI

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
