### PR TITLE
[ZEPPELIN-6089][INFRA][FOLLOWUP] Consider multiple digits when comparing version numbers

### DIFF
--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -270,7 +270,7 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
         for x in versions
         if not x.raw["released"] and not x.raw["archived"] and re.match(r"\d+\.\d+\.\d+", x.name)
     ]
-    versions = sorted(versions, key=lambda x: x.name, reverse=True)
+    versions = sorted(versions, key=lambda x: list(map(int, x.name.split('.'))), reverse=True)
 
     default_fix_versions = []
     for b in merge_branches:

--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -288,7 +288,8 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
                 # For example, assuming
                 # versions = ['4.0.0', '3.5.1', '3.5.0', '3.4.2', '3.3.4', '3.3.3']
                 # we've found two candidates for branch-3.5, we pick the last/smallest one
-                default_fix_versions.append(found_versions[-1])
+                if found_versions[-1] not in default_fix_versions:
+                    default_fix_versions.append(found_versions[-1])
             else:
                 print_error(
                     "Target version for %s is not found on JIRA, it may be archived or "

--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -538,8 +538,7 @@ def main():
 
     branches = http_get("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))
-    # Assumes branch names can be sorted lexicographically
-    branch_names = sorted(branch_names, reverse=True)
+    branch_names = sorted(branch_names, key=lambda x: list(map(int, x.removeprefix("branch-").split('.'))), reverse=True)
     branch_iter = iter(branch_names)
 
     pr_num = bold_input("Which pull request would you like to merge? (e.g. 34): ")


### PR DESCRIPTION
### What is this PR for?

This PR fixes some issues in the `dev/merge_zeppelin_pr.py` to make it smarter in suggesting "backport branch" and "fixed versions".

1. improve the `x.y.z` version comparing

   For versions: `["0.9.1", "0.10.1", "0.11.3", "0.12.0"]`
    
   Previously, it was a simple string comparison, so the desc sorted result is `["0.9.1", "0.12.0", "0.11.3", "0.10.1"]`; this PR changes it by interpreting each x, y, z as an int value and comparing sequence, thus the desc sorted result is `["0.12.0", "0.11.3", "0.10.1", "0.9.1"]`

2. improve the `branch-x.y` branch comparing

   similar to 1, `branch-0.10` is higher than `branch-0.9`

3. dedup `found_versions`

   before
   ```
   Enter comma-separated fix version(s) [0.12.0,0.12.0]:
   ```
   after
   ```
   Enter comma-separated fix version(s) [0.12.0]:
   ```

### What type of PR is it?

Improvement

### Todos

### What is the Jira issue?

ZEPPELIN-6089

### How should this be tested?

Manually tested by using the updated script to merge three PRs.

```
$ dev/merge_zeppelin_pr.py
git rev-parse --abbrev-ref HEAD
Which pull request would you like to merge? (e.g. 34): 4850
=== JIRA ZEPPELIN-6112 ===
Summary		Unable to serve documentation website
Assignee	Chan Ho Lee
Status		Open
Url		https://issues.apache.org/jira/browse/ZEPPELIN-6112
Affected	[]


=== Pull Request #4850 ===
title	[ZEPPELIN-6112] Fix running documentation website server
source	tbonelee/fix-docs
target	master
url	https://api.github.com/repos/apache/zeppelin/pulls/4850
Proceed with merging pull request #4850? (y/N): y
git config --get user.name
git config --get user.email
Pull request #4850 merged!
Merge hash: aa5abd57
git fetch apache master
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (1/1), 1.45 KiB | 742.00 KiB/s, done.
From github.com:apache/zeppelin
 * branch                master     -> FETCH_HEAD
   4aff03bb7..aa5abd572  master     -> apache/master

Would you like to pick aa5abd57 into another branch? (y/N): y
Enter a branch name [branch-0.12]:
git fetch apache branch-0.12:PR_TOOL_PICK_PR_4850_BRANCH-0.12
From github.com:apache/zeppelin
 * [new branch]          branch-0.12 -> PR_TOOL_PICK_PR_4850_BRANCH-0.12
git checkout PR_TOOL_PICK_PR_4850_BRANCH-0.12
Switched to branch 'PR_TOOL_PICK_PR_4850_BRANCH-0.12'
git cherry-pick -sx aa5abd57
Pick complete (local ref PR_TOOL_PICK_PR_4850_BRANCH-0.12). Push to apache? (y/N): y
git push apache PR_TOOL_PICK_PR_4850_BRANCH-0.12:branch-0.12
Enumerating objects: 19, done.
Counting objects: 100% (19/19), done.
Delta compression using up to 10 threads
Compressing objects: 100% (10/10), done.
Writing objects: 100% (10/10), 4.27 KiB | 4.27 MiB/s, done.
Total 10 (delta 7), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (7/7), completed with 7 local objects.
remote:
remote: GitHub found 197 vulnerabilities on apache/zeppelin's default branch (18 critical, 68 high, 87 moderate, 24 low). To find out more, visit:
remote:      https://github.com/apache/zeppelin/security/dependabot
remote:
To github.com:apache/zeppelin.git
   3cadfe1f5..671eca882  PR_TOOL_PICK_PR_4850_BRANCH-0.12 -> branch-0.12
git rev-parse PR_TOOL_PICK_PR_4850_BRANCH-0.12
Restoring head pointer to ZEPPELIN-6089-followup
git checkout ZEPPELIN-6089-followup
Switched to branch 'ZEPPELIN-6089-followup'
git branch
Deleting local branch PR_TOOL_PICK_PR_4850_BRANCH-0.12
git branch -D PR_TOOL_PICK_PR_4850_BRANCH-0.12
Pull request #4850 picked into branch-0.12!
Pick hash: 671eca88

Would you like to pick aa5abd57 into another branch? (y/N): n
Would you like to update an associated JIRA? (y/N): y
Enter a JIRA id [ZEPPELIN-6112]:
=== JIRA ZEPPELIN-6112 ===
Summary		Unable to serve documentation website
Assignee	Chan Ho Lee
Status		Open
Url		https://issues.apache.org/jira/browse/ZEPPELIN-6112
Affected	[]

Check if the JIRA information is as expected (y/N): y
Enter comma-separated fix version(s) [0.12.0]:
=== JIRA ZEPPELIN-6112 ===
Summary		Unable to serve documentation website
Assignee	Chan Ho Lee
Status		Resolved
Url		https://issues.apache.org/jira/browse/ZEPPELIN-6112
Affected	[]
Fixed		['0.12.0']

Successfully resolved ZEPPELIN-6112 with fixVersions=['0.12.0']!
```

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
