### PR TITLE
[ZEPPELIN-6050] Upgrade node, npm, yarn version of helium

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/helium/HeliumBundleFactory.java
@@ -70,9 +70,9 @@ import org.slf4j.LoggerFactory;
  */
 public class HeliumBundleFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(HeliumBundleFactory.class);
-  private static final String NODE_VERSION = "v6.9.1";
-  private static final String NPM_VERSION = "3.10.8";
-  private static final String YARN_VERSION = "v0.21.3";
+  private static final String NODE_VERSION = "v16.16.0";
+  private static final String NPM_VERSION = "8.11.0";
+  private static final String YARN_VERSION = "v1.22.0";
   private static final String NPM_PACKAGE_NAME = "npm";
   protected static final String HELIUM_LOCAL_REPO = "helium-bundle";
   private static final String HELIUM_BUNDLES_DIR = "bundles";
@@ -589,7 +589,8 @@ public class HeliumBundleFactory {
 
         if (!webpackRunDetected) {
           String trimed = line.trim();
-          if (trimed.contains("webpack") && trimed.endsWith("--json")) {
+          if (trimed.contains("webpack")
+              && trimed.endsWith("--json --registry=https://registry.npmjs.org/")) {
             webpackRunDetected = true;
           }
           continue;


### PR DESCRIPTION
### What is this PR for?

This PR upgrades the node, npm, and yarn versions of the HeliumBundleFactory in the zeppelin-server module to improve local development environment.
- node: v16.16.0
- npm: v8.11.0
- yarn: v1.22.0

### What type of PR is it?

Improvement

### Todos
* [x] Upgrade node, npm, yarn version

### What is the Jira issue?

[ZEPPELIN-6050](https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6050?filter=allissues)

### How should this be tested?

1. Refer to [docs](https://github.com/apache/zeppelin/blob/master/docs/development/contribution/how_to_contribute_code.md) to configure `zeppelin-site.xml`.
2. Uncomment the property `zeppelin.helium.registry`

```xml
<!--
<property>
  <name>zeppelin.helium.registry</name>
  <value>helium,https://zeppelin.apache.org/helium.json</value>
  <description>Location of external Helium Registry</description>
</property>
-->
```

3. Start the zeppelin-server.
4. Go to `/#/helium` and install any visualizations or spells.(npm dependencies)

### Screenshots (if appropriate)

**Before**

![image](https://github.com/user-attachments/assets/e15591c0-2f75-47f5-b483-f8860ca8d615)

**After**

![image](https://github.com/user-attachments/assets/e4f4b3dd-b945-471f-b0fd-844485f84aa9)

![image](https://github.com/user-attachments/assets/6cc435c9-3337-48d0-a406-faa1eaab75b3)


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
