### PR TITLE
[ZEPPELIN-6137] Fix Windows compile tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ platform:
 build: Script
 
 os:
-  - Visual Studio 2022
+  - Visual Studio 2019
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: True
@@ -40,7 +40,7 @@ cache:
   - '%USERPROFILE%/.m2'
 
 build_script:
-  - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: set JAVA_HOME=C:\Program Files\Java\jdk11
   - cmd: >-
       ./mvnw.cmd clean package -DskipTests ^
       -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade.mojo.ShadeMojo=warn ^


### PR DESCRIPTION
### What is this PR for?
This pull request changes the JDK for appveyor to JDK 11.
Please note that only the “Visual Studio 2019” worker image has JDK 11 installed. “Visual Studio 2022”, on the other hand, does not have JDK 11 installed. Take a look into https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6137

### How should this be tested?
* appveyor tests

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
