### PR TITLE
[ZEPPELIN-6034] Write a Dockerfile for shell interpreter

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -23,12 +23,16 @@ WORKDIR /zeppelin
 
 RUN chmod +x ./mvnw
 
-RUN ./mvnw install -am -pl zeppelin-interpreter,shell -DskipTests
+RUN ./mvnw package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,shell -DskipTests
 
 
 FROM openjdk:11
 
-COPY --from=builder /zeppelin /zeppelin
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/sh /zeppelin/interpreter/sh
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
 
 WORKDIR /zeppelin
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:11
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+ENV SHELL_INTERPRETER_PORT=8081
+
+RUN chmod +x ./mvnw && chmod +x ./bin/interpreter.sh
+
+RUN ./mvnw install -am -pl zeppelin-interpreter,shell -DskipTests
+
+CMD ./bin/interpreter.sh -d interpreter/sh -c host.docker.internal -p ${INTERPRETER_EVENT_SERVER_PORT} -r ${SHELL_INTERPRETER_PORT}:${SHELL_INTERPRETER_PORT} -i sh-shared_process -l ./local-repo -g sh

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -15,16 +15,25 @@
 # limitations under the License.
 #
 
-FROM openjdk:11
+FROM openjdk:11 as builder
 
 COPY . /zeppelin/
 
 WORKDIR /zeppelin
 
-ENV SHELL_INTERPRETER_PORT=8081
-
-RUN chmod +x ./mvnw && chmod +x ./bin/interpreter.sh
+RUN chmod +x ./mvnw
 
 RUN ./mvnw install -am -pl zeppelin-interpreter,shell -DskipTests
+
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin /zeppelin
+
+WORKDIR /zeppelin
+
+ENV SHELL_INTERPRETER_PORT=8081
+
+RUN chmod +x ./bin/interpreter.sh
 
 CMD ./bin/interpreter.sh -d interpreter/sh -c host.docker.internal -p ${INTERPRETER_EVENT_SERVER_PORT} -r ${SHELL_INTERPRETER_PORT}:${SHELL_INTERPRETER_PORT} -i sh-shared_process -l ./local-repo -g sh

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,9 +1,9 @@
 ## Overview
 Shell interpreter for Apache Zeppelin
 
-A shell interpreter process is created when a paragraph using the shell interpreter is executed for the first time.
 ## Run the interpreter with docker
 You can run the shell interpreter as a standalone docker container.
+
 ### step 1. Specify the configuration for the shell interpreter
 ```bash
     # conf/interpreter.json

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,35 @@
+## Overview
+Shell interpreter for Apache Zeppelin
+
+A shell interpreter process is created when a paragraph using the shell interpreter is executed for the first time.
+## Run the interpreter with docker
+You can run the shell interpreter as a standalone docker container.
+### step 1. Specify the configuration for the shell interpreter
+```bash
+    # conf/interpreter.json
+    
+    "sh": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### step 2. Build and run the shell interpreter
+```bash
+zeppelin $ ./mvnw clean install -DskipTests
+ 
+zeppelin $ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+zeppelin $ docker build -f ./shell/Dockerfile -t shell-interpreter .
+
+zeppelin $ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8081 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  shell-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a shell interpreter. 
Although the interpreters are currently running as separate JVM processes, the existing structure confines them to a single machine, resulting in low availability. As a first step to address this, I've created a docker image for the shell interpreter using independent computing resources.

Since the current system wasn't designed with modular operation in mind, this PR involves some complexities in terms of configuration and testing. I'm planning to dockerize the other interpreters too, and I’ll try to iron out these kinks as I go.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
* [ZEPPELIN-6034](https://issues.apache.org/jira/browse/ZEPPELIN-6034)

### How should this be tested?
* Build and run the docker container
* Verify that the shell interpreter container communicates with the zeppelin server

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
