### PR TITLE
[ZEPPELIN-6003] Log source info of SQL in JDBCInterpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -763,6 +763,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     Statement statement;
     ResultSet resultSet = null;
     String paragraphId = context.getParagraphId();
+    String noteId = context.getNoteId();
     String user = getUser(context);
 
     try {
@@ -799,7 +800,8 @@ public class JDBCInterpreter extends KerberosInterpreter {
           // so we need to trim it first in this case.
           sqlToExecute = sqlToExecute.trim();
         }
-        LOGGER.info("Execute sql: " + sqlToExecute);
+        LOGGER.info(String.format("[%s|%s|%s] Execute sql: %s",
+                user, noteId, paragraphId, sqlToExecute));
         statement = connection.createStatement();
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -800,8 +800,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
           // so we need to trim it first in this case.
           sqlToExecute = sqlToExecute.trim();
         }
-        LOGGER.info(String.format("[%s|%s|%s] Execute sql: %s",
-                user, noteId, paragraphId, sqlToExecute));
+        LOGGER.info("[{}|{}|{}] Execute sql: {}", user, noteId, paragraphId, sqlToExecute);
         statement = connection.createStatement();
 
         // fetch n+1 rows in order to indicate there's more rows available (for large selects)


### PR DESCRIPTION
### What is this PR for?
Currently we can monitor running SQL in JDBCInterpreter  but unable to know who/which note fire the SQL, especially a couple of users using zeppelin at the same time. 

Bond the SQL with additional info,  we can inform the user with user/noteid/paragragh info  if needed

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6003

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
