### PR TITLE
[ZEPPELIN-6007] Enhance release scripts for tar shasum commands detection

### DIFF
--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -20,11 +20,17 @@
 # common fucntions
 
 if [[ -z "${TAR}" ]]; then
-  TAR="/usr/bin/tar"
+  TAR="tar"
+    if [ "$(uname -s)" = "Darwin" ]; then
+      TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
+    fi
 fi
 
 if [[ -z "${SHASUM}" ]]; then
-  SHASUM="/usr/bin/shasum"
+  SHASUM="sha512sum"
+  if [ "$(uname)" == "Darwin" ]; then
+      SHASUM="shasum -a 512"
+  fi
 fi
 
 if [[ -z "${WORKING_DIR}" ]]; then

--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -29,7 +29,7 @@ fi
 if [[ -z "${SHASUM}" ]]; then
   SHASUM="sha512sum"
   if [ "$(uname -s)" = "Darwin" ]; then
-      SHASUM="shasum -a 512"
+    SHASUM="shasum -a 512"
   fi
 fi
 

--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -21,9 +21,9 @@
 
 if [[ -z "${TAR}" ]]; then
   TAR="tar"
-    if [ "$(uname -s)" = "Darwin" ]; then
-      TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
-    fi
+  if [ "$(uname -s)" = "Darwin" ]; then
+    TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
+  fi
 fi
 
 if [[ -z "${SHASUM}" ]]; then

--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -28,7 +28,7 @@ fi
 
 if [[ -z "${SHASUM}" ]]; then
   SHASUM="sha512sum"
-  if [ "$(uname)" == "Darwin" ]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
       SHASUM="shasum -a 512"
   fi
 fi


### PR DESCRIPTION
### What is this PR for?

When untar the 0.11.1 RC1 tgz on Linux, I found the following warnings. It's actually caused by macOS `tar`'s default behavior, see more details at [SPARK-43395](https://issues.apache.org/jira/browse/SPARK-43395)
```
➜  zeppelin-0.11.1-rc1 tar -xzf zeppelin-0.11.1-bin-all.tgz
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.provenance'
```

Similarly, `shasum` is also different on macOS and Linux.

### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?

ZEPPELIN-6007

### How should this be tested?

Manually test.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
