### PR TITLE
[ZEPPELIN-6077] Remove raw types for AngularObject

### DIFF
--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularElem.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularElem.scala
@@ -29,7 +29,7 @@ import scala.xml._
   */
 abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
                                    val modelName: String,
-                                   val angularObjects: Map[String, AngularObject[Any]],
+                                   val angularObjects: Map[String, AngularObject],
                                    prefix: String,
                                    label: String,
                                    attributes1: MetaData,
@@ -70,7 +70,7 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
     * @return
     */
   @ZeppelinApi
-  def model(name: String, value: Any): AbstractAngularElem = {
+  def model(name: String, value: AnyRef): AbstractAngularElem = {
     val registry = interpreterContext.getAngularObjectRegistry
 
     // create AngularFunction in current paragraph
@@ -79,7 +79,7 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
       Null)
 
     val angularObject = addAngularObject(name, value)
-      .asInstanceOf[AngularObject[Any]]
+      .asInstanceOf[AngularObject]
 
     newElem(
       interpreterContext,
@@ -111,7 +111,7 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
     * @return
     */
   @ZeppelinApi
-  def model(): Any = {
+  def model(): AnyRef = {
     if (angularObjects.contains(modelName)) {
       angularObjects(modelName).get()
     } else {
@@ -134,7 +134,7 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
       Text(s"${functionName}=${functionName} + 1"),
       Null)
 
-    val angularObject = addAngularObject(functionName, 0)
+    val angularObject = addAngularObject(functionName, Int.box(0))
 
     angularObject.addWatcher(new AngularObjectWatcher(interpreterContext) {
       override def watch(oldObject: scala.Any, newObject: scala.Any, context: InterpreterContext)
@@ -151,11 +151,11 @@ abstract class AbstractAngularElem(val interpreterContext: InterpreterContext,
       elem)
   }
 
-  protected def addAngularObject(name: String, value: Any): AngularObject[Any]
+  protected def addAngularObject(name: String, value: AnyRef): AngularObject
 
   protected def newElem(interpreterContext: InterpreterContext,
                         name: String,
-                        angularObjects: Map[String, AngularObject[Any]],
+                        angularObjects: Map[String, AngularObject],
                         elem: scala.xml.Elem): AbstractAngularElem
 
   /**

--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularModel.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/AbstractAngularModel.scala
@@ -35,13 +35,13 @@ abstract class AbstractAngularModel(name: String) {
     * @param newValue value
     */
   @ZeppelinApi
-  def this(name: String, newValue: Any) = {
+  def this(name: String, newValue: AnyRef) = {
     this(name)
     value(newValue)
   }
 
-  protected def getAngularObject(): AngularObject[Any]
-  protected def addAngularObject(value: Any): AngularObject[Any]
+  protected def getAngularObject(): AngularObject
+  protected def addAngularObject(value: AnyRef): AngularObject
 
   /**
     * Get value of the model
@@ -49,7 +49,7 @@ abstract class AbstractAngularModel(name: String) {
     * @return
     */
   @ZeppelinApi
-  def apply(): Any = {
+  def apply(): AnyRef = {
     value()
   }
 
@@ -59,7 +59,7 @@ abstract class AbstractAngularModel(name: String) {
     * @return
     */
   @ZeppelinApi
-  def value(): Any = {
+  def value(): AnyRef = {
     val angularObject = getAngularObject()
     if (angularObject == null) {
       None
@@ -69,7 +69,7 @@ abstract class AbstractAngularModel(name: String) {
   }
 
   @ZeppelinApi
-  def apply(newValue: Any): Unit = {
+  def apply(newValue: AnyRef): Unit = {
     value(newValue)
   }
 
@@ -80,7 +80,7 @@ abstract class AbstractAngularModel(name: String) {
     * @param newValue
     */
   @ZeppelinApi
-  def value(newValue: Any): Unit = {
+  def value(newValue: AnyRef): Unit = {
     var angularObject = getAngularObject()
     if (angularObject == null) {
       // create new object
@@ -92,7 +92,7 @@ abstract class AbstractAngularModel(name: String) {
   }
 
   @ZeppelinApi
-  def remove(): Any = {
+  def remove(): AnyRef = {
     val angularObject = getAngularObject()
 
     if (angularObject == null) {

--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularElem.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularElem.scala
@@ -29,7 +29,7 @@ import scala.xml._
   */
 class AngularElem(override val interpreterContext: InterpreterContext,
                   override val modelName: String,
-                  override val angularObjects: Map[String, AngularObject[Any]],
+                  override val angularObjects: Map[String, AngularObject],
                   prefix: String,
                   label: String,
                   attributes1: MetaData,
@@ -40,15 +40,15 @@ class AngularElem(override val interpreterContext: InterpreterContext,
     interpreterContext, modelName, angularObjects, prefix, label, attributes1, scope,
     minimizeEmpty, child: _*) {
 
-  override protected def addAngularObject(name: String, value: Any): AngularObject[Any] = {
+  override protected def addAngularObject(name: String, value: AnyRef): AngularObject = {
     val registry = interpreterContext.getAngularObjectRegistry
-    registry.add(name, value, interpreterContext.getNoteId, null).asInstanceOf[AngularObject[Any]]
+    registry.add(name, value, interpreterContext.getNoteId, null).asInstanceOf[AngularObject]
 
   }
 
   override protected def newElem(interpreterContext: InterpreterContext,
                                  name: String,
-                                 angularObjects: Map[String, AngularObject[Any]],
+                                 angularObjects: Map[String, AngularObject],
                                  elem: scala.xml.Elem): angular.AbstractAngularElem = {
     new AngularElem(
       interpreterContext,
@@ -66,7 +66,7 @@ class AngularElem(override val interpreterContext: InterpreterContext,
 object AngularElem {
   implicit def Elem2AngularDisplayElem(elem: Elem): AbstractAngularElem = {
     new AngularElem(InterpreterContext.get(), null,
-      Map[String, AngularObject[Any]](),
+      Map[String, AngularObject](),
       elem.prefix, elem.label, elem.attributes, elem.scope, elem.minimizeEmpty, elem.child:_*);
   }
 

--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModel.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModel.scala
@@ -26,17 +26,17 @@ import org.apache.zeppelin.interpreter.InterpreterContext
 class AngularModel(name: String)
   extends org.apache.zeppelin.display.angular.AbstractAngularModel(name) {
 
-  def this(name: String, newValue: Any) = {
+  def this(name: String, newValue: AnyRef) = {
     this(name)
     value(newValue)
   }
 
-  override protected def getAngularObject(): AngularObject[Any] = {
-    registry.get(name, context.getNoteId, null).asInstanceOf[AngularObject[Any]]
+  override protected def getAngularObject(): AngularObject = {
+    registry.get(name, context.getNoteId, null).asInstanceOf[AngularObject]
   }
 
-  override protected def addAngularObject(value: Any): AngularObject[Any] = {
-    registry.add(name, value, context.getNoteId, null).asInstanceOf[AngularObject[Any]]
+  override protected def addAngularObject(value: AnyRef): AngularObject = {
+    registry.add(name, value, context.getNoteId, null).asInstanceOf[AngularObject]
   }
 }
 
@@ -46,7 +46,7 @@ object AngularModel {
     new AngularModel(name)
   }
 
-  def apply(name: String, newValue: Any): AbstractAngularModel = {
+  def apply(name: String, newValue: AnyRef): AbstractAngularModel = {
     new AngularModel(name, newValue)
   }
 }

--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularElem.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularElem.scala
@@ -30,7 +30,7 @@ import scala.xml._
   */
 class AngularElem(override val interpreterContext: InterpreterContext,
                   override val modelName: String,
-                  override val angularObjects: Map[String, AngularObject[Any]],
+                  override val angularObjects: Map[String, AngularObject],
                   prefix: String,
                   label: String,
                   attributes1: MetaData,
@@ -41,16 +41,16 @@ class AngularElem(override val interpreterContext: InterpreterContext,
     interpreterContext, modelName, angularObjects, prefix, label, attributes1, scope,
     minimizeEmpty, child: _*) {
 
-  override protected def addAngularObject(name: String, value: Any): AngularObject[Any] = {
+  override protected def addAngularObject(name: String, value: Object): AngularObject = {
     val registry = interpreterContext.getAngularObjectRegistry
     registry.add(name, value, interpreterContext.getNoteId, interpreterContext.getParagraphId)
-      .asInstanceOf[AngularObject[Any]]
+      .asInstanceOf[AngularObject]
 
   }
 
   override protected def newElem(interpreterContext: InterpreterContext,
                                  name: String,
-                                 angularObjects: Map[String, AngularObject[Any]],
+                                 angularObjects: Map[String, AngularObject],
                                  elem: scala.xml.Elem): angular.AbstractAngularElem = {
     new AngularElem(
       interpreterContext,
@@ -68,7 +68,7 @@ class AngularElem(override val interpreterContext: InterpreterContext,
 object AngularElem {
   implicit def Elem2AngularDisplayElem(elem: Elem): AbstractAngularElem = {
     new AngularElem(InterpreterContext.get(), null,
-      Map[String, AngularObject[Any]](),
+      Map[String, AngularObject](),
       elem.prefix, elem.label, elem.attributes, elem.scope, elem.minimizeEmpty, elem.child:_*);
   }
 

--- a/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModel.scala
+++ b/spark/interpreter/src/main/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModel.scala
@@ -25,19 +25,19 @@ import org.apache.zeppelin.display.angular.AbstractAngularModel
 class AngularModel(name: String)
   extends org.apache.zeppelin.display.angular.AbstractAngularModel(name) {
 
-  def this(name: String, newValue: Any) = {
+  def this(name: String, newValue: AnyRef) = {
     this(name)
     value(newValue)
   }
 
-  override protected def getAngularObject(): AngularObject[Any] = {
+  override protected def getAngularObject(): AngularObject = {
     registry.get(name,
-      context.getNoteId, context.getParagraphId).asInstanceOf[AngularObject[Any]]
+      context.getNoteId, context.getParagraphId).asInstanceOf[AngularObject]
   }
 
-  override protected def addAngularObject(value: Any): AngularObject[Any] = {
+  override protected def addAngularObject(value: AnyRef): AngularObject = {
     registry.add(name, value,
-      context.getNoteId, context.getParagraphId).asInstanceOf[AngularObject[Any]]
+      context.getNoteId, context.getParagraphId).asInstanceOf[AngularObject]
   }
 }
 
@@ -47,7 +47,7 @@ object AngularModel {
     new AngularModel(name)
   }
 
-  def apply(name: String, newValue: Any): AbstractAngularModel = {
+  def apply(name: String, newValue: AnyRef): AbstractAngularModel = {
     new AngularModel(name, newValue)
   }
 }

--- a/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularElemTest.scala
+++ b/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularElemTest.scala
@@ -142,7 +142,7 @@ trait AbstractAngularElemTest
 
   // simulate click
   def fireEvent(eventName: String, elem: org.apache.zeppelin.display.angular.AbstractAngularElem) = {
-    val angularObject: AngularObject[Any] = elem.angularObjects(eventName);
+    val angularObject: AngularObject = elem.angularObjects(eventName);
     angularObject.set("event");
   }
 }

--- a/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularModelTest.scala
+++ b/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/AbstractAngularModelTest.scala
@@ -41,7 +41,7 @@ with BeforeAndAfter with BeforeAndAfterEach with Eventually {
   }
 
   def angularModel(name: String): AbstractAngularModel
-  def angularModel(name: String, value: Any): AbstractAngularModel
+  def angularModel(name: String, value: AnyRef): AbstractAngularModel
 
   "AngularModel" should "able to create AngularObject" in {
     val registry = InterpreterContext.get().getAngularObjectRegistry

--- a/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModelTest.scala
+++ b/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/notebookscope/AngularModelTest.scala
@@ -26,7 +26,7 @@ class AngularModelTest extends AbstractAngularModelTest {
     AngularModel(name)
   }
 
-  override def angularModel(name: String, value: Any): AbstractAngularModel = {
+  override def angularModel(name: String, value: AnyRef): AbstractAngularModel = {
     AngularModel(name, value)
   }
 }

--- a/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModelTest.scala
+++ b/spark/interpreter/src/test/scala/org/apache/zeppelin/display/angular/paragraphscope/AngularModelTest.scala
@@ -26,7 +26,7 @@ class AngularModelTest extends AbstractAngularModelTest {
     AngularModel(name)
   }
 
-  override def angularModel(name: String, value: Any): AbstractAngularModel = {
+  override def angularModel(name: String, value: AnyRef): AbstractAngularModel = {
     AngularModel(name, value)
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
@@ -17,8 +17,8 @@
 package org.apache.zeppelin.display;
 
 public class AngularObjectBuilder {
-  public static <T> AngularObject<T> build(String varName, T value, String noteId,
+  public static AngularObject build(String varName, Object value, String noteId,
           String paragraphId) {
-    return new AngularObject<>(varName, value, noteId, paragraphId, null);
+    return new AngularObject(varName, value, noteId, paragraphId, null);
   }
 }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/socket/NotebookServerTest.java
@@ -670,7 +670,7 @@ class NotebookServerTest extends AbstractTestRestApi {
 
       when(paragraph.getBindedInterpreter().getInterpreterGroup()).thenReturn(mdGroup);
 
-      final AngularObject<String> ao1 = AngularObjectBuilder.build(varName, value, "noteId",
+      final AngularObject ao1 = AngularObjectBuilder.build(varName, value, "noteId",
               "paragraphId");
 
       when(mdRegistry.addAndNotifyRemoteProcess(varName, value, "noteId", "paragraphId"))
@@ -729,7 +729,7 @@ class NotebookServerTest extends AbstractTestRestApi {
 
       when(paragraph.getBindedInterpreter().getInterpreterGroup()).thenReturn(mdGroup);
 
-      final AngularObject<String> ao1 = AngularObjectBuilder.build(varName, value, "noteId",
+      final AngularObject ao1 = AngularObjectBuilder.build(varName, value, "noteId",
               "paragraphId");
       when(mdRegistry.removeAndNotifyRemoteProcess(varName, "noteId", "paragraphId")).thenReturn(ao1);
       NotebookSocket conn = mock(NotebookSocket.class);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -286,7 +286,7 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
   @Override
   public void addAngularObject(String intpGroupId, String json) throws InterpreterRPCException, TException {
     LOGGER.debug("Add AngularObject, interpreterGroupId: {}, json: {}", intpGroupId, json);
-    AngularObject<?> angularObject = AngularObject.fromJson(json);
+    AngularObject angularObject = AngularObject.fromJson(json);
     InterpreterGroup interpreterGroup =
         interpreterSettingManager.getInterpreterGroupById(intpGroupId);
     if (interpreterGroup == null) {
@@ -314,7 +314,7 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
 
   @Override
   public void updateAngularObject(String intpGroupId, String json) throws InterpreterRPCException, TException {
-    AngularObject<?> angularObject = AngularObject.fromJson(json);
+    AngularObject angularObject = AngularObject.fromJson(json);
     InterpreterGroup interpreterGroup =
         interpreterSettingManager.getInterpreterGroupById(intpGroupId);
     if (interpreterGroup == null) {

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/display/AngularObjectBuilder.java
@@ -19,8 +19,8 @@ package org.apache.zeppelin.display;
 
 public class AngularObjectBuilder {
 
-    public static <T> AngularObject<T> build(String varName, T value, String noteId,
+    public static  AngularObject build(String varName, Object value, String noteId,
                                              String paragraphId) {
-        return new AngularObject<>(varName, value, noteId, paragraphId, null);
+        return new AngularObject(varName, value, noteId, paragraphId, null);
     }
 }

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/ParagraphTest.java
@@ -221,10 +221,10 @@ class ParagraphTest extends AbstractInterpreterTest {
     final Paragraph paragraph = new Paragraph(note, null);
     final String paragraphId = paragraph.getId();
 
-    final AngularObject<String> nameAO = AngularObjectBuilder.build("name", "DuyHai DOAN", noteId,
+    final AngularObject nameAO = AngularObjectBuilder.build("name", "DuyHai DOAN", noteId,
             paragraphId);
 
-    final AngularObject<Integer> ageAO = AngularObjectBuilder.build("age", 34, noteId, null);
+    final AngularObject ageAO = AngularObjectBuilder.build("age", 34, noteId, null);
 
     when(note.getId()).thenReturn(noteId);
     when(registry.get("name", noteId, paragraphId)).thenReturn(nameAO);


### PR DESCRIPTION
### What is this PR for?
This pull request removes the raw use of the AngularObject. The generic version has been removed. AngularObject now contains an object reference.
As a result, warnings from the IDE due to raw use disappear. The code is also easier to read.


### What type of PR is it?
 - Refactoring

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6077

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
