### PR TITLE
[ZEPPELIN-6099] Fix default ZEPPELIN_ANGULAR_WAR value

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -963,7 +963,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_SSL_TRUSTSTORE_TYPE("zeppelin.ssl.truststore.type", null),
     ZEPPELIN_SSL_TRUSTSTORE_PASSWORD("zeppelin.ssl.truststore.password", null),
     ZEPPELIN_WAR("zeppelin.war", "zeppelin-web/dist"),
-    ZEPPELIN_ANGULAR_WAR("zeppelin.angular.war", "zeppelin-web-angular/dist"),
+    ZEPPELIN_ANGULAR_WAR("zeppelin.angular.war", "zeppelin-web-angular/dist/zeppelin"),
     ZEPPELIN_WAR_TEMPDIR("zeppelin.war.tempdir", "webapps"),
     ZEPPELIN_JMX_ENABLE("zeppelin.jmx.enable", false),
     ZEPPELIN_JMX_PORT("zeppelin.jmx.port", 9996),


### PR DESCRIPTION
### What is this PR for?
The misconfigured default `ZEPPELIN_ANGULAR_WAR` value is causing the failure to load the new UI web application files on development environment.
The new UI web apps are built into `ZEPPELIN_HOME/zeppelin-web-angular/dist/zeppelin`, but the default value lacks the `/zeppelin` postfix.
When developers run Zeppelin with `ZeppelinServer.main` method, it defaults to the incorrect `ZEPPELIN_ANGULAR_WAR` value, leading to failure to load the web apps.
*Note: This issue does not occur when Zeppelin is run using shell scripts in the `bin`, as they correctly set the `ZEPPELIN_ANGULAR_WAR` value.*

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/6099

### How should this be tested?
* Build Zeppelin
* Run Zeppelin using `ZeppelinServer.main` method and connect to `http://localhost:8080`

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
