### PR TITLE
[ZEPPELIN-6113] Write a Dockerfile for mongodb interpreter image build

### DIFF
--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:11 as builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,mongodb -DskipTests
+
+
+FROM openjdk:11
+
+RUN apt-get update && \
+    apt-get install -y wget gnupg && \
+    wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | tee /etc/apt/trusted.gpg.d/mongodb-server-7.0.asc
+
+RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+
+RUN apt-get update && \
+    apt-get install -y mongodb-mongosh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+COPY --from=builder /zeppelin/interpreter/mongodb /zeppelin/interpreter/mongodb
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV MONGO_DB_INTERPRETER_PORT=8083
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ./bin/interpreter.sh \
+     -d ./interpreter/mongodb \
+     -c host.docker.internal \
+     -p "${INTERPRETER_EVENT_SERVER_PORT}" \
+     -r "${MONGO_DB_INTERPRETER_PORT}:${MONGO_DB_INTERPRETER_PORT}" \
+     -i mongodb-shared_process \
+     -l ./local-repo \
+     -g mongodb

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -3,6 +3,40 @@ MongoDB interpreter for Apache Zeppelin. Thanksgiving to [bbonnin/zeppelin-mongo
 I found bbonnin's mongodb interpreter was not working with newest zeppelin version, it has not been maintained for a long time.
 so I forked this for those people who want to use mongodb in zeppelin.
 
-### Technical overview
+## Technical overview
 it use mongo shell to execute scripts.All you need to do is to configure mongodb interpreter,
 and then study mongo aggregate functions.
+
+## How to run the interpreter with docker
+You can run the mongodb interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the mongodb interpreter
+* NOTE: Your mongodb properties should be configured using the host environment settings, such as the URL, username, and password.
+```bash
+    # conf/interpreter.json
+    
+    "mongodb": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the mongodb interpreter
+```bash
+zeppelin $ ./mvnw clean install -DskipTests
+ 
+zeppelin $ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+zeppelin $ docker build -f ./mongodb/Dockerfile -t mongodb-interpreter .
+
+zeppelin $ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8083 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  mongodb-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a MongoDB interpreter container. I think it could be helpful to use distributed computing resources.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
* [ZEPPELIN-6113]

### How should this be tested?
* Build and run the docker container
* Verify that the shell interpreter container communicates with the zeppelin server

### Questions:
* Does the license files need to update? Y
* Is there breaking changes for older versions? N
* Does this needs documentation? Y
