### PR TITLE
[HOTFIX] Escape envs when using `.conf` interpreter

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -101,6 +101,9 @@ fi
 
 . "${bin}/common.sh"
 
+# Escape envs
+ZEPPELIN_INTP_CLASSPATH_OVERRIDES=$(printf %q "${ZEPPELIN_INTP_CLASSPATH_OVERRIDES}")
+
 check_java_version
 
 ZEPPELIN_INTERPRETER_API_JAR=$(find "${ZEPPELIN_HOME}/interpreter" -name 'zeppelin-interpreter-shaded-*.jar')


### PR DESCRIPTION
### What is this PR for?
Escaping envs to avoid `malicious code in envs`


### What type of PR is it?
Hot Fix

### Todos
* [ ] - Task

### What is the Jira issue?
N/A

### How should this be tested?
- Add shell commends inside envs
- It shouldn't be executed

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
