### PR TITLE
[ZEPPELIN-6127] Fix setting incorrect ZEPPELIN_ANGULAR_WAR value

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -51,7 +51,7 @@ if [[ -z "${ZEPPELIN_WAR}" ]]; then
 fi
 
 if [[ -z "${ZEPPELIN_ANGULAR_WAR}" ]]; then
-  if [[ -d "${ZEPPELIN_HOME}/zeppelin-web/dist" ]]; then
+  if [[ -d "${ZEPPELIN_HOME}/zeppelin-web-angular/dist/zeppelin" ]]; then
     export ZEPPELIN_ANGULAR_WAR="${ZEPPELIN_HOME}/zeppelin-web-angular/dist/zeppelin"
   else
     ZEPPELIN_ANGULAR_WAR=$(find -L "${ZEPPELIN_HOME}" -name "zeppelin-web-angular*.war")


### PR DESCRIPTION
### What is this PR for?
When setting `ZEPPELIN_ANGULAR_WAR`, it should check for the `${ZEPPELIN_HOME}/zeppelin-web-angular/dist/zeppelin` directory.

However, it currently checks for the `${ZEPPELIN_HOME}/zeppelin-web/dist` directory, causing an issue where the new UI load fails if the classic UI is not built.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6127

### How should this be tested?
- Clear classic UI `dist` directory. (remove `${ZEPPELIN_HOME}/zeppelin-web/dist` directory)
- Build without classic UI profile (`./mvnw package -DskipTests -Pinclude-hadoop`)
- Run Zeppelin with daemon script. (`./bin/zeppelin-daemon.sh start`)
- Ensure the new UI loads properly at `http://localhost:8080/`.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
