### PR TITLE
[ZEPPELIN-6086] Unofficial support for Spark 4.0

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -360,6 +360,8 @@ jobs:
             java: 8
           - python: 3.8
             java: 8
+          - python: 3.9
+            java: 17
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -398,30 +400,40 @@ jobs:
         run: |
           R -e "IRkernel::installspec()"
       - name: run spark-3.2 tests with scala-2.12 and python-${{ matrix.python }}
+        if: matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.2 -Pspark-scala-2.12 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.2 tests with scala-2.13 and python-${{ matrix.python }}
+        if: matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.2 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.3 tests with scala-2.12 and python-${{ matrix.python }}
+        if: matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.3 -Pspark-scala-2.12 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.3 tests with scala-2.13 and python-${{ matrix.python }}
+        if: matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.3 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.4 tests with scala-2.13 and python-${{ matrix.python }}
+        if: matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.4 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.5 tests with scala-2.13 and python-${{ matrix.python }}
-        if: matrix.python >= '3.8'
+        if: matrix.python >= '3.8' && matrix.java <= '11'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.5 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
+      - name: run spark-4.0 tests with scala-2.13 and python-${{ matrix.python }}
+        if: matrix.java >= '17'
+        run: |
+          rm -rf spark/interpreter/metastore_db
+          ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-4.0 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
 
   # The version combination is based on the facts:
   # 1. official Livy 0.8 binary tarball is built against Spark 2.4

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -425,7 +425,7 @@ jobs:
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.4 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}
       - name: run spark-3.5 tests with scala-2.13 and python-${{ matrix.python }}
-        if: matrix.python >= '3.8' && matrix.java <= '11'
+        if: matrix.python >= '3.8'
         run: |
           rm -rf spark/interpreter/metastore_db
           ./mvnw verify -pl spark-submit,spark/interpreter -am -Dtest=org/apache/zeppelin/spark/* -Pspark-3.5 -Pspark-scala-2.13 -Phadoop3 -Pintegration -DfailIfNoTests=false ${MAVEN_ARGS}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # metals
 .bloop
 .metals
+.venv
 
 # interpreter temp files
 derby.log

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -64,27 +64,7 @@
     <pyspark.test.exclude>**/PySparkInterpreterMatplotlibTest.java</pyspark.test.exclude>
     <pyspark.test.include>**/*Test.*</pyspark.test.include>
 
-    <!-- Needed for testing on Java 17 -->
-    <extraJavaTestArgs>
-      -XX:+IgnoreUnrecognizedVMOptions
-      --add-modules=jdk.incubator.vector
-      --add-opens=java.base/java.lang=ALL-UNNAMED
-      --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-      --add-opens=java.base/java.io=ALL-UNNAMED
-      --add-opens=java.base/java.net=ALL-UNNAMED
-      --add-opens=java.base/java.nio=ALL-UNNAMED
-      --add-opens=java.base/java.util=ALL-UNNAMED
-      --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-      --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-      --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
-      --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-      --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
-      --add-opens=java.base/sun.security.action=ALL-UNNAMED
-      --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
-      -Djdk.reflect.useDirectMethodHandle=false
-      -Dio.netty.tryReflectionSetAccessible=true
-    </extraJavaTestArgs>
+    <extraJavaTestArgs></extraJavaTestArgs>
   </properties>
 
   <dependencies>
@@ -566,6 +546,35 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>java-17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <extraJavaTestArgs>
+          -XX:+IgnoreUnrecognizedVMOptions
+          --add-modules=jdk.incubator.vector
+          --add-opens=java.base/java.lang=ALL-UNNAMED
+          --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+          --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+          --add-opens=java.base/java.io=ALL-UNNAMED
+          --add-opens=java.base/java.net=ALL-UNNAMED
+          --add-opens=java.base/java.nio=ALL-UNNAMED
+          --add-opens=java.base/java.util=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+          --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+          --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+          --add-opens=java.base/sun.security.action=ALL-UNNAMED
+          --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+          -Djdk.reflect.useDirectMethodHandle=false
+          -Dio.netty.tryReflectionSetAccessible=true
+        </extraJavaTestArgs>
+      </properties>
+    </profile>
 
     <!-- profile spark-scala-x only affect the unit test in spark/interpreter module -->
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -166,6 +166,13 @@
       <artifactId>spark-core_${spark.scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <!-- Leads to conflicting Jackson versions -->
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -565,7 +572,7 @@
         <spark.version>4.0.0-preview1</spark.version>
         <protobuf.version>3.21.12</protobuf.version>
         <py4j.version>0.10.9.7</py4j.version>
-        <jackson.version>2.17.1</jackson.version>
+        <libthrift.version>0.16.0</libthrift.version>
       </properties>
     </profile>
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -63,6 +63,28 @@
     <!-- settings -->
     <pyspark.test.exclude>**/PySparkInterpreterMatplotlibTest.java</pyspark.test.exclude>
     <pyspark.test.include>**/*Test.*</pyspark.test.include>
+
+    <!-- Needed for testing on Java 17 -->
+    <extraJavaTestArgs>
+      -XX:+IgnoreUnrecognizedVMOptions
+      --add-modules=jdk.incubator.vector
+      --add-opens=java.base/java.lang=ALL-UNNAMED
+      --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+      --add-opens=java.base/java.io=ALL-UNNAMED
+      --add-opens=java.base/java.net=ALL-UNNAMED
+      --add-opens=java.base/java.nio=ALL-UNNAMED
+      --add-opens=java.base/java.util=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+      --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+      --add-opens=java.base/sun.security.action=ALL-UNNAMED
+      --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+      -Djdk.reflect.useDirectMethodHandle=false
+      -Dio.netty.tryReflectionSetAccessible=true
+    </extraJavaTestArgs>
   </properties>
 
   <dependencies>
@@ -391,7 +413,7 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx3072m -XX:MaxMetaspaceSize=256m</argLine>
+          <argLine>-Xmx3072m -XX:MaxMetaspaceSize=256m ${extraJavaTestArgs}</argLine>
           <excludes>
             <exclude>${pyspark.test.exclude}</exclude>
             <exclude>${tests.to.exclude}</exclude>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -565,6 +565,7 @@
         <spark.version>4.0.0-preview1</spark.version>
         <protobuf.version>3.21.12</protobuf.version>
         <py4j.version>0.10.9.7</py4j.version>
+        <jackson.version>2.17.1</jackson.version>
       </properties>
     </profile>
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -338,7 +338,7 @@
               <target>
                 <delete dir="../../interpreter/spark/pyspark" />
                 <copy file="${project.build.directory}/${spark.archive}/python/lib/py4j-${py4j.version}-src.zip" todir="${project.build.directory}/../../../interpreter/spark/pyspark" />
-                <zip basedir="${project.build.directory}/${spark.archive}/python" destfile="${project.build.directory}/../../../interpreter/spark/pyspark/pyspark.zip" includes="pyspark/*.py,pyspark/**/*.py" />
+                <zip basedir="${project.build.directory}/${spark.archive}/python" destfile="${project.build.directory}/../../../interpreter/spark/pyspark/pyspark.zip" includes="pyspark/" />
               </target>
             </configuration>
           </execution>
@@ -556,6 +556,15 @@
       <properties>
         <spark.scala.version>2.12.17</spark.scala.version>
         <spark.scala.binary.version>2.12</spark.scala.binary.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>spark-4.0</id>
+      <properties>
+        <spark.version>4.0.0-preview1</spark.version>
+        <protobuf.version>3.21.12</protobuf.version>
+        <py4j.version>0.10.9.7</py4j.version>
       </properties>
     </profile>
 

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -169,7 +169,7 @@
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
-        <!-- Leads to conflicting Jackson versions -->
+        <!-- Leads to conflicting Jackson versions in tests -->
         <exclusion>
           <groupId>org.apache.avro</groupId>
           <artifactId>*</artifactId>

--- a/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
+++ b/spark/interpreter/src/main/java/org/apache/zeppelin/spark/SparkInterpreter.java
@@ -87,7 +87,7 @@ public class SparkInterpreter extends AbstractInterpreter {
     }
 
     this.enableSupportedVersionCheck = java.lang.Boolean.parseBoolean(
-        properties.getProperty("zeppelin.spark.enableSupportedVersionCheck", "true"));
+        properties.getProperty("zeppelin.spark.enableSupportedVersionCheck", "false"));
     innerInterpreterClassMap.put("2.12", "org.apache.zeppelin.spark.SparkScala212Interpreter");
     innerInterpreterClassMap.put("2.13", "org.apache.zeppelin.spark.SparkScala213Interpreter");
   }

--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -19,7 +19,10 @@ import warnings
 
 from py4j.java_gateway import java_import
 from pyspark.conf import SparkConf
-from pyspark.context import SparkContext
+try:
+  from pyspark.context import SparkContext
+except ImportError:
+  from pyspark.core.context import SparkContext
 
 # for back compatibility
 from pyspark.sql import SQLContext, Row

--- a/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
+++ b/spark/interpreter/src/main/resources/python/zeppelin_pyspark.py
@@ -19,13 +19,10 @@ import warnings
 
 from py4j.java_gateway import java_import
 from pyspark.conf import SparkConf
-try:
-  from pyspark.context import SparkContext
-except ImportError:
-  from pyspark.core.context import SparkContext
+from pyspark import SparkContext
 
 # for back compatibility
-from pyspark.sql import SQLContext, Row
+from pyspark.sql import SQLContext
 
 intp = gateway.entry_point
 

--- a/spark/spark-shims/src/main/java/org/apache/zeppelin/spark/SparkShims.java
+++ b/spark/spark-shims/src/main/java/org/apache/zeppelin/spark/SparkShims.java
@@ -58,7 +58,7 @@ public abstract class SparkShims {
   private static SparkShims loadShims(int sparkMajorVersion, Properties properties, Object entryPoint)
       throws Exception {
     Class<?> sparkShimsClass;
-    if (sparkMajorVersion == 3) {
+    if (sparkMajorVersion == 3 || sparkMajorVersion == 4) {
       LOGGER.info("Initializing shims for Spark 3.x");
       sparkShimsClass = Class.forName("org.apache.zeppelin.spark.Spark3Shims");
     } else {

--- a/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
+++ b/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
@@ -64,7 +64,8 @@ public class Spark3Shims extends SparkShims {
   @Override
   public String showDataFrame(Object obj, int maxResult, InterpreterContext context) {
     if (obj instanceof Dataset) {
-      Dataset<Row> df = ((Dataset) obj).toDF();
+      @SuppressWarnings("unchecked")
+      Dataset<Row> df = ((Dataset<Object>) obj).toDF();
       String[] columns = df.columns();
       // DDL will empty DataFrame
       if (columns.length == 0) {
@@ -111,8 +112,8 @@ public class Spark3Shims extends SparkShims {
     }
   }
 
-  private List sparkRowToList(Row row) {
-    List list = new ArrayList();
+  private List<Object> sparkRowToList(Row row) {
+    List<Object> list = new ArrayList<>();
     for (int i = 0; i< row.size(); i++) {
       list.add(row.get(i));
     }

--- a/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
+++ b/spark/spark3-shims/src/main/java/org/apache/zeppelin/spark/Spark3Shims.java
@@ -64,8 +64,7 @@ public class Spark3Shims extends SparkShims {
   @Override
   public String showDataFrame(Object obj, int maxResult, InterpreterContext context) {
     if (obj instanceof Dataset) {
-      @SuppressWarnings("unchecked")
-      Dataset<Row> df = ((Dataset<Object>) obj).toDF();
+      Dataset<Row> df = ((Dataset) obj).toDF();
       String[] columns = df.columns();
       // DDL will empty DataFrame
       if (columns.length == 0) {
@@ -112,8 +111,8 @@ public class Spark3Shims extends SparkShims {
     }
   }
 
-  private List<Object> sparkRowToList(Row row) {
-    List<Object> list = new ArrayList<>();
+  private List sparkRowToList(Row row) {
+    List list = new ArrayList();
     for (int i = 0; i< row.size(); i++) {
       list.add(row.get(i));
     }


### PR DESCRIPTION
### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html

Add support for Spark 4. There are a few changes to actually get the interpreter to work correctly, and then a few required to get the tests to work. I did not bump the max supported version since the actual 4.0 release is not out yet.

### What type of PR is it?
Improvement
*Please leave your type of PR only*

### Todos
* [ ] - Disable 4.0 tests in CI and re-enable supported version check

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-6086

### How should this be tested?
A CI stage is added for Spark 4.0 tests, but these will need to be disabled until 4.0 is officially supported.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Maybe
