### PR TITLE
[ZEPPELIN-6085] Add configuration option for setting the default UI

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -56,6 +56,12 @@
 </property>
 
 <property>
+  <name>zeppelin.default.ui</name>
+  <value>new</value>
+  <description>Default UI for Zeppelin. Options: classic or new</description>
+</property>
+
+<property>
   <name>zeppelin.notebook.dir</name>
   <value>notebook</value>
   <description>path or URI for notebook persist</description>

--- a/docs/quickstart/explore_ui.md
+++ b/docs/quickstart/explore_ui.md
@@ -35,6 +35,21 @@ Afterward, you can switch to the classic UI via the `Swtich to Classic UI` butto
 
 <img src="{{BASE_PATH}}/assets/themes/zeppelin/img/ui-img/switch_to_classic_ui.png" width="130" />
 
+
+### Configuring the default UI
+
+Zeppelin allows you to configure the default, especially for users who prefer the classic UI.
+
+To set the default UI to classic, add the following property to the `zeppelin-site.xml` file:
+
+```xml
+<property>
+  <name>zeppelin.default.ui</name>
+  <value>classic</value>
+  <description>Default UI for Zeppelin. Options: classic or new. Default configuration is 'new'</description>
+</property>
+```
+
 ## Main home
 
 The first time you connect to Zeppelin ([default installations start on http://localhost:8080](http://localhost:8080/)), you'll land at the main page similar to the below screen capture.

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -218,6 +218,12 @@ Sources descending by priority:
     <td>Location of the jetty temporary directory</td>
   </tr>
   <tr>
+    <td><h6 class="properties">ZEPPELIN_DEFAULT_UI</h6></td>
+    <td><h6 class="properties">zeppelin.default.ui</h6></td>
+    <td>new</td>
+    <td>Default UI for Zeppelin. <br />Options: <code>classic</code> or <code>new</code></td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_NOTEBOOK_DIR</h6></td>
     <td><h6 class="properties">zeppelin.notebook.dir</h6></td>
     <td>notebook</td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -80,6 +80,11 @@ public class ZeppelinConfiguration {
     DOCKER
   }
 
+  public enum DEFAULT_UI {
+    NEW,
+    CLASSIC
+  }
+
   // private constructor, so that it is singleton.
   private ZeppelinConfiguration(@Nullable String filename) {
      try {
@@ -903,6 +908,10 @@ public class ZeppelinConfiguration {
 
   public boolean isPrometheusMetricEnabled() {
     return getBoolean(ConfVars.ZEPPELIN_METRIC_ENABLE_PROMETHEUS);
+  }
+
+  public DEFAULT_UI getDefaultUi() {
+    return DEFAULT_UI.valueOf(getString(ConfVars.ZEPPELIN_DEFAULT_UI).toUpperCase());
   }
 
   /**

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -965,6 +965,8 @@ public class ZeppelinConfiguration {
     ZEPPELIN_WAR("zeppelin.war", "zeppelin-web/dist"),
     ZEPPELIN_ANGULAR_WAR("zeppelin.angular.war", "zeppelin-web-angular/dist/zeppelin"),
     ZEPPELIN_WAR_TEMPDIR("zeppelin.war.tempdir", "webapps"),
+    // "new" or "classic"
+    ZEPPELIN_DEFAULT_UI("zeppelin.default.ui", "new"),
     ZEPPELIN_JMX_ENABLE("zeppelin.jmx.enable", false),
     ZEPPELIN_JMX_PORT("zeppelin.jmx.port", 9996),
 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -158,7 +158,6 @@ public class ZeppelinServer implements AutoCloseable {
     jettyWebServer = setupJettyServer();
     sharedServiceLocator = ServiceLocatorFactory.getInstance().create(serviceLocatorName);
     storage = ConfigStorage.createConfigStorage(zConf);
-
   }
 
   public void startZeppelin() {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -90,7 +90,6 @@ import org.apache.zeppelin.notebook.scheduler.NoSchedulerService;
 import org.apache.zeppelin.notebook.scheduler.QuartzSchedulerService;
 import org.apache.zeppelin.notebook.scheduler.SchedulerService;
 import org.apache.zeppelin.plugin.PluginManager;
-import org.apache.zeppelin.rest.exception.WebApplicationExceptionMapper;
 import org.apache.zeppelin.search.LuceneSearch;
 import org.apache.zeppelin.search.NoSearchService;
 import org.apache.zeppelin.search.SearchService;
@@ -143,8 +142,8 @@ public class ZeppelinServer implements AutoCloseable {
   private final Server jettyWebServer;
   private final ServiceLocator sharedServiceLocator;
   private final ConfigStorage storage;
-  private final String classicWebAppContextPath;
-  private final String newWebAppContextPath;
+  private final String classicUiWebAppContextPath;
+  private final String newUiWebAppContextPath;
 
   public ZeppelinServer(ZeppelinConfiguration zConf) throws IOException {
     this(zConf, DEFAULT_SERVICE_LOCATOR_NAME);
@@ -162,11 +161,11 @@ public class ZeppelinServer implements AutoCloseable {
     sharedServiceLocator = ServiceLocatorFactory.getInstance().create(serviceLocatorName);
     storage = ConfigStorage.createConfigStorage(zConf);
     if (isNewUiDefault(zConf)) {
-      classicWebAppContextPath = NON_DEFAULT_CLASSIC_UI_WEB_APP_CONTEXT_PATH;
-      newWebAppContextPath = zConf.getServerContextPath();
+      classicUiWebAppContextPath = NON_DEFAULT_CLASSIC_UI_WEB_APP_CONTEXT_PATH;
+      newUiWebAppContextPath = zConf.getServerContextPath();
     } else {
-      classicWebAppContextPath = zConf.getServerContextPath();
-      newWebAppContextPath = NON_DEFAULT_NEW_UI_WEB_APP_CONTEXT_PATH;
+      classicUiWebAppContextPath = zConf.getServerContextPath();
+      newUiWebAppContextPath = NON_DEFAULT_NEW_UI_WEB_APP_CONTEXT_PATH;
     }
   }
 
@@ -237,11 +236,13 @@ public class ZeppelinServer implements AutoCloseable {
         });
 
     // Multiple Web UI
-    final WebAppContext defaultWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_ANGULAR_WAR), newWebAppContextPath);
-    final WebAppContext classicWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_WAR), classicWebAppContextPath);
+    final WebAppContext newUiWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_ANGULAR_WAR),
+        newUiWebAppContextPath);
+    final WebAppContext classicUiWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_WAR),
+        classicUiWebAppContextPath);
 
-    initWebApp(defaultWebApp);
-    initWebApp(classicWebApp);
+    initWebApp(newUiWebApp);
+    initWebApp(classicUiWebApp);
 
     NotebookRepo repo =
         ServiceLocatorUtilities.getService(sharedServiceLocator, NotebookRepo.class.getName());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -142,8 +142,6 @@ public class ZeppelinServer implements AutoCloseable {
   private final Server jettyWebServer;
   private final ServiceLocator sharedServiceLocator;
   private final ConfigStorage storage;
-  private final String classicUiWebAppContextPath;
-  private final String newUiWebAppContextPath;
 
   public ZeppelinServer(ZeppelinConfiguration zConf) throws IOException {
     this(zConf, DEFAULT_SERVICE_LOCATOR_NAME);
@@ -160,13 +158,7 @@ public class ZeppelinServer implements AutoCloseable {
     jettyWebServer = setupJettyServer();
     sharedServiceLocator = ServiceLocatorFactory.getInstance().create(serviceLocatorName);
     storage = ConfigStorage.createConfigStorage(zConf);
-    if (isNewUiDefault(zConf)) {
-      classicUiWebAppContextPath = NON_DEFAULT_CLASSIC_UI_WEB_APP_CONTEXT_PATH;
-      newUiWebAppContextPath = zConf.getServerContextPath();
-    } else {
-      classicUiWebAppContextPath = zConf.getServerContextPath();
-      newUiWebAppContextPath = NON_DEFAULT_NEW_UI_WEB_APP_CONTEXT_PATH;
-    }
+
   }
 
   public void startZeppelin() {
@@ -236,6 +228,15 @@ public class ZeppelinServer implements AutoCloseable {
         });
 
     // Multiple Web UI
+    String classicUiWebAppContextPath;
+    String newUiWebAppContextPath;
+    if (isNewUiDefault(zConf)) {
+      classicUiWebAppContextPath = NON_DEFAULT_CLASSIC_UI_WEB_APP_CONTEXT_PATH;
+      newUiWebAppContextPath = zConf.getServerContextPath();
+    } else {
+      classicUiWebAppContextPath = zConf.getServerContextPath();
+      newUiWebAppContextPath = NON_DEFAULT_NEW_UI_WEB_APP_CONTEXT_PATH;
+    }
     final WebAppContext newUiWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_ANGULAR_WAR),
         newUiWebAppContextPath);
     final WebAppContext classicUiWebApp = setupWebAppContext(contexts, zConf, zConf.getString(ConfVars.ZEPPELIN_WAR),
@@ -345,7 +346,6 @@ public class ZeppelinServer implements AutoCloseable {
       }
     }
   }
-
   private void initMetrics() {
     if (zConf.isJMXEnabled()) {
       Metrics.addRegistry(new JmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM));

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -650,7 +650,7 @@ public class ZeppelinServer implements AutoCloseable {
       webApp.setTempDirectory(warTempDirectory);
     }
     // Explicit bind to root
-    webApp.addServlet(new ServletHolder(new IndexHtmlServlet(zConf)), "/index.html");
+    webApp.addServlet(new ServletHolder(new IndexHtmlServlet(zConf, contextPath)), "/index.html");
     contexts.addHandler(webApp);
 
     webApp.addFilter(new FilterHolder(new CorsFilter(zConf)), "/*", EnumSet.allOf(DispatcherType.class));

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -360,6 +360,7 @@ public class ZeppelinServer implements AutoCloseable {
     new UptimeMetrics().bindTo(Metrics.globalRegistry);
     new JVMInfoBinder().bindTo(Metrics.globalRegistry);
   }
+
   public void shutdown(int exitCode) {
     if (!duringShutdown.getAndSet(true)) {
       LOGGER.info("Shutting down Zeppelin Server ... - ExitCode {}", exitCode);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/server/IndexHtmlServletTest.java
@@ -56,7 +56,7 @@ class IndexHtmlServletTest {
         .thenReturn(new URL("file:" + FILE_PATH_INDEX_HTML_ZEPPELIN_WEB));
       when(sc.getServletContext()).thenReturn(ctx);
 
-      IndexHtmlServlet servlet = new IndexHtmlServlet(zConf);
+      IndexHtmlServlet servlet = new IndexHtmlServlet(zConf, null);
       servlet.init(sc);
 
       HttpServletResponse mockResponse = mock(HttpServletResponse.class);
@@ -90,7 +90,7 @@ class IndexHtmlServletTest {
         .thenReturn(new URL("file:" + FILE_PATH_INDEX_HTML_ZEPPELIN_WEB_ANGULAR));
       when(sc.getServletContext()).thenReturn(ctx);
 
-      IndexHtmlServlet servlet = new IndexHtmlServlet(zConf);
+      IndexHtmlServlet servlet = new IndexHtmlServlet(zConf, null);
       servlet.init(sc);
 
       HttpServletResponse mockResponse = mock(HttpServletResponse.class);

--- a/zeppelin-web-angular/package.json
+++ b/zeppelin-web-angular/package.json
@@ -5,7 +5,7 @@
     "postinstall": "npm run build:projects",
     "ng": "./node_modules/.bin/ng",
     "start": "ng serve --proxy-config proxy.conf.js --extra-webpack-config webpack.partial.js",
-    "build": "ng build --prod --extra-webpack-config webpack.partial.js --base-href /",
+    "build": "ng build --prod --extra-webpack-config webpack.partial.js",
     "build:projects": "npm run build-project:sdk && npm run build-project:vis && npm run build-project:helium",
     "build-helium-vis-example": " ng build --project helium-vis-example",
     "build-project:sdk": " ng build --project zeppelin-sdk",

--- a/zeppelin-web-angular/src/app/share/header/header.component.html
+++ b/zeppelin-web-angular/src/app/share/header/header.component.html
@@ -67,7 +67,7 @@
           <li nz-menu-item (click)="logout()">Logout</li>
         </ng-container>
         <li nz-menu-divider></li>
-        <li nz-menu-item><a href="/classic">Switch to Classic UI</a></li>
+        <li nz-menu-item><a [href]="classicUiHref">Switch to Classic UI</a></li>
       </ul>
     </nz-dropdown-menu>
   </div>

--- a/zeppelin-web-angular/src/app/share/header/header.component.ts
+++ b/zeppelin-web-angular/src/app/share/header/header.component.ts
@@ -34,6 +34,7 @@ export class HeaderComponent extends MessageListenersManager implements OnInit, 
   connectStatus = 'error';
   noteListVisible = false;
   queryStr: string | null = null;
+  classicUiHref: string;
 
   about() {
     this.nzModalService.create({
@@ -69,6 +70,7 @@ export class HeaderComponent extends MessageListenersManager implements OnInit, 
     private cdr: ChangeDetectorRef
   ) {
     super(messageService);
+    this.classicUiHref = this.resolveClassicUiHref();
   }
 
   ngOnInit() {
@@ -97,5 +99,13 @@ export class HeaderComponent extends MessageListenersManager implements OnInit, 
     this.destroy$.next();
     this.destroy$.complete();
     super.ngOnDestroy();
+  }
+
+  private resolveClassicUiHref() {
+    if (location.pathname === '/') {
+      return '/classic';
+    } else {
+      return '/';
+    }
   }
 }

--- a/zeppelin-web-angular/src/index.html
+++ b/zeppelin-web-angular/src/index.html
@@ -17,7 +17,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="./assets/images/zeppelin.png" type="image/x-icon">
   <title>Zeppelin</title>
-  <base href="/">
 </head>
 <body>
 <zeppelin-root>

--- a/zeppelin-web-angular/src/index.html
+++ b/zeppelin-web-angular/src/index.html
@@ -43,6 +43,14 @@
         "HTML-CSS": { availableFonts: ["TeX"] },
         messageStyle: "none"
       }
+      const origin = window.location.origin;
+      const pathname = window.location.pathname;
+      config.root = window.location.origin + (
+        // remove trailing slash
+        pathname.charAt(pathname.length - 1) === '/' ?
+          pathname.slice(0, -1) :
+          pathname
+      );
       MathJax.Hub.Config(config);
     </script>
 </body>

--- a/zeppelin-web/src/components/navbar/navbar.controller.js
+++ b/zeppelin-web/src/components/navbar/navbar.controller.js
@@ -270,6 +270,14 @@ function NavCtrl($scope, $rootScope, $http, $routeParams, $location,
     }
   });
 
+  $scope.resolveNewUiHref = function() {
+    if (location.pathname === '/') {
+      return '/new';
+    } else {
+      return '/';
+    }
+  };
+
   $rootScope.isRevisionSupported = function() {
     return revisionSupported;
   };

--- a/zeppelin-web/src/components/navbar/navbar.html
+++ b/zeppelin-web/src/components/navbar/navbar.html
@@ -106,7 +106,7 @@ limitations under the License.
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'" role="separator" style="margin: 5px 0;" class="divider"></li>
               <li ng-if="ticket.principal && ticket.principal !== 'anonymous'"><a ng-click="navbar.logout()">Logout</a></li>
               <li role="separator" style="margin: 5px 0;" class="divider"></li>
-              <li><a href="/">Switch to Default UI</a></li>
+              <li><a ng-href="{{ resolveNewUiHref() }}">Switch to Default UI</a></li>
             </ul>
           </div>
         </li>

--- a/zeppelin-web/src/index.html
+++ b/zeppelin-web/src/index.html
@@ -159,7 +159,14 @@ limitations under the License.
       }
       // add root only if it's not dev mode
       if (Number(location.port) !== WEB_PORT) {
-        config.root = '.';
+        const origin = window.location.origin;
+        const pathname = window.location.pathname;
+        config.root = window.location.origin + (
+          // remove trailing slash
+          pathname.charAt(pathname.length - 1) === '/' ?
+            pathname.slice(0, -1) :
+            pathname
+        );
       }
       MathJax.Hub.Config(config);
     </script>


### PR DESCRIPTION
### What is this PR for?

This PR introduces a new configuration option `zeppelin.default.ui` to set the default UI for Zeppelin.
The available options for this setting are `new` and `classic`.
By default, the value is set to `new`, meaning the new UI will be served at the root path (`"/"`), while the classic UI will be available at `"/classic"`.
If the configuration is set to `classic`, the classic UI will be served at `"/"`, and the new UI at `"/new"`.


### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6085
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
- Testing the `new` option :
  - Set the `zeppelin.default.ui` config to `new` (the default).
  - Verify that the new UI is served at the root (`"/"`) and the classic UI is available at `"/classic"`.
  - Verify that navigating between pages works without any issue.
  - Verify that the UI switching button works properly in both UIs.
- Testing `classic` option :
  - Similar steps as the above, except the new UI is served at `"/classic"` and the classic UI is available at the root (`"/"`)

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, documentation for the new configuration option has been added.
