### PR TITLE
[ZEPPELIN-6065] Remove broken links on the Apache Shiro authentication page

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -100,7 +100,7 @@ group1 = *
 
 ## Configure Realm (optional)
 Realms are responsible for authentication and authorization in Apache Zeppelin. By default, Apache Zeppelin uses **IniRealm** (users and groups are configurable in `conf/shiro.ini` file under `[user]` and `[group]` section). You can also leverage Shiro Realms like **JndiLdapRealm**, **JdbcRealm** or create **AuthorizingRealm**.
-To learn more about Apache Shiro Realm, please check [this documentation](http://shiro.apache.org/realm.html).
+To learn more about Apache Shiro Realm, please check [this documentation](https://shiro.apache.org/realm.html).
 
 We also provide community custom Realms.
 

--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -99,7 +99,7 @@ group1 = *
 ```
 
 ## Configure Realm (optional)
-Realms are responsible for authentication and authorization in Apache Zeppelin. By default, Apache Zeppelin uses [IniRealm](https://shiro.apache.org/static/latest/apidocs/org/apache/shiro/realm/text/IniRealm.html) (users and groups are configurable in `conf/shiro.ini` file under `[user]` and `[group]` section). You can also leverage Shiro Realms like [JndiLdapRealm](https://shiro.apache.org/static/latest/apidocs/org/apache/shiro/realm/ldap/JndiLdapRealm.html), [JdbcRealm](https://shiro.apache.org/static/latest/apidocs/org/apache/shiro/realm/jdbc/JdbcRealm.html) or create [our own](https://shiro.apache.org/static/latest/apidocs/org/apache/shiro/realm/AuthorizingRealm.html).
+Realms are responsible for authentication and authorization in Apache Zeppelin. By default, Apache Zeppelin uses **IniRealm** (users and groups are configurable in `conf/shiro.ini` file under `[user]` and `[group]` section). You can also leverage Shiro Realms like **JndiLdapRealm**, **JdbcRealm** or create **AuthorizingRealm**.
 To learn more about Apache Shiro Realm, please check [this documentation](http://shiro.apache.org/realm.html).
 
 We also provide community custom Realms.


### PR DESCRIPTION
### What is this PR for?
Some links on the [Apache Shiro authentication page](https://zeppelin.apache.org/docs/latest/setup/security/shiro_authentication.html#1-enable-shiro:~:text=Realms%20are%20responsible,this%20documentation.) have been broken. It looks like the linked docs have been removed as the Shiro version was updated to 2.0. The 2.0 versions do not seem to provide apidocs for each realm, so I have removed these links to avoid confusion.

### What type of PR is it?
Bug Fix
Documentation
### Todos
### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6065

### How should this be tested?
* review

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
