### PR TITLE
[ZEPPELIN-6096] Cursor appears cut off in Notebook editor

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -59,7 +59,7 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
   @Output() readonly editorFocus = new EventEmitter<void>();
   private editor: IStandaloneCodeEditor;
   private monacoDisposables: IDisposable[] = [];
-  height = 0;
+  height = 18;
   interpreterName: string;
 
   autoAdjustEditorHeight() {


### PR DESCRIPTION
### What is this PR for?

https://github.com/user-attachments/assets/6204b6f5-409e-4cd1-8901-eb09114e9ded

Steps to reproduce:
1. Make a new Paragraph.
2. Refresh the page.
3. Click on the paragraph to make the cursor blink.

[How to solve]
https://github.com/apache/zeppelin/blob/bdf5b067b6bdde2614b98a6a3f6a7b5d6637e57c/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts#L62

Set default value of editor's height

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6096](https://issues.apache.org/jira/browse/ZEPPELIN-6096)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
