### PR TITLE
[ZEPPELIN-6048] Write a Dockerfile for jdbc interpreter image build

### DIFF
--- a/jdbc/Dockerfile
+++ b/jdbc/Dockerfile
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:11 as builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,jdbc -DskipTests
+
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/jdbc /zeppelin/interpreter/jdbc
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV JDBC_INTERPRETER_PORT=8082
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ["./bin/interpreter.sh", \
+    "-d", "./interpreter/jdbc", \
+    "-c", "host.docker.internal", \
+    "-p", "${INTERPRETER_EVENT_SERVER_PORT}", \
+    "-r", "${JDBC_INTERPRETER_PORT}:${JDBC_INTERPRETER_PORT}", \
+    "-i", "jdbc-shared_process", \
+    "-l", "./local-repo", \
+    "-g", "jdbc"]

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -1,0 +1,36 @@
+## Overview
+Jdbc interpreter for Apache Zeppelin
+
+## Run the interpreter with docker
+You can run the jdbc interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the jdbc interpreter
+* NOTE: Your jdbc properties should be configured using the host environment settings, such as the URL, username, and password.
+```bash
+    # conf/interpreter.json
+    
+    "jdbc": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the jdbc interpreter
+```bash
+zeppelin $ ./mvnw clean install -DskipTests
+ 
+zeppelin $ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+zeppelin $ docker build -f ./jdbc/Dockerfile -t jdbc-interpreter .
+
+zeppelin $ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8082 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  jdbc-interpreter
+```

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -40,4 +40,11 @@ ENV SHELL_INTERPRETER_PORT=8081
 
 RUN chmod +x ./bin/interpreter.sh
 
-CMD ./bin/interpreter.sh -d interpreter/sh -c host.docker.internal -p ${INTERPRETER_EVENT_SERVER_PORT} -r ${SHELL_INTERPRETER_PORT}:${SHELL_INTERPRETER_PORT} -i sh-shared_process -l ./local-repo -g sh
+CMD ["./bin/interpreter.sh", \
+    "-d", "interpreter/sh", \
+    "-c", "host.docker.internal", \
+    "-p", "${INTERPRETER_EVENT_SERVER_PORT}", \
+    "-r", "${SHELL_INTERPRETER_PORT}:${SHELL_INTERPRETER_PORT}", \
+    "-i", "sh-shared_process", \
+    "-l", "./local-repo", \
+    "-g", "sh"]

--- a/shell/README.md
+++ b/shell/README.md
@@ -4,7 +4,7 @@ Shell interpreter for Apache Zeppelin
 ## Run the interpreter with docker
 You can run the shell interpreter as a standalone docker container.
 
-### step 1. Specify the configuration for the shell interpreter
+### Step 1. Specify the configuration for the shell interpreter
 ```bash
     # conf/interpreter.json
     
@@ -20,7 +20,7 @@ You can run the shell interpreter as a standalone docker container.
       }
 ````
 
-### step 2. Build and run the shell interpreter
+### Step 2. Build and run the shell interpreter
 ```bash
 zeppelin $ ./mvnw clean install -DskipTests
  


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a JDBC interpreter container. It’s the second interpreter to be dockerized, after the shell interpreter (#4781). Like I said in the previous PR, the configuration and testing are a little complex at the moment. I plan to improve this in future work.

### What type of PR is it?
Feature
### Todos
### What is the Jira issue?
* [ZEPPELIN-6048](https://issues.apache.org/jira/browse/ZEPPELIN-6048)
### How should this be tested?
* Build and run the docker container
* Verify that the jdbc interpreter container communicates with the zeppelin server

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes. Docs added
