### PR TITLE
[ZEPPELIN-6124] cannot accessed URL of the wiki in Roadmap.md file

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,4 +1,46 @@
 
 # Zeppelin Roadmap
 
-Please check https://cwiki.apache.org/confluence/display/ZEPPELIN/Zeppelin+Roadmap for details
+---
+
+## Zeppelin Roadmap Summary
+
+### Security and Stability
+- Authentication/authorization
+- Multi-tenancy
+- User impersonation
+- Memory management
+- Disaster recovery
+- High availability
+
+### Enterprise Readiness
+- Multi-user support
+- Job scheduling/management
+- Monitoring (JMX)
+- Notebook authorization
+- Impersonation
+
+
+### Interpreter Enhancements
+- JUnit5, Spark, JDK 11
+- Dynamic interpreter loading
+- JDBC, Python, R support
+- New interpreters
+- Cluster manager (proposal)
+
+### Usability and Visualization Improvements
+- Table pagination, filtering, sorting
+- Data export (CSV)
+- Pluggable visualizations
+- Notebook folder structure
+- Customizable graphs
+- Front-end performance
+
+## details
+- Please check our [wiki](https://cwiki.apache.org/confluence/x/YJRzAw) for more details
+
+
+
+
+
+


### PR DESCRIPTION
### What is this PR for?
- This PR addresses an issue where the wiki page cannot be accessed correctly in some environments, even when the URL of the roadmap is entered. The "Roadmap.md" file in the project's root directory contains a URL linking to the roadmap document on the wiki. However, clicking this URL fails to provide proper access.

### What type of PR is it?
Documentation
*Please leave your type of PR only*

### Todos
* [x] - Implement URL extraction feature from the wiki.

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6124
* Put link here, and add [ZEPPELIN-6124](https://issues.apache.org/jira/browse/ZEPPELIN-6124) in PR title

### How should this be tested?
* This is a simple modification to the document Therefore, there is nothing to test; 
  * you only need to read the document to check if it aligns with the project's direction and click on the wiki URL link to see if it works properly.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? : `no`
* Is there breaking changes for older versions? : `no`
* Does this needs documentation? : `no`
