### PR TITLE
[HOTFIX] Escaping vulnerable text  when modal opens

### DIFF
--- a/zeppelin-web/src/app/helium/helium.controller.js
+++ b/zeppelin-web/src/app/helium/helium.controller.js
@@ -240,10 +240,10 @@ export default function HeliumCtrl($scope, $rootScope, $sce,
           `<div style="color:gray">${getHeliumTypeText(type)}</div>` +
           '<hr style="margin-top: 10px; margin-bottom: 10px;" />' +
           '<div style="font-size: 14px;">Description</div>' +
-          `<div style="color:gray">${description}</div>` +
+          `<div style="color:gray">${_.escape(description)}</div>` +
           '<hr style="margin-top: 10px; margin-bottom: 10px;" />' +
           '<div style="font-size: 14px;">License</div>' +
-          `<div style="color:gray">${license}</div>`,
+          `<div style="color:gray">${_.escape(license)}</div>`,
         callback: function(result) {
           if (result) {
             confirm.$modalFooter.find('button').addClass('disabled');


### PR DESCRIPTION
### What is this PR for?
#### Description
- Relate : https://github.com/apache/zeppelin/pull/3449
- Thanks to above PR, using Helium got much safer. But there're still remaning vulnerability issues with Hellium package.
- If somebody makes malicious Hellium package, it can lead to serious consequences.

#### Solution
- `zeppelin-web` is dependent on `lodash@3.9.3` which supports escaping method `_.escape`
- I applied `_.escape(vulnerable-text)` to vulnerable text.

### AS-IS
![화면 기록 2024-08-17 오후 3 57 43](https://github.com/user-attachments/assets/58ac0ed7-b483-4484-b4e3-3d6b0ab6f920)
![image](https://github.com/user-attachments/assets/65ccc3ab-2bb3-44a4-a032-00fc0157f6c9)
_You can see the HTML is not escaped and `<img>` tag has rendered_

### TO-BE
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/8d217b66-5692-4186-a5c8-5bcc87460dc5">

![image](https://github.com/user-attachments/assets/66dfae6b-2dd6-4fa7-b045-151d86f76af6)
_HTML is escaped and `<`, `>` has converted into HTML Entity which is safer_


### What type of PR is it?
Hot Fix

### Todos
* [x] - Escape HTML message before renders

### What is the Jira issue?
- N/A

### How should this be tested?
- N/A

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? NO
* Is there breaking changes for older versions? NO
* Does this needs documentation? NO
