### PR TITLE
[ZEPPELIN-6027] Enhanced Integration with Apache Kyuubi

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -39,6 +39,7 @@
     <h2.version>2.2.220</h2.version>
     <commons.dbcp2.version>2.0.1</commons.dbcp2.version>
     <hive3.version>3.1.3</hive3.version>
+    <kyuubi.version>1.9.1</kyuubi.version>
 
     <!--test library versions-->
     <mockrunner.jdbc.version>1.0.8</mockrunner.jdbc.version>
@@ -133,6 +134,13 @@
           <groupId>org.apache.hbase</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kyuubi</groupId>
+      <artifactId>kyuubi-hive-jdbc-shaded</artifactId>
+      <version>${kyuubi.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -35,6 +35,7 @@ import org.apache.zeppelin.interpreter.SingleRowInterpreterResult;
 import org.apache.zeppelin.interpreter.ZeppelinContext;
 import org.apache.zeppelin.interpreter.util.SqlSplitter;
 import org.apache.zeppelin.jdbc.hive.HiveUtils;
+import org.apache.zeppelin.jdbc.kyuubi.KyuubiUtils;
 import org.apache.zeppelin.tabledata.TableDataUtils;
 import org.apache.zeppelin.util.PropertiesUtil;
 import org.slf4j.Logger;
@@ -825,10 +826,16 @@ public class JDBCInterpreter extends KerberosInterpreter {
           String jdbcURL = getJDBCConfiguration(user).getProperty().getProperty(URL_KEY);
           String driver =
                   getJDBCConfiguration(user).getProperty().getProperty(DRIVER_KEY);
-          if (jdbcURL != null && jdbcURL.startsWith("jdbc:hive2://")
-                  && driver != null && driver.equals("org.apache.hive.jdbc.HiveDriver")) {
+          if (jdbcURL != null && driver != null) {
+            if (driver.equals("org.apache.hive.jdbc.HiveDriver") &&
+                jdbcURL.startsWith("jdbc:hive2://")) {
             HiveUtils.startHiveMonitorThread(statement, context,
                     Boolean.parseBoolean(getProperty("hive.log.display", "true")), this);
+            } else if (driver.equals("org.apache.kyuubi.jdbc.KyuubiHiveDriver") &&
+                (jdbcURL.startsWith("jdbc:kyuubi://") || jdbcURL.startsWith("jdbc:hive2://"))) {
+              KyuubiUtils.startMonitorThread(connection, statement, context,
+                  Boolean.parseBoolean(getProperty("kyuubi.log.display", "true")), this);
+            }
           }
           boolean isResultSetAvailable = statement.execute(sqlToExecute);
           getJDBCConfiguration(user).setConnectionInDBDriverPoolSuccessful();

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -829,7 +829,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
           if (jdbcURL != null && driver != null) {
             if (driver.equals("org.apache.hive.jdbc.HiveDriver") &&
                 jdbcURL.startsWith("jdbc:hive2://")) {
-            HiveUtils.startHiveMonitorThread(statement, context,
+              HiveUtils.startHiveMonitorThread(statement, context,
                     Boolean.parseBoolean(getProperty("hive.log.display", "true")), this);
             } else if (driver.equals("org.apache.kyuubi.jdbc.KyuubiHiveDriver") &&
                 (jdbcURL.startsWith("jdbc:kyuubi://") || jdbcURL.startsWith("jdbc:hive2://"))) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/BeelineInPlaceUpdateStream.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/BeelineInPlaceUpdateStream.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.jdbc.kyuubi;
+
+
+import org.apache.hadoop.hive.common.log.InPlaceUpdate;
+import org.apache.hadoop.hive.common.log.ProgressMonitor;
+import org.apache.kyuubi.jdbc.hive.logs.InPlaceUpdateStream;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TJobExecutionStatus;
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.TProgressUpdateResp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintStream;
+import java.util.List;
+
+public class BeelineInPlaceUpdateStream implements InPlaceUpdateStream {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BeelineInPlaceUpdateStream.class);
+
+  private InPlaceUpdate inPlaceUpdate;
+  private EventNotifier notifier;
+  private long lastUpdateTimestamp;
+
+  public BeelineInPlaceUpdateStream(PrintStream out,
+                                    EventNotifier notifier) {
+    this.inPlaceUpdate = new InPlaceUpdate(out);
+    this.notifier = notifier;
+  }
+
+  @Override
+  public void update(TProgressUpdateResp response) {
+    if (response == null || response.getStatus().equals(TJobExecutionStatus.NOT_AVAILABLE)) {
+      /*
+        we set it to completed if there is nothing the server has to report
+        for example, DDL statements
+      */
+      notifier.progressBarCompleted();
+    } else if (notifier.isOperationLogUpdatedAtLeastOnce()) {
+      /*
+        try to render in place update progress bar only if the operations logs is update at
+        least once
+        as this will hopefully allow printing the metadata information like query id,
+        application id
+        etc. have to remove these notifiers when the operation logs get merged into
+        GetOperationStatus
+      */
+      lastUpdateTimestamp = System.currentTimeMillis();
+      LOGGER.info("update progress: {}", response.getProgressedPercentage());
+      inPlaceUpdate.render(new ProgressMonitorWrapper(response));
+    }
+  }
+
+  public long getLastUpdateTimestamp() {
+    return lastUpdateTimestamp;
+  }
+
+  @Override
+  public EventNotifier getEventNotifier() {
+    return notifier;
+  }
+
+  static class ProgressMonitorWrapper implements ProgressMonitor {
+    private TProgressUpdateResp response;
+
+    ProgressMonitorWrapper(TProgressUpdateResp response) {
+      this.response = response;
+    }
+
+    @Override
+    public List<String> headers() {
+      return response.getHeaderNames();
+    }
+
+    @Override
+    public List<List<String>> rows() {
+      return response.getRows();
+    }
+
+    @Override
+    public String footerSummary() {
+      return response.getFooterSummary();
+    }
+
+    @Override
+    public long startTime() {
+      return response.getStartTime();
+    }
+
+    @Override
+    public String executionStatus() {
+      throw new UnsupportedOperationException(
+              "This should never be used for anything. All the required data is " +
+                      "available via other methods"
+      );
+    }
+
+    @Override
+    public double progressedPercentage() {
+      return response.getProgressedPercentage();
+    }
+  }
+}
+

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/KyuubiUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/KyuubiUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.jdbc.kyuubi;
+
+import org.apache.commons.dbcp2.DelegatingConnection;
+import org.apache.commons.dbcp2.DelegatingStatement;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kyuubi.jdbc.hive.KyuubiConnection;
+import org.apache.kyuubi.jdbc.hive.KyuubiStatement;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.jdbc.JDBCInterpreter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class include hive specific stuff.
+ * e.g. Display hive job execution info.
+ *
+ */
+public class KyuubiUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(KyuubiUtils.class);
+  private static final int DEFAULT_QUERY_PROGRESS_INTERVAL = 1000;
+  /**
+   * Display hive job execution info
+   */
+  public static void startMonitorThread(Connection conn,
+                                        Statement stmt,
+                                        InterpreterContext context,
+                                        boolean displayLog,
+                                        JDBCInterpreter jdbcInterpreter) {
+    KyuubiConnection kyuubiConn = (KyuubiConnection)
+            ((DelegatingConnection<?>) ((DelegatingConnection<?>) conn).getDelegate()).getDelegate();
+    KyuubiStatement kyuubiStmt = (KyuubiStatement)
+            ((DelegatingStatement) ((DelegatingStatement) stmt).getDelegate()).getDelegate();
+    // need to use final variable progressBar in thread, so need progressBarTemp here.
+    final ProgressBar progressBar = new ProgressBar();
+    final long queryInterval = Long.parseLong(
+            jdbcInterpreter.getProperty("zeppelin.jdbc.kyuubi.monitor.query_interval",
+                    DEFAULT_QUERY_PROGRESS_INTERVAL + ""));
+    Thread thread = new Thread(() -> {
+      String jobUrlTemplate = jdbcInterpreter.getProperty("zeppelin.jdbc.kyuubi.jobUrl.template");
+      boolean jobUrlExtracted = false;
+
+      try {
+        while (kyuubiStmt.hasMoreLogs() && !kyuubiStmt.isClosed() && !Thread.interrupted()) {
+          Thread.sleep(queryInterval);
+          List<String> logs = kyuubiStmt.getExecLog();
+          String logsOutput = StringUtils.join(logs, System.lineSeparator());
+          LOGGER.debug("Kyuubi job output: {}", logsOutput);
+          boolean displayLogProperty = context.getBooleanLocalProperty("displayLog", displayLog);
+          if (displayLogProperty && !StringUtils.isBlank(logsOutput)) {
+            context.out.write(logsOutput + "\n");
+            context.out.flush();
+            progressBar.operationLogShowedToUser();
+          }
+
+          if (!jobUrlExtracted) {
+            String appId = kyuubiConn.getEngineId();
+            String appUrl = kyuubiConn.getEngineUrl();
+            String jobUrl = null;
+            // prefer to use customized template, and fallback to Kyuubi returned engine url
+            if (StringUtils.isNotBlank(jobUrlTemplate) && StringUtils.isNotBlank(appId)) {
+              jobUrl = jobUrlTemplate.replace("{{applicationId}}", appId);
+            } else if (StringUtils.isNotBlank(appUrl)) {
+              jobUrl = appUrl;
+            }
+            if (jobUrl != null) {
+              LOGGER.info("Detected Kyuubi engine URL: {}", jobUrl);
+              Map<String, String> infos = new HashMap<>();
+              infos.put("jobUrl", jobUrl);
+              infos.put("label", "KYUUBI JOB");
+              infos.put("tooltip", "View Application Web UI");
+              infos.put("noteId", context.getNoteId());
+              infos.put("paraId", context.getParagraphId());
+              context.getIntpEventClient().onParaInfosReceived(infos);
+              jobUrlExtracted = true;
+            }
+          }
+        }
+      } catch (InterruptedException e) {
+        LOGGER.warn("Kyuubi monitor thread is interrupted", e);
+        Thread.currentThread().interrupt();
+      } catch (Exception e) {
+        LOGGER.warn("Fail to monitor KyuubiStatement", e);
+      }
+
+      LOGGER.info("KyuubiMonitor-Thread is finished");
+    });
+    thread.setName("KyuubiMonitor-Thread");
+    thread.setDaemon(true);
+    thread.start();
+    LOGGER.info("Start KyuubiMonitor-Thread for sql: {}", kyuubiStmt);
+
+    progressBar.setInPlaceUpdateStream(kyuubiStmt, context.out);
+  }
+}

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/KyuubiUtils.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/KyuubiUtils.java
@@ -50,8 +50,8 @@ public class KyuubiUtils {
                                         InterpreterContext context,
                                         boolean displayLog,
                                         JDBCInterpreter jdbcInterpreter) {
-    KyuubiConnection kyuubiConn = (KyuubiConnection)
-            ((DelegatingConnection<?>) ((DelegatingConnection<?>) conn).getDelegate()).getDelegate();
+    KyuubiConnection kyuubiConn = (KyuubiConnection) ((DelegatingConnection<?>)
+        ((DelegatingConnection<?>) conn).getDelegate()).getDelegate();
     KyuubiStatement kyuubiStmt = (KyuubiStatement)
             ((DelegatingStatement) ((DelegatingStatement) stmt).getDelegate()).getDelegate();
     // need to use final variable progressBar in thread, so need progressBarTemp here.

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/ProgressBar.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/kyuubi/ProgressBar.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.jdbc.kyuubi;
+
+import org.apache.kyuubi.jdbc.hive.KyuubiStatement;
+import org.apache.kyuubi.jdbc.hive.logs.InPlaceUpdateStream;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class ProgressBar {
+  private InPlaceUpdateStream.EventNotifier eventNotifier;
+  private BeelineInPlaceUpdateStream beelineInPlaceUpdateStream;
+
+  public ProgressBar() {
+    this.eventNotifier = new InPlaceUpdateStream.EventNotifier();
+  }
+
+  public void operationLogShowedToUser() {
+    this.eventNotifier.operationLogShowedToUser();
+  }
+
+  public BeelineInPlaceUpdateStream getInPlaceUpdateStream(OutputStream out) {
+    beelineInPlaceUpdateStream = new BeelineInPlaceUpdateStream(
+            new PrintStream(out),
+            eventNotifier
+    );
+    return beelineInPlaceUpdateStream;
+  }
+
+  public BeelineInPlaceUpdateStream getBeelineInPlaceUpdateStream() {
+    return beelineInPlaceUpdateStream;
+  }
+
+  public void setInPlaceUpdateStream(KyuubiStatement kyuubiStmt, OutputStream out){
+    kyuubiStmt.setInPlaceUpdateStream(this.getInPlaceUpdateStream(out));
+  }
+}

--- a/jdbc/src/main/resources/interpreter-setting.json
+++ b/jdbc/src/main/resources/interpreter-setting.json
@@ -150,6 +150,27 @@
         "defaultValue": true,
         "description": "Set application tag for applications started by hive engines",
         "type": "checkbox"
+      },
+      "zeppelin.jdbc.kyuubi.timeout.threshold": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.kyuubi.timeout.threshold",
+        "defaultValue": "60000",
+        "description": "Timeout for kyuubi job timeout",
+        "type": "number"
+      },
+      "zeppelin.jdbc.kyuubi.monitor.query_interval": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.kyuubi.monitor.query_interval",
+        "defaultValue": "1000",
+        "description": "Query interval for kyuubi statement",
+        "type": "number"
+      },
+      "zeppelin.jdbc.kyuubi.jobUrl.template": {
+        "envName": null,
+        "propertyName": "zeppelin.jdbc.kyuubi.jobUrl.template",
+        "defaultValue": "",
+        "description": "The Kyuubi engine URL pattern, supports {{applicationId}} as placeholder",
+        "type": "string"
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?

[Apache Kyuubi](https://kyuubi.apache.org) is a distributed and multi-tenant gateway to provide serverless SQL on Lakehouses. Namely, the latest [v1.9.1](https://kyuubi.apache.org/release/1.9.1.html) adds support for [Apache Spark 4.0.0-preview1](https://spark.apache.org/news/spark-4.0.0-preview1.html), integrated Zeppelin with Kyuubi unblocks users to adopt new Spark seamlessly. 

Kyuubi supports multiple computing engines, e.g. Spark, Flink, Hive, Trino, Doris, and multiple languages, e.g. SQL, Scala, PySpark.

This PR forces on the existing Spark SQL cases, adding support for:

- extracting logs
- jumping job web page

### What type of PR is it?

Feature

### What is the Jira issue?

ZEPPELIN-6027

### How should this be tested?

Manually tested, as the existing Hive has no UT either.

### Screenshots (if appropriate)

![image](https://github.com/apache/zeppelin/assets/26535726/1b82d51e-3625-4219-8d87-4d22742fd690)

<img width="1200" alt="Xnip2024-06-28_22-33-44" src="https://github.com/apache/zeppelin/assets/26535726/b8d50cc9-7a1c-4c1c-95d0-452dd43a4757">

<img width="1475" alt="Xnip2024-06-28_22-54-25" src="https://github.com/apache/zeppelin/assets/26535726/7d544a6c-7bc4-4cf6-a54e-7d2fcdebd4e3">

<img width="1475" alt="image" src="https://github.com/apache/zeppelin/assets/26535726/dee6feb0-ff58-47a2-a1e5-4ba7de29a0de">


### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No,
* Does this needs documentation? Yes, but maybe later, in dedicated PR.
