### PR TITLE
[HOTFIX] Change the link of `helium.json` from S3 to zeppelin.apache.org

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -410,7 +410,7 @@
 <!--
 <property>
   <name>zeppelin.helium.registry</name>
-  <value>helium,https://s3.amazonaws.com/helium-package/helium.json</value>
+  <value>helium,https://zeppelin.apache.org/helium.json</value>
   <description>Location of external Helium Registry</description>
 </property>
 -->

--- a/docs/development/helium/overview.md
+++ b/docs/development/helium/overview.md
@@ -40,4 +40,4 @@ Currently, Helium supports 4 types of package.
 ## Configuration
 
 Zeppelin ships with several builtin helium plugins which is located in $ZEPPELIN_HOME/heliums. If you want to try more types of heliums plugins,
-you can configure `zeppelin.helium.registry` to be `helium,https://s3.amazonaws.com/helium-package/helium.json` in zeppelin-site.xml. `https://s3.amazonaws.com/helium-package/helium.json` will be updated regularly.
+you can configure `zeppelin.helium.registry` to be `helium,https://zeppelin.apache.org/helium.json` in zeppelin-site.xml. `https://zeppelin.apache.org/helium.json` will be updated regularly.


### PR DESCRIPTION
### What is this PR for?
Changing the default link for helium.json from s3 to zeppelin.apache.org


### What type of PR is it?
Hot Fix

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? Yes but already did it.
