### PR TITLE
[ZEPPELIN-6125] Enable updates on the same branch using dev/checkout_zeppelin_pr.sh

### DIFF
--- a/dev/checkout_zeppelin_pr.sh
+++ b/dev/checkout_zeppelin_pr.sh
@@ -58,5 +58,9 @@ shift "$(($OPTIND -1))"
 
 PR_NUM=$1
 
-git fetch ${APACHE_ZEPPELIN_REMOTE_REPO_NAME} pull/${PR_NUM}/head:PR_${PR_NUM} ${FORCE}
-git checkout PR_${PR_NUM}
+if [[ $(git rev-parse --abbrev-ref HEAD) == "PR_${PR_NUM}" ]]; then
+  git pull ${APACHE_ZEPPELIN_REMOTE_REPO_NAME} pull/${PR_NUM}/head:PR_${PR_NUM} ${FORCE}
+else
+  git fetch ${APACHE_ZEPPELIN_REMOTE_REPO_NAME} pull/${PR_NUM}/head:PR_${PR_NUM} ${FORCE}
+  git checkout PR_${PR_NUM}
+fi


### PR DESCRIPTION
### What is this PR for?
The `dev/checkout_zeppelin_pr.sh` script is useful for locally checking out PR commits.

Currently, it fetches the PR and checks out a new branch.

However, if the script is run while already on the target branch, the updates are not reflected because `git checkout` does not move the `HEAD` when the current branch is already checked out.

To resolve this, the script has been updated to use `git pull` instead when the current branch is already checked out.


### What type of PR is it?
Improvement

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6125
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
