### PR TITLE
[ZEPPELIN-6109] Add temporary Helium page with iframe for new UI

### DIFF
--- a/zeppelin-web-angular/package-lock.json
+++ b/zeppelin-web-angular/package-lock.json
@@ -74,6 +74,9 @@
         "tsickle": "0.37.0",
         "tslint": "~5.15.0",
         "typescript": "3.5.3"
+      },
+      "engines": {
+        "node": "<17.0.0"
       }
     },
     "node_modules/@angular-devkit/architect": {

--- a/zeppelin-web-angular/src/app/pages/workspace/helium/helium-routing.module.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/helium/helium-routing.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { HeliumComponent } from './helium.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HeliumComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class HeliumRoutingModule {}

--- a/zeppelin-web-angular/src/app/pages/workspace/helium/helium.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/helium/helium.component.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, Component } from '@angular/core';
+
+@Component({
+  selector: 'zeppelin-helium',
+  template: `
+    <iframe src="/classic/#/helium" width="100%" height="100%" style="border: none; margin-top: -50px"></iframe>
+  `,
+  styles: [
+    `
+      iframe {
+        width: 100%;
+        height: calc(100vh - 50px);
+        border: none;
+      }
+    `
+  ]
+})
+export class HeliumComponent implements AfterViewInit {
+  constructor() {}
+
+  ngAfterViewInit() {
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+
+    iframe.onload = () => {
+      const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      if (iframeDocument) {
+        const navbar = iframeDocument.querySelector('div[src*="components/navbar/navbar.html"]') as HTMLElement;
+
+        if (navbar) {
+          navbar.style.setProperty('display', 'none', 'important');
+        }
+      }
+    };
+  }
+}

--- a/zeppelin-web-angular/src/app/pages/workspace/helium/helium.module.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/helium/helium.module.ts
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { HeliumRoutingModule } from './helium-routing.module';
+import { HeliumComponent } from './helium.component';
+
+@NgModule({
+  declarations: [HeliumComponent],
+  imports: [CommonModule, HeliumRoutingModule]
+})
+export class HeliumModule {}

--- a/zeppelin-web-angular/src/app/pages/workspace/workspace-routing.module.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/workspace-routing.module.ts
@@ -50,6 +50,10 @@ const routes: Routes = [
           import('@zeppelin/pages/workspace/interpreter/interpreter.module').then(m => m.InterpreterModule)
       },
       {
+        path: 'helium',
+        loadChildren: () => import('@zeppelin/pages/workspace/helium/helium.module').then(m => m.HeliumModule)
+      },
+      {
         path: 'configuration',
         loadChildren: () =>
           import('@zeppelin/pages/workspace/configuration/configuration.module').then(m => m.ConfigurationModule)

--- a/zeppelin-web-angular/src/app/share/header/header.component.html
+++ b/zeppelin-web-angular/src/app/share/header/header.component.html
@@ -56,9 +56,9 @@
             [routerLink]="['/credential']">Credential
           </a>
         </li>
-<!--        <li nz-menu-item routerLinkActive="ant-dropdown-menu-item-selected">-->
-<!--          <a [routerLink]="['/helium']">Helium</a>-->
-<!--        </li>-->
+        <li nz-menu-item routerLinkActive="ant-dropdown-menu-item-selected">
+          <a [routerLink]="['/helium']">Helium</a>
+        </li>
         <li nz-menu-item routerLinkActive="ant-dropdown-menu-item-selected">
           <a [routerLink]="['/configuration']">Configuration</a>
         </li>


### PR DESCRIPTION
### What is this PR for?
In the new UI, there is an issue where the Helium page does not appear. It seems that the Helium page has not yet been converted from AngularJS to Angular. For now, to provide the page to users, I added the existing AngularJS page to render within an iframe.

### What type of PR is it?
Bug Fix

### Todos
* Convert helium page to Angular 

### What is the Jira issue?
* ZEPPELIN-6109

### How should this be tested?
* Check the helium page with new UI

### Screenshots (if appropriate)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/dfd49e5f-41d6-47b3-89b7-51adfe763173">

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
