### PR TITLE
[ZEPPELIN-6049] Change hadoop-client-api scope in R module to fix class not found error

### DIFF
--- a/rlang/pom.xml
+++ b/rlang/pom.xml
@@ -116,6 +116,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What is this PR for?
Fixes an issue where IR interpreter fails to initialize `SparkRBackend` due to the inability to find `org.apache.hadoop.fs.FSDataInputStream`.

The dependency scope of the `hadoop-client-api` module, which includes `FSDataInputStream`, was set to `provided`(inherited from the root).
The method that failed was invoked using Java reflection, which may have prevented the class from being found at runtime.
Therefore, I changed the dependency scope of the `hadoop-client-api` module to `compile`.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6049/

### How should this be tested?
Build Zeppelin and run some code with `%r.ir` interpreter.

### Screenshots (if appropriate)

#### Before fix
![image](https://github.com/user-attachments/assets/f6ad5edd-ac48-462a-b1a0-08af4fd656b4)

#### After fix
<img width="339" alt="image" src="https://github.com/user-attachments/assets/e883ac8b-28ca-4db2-ae74-0d93ef63cda0">


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
