### PR TITLE
Revert "[MINOR] Add some GitHub features for PR (#4452)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,11 +34,6 @@ github:
     merge: false
     squash: true
     rebase: false
-  protected_branches:
-    master:
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        required_approving_review_count: 1
   autolink_jira:
     - ZEPPELIN
 


### PR DESCRIPTION
This reverts commit d045c3b2d8c6892128d25ec164598b0c0317e2e5.

### What is this PR for?

As discussed in https://github.com/apache/zeppelin/pull/4831, we need to revert d045c3b2d8c6892128d25ec164598b0c0317e2e5 to make the `dev/merge_zeppelin_pr.py` work. 

### What type of PR is it?

Bug Fix

### What is the Jira issue?

N/A

### How should this be tested?

This is a dev only change, I will verify `dev/merge_zeppelin_pr.py` after merging this.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
