### PR TITLE
[ZEPPELIN-6103] Revert "[HOTFIX] Escape envs when using `.conf` (#4715)"

### DIFF
--- a/bin/interpreter.sh
+++ b/bin/interpreter.sh
@@ -101,9 +101,6 @@ fi
 
 . "${bin}/common.sh"
 
-# Escape envs
-ZEPPELIN_INTP_CLASSPATH_OVERRIDES=$(printf %q "${ZEPPELIN_INTP_CLASSPATH_OVERRIDES}")
-
 check_java_version
 
 ZEPPELIN_INTERPRETER_API_JAR=$(find "${ZEPPELIN_HOME}/interpreter" -name 'zeppelin-interpreter-shaded-*.jar')


### PR DESCRIPTION
### What is this PR for?
This PR reverts commit dd08a3966ef3b0b40f13d0291d7cac5ec3dd9f9c which was merged with #4715

I have set the environment variable `ZEPPELIN_INTP_CLASSPATH_OVERRIDES`, which now no longer works due to the change.

I have set the environment variable to the value `/usr/share/java/*`, which in my opinion represents a valid classpath.

`printf %q "/usr/share/java/*"` results in `/usr/share/java/\*`, which is no longer a valid classpath.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6103

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
