### PR TITLE
[ZEPPELIN-6029] Set COPYFILE_DISABLE=1 for macOS tar

### DIFF
--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -22,7 +22,8 @@
 if [[ -z "${TAR}" ]]; then
   TAR="tar"
   if [ "$(uname -s)" = "Darwin" ]; then
-    TAR="tar --no-mac-metadata --no-xattrs --no-fflags --disable-copyfile"
+    export COPYFILE_DISABLE=1
+    TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
   fi
 fi
 

--- a/dev/common_release.sh
+++ b/dev/common_release.sh
@@ -22,7 +22,7 @@
 if [[ -z "${TAR}" ]]; then
   TAR="tar"
   if [ "$(uname -s)" = "Darwin" ]; then
-    TAR="tar --no-mac-metadata --no-xattrs --no-fflags"
+    TAR="tar --no-mac-metadata --no-xattrs --no-fflags --disable-copyfile"
   fi
 fi
 


### PR DESCRIPTION
### What is this PR for?

It was reported in ZEPPELIN-6029 that `zeppelin-0.11.1-bin-all.tgz` contains obsolete hidden files.

For every `$FILE` inside the Archive there is a second file called `._FILE`, e.g.
```
./lib/libthrift-0.13.0.jar
./lib/._libthrift-0.13.0.jar
```

I'm not sure how this happened, but according to https://apple.stackexchange.com/questions/280913/tar-excluding-files, `COPYFILE_DISABLE=1` should be used to address this issue.

### What type of PR is it?

Bug Fix

### What is the Jira issue?

ZEPPELIN-6029

### How should this be tested?

cc @jongyoul who is the release manager of Zeppelin 0.11.1

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
