### PR TITLE
[ZEPPELIN-1480] rework websocket sending to prevent partial frontend hangup

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookSocket.java
@@ -44,13 +44,13 @@ public class NotebookSocket {
   }
 
   public String getHeader(String key) {
-      return String.valueOf(headers.get(key));
+    return String.valueOf(headers.get(key));
   }
 
   public void send(String serializeMessage) throws IOException {
     session.getAsyncRemote().sendText(serializeMessage, result -> {
       if (result.getException() != null) {
-          LOGGER.error("Failed to send async message for User {} in Session {}: {}", this.user, this.session.getId(), result.getException());
+        LOGGER.error("Failed to send async message for User {} in Session {}: {}", this.user, this.session.getId(), result.getException());
       }
     });
   }


### PR DESCRIPTION
### What is this PR for?
Zeppelin Frontend sometimes stops working with following error in the log:
"Blocking message pending 10000 for BLOCKING"

According to Jetty documentation, Websocket writes need to be thread safe or the async functions need to be used.

This PR addresses the issue and makes the send requests thread safe

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-1480

### How should this be tested?
This problem only occurs in production size deployments and is inherently a race condition

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
