### PR TITLE
[ZEPPELIN-6088] Fix some flaky tests in zeppelin-integration

### DIFF
--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/PersonalizeActionsIT.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.integration;
 import org.apache.zeppelin.AbstractZeppelinIT;
 import org.apache.zeppelin.MiniZeppelinServer;
 import org.apache.zeppelin.WebDriverManager;
+import org.apache.zeppelin.ZeppelinITUtils;
 import org.apache.zeppelin.test.DownloadUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -239,6 +240,7 @@ public class PersonalizeActionsIT extends AbstractZeppelinIT {
 
       pollingWait(By.xpath(getParagraphXPath(1) +
           "//button[contains(@uib-tooltip, 'Table')]"), MAX_BROWSER_TIMEOUT_SEC).click();
+      ZeppelinITUtils.sleep(1000, false);
       assertEquals("fa fa-table", manager.getWebDriver().findElement(By.xpath(getParagraphXPath(1)
           + "//button[contains(@class," +
           "'btn btn-default btn-sm ng-binding ng-scope active')]//i")).getAttribute("class"));

--- a/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
+++ b/zeppelin-integration/src/test/java/org/apache/zeppelin/integration/SparkParagraphIT.java
@@ -188,6 +188,7 @@ class SparkParagraphIT extends AbstractZeppelinIT {
       ZeppelinITUtils.sleep(2000, false);
       cancelParagraph(1);
       waitForParagraph(1, "ABORT");
+      ZeppelinITUtils.sleep(1000, false);
 
       assertEquals("ABORT", getParagraphStatus(1),
           "First paragraph status is " + getParagraphStatus(1));


### PR DESCRIPTION
### What is this PR for?

It seems that some integration tests are randomly failing due to timing discrepancies between rendering and verification.

To ensure that the values are validated after rendering is fully completed, I added a slight sleep time.

Before the fix, 7 out of 20 runs failed in my personal repository's Github Actions due to one or both the two tests.
However, after the fix, there were no failures from those two tests in 30 runs.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6088

### How should this be tested?
- CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
