### PR TITLE
[ZEPPELIN-6117][INFRA] Remove deprecated Mambaforge

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -74,7 +74,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3.9_with_R.yml
           python-version: 3.9
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -125,7 +124,6 @@ jobs:
           activate-environment: python_3_with_R_and_tensorflow
           environment-file: testing/env_python_3_with_R_and_tensorflow.yml
           python-version: 3.9
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -173,7 +171,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_${{ matrix.python }}_with_R.yml
           python-version: ${{ matrix.python }}
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -229,7 +226,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -286,7 +282,6 @@ jobs:
           activate-environment: python_3_with_flink
           environment-file: testing/env_python_3_with_flink_${{ matrix.flink }}.yml
           python-version: ${{ matrix.python }}
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -336,7 +331,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -389,7 +383,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_${{ matrix.python }}_with_R.yml
           python-version: ${{ matrix.python }}
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false
@@ -453,7 +446,6 @@ jobs:
           activate-environment: python_37_with_R
           environment-file: testing/env_python_3.7_with_R.yml
           python-version: 3.7
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -118,7 +118,6 @@ jobs:
           activate-environment: python_3_with_R
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
-          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           auto-activate-base: false


### PR DESCRIPTION
### What is this PR for?

CI start failing at "Setup conda environment" because of

> October 2024: The Mambaforge installers will refuse to install during several pre-specified date ranges (i.e., ["brownouts"](https://en.wikipedia.org/wiki/Brownout_(software_engineering))) in order to encourage users to switch to Miniforge. These dates are
> - Every two weeks in October 2024 (2024-10-01, 2024-10-15)

https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

The fix refers to https://github.com/conda-incubator/setup-miniconda/pull/360

### What type of PR is it?

Bug Fix

### Todos

### What is the Jira issue?

ZEPPELIN-6117

### How should this be tested?

Pass GHA.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
