### PR TITLE
[ZEPPELIN-6022] Skip decryption of credentials.json when file is empty

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -139,7 +139,7 @@ public class Credentials {
   private void loadFromFile() throws IOException {
     try {
       String json = storage.loadCredentials();
-      if (json != null && encryptor != null && !json.isEmpty()) {
+      if (encryptor != null && StringUtils.isNotBlank(json)) {
         json = encryptor.decrypt(json);
       }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/user/Credentials.java
@@ -139,7 +139,7 @@ public class Credentials {
   private void loadFromFile() throws IOException {
     try {
       String json = storage.loadCredentials();
-      if (json != null && encryptor != null) {
+      if (json != null && encryptor != null && !json.isEmpty()) {
         json = encryptor.decrypt(json);
       }
 


### PR DESCRIPTION
### What is this PR for?
This PR skip credentials.json decryption if the file is empty. 
This allow using of type=bind on conf/credentials.json when running docker image especially for initial startup where credentials.json does not exist


### What type of PR is it?
Improvement

*Please leave your type of PR only*

### Todos
* [ ] - Task

### What is the Jira issue?
(https://issues.apache.org/jira/browse/ZEPPELIN-6022)

### How should this be tested?
* CI with automated test

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Maybe
