### PR TITLE
[ZEPPELIN-6038] Unification of the Logger variable

### DIFF
--- a/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
+++ b/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
@@ -48,7 +48,7 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  */
 public class AlluxioInterpreter extends Interpreter {
   
-  Logger logger = LoggerFactory.getLogger(AlluxioInterpreter.class);
+  Logger LOGGER = LoggerFactory.getLogger(AlluxioInterpreter.class);
 
   protected static final String ALLUXIO_MASTER_HOSTNAME = "alluxio.master.hostname";
   protected static final String ALLUXIO_MASTER_PORT = "alluxio.master.port";
@@ -84,7 +84,7 @@ public class AlluxioInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    logger.info("Starting Alluxio shell to connect to " + alluxioMasterHostname +
+    LOGGER.info("Starting Alluxio shell to connect to " + alluxioMasterHostname +
         " on port " + alluxioMasterPort);
     // Setting the extra parameters being set in the interpreter config starting with alluxio
     filteredProperties("alluxio.").forEach(x -> System.setProperty(x, properties.getProperty(x)));
@@ -98,11 +98,11 @@ public class AlluxioInterpreter extends Interpreter {
 
   @Override
   public void close() {
-    logger.info("Closing Alluxio shell");
+    LOGGER.info("Closing Alluxio shell");
     try {
       fs.close();
     } catch (IOException e) {
-      logger.error("Cannot close connection", e);
+      LOGGER.error("Cannot close connection", e);
     }
   }
 

--- a/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
+++ b/alluxio/src/main/java/org/apache/zeppelin/alluxio/AlluxioInterpreter.java
@@ -47,8 +47,8 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  * Alluxio interpreter for Zeppelin.
  */
 public class AlluxioInterpreter extends Interpreter {
-  
-  Logger LOGGER = LoggerFactory.getLogger(AlluxioInterpreter.class);
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AlluxioInterpreter.class);
 
   protected static final String ALLUXIO_MASTER_HOSTNAME = "alluxio.master.hostname";
   protected static final String ALLUXIO_MASTER_PORT = "alluxio.master.port";

--- a/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
+++ b/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
@@ -79,7 +79,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  * 
  */
 public class BigQueryInterpreter extends Interpreter {
-  private static Logger logger = LoggerFactory.getLogger(BigQueryInterpreter.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(BigQueryInterpreter.class);
   private static final char NEWLINE = '\n';
   private static final char TAB = '\t';
   private static Bigquery service = null;
@@ -117,9 +117,9 @@ public class BigQueryInterpreter extends Interpreter {
           try {
             service = createAuthorizedClient();
             exceptionOnConnect = null;
-            logger.info("Opened BigQuery SQL Connection");
+            LOGGER.info("Opened BigQuery SQL Connection");
           } catch (IOException e) {
-            logger.error("Cannot open connection", e);
+            LOGGER.error("Cannot open connection", e);
             exceptionOnConnect = e;   
             close();
           }
@@ -243,7 +243,7 @@ public class BigQueryInterpreter extends Interpreter {
     try {
       pages = run(sql, projId, wTime, maxRows, useLegacySql);
     } catch (IOException ex) {
-      logger.error(ex.getMessage());
+      LOGGER.error(ex.getMessage());
       return new InterpreterResult(Code.ERROR, ex.getMessage());
     }
     try {
@@ -261,7 +261,7 @@ public class BigQueryInterpreter extends Interpreter {
       final String projId, final long wTime, final long maxRows, Boolean useLegacySql)
           throws IOException {
     try {
-      logger.info("Use legacy sql: {}", useLegacySql);
+      LOGGER.info("Use legacy sql: {}", useLegacySql);
       QueryResponse query;
       query = service
           .jobs()
@@ -283,14 +283,14 @@ public class BigQueryInterpreter extends Interpreter {
 
   @Override
   public void close() {
-    logger.info("Close bqsql connection!");
+    LOGGER.info("Close bqsql connection!");
 
     service = null;
   }
 
   @Override
   public InterpreterResult interpret(String sql, InterpreterContext contextInterpreter) {
-    logger.info("Run SQL command '{}'", sql);
+    LOGGER.info("Run SQL command '{}'", sql);
     return executeSql(sql);
   }
 
@@ -312,19 +312,19 @@ public class BigQueryInterpreter extends Interpreter {
 
   @Override
   public void cancel(InterpreterContext context) {
-    logger.info("Trying to Cancel current query statement.");
+    LOGGER.info("Trying to Cancel current query statement.");
 
     if (service != null && jobId != null && projectId != null) {
       try {
         Bigquery.Jobs.Cancel request = service.jobs().cancel(projectId, jobId);
         JobCancelResponse response = request.execute();
         jobId = null;
-        logger.info("Query Execution cancelled");
+        LOGGER.info("Query Execution cancelled");
       } catch (IOException ex) {
-        logger.error("Could not cancel the SQL execution");
+        LOGGER.error("Could not cancel the SQL execution");
       }
     } else {
-      logger.info("Query Execution was already cancelled");
+      LOGGER.info("Query Execution was already cancelled");
     }
   }
 

--- a/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
+++ b/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
@@ -79,7 +79,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  * 
  */
 public class BigQueryInterpreter extends Interpreter {
-  private static Logger LOGGER = LoggerFactory.getLogger(BigQueryInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryInterpreter.class);
   private static final char NEWLINE = '\n';
   private static final char TAB = '\t';
   private static Bigquery service = null;

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -71,7 +71,7 @@ import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.T
  * Elasticsearch Interpreter for Zeppelin.
  */
 public class ElasticsearchInterpreter extends Interpreter {
-  private static Logger LOGGER = LoggerFactory.getLogger(ElasticsearchInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchInterpreter.class);
 
   private static final String HELP = "Elasticsearch interpreter:\n"
       + "General format: <command> /<indices>/<types>/<id> <option> <JSON>\n"

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -71,7 +71,7 @@ import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.T
  * Elasticsearch Interpreter for Zeppelin.
  */
 public class ElasticsearchInterpreter extends Interpreter {
-  private static Logger logger = LoggerFactory.getLogger(ElasticsearchInterpreter.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(ElasticsearchInterpreter.class);
 
   private static final String HELP = "Elasticsearch interpreter:\n"
       + "General format: <command> /<indices>/<types>/<id> <option> <JSON>\n"
@@ -114,7 +114,7 @@ public class ElasticsearchInterpreter extends Interpreter {
 
   @Override
   public void open() {
-    logger.info("Properties: {}", getProperties());
+    LOGGER.info("Properties: {}", getProperties());
 
     ElasticsearchClientType clientType =
             ElasticsearchClientTypeBuilder
@@ -125,7 +125,7 @@ public class ElasticsearchInterpreter extends Interpreter {
       this.resultSize = Integer.parseInt(getProperty(ELASTICSEARCH_RESULT_SIZE));
     } catch (final NumberFormatException e) {
       this.resultSize = 10;
-      logger.error("Unable to parse " + ELASTICSEARCH_RESULT_SIZE + " : " +
+      LOGGER.error("Unable to parse " + ELASTICSEARCH_RESULT_SIZE + " : " +
           getProperty(ELASTICSEARCH_RESULT_SIZE), e);
     }
 
@@ -135,10 +135,10 @@ public class ElasticsearchInterpreter extends Interpreter {
       } else if (clientType.isHttp()) {
         elsClient = new HttpBasedClient(getProperties());
       } else {
-        logger.error("Unknown type of Elasticsearch client: " + clientType);
+        LOGGER.error("Unknown type of Elasticsearch client: " + clientType);
       }
     } catch (final IOException e) {
-      logger.error("Open connection with Elasticsearch", e);
+      LOGGER.error("Open connection with Elasticsearch", e);
     }
   }
 
@@ -151,7 +151,7 @@ public class ElasticsearchInterpreter extends Interpreter {
 
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext interpreterContext) {
-    logger.info("Run Elasticsearch command '" + cmd + "'");
+    LOGGER.info("Run Elasticsearch command '" + cmd + "'");
 
     if (StringUtils.isEmpty(cmd) || StringUtils.isEmpty(cmd.trim())) {
       return new InterpreterResult(InterpreterResult.Code.SUCCESS);
@@ -451,7 +451,7 @@ public class ElasticsearchInterpreter extends Interpreter {
           headerKeys.addAll(bucketMap.keySet());
           buckets.add(bucketMap);
         } catch (final IOException e) {
-          logger.error("Processing bucket: " + e.getMessage(), e);
+          LOGGER.error("Processing bucket: " + e.getMessage(), e);
         }
       }
 

--- a/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
@@ -44,7 +44,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  *
  */
 public abstract class FileInterpreter extends Interpreter {
-  Logger logger = LoggerFactory.getLogger(FileInterpreter.class);
+  Logger LOGGER = LoggerFactory.getLogger(FileInterpreter.class);
   String currentDir = null;
   CommandArgs args = null;
 
@@ -108,13 +108,13 @@ public abstract class FileInterpreter extends Interpreter {
   // Handle the command handling uniformly across all file systems
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext contextInterpreter) {
-    logger.info("Run File command '" + cmd + "'");
+    LOGGER.info("Run File command '" + cmd + "'");
 
     args = new CommandArgs(cmd);
     args.parseArgs();
 
     if (args.command == null) {
-      logger.info("Error: No command");
+      LOGGER.info("Error: No command");
       return new InterpreterResult(Code.ERROR, Type.TEXT, "No command");
     }
 
@@ -133,7 +133,7 @@ public abstract class FileInterpreter extends Interpreter {
         String results = listAll(newPath);
         return new InterpreterResult(Code.SUCCESS, Type.TEXT, results);
       } catch (Exception e) {
-        logger.error("Error listing files in path " + newPath, e);
+        LOGGER.error("Error listing files in path " + newPath, e);
         return new InterpreterResult(Code.ERROR, Type.TEXT, e.getMessage());
       }
 

--- a/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
@@ -44,7 +44,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  *
  */
 public abstract class FileInterpreter extends Interpreter {
-  Logger LOGGER = LoggerFactory.getLogger(FileInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileInterpreter.class);
   String currentDir = null;
   CommandArgs args = null;
 

--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -33,11 +33,14 @@ import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterContext;
 import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * HDFS implementation of File interpreter for Zeppelin.
  */
 public class HDFSFileInterpreter extends FileInterpreter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HDFSFileInterpreter.class);
   static final String HDFS_URL = "hdfs.url";
   static final String HDFS_USER = "hdfs.user";
   static final String HDFS_MAXLENGTH = "hdfs.maxlength";
@@ -50,7 +53,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
     String userName = getProperty(HDFS_USER);
     String hdfsUrl = getProperty(HDFS_URL);
     int i = Integer.parseInt(getProperty(HDFS_MAXLENGTH));
-    cmd = new HDFSCommand(hdfsUrl, userName, logger, i);
+    cmd = new HDFSCommand(hdfsUrl, userName, LOGGER, i);
     gson = new Gson();
   }
 
@@ -132,10 +135,10 @@ public class HDFSFileInterpreter extends FileInterpreter {
   private void testConnection() {
     try {
       if (isDirectory("/")) {
-        logger.info("Successfully created WebHDFS connection");
+        LOGGER.info("Successfully created WebHDFS connection");
       }
     } catch (Exception e) {
-      logger.error("testConnection: Cannot open WebHDFS connection. Bad URL: " + "/", e);
+      LOGGER.error("testConnection: Cannot open WebHDFS connection. Bad URL: " + "/", e);
       exceptionOnConnect = e;
     }
   }
@@ -212,7 +215,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
         return listOne(filePath, sfs.fileStatus);
       }
     } catch (Exception e) {
-      logger.error("listFile: " + filePath, e);
+      LOGGER.error("listFile: " + filePath, e);
     }
     return "No such File or directory";
   }
@@ -246,7 +249,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
         return listFile(path);
       }
     } catch (Exception e) {
-      logger.error("listall: listDir " + path, e);
+      LOGGER.error("listall: listDir " + path, e);
       throw new InterpreterException("Could not find file or directory:\t" + path);
     }
   }
@@ -264,7 +267,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
         return sfs.fileStatus.type.equals("DIRECTORY");
       }
     } catch (Exception e) {
-      logger.error("IsDirectory: " + path, e);
+      LOGGER.error("IsDirectory: " + path, e);
       return false;
     }
     return ret;
@@ -273,7 +276,7 @@ public class HDFSFileInterpreter extends FileInterpreter {
   @Override
   public List<InterpreterCompletion> completion(String buf, int cursor,
       InterpreterContext interpreterContext) {
-    logger.info("Completion request at position\t" + cursor + " in string " + buf);
+    LOGGER.info("Completion request at position\t" + cursor + " in string " + buf);
     final List<InterpreterCompletion> suggestions = new ArrayList<>();
     if (StringUtils.isEmpty(buf)) {
       suggestions.add(new InterpreterCompletion("ls", "ls", CompletionType.command.name()));
@@ -337,11 +340,11 @@ public class HDFSFileInterpreter extends FileInterpreter {
           }
         }
       } catch (Exception e) {
-        logger.error("listall: listDir " + globalPath, e);
+        LOGGER.error("listall: listDir " + globalPath, e);
         return null;
       }
     } else {
-      logger.info("path is not a directory.  No values suggested.");
+      LOGGER.info("path is not a directory.  No values suggested.");
     }
 
     //Error in string.

--- a/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
+++ b/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.google.gson.Gson;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,7 +35,6 @@ import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests Interpreter by running pre-determined commands against mock file system.

--- a/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
+++ b/file/src/test/java/org/apache/zeppelin/file/HDFSFileInterpreterTest.java
@@ -34,6 +34,7 @@ import org.apache.zeppelin.completer.CompletionType;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests Interpreter by running pre-determined commands against mock file system.
@@ -274,12 +275,14 @@ class MockHDFSCommand extends HDFSCommand {
  * Mock Interpreter - uses Mock HDFS command.
  */
 class MockHDFSFileInterpreter extends HDFSFileInterpreter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MockHDFSFileInterpreter.class);
+
   @Override
   public void prepare() {
     // Run commands against mock File System instead of WebHDFS
     int i = Integer.parseInt(getProperty(HDFS_MAXLENGTH) == null ? "1000"
             : getProperty(HDFS_MAXLENGTH));
-    cmd = new MockHDFSCommand("", "", logger, i);
+    cmd = new MockHDFSCommand("", "", LOGGER, i);
     gson = new Gson();
   }
 

--- a/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterpreter.java
+++ b/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/FlinkSqlInterpreter.java
@@ -26,7 +26,7 @@ import java.util.Properties;
 
 public abstract class FlinkSqlInterpreter extends AbstractInterpreter {
 
-  protected static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterpreter.class);
 
   protected FlinkInterpreter flinkInterpreter;
   protected FlinkShims flinkShims;

--- a/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
+++ b/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/sql/AbstractStreamSqlJob.java
@@ -55,7 +55,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  *
  */
 public abstract class AbstractStreamSqlJob {
-  private static Logger LOGGER = LoggerFactory.getLogger(AbstractStreamSqlJob.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStreamSqlJob.class);
 
   private static AtomicInteger SQL_INDEX = new AtomicInteger(0);
   protected StreamExecutionEnvironment senv;

--- a/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
+++ b/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/sql/AppendStreamSqlJob.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 public class AppendStreamSqlJob extends AbstractStreamSqlJob {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(UpdateStreamSqlJob.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpdateStreamSqlJob.class);
 
   private List<Row> materializedTable = new ArrayList<>();
   private long tsWindowThreshold;

--- a/flink/flink-scala-2.12/src/test/java/org/apache/zeppelin/flink/FlinkSqlInterpreterTest.java
+++ b/flink/flink-scala-2.12/src/test/java/org/apache/zeppelin/flink/FlinkSqlInterpreterTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(FlinkStandaloneHiveRunner.class)
 public abstract class FlinkSqlInterpreterTest {
 
-  protected static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterpreterTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlinkSqlInterpreterTest.class);
 
 
   protected FlinkInterpreter flinkInterpreter;

--- a/flink/flink-scala-2.12/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
+++ b/flink/flink-scala-2.12/src/test/java/org/apache/zeppelin/flink/FlinkStreamSqlInterpreterTest.java
@@ -28,6 +28,8 @@ import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.interpreter.InterpreterResultMessage;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -41,7 +43,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class FlinkStreamSqlInterpreterTest extends FlinkSqlInterpreterTest {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlinkStreamSqlInterpreterTest.class);
 
   private static class FlinkJobListener implements JobListener {
 

--- a/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkVersion.java
+++ b/flink/flink-shims/src/main/java/org/apache/zeppelin/flink/FlinkVersion.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class FlinkVersion {
-  private static final Logger logger = LoggerFactory.getLogger(FlinkVersion.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlinkVersion.class);
 
   private int majorVersion;
   private int minorVersion;
@@ -50,7 +50,7 @@ public class FlinkVersion {
       this.version = Integer.parseInt(String.format("%d%02d%02d",
               majorVersion, minorVersion, patchVersion));
     } catch (Exception e) {
-      logger.error("Can not recognize Flink version " + versionString +
+      LOGGER.error("Can not recognize Flink version " + versionString +
           ". Assume it's a future release", e);
     }
   }

--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -161,7 +161,8 @@ public class GroovyInterpreter extends Interpreter {
       //put shared bindings evaluated in this interpreter
       bindings.putAll(sharedBindings);
       //put predefined bindings
-      bindings.put("g", new GObject(LOGGER, out, this.getProperties(), contextInterpreter, bindings));
+      bindings.put("g",
+              new GObject(LOGGER, out, this.getProperties(), contextInterpreter, bindings));
       bindings.put("out", new PrintWriter(out, true));
 
       script.run();

--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -51,7 +51,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  * Groovy interpreter for Zeppelin.
  */
 public class GroovyInterpreter extends Interpreter {
-  Logger LOGGER = LoggerFactory.getLogger(GroovyInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(GroovyInterpreter.class);
   GroovyShell shell = null; //new GroovyShell();
   //here we will store Interpreters shared variables. concurrent just in case.
   Map<String, Object> sharedBindings = new ConcurrentHashMap<String, Object>();

--- a/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
+++ b/groovy/src/main/java/org/apache/zeppelin/groovy/GroovyInterpreter.java
@@ -51,7 +51,7 @@ import org.apache.zeppelin.scheduler.SchedulerFactory;
  * Groovy interpreter for Zeppelin.
  */
 public class GroovyInterpreter extends Interpreter {
-  Logger log = LoggerFactory.getLogger(GroovyInterpreter.class);
+  Logger LOGGER = LoggerFactory.getLogger(GroovyInterpreter.class);
   GroovyShell shell = null; //new GroovyShell();
   //here we will store Interpreters shared variables. concurrent just in case.
   Map<String, Object> sharedBindings = new ConcurrentHashMap<String, Object>();
@@ -76,10 +76,10 @@ public class GroovyInterpreter extends Interpreter {
                 .getPath());
         classes = new File(jar.getParentFile(), "classes").toString();
       } catch (Exception e) {
-        log.error(e.getMessage());
+        LOGGER.error(e.getMessage());
       }
     }
-    log.info("groovy classes classpath: " + classes);
+    LOGGER.info("groovy classes classpath: " + classes);
     if (classes != null && classes.length() > 0) {
       File fClasses = new File(classes);
       if (!fClasses.exists()) {
@@ -161,15 +161,15 @@ public class GroovyInterpreter extends Interpreter {
       //put shared bindings evaluated in this interpreter
       bindings.putAll(sharedBindings);
       //put predefined bindings
-      bindings.put("g", new GObject(log, out, this.getProperties(), contextInterpreter, bindings));
+      bindings.put("g", new GObject(LOGGER, out, this.getProperties(), contextInterpreter, bindings));
       bindings.put("out", new PrintWriter(out, true));
 
       script.run();
       //let's get shared variables defined in current script and store them in shared map
       for (Map.Entry<String, Object> e : bindings.entrySet()) {
         if (!predefinedBindings.contains(e.getKey())) {
-          if (log.isTraceEnabled()) {
-            log.trace("groovy script variable " + e);  //let's see what we have...
+          if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("groovy script variable " + e);  //let's see what we have...
           }
           sharedBindings.put(e.getKey(), e.getValue());
         }
@@ -181,7 +181,7 @@ public class GroovyInterpreter extends Interpreter {
     } catch (Throwable t) {
       t = StackTraceUtils.deepSanitize(t);
       String msg = t.toString() + "\n at " + t.getStackTrace()[0];
-      log.error("Failed to run script: " + t + "\n" + cmd + "\n", t);
+      LOGGER.error("Failed to run script: " + t + "\n" + cmd + "\n", t);
       return new InterpreterResult(Code.ERROR, msg);
     }
   }
@@ -199,7 +199,7 @@ public class GroovyInterpreter extends Interpreter {
           t.interrupt();
           //t.stop(); //TODO(dlukyanov): need some way to terminate maybe through GObject..
         } catch (Throwable t) {
-          log.error("Failed to cancel script: " + t, t);
+          LOGGER.error("Failed to cancel script: " + t, t);
         }
       }
     }

--- a/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
+++ b/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
@@ -57,7 +57,7 @@ public class HbaseInterpreter extends Interpreter {
   public static final String HBASE_RUBY_SRC = "hbase.ruby.sources";
   public static final String HBASE_TEST_MODE = "zeppelin.hbase.test.mode";
 
-  private Logger LOGGER = LoggerFactory.getLogger(HbaseInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HbaseInterpreter.class);
   private ScriptingContainer scriptingContainer;
 
   private StringWriter writer;

--- a/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
+++ b/hbase/src/main/java/org/apache/zeppelin/hbase/HbaseInterpreter.java
@@ -57,7 +57,7 @@ public class HbaseInterpreter extends Interpreter {
   public static final String HBASE_RUBY_SRC = "hbase.ruby.sources";
   public static final String HBASE_TEST_MODE = "zeppelin.hbase.test.mode";
 
-  private Logger logger = LoggerFactory.getLogger(HbaseInterpreter.class);
+  private Logger LOGGER = LoggerFactory.getLogger(HbaseInterpreter.class);
   private ScriptingContainer scriptingContainer;
 
   private StringWriter writer;
@@ -77,8 +77,8 @@ public class HbaseInterpreter extends Interpreter {
       String rubySrc = getProperty(HBASE_RUBY_SRC);
       Path absRubySrc = Paths.get(hbaseHome, rubySrc).toAbsolutePath();
 
-      logger.info("Home:" + hbaseHome);
-      logger.info("Ruby Src:" + rubySrc);
+      LOGGER.info("Home:" + hbaseHome);
+      LOGGER.info("Ruby Src:" + rubySrc);
 
       File f = absRubySrc.toFile();
       if (!f.exists() || !f.isDirectory()) {
@@ -86,7 +86,7 @@ public class HbaseInterpreter extends Interpreter {
             + "'");
       }
 
-      logger.info("Absolute Ruby Source:" + absRubySrc.toString());
+      LOGGER.info("Absolute Ruby Source:" + absRubySrc.toString());
       // hirb.rb:41 requires the following system properties to be set.
       Properties sysProps = System.getProperties();
       sysProps.setProperty(HBASE_RUBY_SRC, absRubySrc.toString());
@@ -112,14 +112,14 @@ public class HbaseInterpreter extends Interpreter {
   @Override
   public InterpreterResult interpret(String cmd, InterpreterContext interpreterContext) {
     try {
-      logger.info(cmd);
+      LOGGER.info(cmd);
       this.writer.getBuffer().setLength(0);
       this.scriptingContainer.runScriptlet(cmd);
       this.writer.flush();
-      logger.debug(writer.toString());
+      LOGGER.debug(writer.toString());
       return new InterpreterResult(InterpreterResult.Code.SUCCESS, writer.getBuffer().toString());
     } catch (Throwable t) {
-      logger.error("Can not run '" + cmd + "'", t);
+      LOGGER.error("Can not run '" + cmd + "'", t);
       return new InterpreterResult(InterpreterResult.Code.ERROR, t.getMessage());
     }
   }

--- a/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinApplicationDevServer.java
+++ b/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinApplicationDevServer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * Run this server for development mode.
  */
 public class ZeppelinApplicationDevServer extends ZeppelinDevServer {
-  final Logger logger = LoggerFactory.getLogger(ZeppelinApplicationDevServer.class);
+  final Logger LOGGER = LoggerFactory.getLogger(ZeppelinApplicationDevServer.class);
 
   private final String className;
   private final ResourceSet resourceSet;
@@ -70,7 +70,7 @@ public class ZeppelinApplicationDevServer extends ZeppelinDevServer {
   @Override
   public InterpreterResult interpret(String st, InterpreterContext context) {
     if (app == null) {
-      logger.info("Create instance " + className);
+      LOGGER.info("Create instance " + className);
       try {
         Class<?> appClass = ClassLoader.getSystemClassLoader().loadClass(className);
         Constructor<?> constructor = appClass.getConstructor(ApplicationContext.class);
@@ -84,19 +84,19 @@ public class ZeppelinApplicationDevServer extends ZeppelinDevServer {
         ApplicationContext appContext = getApplicationContext(context);
         app = (Application) constructor.newInstance(appContext);
       } catch (Exception e) {
-        logger.error(e.getMessage(), e);
+        LOGGER.error(e.getMessage(), e);
         return new InterpreterResult(Code.ERROR, e.getMessage());
       }
     }
 
     try {
-      logger.info("Run " + className);
+      LOGGER.info("Run " + className);
       app.context().out.clear();
       app.context().out.setType(InterpreterResult.Type.ANGULAR);
       transferTableResultDataToFrontend();
       app.run(resourceSet);
     } catch (IOException | ApplicationException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new InterpreterResult(Code.ERROR, e.getMessage());
     }
     return new InterpreterResult(Code.SUCCESS, "");
@@ -157,7 +157,7 @@ public class ZeppelinApplicationDevServer extends ZeppelinDevServer {
               eventClient.onInterpreterOutputUpdate(noteId, paragraphId,
                   index, out.getType(), new String(out.toByteArray()));
             } catch (IOException e) {
-              logger.error(e.getMessage(), e);
+              LOGGER.error(e.getMessage(), e);
             }
           }
 

--- a/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinApplicationDevServer.java
+++ b/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinApplicationDevServer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * Run this server for development mode.
  */
 public class ZeppelinApplicationDevServer extends ZeppelinDevServer {
-  final Logger LOGGER = LoggerFactory.getLogger(ZeppelinApplicationDevServer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinApplicationDevServer.class);
 
   private final String className;
   private final ResourceSet resourceSet;

--- a/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinDevServer.java
+++ b/helium-dev/src/main/java/org/apache/zeppelin/helium/ZeppelinDevServer.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ZeppelinDevServer extends
     RemoteInterpreterServer implements InterpreterEvent, InterpreterOutputChangeListener {
-  private static final Logger logger = LoggerFactory.getLogger(ZeppelinDevServer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinDevServer.class);
 
   private DevInterpreter interpreter = null;
   private InterpreterOutput out;
@@ -87,7 +87,7 @@ public class ZeppelinDevServer extends
               eventClient.onInterpreterOutputUpdate(noteId, paragraphId,
                   index, out.getType(), new String(out.toByteArray()));
             } catch (IOException e) {
-              logger.error(e.getMessage(), e);
+              LOGGER.error(e.getMessage(), e);
             }
           }
         }, this);

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -45,7 +45,7 @@ import java.util.List;
  * StaticRepl for compling the java code in memory
  */
 public class StaticRepl {
-  static Logger logger = LoggerFactory.getLogger(StaticRepl.class);
+  static Logger LOGGER = LoggerFactory.getLogger(StaticRepl.class);
 
   public static String execute(String generatedClassName, String code) throws Exception {
 
@@ -80,7 +80,7 @@ public class StaticRepl {
 
     // if there isn't Main method, will retuen error
     if (mainClassName == null) {
-      logger.error("Exception for Main method", "There isn't any class "
+      LOGGER.error("Exception for Main method", "There isn't any class "
           + "containing static main method.");
       throw new Exception("There isn't any class containing static main method.");
     }
@@ -123,7 +123,7 @@ public class StaticRepl {
 
       System.setOut(oldOut);
       System.setErr(oldErr);
-      logger.error("Exception in Interpreter while compilation", baosErr.toString());
+      LOGGER.error("Exception in Interpreter while compilation", baosErr.toString());
       throw new Exception(baosErr.toString());
     } else {
       try {
@@ -147,7 +147,7 @@ public class StaticRepl {
 
       } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
           | InvocationTargetException e) {
-        logger.error("Exception in Interpreter while execution", e);
+        LOGGER.error("Exception in Interpreter while execution", e);
         System.err.println(e);
         e.printStackTrace(newErr);
         throw new Exception(baosErr.toString(), e);

--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -45,7 +45,7 @@ import java.util.List;
  * StaticRepl for compling the java code in memory
  */
 public class StaticRepl {
-  static Logger LOGGER = LoggerFactory.getLogger(StaticRepl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(StaticRepl.class);
 
   public static String execute(String generatedClassName, String code) throws Exception {
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -39,7 +39,7 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  * SQL auto complete functionality for the JdbcInterpreter.
  */
 public class SqlCompleter {
-  private static Logger logger = LoggerFactory.getLogger(SqlCompleter.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(SqlCompleter.class);
 
   /**
    * Delimiter that can split SQL statement in keyword list.
@@ -83,7 +83,7 @@ public class SqlCompleter {
   }
 
   public int complete(String buffer, int cursor, List<InterpreterCompletion> candidates) {
-    logger.debug("Complete with buffer = " + buffer + ", cursor = " + cursor);
+    LOGGER.debug("Complete with buffer = " + buffer + ", cursor = " + cursor);
 
     // The delimiter breaks the buffer into separate words (arguments), separated by the
     // white spaces.
@@ -102,7 +102,7 @@ public class SqlCompleter {
     int complete = completeName(cursorArgument, argumentPosition, candidates,
             findAliasesInSQL(argumentList.getArguments()));
 
-    logger.debug("complete:" + complete + ", size:" + candidates.size());
+    LOGGER.debug("complete:" + complete + ", size:" + candidates.size());
     return complete;
   }
 
@@ -137,7 +137,7 @@ public class SqlCompleter {
         schemas.close();
       }
     } catch (SQLException t) {
-      logger.error("Failed to retrieve the schema names", t);
+      LOGGER.error("Failed to retrieve the schema names", t);
     }
     return res;
   }
@@ -169,7 +169,7 @@ public class SqlCompleter {
         schemas.close();
       }
     } catch (SQLException t) {
-      logger.error("Failed to retrieve the schema names", t);
+      LOGGER.error("Failed to retrieve the schema names", t);
     }
     return res;
   }
@@ -182,7 +182,7 @@ public class SqlCompleter {
         tables.add(table);
       }
     } catch (Throwable t) {
-      logger.error("Failed to retrieve the table name", t);
+      LOGGER.error("Failed to retrieve the table name", t);
     }
   }
 
@@ -203,7 +203,7 @@ public class SqlCompleter {
         columns.add(column);
       }
     } catch (Throwable t) {
-      logger.error("Failed to retrieve the column name", t);
+      LOGGER.error("Failed to retrieve the column name", t);
     }
   }
 
@@ -220,7 +220,7 @@ public class SqlCompleter {
         // Add the driver specific SQL completions
         String driverSpecificKeywords =
                 "/" + meta.getDriverName().replace(" ", "-").toLowerCase() + "-sql.keywords";
-        logger.info("JDBC DriverName: {}", driverSpecificKeywords);
+        LOGGER.info("JDBC DriverName: {}", driverSpecificKeywords);
         if (SqlCompleter.class.getResource(driverSpecificKeywords) != null) {
           String driverKeywords =
                   new BufferedReader(new InputStreamReader(
@@ -229,7 +229,7 @@ public class SqlCompleter {
           keywords += "," + driverKeywords.toUpperCase();
         }
       } catch (IOException | SQLException e) {
-        logger.debug("fail to get driver specific SQL completions for " +
+        LOGGER.debug("fail to get driver specific SQL completions for " +
             meta.getClass().getName() + " : " + e, e);
       }
 
@@ -237,27 +237,27 @@ public class SqlCompleter {
       try {
         keywords += "," + meta.getSQLKeywords();
       } catch (SQLException e) {
-        logger.debug("fail to get SQL key words from database metadata: " + e, e);
+        LOGGER.debug("fail to get SQL key words from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getStringFunctions();
       } catch (SQLException e) {
-        logger.debug("fail to get string function names from database metadata: " + e, e);
+        LOGGER.debug("fail to get string function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getNumericFunctions();
       } catch (SQLException e) {
-        logger.debug("fail to get numeric function names from database metadata: " + e, e);
+        LOGGER.debug("fail to get numeric function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getSystemFunctions();
       } catch (SQLException e) {
-        logger.debug("fail to get system function names from database metadata: " + e, e);
+        LOGGER.debug("fail to get system function names from database metadata: " + e, e);
       }
       try {
         keywords += "," + meta.getTimeDateFunctions();
       } catch (SQLException e) {
-        logger.debug("fail to get time date function names from database metadata: " + e, e);
+        LOGGER.debug("fail to get time date function names from database metadata: " + e, e);
       }
 
       // Set all keywords to lower-case versions
@@ -332,12 +332,12 @@ public class SqlCompleter {
           initColumns(schemaTable, columns);
         }
 
-        logger.info("Completer initialized with " + schemas.size() + " schemas, " +
+        LOGGER.info("Completer initialized with " + schemas.size() + " schemas, " +
             columns.size() + " tables and " + keywords.size() + " keywords");
       }
 
     } catch (SQLException | IOException e) {
-      logger.error("Failed to update the metadata completions", e);
+      LOGGER.error("Failed to update the metadata completions", e);
     }
   }
 

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/SqlCompleter.java
@@ -39,7 +39,7 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  * SQL auto complete functionality for the JdbcInterpreter.
  */
 public class SqlCompleter {
-  private static Logger LOGGER = LoggerFactory.getLogger(SqlCompleter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqlCompleter.class);
 
   /**
    * Delimiter that can split SQL statement in keyword list.

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/SqlCompleterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/SqlCompleterTest.java
@@ -128,7 +128,7 @@ class SqlCompleterTest {
     }
   }
 
-  private Logger LOGGER = LoggerFactory.getLogger(SqlCompleterTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqlCompleterTest.class);
 
   private CompleterTester tester;
 

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/SqlCompleterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/SqlCompleterTest.java
@@ -92,7 +92,7 @@ class SqlCompleterTest {
 
       String explain = explain(buffer, cursor, candidates);
 
-      logger.info(explain);
+      LOGGER.info(explain);
 
       assertEquals(expected, new HashSet<>(candidates), "Buffer [" + buffer.replace(" ", ".")
               + "] and Cursor[" + cursor + "] " + explain);
@@ -128,7 +128,7 @@ class SqlCompleterTest {
     }
   }
 
-  private Logger logger = LoggerFactory.getLogger(SqlCompleterTest.class);
+  private Logger LOGGER = LoggerFactory.getLogger(SqlCompleterTest.class);
 
   private CompleterTester tester;
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/BaseLivyInterpreter.java
@@ -85,7 +85,7 @@ import org.apache.zeppelin.interpreter.thrift.InterpreterCompletion;
  */
 public abstract class BaseLivyInterpreter extends Interpreter {
 
-  protected static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseLivyInterpreter.class);
   private static Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
   private static final String SESSION_NOT_FOUND_PATTERN = "(.*)\"Session '\\d+' not found.\"(.*)";
 

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivySparkSQLInterpreter.java
@@ -42,12 +42,15 @@ import org.apache.zeppelin.interpreter.InterpreterUtils;
 import org.apache.zeppelin.interpreter.ResultMessages;
 import org.apache.zeppelin.scheduler.Scheduler;
 import org.apache.zeppelin.scheduler.SchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Livy SparkSQL Interpreter for Zeppelin.
  */
 public class LivySparkSQLInterpreter extends BaseLivyInterpreter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LivySparkSQLInterpreter.class);
 
   public static final String ZEPPELIN_LIVY_SPARK_SQL_FIELD_TRUNCATE =
       "zeppelin.livy.spark.sql.field.truncate";

--- a/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
+++ b/livy/src/main/java/org/apache/zeppelin/livy/LivyVersion.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Provide reading comparing capability of livy version.
  */
 public class LivyVersion {
-  private static final Logger logger = LoggerFactory.getLogger(LivyVersion.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LivyVersion.class);
 
   protected static final LivyVersion LIVY_0_2_0 = LivyVersion.fromVersionString("0.2.0");
   protected static final LivyVersion LIVY_0_3_0 = LivyVersion.fromVersionString("0.3.0");
@@ -52,7 +52,7 @@ public class LivyVersion {
       // version is always 5 digits. (e.g. 2.0.0 -> 20000, 1.6.2 -> 10602)
       version = Integer.parseInt(String.format("%d%02d%02d", major, minor, patch));
     } catch (Exception e) {
-      logger.error("Can not recognize Livy version " + versionString +
+      LOGGER.error("Can not recognize Livy version " + versionString +
           ". Assume it's a future release", e);
 
       // assume it is future release

--- a/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/LivyInterpreterIT.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class LivyInterpreterIT extends WithLivyServer {
-  private static final Logger LOG = LoggerFactory.getLogger(LivyInterpreterIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LivyInterpreterIT.class);
   private static Properties properties;
 
   @BeforeAll

--- a/livy/src/test/java/org/apache/zeppelin/livy/WithLivyServer.java
+++ b/livy/src/test/java/org/apache/zeppelin/livy/WithLivyServer.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract class WithLivyServer {
-  private static final Logger LOG = LoggerFactory.getLogger(WithLivyServer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(WithLivyServer.class);
 
   private static Optional<Process> livy = Optional.empty();
 
@@ -53,11 +53,11 @@ abstract class WithLivyServer {
 
   public static boolean checkPreCondition() {
     if (System.getenv("LIVY_HOME") == null) {
-      LOG.warn(("livy integration is skipped because LIVY_HOME is not set"));
+      LOGGER.warn(("livy integration is skipped because LIVY_HOME is not set"));
       return false;
     }
     if (System.getenv("SPARK_HOME") == null) {
-      LOG.warn(("livy integration is skipped because SPARK_HOME is not set"));
+      LOGGER.warn(("livy integration is skipped because SPARK_HOME is not set"));
       return false;
     }
     return true;
@@ -78,14 +78,14 @@ abstract class WithLivyServer {
         Paths.get(LIVY_HOME, "conf", "log4j.properties.template"),
         LIVY_CONF_DIR.toPath().resolve("log4j.properties"));
 
-    LOG.info("SPARK_HOME: {}", SPARK_HOME);
-    LOG.info("LIVY_HOME: {}", LIVY_HOME);
-    LOG.info("LIVY_CONF_DIR: {}", LIVY_CONF_DIR.getAbsolutePath());
-    LOG.info("LIVY_LOG_DIR: {}", LIVY_LOG_DIR.getAbsolutePath());
+    LOGGER.info("SPARK_HOME: {}", SPARK_HOME);
+    LOGGER.info("LIVY_HOME: {}", LIVY_HOME);
+    LOGGER.info("LIVY_CONF_DIR: {}", LIVY_CONF_DIR.getAbsolutePath());
+    LOGGER.info("LIVY_LOG_DIR: {}", LIVY_LOG_DIR.getAbsolutePath());
 
     File logFile = new File(TMP_DIR, "output.log");
     assertTrue(logFile.createNewFile());
-    LOG.info("Redirect Livy's log to {}", logFile.getAbsolutePath());
+    LOGGER.info("Redirect Livy's log to {}", logFile.getAbsolutePath());
 
     ProcessBuilder pb = new ProcessBuilder(LIVY_HOME + "/bin/livy-server")
         .directory(TMP_DIR)
@@ -116,7 +116,7 @@ abstract class WithLivyServer {
       }
     });
 
-    LOG.info("Livy Server is started at {}", LIVY_ENDPOINT);
+    LOGGER.info("Livy Server is started at {}", LIVY_ENDPOINT);
     livy = Optional.of(livyProc);
   }
 
@@ -124,16 +124,16 @@ abstract class WithLivyServer {
   public static void afterAll() {
     livy.filter(Process::isAlive).ifPresent(proc -> {
       try {
-        LOG.info("Stopping the Livy Server running at {}", LIVY_ENDPOINT);
+        LOGGER.info("Stopping the Livy Server running at {}", LIVY_ENDPOINT);
         proc.destroy();
         if (!proc.waitFor(10, SECONDS)) {
-          LOG.warn("Forcibly stopping the Livy Server running at {}", LIVY_ENDPOINT);
+          LOGGER.warn("Forcibly stopping the Livy Server running at {}", LIVY_ENDPOINT);
           proc.destroyForcibly();
           assertFalse(proc.isAlive());
         }
       } catch (InterruptedException ignore) {
         if (proc.isAlive()) {
-          LOG.warn("Forcibly stopping the Livy Server running at {}", LIVY_ENDPOINT);
+          LOGGER.warn("Forcibly stopping the Livy Server running at {}", LIVY_ENDPOINT);
           proc.destroyForcibly();
           assertFalse(proc.isAlive());
         }

--- a/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jConnectionManager.java
+++ b/neo4j/src/main/java/org/apache/zeppelin/graph/neo4j/Neo4jConnectionManager.java
@@ -47,7 +47,7 @@ import org.apache.zeppelin.resource.ResourcePool;
  * Neo4j connection manager for Zeppelin.
  */
 public class Neo4jConnectionManager {
-  static final Logger LOGGER = LoggerFactory.getLogger(Neo4jConnectionManager.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Neo4jConnectionManager.class);
 
   public static final String NEO4J_SERVER_URL = "neo4j.url";
   public static final String NEO4J_DATABASE = "neo4j.database";

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
  * TODO(zjffdu) Add removing conda env
  */
 public class PythonCondaInterpreter extends Interpreter {
-  private static Logger logger = LoggerFactory.getLogger(PythonCondaInterpreter.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(PythonCondaInterpreter.class);
   public static final String ZEPPELIN_PYTHON = "zeppelin.python";
   public static final String CONDA_PYTHON_PATH = "/bin/python";
   public static final String DEFAULT_ZEPPELIN_PYTHON = "python";
@@ -162,7 +162,7 @@ public class PythonCondaInterpreter extends Interpreter {
   }
 
   private void restartPythonProcess() throws InterpreterException {
-    logger.debug("Restarting PythonInterpreter");
+    LOGGER.debug("Restarting PythonInterpreter");
     PythonInterpreter pythonInterpreter =
         getInterpreterInTheSameSessionByClassName(PythonInterpreter.class, false);
     pythonInterpreter.close();
@@ -247,7 +247,7 @@ public class PythonCondaInterpreter extends Interpreter {
       out.setType(InterpreterResult.Type.HTML);
       out.writeResource("output_templates/conda_usage.html");
     } catch (IOException e) {
-      logger.error("Can't print usage", e);
+      LOGGER.error("Can't print usage", e);
     }
   }
 
@@ -383,7 +383,7 @@ public class PythonCondaInterpreter extends Interpreter {
 
   public static String runCommand(List<String> commands)
       throws IOException, InterruptedException {
-    logger.info("Starting shell commands: " + StringUtils.join(commands, " "));
+    LOGGER.info("Starting shell commands: " + StringUtils.join(commands, " "));
     Process process = Runtime.getRuntime().exec(commands.toArray(new String[0]));
     StreamGobbler errorGobbler = new StreamGobbler(process.getErrorStream());
     StreamGobbler outputGobbler = new StreamGobbler(process.getInputStream());
@@ -392,7 +392,7 @@ public class PythonCondaInterpreter extends Interpreter {
     if (process.waitFor() != 0) {
       throw new IOException("Fail to run shell commands: " + StringUtils.join(commands, " "));
     }
-    logger.info("Complete shell commands: " + StringUtils.join(commands, " "));
+    LOGGER.info("Complete shell commands: " + StringUtils.join(commands, " "));
     return outputGobbler.getOutput();
   }
 
@@ -415,7 +415,7 @@ public class PythonCondaInterpreter extends Interpreter {
           output.append(line + "\n");
           // logging per 5 seconds
           if ((System.currentTimeMillis() - startTime) > 5000) {
-            logger.info(line);
+            LOGGER.info(line);
             startTime = System.currentTimeMillis();
           }
         }

--- a/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonCondaInterpreter.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
  * TODO(zjffdu) Add removing conda env
  */
 public class PythonCondaInterpreter extends Interpreter {
-  private static Logger LOGGER = LoggerFactory.getLogger(PythonCondaInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PythonCondaInterpreter.class);
   public static final String ZEPPELIN_PYTHON = "zeppelin.python";
   public static final String CONDA_PYTHON_PATH = "/bin/python";
   public static final String DEFAULT_ZEPPELIN_PYTHON = "python";

--- a/python/src/main/java/org/apache/zeppelin/python/PythonDockerInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonDockerInterpreter.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
  * Helps run python interpreter on a docker container
  */
 public class PythonDockerInterpreter extends Interpreter {
-  Logger logger = LoggerFactory.getLogger(PythonDockerInterpreter.class);
+  Logger LOGGER = LoggerFactory.getLogger(PythonDockerInterpreter.class);
   Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   Pattern deactivatePattern = Pattern.compile("deactivate");
   Pattern helpPattern = Pattern.compile("help");
@@ -122,7 +122,7 @@ public class PythonDockerInterpreter extends Interpreter {
       out.setType(InterpreterResult.Type.HTML);
       out.writeResource("output_templates/docker_usage.html");
     } catch (IOException e) {
-      logger.error("Can't print usage", e);
+      LOGGER.error("Can't print usage", e);
     }
   }
 
@@ -166,7 +166,7 @@ public class PythonDockerInterpreter extends Interpreter {
     try {
       exit = runCommand(out, "docker", "pull", image);
     } catch (IOException | InterruptedException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       throw new InterpreterException(e);
     }
     return exit == 0;

--- a/python/src/main/java/org/apache/zeppelin/python/PythonDockerInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonDockerInterpreter.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
  * Helps run python interpreter on a docker container
  */
 public class PythonDockerInterpreter extends Interpreter {
-  Logger LOGGER = LoggerFactory.getLogger(PythonDockerInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PythonDockerInterpreter.class);
   Pattern activatePattern = Pattern.compile("activate\\s*(.*)");
   Pattern deactivatePattern = Pattern.compile("deactivate");
   Pattern helpPattern = Pattern.compile("help");

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -57,7 +57,8 @@ import static org.mockito.Mockito.mock;
  */
 abstract class PythonInterpreterPandasSqlTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
+  private static final Logger LOGGER =
+          LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
 
   protected boolean useIPython;
   private InterpreterGroup intpGroup;

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.mock;
 abstract class PythonInterpreterPandasSqlTest {
 
   private static final Logger LOGGER =
-          LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
+      LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
 
   protected boolean useIPython;
   private InterpreterGroup intpGroup;

--- a/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
+++ b/python/src/test/java/org/apache/zeppelin/python/PythonInterpreterPandasSqlTest.java
@@ -57,8 +57,7 @@ import static org.mockito.Mockito.mock;
  */
 abstract class PythonInterpreterPandasSqlTest {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PythonInterpreterPandasSqlTest.class);
 
   protected boolean useIPython;
   private InterpreterGroup intpGroup;

--- a/rlang/src/main/java/org/apache/zeppelin/r/ZeppelinR.java
+++ b/rlang/src/main/java/org/apache/zeppelin/r/ZeppelinR.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * R repl interaction
  */
 public class ZeppelinR {
-  private static Logger LOGGER = LoggerFactory.getLogger(ZeppelinR.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinR.class);
 
   private RInterpreter rInterpreter;
   private RProcessLogOutputStream processOutputStream;

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/PySparkInterpreter.java
@@ -48,7 +48,7 @@ import java.util.Properties;
  */
 public class PySparkInterpreter extends PythonInterpreter {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreter.class);
 
   private SparkInterpreter sparkInterpreter;
   private InterpreterContext curIntpContext;

--- a/spark/interpreter/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
+++ b/spark/interpreter/src/test/java/org/apache/zeppelin/spark/PySparkInterpreterMatplotlibTest.java
@@ -56,7 +56,7 @@ public class PySparkInterpreterMatplotlibTest {
   static SparkInterpreter sparkInterpreter;
   static PySparkInterpreter pyspark;
   static InterpreterGroup intpGroup;
-  static Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreterTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PySparkInterpreterTest.class);
   static InterpreterContext context;
 
   public static class AltPySparkInterpreter extends PySparkInterpreter {

--- a/spark/spark-shims/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/spark-shims/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * Provide reading comparing capability of spark version returned from SparkContext.version()
  */
 public class SparkVersion {
-  private static final Logger logger = LoggerFactory.getLogger(SparkVersion.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkVersion.class);
 
   public static final SparkVersion SPARK_3_2_0 = SparkVersion.fromVersionString("3.2.0");
 
@@ -60,7 +60,7 @@ public class SparkVersion {
       // version is always 5 digits. (e.g. 2.0.0 -> 20000, 1.6.2 -> 10602)
       version = Integer.parseInt(String.format("%d%02d%02d", majorVersion, minorVersion, patchVersion));
     } catch (Exception e) {
-      logger.error("Can not recognize Spark version " + versionString +
+      LOGGER.error("Can not recognize Spark version " + versionString +
           ". Assume it's a future release", e);
 
       // assume it is future release

--- a/zeppelin-examples/zeppelin-example-clock/src/main/java/org/apache/zeppelin/example/app/clock/Clock.java
+++ b/zeppelin-examples/zeppelin-example-clock/src/main/java/org/apache/zeppelin/example/app/clock/Clock.java
@@ -33,7 +33,7 @@ import java.util.Date;
  * Get java.util.Date from resource pool and display it
  */
 public class Clock extends Application {
-  private final Logger logger = LoggerFactory.getLogger(Clock.class);
+  private final Logger LOGGER = LoggerFactory.getLogger(Clock.class);
 
   Date date;
   boolean shutdown = false;

--- a/zeppelin-examples/zeppelin-example-clock/src/main/java/org/apache/zeppelin/example/app/clock/Clock.java
+++ b/zeppelin-examples/zeppelin-example-clock/src/main/java/org/apache/zeppelin/example/app/clock/Clock.java
@@ -33,7 +33,7 @@ import java.util.Date;
  * Get java.util.Date from resource pool and display it
  */
 public class Clock extends Application {
-  private final Logger LOGGER = LoggerFactory.getLogger(Clock.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Clock.class);
 
   Date date;
   boolean shutdown = false;

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -48,7 +48,7 @@ abstract public class AbstractZeppelinIT {
 
   protected WebDriverManager manager;
 
-  protected final static Logger LOG = LoggerFactory.getLogger(AbstractZeppelinIT.class);
+  protected final static Logger LOGGER = LoggerFactory.getLogger(AbstractZeppelinIT.class);
   protected static final long MIN_IMPLICIT_WAIT = 5;
   protected static final long MAX_IMPLICIT_WAIT = 30;
   protected static final long MAX_BROWSER_TIMEOUT_SEC = 30;
@@ -206,9 +206,9 @@ abstract public class AbstractZeppelinIT {
   }
 
   protected void handleException(String message, Exception e) throws Exception {
-    LOG.error(message, e);
+    LOGGER.error(message, e);
     File scrFile = ((TakesScreenshot) manager.getWebDriver()).getScreenshotAs(OutputType.FILE);
-    LOG.error("ScreenShot::\ndata:image/png;base64," + new String(Base64.encodeBase64(FileUtils.readFileToByteArray(scrFile))));
+    LOGGER.error("ScreenShot::\ndata:image/png;base64," + new String(Base64.encodeBase64(FileUtils.readFileToByteArray(scrFile))));
     throw e;
   }
 

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/AbstractZeppelinIT.java
@@ -48,7 +48,7 @@ abstract public class AbstractZeppelinIT {
 
   protected WebDriverManager manager;
 
-  protected final static Logger LOGGER = LoggerFactory.getLogger(AbstractZeppelinIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractZeppelinIT.class);
   protected static final long MIN_IMPLICIT_WAIT = 5;
   protected static final long MAX_IMPLICIT_WAIT = 30;
   protected static final long MAX_BROWSER_TIMEOUT_SEC = 30;

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/CommandExecutor.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/CommandExecutor.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class CommandExecutor {
 
-  public final static Logger LOG = LoggerFactory.getLogger(CommandExecutor.class);
+  public final static Logger LOGGER = LoggerFactory.getLogger(CommandExecutor.class);
 
   public enum IGNORE_ERRORS {
     TRUE,
@@ -43,7 +43,7 @@ public class CommandExecutor {
     List<String> subCommandsAsList = new ArrayList<>(Arrays.asList(command));
     String mergedCommand = StringUtils.join(subCommandsAsList, " ");
 
-    LOG.info("Sending command \"" + mergedCommand + "\" to localhost");
+    LOGGER.info("Sending command \"" + mergedCommand + "\" to localhost");
 
     ProcessBuilder processBuilder = new ProcessBuilder(command);
     Process process = null;
@@ -58,11 +58,11 @@ public class CommandExecutor {
     int exit_code = data_of_process.getExitCodeValue();
 
     if (!printToConsole)
-      LOG.trace(output_of_process.toString());
+      LOGGER.trace(output_of_process.toString());
     else
-      LOG.debug(output_of_process.toString());
+      LOGGER.debug(output_of_process.toString());
     if (ignore_errors == IGNORE_ERRORS.FALSE && exit_code != NORMAL_EXIT) {
-      LOG.error(String.format("*********************Command '%s' failed with exitcode %s *********************", mergedCommand, exit_code));
+      LOGGER.error(String.format("*********************Command '%s' failed with exitcode %s *********************", mergedCommand, exit_code));
     }
     return output_of_process;
   }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/CommandExecutor.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/CommandExecutor.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class CommandExecutor {
 
-  public final static Logger LOGGER = LoggerFactory.getLogger(CommandExecutor.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CommandExecutor.class);
 
   public enum IGNORE_ERRORS {
     TRUE,

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/ProcessData.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/ProcessData.java
@@ -37,7 +37,7 @@ public class ProcessData {
     PROCESS_DATA_OBJECT
   }
 
-  private final static Logger LOGGER = LoggerFactory.getLogger(ProcessData.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessData.class);
 
   private Process checked_process;
   private boolean printToConsole = false;

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/ProcessData.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/ProcessData.java
@@ -37,7 +37,7 @@ public class ProcessData {
     PROCESS_DATA_OBJECT
   }
 
-  private final static Logger LOG = LoggerFactory.getLogger(ProcessData.class);
+  private final static Logger LOGGER = LoggerFactory.getLogger(ProcessData.class);
 
   private Process checked_process;
   private boolean printToConsole = false;
@@ -167,7 +167,7 @@ public class ProcessData {
       InputStream inErrors = this.checked_process.getErrorStream();
       BufferedReader inReader = new BufferedReader(new InputStreamReader(in));
       BufferedReader inReaderErrors = new BufferedReader(new InputStreamReader(inErrors));
-      LOG.trace("Started retrieving data from streams of attached process: " + this.checked_process);
+      LOGGER.trace("Started retrieving data from streams of attached process: " + this.checked_process);
 
       long lastStreamDataTime = System.currentTimeMillis();   //Store start time to be able to finish method if command hangs
       long unconditionalExitTime = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(unconditionalExitDelayMinutes, TimeUnit.MINUTES); // Stop after 'unconditionalExitDelayMinutes' even if process is alive and sending output
@@ -212,9 +212,9 @@ public class ProcessData {
             if (printToConsole) {
               if (!temp.trim().equals("")) {
                 if (temp.toLowerCase().contains("error") || temp.toLowerCase().contains("failed")) {
-                  LOG.warn(temp.trim());
+                  LOGGER.warn(temp.trim());
                 } else {
-                  LOG.debug(temp.trim());
+                  LOGGER.debug(temp.trim());
                 }
               }
             }
@@ -225,22 +225,22 @@ public class ProcessData {
 
         if ((System.currentTimeMillis() - lastStreamDataTime > silenceTimeout) ||     //Exit if silenceTimeout ms has passed from last stream read. Means process is alive but not sending any data.
             (System.currentTimeMillis() > unconditionalExitTime)) {                    //Exit unconditionally - guards against alive process continuously sending data.
-          LOG.info("Conditions: " + (System.currentTimeMillis() - lastStreamDataTime > silenceTimeout) + " " +
+          LOGGER.info("Conditions: " + (System.currentTimeMillis() - lastStreamDataTime > silenceTimeout) + " " +
               (System.currentTimeMillis() > unconditionalExitTime));
           this.checked_process.destroy();
           try {
             if ((System.currentTimeMillis() > unconditionalExitTime)) {
-              LOG.error(
+              LOGGER.error(
                   "!@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@Unconditional exit occured@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@!\nsome process hag up for more than "
                       + unconditionalExitDelayMinutes + " minutes.");
             }
-            LOG.error("!##################################!");
+            LOGGER.error("!##################################!");
             StringWriter sw = new StringWriter();
             Exception e = new Exception("Exited from buildOutputAndErrorStreamData by timeout");
             e.printStackTrace(new PrintWriter(sw)); //Get stack trace
-            LOG.error(String.valueOf(e), e);
+            LOGGER.error(String.valueOf(e), e);
           } catch (Exception ignore) {
-            LOG.info("Exception in ProcessData while buildOutputAndErrorStreamData ", ignore);
+            LOGGER.info("Exception in ProcessData while buildOutputAndErrorStreamData ", ignore);
           }
           break;
         }

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/InterpreterModeActionsIT.java
@@ -45,7 +45,7 @@ import java.time.Duration;
 
 
 public class InterpreterModeActionsIT extends AbstractZeppelinIT {
-  private static final Logger LOG = LoggerFactory.getLogger(InterpreterModeActionsIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterModeActionsIT.class);
 
   private final static String AUTH_SHIRO = "[users]\n" +
       "admin = password1, admin\n" +
@@ -232,7 +232,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "[contains(.,'Do you want to restart python interpreter?')]" +
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not testGloballyAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not testGloballyAction");
       boolean invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -390,7 +390,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "[contains(.,'Do you want to restart python interpreter?')]" +
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
       boolean invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -432,7 +432,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "[contains(.,'Do you want to restart python interpreter?')]" +
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
       invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -524,7 +524,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "[contains(.,'Do you want to restart this interpreter?')]" +
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserScopedAction");
       invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -674,7 +674,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
 
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
       boolean invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -717,7 +717,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
 
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
       invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));
@@ -809,7 +809,7 @@ public class InterpreterModeActionsIT extends AbstractZeppelinIT {
           "[contains(.,'Do you want to restart this interpreter?')]" +
           "//div[@class='bootstrap-dialog-footer-buttons']//button[contains(., 'OK')]"));
       locator = By.xpath("//div[@class='modal-dialog'][contains(.,'Do you want to restart python interpreter?')]");
-      LOG.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
+      LOGGER.info("Holding on until if interpreter restart dialog is disappeared or not in testPerUserIsolatedAction");
       invisibilityStatus =
         (new WebDriverWait(manager.getWebDriver(), Duration.ofSeconds(MAX_BROWSER_TIMEOUT_SEC)))
           .until(ExpectedConditions.invisibilityOfElementLocated(locator));

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinIT.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 class ZeppelinIT extends AbstractZeppelinIT {
-  private static final Logger LOG = LoggerFactory.getLogger(ZeppelinIT.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinIT.class);
 
   private static MiniZeppelinServer zepServer;
 
@@ -213,7 +213,7 @@ class ZeppelinIT extends AbstractZeppelinIT {
           "//div[@class='modal-footer']//button[contains(.,'OK')]"));
       ZeppelinITUtils.sleep(100, false);
 
-      LOG.info("testCreateNotebook Test executed");
+      LOGGER.info("testCreateNotebook Test executed");
     } catch (Exception e) {
       handleException("Exception in ZeppelinIT while testAngularDisplay ", e);
     }
@@ -346,7 +346,7 @@ class ZeppelinIT extends AbstractZeppelinIT {
       deleteTestNotebook(manager.getWebDriver());
       ZeppelinITUtils.sleep(1000, false);
 
-      LOG.info("testAngularRunParagraph Test executed");
+      LOGGER.info("testAngularRunParagraph Test executed");
     }  catch (Exception e) {
       handleException("Exception in ZeppelinIT while testAngularRunParagraph", e);
     }
@@ -362,7 +362,7 @@ class ZeppelinIT extends AbstractZeppelinIT {
       waitForParagraph(1, "READY");
 
       String currentUrl = manager.getWebDriver().getCurrentUrl();
-      LOG.info("currentUrl = " + currentUrl);
+      LOGGER.info("currentUrl = " + currentUrl);
 
       //delete created notebook to trash
       deleteTestNotebook(manager.getWebDriver());
@@ -375,7 +375,7 @@ class ZeppelinIT extends AbstractZeppelinIT {
       // delete note from trash
       deleteTrashNotebook(manager.getWebDriver());
       ZeppelinITUtils.sleep(2000, false);
-      LOG.info("deleteTrashNode executed");
+      LOGGER.info("deleteTrashNode executed");
     }  catch (Exception e) {
       handleException("Exception in ZeppelinIT while deleteTrashNode", e);
     }

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/FlinkIntegrationTest.java
@@ -49,7 +49,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 
 public abstract class FlinkIntegrationTest {
-  private static Logger LOGGER = LoggerFactory.getLogger(FlinkIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlinkIntegrationTest.class);
 
   private static MiniHadoopCluster hadoopCluster;
   private static MiniZeppelinServer zepServer;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/MiniHadoopCluster.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/MiniHadoopCluster.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  */
 public class MiniHadoopCluster {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(MiniHadoopCluster.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MiniHadoopCluster.class);
 
   private Configuration hadoopConf;
   private MiniDFSCluster dfsCluster;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkIntegrationTest.java
@@ -59,7 +59,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public abstract class SparkIntegrationTest {
-  private static Logger LOGGER = LoggerFactory.getLogger(SparkIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkIntegrationTest.class);
 
   private static MiniHadoopCluster hadoopCluster;
   private static InterpreterFactory interpreterFactory;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkSubmitIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/SparkSubmitIntegrationTest.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 
 public class SparkSubmitIntegrationTest {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(SparkSubmitIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkSubmitIntegrationTest.class);
 
   private static MiniHadoopCluster hadoopCluster;
   private static InterpreterFactory interpreterFactory;

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientIntegrationTest.java
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(ZeppelinClientIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinClientIntegrationTest.class);
   private static Notebook notebook;
 
   private static ClientConfig clientConfig;
@@ -86,7 +86,7 @@ class ZeppelinClientIntegrationTest extends AbstractTestRestApi {
   @Test
   void testZeppelinVersion() throws Exception {
     String version = zeppelinClient.getVersion();
-    LOG.info("Zeppelin version: " + version);
+    LOGGER.info("Zeppelin version: " + version);
     assertNotNull(version);
   }
 

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientWithAuthIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/ZeppelinClientWithAuthIntegrationTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 class ZeppelinClientWithAuthIntegrationTest extends AbstractTestRestApi {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ZeppelinClientWithAuthIntegrationTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinClientWithAuthIntegrationTest.class);
 
   private static ClientConfig clientConfig;
   private static ZeppelinClient zeppelinClient;
@@ -69,7 +69,7 @@ class ZeppelinClientWithAuthIntegrationTest extends AbstractTestRestApi {
   @Test
   void testZeppelinVersion() throws Exception {
     String version = zeppelinClient.getVersion();
-    LOG.info("Zeppelin version: " + version);
+    LOGGER.info("Zeppelin version: " + version);
     assertNotNull(version);
   }
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterManagerServer.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterManagerServer.java
@@ -57,7 +57,7 @@ import static org.apache.zeppelin.cluster.meta.ClusterMetaType.SERVER_META;
  * 2. Remotely create interpreter's thrift service
  */
 public class ClusterManagerServer extends ClusterManager {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterManagerServer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerServer.class);
 
   private static ClusterManagerServer instance = null;
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterMonitor.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterMonitor.java
@@ -41,7 +41,7 @@ import static org.apache.zeppelin.cluster.meta.ClusterMetaType.SERVER_META;
  * 3. checks the heartbeat timeout of the zeppelin-server and interperter processes
  */
 public class ClusterMonitor {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterMonitor.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterMonitor.class);
 
   // Whether the thread has started
   private static AtomicBoolean running = new AtomicBoolean(true);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterStateMachine.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterStateMachine.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * Metadata information can be manipulated by put, get, remove, index, and snapshot.
  */
 public class ClusterStateMachine extends AbstractPrimitiveService {
-  private static Logger logger = LoggerFactory.getLogger(ClusterStateMachine.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(ClusterStateMachine.class);
   private ClusterMeta clusterMeta = new ClusterMeta();
 
   // Command to operation a variable in cluster state machine
@@ -86,8 +86,8 @@ public class ClusterStateMachine extends AbstractPrimitiveService {
 
   @Override
   public void backup(BackupOutput writer) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("ClusterStateMachine.backup()");
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("ClusterStateMachine.backup()");
     }
 
     // backup SERVER_META
@@ -135,8 +135,8 @@ public class ClusterStateMachine extends AbstractPrimitiveService {
 
   @Override
   public void restore(BackupInput reader) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("ClusterStateMachine.restore()");
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("ClusterStateMachine.restore()");
     }
 
     clusterMeta = new ClusterMeta();

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterStateMachine.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/ClusterStateMachine.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * Metadata information can be manipulated by put, get, remove, index, and snapshot.
  */
 public class ClusterStateMachine extends AbstractPrimitiveService {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterStateMachine.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterStateMachine.class);
   private ClusterMeta clusterMeta = new ClusterMeta();
 
   // Command to operation a variable in cluster state machine

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/listener/ZeppelinClusterMembershipEventListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/cluster/listener/ZeppelinClusterMembershipEventListener.java
@@ -27,8 +27,7 @@ import org.slf4j.LoggerFactory;
  * Monitor whether the metadata in the cluster server changes
  */
 public class ZeppelinClusterMembershipEventListener implements ClusterMembershipEventListener {
-  private static final Logger LOGGER
-      = LoggerFactory.getLogger(ZeppelinClusterMembershipEventListener.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinClusterMembershipEventListener.class);
 
   @Override
   public void event(ClusterMembershipEvent event) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositoryListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositoryListener.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Simple listener that print log.
  */
 public class RepositoryListener extends AbstractRepositoryListener {
-  Logger LOGGER = LoggerFactory.getLogger(RepositoryListener.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryListener.class);
 
   public RepositoryListener() {}
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositoryListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/RepositoryListener.java
@@ -26,93 +26,93 @@ import org.slf4j.LoggerFactory;
  * Simple listener that print log.
  */
 public class RepositoryListener extends AbstractRepositoryListener {
-  Logger logger = LoggerFactory.getLogger(RepositoryListener.class);
+  Logger LOGGER = LoggerFactory.getLogger(RepositoryListener.class);
 
   public RepositoryListener() {}
 
   @Override
   public void artifactDeployed(RepositoryEvent event) {
-    logger.info("Deployed " + event.getArtifact() + " to " + event.getRepository());
+    LOGGER.info("Deployed " + event.getArtifact() + " to " + event.getRepository());
   }
 
   @Override
   public void artifactDeploying(RepositoryEvent event) {
-    logger.info("Deploying " + event.getArtifact() + " to " + event.getRepository());
+    LOGGER.info("Deploying " + event.getArtifact() + " to " + event.getRepository());
   }
 
   @Override
   public void artifactDescriptorInvalid(RepositoryEvent event) {
-    logger.info("Invalid artifact descriptor for " + event.getArtifact() + ": "
+    LOGGER.info("Invalid artifact descriptor for " + event.getArtifact() + ": "
                                                    + event.getException().getMessage());
   }
 
   @Override
   public void artifactDescriptorMissing(RepositoryEvent event) {
-    logger.info("Missing artifact descriptor for " + event.getArtifact());
+    LOGGER.info("Missing artifact descriptor for " + event.getArtifact());
   }
 
   @Override
   public void artifactInstalled(RepositoryEvent event) {
-    logger.info("Installed " + event.getArtifact() + " to " + event.getFile());
+    LOGGER.info("Installed " + event.getArtifact() + " to " + event.getFile());
   }
 
   @Override
   public void artifactInstalling(RepositoryEvent event) {
-    logger.info("Installing " + event.getArtifact() + " to " + event.getFile());
+    LOGGER.info("Installing " + event.getArtifact() + " to " + event.getFile());
   }
 
   @Override
   public void artifactResolved(RepositoryEvent event) {
-    logger.info("Resolved artifact " + event.getArtifact() + " from " + event.getRepository());
+    LOGGER.info("Resolved artifact " + event.getArtifact() + " from " + event.getRepository());
   }
 
   @Override
   public void artifactDownloading(RepositoryEvent event) {
-    logger.info("Downloading artifact " + event.getArtifact() + " from " + event.getRepository());
+    LOGGER.info("Downloading artifact " + event.getArtifact() + " from " + event.getRepository());
   }
 
   @Override
   public void artifactDownloaded(RepositoryEvent event) {
-    logger.info("Downloaded artifact " + event.getArtifact() + " from " + event.getRepository());
+    LOGGER.info("Downloaded artifact " + event.getArtifact() + " from " + event.getRepository());
   }
 
   @Override
   public void artifactResolving(RepositoryEvent event) {
-    logger.info("Resolving artifact " + event.getArtifact());
+    LOGGER.info("Resolving artifact " + event.getArtifact());
   }
 
   @Override
   public void metadataDeployed(RepositoryEvent event) {
-    logger.info("Deployed " + event.getMetadata() + " to " + event.getRepository());
+    LOGGER.info("Deployed " + event.getMetadata() + " to " + event.getRepository());
   }
 
   @Override
   public void metadataDeploying(RepositoryEvent event) {
-    logger.info("Deploying " + event.getMetadata() + " to " + event.getRepository());
+    LOGGER.info("Deploying " + event.getMetadata() + " to " + event.getRepository());
   }
 
   @Override
   public void metadataInstalled(RepositoryEvent event) {
-    logger.info("Installed " + event.getMetadata() + " to " + event.getFile());
+    LOGGER.info("Installed " + event.getMetadata() + " to " + event.getFile());
   }
 
   @Override
   public void metadataInstalling(RepositoryEvent event) {
-    logger.info("Installing " + event.getMetadata() + " to " + event.getFile());
+    LOGGER.info("Installing " + event.getMetadata() + " to " + event.getFile());
   }
 
   @Override
   public void metadataInvalid(RepositoryEvent event) {
-    logger.info("Invalid metadata " + event.getMetadata());
+    LOGGER.info("Invalid metadata " + event.getMetadata());
   }
 
   @Override
   public void metadataResolved(RepositoryEvent event) {
-    logger.info("Resolved metadata " + event.getMetadata() + " from " + event.getRepository());
+    LOGGER.info("Resolved metadata " + event.getMetadata() + " from " + event.getRepository());
   }
 
   @Override
   public void metadataResolving(RepositoryEvent event) {
-    logger.info("Resolving metadata " + event.getMetadata() + " from " + event.getRepository());
+    LOGGER.info("Resolving metadata " + event.getMetadata() + " from " + event.getRepository());
   }
 }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * Simple listener that show deps downloading progress.
  */
 public class TransferListener extends AbstractTransferListener {
-  private Logger LOGGER = LoggerFactory.getLogger(TransferListener.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransferListener.class);
 
   private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/dep/TransferListener.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * Simple listener that show deps downloading progress.
  */
 public class TransferListener extends AbstractTransferListener {
-  private Logger logger = LoggerFactory.getLogger(TransferListener.class);
+  private Logger LOGGER = LoggerFactory.getLogger(TransferListener.class);
 
   private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
 
@@ -46,7 +46,7 @@ public class TransferListener extends AbstractTransferListener {
     String message =
         event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploading" : "Downloading";
 
-    logger.info(message + ": " + event.getResource().getRepositoryUrl()
+    LOGGER.info(message + ": " + event.getResource().getRepositoryUrl()
                 + event.getResource().getResourceName());
   }
 
@@ -69,7 +69,7 @@ public class TransferListener extends AbstractTransferListener {
     pad(buffer, pad);
     buffer.append('\r');
 
-    logger.info(buffer.toString());
+    LOGGER.info(buffer.toString());
   }
 
   private String getStatus(long complete, long total) {
@@ -112,7 +112,7 @@ public class TransferListener extends AbstractTransferListener {
         throughput = " at " + format.format(kbPerSec) + " KB/sec";
       }
 
-      logger.info(type + ": " + resource.getRepositoryUrl() + resource.getResourceName() + " ("
+      LOGGER.info(type + ": " + resource.getRepositoryUrl() + resource.getResourceName() + " ("
           + len + throughput + ")");
     }
   }
@@ -120,7 +120,7 @@ public class TransferListener extends AbstractTransferListener {
   @Override
   public void transferFailed(TransferEvent event) {
     transferCompleted(event);
-    logger.warn("Unsuccessful transfer", event.getException());
+    LOGGER.warn("Unsuccessful transfer", event.getException());
   }
 
   private void transferCompleted(TransferEvent event) {
@@ -128,12 +128,12 @@ public class TransferListener extends AbstractTransferListener {
     StringBuilder buffer = new StringBuilder(64);
     pad(buffer, lastLength);
     buffer.append('\r');
-    logger.info(buffer.toString());
+    LOGGER.info(buffer.toString());
   }
 
   @Override
   public void transferCorrupted(TransferEvent event) {
-    logger.error("Corrupted transfer", event.getException());
+    LOGGER.error("Corrupted transfer", event.getException());
   }
 
   private long toKB(long bytes) {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/AngularObject.java
@@ -178,7 +178,7 @@ public class AngularObject<T> implements JsonSerializable {
       emit();
     }
     LOGGER.debug("Update angular object: {} with value: {}", name, o);
-    final Logger logger = LoggerFactory.getLogger(AngularObject.class);
+    final Logger LOGGER = LoggerFactory.getLogger(AngularObject.class);
     List<AngularObjectWatcher> ws = new LinkedList<>();
     synchronized (watchers) {
       ws.addAll(watchers);
@@ -192,7 +192,7 @@ public class AngularObject<T> implements JsonSerializable {
           try {
             w.watch(before, after);
           } catch (Exception e) {
-            logger.error("Exception on watch", e);
+            LOGGER.error("Exception on watch", e);
           }
         }
       });

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/ApplicationLoader.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/ApplicationLoader.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * Load application
  */
 public class ApplicationLoader {
-  Logger logger = LoggerFactory.getLogger(ApplicationLoader.class);
+  Logger LOGGER = LoggerFactory.getLogger(ApplicationLoader.class);
 
   private final DependencyResolver depResolver;
   private final ResourcePool resourcePool;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/ApplicationLoader.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/helium/ApplicationLoader.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * Load application
  */
 public class ApplicationLoader {
-  Logger LOGGER = LoggerFactory.getLogger(ApplicationLoader.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationLoader.class);
 
   private final DependencyResolver depResolver;
   private final ResourcePool resourcePool;

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
@@ -31,7 +31,7 @@ import java.util.List;
  * Interpreter result template.
  */
 public class InterpreterResult implements Serializable, JsonSerializable {
-  transient Logger logger = LoggerFactory.getLogger(InterpreterResult.class);
+  transient Logger LOGGER = LoggerFactory.getLogger(InterpreterResult.class);
   private static final Gson gson = new Gson();
 
   /**
@@ -92,7 +92,7 @@ public class InterpreterResult implements Serializable, JsonSerializable {
       this.msg.addAll(out.toInterpreterResultMessage());
       out.close();
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
     }
 
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResult.java
@@ -31,7 +31,7 @@ import java.util.List;
  * Interpreter result template.
  */
 public class InterpreterResult implements Serializable, JsonSerializable {
-  transient Logger LOGGER = LoggerFactory.getLogger(InterpreterResult.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterResult.class);
   private static final Gson gson = new Gson();
 
   /**

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
@@ -33,7 +33,7 @@ import java.util.List;
  * InterpreterMessageOutputStream
  */
 public class InterpreterResultMessageOutput extends OutputStream {
-  Logger logger = LoggerFactory.getLogger(InterpreterResultMessageOutput.class);
+  Logger LOGGER = LoggerFactory.getLogger(InterpreterResultMessageOutput.class);
   private final int NEW_LINE_CHAR = '\n';
   private List<String> resourceSearchPaths;
 
@@ -275,7 +275,7 @@ public class InterpreterResultMessageOutput extends OutputStream {
     try {
       return "%" + type.name().toLowerCase() + " " + new String(toByteArray());
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return "%" + type.name().toLowerCase() + "\n";
     }
   }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/InterpreterResultMessageOutput.java
@@ -33,7 +33,7 @@ import java.util.List;
  * InterpreterMessageOutputStream
  */
 public class InterpreterResultMessageOutput extends OutputStream {
-  Logger LOGGER = LoggerFactory.getLogger(InterpreterResultMessageOutput.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterResultMessageOutput.class);
   private final int NEW_LINE_CHAR = '\n';
   private List<String> resourceSearchPaths;
 

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventService.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventService.java
@@ -1434,7 +1434,7 @@ public class RemoteInterpreterEventService {
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
-    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }
@@ -2102,7 +2102,7 @@ public class RemoteInterpreterEventService {
   }
 
   public static class AsyncProcessor<I extends AsyncIface> extends org.apache.thrift.TBaseAsyncProcessor<I> {
-    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
     public AsyncProcessor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.AsyncProcessFunction<I, ? extends org.apache.thrift.TBase, ?>>()));
     }
@@ -2154,10 +2154,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2170,22 +2170,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2218,10 +2218,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2234,22 +2234,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2282,10 +2282,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2298,22 +2298,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2346,10 +2346,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2362,22 +2362,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2410,10 +2410,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2426,22 +2426,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2474,10 +2474,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2490,22 +2490,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2538,10 +2538,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2554,22 +2554,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2602,10 +2602,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2618,22 +2618,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2666,10 +2666,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2682,22 +2682,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2730,10 +2730,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2746,22 +2746,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2794,10 +2794,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2810,22 +2810,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2858,10 +2858,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2874,22 +2874,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2922,10 +2922,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2938,22 +2938,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2986,10 +2986,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3002,22 +3002,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3050,10 +3050,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3066,22 +3066,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3114,10 +3114,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3130,22 +3130,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3179,10 +3179,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3195,22 +3195,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3244,10 +3244,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3260,22 +3260,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3309,10 +3309,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3325,22 +3325,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3374,10 +3374,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3390,22 +3390,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3439,10 +3439,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3451,22 +3451,22 @@ public class RemoteInterpreterEventService {
             org.apache.thrift.TSerializable msg;
             getAllLibraryMetadatas_result result = new getAllLibraryMetadatas_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3500,10 +3500,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3512,22 +3512,22 @@ public class RemoteInterpreterEventService {
             org.apache.thrift.TSerializable msg;
             getLibrary_result result = new getLibrary_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventService.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterEventService.java
@@ -1434,7 +1434,7 @@ public class RemoteInterpreterEventService {
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
+    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }
@@ -2102,7 +2102,7 @@ public class RemoteInterpreterEventService {
   }
 
   public static class AsyncProcessor<I extends AsyncIface> extends org.apache.thrift.TBaseAsyncProcessor<I> {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
+    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
     public AsyncProcessor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.AsyncProcessFunction<I, ? extends org.apache.thrift.TBase, ?>>()));
     }
@@ -2154,10 +2154,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2170,22 +2170,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2218,10 +2218,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2234,22 +2234,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2282,10 +2282,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2298,22 +2298,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2346,10 +2346,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2362,22 +2362,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2410,10 +2410,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2426,22 +2426,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2474,10 +2474,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2490,22 +2490,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2538,10 +2538,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2554,22 +2554,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2602,10 +2602,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2618,22 +2618,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2666,10 +2666,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2682,22 +2682,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2730,10 +2730,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2746,22 +2746,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2794,10 +2794,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2810,22 +2810,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2858,10 +2858,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2874,22 +2874,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2922,10 +2922,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2938,22 +2938,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2986,10 +2986,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3002,22 +3002,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3050,10 +3050,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3066,22 +3066,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3114,10 +3114,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3130,22 +3130,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3179,10 +3179,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3195,22 +3195,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3244,10 +3244,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3260,22 +3260,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3309,10 +3309,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3325,22 +3325,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3374,10 +3374,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3390,22 +3390,22 @@ public class RemoteInterpreterEventService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3439,10 +3439,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3451,22 +3451,22 @@ public class RemoteInterpreterEventService {
             org.apache.thrift.TSerializable msg;
             getAllLibraryMetadatas_result result = new getAllLibraryMetadatas_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3500,10 +3500,10 @@ public class RemoteInterpreterEventService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3512,22 +3512,22 @@ public class RemoteInterpreterEventService {
             org.apache.thrift.TSerializable msg;
             getLibrary_result result = new getLibrary_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
@@ -1610,7 +1610,7 @@ public class RemoteInterpreterService {
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
-    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }
@@ -2314,7 +2314,7 @@ public class RemoteInterpreterService {
   }
 
   public static class AsyncProcessor<I extends AsyncIface> extends org.apache.thrift.TBaseAsyncProcessor<I> {
-    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
     public AsyncProcessor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.AsyncProcessFunction<I, ? extends org.apache.thrift.TBase, ?>>()));
     }
@@ -2367,10 +2367,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2383,22 +2383,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2431,10 +2431,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2447,22 +2447,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2495,10 +2495,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2511,22 +2511,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2559,10 +2559,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2575,22 +2575,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2623,10 +2623,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2639,22 +2639,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2688,10 +2688,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2704,22 +2704,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2752,10 +2752,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2768,22 +2768,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2818,10 +2818,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2834,22 +2834,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2883,10 +2883,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2899,22 +2899,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2948,10 +2948,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2964,22 +2964,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3012,10 +3012,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3024,22 +3024,22 @@ public class RemoteInterpreterService {
             org.apache.thrift.TSerializable msg;
             shutdown_result result = new shutdown_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3073,10 +3073,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3089,22 +3089,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3138,10 +3138,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3154,22 +3154,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3203,10 +3203,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3219,22 +3219,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3269,10 +3269,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3285,22 +3285,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3334,10 +3334,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3350,22 +3350,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3398,10 +3398,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3414,22 +3414,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3462,10 +3462,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3478,22 +3478,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3526,10 +3526,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3542,22 +3542,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3590,10 +3590,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3606,22 +3606,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3655,10 +3655,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3671,22 +3671,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3720,10 +3720,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3736,22 +3736,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3785,10 +3785,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              _LOGGER.error("TTransportException writing to internal frame buffer", e);
+              LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              _LOGGER.error("Exception writing to internal frame buffer", e);
+              LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3801,22 +3801,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              _LOGGER.error("TTransportException inside handler", e);
+              LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              _LOGGER.error("TApplicationException inside handler", e);
+              LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              _LOGGER.error("Exception inside handler", e);
+              LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              _LOGGER.error("Exception writing to internal frame buffer", ex);
+              LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/interpreter/thrift/RemoteInterpreterService.java
@@ -1610,7 +1610,7 @@ public class RemoteInterpreterService {
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
+    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }
@@ -2314,7 +2314,7 @@ public class RemoteInterpreterService {
   }
 
   public static class AsyncProcessor<I extends AsyncIface> extends org.apache.thrift.TBaseAsyncProcessor<I> {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
+    private static final org.slf4j.Logger _LOGGER = org.slf4j.LoggerFactory.getLogger(AsyncProcessor.class.getName());
     public AsyncProcessor(I iface) {
       super(iface, getProcessMap(new java.util.HashMap<java.lang.String, org.apache.thrift.AsyncProcessFunction<I, ? extends org.apache.thrift.TBase, ?>>()));
     }
@@ -2367,10 +2367,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2383,22 +2383,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2431,10 +2431,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2447,22 +2447,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2495,10 +2495,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2511,22 +2511,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2559,10 +2559,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2575,22 +2575,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2623,10 +2623,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2639,22 +2639,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2688,10 +2688,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2704,22 +2704,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2752,10 +2752,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2768,22 +2768,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2818,10 +2818,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2834,22 +2834,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2883,10 +2883,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2899,22 +2899,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -2948,10 +2948,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -2964,22 +2964,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3012,10 +3012,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3024,22 +3024,22 @@ public class RemoteInterpreterService {
             org.apache.thrift.TSerializable msg;
             shutdown_result result = new shutdown_result();
             if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3073,10 +3073,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3089,22 +3089,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3138,10 +3138,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3154,22 +3154,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3203,10 +3203,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3219,22 +3219,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3269,10 +3269,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3285,22 +3285,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3334,10 +3334,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3350,22 +3350,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3398,10 +3398,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3414,22 +3414,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3462,10 +3462,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3478,22 +3478,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3526,10 +3526,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3542,22 +3542,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3590,10 +3590,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3606,22 +3606,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3655,10 +3655,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3671,22 +3671,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3720,10 +3720,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3736,22 +3736,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }
@@ -3785,10 +3785,10 @@ public class RemoteInterpreterService {
             try {
               fcall.sendResponse(fb, result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
             } catch (org.apache.thrift.transport.TTransportException e) {
-              LOGGER.error("TTransportException writing to internal frame buffer", e);
+              _LOGGER.error("TTransportException writing to internal frame buffer", e);
               fb.close();
             } catch (java.lang.Exception e) {
-              LOGGER.error("Exception writing to internal frame buffer", e);
+              _LOGGER.error("Exception writing to internal frame buffer", e);
               onError(e);
             }
           }
@@ -3801,22 +3801,22 @@ public class RemoteInterpreterService {
               result.setExIsSet(true);
               msg = result;
             } else if (e instanceof org.apache.thrift.transport.TTransportException) {
-              LOGGER.error("TTransportException inside handler", e);
+              _LOGGER.error("TTransportException inside handler", e);
               fb.close();
               return;
             } else if (e instanceof org.apache.thrift.TApplicationException) {
-              LOGGER.error("TApplicationException inside handler", e);
+              _LOGGER.error("TApplicationException inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TApplicationException)e;
             } else {
-              LOGGER.error("Exception inside handler", e);
+              _LOGGER.error("Exception inside handler", e);
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
             }
             try {
               fcall.sendResponse(fb,msg,msgType,seqid);
             } catch (java.lang.Exception ex) {
-              LOGGER.error("Exception writing to internal frame buffer", ex);
+              _LOGGER.error("Exception writing to internal frame buffer", ex);
               fb.close();
             }
           }

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/resource/Resource.java
@@ -422,8 +422,8 @@ public class Resource implements JsonSerializable, Serializable {
   }
 
   private void logException(Exception e) {
-    Logger logger = LoggerFactory.getLogger(Resource.class);
-    logger.error(e.getMessage(), e);
+    Logger LOGGER = LoggerFactory.getLogger(Resource.class);
+    LOGGER.error(e.getMessage(), e);
   }
 
   public String toJson() {

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/JobProgressPoller.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/scheduler/JobProgressPoller.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JobProgressPoller extends Thread {
   public static final long DEFAULT_INTERVAL_MSEC = 500;
-  private static final Logger logger = LoggerFactory.getLogger(JobProgressPoller.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobProgressPoller.class);
 
   private Job<?> job;
   private long intervalMs;
@@ -55,7 +55,7 @@ public class JobProgressPoller extends Thread {
               listener.onProgressUpdate(job, job.progress());
             }
           } catch (Exception e) {
-            logger.error("Can not get or update progress", e);
+            LOGGER.error("Can not get or update progress", e);
           }
         }
         Thread.sleep(intervalMs);

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/user/AuthenticationInfo.java
@@ -35,7 +35,7 @@ import com.google.gson.Gson;
  *
  */
 public class AuthenticationInfo implements JsonSerializable {
-  private static final Logger LOG = LoggerFactory.getLogger(AuthenticationInfo.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationInfo.class);
   private static final Gson GSON = new Gson();
 
   String user;
@@ -119,7 +119,7 @@ public class AuthenticationInfo implements JsonSerializable {
 
   public static boolean isAnonymous(AuthenticationInfo subject) {
     if (subject == null) {
-      LOG.warn("Subject is null, assuming anonymous. "
+      LOGGER.warn("Subject is null, assuming anonymous. "
           + "Not recommended to use subject as null except in tests");
       return true;
     }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/cluster/ClusterMultiNodeTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/cluster/ClusterMultiNodeTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ClusterMultiNodeTest {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterMultiNodeTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterMultiNodeTest.class);
 
   private static List<ClusterManagerServer> clusterServers = new ArrayList<>();
   private static ClusterManagerClient clusterClient = null;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/cluster/ClusterSingleNodeTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/cluster/ClusterSingleNodeTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 
 class ClusterSingleNodeTest {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterSingleNodeTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterSingleNodeTest.class);
   private static ZeppelinConfiguration zConf;
 
   private static ClusterManagerServer clusterServer = null;

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/SleepingJob.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/scheduler/SleepingJob.java
@@ -33,7 +33,7 @@ public class SleepingJob extends Job {
   private long start;
   private int count;
 
-  static Logger LOGGER = LoggerFactory.getLogger(SleepingJob.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SleepingJob.class);
   private Object results;
 
 

--- a/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterCheck.java
+++ b/zeppelin-plugins/launcher/cluster/src/main/java/org/apache/zeppelin/interpreter/launcher/ClusterInterpreterCheck.java
@@ -31,8 +31,7 @@ import static org.apache.zeppelin.cluster.meta.ClusterMeta.INTP_TSERVER_PORT;
 // Metadata registered in the cluster by the interpreter process,
 // Keep the interpreter process started
 public class ClusterInterpreterCheck implements Runnable {
-  private static final Logger LOGGER
-      = LoggerFactory.getLogger(ClusterInterpreterCheck.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterInterpreterCheck.class);
 
   private final InterpreterClient intpProcess;
   private final String intpGroupId;

--- a/zeppelin-plugins/launcher/yarn/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnInterpreterLauncher.java
+++ b/zeppelin-plugins/launcher/yarn/src/main/java/org/apache/zeppelin/interpreter/launcher/YarnInterpreterLauncher.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class YarnInterpreterLauncher extends InterpreterLauncher {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(YarnInterpreterLauncher.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(YarnInterpreterLauncher.class);
 
   public YarnInterpreterLauncher(ZeppelinConfiguration zConf, RecoveryStorage recoveryStorage) {
     super(zConf, recoveryStorage);

--- a/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/github/src/main/java/org/apache/zeppelin/notebook/repo/GitHubNotebookRepo.java
@@ -49,14 +49,14 @@ import java.net.URISyntaxException;
  * username + password authentication, not just GitHub.
  */
 public class GitHubNotebookRepo extends GitNotebookRepo {
-  private static final Logger LOG = LoggerFactory.getLogger(GitHubNotebookRepo.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(GitHubNotebookRepo.class);
   private ZeppelinConfiguration zConf;
   private Git git;
 
   @Override
   public void init(ZeppelinConfiguration zConf, NoteParser noteParser) throws IOException {
     super.init(zConf, noteParser);
-    LOG.debug("initializing GitHubNotebookRepo");
+    LOGGER.debug("initializing GitHubNotebookRepo");
     this.git = super.getGit();
     this.zConf = zConf;
 
@@ -79,20 +79,20 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
   private void configureRemoteStream() {
     try {
-      LOG.debug("Setting up remote stream");
+      LOGGER.debug("Setting up remote stream");
       RemoteAddCommand remoteAddCommand = git.remoteAdd();
       remoteAddCommand.setName(zConf.getZeppelinNotebookGitRemoteOrigin());
       remoteAddCommand.setUri(new URIish(zConf.getZeppelinNotebookGitURL()));
       remoteAddCommand.call();
     } catch (GitAPIException e) {
-      LOG.error("Error configuring GitHub", e);
+      LOGGER.error("Error configuring GitHub", e);
     } catch (URISyntaxException e) {
-      LOG.error("Error in GitHub URL provided", e);
+      LOGGER.error("Error in GitHub URL provided", e);
     }
   }
 
   private void updateRemoteStream() {
-    LOG.debug("Updating remote stream");
+    LOGGER.debug("Updating remote stream");
 
     pullFromRemoteStream();
     pushToRemoteSteam();
@@ -100,7 +100,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
   private void pullFromRemoteStream() {
     try {
-      LOG.debug("Pulling latest changes from remote stream");
+      LOGGER.debug("Pulling latest changes from remote stream");
       PullCommand pullCommand = git.pull();
       pullCommand.setCredentialsProvider(
         new UsernamePasswordCredentialsProvider(
@@ -112,13 +112,13 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
       pullCommand.call();
 
     } catch (GitAPIException e) {
-      LOG.error("Error when pulling latest changes from remote repository", e);
+      LOGGER.error("Error when pulling latest changes from remote repository", e);
     }
   }
 
   private void pushToRemoteSteam() {
     try {
-      LOG.debug("Pushing latest changes to remote stream");
+      LOGGER.debug("Pushing latest changes to remote stream");
       PushCommand pushCommand = git.push();
       pushCommand.setCredentialsProvider(
         new UsernamePasswordCredentialsProvider(
@@ -129,7 +129,7 @@ public class GitHubNotebookRepo extends GitNotebookRepo {
 
       pushCommand.call();
     } catch (GitAPIException e) {
-      LOG.error("Error when pushing latest changes to remote repository", e);
+      LOGGER.error("Error when pushing latest changes to remote repository", e);
     }
   }
 }

--- a/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
+++ b/zeppelin-plugins/notebookrepo/mongo/src/main/java/org/apache/zeppelin/notebook/repo/MongoNotebookRepo.java
@@ -54,7 +54,7 @@ import org.apache.zeppelin.user.AuthenticationInfo;
  */
 public class MongoNotebookRepo extends AbstractNotebookRepo {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MongoNotebookRepo.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoNotebookRepo.class);
 
   private MongoClient client;
 
@@ -107,7 +107,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public Map<String, NoteInfo> list(AuthenticationInfo subject) throws IOException {
-    LOG.debug("list repo.");
+    LOGGER.debug("list repo.");
     Map<String, NoteInfo> infos = new HashMap<>();
 
     Document match = new Document("$match", new Document(Fields.IS_DIR, false));
@@ -144,7 +144,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public Note get(String noteId, String notePath, AuthenticationInfo subject) throws IOException {
-    LOG.debug("get note, noteId: {}, notePath:{}", noteId, notePath);
+    LOGGER.debug("get note, noteId: {}, notePath:{}", noteId, notePath);
 
     return getNote(noteId, notePath);
   }
@@ -160,7 +160,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public void save(Note note, AuthenticationInfo subject) throws IOException {
-    LOG.debug("save note, note: {}", note);
+    LOGGER.debug("save note, note: {}", note);
     String[] pathArray = toPathArray(note.getPath(), false);
 
     try (AutoLock autoLock = lock.lockForWrite()) {
@@ -178,7 +178,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
       saveNoteOrIgnore(note);
       saveNotePathOrIgnore(note.getId(), note.getName(), pId);
     } catch (Exception e) {
-      LOG.warn("ignore error when insert note '{}': {}", note, e.getMessage());
+      LOGGER.warn("ignore error when insert note '{}': {}", note, e.getMessage());
     }
   }
 
@@ -220,7 +220,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
   @Override
   public void move(String noteId, String notePath, String newNotePath,
                    AuthenticationInfo subject) throws IOException {
-    LOG.debug("move note, noteId: {}, notePath: {}, newNotePath: {}",
+    LOGGER.debug("move note, noteId: {}, notePath: {}, newNotePath: {}",
         noteId, notePath, newNotePath);
     if (StringUtils.equals(notePath, newNotePath)) {
       return;
@@ -247,7 +247,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
   @Override
   public void move(String folderPath, String newFolderPath,
                    AuthenticationInfo subject) throws IOException {
-    LOG.debug("move folder, folderPath: {}, newFolderPath: {}", folderPath, newFolderPath);
+    LOGGER.debug("move folder, folderPath: {}, newFolderPath: {}", folderPath, newFolderPath);
     if (StringUtils.equals(folderPath, newFolderPath)) {
       return;
     }
@@ -274,7 +274,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
   @Override
   public void remove(String noteId, String notePath,
                      AuthenticationInfo subject) throws IOException {
-    LOG.debug("remove note, noteId:{}, notePath:{}", noteId, notePath);
+    LOGGER.debug("remove note, noteId:{}, notePath:{}", noteId, notePath);
 
     try (AutoLock autoLock = lock.lockForWrite()) {
       folders.deleteOne(eq(Fields.ID, noteId));
@@ -297,7 +297,7 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public void remove(String folderPath, AuthenticationInfo subject) throws IOException {
-    LOG.debug("remove folder, folderPath: {}", folderPath);
+    LOGGER.debug("remove folder, folderPath: {}", folderPath);
     String[] pathArray = toPathArray(folderPath, true);
 
     try (AutoLock autoLock = lock.lockForWrite()) {
@@ -334,13 +334,13 @@ public class MongoNotebookRepo extends AbstractNotebookRepo {
 
   @Override
   public List<NotebookRepoSettingsInfo> getSettings(AuthenticationInfo subject) {
-    LOG.warn("Method not implemented");
+    LOGGER.warn("Method not implemented");
     return Collections.emptyList();
   }
 
   @Override
   public void updateSettings(Map<String, String> settings, AuthenticationInfo subject) {
-    LOG.warn("Method not implemented");
+    LOGGER.warn("Method not implemented");
   }
 
   /**

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosAuthenticationFilter.java
@@ -33,7 +33,7 @@ import java.util.Collection;
  */
 public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(KerberosAuthenticationFilter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(KerberosAuthenticationFilter.class);
 
   @Override
   protected void saveRequestAndRedirectToLogin(ServletRequest request, ServletResponse response) {
@@ -71,7 +71,7 @@ public class KerberosAuthenticationFilter extends PassThruAuthenticationFilter {
     if (kerberosRealm != null) {
       kerberosRealm.doKerberosAuth(request, response, filterChain);
     } else {
-      LOG.error("Looks like this filter is enabled without enabling KerberosRealm, please refer"
+      LOGGER.error("Looks like this filter is enabled without enabling KerberosRealm, please refer"
           + " to https://zeppelin.apache.org/docs/latest/security/shiroauthentication.html"
           + "#kerberos-auth");
     }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -82,7 +82,7 @@ import java.util.regex.Pattern;
  *
  */
 public class KerberosRealm extends AuthorizingRealm {
-  public static final Logger LOG = LoggerFactory.getLogger(KerberosRealm.class);
+  public static final Logger LOGGER = LoggerFactory.getLogger(KerberosRealm.class);
 
   // Configs to set in shiro.ini
   private String principal = null;
@@ -245,13 +245,13 @@ public class KerberosRealm extends AuthorizingRealm {
       serverSubject.getPrivateCredentials().add(keytabInstance);
       for (String spnegoPrincipal : spnegoPrincipals) {
         Principal krbPrincipal = new KerberosPrincipal(spnegoPrincipal);
-        LOG.info("Using keytab {}, for principal {}",
+        LOGGER.info("Using keytab {}, for principal {}",
             keytab, krbPrincipal);
         serverSubject.getPrincipals().add(krbPrincipal);
       }
 
       if (nameRules == null || nameRules.trim().length() == 0) {
-        LOG.warn("No auth_to_local rules defined, DEFAULT will be used.");
+        LOGGER.warn("No auth_to_local rules defined, DEFAULT will be used.");
         nameRules = "DEFAULT";
       }
 
@@ -261,7 +261,7 @@ public class KerberosRealm extends AuthorizingRealm {
         try {
           gssManager = Subject.doAs(serverSubject,
                   (PrivilegedExceptionAction<GSSManager>) GSSManager::getInstance);
-          LOG.trace("SPNEGO gssManager initialized.");
+          LOGGER.trace("SPNEGO gssManager initialized.");
         } catch (PrivilegedActionException ex) {
           throw ex.getException();
         }
@@ -301,18 +301,18 @@ public class KerberosRealm extends AuthorizingRealm {
       try {
         provider = new FileSignerSecretProvider();
         provider.init(config, null, tokenValidity);
-        LOG.info("File based secret signer initialized.");
+        LOGGER.info("File based secret signer initialized.");
       } catch (Exception e) {
-        LOG.info("Unable to initialize FileSignerSecretProvider, " +
+        LOGGER.info("Unable to initialize FileSignerSecretProvider, " +
             "falling back to use random secrets.");
         provider = new RandomSignerSecretProvider();
         provider.init(config, null, tokenValidity);
-        LOG.info("Random secret signer initialized.");
+        LOGGER.info("Random secret signer initialized.");
       }
     } else if ("random".equals(secretProvider)) {
       provider = new RandomSignerSecretProvider();
       provider.init(config, null, tokenValidity);
-      LOG.info("Random secret signer initialized.");
+      LOGGER.info("Random secret signer initialized.");
     } else {
       throw new RuntimeException(
           "Custom secret signer not implemented yet. Use 'file' or 'random'.");
@@ -360,7 +360,7 @@ public class KerberosRealm extends AuthorizingRealm {
       hadoopGroups.refresh();
       final List<String> groupList = hadoopGroups.getGroups(mappedPrincipalName);
 
-      LOG.debug(String.format("group found %s, %s",
+      LOGGER.debug(String.format("group found %s, %s",
             mappedPrincipalName, groupList.toString()));
 
       groups = new HashSet<>(groupList);
@@ -368,10 +368,10 @@ public class KerberosRealm extends AuthorizingRealm {
     } catch (final IOException e) {
       if (e.toString().contains("No groups found for user")) {
         /* no groups found move on */
-        LOG.info(String.format("No groups found for user %s", mappedPrincipalName));
+        LOGGER.info(String.format("No groups found for user %s", mappedPrincipalName));
       } else {
         /* Log the error and return empty group */
-        LOG.info(String.format("errorGettingUserGroups for %s", mappedPrincipalName));
+        LOGGER.info(String.format("errorGettingUserGroups for %s", mappedPrincipalName));
         throw new AuthorizationException(e);
       }
       groups = new HashSet<>();
@@ -425,15 +425,15 @@ public class KerberosRealm extends AuthorizingRealm {
       AuthenticationToken token;
       try {
         token = getToken(httpRequest);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Got token {} from httpRequest {}", token,
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Got token {} from httpRequest {}", token,
               getRequestURL(httpRequest));
           if (null != token) {
-            LOG.debug("token.isExpired() = " + token.isExpired());
+            LOGGER.debug("token.isExpired() = " + token.isExpired());
           }
         }
       } catch (AuthenticationException ex) {
-        LOG.warn("AuthenticationToken ignored: " + ex.getMessage());
+        LOGGER.warn("AuthenticationToken ignored: " + ex.getMessage());
         if (!ex.getMessage().equals("Empty token")) {
           // will be sent back in a 401 unless filter authenticates
           authenticationEx = ex;
@@ -442,8 +442,8 @@ public class KerberosRealm extends AuthorizingRealm {
       }
       if (managementOperation(token, httpRequest, httpResponse)) {
         if (token == null || token.isExpired()) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Request [{}] triggering authentication. handler: {}",
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Request [{}] triggering authentication. handler: {}",
                 getRequestURL(httpRequest), this.getClass());
           }
           token = authenticate(httpRequest, httpResponse);
@@ -462,8 +462,8 @@ public class KerberosRealm extends AuthorizingRealm {
         }
         if (token != null) {
           unauthorizedResponse = false;
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Request [{}] user [{}] authenticated",
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Request [{}] user [{}] authenticated",
                 getRequestURL(httpRequest), token.getUserName());
           }
           final AuthenticationToken authToken = token;
@@ -509,8 +509,8 @@ public class KerberosRealm extends AuthorizingRealm {
           doFilter(filterChain, httpRequest, httpResponse);
         }
       } else {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("managementOperation returned false for request {}."
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("managementOperation returned false for request {}."
               + " token: {}", getRequestURL(httpRequest), token);
         }
         unauthorizedResponse = false;
@@ -519,10 +519,10 @@ public class KerberosRealm extends AuthorizingRealm {
       // exception from the filter itself is fatal
       errCode = HttpServletResponse.SC_FORBIDDEN;
       authenticationEx = ex;
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Authentication exception: " + ex.getMessage(), ex);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Authentication exception: " + ex.getMessage(), ex);
       } else {
-        LOG.warn("Authentication exception: " + ex.getMessage());
+        LOGGER.warn("Authentication exception: " + ex.getMessage());
       }
     }
     if (unauthorizedResponse) {
@@ -569,9 +569,9 @@ public class KerberosRealm extends AuthorizingRealm {
       response.setHeader(KerberosAuthenticator.WWW_AUTHENTICATE, KerberosAuthenticator.NEGOTIATE);
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
       if (authorization == null) {
-        LOG.trace("SPNEGO starting for url: {}", request.getRequestURL());
+        LOGGER.trace("SPNEGO starting for url: {}", request.getRequestURL());
       } else {
-        LOG.warn("'" + KerberosAuthenticator.AUTHORIZATION +
+        LOGGER.warn("'" + KerberosAuthenticator.AUTHORIZATION +
             "' does not start with '" +
             KerberosAuthenticator.NEGOTIATE + "' :  {}", authorization);
       }
@@ -612,7 +612,7 @@ public class KerberosRealm extends AuthorizingRealm {
     GSSCredential gssCreds = null;
     AuthenticationToken token = null;
     try {
-      LOG.trace("SPNEGO initiated with server principal [{}]", serverPrincipal);
+      LOGGER.trace("SPNEGO initiated with server principal [{}]", serverPrincipal);
       gssCreds = this.gssManager.createCredential(
           this.gssManager.createName(serverPrincipal,
               KerberosUtil.NT_GSS_KRB5_PRINCIPAL_OID),
@@ -630,14 +630,14 @@ public class KerberosRealm extends AuthorizingRealm {
       }
       if (!gssContext.isEstablished()) {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        LOG.trace("SPNEGO in progress");
+        LOGGER.trace("SPNEGO in progress");
       } else {
         String clientPrincipal = gssContext.getSrcName().toString();
         KerberosName kerberosName = new KerberosName(clientPrincipal);
         String userName = kerberosName.getShortName();
         token = new AuthenticationToken(userName, clientPrincipal, TYPE);
         response.setStatus(HttpServletResponse.SC_OK);
-        LOG.trace("SPNEGO completed for client principal [{}]",
+        LOGGER.trace("SPNEGO completed for client principal [{}]",
             clientPrincipal);
       }
     } finally {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/kerberos/KerberosRealm.java
@@ -82,7 +82,7 @@ import java.util.regex.Pattern;
  *
  */
 public class KerberosRealm extends AuthorizingRealm {
-  public static final Logger LOGGER = LoggerFactory.getLogger(KerberosRealm.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(KerberosRealm.class);
 
   // Configs to set in shiro.ini
   private String principal = null;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/ClusterRestApi.java
@@ -47,7 +47,7 @@ import java.util.Map.Entry;
 @Path("/cluster")
 @Produces("application/json")
 public class ClusterRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(ClusterRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterRestApi.class);
   Gson gson = new Gson();
 
   private ClusterManagerServer clusterManagerServer;
@@ -63,7 +63,7 @@ public class ClusterRestApi {
     if (zConf.isClusterMode()) {
       clusterManagerServer = ClusterManagerServer.getInstance(zConf);
     } else {
-      LOG.warn("Cluster mode is disabled, ClusterRestApi won't work");
+      LOGGER.warn("Cluster mode is disabled, ClusterRestApi won't work");
     }
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -57,7 +57,7 @@ import org.apache.zeppelin.server.JsonResponse;
 @Produces("application/json")
 @Singleton
 public class HeliumRestApi {
-  Logger logger = LoggerFactory.getLogger(HeliumRestApi.class);
+  Logger LOGGER = LoggerFactory.getLogger(HeliumRestApi.class);
 
   private final Helium helium;
   private final Notebook notebook;
@@ -78,7 +78,7 @@ public class HeliumRestApi {
     try {
       return new JsonResponse<>(Response.Status.OK, "", helium.getAllPackageInfo()).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -92,7 +92,7 @@ public class HeliumRestApi {
     try {
       return new JsonResponse<>(Response.Status.OK, "", helium.getAllEnabledPackages()).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -112,7 +112,7 @@ public class HeliumRestApi {
       return new JsonResponse<>(
           Response.Status.OK, "", helium.getSinglePackageInfo(packageName)).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -136,7 +136,7 @@ public class HeliumRestApi {
           try {
             return new JsonResponse<>(Response.Status.OK, "", helium.suggestApp(paragraph)).build();
           } catch (RuntimeException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
           }
         });
@@ -166,7 +166,7 @@ public class HeliumRestApi {
             return new JsonResponse<>(Response.Status.OK, "",
                     helium.getApplicationFactory().loadAndRun(pkg, paragraph)).build();
           } catch (RuntimeException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
           }
         });
@@ -216,7 +216,7 @@ public class HeliumRestApi {
         return Response.ok(stringified).build();
       }
     } catch (Exception e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       // returning error will prevent zeppelin front-end render any notebook.
       // visualization load fail doesn't need to block notebook rendering work.
       // so it's better return ok instead of any error.
@@ -234,7 +234,7 @@ public class HeliumRestApi {
         return new JsonResponse<>(Response.Status.NOT_FOUND).build();
       }
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -249,7 +249,7 @@ public class HeliumRestApi {
         return new JsonResponse<>(Response.Status.NOT_FOUND).build();
       }
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -272,7 +272,7 @@ public class HeliumRestApi {
 
       return new JsonResponse<>(Response.Status.OK, config).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -284,7 +284,7 @@ public class HeliumRestApi {
       Map<String, Map<String, Object>> config = helium.getAllPackageConfig();
       return new JsonResponse<>(Response.Status.OK, config).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -310,7 +310,7 @@ public class HeliumRestApi {
 
       return new JsonResponse<>(Response.Status.OK, config).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -331,7 +331,7 @@ public class HeliumRestApi {
       helium.updatePackageConfig(artifact, packageConfig);
       return new JsonResponse<>(Response.Status.OK, packageConfig).build();
     } catch (JsonParseException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.BAD_REQUEST,
           e.getMessage()).build();
     } catch (IOException | RuntimeException e) {
@@ -347,7 +347,7 @@ public class HeliumRestApi {
       List<String> order = helium.getVisualizationPackageOrder();
       return new JsonResponse<>(Response.Status.OK, order).build();
     } catch (RuntimeException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }
@@ -361,7 +361,7 @@ public class HeliumRestApi {
       helium.setVisualizationPackageOrder(orderedList);
       return new JsonResponse<>(Response.Status.OK).build();
     } catch (IOException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return new JsonResponse<>(Response.Status.INTERNAL_SERVER_ERROR, e.getMessage()).build();
     }
   }

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/HeliumRestApi.java
@@ -57,7 +57,7 @@ import org.apache.zeppelin.server.JsonResponse;
 @Produces("application/json")
 @Singleton
 public class HeliumRestApi {
-  Logger LOGGER = LoggerFactory.getLogger(HeliumRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeliumRestApi.class);
 
   private final Helium helium;
   private final Notebook notebook;

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/LoginRestApi.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 @Produces("application/json")
 @Singleton
 public class LoginRestApi extends AbstractRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(LoginRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LoginRestApi.class);
   private final ZeppelinConfiguration zConf;
 
   private final AuthorizationService authorizationService;
@@ -90,7 +90,7 @@ public class LoginRestApi extends AbstractRestApi {
             response = proceedToLogin(currentUser, token);
           }
         } catch (ParseException e) {
-          LOG.error("ParseException in LoginRestApi: ", e);
+          LOGGER.error("ParseException in LoginRestApi: ", e);
         }
       }
       if (response == null) {
@@ -116,12 +116,12 @@ public class LoginRestApi extends AbstractRestApi {
           }
         }
         if (null == response) {
-          LOG.warn("No Kerberos token received");
+          LOGGER.warn("No Kerberos token received");
           response = new JsonResponse<>(Status.UNAUTHORIZED, "", null);
         }
         return response.build();
       } catch (AuthenticationException e){
-        LOG.error("Error in Login", e);
+        LOGGER.error("Error in Login", e);
       }
     }
     return new JsonResponse<>(Status.METHOD_NOT_ALLOWED).build();
@@ -133,7 +133,7 @@ public class LoginRestApi extends AbstractRestApi {
       for (Realm realm : realmsList) {
         String name = realm.getClass().getName();
 
-        LOG.debug("RealmClass.getName: {}", name);
+        LOGGER.debug("RealmClass.getName: {}", name);
 
         if (name.equals("org.apache.zeppelin.realm.kerberos.KerberosRealm")) {
           return (KerberosRealm) realm;
@@ -206,7 +206,7 @@ public class LoginRestApi extends AbstractRestApi {
       // password didn't match, try again?
       // account for that username is locked - can't login.  Show them a message?
       // unexpected condition - error?
-      LOG.error("Exception in login: ", uae);
+      LOGGER.error("Exception in login: ", uae);
     }
     return response;
   }
@@ -223,13 +223,13 @@ public class LoginRestApi extends AbstractRestApi {
   @ZeppelinApi
   public Response postLogin(@FormParam("userName") String userName,
       @FormParam("password") String password) {
-    LOG.debug("userName: {}", userName);
+    LOGGER.debug("userName: {}", userName);
     // ticket set to anonymous for anonymous user. Simplify testing.
     Subject currentUser = SecurityUtils.getSubject();
     if (currentUser.isAuthenticated()) {
       currentUser.logout();
     }
-    LOG.debug("currentUser: {}", currentUser);
+    LOGGER.debug("currentUser: {}", currentUser);
     JsonResponse<Map<String, String>> response = null;
     if (!currentUser.isAuthenticated()) {
 
@@ -242,7 +242,7 @@ public class LoginRestApi extends AbstractRestApi {
       response = new JsonResponse<>(Response.Status.FORBIDDEN, "", null);
     }
 
-    LOG.info(response.toString());
+    LOGGER.info(response.toString());
     return response.build();
   }
 
@@ -274,7 +274,7 @@ public class LoginRestApi extends AbstractRestApi {
       data.put("isLogoutAPI", kerberosRealm.getLogoutAPI().toString());
     }
     JsonResponse<Map<String, String>> response = new JsonResponse<>(status, "", data);
-    LOG.info(response.toString());
+    LOGGER.info(response.toString());
     return response.build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRepoRestApi.java
@@ -52,7 +52,7 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 @Produces("application/json")
 @Singleton
 public class NotebookRepoRestApi extends AbstractRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookRepoRestApi.class);
 
   private final NotebookRepoSync noteRepos;
   private final NotebookServer notebookWsServer;
@@ -73,7 +73,7 @@ public class NotebookRepoRestApi extends AbstractRestApi {
   @ZeppelinApi
   public Response listRepoSettings() {
     AuthenticationInfo subject = new AuthenticationInfo(authenticationService.getPrincipal());
-    LOG.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
+    LOGGER.info("Getting list of NoteRepo with Settings for user {}", subject.getUser());
     List<NotebookRepoWithSettings> settings = noteRepos.getNotebookRepos(subject);
     return new JsonResponse<>(Status.OK, "", settings).build();
   }
@@ -86,11 +86,11 @@ public class NotebookRepoRestApi extends AbstractRestApi {
   @ZeppelinApi
   public Response refreshRepo(){
     AuthenticationInfo subject = new AuthenticationInfo(authenticationService.getPrincipal());
-    LOG.info("Reloading notebook repository for user {}", subject.getUser());
+    LOGGER.info("Reloading notebook repository for user {}", subject.getUser());
     try {
       notebookWsServer.broadcastReloadedNoteList(getServiceContext());
     } catch (IOException e) {
-      LOG.error("Fail to refresh repo", e);
+      LOGGER.error("Fail to refresh repo", e);
     }
     return new JsonResponse<>(Status.OK, "", null).build();
   }
@@ -112,25 +112,25 @@ public class NotebookRepoRestApi extends AbstractRestApi {
     try {
       newSettings = GSON.fromJson(payload, NotebookRepoSettingsRequest.class);
     } catch (JsonSyntaxException e) {
-      LOG.error("Cannot update notebook repo settings", e);
+      LOGGER.error("Cannot update notebook repo settings", e);
       return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
           ImmutableMap.of("error", "Invalid payload structure")).build();
     }
 
     if (NotebookRepoSettingsRequest.isEmpty(newSettings)) {
-      LOG.error("Invalid property");
+      LOGGER.error("Invalid property");
       return new JsonResponse<>(Status.NOT_ACCEPTABLE, "",
           ImmutableMap.of("error", "Invalid payload")).build();
     }
-    LOG.info("User {} is going to change repo setting", subject.getUser());
+    LOGGER.info("User {} is going to change repo setting", subject.getUser());
     NotebookRepoWithSettings updatedSettings =
         noteRepos.updateNotebookRepo(newSettings.getName(), newSettings.getSettings(), subject);
     if (!updatedSettings.isEmpty()) {
-      LOG.info("Broadcasting note list to user {}", subject.getUser());
+      LOGGER.info("Broadcasting note list to user {}", subject.getUser());
       try {
         notebookWsServer.broadcastReloadedNoteList(getServiceContext());
       } catch (IOException e) {
-        LOG.error("Fail to refresh repo.", e);
+        LOGGER.error("Fail to refresh repo.", e);
       }
     }
     return new JsonResponse<>(Status.OK, "", updatedSettings).build();

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/SecurityRestApi.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @Produces("application/json")
 @Singleton
 public class SecurityRestApi extends AbstractRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(SecurityRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecurityRestApi.class);
 
   @Inject
   public SecurityRestApi(AuthenticationService authenticationService) {
@@ -79,7 +79,7 @@ public class SecurityRestApi extends AbstractRestApi {
     data.put("ticket", ticketEntry.getTicket());
 
     JsonResponse<Map<String, String>> response = new JsonResponse<>(Response.Status.OK, "", data);
-    LOG.warn("{}", response);
+    LOGGER.warn("{}", response);
     return response.build();
   }
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -1605,7 +1605,7 @@ public class NotebookServer implements AngularObjectRegistryListener,
             });
         }
       } catch (Throwable t) {
-        NotebookServer.LOGGER.error("Error in running all paragraphs", t);
+        LOGGER.error("Error in running all paragraphs", t);
       }
     });
   }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
@@ -49,7 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class MiniZeppelinServer implements AutoCloseable {
-  protected static final Logger LOG = LoggerFactory.getLogger(MiniZeppelinServer.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(MiniZeppelinServer.class);
 
   private final File zeppelinHome;
   private final File confDir;
@@ -66,7 +66,7 @@ public class MiniZeppelinServer implements AutoCloseable {
       try {
         zepServer.startZeppelin();
       } catch (Exception e) {
-        LOG.error("Exception in MiniZeppelinServer", e);
+        LOGGER.error("Exception in MiniZeppelinServer", e);
         throw new RuntimeException(e);
       }
     }
@@ -79,10 +79,10 @@ public class MiniZeppelinServer implements AutoCloseable {
   public MiniZeppelinServer(String classname, String zeppelinConfiguration) throws IOException {
     this.classname = classname;
     zeppelinHome = Files.createTempDirectory(classname).toFile();
-    LOG.info("ZEPPELIN_HOME: " + zeppelinHome.getAbsolutePath());
+    LOGGER.info("ZEPPELIN_HOME: " + zeppelinHome.getAbsolutePath());
     confDir = new File(zeppelinHome, "conf");
     confDir.mkdirs();
-    LOG.info("ZEPPELIN_CONF_DIR: " + confDir.getAbsolutePath());
+    LOGGER.info("ZEPPELIN_CONF_DIR: " + confDir.getAbsolutePath());
     notebookDir = new File(zeppelinHome, "notebook");
     notebookDir.mkdirs();
 
@@ -142,7 +142,7 @@ public class MiniZeppelinServer implements AutoCloseable {
   public void copyBinDir() throws IOException {
     File binDirDest = new File(zeppelinHome, "bin");
     File binDirSrc = new File(".." + File.separator + "bin");
-    LOG.info("Copy {} to {}", binDirSrc.getAbsolutePath(),
+    LOGGER.info("Copy {} to {}", binDirSrc.getAbsolutePath(),
         binDirDest.getAbsolutePath());
     FileUtils.copyDirectory(binDirSrc, binDirDest);
   }
@@ -158,7 +158,7 @@ public class MiniZeppelinServer implements AutoCloseable {
     File interpreterDirDest = new File(zeppelinHome, "interpreter" + File.separator + interpreterName);
     File interpreterDirSrc =
         new File(".." + File.separator + "interpreter" + File.separator + interpreterName);
-    LOG.info("Copy {}-Interpreter from {} to {}", interpreterName,
+    LOGGER.info("Copy {}-Interpreter from {} to {}", interpreterName,
         interpreterDirSrc.getAbsolutePath(),
         interpreterDirDest.getAbsolutePath());
     FileUtils.copyDirectory(interpreterDirSrc, interpreterDirDest);
@@ -170,7 +170,7 @@ public class MiniZeppelinServer implements AutoCloseable {
     File launcherDirSrc =
         new File(".." + File.separator + "plugins" + File.separator + "Launcher" + File.separator
             + launcherName);
-    LOG.info("Copy {} from {} to {}", launcherName, launcherDirSrc.getAbsolutePath(),
+    LOGGER.info("Copy {} from {} to {}", launcherName, launcherDirSrc.getAbsolutePath(),
         launcherDirDest.getAbsolutePath());
     FileUtils.copyDirectory(launcherDirSrc, launcherDirDest);
   }
@@ -183,7 +183,7 @@ public class MiniZeppelinServer implements AutoCloseable {
         File logPropertiesDest =
             new File(zeppelinHome, "conf" + File.separator + conffile);
         if (!logPropertiesDest.exists()) {
-          LOG.info("Copy {} to {}", logPropertiesSrc.getAbsolutePath(),
+          LOGGER.info("Copy {} to {}", logPropertiesSrc.getAbsolutePath(),
               logPropertiesDest.getAbsolutePath());
           FileUtils.copyFile(logPropertiesSrc, logPropertiesDest);
         }
@@ -199,7 +199,7 @@ public class MiniZeppelinServer implements AutoCloseable {
         File zeppelinInterpreterShadedDest =
             new File(zeppelinHome, "interpreter" + File.separator + interpreterfile);
         if (!zeppelinInterpreterShadedDest.exists()) {
-          LOG.info("Copy {} to {}", zeppelinInterpreterShadedSrc.getAbsolutePath(),
+          LOGGER.info("Copy {} to {}", zeppelinInterpreterShadedSrc.getAbsolutePath(),
               zeppelinInterpreterShadedDest.getAbsolutePath());
           FileUtils.copyFile(zeppelinInterpreterShadedSrc, zeppelinInterpreterShadedDest);
         }
@@ -241,7 +241,7 @@ public class MiniZeppelinServer implements AutoCloseable {
 
   public void start(boolean deleteNotebookData, String serviceLocator)
       throws Exception {
-    LOG.info("Starting ZeppelinServer testClassName: {}", classname);
+    LOGGER.info("Starting ZeppelinServer testClassName: {}", classname);
     // copy the resources files to a temp folder
     zConf.setServerPort(getFreePort());
     zConf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_HOME.getVarName(),
@@ -260,14 +260,14 @@ public class MiniZeppelinServer implements AutoCloseable {
     }
     zConf.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(),
         notebookDir.getPath());
-    LOG.info("Staring ZeppelinServerMock Zeppelin up...");
+    LOGGER.info("Staring ZeppelinServerMock Zeppelin up...");
     this.serviceLocator = serviceLocator;
     zepServer = new ZeppelinServer(zConf, serviceLocator);
     executor = Executors.newSingleThreadExecutor();
     executor.submit(SERVER);
     await().pollDelay(Duration.ofSeconds(2)).atMost(Duration.ofMinutes(3))
         .until(checkIfServerIsRunningCallable());
-    LOG.info("ZeppelinServerMock started.");
+    LOGGER.info("ZeppelinServerMock started.");
   }
 
   public boolean checkIfServerIsRunning() {
@@ -295,14 +295,14 @@ public class MiniZeppelinServer implements AutoCloseable {
 
   public void shutDown(final boolean deleteConfDir) throws Exception {
     if (!executor.isShutdown()) {
-      LOG.info("ZeppelinServerMock shutDown...");
+      LOGGER.info("ZeppelinServerMock shutDown...");
       zepServer.close();
       executor.shutdown();
       executor.shutdownNow();
       await().pollDelay(2, TimeUnit.SECONDS).atMost(3, TimeUnit.MINUTES)
           .until(checkIfServerIsNotRunningCallable());
 
-      LOG.info("ZeppelinServerMock terminated.");
+      LOGGER.info("ZeppelinServerMock terminated.");
 
       if (deleteConfDir) {
         FileUtils.deleteDirectory(confDir);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterAuthEventListenerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterAuthEventListenerTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Set;
 
 public class ClusterAuthEventListenerTest implements ClusterEventListener {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterAuthEventListenerTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterAuthEventListenerTest.class);
 
   public String receiveMsg = null;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterIntpSettingEventListenerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterIntpSettingEventListenerTest.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClusterIntpSettingEventListenerTest implements ClusterEventListener {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterIntpSettingEventListenerTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIntpSettingEventListenerTest.class);
 
   public String receiveMsg = null;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterNoteEventListenerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/cluster/ClusterNoteEventListenerTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ClusterNoteEventListenerTest implements ClusterEventListener {
-  private static Logger LOGGER = LoggerFactory.getLogger(ClusterNoteEventListenerTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterNoteEventListenerTest.class);
 
   public String receiveMsg = null;
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/recovery/RecoveryTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/recovery/RecoveryTest.java
@@ -53,7 +53,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 class RecoveryTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(RecoveryTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RecoveryTest.class);
   private Gson gson = new Gson();
   private static File recoveryDir = null;
   private static MiniZeppelinServer zepServer;
@@ -96,7 +96,7 @@ class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   void testRecovery() throws Exception {
-    LOG.info("Test testRecovery");
+    LOGGER.info("Test testRecovery");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -146,7 +146,7 @@ class RecoveryTest extends AbstractTestRestApi {
           return null;
         });
     } catch (Exception e) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
       throw e;
     } finally {
       if (null != note1Id) {
@@ -157,7 +157,7 @@ class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   void testRecovery_2() throws Exception {
-    LOG.info("Test testRecovery_2");
+    LOGGER.info("Test testRecovery_2");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note2", AuthenticationInfo.ANONYMOUS);
@@ -215,7 +215,7 @@ class RecoveryTest extends AbstractTestRestApi {
           return null;
         });
     } catch (Exception e) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
       throw e;
     } finally {
       if (null != note1Id) {
@@ -226,7 +226,7 @@ class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   void testRecovery_3() throws Exception {
-    LOG.info("Test testRecovery_3");
+    LOGGER.info("Test testRecovery_3");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note3", AuthenticationInfo.ANONYMOUS);
@@ -276,7 +276,7 @@ class RecoveryTest extends AbstractTestRestApi {
           return null;
         });
     } catch (Exception e ) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
       throw e;
     } finally {
       if (null != note1Id) {
@@ -295,7 +295,7 @@ class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   void testRecovery_Running_Paragraph_sh() throws Exception {
-    LOG.info("Test testRecovery_Running_Paragraph_sh");
+    LOGGER.info("Test testRecovery_Running_Paragraph_sh");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note4",
@@ -327,7 +327,7 @@ class RecoveryTest extends AbstractTestRestApi {
       assertEquals("hello\n", p1.getReturn().message().get(0).getData());
       Thread.sleep(5 * 1000);
     } catch (Exception e ) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
       throw e;
     } finally {
       if (null != note1Id) {
@@ -338,7 +338,7 @@ class RecoveryTest extends AbstractTestRestApi {
 
   @Test
   void testRecovery_Finished_Paragraph_python() throws Exception {
-    LOG.info("Test testRecovery_Finished_Paragraph_python");
+    LOGGER.info("Test testRecovery_Finished_Paragraph_python");
     String note1Id = null;
     try {
       InterpreterSettingManager interpreterSettingManager =
@@ -387,7 +387,7 @@ class RecoveryTest extends AbstractTestRestApi {
               "8\n" +
               "9\n", p1.getReturn().message().get(0).getData());
     } catch (Exception e ) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
       throw e;
     } finally {
       if (null != note1Id) {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/AbstractTestRestApi.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 
 public abstract class AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractTestRestApi.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTestRestApi.class);
 
   public static final String REST_API_URL = "/api";
   protected ZeppelinConfiguration zConf;
@@ -146,7 +146,7 @@ public abstract class AbstractTestRestApi {
 
   public CloseableHttpResponse httpGet(String path, String user, String pwd, String cookies)
     throws IOException {
-    LOG.info("Connecting to {}", getUrlToTest(zConf) + path);
+    LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpGet httpGet = new HttpGet(getUrlToTest(zConf) + path);
     httpGet.addHeader("Origin", getUrlToTest(zConf));
     if (userAndPasswordAreNotBlank(user, pwd)) {
@@ -156,7 +156,7 @@ public abstract class AbstractTestRestApi {
       httpGet.setHeader("Cookie", httpGet.getFirstHeader("Cookie") + ";" + cookies);
     }
     CloseableHttpResponse response = getHttpClient().execute(httpGet);
-    LOG.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+    LOGGER.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
     return response;
   }
 
@@ -167,14 +167,14 @@ public abstract class AbstractTestRestApi {
 
   public CloseableHttpResponse httpDelete(String path, String user, String pwd)
       throws IOException {
-    LOG.info("Connecting to {}", getUrlToTest(zConf) + path);
+    LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpDelete httpDelete = new HttpDelete(getUrlToTest(zConf) + path);
     httpDelete.addHeader("Origin", getUrlToTest(zConf));
     if (userAndPasswordAreNotBlank(user, pwd)) {
       httpDelete.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
     }
     CloseableHttpResponse response = getHttpClient().execute(httpDelete);
-    LOG.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+    LOGGER.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
     return response;
   }
 
@@ -185,7 +185,7 @@ public abstract class AbstractTestRestApi {
 
   public CloseableHttpResponse httpPost(String path, String request, String user, String pwd)
       throws IOException {
-    LOG.info("Connecting to {}", getUrlToTest(zConf) + path);
+    LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     RequestConfig localConfig = RequestConfig.custom()
       .setCookieSpec(CookieSpecs.IGNORE_COOKIES)
       .build();
@@ -197,7 +197,7 @@ public abstract class AbstractTestRestApi {
       httpPost.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
     }
     CloseableHttpResponse response = getHttpClient().execute(httpPost);
-    LOG.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+    LOGGER.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
     return response;
   }
 
@@ -208,7 +208,7 @@ public abstract class AbstractTestRestApi {
 
   public CloseableHttpResponse httpPut(String path, String body, String user, String pwd)
       throws IOException {
-    LOG.info("Connecting to {}", getUrlToTest(zConf) + path);
+    LOGGER.info("Connecting to {}", getUrlToTest(zConf) + path);
     HttpPut httpPut = new HttpPut(getUrlToTest(zConf) + path);
     httpPut.addHeader("Origin", getUrlToTest(zConf));
     httpPut.setEntity(new StringEntity(body, ContentType.TEXT_PLAIN));
@@ -216,7 +216,7 @@ public abstract class AbstractTestRestApi {
       httpPut.setHeader("Cookie", "JSESSIONID=" + getCookie(user, pwd));
     }
     CloseableHttpResponse response = getHttpClient().execute(httpPut);
-    LOG.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+    LOGGER.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
     return response;
   }
 
@@ -229,7 +229,7 @@ public abstract class AbstractTestRestApi {
     postParameters.add(new BasicNameValuePair("userName", user));
     httpPost.setEntity(new UrlEncodedFormEntity(postParameters, StandardCharsets.UTF_8));
     try (CloseableHttpResponse response = getHttpClient().execute(httpPost)) {
-      LOG.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+      LOGGER.info("{} - {}", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
       Pattern pattern = Pattern.compile("JSESSIONID=([a-zA-Z0-9-]*)");
       Header[] setCookieHeaders = response.getHeaders("Set-Cookie");
       String jsessionId = null;
@@ -301,7 +301,7 @@ public abstract class AbstractTestRestApi {
         try {
           new JsonParser().parse(body);
         } catch (JsonParseException e) {
-          LOG.error("Exception in AbstractTestRestApi while matchesSafely ", e);
+          LOGGER.error("Exception in AbstractTestRestApi while matchesSafely ", e);
           isValid = false;
         }
         return isValid;
@@ -349,7 +349,7 @@ public abstract class AbstractTestRestApi {
     try {
       executor.execute(cmd);
     } catch (IOException e) {
-      LOG.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/InterpreterRestApiTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class InterpreterRestApiTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(InterpreterRestApiTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(InterpreterRestApiTest.class);
   private Gson gson = new Gson();
   private AuthenticationInfo anonymous;
   private static MiniZeppelinServer zepServer;
@@ -129,7 +129,7 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
     JsonObject jsonRequest = gson.fromJson(rawRequest, JsonElement.class).getAsJsonObject();
     CloseableHttpResponse post = httpPost("/interpreter/setting/", jsonRequest.toString());
     String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-    LOG.info("testSettingCRUD create response\n" + postResponse);
+    LOGGER.info("testSettingCRUD create response\n" + postResponse);
     InterpreterSetting created = convertResponseToInterpreterSetting(postResponse);
     String newSettingId = created.getId();
     // then : call create setting API
@@ -139,7 +139,7 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
     // when: call read setting API
     CloseableHttpResponse get = httpGet("/interpreter/setting/" + newSettingId);
     String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
-    LOG.info("testSettingCRUD get response\n" + getResponse);
+    LOGGER.info("testSettingCRUD get response\n" + getResponse);
     InterpreterSetting previouslyCreated = convertResponseToInterpreterSetting(getResponse);
     // then : read Setting API
     assertThat("Test get method:", get, isAllowed());
@@ -153,14 +153,14 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
     jsonObject.addProperty("type", "textarea");
     jsonRequest.getAsJsonObject("properties").add("propname2", jsonObject);
     CloseableHttpResponse put = httpPut("/interpreter/setting/" + newSettingId, jsonRequest.toString());
-    LOG.info("testSettingCRUD update response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSettingCRUD update response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
     // then: call update setting API
     assertThat("test update method:", put, isAllowed());
     put.close();
 
     // when: call delete setting API
     CloseableHttpResponse delete = httpDelete("/interpreter/setting/" + newSettingId);
-    LOG.info("testSettingCRUD delete response\n" +  EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSettingCRUD delete response\n" +  EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
     // then: call delete setting API
     assertThat("Test delete method:", delete, isAllowed());
     delete.close();
@@ -239,7 +239,7 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
   void testSettingsCreateWithEmptyJson() throws IOException {
     // Call Create Setting REST API
     CloseableHttpResponse post = httpPost("/interpreter/setting/", "");
-    LOG.info("testSettingCRUD create response\n" + EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSettingCRUD create response\n" + EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8));
     assertThat("test create method:", post, isBadRequest());
     post.close();
   }
@@ -271,7 +271,7 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
     JsonObject jsonRequest = gson.fromJson(StringUtils.replace(reqBody, "mdName", "mdValidName"), JsonElement.class).getAsJsonObject();
     CloseableHttpResponse post = httpPost("/interpreter/setting/", jsonRequest.toString());
     String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-    LOG.info("testSetting with valid name\n" + postResponse);
+    LOGGER.info("testSetting with valid name\n" + postResponse);
     InterpreterSetting created = convertResponseToInterpreterSetting(postResponse);
     String newSettingId = created.getId();
     // then : call create setting API
@@ -280,7 +280,7 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
 
     // when: call delete setting API
     CloseableHttpResponse delete = httpDelete("/interpreter/setting/" + newSettingId);
-    LOG.info("testSetting delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSetting delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
     // then: call delete setting API
     assertThat("Test delete method:", delete, isAllowed());
     delete.close();
@@ -288,13 +288,13 @@ class InterpreterRestApiTest extends AbstractTestRestApi {
 
     JsonObject jsonRequest2 = gson.fromJson(StringUtils.replace(reqBody, "mdName", "name space"), JsonElement.class).getAsJsonObject();
     CloseableHttpResponse post2 = httpPost("/interpreter/setting/", jsonRequest2.toString());
-    LOG.info("testSetting with name with space\n" + EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSetting with name with space\n" + EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8));
     assertThat("test create method with space:", post2, isNotFound());
     post2.close();
 
     JsonObject jsonRequest3 = gson.fromJson(StringUtils.replace(reqBody, "mdName", ""), JsonElement.class).getAsJsonObject();
     CloseableHttpResponse post3 = httpPost("/interpreter/setting/", jsonRequest3.toString());
-    LOG.info("testSetting with empty name\n" + EntityUtils.toString(post3.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testSetting with empty name\n" + EntityUtils.toString(post3.getEntity(), StandardCharsets.UTF_8));
     assertThat("test create method with empty name:", post3, isNotFound());
     post3.close();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/KnoxRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/KnoxRestApiTest.java
@@ -42,7 +42,7 @@ public class KnoxRestApiTest extends AbstractTestRestApi {
           "liWYjr0M17Bm9GfPHRRR66s7YuYXa6DLbB4fHE0cyOoQnkfJFpU_vr1xhy0_0URc5v-Gb829b9rxuQfjKe-37h" +
           "qbUdkwww2q6QQETVMvzp0rQKprUClZujyDvh0;";
 
-  private static final Logger LOG = LoggerFactory.getLogger(KnoxRestApiTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(KnoxRestApiTest.class);
 
   Gson gson = new Gson();
   private static MiniZeppelinServer zepServer;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class NotebookRestApiTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookRestApiTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookRestApiTest.class);
   Gson gson = new Gson();
   AuthenticationInfo anonymous;
   private Notebook notebook;
@@ -90,7 +90,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetReloadNote() throws IOException {
-    LOG.info("Running testGetNote");
+    LOGGER.info("Running testGetNote");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -132,7 +132,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteByPath() throws IOException {
-    LOG.info("Running testGetNoteByPath");
+    LOGGER.info("Running testGetNoteByPath");
     String note1Id = null;
     try {
         String notePath = "dir1/note1";
@@ -162,7 +162,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteByPathWithPathNotExist() throws IOException {
-    LOG.info("Running testGetNoteByPathWithPathNotExist");
+    LOGGER.info("Running testGetNoteByPathWithPathNotExist");
     String notePath = "A note that doesn't exist";
     CloseableHttpResponse post = httpPost("/notebook/getByPath" , "{\"notePath\":\""+ notePath + "\"}" );
     assertThat(post, isNotFound());
@@ -175,7 +175,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteRevisionHistory() throws IOException {
-    LOG.info("Running testGetNoteRevisionHistory");
+    LOGGER.info("Running testGetNoteRevisionHistory");
     String note1Id = null;
     try {
       String notePath = "note1";
@@ -235,7 +235,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteByRevision() throws IOException {
-    LOG.info("Running testGetNoteByRevision");
+    LOGGER.info("Running testGetNoteByRevision");
     String note1Id = null;
     try {
       String notePath = "note1";
@@ -279,7 +279,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteParagraphJobStatus() throws IOException {
-    LOG.info("Running testGetNoteParagraphJobStatus");
+    LOGGER.info("Running testGetNoteParagraphJobStatus");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -308,7 +308,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testCheckpointNote() throws IOException {
-    LOG.info("Running testCheckpointNote");
+    LOGGER.info("Running testCheckpointNote");
     String note1Id = null;
     try {
       String notePath = "note1";
@@ -351,7 +351,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testSetNoteRevision() throws IOException {
-    LOG.info("Running testSetNoteRevision");
+    LOGGER.info("Running testSetNoteRevision");
     String note1Id = null;
     try {
       String notePath = "note1";
@@ -399,7 +399,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunParagraphJob() throws Exception {
-    LOG.info("Running testRunParagraphJob");
+    LOGGER.info("Running testRunParagraphJob");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -439,7 +439,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testCancelNoteJob() throws Exception {
-    LOG.info("Running testCancelNoteJob");
+    LOGGER.info("Running testCancelNoteJob");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -482,7 +482,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunParagraphSynchronously() throws IOException {
-    LOG.info("Running testRunParagraphSynchronously");
+    LOGGER.info("Running testRunParagraphSynchronously");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -540,7 +540,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testCreateNote() throws Exception {
-    LOG.info("Running testCreateNote");
+    LOGGER.info("Running testCreateNote");
     String message1 = "{\n\t\"name\" : \"test1\",\n\t\"addingEmptyParagraph\" : true\n}";
     CloseableHttpResponse post1 = httpPost("/notebook/", message1);
     assertThat(post1, isAllowed());
@@ -579,7 +579,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunNoteBlocking() throws IOException {
-    LOG.info("Running testRunNoteBlocking");
+    LOGGER.info("Running testRunNoteBlocking");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -629,7 +629,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunNoteNonBlocking() throws Exception {
-    LOG.info("Running testRunNoteNonBlocking");
+    LOGGER.info("Running testRunNoteNonBlocking");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -685,7 +685,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunNoteBlocking_Isolated() throws IOException {
-    LOG.info("Running testRunNoteBlocking_Isolated");
+    LOGGER.info("Running testRunNoteBlocking_Isolated");
     String note1Id = null;
     try {
       InterpreterSettingManager interpreterSettingManager = notebook.getInterpreterSettingManager();
@@ -741,7 +741,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunNoteNonBlocking_Isolated() throws IOException, InterruptedException {
-    LOG.info("Running testRunNoteNonBlocking_Isolated");
+    LOGGER.info("Running testRunNoteNonBlocking_Isolated");
     String note1Id = null;
     try {
       InterpreterSettingManager interpreterSettingManager = notebook.getInterpreterSettingManager();
@@ -888,7 +888,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunAllParagraph_FirstFailed() throws IOException {
-    LOG.info("Running testRunAllParagraph_FirstFailed");
+    LOGGER.info("Running testRunAllParagraph_FirstFailed");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -938,7 +938,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testCloneNote() throws IOException {
-    LOG.info("Running testCloneNote");
+    LOGGER.info("Running testCloneNote");
     String note1Id = null;
     List<String> clonedNoteIds = new ArrayList<>();
     String text1 = "%text clone note";
@@ -973,7 +973,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
         String text = Arrays.asList(text1, text2).get(i);
 
         String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-        LOG.info("testCloneNote response: {}", postResponse);
+        LOGGER.info("testCloneNote response: {}", postResponse);
         assertThat(post, isAllowed());
         Map<String, Object> resp = gson.fromJson(postResponse,
                 new TypeToken<Map<String, Object>>() {
@@ -1008,7 +1008,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRenameNote() throws IOException {
-    LOG.info("Running testRenameNote");
+    LOGGER.info("Running testRenameNote");
     String noteId = null;
     try {
       String oldName = "old_name";
@@ -1033,7 +1033,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testUpdateParagraphConfig() throws IOException {
-    LOG.info("Running testUpdateParagraphConfig");
+    LOGGER.info("Running testUpdateParagraphConfig");
     String noteId = null;
     try {
       noteId = notebook.createNote("note1", anonymous);
@@ -1072,7 +1072,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testClearAllParagraphOutput() throws IOException {
-    LOG.info("Running testClearAllParagraphOutput");
+    LOGGER.info("Running testClearAllParagraphOutput");
     String noteId = null;
     try {
       // Create note and set result explicitly
@@ -1097,7 +1097,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
       // clear paragraph result
       CloseableHttpResponse put = httpPut("/notebook/" + noteId + "/clear", "");
-      LOG.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
+      LOGGER.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
       assertThat(put, isAllowed());
       put.close();
 
@@ -1127,7 +1127,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunWithServerRestart() throws Exception {
-    LOG.info("Running testRunWithServerRestart");
+    LOGGER.info("Running testRunWithServerRestart");
     String note1Id = null;
     try {
       note1Id = notebook.createNote("note1", anonymous);
@@ -1156,7 +1156,7 @@ class NotebookRestApiTest extends AbstractTestRestApi {
       assertThat(post1, isAllowed());
       post1.close();
       CloseableHttpResponse put = httpPut("/notebook/" + note1Id + "/clear", "");
-      LOG.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
+      LOGGER.info("test clear paragraph output response\n" + EntityUtils.toString(put.getEntity(), StandardCharsets.UTF_8));
       assertThat(put, isAllowed());
       put.close();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/ZeppelinRestApiTest.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class ZeppelinRestApiTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(ZeppelinRestApiTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZeppelinRestApiTest.class);
   Gson gson = new Gson();
   AuthenticationInfo anonymous;
   private static MiniZeppelinServer zepServer;
@@ -108,7 +108,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteInfo() throws IOException {
-    LOG.info("testGetNoteInfo");
+    LOGGER.info("testGetNoteInfo");
     String noteId = null;
     try {
       // Create note to get info
@@ -131,7 +131,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
       CloseableHttpResponse get = httpGet("/notebook/" + noteId);
       String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testGetNoteInfo \n" + getResponse);
+      LOGGER.info("testGetNoteInfo \n" + getResponse);
       assertThat("test note get method:", get, isAllowed());
 
       Map<String, Object> resp = gson.fromJson(getResponse,
@@ -177,20 +177,20 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
         "}}]} ";
     CloseableHttpResponse post = httpPost("/notebook/", jsonRequest);
     String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-    LOG.info("testNoteCreate \n" + postResponse);
+    LOGGER.info("testNoteCreate \n" + postResponse);
     assertThat("test note create method:", post, isAllowed());
 
     Map<String, Object> resp = gson.fromJson(postResponse,
             new TypeToken<Map<String, Object>>() {}.getType());
 
     String newNoteId =  (String) resp.get("body");
-    LOG.info("newNoteId:=" + newNoteId);
+    LOGGER.info("newNoteId:=" + newNoteId);
     notebook.processNote(newNoteId,
       newNote -> {
         assertNotNull(newNote, "Can not find new note by id");
         // This is partial test as newNote is in memory but is not persistent
         String newNoteName = newNote.getName();
-        LOG.info("new note name is: " + newNoteName);
+        LOGGER.info("new note name is: " + newNoteName);
         String expectedNoteName = noteName;
         if (noteName.isEmpty()) {
           expectedNoteName = "Note " + newNoteId;
@@ -224,20 +224,20 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
     String jsonRequest = "{\"name\":\"" + noteName + "\"}";
     CloseableHttpResponse post = httpPost("/notebook/", jsonRequest);
     String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-    LOG.info("testNoteCreate \n" + postResponse);
+    LOGGER.info("testNoteCreate \n" + postResponse);
     assertThat("test note create method:", post, isAllowed());
 
     Map<String, Object> resp = gson.fromJson(postResponse,
             new TypeToken<Map<String, Object>>() {}.getType());
 
     String newNoteId =  (String) resp.get("body");
-    LOG.info("newNoteId:=" + newNoteId);
+    LOGGER.info("newNoteId:=" + newNoteId);
     notebook.processNote(newNoteId,
       newNote -> {
         assertNotNull(newNote, "Can not find new note by id");
         // This is partial test as newNote is in memory but is not persistent
         String newNoteName = newNote.getName();
-        LOG.info("new note name is: " + newNoteName);
+        LOGGER.info("new note name is: " + newNoteName);
         String noteNameTmp = noteName;
         if (StringUtils.isBlank(noteNameTmp)) {
           noteNameTmp = "Untitled Note";
@@ -252,7 +252,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testDeleteNote() throws IOException {
-    LOG.info("testDeleteNote");
+    LOGGER.info("testDeleteNote");
     String noteId = null;
     try {
       //Create note and get ID
@@ -267,13 +267,13 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testDeleteNoteBadId() throws IOException {
-    LOG.info("testDeleteNoteBadId");
+    LOGGER.info("testDeleteNoteBadId");
     testDeleteNotExistNote("bad_ID");
   }
 
   @Test
   void testExportNote() throws IOException {
-    LOG.info("testExportNote");
+    LOGGER.info("testExportNote");
 
     String noteId = null;
     try {
@@ -295,7 +295,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
       // Call export Note REST API
       CloseableHttpResponse get = httpGet("/notebook/export/" + noteId);
       String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testNoteExport \n" + getResponse);
+      LOGGER.info("testNoteExport \n" + getResponse);
       assertThat("test note export method:", get, isAllowed());
 
       Map<String, Object> resp =
@@ -304,7 +304,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
       String exportJSON = (String) resp.get("body");
       assertNotNull("Can not find new notejson", exportJSON);
-      LOG.info("export JSON:=" + exportJSON);
+      LOGGER.info("export JSON:=" + exportJSON);
       get.close();
     } finally {
       if (null != noteId) {
@@ -322,7 +322,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
     String importId = null;
     try {
       noteName = "source note for import";
-      LOG.info("testImportNote");
+      LOGGER.info("testImportNote");
       // create test note
       noteId = notebook.createNote("note1_testImportNotebook", anonymous);
       // use write lock because name is overwritten
@@ -383,7 +383,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   private void testDeleteNote(String noteId) throws IOException {
     CloseableHttpResponse delete = httpDelete(("/notebook/" + noteId));
-    LOG.info("testDeleteNote delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testDeleteNote delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
     assertThat("Test delete method:", delete, isAllowed());
     delete.close();
     // make sure note is deleted
@@ -398,14 +398,14 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   private void testDeleteNotExistNote(String noteId) throws IOException {
     CloseableHttpResponse delete = httpDelete(("/notebook/" + noteId));
-    LOG.info("testDeleteNote delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
+    LOGGER.info("testDeleteNote delete response\n" + EntityUtils.toString(delete.getEntity(), StandardCharsets.UTF_8));
     assertThat("Test delete method:", delete, isNotFound());
     delete.close();
   }
 
   @Test
   void testCloneNote() throws IOException, IllegalArgumentException {
-    LOG.info("testCloneNote");
+    LOGGER.info("testCloneNote");
     String noteId = null;
     String newNoteId = null;
     try {
@@ -429,14 +429,14 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
       String jsonRequest = "{\"name\":\"" + noteName + "\"}";
       CloseableHttpResponse post = httpPost("/notebook/" + noteId, jsonRequest);
       String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testNoteClone \n" + postResponse);
+      LOGGER.info("testNoteClone \n" + postResponse);
       assertThat("test note clone method:", post, isAllowed());
 
       Map<String, Object> resp = gson.fromJson(postResponse,
               new TypeToken<Map<String, Object>>() {}.getType());
 
       newNoteId =  (String) resp.get("body");
-      LOG.info("newNoteId:=" + newNoteId);
+      LOGGER.info("newNoteId:=" + newNoteId);
       notebook.processNote(newNoteId,
         newNote -> {
           assertNotNull(newNote, "Can not find new note by id");
@@ -457,7 +457,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testListNotes() throws IOException {
-    LOG.info("testListNotes");
+    LOGGER.info("testListNotes");
     CloseableHttpResponse get = httpGet("/notebook/");
     assertThat("List notes method", get, isAllowed());
     Map<String, Object> resp = gson.fromJson(EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8),
@@ -474,7 +474,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testNoteJobs() throws Exception {
-    LOG.info("testNoteJobs");
+    LOGGER.info("testNoteJobs");
 
     String noteId = null;
     try {
@@ -514,7 +514,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
         Thread.sleep(1000);
         terminated = notebook.processNote(noteId, note -> note.getParagraph(0).isTerminated());
         if (timeout++ > 10) {
-          LOG.info("testNoteJobs timeout job.");
+          LOGGER.info("testNoteJobs timeout job.");
           break;
         }
       }
@@ -551,7 +551,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testGetNoteJob() throws Exception {
-    LOG.info("testGetNoteJob");
+    LOGGER.info("testGetNoteJob");
 
     String noteId = null;
     try {
@@ -589,7 +589,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
       String responseBody = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
       get.close();
 
-      LOG.info("test get note job: \n" + responseBody);
+      LOGGER.info("test get note job: \n" + responseBody);
       Map<String, Object> resp = gson.fromJson(responseBody,
               new TypeToken<Map<String, Object>>() {}.getType());
 
@@ -606,7 +606,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
         Thread.sleep(100);
         terminated = notebook.processNote(noteId, note -> note.getParagraph(0).isTerminated());
         if (timeout++ > 10) {
-          LOG.info("testGetNoteJob timeout job.");
+          LOGGER.info("testGetNoteJob timeout job.");
           break;
         }
       }
@@ -620,7 +620,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
   @Test
   void testRunParagraphWithParams() throws Exception {
-    LOG.info("testRunParagraphWithParams");
+    LOGGER.info("testRunParagraphWithParams");
 
     String noteId = null;
     try {
@@ -868,7 +868,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
       String jsonRequest = "{\"title\": \"title1\", \"text\": \"text1\"}";
       CloseableHttpResponse post = httpPost("/notebook/" + noteId + "/paragraph", jsonRequest);
       String postResponse = EntityUtils.toString(post.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testInsertParagraph response\n" + postResponse);
+      LOGGER.info("testInsertParagraph response\n" + postResponse);
       assertThat("Test insert method:", post, isAllowed());
       post.close();
 
@@ -876,7 +876,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
               new TypeToken<Map<String, Object>>() {}.getType());
 
       String newParagraphId = (String) resp.get("body");
-      LOG.info("newParagraphId:=" + newParagraphId);
+      LOGGER.info("newParagraphId:=" + newParagraphId);
 
       Paragraph lastParagraph = notebook.processNote(noteId, Note::getLastParagraph);
       notebook.processNote(noteId,
@@ -892,7 +892,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
       // insert to index 0
       String jsonRequest2 = "{\"index\": 0, \"title\": \"title2\", \"text\": \"text2\"}";
       CloseableHttpResponse post2 = httpPost("/notebook/" + noteId + "/paragraph", jsonRequest2);
-      LOG.info("testInsertParagraph response2\n" + EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8));
+      LOGGER.info("testInsertParagraph response2\n" + EntityUtils.toString(post2.getEntity(), StandardCharsets.UTF_8));
       assertThat("Test insert method:", post2, isAllowed());
       post2.close();
 
@@ -905,7 +905,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
                             "\"config\": {\"colWidth\": 9.0, \"title\": true, " +
                             "\"results\": [{\"graph\": {\"mode\": \"pieChart\"}}]}}";
       CloseableHttpResponse post3 = httpPost("/notebook/" + noteId + "/paragraph", jsonRequest3);
-      LOG.info("testInsertParagraph response4\n" + EntityUtils.toString(post3.getEntity(), StandardCharsets.UTF_8));
+      LOGGER.info("testInsertParagraph response4\n" + EntityUtils.toString(post3.getEntity(), StandardCharsets.UTF_8));
       assertThat("Test insert method:", post3, isAllowed());
       post3.close();
 
@@ -996,7 +996,7 @@ class ZeppelinRestApiTest extends AbstractTestRestApi {
 
       CloseableHttpResponse get = httpGet("/notebook/" + noteId + "/paragraph/" + pId);
       String getResponse = EntityUtils.toString(get.getEntity(), StandardCharsets.UTF_8);
-      LOG.info("testGetParagraph response\n" + getResponse);
+      LOGGER.info("testGetParagraph response\n" + getResponse);
       assertThat("Test get method: ", get, isAllowed());
       get.close();
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/security/DirAccessTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.charset.StandardCharsets;
 
 class DirAccessTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(DirAccessTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DirAccessTest.class);
 
   private MiniZeppelinServer zepServer;
 
@@ -46,9 +46,9 @@ class DirAccessTest extends AbstractTestRestApi {
       zepServer.start();
       CloseableHttpResponse getMethod =
           getHttpClient().execute(new HttpGet(getUrlToTest() + "/app"));
-      LOG.info("Invoke getMethod - "
+      LOGGER.info("Invoke getMethod - "
           + EntityUtils.toString(getMethod.getEntity(), StandardCharsets.UTF_8));
-      LOG.info("server port {}", zConf.getServerPort());
+      LOGGER.info("server port {}", zConf.getServerPort());
       assertEquals(HttpStatus.SC_FORBIDDEN, getMethod.getStatusLine().getStatusCode());
     } finally {
       zepServer.destroy();
@@ -65,7 +65,7 @@ class DirAccessTest extends AbstractTestRestApi {
       zepServer.start();
       CloseableHttpResponse getMethod =
           getHttpClient().execute(new HttpGet(getUrlToTest() + "/app"));
-      LOG.info("Invoke getMethod - "
+      LOGGER.info("Invoke getMethod - "
           + EntityUtils.toString(getMethod.getEntity(), StandardCharsets.UTF_8));
       assertEquals(HttpStatus.SC_OK, getMethod.getStatusLine().getStatusCode());
     } finally {

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
 
 /** Basic REST API tests for notebookServer. */
 class NotebookServerTest extends AbstractTestRestApi {
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookServerTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookServerTest.class);
   private static Notebook notebook;
   private static NotebookServer notebookServer;
   private static NotebookService notebookService;
@@ -479,7 +479,7 @@ class NotebookServerTest extends AbstractTestRestApi {
         noteId = notebookServer.importNote(null, context, messageReceived);
       } catch (NullPointerException e) {
         //broadcastNoteList(); failed nothing to worry.
-        LOG.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
+        LOGGER.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
                 "worry ", e);
       }
 
@@ -512,7 +512,7 @@ class NotebookServerTest extends AbstractTestRestApi {
         noteId = notebookServer.importNote(null, context, messageReceived);
       } catch (NullPointerException e) {
         //broadcastNoteList(); failed nothing to worry.
-        LOG.error("Exception in NotebookServerTest while testImportJupyterNote, failed nothing to " +
+        LOGGER.error("Exception in NotebookServerTest while testImportJupyterNote, failed nothing to " +
                 "worry ", e);
       }
 
@@ -715,7 +715,7 @@ class NotebookServerTest extends AbstractTestRestApi {
       noteId = notebookServer.importNote(null, context, messageReceived);
     } catch (NullPointerException e) {
       //broadcastNoteList(); failed nothing to worry.
-      LOG.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
+      LOGGER.error("Exception in NotebookServerTest while testImportNotebook, failed nothing to " +
           "worry ", e);
     } catch (IOException e) {
       e.printStackTrace();

--- a/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
+++ b/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Provide reading comparing capability of semantic version which is used widely in Apache projects
  */
 public class SemanticVersion {
-  private static final Logger LOG = LoggerFactory.getLogger(SemanticVersion.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SemanticVersion.class);
 
   public static SemanticVersion of(String versionString) {
     return new SemanticVersion(versionString);
@@ -54,7 +54,7 @@ public class SemanticVersion {
       // version is always 5 digits. (e.g. 2.0.0 -> 20000, 1.6.2 -> 10602)
       version = Integer.parseInt(String.format("%d%02d%02d", majorVersion, minorVersion, patchVersion));
     } catch (Exception e) {
-      LOG.error("Can not recognize Spark version {}. Assume it's a future release", versionString, e);
+      LOGGER.error("Can not recognize Spark version {}. Assume it's a future release", versionString, e);
       // assume it is future release
       version = 99999;
     }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * Manages helium packages
  */
 public class Helium {
-  private Logger LOGGER = LoggerFactory.getLogger(Helium.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Helium.class);
   private List<HeliumRegistry> registry = new LinkedList<>();
 
   private HeliumConf heliumConf;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/Helium.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * Manages helium packages
  */
 public class Helium {
-  private Logger logger = LoggerFactory.getLogger(Helium.class);
+  private Logger LOGGER = LoggerFactory.getLogger(Helium.class);
   private List<HeliumRegistry> registry = new LinkedList<>();
 
   private HeliumConf heliumConf;
@@ -107,7 +107,7 @@ public class Helium {
     try {
       bundleFactory.buildAllPackages(getBundlePackagesToBundle());
     } catch (Exception e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
     }
   }
 
@@ -138,10 +138,10 @@ public class Helium {
       String[] paths = registryPaths.split(",");
       for (String uri : paths) {
         if (uri.startsWith("http://") || uri.startsWith("https://")) {
-          logger.info("Add helium online registry {}", uri);
+          LOGGER.info("Add helium online registry {}", uri);
           registry.add(new HeliumOnlineRegistry(uri, uri, registryCacheDir, zConf));
         } else {
-          logger.info("Add helium local registry {}", uri);
+          LOGGER.info("Add helium local registry {}", uri);
           registry.add(new HeliumLocalRegistry(uri, uri));
         }
       }
@@ -149,7 +149,7 @@ public class Helium {
 
     File heliumConfFile = new File(path);
     if (!heliumConfFile.isFile()) {
-      logger.warn("{} does not exists", path);
+      LOGGER.warn("{} does not exists", path);
       return new HeliumConf();
     } else {
       String jsonString = FileUtils.readFileToString(heliumConfFile);
@@ -224,7 +224,7 @@ public class Helium {
               allPackages.get(name).add(new HeliumPackageSearchResult(r.name(), pkg, enabled));
             }
           } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
           }
         }
       } else {
@@ -319,7 +319,7 @@ public class Helium {
     HeliumPackageSearchResult pkgInfo = getPackageInfo(name, artifact);
 
     if (pkgInfo == null) {
-      logger.info("Package {} not found", name);
+      LOGGER.info("Package {} not found", name);
       return false;
     }
 
@@ -346,7 +346,7 @@ public class Helium {
     String pkg = heliumConf.getEnabledPackages().get(name);
 
     if (pkg == null) {
-      logger.info("Package {} not found", name);
+      LOGGER.info("Package {} not found", name);
       return false;
     }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * HeliumApplicationFactory
  */
 public class HeliumApplicationFactory implements ApplicationEventListener, NoteEventListener {
-  private final Logger LOGGER = LoggerFactory.getLogger(HeliumApplicationFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeliumApplicationFactory.class);
   private final ExecutorService executor;
   private Notebook notebook;
   private ApplicationEventListener applicationEventListener;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumApplicationFactory.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * HeliumApplicationFactory
  */
 public class HeliumApplicationFactory implements ApplicationEventListener, NoteEventListener {
-  private final Logger logger = LoggerFactory.getLogger(HeliumApplicationFactory.class);
+  private final Logger LOGGER = LoggerFactory.getLogger(HeliumApplicationFactory.class);
   private final ExecutorService executor;
   private Notebook notebook;
   private ApplicationEventListener applicationEventListener;
@@ -108,7 +108,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         RunApplication runTask = new RunApplication(paragraph, appState.getId());
         runTask.run();
       } catch (Exception e) {
-        logger.error(e.getMessage(), e);
+        LOGGER.error(e.getMessage(), e);
 
         if (appState != null) {
           appStatusChange(paragraph, appState.getId(), ApplicationState.Status.ERROR);
@@ -185,7 +185,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         appState = paragraph.getApplicationState(appId);
 
         if (appState == null) {
-          logger.warn("Can not find {} to unload from {}", appId, paragraph.getId());
+          LOGGER.warn("Can not find {} to unload from {}", appId, paragraph.getId());
           return;
         }
         if (appState.getStatus() == ApplicationState.Status.UNLOADED) {
@@ -194,7 +194,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         }
         unload(appState);
       } catch (Exception e) {
-        logger.error(e.getMessage(), e);
+        LOGGER.error(e.getMessage(), e);
         if (appState != null) {
           appStatusChange(paragraph, appId, ApplicationState.Status.ERROR);
           appState.setOutput(e.getMessage());
@@ -263,13 +263,13 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
         appState = paragraph.getApplicationState(appId);
 
         if (appState == null) {
-          logger.warn("Can not find {} to unload from {}", appId, paragraph.getId());
+          LOGGER.warn("Can not find {} to unload from {}", appId, paragraph.getId());
           return;
         }
 
         run(appState);
       } catch (Exception e) {
-        logger.error(e.getMessage(), e);
+        LOGGER.error(e.getMessage(), e);
         if (appState != null) {
           appStatusChange(paragraph, appId, ApplicationState.Status.UNLOADED);
           appState.setOutput(e.getMessage());
@@ -315,7 +315,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
     if (appToUpdate != null) {
       appToUpdate.appendOutput(output);
     } else {
-      logger.error("Can't find app {}", appId);
+      LOGGER.error("Can't find app {}", appId);
     }
 
     if (applicationEventListener != null) {
@@ -332,7 +332,7 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
     if (appToUpdate != null) {
       appToUpdate.setOutput(output);
     } else {
-      logger.error("Can't find app {}", appId);
+      LOGGER.error("Can't find app {}", appId);
     }
 
     if (applicationEventListener != null) {
@@ -375,18 +375,18 @@ public class HeliumApplicationFactory implements ApplicationEventListener, NoteE
       return notebook.processNote(noteId,
         note -> {
           if (note == null) {
-            logger.warn("Note {} not found", noteId);
+            LOGGER.warn("Note {} not found", noteId);
             return null;
           }
           Paragraph paragraph = note.getParagraph(paragraphId);
           if (paragraph == null) {
-            logger.error("Can't get paragraph {}", paragraphId);
+            LOGGER.error("Can't get paragraph {}", paragraphId);
             return null;
           }
           return paragraph.getApplicationState(appId);
         });
     } catch (IOException e) {
-      logger.error("Can't get note {}", noteId);
+      LOGGER.error("Can't get note {}", noteId);
       return null;
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
@@ -59,7 +59,7 @@ import java.util.UUID;
  * ]
  */
 public class HeliumOnlineRegistry extends HeliumRegistry {
-  private Logger LOGGER = LoggerFactory.getLogger(HeliumOnlineRegistry.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeliumOnlineRegistry.class);
   private final Gson gson;
   private final File registryCacheFile;
   private final ZeppelinConfiguration zConf;

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumOnlineRegistry.java
@@ -59,7 +59,7 @@ import java.util.UUID;
  * ]
  */
 public class HeliumOnlineRegistry extends HeliumRegistry {
-  private Logger logger = LoggerFactory.getLogger(HeliumOnlineRegistry.class);
+  private Logger LOGGER = LoggerFactory.getLogger(HeliumOnlineRegistry.class);
   private final Gson gson;
   private final File registryCacheFile;
   private final ZeppelinConfiguration zConf;
@@ -96,14 +96,14 @@ public class HeliumOnlineRegistry extends HeliumRegistry {
       }
       response = client.execute(get);
     } catch (Exception e) {
-      logger.error(e.getMessage());
+      LOGGER.error(e.getMessage());
       return readFromCache();
     }
 
     if (response.getStatusLine().getStatusCode() != 200) {
       // try read from cache
-      if (logger.isErrorEnabled()) {
-        logger.error("{} returned {}", uri(), response.getStatusLine());
+      if (LOGGER.isErrorEnabled()) {
+        LOGGER.error("{} returned {}", uri(), response.getStatusLine());
       }
       return readFromCache();
     } else {
@@ -151,7 +151,7 @@ public class HeliumOnlineRegistry extends HeliumRegistry {
       }
       else return null;
     } catch (Exception ex) {
-      logger.error(ex.getMessage(), ex);
+      LOGGER.error(ex.getMessage(), ex);
       return null;
     }
   }
@@ -165,7 +165,7 @@ public class HeliumOnlineRegistry extends HeliumRegistry {
               new TypeToken<List<HeliumPackage>>() {
               }.getType());
         } catch (FileNotFoundException e) {
-          logger.error(e.getMessage(), e);
+          LOGGER.error(e.getMessage(), e);
           return new LinkedList<>();
         }
       } else {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumRegistrySerializer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumRegistrySerializer.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Type;
  */
 public class HeliumRegistrySerializer
     implements JsonSerializer<HeliumRegistry>, JsonDeserializer<HeliumRegistry> {
-  Logger logger = LoggerFactory.getLogger(HeliumRegistrySerializer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeliumRegistrySerializer.class);
 
   @Override
   public HeliumRegistry deserialize(JsonElement json,
@@ -42,14 +42,14 @@ public class HeliumRegistrySerializer
     String name = jsonObject.get("name").getAsString();
 
     try {
-      logger.info("Restore helium registry {} {} {}", name, className, uri);
+      LOGGER.info("Restore helium registry {} {} {}", name, className, uri);
       Class<HeliumRegistry> cls =
           (Class<HeliumRegistry>) getClass().getClassLoader().loadClass(className);
       Constructor<HeliumRegistry> constructor = cls.getConstructor(String.class, String.class);
       return constructor.newInstance(name, uri);
     } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |
         InstantiationException | InvocationTargetException e) {
-      logger.error(e.getMessage(), e);
+      LOGGER.error(e.getMessage(), e);
       return null;
     }
   }

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
@@ -29,7 +29,7 @@ import java.util.Properties;
 
 public class SessionConfInterpreter extends ConfInterpreter {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(SessionConfInterpreter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SessionConfInterpreter.class);
 
   public SessionConfInterpreter(Properties properties,
                                 String sessionId,

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/remote/AppendOutputRunner.java
@@ -36,8 +36,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  */
 public class AppendOutputRunner implements Runnable {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(AppendOutputRunner.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AppendOutputRunner.class);
   public static final Long BUFFER_TIME_MS = new Long(100);
   private static final Long SAFE_PROCESSING_TIME = new Long(10);
   private static final Long SAFE_PROCESSING_STRING_SIZE = new Long(100000);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/scheduler/RemoteScheduler.java
@@ -88,7 +88,7 @@ public class RemoteScheduler extends AbstractScheduler {
    * RUNNING status. This thread will exist after job is in RUNNING/FINISHED state.
    */
   private class JobStatusPoller extends Thread {
-    private final Logger logger = LoggerFactory.getLogger(JobRunner.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(JobRunner.class);
     private final long checkIntervalMsec;
     private final AtomicBoolean terminate;
     private final JobListener listener;
@@ -120,7 +120,7 @@ public class RemoteScheduler extends AbstractScheduler {
             try {
               terminate.wait(checkIntervalMsec);
             } catch (InterruptedException e) {
-              logger.error("Exception in RemoteScheduler while run this.wait", e);
+              LOGGER.error("Exception in RemoteScheduler while run this.wait", e);
               // Restore interrupted state...
               Thread.currentThread().interrupt();
             }
@@ -158,7 +158,7 @@ public class RemoteScheduler extends AbstractScheduler {
   }
 
   private class JobRunner implements Runnable, JobListener {
-    private final Logger logger = LoggerFactory.getLogger(JobRunner.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(JobRunner.class);
     private final RemoteScheduler scheduler;
     private final Job<?> job;
     private volatile boolean jobExecuted;
@@ -190,7 +190,7 @@ public class RemoteScheduler extends AbstractScheduler {
       try {
         jobStatusPoller.join();
       } catch (InterruptedException e) {
-        logger.error("JobStatusPoller interrupted", e);
+        LOGGER.error("JobStatusPoller interrupted", e);
         // Restore interrupted state...
         Thread.currentThread().interrupt();
       }
@@ -204,7 +204,7 @@ public class RemoteScheduler extends AbstractScheduler {
     @Override
     public void onStatusChange(Job<?> job, Status before, Status after) {
       if (!job.equals(this.job)) {
-        logger.error("StatusChange for an unkown job. {} != {}", this.job.getId(), job.getId());
+        LOGGER.error("StatusChange for an unkown job. {} != {}", this.job.getId(), job.getId());
         return;
       }
       if (!jobExecuted) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/AbstractInterpreterTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.mock;
  *
  */
 public abstract class AbstractInterpreterTest {
-  protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractInterpreterTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractInterpreterTest.class);
 
   protected InterpreterSettingManager interpreterSettingManager;
   protected InterpreterFactory interpreterFactory;

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManagerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/interpreter/lifecycle/TimeoutLifecycleManagerTest.java
@@ -28,6 +28,8 @@ import org.apache.zeppelin.scheduler.Job;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimeoutLifecycleManagerTest extends AbstractInterpreterTest {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutLifecycleManagerTest.class);
   private File zeppelinSiteFile = new File("zeppelin-site.xml");
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/NotebookTest.java
@@ -84,7 +84,7 @@ import static org.mockito.Mockito.mock;
 
 
 class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListener {
-  private static final Logger logger = LoggerFactory.getLogger(NotebookTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookTest.class);
 
   private Notebook notebook;
   private NoteManager noteManager;
@@ -414,7 +414,7 @@ class NotebookTest extends AbstractInterpreterTest implements ParagraphJobListen
           return null;
         });
     } catch (IOException fe) {
-      logger.warn("Failed to create note and paragraph. Possible problem with persisting note, safe to ignore", fe);
+      LOGGER.warn("Failed to create note and paragraph. Possible problem with persisting note, safe to ignore", fe);
     }
 
     assertEquals(1, notebook.getNotesInfo().size());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/GitNotebookRepoTest.java
@@ -57,7 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class GitNotebookRepoTest {
-  private static final Logger LOG = LoggerFactory.getLogger(GitNotebookRepoTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(GitNotebookRepoTest.class);
 
   private static final String TEST_NOTE_ID = "2A94M5J1Z";
   private static final String TEST_NOTE_ID2 = "2A94M5J2Z";
@@ -362,7 +362,7 @@ class GitNotebookRepoTest {
     Note note = notebookRepo.get(TEST_NOTE_ID, TEST_NOTE_PATH, null);
     note.setInterpreterFactory(mock(InterpreterFactory.class));
     int paragraphCount_1 = note.getParagraphs().size();
-    LOG.info("initial paragraph count: {}", paragraphCount_1);
+    LOGGER.info("initial paragraph count: {}", paragraphCount_1);
 
     // checkpoint revision1
     Revision revision1 = notebookRepo.checkpoint(TEST_NOTE_ID, TEST_NOTE_PATH, "set revision: first commit", null);
@@ -379,7 +379,7 @@ class GitNotebookRepoTest {
     notebookRepo.save(note, null);
     int paragraphCount_2 = note.getParagraphs().size();
     assertEquals(paragraphCount_1 + 1, paragraphCount_2);
-    LOG.info("paragraph count after modification: {}", paragraphCount_2);
+    LOGGER.info("paragraph count after modification: {}", paragraphCount_2);
 
     // checkpoint revision2
     Revision revision2 = notebookRepo.checkpoint(TEST_NOTE_ID, TEST_NOTE_PATH, "set revision: second commit", null);

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -71,7 +71,7 @@ class NotebookRepoSyncTest {
   private AuthenticationInfo anonymous;
   private NoteManager noteManager;
   private AuthorizationService authorizationService;
-  private static final Logger LOG = LoggerFactory.getLogger(NotebookRepoSyncTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(NotebookRepoSyncTest.class);
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -95,8 +95,8 @@ class NotebookRepoSyncTest {
     zConf.setProperty(ConfVars.ZEPPELIN_CONFIG_FS_DIR.getVarName(), zeppelinHome.getAbsolutePath() + "/conf");
     zConf.setProperty(ConfVars.ZEPPELIN_PLUGINS_DIR.getVarName(), new File("../../../plugins").getAbsolutePath());
 
-    LOG.info("main Note dir : " + mainNotePath);
-    LOG.info("secondary note dir : " + secNotePath);
+    LOGGER.info("main Note dir : " + mainNotePath);
+    LOGGER.info("secondary note dir : " + secNotePath);
     pluginManager = new PluginManager(zConf);
     interpreterSettingManager = new InterpreterSettingManager(zConf,
         mock(AngularObjectRegistryListener.class), mock(RemoteInterpreterProcessListener.class),
@@ -246,7 +246,7 @@ class NotebookRepoSyncTest {
     try {
       FileUtils.copyDirectory(srcDir, destDir);
     } catch (IOException e) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
     }
 
     assertEquals(0, notebookRepoSync.list(0, anonymous).size());
@@ -280,7 +280,7 @@ class NotebookRepoSyncTest {
     try {
       FileUtils.copyDirectory(srcDir, destDir);
     } catch (IOException e) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
     }
     assertEquals(0, notebookRepoSync.list(0, null).size());
     assertEquals(2, notebookRepoSync.list(1, null).size());
@@ -296,7 +296,7 @@ class NotebookRepoSyncTest {
     try {
       FileUtils.copyDirectory(srcDir, destDir);
     } catch (IOException e) {
-      LOG.error(e.toString(), e);
+      LOGGER.error(e.toString(), e);
     }
     assertEquals(2, notebookRepoSync.list(0, null).size());
     assertEquals(0, notebookRepoSync.list(1, null).size());

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/scheduler/RemoteSchedulerTest.java
@@ -28,6 +28,8 @@ import org.apache.zeppelin.user.AuthenticationInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -36,9 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class RemoteSchedulerTest extends AbstractInterpreterTest
-{
-
+class RemoteSchedulerTest extends AbstractInterpreterTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteSchedulerTest.class);
   private InterpreterSetting interpreterSetting;
   private SchedulerFactory schedulerSvc;
   private static final int TICK_WAIT = 100;


### PR DESCRIPTION
### What is this PR for?
I discovered that the Logger variable differs across files. I want to standardize the Logger variable as "LOGGER" in all files. Please let me know if there are any additional parts that need to be addressed.

### What type of PR is it?
Improvement

### Todos
* [x] - log -> LOGGER
* [x] - LOG -> LOGGER
* [x] - logger -> LOGGER
* [x] - _LOGGER -> LOGGER

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6038

### How should this be tested?
* CI
* Build and run the Zeppelin project

### Screenshots (if appropriate)
![240730_Logger](https://github.com/user-attachments/assets/23210aca-8867-4357-9810-5a0341041b0b)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
