### PR TITLE
[ZEPPELIN-6067] Add docker-compose file for running with Spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ tramp
 
 # pyenv file
 .python-version
+
+# Spark Binary File
+scripts/docker/zeppelin-quick-start/spark-*

--- a/scripts/docker/zeppelin-quick-start/README.md
+++ b/scripts/docker/zeppelin-quick-start/README.md
@@ -6,12 +6,12 @@
 Please go to [install](https://www.docker.com/) to install Docker.
 
 ### Zeppelin Only
-#### Run docker-compose
+#### Run docker compose
 ```bash
 docker compose -f docker-compose-zeppelin-only.yml up
 ```
 
-#### Stop docker-compose
+#### Stop docker compose
 ```bash
 docker compose -f docker-compose-zeppelin-only.yml stop
 ```
@@ -26,4 +26,82 @@ docker compose -f docker-compose-zeppelin-only.yml stop
       ZEPPELIN_JMX_ENABLE: false # Enable JMX by defining "true"
       ZEPPELIN_JMX_PORT: 9996 # Port number which JMX uses
       ZEPPELIN_MEM: -Xmx1024m -XX:MaxMetaspaceSize=512m # JVM mem options
+```
+
+### Zeppelin With Apache Spark
+#### Install Spark Binary File
+```bash
+cd scripts/docker/zeppelin-quick-start
+wget https://archive.apache.org/dist/spark/spark-3.2.4/spark-3.2.4-bin-hadoop3.2.tgz
+tar -xvf spark-3.2.4-bin-hadoop3.2.tgz
+```
+
+#### Run docker compose
+```bash
+docker compose -f docker-compose-with-spark.yml up
+```
+
+#### Stop docker compose
+```bash
+docker compose -f docker-compose-with-spark.yml stop
+```
+
+#### Example
+```
+%spark.conf
+
+SPARK_HOME /opt/spark
+spark.master spark://spark-master:7077
+```
+```
+%spark
+
+val sdf = spark.createDataFrame(Seq((0, "park", 13, 70, "Korea"), (1, "xing", 14, 80, "China"), (2, "john", 15, 90, "USA"))).toDF("id", "name", "age", "score", "country")
+sdf.printSchema
+sdf.show()
+```
+```
+root
+ |-- id: integer (nullable = false)
+ |-- name: string (nullable = true)
+ |-- age: integer (nullable = false)
+ |-- score: integer (nullable = false)
+ |-- country: string (nullable = true)
+
++---+----+---+-----+-------+
+| id|name|age|score|country|
++---+----+---+-----+-------+
+|  0|park| 13|   70|  Korea|
+|  1|xing| 14|   80|  China|
+|  2|john| 15|   90|    USA|
++---+----+---+-----+-------+
+```
+
+### Apache Spark Environment Variables
+Please check the [link](https://github.com/bitnami/containers/blob/main/bitnami/spark/README.md) for more details
+
+```dockerfile
+  spark-master:
+    environment:
+      SPARK_MODE: master # Spark cluster mode to run (can be master or worker)	
+      SPARK_RPC_AUTHENTICATION_ENABLED: no # Enable RPC authentication	
+      SPARK_RPC_ENCRYPTION_ENABLED: no # Enable RPC encryption
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no # Enable local storage encryption	
+      SPARK_SSL_ENABLED: no # Enable SSL configuration
+      SPARK_USER: spark # Spark user
+      SPARK_MASTER_PORT: 7077
+      SPARK_MASTER_WEBUI_PORT: 8080
+
+  spark-worker:
+    environment:
+      SPARK_MODE: worker # Spark cluster mode to run (can be master or worker)
+      SPARK_MASTER_URL: spark://spark-master:7077 # Url where the worker can find the master. Only needed when spark mode is worker.
+      SPARK_WORKER_MEMORY: 2G
+      SPARK_WORKER_CORES: 2
+      SPARK_RPC_AUTHENTICATION_ENABLED: no # Enable RPC authentication
+      SPARK_RPC_ENCRYPTION_ENABLED: no # Enable RPC encryption
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no # Enable local storage encryption
+      SPARK_SSL_ENABLED: no # Enable SSL configuration
+      SPARK_USER: spark # Spark user
+      SPARK_WORKER_WEBUI_PORT: 8081
 ```

--- a/scripts/docker/zeppelin-quick-start/docker-compose-with-spark.yml
+++ b/scripts/docker/zeppelin-quick-start/docker-compose-with-spark.yml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+services:
+  zeppelin:
+    hostname: zeppelin
+    container_name: zeppelin
+    image: docker.io/apache/zeppelin:0.10.1
+    ports:
+      - "8080:8080"
+    environment:
+      ZEPPELIN_PORT: 8080
+      ZEPPELIN_MEM: -Xmx1024m -XX:MaxMetaspaceSize=512m
+      SPARK_HOME: /opt/spark
+    volumes:
+      - ./spark-3.2.4-bin-hadoop3.2:/opt/spark
+
+  spark-master:
+    hostname: spark-master
+    container_name: spark-master
+    image: docker.io/bitnami/spark:3.2.4
+    ports:
+      - "18080:8080"
+      - "7077:7077"
+    environment:
+      SPARK_MODE: master
+      SPARK_RPC_AUTHENTICATION_ENABLED: no
+      SPARK_RPC_ENCRYPTION_ENABLED: no
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
+      SPARK_SSL_ENABLED: no
+      SPARK_USER: spark
+      SPARK_MASTER_PORT: 7077
+      SPARK_MASTER_WEBUI_PORT: 8080
+
+  spark-worker:
+    hostname: spark-worker
+    container_name: spark-worker
+    image: docker.io/bitnami/spark:3.2.4
+    ports:
+      - "18081:8081"
+    environment:
+      SPARK_MODE: worker
+      SPARK_MASTER_URL: spark://spark-master:7077
+      SPARK_WORKER_MEMORY: 2G
+      SPARK_WORKER_CORES: 2
+      SPARK_RPC_AUTHENTICATION_ENABLED: no
+      SPARK_RPC_ENCRYPTION_ENABLED: no
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
+      SPARK_SSL_ENABLED: no
+      SPARK_USER: spark
+      SPARK_WORKER_WEBUI_PORT: 8081
+    depends_on:
+      - spark-master


### PR DESCRIPTION
### What is this PR for?
Provide a YAML file that creates Apache Zeppelin and Apache Spark containers together using the `docker compose` command.

### What type of PR is it?
Improvement

### Todos
* [ ] - Update .gitignore
* [ ] - Add docker-compose-with-spark.yml
* [ ] - Update READMD.md

### What is the Jira issue?
https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6067

### How should this be tested?
* docker compose -f docker-compose-with-spark.yml up
* Run paragraph
```
%spark.conf

SPARK_HOME /opt/spark
spark.master spark://spark-master:7077
```
* Run paragraph
```
%spark

val sdf = spark.createDataFrame(Seq((0, "park", 13, 70, "Korea"), (1, "xing", 14, 80, "China"), (2, "john", 15, 90, "USA"))).toDF("id", "name", "age", "score", "country")
sdf.printSchema
sdf.show()
```
* Result
```
root
 |-- id: integer (nullable = false)
 |-- name: string (nullable = true)
 |-- age: integer (nullable = false)
 |-- score: integer (nullable = false)
 |-- country: string (nullable = true)

+---+----+---+-----+-------+
| id|name|age|score|country|
+---+----+---+-----+-------+
|  0|park| 13|   70|  Korea|
|  1|xing| 14|   80|  China|
|  2|john| 15|   90|    USA|
+---+----+---+-----+-------+
```

### Screenshots (if appropriate)
* Zeppelin UI (http://localhost:8080)
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/bb270d81-510e-4810-baa3-0438cb7753cd">

* Spark Master UI (http://localhost:18080)
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/fb1469b5-17e2-4530-ad81-83a92183a341">

* Spark Worker UI (http://localhost:18081)
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/cd1f7625-ca77-4bd8-b89d-7cf2647cd924">

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
