### PR TITLE
[ZEPPELIN-6110] Specify the Node.js engine version below 17 in the `web-angular`

### DIFF
--- a/zeppelin-web-angular/package.json
+++ b/zeppelin-web-angular/package.json
@@ -15,6 +15,9 @@
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
+  "engines": {
+    "node": "<17.0.0"
+  },
   "private": true,
   "dependencies": {
     "@angular/animations": "~8.2.10",


### PR DESCRIPTION
### What is this PR for?
Specify the Node.js engine version below 17 in the `zeppelin-web-angular` package.json file to avoid errors related to Node.js 17+ and OpenSSL in Webpack.

If we upgrade the Angular version to 13+ in the future, we will be able to use Node.js 17+ as well.

[Reference: nodejs 17: digital envelope routines::unsupported · Issue #14532 · webpack/webpack](https://github.com/webpack/webpack/issues/14532)

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* [ZEPPELIN-6110]

### How should this be tested?
1. Set your Node.js version to 17+
2. Execute `npm run postinstall` in `zeppelin-web-angular`

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
