### PR TITLE
[ZEPPELIN-6130] Write a Dockerfile for Elasticsearch interpreter image build

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,48 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+FROM openjdk:11 AS builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,elasticsearch -DskipTests
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/elasticsearch /zeppelin/interpreter/elasticsearch
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV ELASTICSEARCH_INTERPRETER_PORT=8087
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ./bin/interpreter.sh \
+    -d ./interpreter/elasticsearch \
+    -c host.docker.internal \
+    -p ${INTERPRETER_EVENT_SERVER_PORT} \
+    -r ${ELASTICSEARCH_INTERPRETER_PORT}:${ELASTICSEARCH_INTERPRETER_PORT} \
+    -i elasticsearch-shared_process \
+    -l ./local-repo \
+    -g elasticsearch

--- a/elasticsearch/Dockerfile_elasticsearch
+++ b/elasticsearch/Dockerfile_elasticsearch
@@ -1,0 +1,50 @@
+##
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+FROM openjdk:11
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https curl gnupg
+#    rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
+    echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
+
+RUN apt-get update && \
+    apt-get install -y elasticsearch=7.10.1
+#    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 9200 9300
+
+ENV ES_JAVA_OPTS="-Xms512m -Xmx512m"
+
+RUN chown -R elasticsearch:elasticsearch /var/lib/elasticsearch && \
+    chown -R elasticsearch:elasticsearch /etc/elasticsearch
+
+USER elasticsearch
+
+CMD /usr/share/elasticsearch/bin/elasticsearch \
+    -Enetwork.host=0.0.0.0 \
+    -Ediscovery.type=single-node \
+    -Ecluster.name=elasticsearch \
+    -Ehttp.port=9200 \
+    -Etransport.port=9300 \
+    -Expack.security.enabled=false \
+    -Expack.security.transport.ssl.enabled=false \
+    -Expack.security.http.ssl.enabled=false

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,36 @@
+# Overview
+Elasticsearch interpreter for Apache Zeppelin
+
+## Run the interpreter with docker
+You can run the Elasticsearch interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the elasticsearch interpreter
+```bash
+    # conf/interpreter.json
+
+    "elasticsearch": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": ${INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the elasticsearch interpreter
+```bash
+./mvnw clean install -DskipTests
+ 
+./bin/zeppelin-daemon.sh start
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+docker build -f ./elasticsearch/Dockerfile -t elasticsearch-interpreter .
+docker run \
+--name elasticsearch-interpreter \
+-p 8087:8087 \
+-e INTERPRETER_EVENT_SERVER_PORT=${INTERPRETER_EVENT_SERVER_PORT} \
+elasticsearch-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
This PR adds a Dockerfile to build a elasticsearch interpreter.

### What type of PR is it?
Feature

### Todos
* [x] - README.md
* [x] - Dockerfile
* [x] - Dockerfile_elasticsearch

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6130

### How should this be tested?

* Build and run Elasticsearch with Docker
```bash
# Build
docker build -f ./elasticsearch/Dockerfile_elasticsearch -t elasticsearch .
# Run
docker run -d -p 9200:9200 -p 9300:9300 --name elasticsearch elasticsearch
```

* Build and run the Elasticsearch interpreter with Docker
```bash
# Build
docker build -f ./elasticsearch/Dockerfile -t elasticsearch-interpreter .
# Run
docker run \
--name elasticsearch-interpreter \
-p 8087:8087 \
-e INTERPRETER_EVENT_SERVER_PORT=${__YOUR_INTERPRETER_EVENT_SERVER_PORT__} \
elasticsearch-interpreter
```

* Edit interpreter.json
```bash
# Old
  "elasticsearch": {
      "...": "...",
      "option": {
        "remote": true,
        "port": -1,
        "perNote": "shared",
        "perUser": "shared",
        "isExistingProcess": false,
        "setPermission": false,
        "owners": [],
        "isUserImpersonate": false
      }
    }
# New
  "elasticsearch": {
      "...": "...",
      "option": {
        "remote": true,
        "host": "host.docker.internal",
        "port": ${__YOUR_INTERPRETER_EVENT_SERVER_PORT__},
        "perNote": "shared",
        "perUser": "shared",
        "isExistingProcess": true,
        "setPermission": false,
        "owners": [],
        "isUserImpersonate": false
      }
    }
```

* Verify that the shell interpreter container communicates with the zeppelin server.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
