### PR TITLE
[ZEPPELIN-6135] Fix clean goal not removing interpreter/ output(Spark,Flink)

### DIFF
--- a/flink/flink-scala-2.12/pom.xml
+++ b/flink/flink-scala-2.12/pom.xml
@@ -33,7 +33,6 @@
 
   <properties>
     <!--library versions-->
-    <interpreter.name>flink</interpreter.name>
     <flink.version>${flink1.17.version}</flink.version>
     <flink.scala.version>2.12.7</flink.scala.version>
     <flink.scala.binary.version>2.12</flink.scala.binary.version>

--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -41,6 +41,8 @@
     </modules>
 
     <properties>
+        <interpreter.name>flink</interpreter.name>
+
         <flink1.15.version>1.15.1</flink1.15.version>
         <flink1.16.version>1.16.0</flink1.16.version>
         <flink1.17.version>1.17.1</flink1.17.version>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -265,18 +265,6 @@
     <plugins>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>${project.basedir}/../../interpreter/spark/</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
         <executions>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -33,7 +33,6 @@
   <description>Zeppelin spark support</description>
 
   <properties>
-    <interpreter.name>spark</interpreter.name>
     <!--library versions-->
     <maven.plugin.api.version>3.0</maven.plugin.api.version>
     <aether.version>1.12</aether.version>

--- a/spark/interpreter/pom.xml
+++ b/spark/interpreter/pom.xml
@@ -265,6 +265,18 @@
     <plugins>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${project.basedir}/../../interpreter/spark/</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>com.googlecode.maven-download-plugin</groupId>
         <artifactId>download-maven-plugin</artifactId>
         <executions>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -33,6 +33,8 @@
     <description>Zeppelin Spark Support</description>
 
     <properties>
+        <interpreter.name>spark</interpreter.name>
+
         <spark.version>3.5.3</spark.version>
         <protobuf.version>3.21.12</protobuf.version>
         <py4j.version>0.10.9.7</py4j.version>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -33,8 +33,6 @@
     <description>Zeppelin Spark Support</description>
 
     <properties>
-        <interpreter.name>spark</interpreter.name>
-
         <spark.version>3.5.3</spark.version>
         <protobuf.version>3.21.12</protobuf.version>
         <py4j.version>0.10.9.7</py4j.version>

--- a/spark/spark-scala-parent/pom.xml
+++ b/spark/spark-scala-parent/pom.xml
@@ -108,18 +108,6 @@
         <pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${project.basedir}/../../interpreter/spark/scala-${spark.scala.binary.version}</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
### What is this PR for?
The Maven clean goal does not remove some interpreter files in `interpreter/` directory as expected.
Specifically, the `spark` and `flink` interpreters are not cleaned.

This happens because when extending the `pom.xml` in the `pom.xml` of these interpreters, they lack the `interpreter.name` property.
As a result, the clean target directory configured in `zeppelion-interpreter-parent` was not properly resolved before.


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6135

### How should this be tested?
- Build Zeppelin
- Clean Zeppelin and check if all interpreters are removed in `interpreter/`

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
