### PR TITLE
[ZEPPELIN-6114] Remove broken link for Google Analytics tracking

### DIFF
--- a/docs/setup/basics/how_to_build.md
+++ b/docs/setup/basics/how_to_build.md
@@ -304,5 +304,3 @@ mvn verify
 # or take care of starting/stoping zeppelin-server from packaged zeppelin-distribuion/target
 mvn verify -P using-packaged-distr
 ```
-
-[![Analytics](https://ga-beacon.appspot.com/UA-45176241-4/apache/zeppelin/README.md?pixel)](https://github.com/igrigorik/ga-beacon)


### PR DESCRIPTION
### What is this PR for?
The ga-beacon link for Google Analytics tracking is broken. It is located on the [how_to_build](https://zeppelin.apache.org/docs/0.11.2/setup/basics/how_to_build.html#package) page.

For the following reasons, I removed this linke:
1. The broken link makes the page look poorly maintained. 
2. The ga-beacon doesn't seem to be supported anymore. 
3. The link doesn't seem intended to be on that page. Usually, it should be on the welcome page or across multiple pages. Since [this PR](https://github.com/apache/zeppelin/pull/1615/files#diff-180b6ccd4f65bde6bcd6ce9e7d6872d768d3b18c2e05f8faad36ff6279199ce1R343) relocated the link, I think it might have been unintentional.

### What type of PR is it?
Documentation

### Todos

### What is the Jira issue?
* ZEPPELIN-6114

### How should this be tested?
* Build documentation

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? Y
