### PR TITLE
[ZEPPELIN-6040] Run mode "docker" not working properly

### DIFF
--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/zeppelin:0.11.2-SNAPSHOT
-MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
+MAINTAINER Apache Zeppelin Community <dev@zeppelin.apache.org>
 
 ENV SPARK_VERSION=3.5.1
 ENV HADOOP_VERSION=3

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -16,8 +16,8 @@
 FROM apache/zeppelin:0.11.2-SNAPSHOT
 MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
-ENV SPARK_VERSION=2.3.3
-ENV HADOOP_VERSION=2.7
+ENV SPARK_VERSION=3.5.1
+ENV HADOOP_VERSION=3
 
 USER root
 

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/zeppelin:0.8.0
+FROM apache/zeppelin:0.11.2
 MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
 ENV SPARK_VERSION=2.3.3
 ENV HADOOP_VERSION=2.7
+
+USER root
 
 # support Kerberos certification
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq krb5-user libpam-krb5 && apt-get clean
@@ -25,10 +27,10 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
 RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata && apt-get clean
 
 # auto upload zeppelin interpreter lib
-RUN rm -rf /zeppelin
+RUN rm -rf /opt/zeppelin
 
 RUN rm -rf /spark
-RUN wget https://www-us.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} spark
+RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /spark
 RUN rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -32,5 +32,5 @@ RUN rm -rf /opt/zeppelin
 RUN rm -rf /spark
 RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /spark
+RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark
 RUN rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -31,6 +31,6 @@ RUN rm -rf /opt/zeppelin
 
 RUN rm -rf /spark
 RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${SPARK_BIN_NAME}.tgz
-RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
-RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark
-RUN rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+RUN tar zxvf spark-${SPARK_VERSION}-bin-${SPARK_BIN_NAME}.tgz
+RUN mv spark-${SPARK_VERSION}-bin-${SPARK_BIN_NAME} /opt/spark
+RUN rm spark-${SPARK_VERSION}-bin-${SPARK_BIN_NAME}.tgz

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -16,8 +16,8 @@
 FROM apache/zeppelin:0.11.2-SNAPSHOT
 LABEL maintainer="Apache Zeppelin Community <dev@zeppelin.apache.org>"
 
-ENV SPARK_VERSION=3.5.1
-ENV HADOOP_VERSION=3
+ARG SPARK_VERSION=3.5.1
+ARG SPARK_BIN_NAME=hadoop3
 
 USER root
 
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y curl unzip wget grep sed vim tzdata && 
 RUN rm -rf /opt/zeppelin
 
 RUN rm -rf /spark
-RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
+RUN wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${SPARK_BIN_NAME}.tgz
 RUN tar zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz
 RUN mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark
 RUN rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/zeppelin:0.11.2
+FROM apache/zeppelin:0.11.2-SNAPSHOT
 MAINTAINER Apache Software Foundation <dev@zeppelin.apache.org>
 
 ENV SPARK_VERSION=2.3.3

--- a/scripts/docker/interpreter/Dockerfile
+++ b/scripts/docker/interpreter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM apache/zeppelin:0.11.2-SNAPSHOT
-MAINTAINER Apache Zeppelin Community <dev@zeppelin.apache.org>
+LABEL maintainer="Apache Zeppelin Community <dev@zeppelin.apache.org>"
 
 ENV SPARK_VERSION=3.5.1
 ENV HADOOP_VERSION=3

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -1106,6 +1106,7 @@ public class ZeppelinConfiguration {
 
     // Used by K8s and Docker plugin
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
+    ZEPPELIN_DOCKER_CONTAINER_HOME("zeppelin.docker.container.home", "/opt/zeppelin"),
 
     ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME("zeppelin.docker.container.spark.home", "/spark"),
     ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER("zeppelin.docker.upload.local.lib.to.container", true),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -1108,7 +1108,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_DOCKER_CONTAINER_IMAGE("zeppelin.docker.container.image", "apache/zeppelin:" + Util.getVersion()),
     ZEPPELIN_DOCKER_CONTAINER_HOME("zeppelin.docker.container.home", "/opt/zeppelin"),
 
-    ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME("zeppelin.docker.container.spark.home", "/spark"),
+    ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME("zeppelin.docker.container.spark.home", "/opt/spark"),
     ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER("zeppelin.docker.upload.local.lib.to.container", true),
     ZEPPELIN_DOCKER_HOST("zeppelin.docker.host", "http://0.0.0.0:2375"),
     ZEPPELIN_DOCKER_TIME_ZONE("zeppelin.docker.time.zone", TimeZone.getDefault().getID()),

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -192,7 +192,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     // check if the interpreter process exit script
     // if interpreter process exit, then container need exit
     StringBuilder sbStartCmd = new StringBuilder();
-    sbStartCmd.append("sleep 10; ");
+    sbStartCmd.append("sleep 20; ");
     sbStartCmd.append("process=RemoteInterpreterServer; ");
     sbStartCmd.append("RUNNING_PIDS=$(ps x | grep $process | grep -v grep | awk '{print $1}'); ");
     sbStartCmd.append("while [ ! -z \"$RUNNING_PIDS\" ]; ");

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -324,6 +324,9 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     // remove JAVA_HOME from envs to avoid misconfiguration in container
     envs.remove("JAVA_HOME");
 
+    // remove PATH from envs to avoid misconfiguration in container
+    envs.remove("PATH");
+
     // set container time zone
     envs.put("TZ", zConf.getString(ConfVars.ZEPPELIN_DOCKER_TIME_ZONE));
 

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -321,6 +321,9 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     envs.put("ZEPPELIN_FORCE_STOP", "true");
     envs.put("SPARK_HOME", this.containerSparkHome);
 
+    // remove JAVA_HOME from envs to avoid misconfiguration in container
+    envs.remove("JAVA_HOME");
+
     // set container time zone
     envs.put("TZ", zConf.getString(ConfVars.ZEPPELIN_DOCKER_TIME_ZONE));
 

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -96,6 +96,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   private ZeppelinConfiguration zConf;
 
   private String zeppelinHome;
+  private final String containerZeppelinHome;
 
   @VisibleForTesting
   final String containerSparkHome;
@@ -130,6 +131,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     this.zConf = zConf;
     this.containerName = interpreterGroupId.toLowerCase();
 
+    containerZeppelinHome = zConf.getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_HOME);
     containerSparkHome = zConf.getString(ConfVars.ZEPPELIN_DOCKER_CONTAINER_SPARK_HOME);
     uploadLocalLibToContainter = zConf.getBoolean(
         ConfVars.ZEPPELIN_DOCKER_UPLOAD_LOCAL_LIB_TO_CONTAINTER);
@@ -241,6 +243,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     long timeoutTime = startTime + getConnectTimeout();
     // wait until interpreter send dockerStarted message through thrift rpc
     synchronized (dockerStarted) {
+      LOGGER.info("Waiting for interpreter container to be ready");
       while (!dockerStarted.get() && !Thread.currentThread().isInterrupted()) {
         long timeToTimeout = timeoutTime - System.currentTimeMillis();
         if (timeToTimeout <= 0) {
@@ -293,7 +296,7 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     Properties dockerProperties = new Properties();
 
     // docker template properties
-    dockerProperties.put("CONTAINER_ZEPPELIN_HOME", zeppelinHome);
+    dockerProperties.put("CONTAINER_ZEPPELIN_HOME", containerZeppelinHome);
     dockerProperties.put("zeppelin.interpreter.container.image", containerImage);
     dockerProperties.put("zeppelin.interpreter.group.id", interpreterGroupId);
     dockerProperties.put("zeppelin.interpreter.group.name", interpreterGroupName);
@@ -313,8 +316,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
   @VisibleForTesting
   List<String> getListEnvs() {
     // environment variables
-    envs.put("ZEPPELIN_HOME", zeppelinHome);
-    envs.put("ZEPPELIN_CONF_DIR", zeppelinHome + "/conf");
+    envs.put("ZEPPELIN_HOME", containerZeppelinHome);
+    envs.put("ZEPPELIN_CONF_DIR", containerZeppelinHome + "/conf");
     envs.put("ZEPPELIN_FORCE_STOP", "true");
     envs.put("SPARK_HOME", this.containerSparkHome);
 
@@ -441,18 +444,19 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     HashMap<String, String> copyFiles = new HashMap<>();
 
     // Rebuild directory
-    rmInContainer(containerId, zeppelinHome);
-    mkdirInContainer(containerId, zeppelinHome);
+    rmInContainer(containerId, containerZeppelinHome);
+    mkdirInContainer(containerId, containerZeppelinHome);
 
 
     // 1) zeppelin-site.xml is uploaded to `${CONTAINER_ZEPPELIN_HOME}` directory in the container
     String confPath = "/conf";
     String zeplConfPath = getPathByHome(zeppelinHome, confPath);
-    mkdirInContainer(containerId, zeplConfPath);
-    copyFiles.put(zeplConfPath + "/zeppelin-site.xml", zeplConfPath + "/zeppelin-site.xml");
-    copyFiles.put(zeplConfPath + "/log4j.properties", zeplConfPath + "/log4j.properties");
+    mkdirInContainer(containerId, containerZeppelinHome);
+    String containerZeplConfPath = containerZeppelinHome + confPath;
+    copyFiles.put(zeplConfPath + "/zeppelin-site.xml", containerZeplConfPath + "/zeppelin-site.xml");
+    copyFiles.put(zeplConfPath + "/log4j.properties", containerZeplConfPath + "/log4j.properties");
     copyFiles.put(zeplConfPath + "/log4j_yarn_cluster.properties",
-        zeplConfPath + "/log4j_yarn_cluster.properties");
+        containerZeplConfPath + "/log4j_yarn_cluster.properties");
 
     // 2) upload krb5.conf to container
     String krb5conf = "/etc/krb5.conf";
@@ -512,26 +516,31 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
       //    directory in the container
       String binPath = "/bin";
       String zeplBinPath = getPathByHome(zeppelinHome, binPath);
-      mkdirInContainer(containerId, zeplBinPath);
-      docker.copyToContainer(new File(zeplBinPath).toPath(), containerId, zeplBinPath);
+      String containerZeplBinPath = containerZeppelinHome + binPath;
+      mkdirInContainer(containerId, containerZeplBinPath);
+      docker.copyToContainer(new File(zeplBinPath).toPath(), containerId, containerZeplBinPath);
 
       // 7) ${ZEPPELIN_HOME}/interpreter/spark is uploaded to `${CONTAINER_ZEPPELIN_HOME}`
       //    directory in the container
       String intpGrpPath = "/interpreter/" + interpreterGroupName;
       String intpGrpAllPath = getPathByHome(zeppelinHome, intpGrpPath);
-      mkdirInContainer(containerId, intpGrpAllPath);
-      docker.copyToContainer(new File(intpGrpAllPath).toPath(), containerId, intpGrpAllPath);
+      String containerIntpGrpPath = containerZeppelinHome + intpGrpPath;
+      mkdirInContainer(containerId, containerIntpGrpPath);
+      docker.copyToContainer(new File(intpGrpAllPath).toPath(), containerId, containerIntpGrpPath);
 
       // 8) ${ZEPPELIN_HOME}/lib/interpreter/zeppelin-interpreter-shaded-<version>.jar
       //    is uploaded to `${CONTAINER_ZEPPELIN_HOME}` directory in the container
       String intpPath = "/interpreter";
       String intpAllPath = getPathByHome(zeppelinHome, intpPath);
+      String containerIntpAllPath = containerZeppelinHome + intpPath;
       Collection<File> listFiles = FileUtils.listFiles(new File(intpAllPath),
           FileFilterUtils.suffixFileFilter("jar"), null);
       for (File jarfile : listFiles) {
         String jarfilePath = jarfile.getAbsolutePath();
+        String jarfileName = jarfile.getName();
+        String containerJarfilePath = containerIntpAllPath + "/" + jarfileName;
         if (!StringUtils.isBlank(jarfilePath)) {
-          copyFiles.putIfAbsent(jarfilePath, jarfilePath);
+          copyFiles.putIfAbsent(jarfilePath, containerJarfilePath);
         }
       }
     }

--- a/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
+++ b/zeppelin-plugins/launcher/docker/src/main/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcess.java
@@ -459,7 +459,8 @@ public class DockerInterpreterProcess extends RemoteInterpreterProcess {
     String zeplConfPath = getPathByHome(zeppelinHome, confPath);
     mkdirInContainer(containerId, containerZeppelinHome);
     String containerZeplConfPath = containerZeppelinHome + confPath;
-    copyFiles.put(zeplConfPath + "/zeppelin-site.xml", containerZeplConfPath + "/zeppelin-site.xml");
+    copyFiles.put(
+        zeplConfPath + "/zeppelin-site.xml", containerZeplConfPath + "/zeppelin-site.xml");
     copyFiles.put(zeplConfPath + "/log4j.properties", containerZeplConfPath + "/log4j.properties");
     copyFiles.put(zeplConfPath + "/log4j_yarn_cluster.properties",
         containerZeplConfPath + "/log4j_yarn_cluster.properties");

--- a/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
+++ b/zeppelin-plugins/launcher/docker/src/test/java/org/apache/zeppelin/interpreter/launcher/DockerInterpreterProcessTest.java
@@ -55,7 +55,7 @@ class DockerInterpreterProcessTest {
     DockerInterpreterProcess interpreterProcess = (DockerInterpreterProcess) client;
     assertEquals("name", interpreterProcess.getInterpreterSettingName());
 
-    assertEquals("/spark", interpreterProcess.containerSparkHome);
+    assertEquals("/opt/spark", interpreterProcess.containerSparkHome);
     assertTrue(interpreterProcess.uploadLocalLibToContainter);
     assertNotEquals("http://my-docker-host:2375", interpreterProcess.dockerHost);
   }


### PR DESCRIPTION
### What is this PR for?

Several issues have been identified with the "docker" run mode that are causing it to function improperly. Below are the specific problems encountered:
 #### Base Image Version Issue in `/scripts/docker/interpreter/Dockerfile`:

- The base image version is outdated, currently at `0.8.0`, which is significantly behind the latest version.
- The URL for downloading Spark is not working, causing failures in the build process.
 
#### Host Environment Variables Overriding Container Environment Variables:

-  The `JAVA_HOME` variable from the host is unnecessarily being passed to the container, potentially causing conflicts with the intended Java environment inside the container.
- The `PATH` from the host is being propagated into the container, which may lead to unexpected behavior due to differing paths and binaries.
- The `ZEPPELIN_HOME` variable from the host is also being passed, which can interfere with the Zeppelin environment within the container.

 #### Miscellaneous Issues:

- Additional issues have been identified testing Spark interpreter, I will check for it in another PR

### What type of PR is it?
Bug Fix

### Todos

* [x] - Fix dockerfile
* [ ] - Check for major interpreters
  * [x] md
  * [x] python
  * [x] shell
  * [x] R
  * [ ] spark

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6040

### How should this be tested?

1. Build Zeppelin using the following command:
    
    ```bash
    $ ./mvnw clean package -DskipTests -Pinclude-hadoop
    ```
    
2. Create the `conf/zeppelin-site.xml` file with the following content:
    
    ```xml
    <configuration>
      <property>
        <name>zeppelin.run.mode</name>
        <value>docker</value>
        <description>Zeppelin run mode</description>
      </property>
      <property>
        <name>zeppelin.docker.container.image</name>
        <value>chanho0325/interpreter:0.11.2</value>
        <description>'Docker image I've built with scripts/docker/interpreter/Dockerfile'</description>
      </property>
    </configuration>
    ```
    
4. Start Zeppelin using the command below:
    
    ```bash
    $ ./bin/zeppelin-daemon.sh start
    ```


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
