### PR TITLE
[ZEPPELIN-6002] Fix completer NPE

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -207,8 +207,7 @@ public class SqlCompleter {
     }
   }
 
-  public static Set<String> getSqlKeywordsCompletions(DatabaseMetaData meta) throws IOException,
-          SQLException {
+  public static Set<String> getSqlKeywordsCompletions(DatabaseMetaData meta) throws IOException {
     // Add the default SQL completions
     String keywords =
             new BufferedReader(new InputStreamReader(
@@ -217,11 +216,11 @@ public class SqlCompleter {
     Set<String> completions = new TreeSet<>();
 
     if (null != meta) {
-      // Add the driver specific SQL completions
-      String driverSpecificKeywords =
-              "/" + meta.getDriverName().replace(" ", "-").toLowerCase() + "-sql.keywords";
-      logger.info("JDBC DriverName:" + driverSpecificKeywords);
       try {
+        // Add the driver specific SQL completions
+        String driverSpecificKeywords =
+                "/" + meta.getDriverName().replace(" ", "-").toLowerCase() + "-sql.keywords";
+        logger.info("JDBC DriverName: {}", driverSpecificKeywords);
         if (SqlCompleter.class.getResource(driverSpecificKeywords) != null) {
           String driverKeywords =
                   new BufferedReader(new InputStreamReader(
@@ -229,35 +228,35 @@ public class SqlCompleter {
                           .readLine();
           keywords += "," + driverKeywords.toUpperCase();
         }
-      } catch (Exception e) {
+      } catch (IOException | SQLException e) {
         logger.debug("fail to get driver specific SQL completions for " +
-                driverSpecificKeywords + " : " + e, e);
+            meta.getClass().getName() + " : " + e, e);
       }
 
       // Add the keywords from the current JDBC connection
       try {
         keywords += "," + meta.getSQLKeywords();
-      } catch (Exception e) {
+      } catch (SQLException e) {
         logger.debug("fail to get SQL key words from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getStringFunctions();
-      } catch (Exception e) {
+      } catch (SQLException e) {
         logger.debug("fail to get string function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getNumericFunctions();
-      } catch (Exception e) {
+      } catch (SQLException e) {
         logger.debug("fail to get numeric function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getSystemFunctions();
-      } catch (Exception e) {
+      } catch (SQLException e) {
         logger.debug("fail to get system function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getTimeDateFunctions();
-      } catch (Exception e) {
+      } catch (SQLException e) {
         logger.debug("fail to get time date function names from database metadata: " + e, e);
       }
 


### PR DESCRIPTION
### What is this PR for?
NPE occur when adding the driver specific SQL completions. Some driver(hive-jdbc-uber-2.6.5.0-292.jar in my case) does not implement method `DatabaseMetaData.getDriverName()` well and cause exception , then fail to initialize `keywordCompleter`.

Since it is optional, we should avoid such driver interfere  the default one, and log it for the profession

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6002

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
![image](https://github.com/apache/zeppelin/assets/3809732/b050cb62-785e-4614-8b20-77f32ef677b1)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
