### PR TITLE
[ZEPPELIN-6126] Remove hadoop dependencies out of the final zeppelin-web.war

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -39,6 +39,8 @@
     <!--plugin versions-->
     <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
     <plugin.frontend.npmDownloadRoot>https://registry.npmjs.org/npm/-/</plugin.frontend.npmDownloadRoot>
+    <!-- the scope of the Hadoop dependencies is the same as for the other Zeppelin components -->
+    <hadoop.deps.scope>test</hadoop.deps.scope>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What is this PR for?
This PR removes the Hadoop dependencies in the zeppelin-web.war file. At the moment it is not clear to me how this behavior came about in Zeppelin.

Build Command: `./mvnw clean package -DskipTests -Pinclude-hadoop -Pweb-classic -Pweb-dist -pl zeppelin-web -am`

### What type of PR is it?
Bug Fix

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6126

### Screenshots (if appropriate)
Before:
```
15:53 $ ls -lh zeppelin-web/target/
insgesamt 47M
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:51 classes
drwxrwxr-x  2 pdallig pdallig 4,0K Okt  9 15:51 maven-archiver
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:51 maven-shared-archive-resources
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:51 test-classes
drwxrwxr-x 11 pdallig pdallig 4,0K Okt  9 15:51 zeppelin-web-0.12.0-SNAPSHOT
-rw-rw-r--  1 pdallig pdallig  47M Okt  9 15:51 zeppelin-web-0.12.0-SNAPSHOT.war
```
![grafik](https://github.com/user-attachments/assets/decd7a91-5da6-44b1-b695-d8f9d6309b94)

After:
```
15:53 $ ls -lh zeppelin-web/target/
insgesamt 3,1M
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:57 classes
drwxrwxr-x  2 pdallig pdallig 4,0K Okt  9 15:57 maven-archiver
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:56 maven-shared-archive-resources
drwxrwxr-x  3 pdallig pdallig 4,0K Okt  9 15:57 test-classes
drwxrwxr-x 11 pdallig pdallig 4,0K Okt  9 15:57 zeppelin-web-0.12.0-SNAPSHOT
-rw-rw-r--  1 pdallig pdallig 3,1M Okt  9 15:57 zeppelin-web-0.12.0-SNAPSHOT.war
```
![grafik](https://github.com/user-attachments/assets/63366c81-392a-4053-bcdf-ea13768c3860)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
