### PR TITLE
[ZEPPELIN-6031] Clean up test directories even after unexpected exit of `AbstractInterpreterTest`

### DIFF
--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -112,6 +112,7 @@ public abstract class AbstractInterpreterTest {
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials);
     interpreterSettingManager.setNotebook(notebook);
 
+    // cleanup the test directories on exit
     FileUtils.forceDeleteOnExit(interpreterDir);
     FileUtils.forceDeleteOnExit(confDir);
     FileUtils.forceDeleteOnExit(notebookDir);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -111,6 +111,10 @@ public abstract class AbstractInterpreterTest {
     Credentials credentials = new Credentials(conf, storage);
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials);
     interpreterSettingManager.setNotebook(notebook);
+
+    FileUtils.forceDeleteOnExit(interpreterDir);
+    FileUtils.forceDeleteOnExit(confDir);
+    FileUtils.forceDeleteOnExit(notebookDir);
   }
 
   @AfterEach

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -76,9 +76,14 @@ public abstract class AbstractInterpreterTest {
     notebookDir = new File(zeppelinHome, "notebook_" + getClass().getSimpleName());
     FileUtils.deleteDirectory(notebookDir);
 
+    // Create test directories
     interpreterDir.mkdirs();
     confDir.mkdirs();
     notebookDir.mkdirs();
+    // Clean-up the test directories on exit
+    FileUtils.forceDeleteOnExit(interpreterDir);
+    FileUtils.forceDeleteOnExit(confDir);
+    FileUtils.forceDeleteOnExit(notebookDir);
 
     FileUtils.copyDirectory(new File("src/test/resources/interpreter"), interpreterDir);
     FileUtils.copyDirectory(new File("src/test/resources/conf"), confDir);
@@ -111,11 +116,6 @@ public abstract class AbstractInterpreterTest {
     Credentials credentials = new Credentials(conf, storage);
     notebook = new Notebook(conf, authorizationService, notebookRepo, noteManager, interpreterFactory, interpreterSettingManager, credentials);
     interpreterSettingManager.setNotebook(notebook);
-
-    // cleanup the test directories on exit
-    FileUtils.forceDeleteOnExit(interpreterDir);
-    FileUtils.forceDeleteOnExit(confDir);
-    FileUtils.forceDeleteOnExit(notebookDir);
   }
 
   @AfterEach


### PR DESCRIPTION
### What is this PR for?

Resolves issue [ZEPPELIN-6031](https://issues.apache.org/jira/browse/ZEPPELIN-6031).

Currently, if someone runs tests locally and stop tests there will be left over config files, notebooks, etc.
It seems to happen more frequently with interpreter tests extending `AbstractInterpreterTest`.

This PR resolves by adding `forceDeleteOnExit()` hook so the files are deleted after JVM exit (even after test interruption)

### What type of PR is it?
Improvement

### Todos
* [x] Add `forceDeleteOnExit()` hook so the files are deleted after JVM exit (even after test interruption)

### What is the Jira issue?

https://issues.apache.org/jira/browse/ZEPPELIN-6031

### How should this be tested?

* Just Github Actions will do.

### Screenshots (if appropriate)

### Questions:

* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
