### PR TITLE
[ZEPPELIN-6011] fix Dockerfile JAVA_HOME to openjdk11

### DIFF
--- a/scripts/docker/zeppelin-server/Dockerfile
+++ b/scripts/docker/zeppelin-server/Dockerfile
@@ -40,7 +40,7 @@ ARG version="0.11.1"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     VERSION="${version}" \
     HOME="/opt/zeppelin" \
     ZEPPELIN_HOME="/opt/zeppelin" \


### PR DESCRIPTION
### What is this PR for?
To fix the Dockerfile for Zeppelin Server for `branch-0.11`. The `JAVA_HOME` variable was set to Java 8, while `openjdk11` is being installed.
This issue is already fixed in the master branch.


### What type of PR is it?
Bug Fix

*Please leave your type of PR only*

### Todos
* [ ] - Fix JAVA_HOME variable in `scripts/docker/zeppelin-server/Dockerfile`

### What is the Jira issue?
[* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/](https://issues.apache.org/jira/browse/ZEPPELIN-6011)
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here 
  * Not too sure how to automate this testing as i'm new at this. 


### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
