### PR TITLE
[ZEPPELIN-6122] Write a Dockerfile for java interpreter image build #4865

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openjdk:11 as builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,java -DskipTests
+
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/java /zeppelin/interpreter/java
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV JAVA_INTERPRETER_PORT=8085
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ./bin/interpreter.sh \
+ -d ./interpreter/java \
+ -c host.docker.internal \
+ -p "${INTERPRETER_EVENT_SERVER_PORT}" \
+ -r "${JAVA_INTERPRETER_PORT}:${JAVA_INTERPRETER_PORT}" \
+ -i java-shared_process \
+ -l ./local-repo \
+ -g java

--- a/java/README.md
+++ b/java/README.md
@@ -15,3 +15,36 @@ Current interpreter implementation supports the static REPL. It compiles the cod
  * If there is any error during compilation, it can catch and redirect to Zeppelin.
  
  * `JavaInterpreterUtils` contains useful methods to print out Java collections and leverage Zeppelin's built in visualization. 
+
+## Run the interpreter with docker
+You can run the java interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the interpreter
+```bash
+    # conf/interpreter.json
+    
+    "java": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the interpreter
+```bash
+zeppelin $ ./mvnw clean install -DskipTests
+ 
+zeppelin $ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+zeppelin $ docker build -f ./java/Dockerfile -t java-interpreter .
+
+zeppelin $ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8085 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  java-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a java interpreter container. I think it could be helpful to use distributed computing resources.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
 * [ZEPPELIN-6122]

### How should this be tested?
* Build and run the docker container
* Verify that the interpreter container communicates with the zeppelin server

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Y
* Is there breaking changes for older versions? N
* Does this needs documentation? Y
