### PR TITLE
[ZEPPELIN-6063] Fix delay in paragraph results rendering in new UI

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/share/result/result.component.ts
@@ -224,10 +224,7 @@ export class NotebookParagraphResultComponent implements OnInit, AfterViewInit, 
         this.renderAngular();
         break;
     }
-    this.cdr.markForCheck();
-    if (this.published) {
-      this.cdr.detectChanges();
-    }
+    this.cdr.detectChanges();
   }
 
   renderHTML(): void {


### PR DESCRIPTION
### What is this PR for?

In new UI, the results are rendered only after some interactions, such as a click on the other paragraph.

This PR addresses the issue by ensuring immediate rendering of the results when they are set in the `ngAfterViewInit` lifecycle hook. Previously, `markForCheck()` was used after setting `this.innerHTML`, which scheduled the component to be checked in the next change detection cycle but did not trigger an immediate update.
This has been changed to `detectChanges()` to force an immediate change detection, ensuring that the results are rendered right after they are set, without needing further user interaction.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6063

### How should this be tested?
- Run any paragraph in new UI

### Screenshots (if appropriate)

#### Before

![Aug-23-2024 19-59-47](https://github.com/user-attachments/assets/bce85eba-7672-423f-b66b-b8f433216617)

#### After

![Aug-23-2024 20-27-01](https://github.com/user-attachments/assets/27beb526-fcbd-4f46-9e21-c3a6f8a720b7)


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
