### PR TITLE
[ZEPPELIN-6121] Write a Dockerfile for python interpreter image build

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -28,6 +28,11 @@ RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interprete
 
 FROM openjdk:11
 
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /zeppelin/bin /zeppelin/bin/
 COPY --from=builder /zeppelin/conf /zeppelin/conf
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -30,6 +30,7 @@ FROM openjdk:11
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip && \
+    pip3 install jupyter-client grpcio protobuf~=3.20 ipython ipykernel && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:11 as builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,python -DskipTests
+
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/python /zeppelin/interpreter/python
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV PYTHON_INTERPRETER_PORT=8084
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ./bin/interpreter.sh \
+ -d ./interpreter/python \
+ -c host.docker.internal \
+ -p "${INTERPRETER_EVENT_SERVER_PORT}" \
+ -r "${PYTHON_INTERPRETER_PORT}:${PYTHON_INTERPRETER_PORT}" \
+ -i python-shared_process \
+ -l ./local-repo \
+ -g python

--- a/python/README.md
+++ b/python/README.md
@@ -64,3 +64,35 @@ Current interpreter delegate the whole work to ipython kernel via `jupyter_clien
 Zeppelin interpreter process will communicate with the python process via `grpc`. Ideally every feature works in IPython should work in Zeppelin as well.
 
 
+## Run the interpreter with docker
+You can run the python interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the interpreter
+```bash
+    # conf/interpreter.json
+    
+    "python": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the interpreter
+```bash
+zeppelin $ ./mvnw clean install -DskipTests
+ 
+zeppelin $ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+zeppelin $ docker build -f ./python/Dockerfile -t python-interpreter .
+
+zeppelin $ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8084 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  python-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a Python interpreter container. I think it could be helpful to use distributed computing resources.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
* [ZEPPELIN-6121](https://issues.apache.org/jira/browse/ZEPPELIN-6121)

### How should this be tested?
* Build and run the docker container
* Verify that the interpreter container communicates with the zeppelin server

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Y
* Is there breaking changes for older versions? N
* Does this needs documentation? Y
