### PR TITLE
[ZEPPELIN-6073][BUILD] Canonicalize binary distribution tarball name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "unsafe-perm=true" > ~/.npmrc && \
     ./mvnw -B package -DskipTests -Pbuild-distr -Pspark-3.3 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist && \
     # Example with doesn't compile all interpreters
     # ./mvnw -B package -DskipTests -Pbuild-distr -Pspark-3.2 -Pinclude-hadoop -Phadoop3 -Pspark-scala-2.12 -Pweb-angular -Pweb-dist -pl '!groovy,!livy,!hbase,!file,!flink' && \
-    mv /workspace/zeppelin/zeppelin-distribution/target/zeppelin-*/zeppelin-* /opt/zeppelin/ && \
+    mv /workspace/zeppelin/zeppelin-distribution/target/zeppelin-*-bin/zeppelin-*-bin /opt/zeppelin/ && \
     # Removing stuff saves time, because docker creates a temporary layer
     rm -rf ~/.m2 && \
     rm -rf /workspace/zeppelin/*

--- a/dev/create_release.sh
+++ b/dev/create_release.sh
@@ -72,8 +72,8 @@ function make_binary_release() {
   fi
 
   # re-create package with proper dir name with binary license
-  cd zeppelin-distribution/target/zeppelin-*
-  mv zeppelin-* "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
+  cd zeppelin-distribution/target/zeppelin-${RELEASE_VERSION}-bin
+  mv zeppelin-${RELEASE_VERSION}-bin "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}"
   cat ../../src/bin_license/LICENSE >> "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/LICENSE"
   cat ../../src/bin_license/NOTICE >> "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/NOTICE"
   cp ../../src/bin_license/licenses/* "zeppelin-${RELEASE_VERSION}-bin-${BIN_RELEASE_NAME}/licenses/"

--- a/docs/quickstart/kubernetes.md
+++ b/docs/quickstart/kubernetes.md
@@ -169,7 +169,7 @@ $ ./mvnw package -DskipTests -Pbuild-distr <your flags>
 Binary package will be created under `zeppelin-distribution/target` directory. Move created package file under `scripts/docker/zeppelin/bin/` directory.
 
 ```
-$ mv zeppelin-distribution/target/zeppelin-*.tar.gz scripts/docker/zeppelin/bin/
+$ mv zeppelin-distribution/target/zeppelin-*-bin.tgz scripts/docker/zeppelin/bin/
 ```
 
 `scripts/docker/zeppelin/bin/Dockerfile` downloads package from internet. Modify the file to add package from filesystem.

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 
     <!-- plugin versions -->
     <plugin.antrun.version>1.8</plugin.antrun.version>
-    <plugin.assembly.version>3.2.0</plugin.assembly.version>
+    <plugin.assembly.version>3.7.1</plugin.assembly.version>
     <plugin.avro.version>1.7.7</plugin.avro.version>
     <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
     <plugin.buildnumber.version>1.4</plugin.buildnumber.version>

--- a/zeppelin-distribution/README.md
+++ b/zeppelin-distribution/README.md
@@ -20,7 +20,7 @@
 Apache Zeppelin is distributed as a single gzip archive with the following structure:
 
 ```
-Zeppelin
+zeppelin-<version>-bin
  ├── bin
  │   ├── zeppelin.sh
  │   └── zeppelin-daemon.sh

--- a/zeppelin-distribution/build-infrastructure.md
+++ b/zeppelin-distribution/build-infrastructure.md
@@ -25,7 +25,7 @@
                        v v v
   Zeppelin Server  <- Zengine
          +               |
-    zeppeli web          v
+   Zeppelin Web          v
                         ZAN
 ```
 
@@ -44,12 +44,12 @@
  - compile                => *.class, minify *.js
  - build modules          => *.jar, war
  - test                   => UnitTest reports
- - package -P build-distr => final .zip
+ - package -P build-distr => final .tgz
  - integration-test       => selenium over running zeppelin-server (from package)
 
 
 ## Verify
 
- - pre-inegration-test   => start Zeppelin
+ - pre-integration-test   => start Zeppelin
  - integration-test
- - post-inegration-test  => stop Zeppelin
+ - post-integration-test  => stop Zeppelin

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -144,8 +144,8 @@
               <bucketName>zeppel.in</bucketName>
               <endpoint>s3-ap-northeast-1.amazonaws.com</endpoint>
               <makePublic>true</makePublic>
-              <sourceFile>zeppelin-distribution/target/zeppelin-${project.version}.tar.gz</sourceFile>
-              <destinationFile>zeppelin-${project.version}.tar.gz</destinationFile>
+              <sourceFile>zeppelin-distribution/target/zeppelin-${project.version}-bin.tgz</sourceFile>
+              <destinationFile>zeppelin-${project.version}-bin.tgz</destinationFile>
             </configuration>
             <executions>
               <execution>

--- a/zeppelin-distribution/pom.xml
+++ b/zeppelin-distribution/pom.xml
@@ -66,7 +66,7 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
-          <finalName>${project.parent.artifactId}-${project.version}</finalName>
+          <finalName>${project.parent.artifactId}-${project.version}-bin</finalName>
           <appendAssemblyId>false</appendAssemblyId>
           <attach>false</attach>
           <tarLongFileMode>posix</tarLongFileMode>

--- a/zeppelin-distribution/src/assemble/distribution.xml
+++ b/zeppelin-distribution/src/assemble/distribution.xml
@@ -15,17 +15,15 @@
   ~ limitations under the License.
   -->
 
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
   <id>final-distribution</id>
   <formats>
     <format>dir</format>
-    <format>tar.gz</format>
-    <!-- format>zip</format -->
+    <format>tgz</format>
   </formats>
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>zeppelin-${project.version}</baseDirectory>
+  <baseDirectory>zeppelin-${project.version}-bin</baseDirectory>
 
   <dependencySets>
     <dependencySet>
@@ -57,7 +55,6 @@
         <include>README.md</include>
         <include>LICENSE*</include>
         <include>NOTICE</include>
-        <include>DISCLAIMER</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/zeppelin-integration/pom.xml
+++ b/zeppelin-integration/pom.xml
@@ -255,7 +255,7 @@
       </activation>
       <properties>
         <zeppelin.daemon.package.base>
-          ../zeppelin-distribution/target/zeppelin-${project.version}/zeppelin-${project.version}/bin
+          ../zeppelin-distribution/target/zeppelin-${project.version}-bin/zeppelin-${project.version}-bin/bin
         </zeppelin.daemon.package.base>
       </properties>
     </profile>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -475,7 +475,7 @@
       </activation>
       <properties>
         <zeppelin.daemon.package.base>
-	        ../zeppelin-distribution/target/zeppelin-${project.version}/zeppelin-${project.version}/bin
+	        ../zeppelin-distribution/target/zeppelin-${project.version}-bin/zeppelin-${project.version}-bin/bin
         </zeppelin.daemon.package.base>
       </properties>
     </profile>


### PR DESCRIPTION
### What is this PR for?

This PR aims to canonicalize the binary distribution tarball name assembled by Maven.

Currently, the `./mvnw clean package -Pbuild-distr -DskipTests` produces `zeppelin-0.12.0-SNAPSHOT.tar.gz`, while the final release tarballs are `zeppelin-0.11.1-bin-all.tgz` and `zeppelin-0.11.1-bin-netinst.tgz`.

After this change, `./mvnw clean package -Pbuild-distr -DskipTests` produces `zeppelin-0.12.0-SNAPSHOT-bin.tgz`.

### What type of PR is it?

Improvement

### What is the Jira issue?

ZEPPELIN-6073

### How should this be tested?

Pass existing GHA and manually run maven command to package the binary tarball.

```
$ ./mvnw clean package -Pbuild-distr -DskipTests
```

```
...
[INFO] -------------< org.apache.zeppelin:zeppelin-distribution >--------------
[INFO] Building Zeppelin: Packaging distribution 0.12.0-SNAPSHOT        [64/64]
[INFO] --------------------------------[ pom ]---------------------------------
...
[INFO] --- maven-assembly-plugin:3.7.1:single (make-assembly) @ zeppelin-distribution ---
[INFO] Reading assembly descriptor: src/assemble/distribution.xml
[INFO] Copying files to /Users/chengpan/Projects/apache-zeppelin/zeppelin-distribution/target/zeppelin-0.12.0-SNAPSHOT-bin
[INFO] 838 files copied to /Users/chengpan/Projects/apache-zeppelin/zeppelin-distribution/target/zeppelin-0.12.0-SNAPSHOT-bin
[INFO] Building tar: /Users/chengpan/Projects/apache-zeppelin/zeppelin-distribution/target/zeppelin-0.12.0-SNAPSHOT-bin.tgz
...
```

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
