### PR TITLE
[HOTFIX] Remove rendering helium description as HTML in Frontend

### DIFF
--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/helium/HeliumPackageTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/helium/HeliumPackageTest.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.helium;
 
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Map;
 
@@ -31,7 +32,7 @@ class HeliumPackageTest {
     String examplePackage = "{\n" +
         "  \"type\" : \"SPELL\",\n" +
         "  \"name\" : \"echo-spell\",\n" +
-        "  \"description\" : \"'%echo' - return just what receive (example)\",\n" +
+        "  \"description\" : \"'%echo' - return just what receive (example)i<img src onerror=alert(3)>\",\n" +
         "  \"artifact\" : \"./zeppelin-examples/zeppelin-example-spell-echo\",\n" +
         "  \"license\" : \"Apache-2.0\",\n" +
         "  \"icon\" : \"<i class='fa fa-repeat'></i>\",\n" +
@@ -44,6 +45,7 @@ class HeliumPackageTest {
     HeliumPackage p = HeliumPackage.fromJson(examplePackage);
     assertEquals("%echo", p.getSpellInfo().getMagic());
     assertEquals(escapeHtml4("%echo <TEXT>"), p.getSpellInfo().getUsage());
+    assertNotEquals("'%echo' - return just what receive (example)i<img src onerror=alert(3)>", p.getDescription());
   }
 
   @Test

--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -374,7 +374,7 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
   };
 
   $scope.getDescriptionText = function(pkgSearchResult) {
-    return $sce.trustAsHtml(pkgSearchResult.pkg.description);
+    return pkgSearchResult.pkg.description;
   };
 
   init();


### PR DESCRIPTION
### What is this PR for?
Removing wrong logic for rendering helium description in helium

### What type of PR is it?
Hot Fix

### Todos
* [x] - remove `$sce.trustAsHtml()`

### What is the Jira issue?
N/A

### How should this be tested?
JS in a helium description shouldn't be executed.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
