### PR TITLE
[ZEPPELIN-6108] Update MongoDB interpreter default shell value from mongo to mongosh

### DIFF
--- a/docs/interpreter/mongodb.md
+++ b/docs/interpreter/mongodb.md
@@ -45,7 +45,7 @@ Second, create mongodb interpreter in Zeppelin.
   </tr>
   <tr>
     <td>mongo.shell.path</td>
-    <td>mongo</td>
+    <td>mongosh</td>
     <td>MongoDB shell local path. <br/> Use `which mongo` to get local path in linux or mac.</td>
   </tr>
   <tr>

--- a/docs/interpreter/mongodb.md
+++ b/docs/interpreter/mongodb.md
@@ -46,7 +46,7 @@ Second, create mongodb interpreter in Zeppelin.
   <tr>
     <td>mongo.shell.path</td>
     <td>mongosh</td>
-    <td>MongoDB shell local path. <br/> Use `which mongo` to get local path in linux or mac.</td>
+    <td>MongoDB shell local path. <br/> Use `which mongosh` to get local path in linux or mac. <br>(For below [version 5.0](https://www.mongodb.com/docs/manual/release-notes/5.0/#shell-changes), check `mongo`)</td>
   </tr>
   <tr>
      <td>mongo.shell.command.table.limit</td>

--- a/mongodb/src/main/resources/interpreter-setting.json
+++ b/mongodb/src/main/resources/interpreter-setting.json
@@ -7,7 +7,7 @@
       "mongo.shell.path": {
         "envName": "MONGO_SHELL_PATH",
         "propertyName": "mongo.shell.path",
-        "defaultValue": "mongo",
+        "defaultValue": "mongosh",
         "description": "MongoDB shell local path",
         "type": "string"
       },


### PR DESCRIPTION
### What is this PR for?
Since the release of MongoDB 5.0, the mongo shell has been deprecated and replaced by mongosh. Although MongoDB 5.0 was released in July 2021, Apache Zeppelin still uses mongo as the default shell. Updating the default shell from mongo to mongosh would help beginners adapt more easily and align with current MongoDB standards.

[Reference: MongoDB 5.0 Release Note](https://www.mongodb.com/docs/manual/release-notes/5.0/#shell-changes)

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-6108]

### How should this be tested?
* Run the MongoDB notebook

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? Y (update the docs)