### PR TITLE
[ZEPPELIN-6105] add 'reload note' button to the new interface

### DIFF
--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
@@ -39,6 +39,7 @@ import {
   ParagraphMoved,
   RemoveFolder,
   RemoveNoteForms,
+  ReloadNote,
   RestoreFolder,
   RestoreNote,
   SaveNoteFormsReceived,
@@ -121,6 +122,7 @@ export interface MessageSendDataTypeMap {
   [OP.RESTORE_ALL]: undefined;
   [OP.EMPTY_TRASH]: undefined;
   [OP.RELOAD_NOTES_FROM_REPO]: undefined;
+  [OP.RELOAD_NOTE]: ReloadNote;
   [OP.GET_NOTE]: GetNode;
   [OP.NEW_NOTE]: NewNote;
   [OP.MOVE_NOTE_TO_TRASH]: MoveNoteToTrash;

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-notebook.interface.ts
@@ -23,6 +23,7 @@ interface Name {
 export type GetNode = ID;
 export type MoveNoteToTrash = ID;
 export type MoveFolderToTrash = ID;
+export type ReloadNote = ID;
 export type RestoreNote = ID;
 export type RestoreFolder = ID;
 export type DeleteNote = ID;

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -196,6 +196,13 @@ export enum OP {
   RELOAD_NOTES_FROM_REPO = 'RELOAD_NOTES_FROM_REPO',
 
   /**
+   * [c-s]
+   * reload note
+   * @param id note id
+   */
+  RELOAD_NOTE = 'RELOAD_NOTE',
+
+  /**
    * [s-c]
    * list of note infos
    * @param notes serialized List<NoteInfo> object

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/message.ts
@@ -261,6 +261,10 @@ export class Message {
     this.send<OP.RELOAD_NOTES_FROM_REPO>(OP.RELOAD_NOTES_FROM_REPO);
   }
 
+  reloadNote(noteId: string): void {
+    this.send<OP.RELOAD_NOTE>(OP.RELOAD_NOTE, { id: noteId })
+  }
+
   getNote(noteId: string): void {
     this.send<OP.GET_NOTE>(OP.GET_NOTE, { id: noteId });
   }

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.html
@@ -67,6 +67,14 @@
               [disabled]="revisionView">
         <i nz-icon nzType="download" nzTheme="outline"></i>
       </button>
+      <button nz-button
+              nz-tooltip
+              nzTitle="Reload from note file"
+              (click)="reloadNote()"
+              *ngIf="!viewOnly"
+              [disabled]="revisionView">
+        <i nz-icon nzType="reload" nzTheme="outline"></i>
+      </button>
       <ng-container *ngIf="principal && principal !== 'anonymous' && !viewOnly">
         <ng-container [ngSwitch]="note.config.personalizedMode">
           <button *ngSwitchCase="'true'"

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/action-bar/action-bar.component.ts
@@ -194,6 +194,10 @@ export class NotebookActionBarComponent extends MessageListenersManager implemen
     }
   }
 
+  reloadNote() {
+    this.messageService.reloadNote(this.note.id);
+  }
+
   toggleAllEditor() {
     this.editorHide = !this.editorHide;
     this.editorHideChange.emit(this.editorHide);

--- a/zeppelin-web-angular/src/app/services/message.service.ts
+++ b/zeppelin-web-angular/src/app/services/message.service.ts
@@ -137,6 +137,10 @@ export class MessageService extends Message implements OnDestroy {
     super.reloadAllNotesFromRepo();
   }
 
+  reloadNote(noteId: string): void {
+    super.reloadNote(noteId);
+  }
+
   getNote(noteId: string): void {
     super.getNote(noteId);
   }


### PR DESCRIPTION
### What is this PR for?
Add missing button to action bar to reload note. This button exists in the old interface, but is missing in /next

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6105

### Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/199b69f5-c19d-497e-aa33-1ab29d22ad50)

