### PR TITLE
[ZEPPELIN-6101][FOLLOWUP] Fix build with profile include-hadoop

### DIFF
--- a/zeppelin-interpreter/pom.xml
+++ b/zeppelin-interpreter/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
       <exclusions>


### PR DESCRIPTION
### What is this PR for?

when building with `-Pinclude-hadoop`, `com.google.code.findbugs:jsr305`'s scope becomes runtime thus failing the build.

### What type of PR is it?

Bug Fix

### Todos

### What is the Jira issue?

ZEPPELIN-6101

### How should this be tested?

tested with the command `./mvnw clean package -Pbuild-distr -DskipTests -Pinclude-hadoop`

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
