### PR TITLE
[ZEPPELIN-6051] Skip the hidden files in notebook listing (branch-0.11)

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -38,6 +38,7 @@ import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
 import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.notebook.NoteInfo;
+import org.apache.zeppelin.notebook.exception.CorruptedNoteException;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,11 +103,13 @@ public class VFSNotebookRepo implements NotebookRepo {
 
   private Map<String, NoteInfo> listFolder(FileObject fileObject) throws IOException {
     Map<String, NoteInfo> noteInfos = new HashMap<>();
+
+    if (fileObject.getName().getBaseName().startsWith(".")) {
+      LOGGER.warn("Skip hidden item: {}", fileObject.getName());
+      return noteInfos;
+    }
+
     if (fileObject.isFolder()) {
-      if (fileObject.getName().getBaseName().startsWith(".")) {
-        LOGGER.warn("Skip hidden folder: {}", fileObject.getName().getPath());
-        return noteInfos;
-      }
       for (FileObject child : fileObject.getChildren()) {
         noteInfos.putAll(listFolder(child));
       }
@@ -133,10 +136,21 @@ public class VFSNotebookRepo implements NotebookRepo {
         NameScope.DESCENDENT);
     String json = IOUtils.toString(noteFile.getContent().getInputStream(),
         conf.getString(ConfVars.ZEPPELIN_ENCODING));
-    Note note = Note.fromJson(noteId, json);
-    // setPath here just for testing, because actually NoteManager will setPath
-    note.setPath(notePath);
-    return note;
+
+    try {
+      Note note = Note.fromJson(noteId, json);
+      // setPath here just for testing, because actually NoteManager will setPath
+      note.setPath(notePath);
+      return note;
+    } catch (CorruptedNoteException e) {
+      String errorMessage = String.format(
+          "Fail to parse note json. Please check the file at this path to resolve the issue. "
+              + "Path: %s, "
+              + "Content: %s",
+          rootNotebookFolder + notePath, json
+      );
+      throw new CorruptedNoteException(noteId, errorMessage, e);
+    }
   }
 
   @Override

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepoTest.java
@@ -17,7 +17,15 @@
 
 package org.apache.zeppelin.notebook.repo;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.notebook.Note;
@@ -28,24 +36,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class VFSNotebookRepoTest {
 
   private ZeppelinConfiguration zConf;
   private VFSNotebookRepo notebookRepo;
-  private File notebookDir;
 
   @BeforeEach
   public void setUp() throws IOException {
-    notebookDir = Files.createTempDirectory("notebookDir").toFile();
+    File notebookDir = Files.createTempDirectory("notebookDir").toFile();
     System.setProperty(ZeppelinConfiguration.ConfVars.ZEPPELIN_NOTEBOOK_DIR.getVarName(),
         notebookDir.getAbsolutePath());
     notebookRepo = new VFSNotebookRepo();
@@ -55,7 +53,8 @@ public class VFSNotebookRepoTest {
 
   @AfterEach
   public void tearDown() throws IOException {
-    FileUtils.deleteDirectory(notebookDir);
+    File rootDir = new File(notebookRepo.rootNotebookFolder);
+    FileUtils.deleteDirectory(rootDir);
   }
 
   @Test
@@ -127,7 +126,7 @@ public class VFSNotebookRepoTest {
     assertEquals(1, repoSettings.size());
     NotebookRepoSettingsInfo settingInfo = repoSettings.get(0);
     assertEquals("Notebook Path", settingInfo.name);
-    assertEquals(notebookDir.getAbsolutePath(), settingInfo.selected);
+    assertEquals(notebookRepo.rootNotebookFolder, settingInfo.selected);
 
     createNewNote("{}", "id2", "my_project/name2");
     assertEquals(1, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
@@ -139,8 +138,33 @@ public class VFSNotebookRepoTest {
     assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
   }
 
+  @Test
+  void testSkipInvalidFileName() throws IOException {
+    assertEquals(0, notebookRepo.list(AuthenticationInfo.ANONYMOUS).size());
+
+    createNewNote("{}", "hidden_note", "my_project/.hidden_note");
+
+    Map<String, NoteInfo> noteInfos = notebookRepo.list(AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, noteInfos.size());
+  }
+
+  @Test
+  void testSkipInvalidDirectoryName() throws IOException {
+    createNewDirectory(".hidden_dir");
+
+    createNewNote("{}", "hidden_note", "my_project/.hidden_dir/note");
+
+    Map<String, NoteInfo> noteInfos = notebookRepo.list(AuthenticationInfo.ANONYMOUS);
+    assertEquals(0, noteInfos.size());
+  }
+
   private void createNewNote(String content, String noteId, String noteName) throws IOException {
     FileUtils.writeStringToFile(
-        new File(notebookDir + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
+        new File(notebookRepo.rootNotebookFolder + "/" + noteName + "_" + noteId + ".zpln"), content, StandardCharsets.UTF_8);
+  }
+
+  private void createNewDirectory(String dirName) {
+    File dir = new File(notebookRepo.rootNotebookFolder + "/" + dirName);
+    dir.mkdir();
   }
 }


### PR DESCRIPTION
### What is this PR for? 
This change was already merged into master with #4792.
This PR applies the changes to release-0.11 to avoid conflicts.

### What type of PR is it?
Improvement
### Todos
### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6051
### How should this be tested?
* Create a notebook that can't be parsed and try to open it.
### Screenshots (if appropriate)
### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No