### PR TITLE
[ZEPPELIN-6095] validate decoded url in jdbc interpreter

### DIFF
--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -591,13 +591,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
 
   private void validateConnectionUrl(String url) {
     String decodedUrl;
-    try {
-      decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8.toString());
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalArgumentException("Connection URL decode failed");
-    }
+    decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
 
-    if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
+      if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
             containsIgnoreCase(decodedUrl, AUTO_DESERIALIZE) ||
             containsIgnoreCase(decodedUrl, ALLOW_LOCAL_IN_FILE_NAME) ||
             containsIgnoreCase(decodedUrl, ALLOW_URL_IN_LOCAL_IN_FILE_NAME)) {

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -42,6 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -587,10 +589,18 @@ public class JDBCInterpreter extends KerberosInterpreter {
   }
 
   private void validateConnectionUrl(String url) {
-    if (containsIgnoreCase(url, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
-        containsIgnoreCase(url, AUTO_DESERIALIZE) ||
-        containsIgnoreCase(url, ALLOW_LOCAL_IN_FILE_NAME) ||
-        containsIgnoreCase(url, ALLOW_URL_IN_LOCAL_IN_FILE_NAME)) {
+    String decodedUrl;
+    try {
+      decodedUrl = URLDecoder.decode(url, "UTF-8").replaceAll("\\s", "");
+    } catch (UnsupportedEncodingException e) {
+      LOGGER.info("fail to decode url : {}. continue to get connection.", url, e);
+      return;
+    }
+
+    if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
+            containsIgnoreCase(decodedUrl, AUTO_DESERIALIZE) ||
+            containsIgnoreCase(decodedUrl, ALLOW_LOCAL_IN_FILE_NAME) ||
+            containsIgnoreCase(decodedUrl, ALLOW_URL_IN_LOCAL_IN_FILE_NAME)) {
       throw new IllegalArgumentException("Connection URL contains sensitive configuration");
     }
   }

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -591,7 +591,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private void validateConnectionUrl(String url) {
     String decodedUrl;
     try {
-      decodedUrl = URLDecoder.decode(url, "UTF-8").replaceAll("\\s", "");
+      decodedUrl = URLDecoder.decode(url, "UTF-8");
     } catch (UnsupportedEncodingException e) {
       LOGGER.info("fail to decode url : {}. continue to get connection.", url, e);
       return;

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -591,10 +592,9 @@ public class JDBCInterpreter extends KerberosInterpreter {
   private void validateConnectionUrl(String url) {
     String decodedUrl;
     try {
-      decodedUrl = URLDecoder.decode(url, "UTF-8");
+      decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8.toString());
     } catch (UnsupportedEncodingException e) {
-      LOGGER.info("fail to decode url : {}. continue to get connection.", url, e);
-      return;
+      throw new IllegalArgumentException("Connection URL decode failed");
     }
 
     if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||

--- a/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
+++ b/jdbc/src/main/java/org/apache/zeppelin/jdbc/JDBCInterpreter.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
@@ -593,7 +592,7 @@ public class JDBCInterpreter extends KerberosInterpreter {
     String decodedUrl;
     decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
 
-      if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
+    if (containsIgnoreCase(decodedUrl, ALLOW_LOAD_LOCAL_IN_FILE_NAME) ||
             containsIgnoreCase(decodedUrl, AUTO_DESERIALIZE) ||
             containsIgnoreCase(decodedUrl, ALLOW_LOCAL_IN_FILE_NAME) ||
             containsIgnoreCase(decodedUrl, ALLOW_URL_IN_LOCAL_IN_FILE_NAME)) {

--- a/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
+++ b/jdbc/src/test/java/org/apache/zeppelin/jdbc/JDBCInterpreterTest.java
@@ -762,6 +762,21 @@ public class JDBCInterpreterTest extends BasicJDBCTestCaseAdapter {
             interpreterResult.message().get(0).getData());
   }
 
+  @Test
+  void testValidateConnectionUrlEncoded() throws IOException, InterpreterException {
+    Properties properties = new Properties();
+    properties.setProperty("default.driver", "org.h2.Driver");
+    properties.setProperty("default.url", getJdbcConnection() + ";%61llowLoadLocalInfile=true");
+    properties.setProperty("default.user", "");
+    properties.setProperty("default.password", "");
+    JDBCInterpreter jdbcInterpreter = new JDBCInterpreter(properties);
+    jdbcInterpreter.open();
+    InterpreterResult interpreterResult = jdbcInterpreter.interpret("SELECT 1", context);
+    assertEquals(InterpreterResult.Code.ERROR, interpreterResult.code());
+    assertEquals("Connection URL contains improper configuration",
+            interpreterResult.message().get(0).getData());
+  }
+
   private InterpreterContext getInterpreterContext() {
     return InterpreterContext.builder()
             .setAuthenticationInfo(new AuthenticationInfo("testUser"))


### PR DESCRIPTION
### What is this PR for?

Add some validation check conditions to existing url validator in jdbc interpreter. So now it can check URLs with the conditions below if it has an unallowable configuration.
- UTF-8 encoded

### What type of PR is it?

Improvement

### Todos
* [ ] - Task

### What is the Jira issue?

[ZEPPELIN-6095](https://issues.apache.org/jira/browse/ZEPPELIN-6095)

### How should this be tested?

Input the url with unallowable configurations in UTF-8 encoded in JDBC type interpreter.  Then run the command in notebook and see if the command is blocked from running.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
