### PR TITLE
[ZEPPELIN-6017] Revert changes about ZEPPELIN_IDENT_STRING in ZEPPELIN-5421

### DIFF
--- a/bin/common.cmd
+++ b/bin/common.cmd
@@ -86,6 +86,10 @@ if not defined JAVA_HOME (
     set ZEPPELIN_RUNNER=%JAVA_HOME%\bin\java
 )
 
+if not defined ZEPPELIN_IDENT_STRING (
+    set ZEPPELIN_IDENT_STRING=%USERNAME%
+)
+
 if not defined ZEPPELIN_INTERPRETER_REMOTE_RUNNER (
     set ZEPPELIN_INTERPRETER_REMOTE_RUNNER=bin\interpreter.cmd
 )

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -171,6 +171,10 @@ else
 fi
 export ZEPPELIN_RUNNER
 
+if [[ -z "$ZEPPELIN_IDENT_STRING" ]]; then
+  export ZEPPELIN_IDENT_STRING="${USER}"
+fi
+
 if [[ -z "$ZEPPELIN_INTERPRETER_REMOTE_RUNNER" ]]; then
   export ZEPPELIN_INTERPRETER_REMOTE_RUNNER="bin/interpreter.sh"
 fi


### PR DESCRIPTION
### What is this PR for?
#4146 delete the definition check about ZEPPELIN_IDENT_STRING in case of surefire version upgrade 
but it will make the log file names become: 
```
zeppelin--SERVER.log
zeppelin--SERVER.out
zeppelin-interpreter-jdbc-shared_process–SERVER.log
```
in the defintion of:
```
zeppelin-${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.log
zeppelin-${ZEPPELIN_IDENT_STRING}-${HOSTNAME}.out
zeppelin-interpreter-%INTERPRETER_ID%%ZEPPELIN_IDENT_STRING%%HOSTNAME%.log
```

so, we revert changes about ZEPPELIN_IDENT_STRING to fix the filename

### What type of PR is it?
Hot Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6017