### PR TITLE
[NO-ISSUE] Use reload4j instead of log4j

### DIFF
--- a/flink/flink-scala-2.12/pom.xml
+++ b/flink/flink-scala-2.12/pom.xml
@@ -295,6 +295,12 @@
       <artifactId>hadoop-common</artifactId>
       <version>${flink.hadoop.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->
-    <slf4j.version>1.7.36</slf4j.version>
+    <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
     <libthrift.version>0.13.0</libthrift.version>
     <flexmark.all.version>0.62.2</flexmark.all.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,8 @@
     <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->
-    <slf4j.version>1.7.35</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <reload4j.version>1.2.25</reload4j.version>
     <libthrift.version>0.13.0</libthrift.version>
     <flexmark.all.version>0.62.2</flexmark.all.version>
     <gson.version>2.8.9</gson.version>
@@ -230,6 +231,18 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-reload4j</artifactId>
         <version>${slf4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>${reload4j.version}</version>
       </dependency>
 
       <!--  Use jcl-over-slf4j instead of commons-logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1124,6 +1128,14 @@
             <artifactId>commons-logging</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -1337,6 +1349,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,7 @@
     <plugin.frontend.version>1.12.1</plugin.frontend.version>
 
     <!-- common library versions -->
-    <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>1.2.17</log4j.version>
+    <slf4j.version>1.7.35</slf4j.version>
     <libthrift.version>0.13.0</libthrift.version>
     <flexmark.all.version>0.62.2</flexmark.all.version>
     <gson.version>2.8.9</gson.version>
@@ -229,7 +228,7 @@
 
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-reload4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
 
@@ -238,12 +237,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
       </dependency>
 
       <dependency>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -131,6 +131,12 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -91,6 +91,11 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -206,6 +211,7 @@
                     <artifactSet>
                         <excludes>
                             <exclude>org.apache.zeppelin:zeppelin-interpreter-shaded</exclude>
+                            <exclude>log4j:log4j</exclude>
                         </excludes>
                     </artifactSet>
                     <outputFile>${project.build.directory}/../../interpreter/r/${interpreter.jar.name}-${project.version}.jar</outputFile>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -83,6 +83,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/submarine/pom.xml
+++ b/submarine/pom.xml
@@ -106,6 +106,14 @@
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-core-asl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/zeppelin-distribution/src/bin_license/LICENSE
+++ b/zeppelin-distribution/src/bin_license/LICENSE
@@ -226,6 +226,7 @@ The following components are provided under Apache License.
     (Apache 2.0) Dropwizard Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.1.14) - https://github.com/dropwizard/metrics/blob/release/4.1.x/LICENSE
     (Apache 2.0) Dropwizard Metrics Health Checks (io.dropwizard.metrics:metrics-healthchecks:4.1.14) - https://github.com/dropwizard/metrics/blob/release/4.1.x/LICENSE
     (Apache 2.0) Dropwizard Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.1.14) - https://github.com/dropwizard/metrics/blob/release/4.1.x/LICENSE
+    (Apache 2.0) reload4j v1.2.25 (ch.qos.reload4j:reload4j:jar:1.2.25 - https://reload4j.qos.ch/) - https://github.com/qos-ch/reload4j/blob/master/LICENSE
 
 ========================================================================
 MIT licenses
@@ -257,9 +258,9 @@ The text of each license is also included at licenses/LICENSE-[project]-[version
     (The MIT License) moment-duration-format v1.3.0 (https://github.com/jsmreese/moment-duration-format) - https://github.com/jsmreese/moment-duration-format/blob/1.3.0/LICENSE
     (The MIT License) angular-ui-grid v4.0.4 (https://github.com/angular-ui/ui-grid) - https://github.com/angular-ui/ui-grid/blob/v4.0.4/LICENSE.md
     (The MIT License) Pikaday v1.3.2 (https://github.com/dbushell/Pikaday) - https://github.com/dbushell/Pikaday/blob/1.3.2/LICENSE
-    (The MIT License) slf4j v1.7.10 (org.slf4j:slf4j-api:jar:1.7.10 - http://www.slf4j.org) - http://www.slf4j.org/license.html
+    (The MIT License) slf4j v1.7.35 (org.slf4j:slf4j-api:jar:1.7.35 - http://www.slf4j.org) - http://www.slf4j.org/license.html
     (The MIT License) slf4j v1.7.21 (org.slf4j:slf4j-simple:1.7.21 - http://www.slf4j.org) - http://www.slf4j.org/license.html
-    (The MIT License) slf4j-log4j12 v1.7.10 (org.slf4j:slf4j-log4j12:jar:1.7.10 - http://www.slf4j.org) - http://www.slf4j.org/license.html
+    (The MIT License) slf4j-reload4j v1.7.35 (org.slf4j:slf4j-reload4j:jar:1.7.35 - http://www.slf4j.org) - http://www.slf4j.org/license.html
     (The MIT License) bcprov-jdk15on v1.70 (org.bouncycastle:bcprov-jdk15on:jar:1.70 - http://www.bouncycastle.org/java.html) - http://www.bouncycastle.org/licence.html
     (The MIT License) AnchorJS (https://github.com/bryanbraun/anchorjs) - https://github.com/bryanbraun/anchorjs/blob/master/README.md#license
     (The MIT License) moment-duration-format v1.3.0 (https://github.com/jsmreese/moment-duration-format) - https://github.com/jsmreese/moment-duration-format/blob/master/LICENSE

--- a/zeppelin-examples/zeppelin-example-clock/pom.xml
+++ b/zeppelin-examples/zeppelin-example-clock/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-examples/zeppelin-example-clock/pom.xml
+++ b/zeppelin-examples/zeppelin-example-clock/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
+++ b/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
+++ b/zeppelin-examples/zeppelin-example-horizontalbar/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     
     <dependency>

--- a/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-echo/pom.xml
@@ -54,6 +54,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     
     <dependency>

--- a/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-flowchart/pom.xml
@@ -54,6 +54,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     
     <dependency>

--- a/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-markdown/pom.xml
@@ -54,6 +54,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
@@ -52,7 +52,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     
     <dependency>

--- a/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
+++ b/zeppelin-examples/zeppelin-example-spell-translator/pom.xml
@@ -54,6 +54,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -62,7 +62,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-interpreter-parent/pom.xml
+++ b/zeppelin-interpreter-parent/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
 
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>

--- a/zeppelin-interpreter-shaded/pom.xml
+++ b/zeppelin-interpreter-shaded/pom.xml
@@ -54,11 +54,10 @@
           <artifactSet>
             <excludes>
               <!-- Leave slf4j unshaded so downstream users can configure logging. -->
-              <exclude>org.slf4j:slf4j-api</exclude>
-              <exclude>org.slf4j:slf4j-log4j12</exclude>
-              <exclude>org.slf4j:jcl-over-slf4j</exclude>
+              <exclude>org.slf4j:*</exclude>
               <!-- Leave log4j unshaded so downstream users can configure logging. -->
               <exclude>log4j:log4j</exclude>
+              <exclude>ch.qos.reload4j:reload4j</exclude>
             </excludes>
           </artifactSet>
           <filters>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -269,11 +269,27 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-log4j12</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-yarn-client</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
 

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -138,7 +138,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
 
     <dependency>

--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -142,6 +142,11 @@
     </dependency>
 
     <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>

--- a/zeppelin-jupyter-interpreter-shaded/pom.xml
+++ b/zeppelin-jupyter-interpreter-shaded/pom.xml
@@ -66,6 +66,11 @@
       <version>${google.errorprone.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -100,6 +105,7 @@
           <artifactSet>
             <excludes>
               <exclude>org.apache.zeppelin:zeppelin-interpreter-shaded</exclude>
+              <exclude>log4j:log4j</exclude>
             </excludes>
           </artifactSet>
           <relocations>

--- a/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+++ b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
@@ -84,12 +84,6 @@
                     <artifactId>hadoop-client</artifactId>
                     <scope>provided</scope>
                     <version>${hadoop.version}</version>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>org.slf4j</groupId>
-                            <artifactId>slf4j-reload4j</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.hadoop</groupId>

--- a/zeppelin-plugins/notebookrepo/filesystem/pom.xml
+++ b/zeppelin-plugins/notebookrepo/filesystem/pom.xml
@@ -84,6 +84,12 @@
                     <artifactId>hadoop-client</artifactId>
                     <scope>provided</scope>
                     <version>${hadoop.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-reload4j</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.hadoop</groupId>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -86,7 +86,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
+          <artifactId>slf4j-reload4j</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -102,7 +102,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -94,10 +94,6 @@
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
           <artifactId>jcl-over-slf4j</artifactId>
         </exclusion>
       </exclusions>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -86,7 +86,15 @@
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
           <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -103,6 +111,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/zeppelin-zengine/pom.xml
+++ b/zeppelin-zengine/pom.xml
@@ -321,6 +321,12 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What is this PR for?

* reload4j does not prevent us moving to log4jv2 later
* reload4j fixes some security issues in log4j
* it doesn't feel great for an ASF project to still be using insecure logging frameworks like log4j v1

### What type of PR is it?
Bug Fix
Improvement
Feature
Documentation
Hot Fix
Refactoring
*Please leave your type of PR only*

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
