### PR TITLE
[ZEPPELIN-6104] Fix NPE when some MongoDB Interpreter configs are missing

### DIFF
--- a/mongodb/src/main/java/org/apache/zeppelin/mongodb/MongoDbInterpreter.java
+++ b/mongodb/src/main/java/org/apache/zeppelin/mongodb/MongoDbInterpreter.java
@@ -197,8 +197,8 @@ public class MongoDbInterpreter extends Interpreter {
   private void prepareShellExtension(){
     shellExtension = shellExtension.replace("TABLE_LIMIT_PLACEHOLDER", getProperty("mongo.shell.command.table.limit"))
             .replace("TARGET_DB_PLACEHOLDER", getProperty("mongo.server.database"))
-            .replace("USER_NAME_PLACEHOLDER", getProperty("mongo.server.username"))
-            .replace("PASSWORD_PLACEHOLDER", getProperty("mongo.server.password"))
-            .replace("AUTH_DB_PLACEHOLDER", getProperty("mongo.server.authenticationDatabase"));
+            .replace("USER_NAME_PLACEHOLDER", getProperty("mongo.server.username", ""))
+            .replace("PASSWORD_PLACEHOLDER", getProperty("mongo.server.password", ""))
+            .replace("AUTH_DB_PLACEHOLDER", getProperty("mongo.server.authenticationDatabase", ""));
   }
 }


### PR DESCRIPTION
### What is this PR for?
This PR avoids an NPE when some MongoDB Interpreter configs are missing by replacing them with empty strings.

If certain MongoDB Interpreter configs, such as the username, password, or authenticationDatabase, are not entered, it throws an NPE. MongoDB allows logins without authentication when authentication is not enabled, so these configs are not always required. Since authentication is off by default in MongoDB, and these configs are also empty by default in Apache Zeppelin, this could be confusing for users.
And as you can see in [shell_extension.js](https://github.com/apache/zeppelin/blob/ac48cc2db1b55257230cae2c382961da2a9cf80d/mongodb/src/main/resources/shell_extension.js#L115), the MongoDB interpreter appears to be designed to skip authorization when the username is null.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-6104]

### How should this be tested?
* run the MongoDB notebook

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
