### PR TITLE
[ZEPPELIN-6051] Skip the hidden files in notebook listing (reopen)

### DIFF
--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -172,7 +172,7 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, sa
         closeByBackdrop: false,
         closeByKeyboard: false,
         title: 'Details',
-        message: _.escape(data.info.toString()).replace(/\n/g, '<br>'),
+        message: _.escape(data.info.toString()),
         buttons: [{
           // close all the dialogs when there are error on running all paragraphs
           label: 'Close',

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -172,7 +172,7 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, sa
         closeByBackdrop: false,
         closeByKeyboard: false,
         title: 'Details',
-        message: _.escape(data.info.toString()),
+        message: _.escape(data.info.toString()).replace(/\n/g, '<br>'),
         buttons: [{
           // close all the dialogs when there are error on running all paragraphs
           label: 'Close',

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -102,11 +102,13 @@ public class VFSNotebookRepo extends AbstractNotebookRepo {
 
   private Map<String, NoteInfo> listFolder(FileObject fileObject) throws IOException {
     Map<String, NoteInfo> noteInfos = new HashMap<>();
+
+    if (fileObject.getName().getBaseName().startsWith(".")) {
+      LOGGER.warn("Skip hidden item: {}", fileObject.getName());
+      return noteInfos;
+    }
+
     if (fileObject.isFolder()) {
-      if (fileObject.getName().getBaseName().startsWith(".")) {
-        LOGGER.warn("Skip hidden folder: {}", fileObject.getName().getPath());
-        return noteInfos;
-      }
       for (FileObject child : fileObject.getChildren()) {
         noteInfos.putAll(listFolder(child));
       }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -145,11 +145,9 @@ public class VFSNotebookRepo extends AbstractNotebookRepo {
       return note;
     } catch (CorruptedNoteException e) {
       String errorMessage = String.format(
-          "Fail to parse note json"
-          + "\nPlease check the file at this path to resolve the issue."
-          + "\n"
-          + "\nPath: %s"
-          + "\nContent: %s",
+          "Fail to parse note json. Please check the file at this path to resolve the issue. "
+          + "Path: %s, "
+          + "Content: %s",
           rootNotebookFolder + notePath, json
       );
       throw new CorruptedNoteException(noteId, errorMessage, e);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -149,8 +149,33 @@ class VFSNotebookRepoTest {
     assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
   }
 
+  @Test
+  void testSkipInValidFileName() throws IOException {
+    assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
+
+    createNewNote("{}", "hidden_note", "my_project/.hidden_note");
+
+    Map<String, NoteInfo> noteInfos = notebookRepo.list(AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, noteInfos.size());
+  }
+
+  @Test
+  void testSkipInvalidDirectoryName() throws IOException {
+    createNewDirectory(".hidden_dir");
+
+    createNewNote("{}", "hidden_note", "my_project/.hidden_dir/note");
+
+    Map<String, NoteInfo> noteInfos = notebookRepo.list(AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, noteInfos.size());
+  }
+
   private void createNewNote(String content, String noteId, String noteName) throws IOException {
     FileUtils.writeStringToFile(
         new File(notebookDir + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
+  }
+
+  private void createNewDirectory(String dirName) {
+    File dir = new File(notebookDir + "/" + dirName);
+    dir.mkdir();
   }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -149,7 +149,7 @@ class VFSNotebookRepoTest {
   }
 
   @Test
-  void testSkipInValidFileName() throws IOException {
+  void testSkipInvalidFileName() throws IOException {
     assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
 
     createNewNote("{}", "hidden_note", "my_project/.hidden_note");

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -45,22 +45,21 @@ class VFSNotebookRepoTest {
   private ZeppelinConfiguration zConf;
   private NoteParser noteParser;
   private VFSNotebookRepo notebookRepo;
-  private File notebookDir;
 
   @BeforeEach
   public void setUp() throws IOException {
+    File notebookDir = Files.createTempDirectory(this.getClass().getSimpleName()).toFile();
     zConf = ZeppelinConfiguration.load();
     noteParser = new GsonNoteParser(zConf);
-    notebookDir = Files.createTempDirectory(this.getClass().getSimpleName()).toFile();
-    zConf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(),
-        notebookDir.getAbsolutePath());
+    zConf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(), notebookDir.getAbsolutePath());
     notebookRepo = new VFSNotebookRepo();
     notebookRepo.init(zConf, noteParser);
   }
 
   @AfterEach
   public void tearDown() throws IOException {
-    FileUtils.deleteDirectory(notebookDir);
+    File rootDir = new File(notebookRepo.rootNotebookFolder);
+    FileUtils.deleteDirectory(rootDir);
   }
 
   @Test
@@ -137,7 +136,7 @@ class VFSNotebookRepoTest {
     assertEquals(1, repoSettings.size());
     NotebookRepoSettingsInfo settingInfo = repoSettings.get(0);
     assertEquals("Notebook Path", settingInfo.name);
-    assertEquals(notebookDir.getAbsolutePath(), settingInfo.selected);
+    assertEquals(notebookRepo.rootNotebookFolder, settingInfo.selected);
 
     createNewNote("{}", "id2", "my_project/name2");
     assertEquals(1, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
@@ -171,11 +170,11 @@ class VFSNotebookRepoTest {
 
   private void createNewNote(String content, String noteId, String noteName) throws IOException {
     FileUtils.writeStringToFile(
-        new File(notebookDir + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
+        new File(notebookRepo.rootNotebookFolder + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
   }
 
   private void createNewDirectory(String dirName) {
-    File dir = new File(notebookDir + "/" + dirName);
+    File dir = new File(notebookRepo.rootNotebookFolder + "/" + dirName);
     dir.mkdir();
   }
 }


### PR DESCRIPTION
### What is this PR for?
This PR reopens #4789. It was accidentally closed while resolving conflicts. @Reamer 

This PR modifies the notebook listing logic to exclude hidden files that start with `.`. 
This is because showing non-executable files, such as meta files, could confuse users, as seen in this issue [ZEPPELIN-6051](https://issues.apache.org/jira/browse/ZEPPELIN-6051).

Additionally I have enhanced the error popup message to be more specific, which appears when a user opens a notebook with parsing errors. I think it would be more helpful for users to recognize and resolve the issues on their own.

### What type of PR is it?
* Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6051

### How should this be tested?
* Create a notebook that can't be parsed and try to open it.

### Screenshots (if appropriate)
as-is
<img width="400" alt="Screenshot 2024-08-12 at 01 15 41" src="https://github.com/user-attachments/assets/a5ad7493-dff6-4c20-b6ab-2866abe1f89e">

~~to-be~~
<img width="400" alt="Screenshot 2024-08-12 at 01 14 15" src="https://github.com/user-attachments/assets/c3098b6e-7e2a-4848-b68b-eef25015d288">

to-be
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0797e617-1a8c-473e-99ea-a4be3429dbf9">

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No