### PR TITLE
[ZEPPELIN-6136] Java release to 11

### DIFF
--- a/docs/development/contribution/how_to_contribute_code.md
+++ b/docs/development/contribution/how_to_contribute_code.md
@@ -41,8 +41,7 @@ You are free to use whatever IDE you prefer, or your favorite command line edito
 
 To build the code, install
 
-  * Oracle Java 8
-  * Apache Maven
+  * Java 11
 
 ## Getting the source code
 First of all, you need Zeppelin source code. The official location of Zeppelin is [https://gitbox.apache.org/repos/asf/zeppelin.git](https://gitbox.apache.org/repos/asf/zeppelin.git).
@@ -55,10 +54,10 @@ Get the source code on your development machine using git.
 git clone git://gitbox.apache.org/repos/asf/zeppelin.git zeppelin
 ```
 
-You may also want to develop against a specific branch. For example, for branch-0.5.6
+You may also want to develop against a specific branch. For example, for branch-0.11.0
 
 ```bash
-git clone -b branch-0.5.6 git://gitbox.apache.org/repos/asf/zeppelin.git zeppelin
+git clone -b branch-0.11.0 git://gitbox.apache.org/repos/asf/zeppelin.git zeppelin
 ```
 
 Apache Zeppelin follows [Fork & Pull](https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Development-workflow-with-Git:-Fork,-Branching,-Commits,-and-Pull-Request) as a source control workflow.

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- language versions -->
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <!-- These two lines could be changed like `maven.compiler.release` after updating JDK11 -->
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
### What is this PR for?
Small change, big effect. This pull request changes the Maven compiler setting to JDK 11.


### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6136

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? YES
* Does this needs documentation? Yes
