### PR TITLE
[ZEPPELIN-6076] Fix rendering runtime dynamic components in new UI

### DIFF
--- a/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ng-zorro-antd-module.ts
+++ b/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ng-zorro-antd-module.ts
@@ -10,7 +10,7 @@
  * limitations under the License.
  */
 
-import { NgModule } from '@angular/core';
+import { NgModule } from './ngmodule.decorator';
 
 import { NzAffixModule } from 'ng-zorro-antd/affix';
 import { NzAlertModule } from 'ng-zorro-antd/alert';

--- a/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
+++ b/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // importing NgModule and Component from @angular/core
 // and re-exporting them to prevent AOT compiler from removing them
 import { Component, NgModule } from '@angular/core';

--- a/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
+++ b/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
@@ -1,0 +1,2 @@
+import { Component, NgModule } from '@angular/core';
+export { NgModule, Component };

--- a/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
+++ b/zeppelin-web-angular/src/app/core/runtime-dynamic-module/ngmodule.decorator.ts
@@ -1,2 +1,4 @@
+// importing NgModule and Component from @angular/core
+// and re-exporting them to prevent AOT compiler from removing them
 import { Component, NgModule } from '@angular/core';
 export { NgModule, Component };

--- a/zeppelin-web-angular/src/app/core/runtime-dynamic-module/runtime-dynamic-module.module.ts
+++ b/zeppelin-web-angular/src/app/core/runtime-dynamic-module/runtime-dynamic-module.module.ts
@@ -10,9 +10,9 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NzModule } from './ng-zorro-antd-module';
+import { NgModule } from './ngmodule.decorator';
 
 @NgModule({
   declarations: [],


### PR DESCRIPTION
### What is this PR for?

The current issue is that the new UI fails to render dynamically created components at runtime, which causes the `%sh.terminal` interpreter to malfunction.

This problem occurs because Angular's AOT compiler removes decorators during the build process.([related issue](https://github.com/angular/angular-cli/issues/9306))

As far as I know, Angular does not support JIT compilation alongside the AOT compiler.

However, we need to render runtime dynamic components for compatibility reasons.

By Importing and re-exporting Angular core decorators, we can prevent the AOT compiler from removing them.
(https://github.com/angular/angular-cli/issues/9306#issuecomment-435404174)
I believe there are two possible solutions: either implementing this fix or turning off AOT compilation.
However, giving up the performance benefits of AOT compilation is not ideal, So I chose this approach.

### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6076

### How should this be tested?
- Run `%sh.terminal` interpreter and see if it renders well. 
  Note: Since Angular dev servers do not use AOT compilation, testing in development mode will not reproduce the issue.

### Screenshots (if appropriate)

#### Before

![image](https://github.com/user-attachments/assets/09c20c58-e86b-4432-b2ed-ee971c74af8a)

#### After

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/b7f6273b-4323-4f59-a23f-02e7696196b7">
- The connection status message appears broken due to incompatibility between Angular and AngularJS syntax, but this does not affect functionality. (This can be addressed in a separate issue.)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
