### PR TITLE
[NO-ISSUE] Implement Origin check for terminal interpreter WebSocket connections

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
@@ -141,7 +141,8 @@ public class TerminalInterpreter extends KerberosInterpreter {
       mapIpMapping = gson.fromJson(strIpMapping, new TypeToken<Map<String, String>>(){}.getType());
     }
 
-    createTerminalDashboard(context.getNoteId(), context.getParagraphId(), terminalHostIp, terminalPort);
+    createTerminalDashboard(context.getNoteId(), context.getParagraphId(),
+        terminalHostIp, terminalPort);
 
     return new InterpreterResult(Code.SUCCESS);
   }

--- a/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/TerminalInterpreter.java
@@ -247,6 +247,11 @@ public class TerminalInterpreter extends KerberosInterpreter {
   }
 
   @VisibleForTesting
+  public String getTerminalHostIp() {
+    return terminalHostIp;
+  }
+
+  @VisibleForTesting
   public boolean terminalThreadIsRunning() {
     return terminalThread.isRunning();
   }

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
@@ -18,7 +18,9 @@
 package org.apache.zeppelin.shell.terminal;
 
 import javax.websocket.server.ServerContainer;
+import javax.websocket.server.ServerEndpointConfig;
 
+import org.apache.zeppelin.shell.terminal.websocket.TerminalSessionConfigurator;
 import org.apache.zeppelin.shell.terminal.websocket.TerminalSocket;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -72,7 +74,10 @@ public class TerminalThread extends Thread {
 
     try {
       ServerContainer container = WebSocketServerContainerInitializer.configureContext(context);
-      container.addEndpoint(TerminalSocket.class);
+      container.addEndpoint(
+          ServerEndpointConfig.Builder.create(TerminalSocket.class, "/")
+              .configurator(new TerminalSessionConfigurator())
+              .build());
       jettyServer.start();
       jettyServer.join();
     } catch (Exception e) {

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/TerminalThread.java
@@ -40,9 +40,11 @@ public class TerminalThread extends Thread {
   private Server jettyServer = new Server();
 
   private int port = 0;
+  private String allwedOrigin;
 
-  public TerminalThread(int port) {
+  public TerminalThread(int port, String allwedOrigin) {
     this.port = port;
+    this.allwedOrigin = allwedOrigin;
   }
 
   public void run() {
@@ -76,7 +78,7 @@ public class TerminalThread extends Thread {
       ServerContainer container = WebSocketServerContainerInitializer.configureContext(context);
       container.addEndpoint(
           ServerEndpointConfig.Builder.create(TerminalSocket.class, "/")
-              .configurator(new TerminalSessionConfigurator())
+              .configurator(new TerminalSessionConfigurator(allwedOrigin))
               .build());
       jettyServer.start();
       jettyServer.join();

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -34,7 +34,6 @@ public class TerminalSessionConfigurator  extends Configurator {
     boolean allowed = allowedOrigin.equals(originHeaderValue);
     LOGGER.info("Checking origin for TerminalSessionConfigurator: " +
         originHeaderValue + " allowed: " + allowed);
-    LOGGER.info("Allowed origin: " + allowedOrigin);
     return allowed;
   }
 }

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.shell.terminal.websocket;
 
 import javax.websocket.server.ServerEndpointConfig.Configurator;

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -1,0 +1,15 @@
+package org.apache.zeppelin.shell.terminal.websocket;
+
+import javax.websocket.server.ServerEndpointConfig.Configurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TerminalSessionConfigurator  extends Configurator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TerminalSessionConfigurator.class);
+
+  @Override
+  public boolean checkOrigin(String originHeaderValue) {
+    LOGGER.info("TerminalSessionConfigurator checkOrigin: " + originHeaderValue);
+    return super.checkOrigin(originHeaderValue);
+  }
+}

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -6,10 +6,16 @@ import org.slf4j.LoggerFactory;
 
 public class TerminalSessionConfigurator  extends Configurator {
   private static final Logger LOGGER = LoggerFactory.getLogger(TerminalSessionConfigurator.class);
+  private String allowedOrigin;
+
+  public TerminalSessionConfigurator(String allowedOrigin) {
+    this.allowedOrigin = allowedOrigin;
+  }
 
   @Override
   public boolean checkOrigin(String originHeaderValue) {
-    LOGGER.info("TerminalSessionConfigurator checkOrigin: " + originHeaderValue);
-    return super.checkOrigin(originHeaderValue);
+    boolean allowed = allowedOrigin.equals(originHeaderValue);
+    LOGGER.info("Checking origin for TerminalSessionConfigurator: " + originHeaderValue + " allowed: " + allowed);
+    return allowed;
   }
 }

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -16,6 +16,7 @@ public class TerminalSessionConfigurator  extends Configurator {
   public boolean checkOrigin(String originHeaderValue) {
     boolean allowed = allowedOrigin.equals(originHeaderValue);
     LOGGER.info("Checking origin for TerminalSessionConfigurator: " + originHeaderValue + " allowed: " + allowed);
+    LOGGER.info("Allowed origin: " + allowedOrigin);
     return allowed;
   }
 }

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSessionConfigurator.java
@@ -32,7 +32,8 @@ public class TerminalSessionConfigurator  extends Configurator {
   @Override
   public boolean checkOrigin(String originHeaderValue) {
     boolean allowed = allowedOrigin.equals(originHeaderValue);
-    LOGGER.info("Checking origin for TerminalSessionConfigurator: " + originHeaderValue + " allowed: " + allowed);
+    LOGGER.info("Checking origin for TerminalSessionConfigurator: " +
+        originHeaderValue + " allowed: " + allowed);
     LOGGER.info("Allowed origin: " + allowedOrigin);
     return allowed;
   }

--- a/shell/src/test/java/org/apache/zeppelin/shell/TerminalInterpreterTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/TerminalInterpreterTest.java
@@ -28,7 +28,6 @@ import org.apache.zeppelin.interpreter.InterpreterException;
 import org.apache.zeppelin.interpreter.InterpreterResult;
 import org.apache.zeppelin.shell.terminal.TerminalSocketTest;
 import org.eclipse.jetty.util.component.LifeCycle;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -351,7 +350,7 @@ class TerminalInterpreterTest extends BaseInterpreterTest {
     assertEquals("Connect failure", exception.getMessage());
   }
 
-  private static @NotNull ClientEndpointConfig getOriginRequestHeaderConfig(String origin) {
+  private static ClientEndpointConfig getOriginRequestHeaderConfig(String origin) {
     Configurator configurator = new Configurator() {
       @Override
       public void beforeRequest(Map<String, List<String>> headers) {

--- a/shell/src/test/java/org/apache/zeppelin/shell/terminal/TerminalSocketTest.java
+++ b/shell/src/test/java/org/apache/zeppelin/shell/terminal/TerminalSocketTest.java
@@ -17,49 +17,40 @@
 
 package org.apache.zeppelin.shell.terminal;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.websocket.CloseReason;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.websocket.ClientEndpoint;
-import javax.websocket.CloseReason;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
-import java.util.ArrayList;
-import java.util.List;
-
-@ClientEndpoint
-@ServerEndpoint(value = "/")
-public class TerminalSocketTest {
+public class TerminalSocketTest extends Endpoint {
   private static final Logger LOGGER = LoggerFactory.getLogger(TerminalSocketTest.class);
 
   public static final List<String> ReceivedMsg = new ArrayList();
 
-  @OnOpen
-  public void onWebSocketConnect(Session sess)
-  {
-    LOGGER.info("Socket Connected: " + sess);
+  @Override
+  public void onOpen(Session session, EndpointConfig endpointConfig) {
+    LOGGER.info("Socket Connected: " + session);
+
+    session.addMessageHandler(new javax.websocket.MessageHandler.Whole<String>() {
+      @Override
+      public void onMessage(String message) {
+        LOGGER.info("Received TEXT message: " + message);
+        ReceivedMsg.add(message);
+      }
+    });
   }
 
-  @OnMessage
-  public void onWebSocketText(String message)
-  {
-    LOGGER.info("Received TEXT message: " + message);
-    ReceivedMsg.add(message);
+  @Override
+  public void onClose(Session session, CloseReason closeReason) {
+    LOGGER.info("Socket Closed: " + closeReason);
   }
 
-  @OnClose
-  public void onWebSocketClose(CloseReason reason)
-  {
-    LOGGER.info("Socket Closed: " + reason);
-  }
-
-  @OnError
-  public void onWebSocketError(Throwable cause)
-  {
+  @Override
+  public void onError(Session session, Throwable cause) {
     LOGGER.error(cause.getMessage(), cause);
   }
 }


### PR DESCRIPTION
### What is this PR for?

This PR adds an Origin check to ensure that WebSocket connections are initiated from trusted sources only.
By validating the `Origin` header in the initial WebSocket handshake, we can prevent unauthorized or malicious websites from establishing WebSocket connections with our server.

Changes:
- Added server-side validation of the `Origin` header during WebSocket connection requests.

Other security enhancements may be needed and can be handled in future iterations.

### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
