### PR TITLE
[ZEPPELIN-6039] Exclude dependencies in plugin docker launcher

### DIFF
--- a/zeppelin-plugins/launcher/docker/pom.xml
+++ b/zeppelin-plugins/launcher/docker/pom.xml
@@ -49,12 +49,28 @@
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
       <version>2.5.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jsoup</groupId>
+          <artifactId>jsoup</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <classifier>shaded</classifier>
       <version>8.15.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What is this PR for?
Exclude dependencies that use a different version than the global version.

### What type of PR is it?
Improvement

### Todos
* [x] - Exclude jsoup:1.10.3, guava:25.0-jre in jinjava dependency
* [x] - Exclude commons-compress:1.18 in docker-client

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6039

### How should this be tested?
CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
