### PR TITLE
[ZEPPELIN-6079] Fix Interpreter Configuration not working in new UI

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/interpreter/item/item.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/interpreter/item/item.component.ts
@@ -291,9 +291,10 @@ export class InterpreterItemComponent extends DestroyHookComponent implements On
 
       // set dependencies fields
       this.interpreter.dependencies.forEach(e => {
+        const exclusions = Array.isArray(e.exclusions) ? e.exclusions : [];
         this.dependenciesFormArray.push(
           this.formBuilder.group({
-            exclusions: [e.exclusions.join(',')],
+            exclusions: [exclusions.join(',')],
             groupArtifactVersion: [e.groupArtifactVersion, [Validators.required]]
           })
         );


### PR DESCRIPTION
### What is this PR for?
There was an error in the new UI, that if dependencies of a interpreter was set in old UI, user could not see and edit the interpreter in new UI. More details about the issue can be seen in the comments [HERE](https://github.com/apache/zeppelin/pull/4727)


**Before**
Congifuring interpreter in old UI:
<img width="1512" alt="Screenshot 2024-09-07 at 3 19 55 AM" src="https://github.com/user-attachments/assets/db51e93a-cf9c-4913-9c32-3c765cdb8dae">

Not being able to interact with the configured interpreter in new UI:
![Screen Recording 2024-09-07 at 3 22 38 AM](https://github.com/user-attachments/assets/b3db8a80-0bdb-40d6-873a-501a9b828c1a)

**After**
Successfully can view and edit the configuration in new UI:
![Screen Recording 2024-09-07 at 3 27 19 AM](https://github.com/user-attachments/assets/328af01b-d119-4f0f-ac8a-1ec7306a7bd7)
(Please don't mind the logs starting with '#####' and 'EXCLUSIONS' - I forgot to remove it when taking the screenshot)



### What type of PR is it?
Bug Fix


### Todos
* [x] - Fix error

### What is the Jira issue?
[ZEPPELIN-6079](https://issues.apache.org/jira/browse/ZEPPELIN-6079)

### How should this be tested?
* Build and test - configure an interpreter via the old UI, and then switch to the new UI to verify that dependencies are now visible and editable.


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
