### PR TITLE
[ZEPPELIN-6011] fix `zeppelin/scripts/docker/zeppelin/bin/Dockerfile` Dockerfile JAVA_HOME to openjdk11 

### DIFF
--- a/scripts/docker/zeppelin-server/Dockerfile
+++ b/scripts/docker/zeppelin-server/Dockerfile
@@ -40,7 +40,7 @@ ARG version="0.11.1"
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     VERSION="${version}" \
     HOME="/opt/zeppelin" \
     ZEPPELIN_HOME="/opt/zeppelin" \

--- a/scripts/docker/zeppelin/bin/Dockerfile
+++ b/scripts/docker/zeppelin/bin/Dockerfile
@@ -24,13 +24,13 @@ ENV LOG_TAG="[ZEPPELIN_${Z_VERSION}]:" \
     HOME="/opt/zeppelin" \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
     ZEPPELIN_ADDR="0.0.0.0"
 
 RUN echo "$LOG_TAG install basic packages" && \
     apt-get -y update && \
     # Switch back to install JRE instead of JDK when moving to JDK9 or later.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-8-jdk-headless wget unzip && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y locales language-pack-en tini openjdk-11-jdk-headless wget unzip && \
     # Cleanup
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoclean && \


### PR DESCRIPTION
### What is this PR for?
To update `zeppelin/scripts/docker/zeppelin/bin/Dockerfile` to OpenJDK 11

Follow up PR from https://github.com/apache/zeppelin/pull/4751

### What type of PR is it?
Bug Fix



### What is the Jira issue?
* [ZEPPELIN-6011](https://issues.apache.org/jira/browse/ZEPPELIN-6011)


### How should this be tested?
* Outline any manual steps to test the PR here.
  * Not too sure how to automate this testing as i'm new at this.

