### PR TITLE
[NO-ISSUE] Reduce the minimum column width in table view

### DIFF
--- a/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.html
+++ b/zeppelin-web-angular/src/app/visualizations/table/table-visualization.component.html
@@ -37,12 +37,13 @@
 <nz-table #table
           nzSize="small"
           nzShowSizeChanger
+          [nzScroll]="{ x: '1300px' }"
           [nzData]="rows"
           [nzFooter]="aggregatesFooter">
   <thead>
   <tr>
     <th *ngFor="let col of columns"
-        nzWidth="800px"
+        nzWidth="200px"
         nzShowSort
         nzCustomFilter
         [nzSortKey]="col"


### PR DESCRIPTION
…sively wide column widths resulted in the remaining fields being squeezed out of the screen, and nz table did not have a scroll bar set to display scrolling.

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html
When I am using the new Zeppelin interface for querying with jdbc or Spark SQL, the resulting table cannot display all the content.
Example: If there is a MySQL table as follows.
![image](https://github.com/apache/zeppelin/assets/23468656/cfd74ce8-d7c5-471a-bc9b-94d0b2bf9247)
When using zeppelin jdbc queries, the following results will be obtained:
![image](https://github.com/apache/zeppelin/assets/23468656/70affe07-d6d8-4081-a861-0de59ea4c8df)
You can see that only two fields are displayed.
The specific reason is that the use of excessively wide column widths resulted in the remaining fields being squeezed out of the screen, and nz table did not have a scroll bar set to display scrolling.

### What type of PR is it?
Improvement
*Please leave your type of PR only*

### Todos
* [ ] - Task
The solution is as follows:
*  1. Add a horizontal scrollbar to the nz table of Angular JS by modifying it, so that the remaining fields can be displayed by scrolling.
*  2. Adjust the column width to be too wide for better display.
### What is the Jira issue?
NONE

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
![image](https://github.com/apache/zeppelin/assets/23468656/a4f12c70-c7e4-42eb-954e-0fa8f2007d47)
![image](https://github.com/apache/zeppelin/assets/23468656/1d2810d0-3a7c-41b2-8c04-4413ea05872c)

### Questions:
* Does the license files need to update?
 No need
* Is there breaking changes for older versions?
no
* Does this needs documentation?
No need
