### PR TITLE
[ZEPPELIN-6035] fix Cron setting for Notebook

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -898,8 +898,10 @@ public class NotebookService {
             return null;
           }
         } else {
-          String requestCronUser = (String) config.get("cronExecutingUser");
-          Set<String> requestCronRoles = (Set<String>) config.get("cronExecutingRoles");
+          AuthenticationInfo requestingAuth = new AuthenticationInfo((String)config.get("cronExecutingUser"),(String) config.get("cronExecutingRoles"), null);
+
+          String requestCronUser = requestingAuth.getUser();
+          Set<String> requestCronRoles = requestingAuth.getRoles();
 
           if (!authorizationService.hasRunPermission(Collections.singleton(requestCronUser), note.getId())) {
             LOGGER.error("Wrong cronExecutingUser: {}", requestCronUser);


### PR DESCRIPTION
### What is this PR for?
Fixes an issue where the Zeppelin Frontend was unable to create or update cron settings for any notebook. Fixes incorrect parsing of the roles submitted in the change request.


### What type of PR is it?
Bug Fix

### Todos
-

### What is the Jira issue?
(https://issues.apache.org/jira/browse/ZEPPELIN-6035)

### How should this be tested?
Open Zeppelin Web UI
Open any Notebook
Click the Cron Icon
set any cron expression
Expected Behaviour:
- no Error should occur
- the new cron expression is saved in the notebook
- the notebook is automatically  run according to the cron expression

### Screenshots (if appropriate)
Image of the Error Message that is fixed with this MR
![image](https://github.com/user-attachments/assets/040e20b3-adf9-44b9-a859-259c998e3901)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
