### PR TITLE
[ZEPPELIN-6028] Enhance default value assignment for ZEPPELIN_IDENT_STRING

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -172,6 +172,10 @@ fi
 export ZEPPELIN_RUNNER
 
 if [[ -z "$ZEPPELIN_IDENT_STRING" ]]; then
+  # if for some reason the shell doesn't have $USER defined
+  # (e.g., ssh'd in to execute a command)
+  # let's get the effective username and use that
+  USER=${USER:-$(id -nu)}
   export ZEPPELIN_IDENT_STRING="${USER}"
 fi
 


### PR DESCRIPTION
### What is this PR for?

In some cases, `$USER` is not available, this PR follows Hadoop[1] to enhance the `USER` evaluation.

For example, there is no `$USER` when login to docker
```
$ docker run -t -i ubuntu:latest
root@1dbeaefd6cd4:/# echo $USER

root@1dbeaefd6cd4:/# exit
```

[1] https://github.com/apache/hadoop/blob/rel/release-3.4.0/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh#L893-L896

### What type of PR is it?

Improvement

### What is the Jira issue?

ZEPPELIN-6028

### How should this be tested?

Review.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
