### PR TITLE
[ZEPPELIN-6138] Update Apache Parent

### DIFF
--- a/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
+++ b/bigquery/src/main/java/org/apache/zeppelin/bigquery/BigQueryInterpreter.java
@@ -101,10 +101,10 @@ public class BigQueryInterpreter extends Interpreter {
 
   private static final Function<CharSequence, String> sequenceToStringTransformer =
       new Function<CharSequence, String>() {
-      public String apply(CharSequence seq) {
-        return seq.toString();
-      }
-    };
+        public String apply(CharSequence seq) {
+          return seq.toString();
+        }
+      };
 
   public BigQueryInterpreter(Properties property) {
     super(property);

--- a/build-tools/src/main/resources/zeppelin/checkstyle.xml
+++ b/build-tools/src/main/resources/zeppelin/checkstyle.xml
@@ -46,6 +46,13 @@ limitations under the License.
       value='All TODOs should be named.  e.g. "TODO(johndoe): Refactor when v2 is released."'/>
   </module>
 
+  <!-- Checks if a line is too long. -->
+  <module name="LineLength">
+    <property name="severity" value="error"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$"/>
+  </module>
+
   <!-- <module name="JavadocPackage"> - Checks that each Java package has
     a Javadoc file used for commenting. Only allows a package-info.java, not
     package.html. </module> -->
@@ -69,14 +76,11 @@ limitations under the License.
     <!-- Checks for Javadoc comments. -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html -->
     <module name="JavadocMethod">
-      <property name="scope" value="protected"/>
       <property name="severity" value="warning"/>
-      <property name="allowMissingJavadoc" value="true"/>
+      <property name="accessModifiers" value="protected"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
-      <property name="allowUndeclaredRTE" value="true"/>
+      <property name="validateThrows" value="false"/>
     </module>
 
     <module name="JavadocStyle">
@@ -165,21 +169,6 @@ limitations under the License.
 
 
     <!-- LENGTH and CODING CHECKS -->
-
-    <module name="LineLength">
-      <!-- Checks if a line is too long. -->
-      <property name="max"
-        value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}"
-        default="100"/>
-      <property name="severity" value="error"/>
-
-      <!-- The default ignore pattern exempts the following elements: - import
-        statements - long URLs inside comments -->
-
-      <property name="ignorePattern"
-        value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
-        default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$"/>
-    </module>
 
     <module name="LeftCurly">
       <!-- Checks for placement of the left curly brace ('{'). -->

--- a/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
+++ b/elasticsearch/src/test/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreterTest.java
@@ -101,26 +101,24 @@ public class ElasticsearchInterpreterTest {
               .field("headers", Arrays.asList("Accept: *.*", "Host: apache.org"))
             .endObject()
             .field("status", STATUS[RandomUtils.nextInt(0, STATUS.length)])
-            .field("content_length", RandomUtils.nextInt(0, 2000))
-          )
-        .get();
+            .field("content_length", RandomUtils.nextInt(0, 2000)))
+            .get();
     }
 
     for (int i = 1; i < 3; i++) {
       elsClient.prepareIndex("logs", "http", "very/strange/id#" + i)
         .setRefresh(true)
         .setSource(jsonBuilder()
-            .startObject()
-              .field("date", new Date())
-              .startObject("request")
-                .field("method", METHODS[RandomUtils.nextInt(0, METHODS.length)])
-                .field("url", "/zeppelin/" + UUID.randomUUID().toString())
-                .field("headers", Arrays.asList("Accept: *.*", "Host: apache.org"))
-              .endObject()
-              .field("status", STATUS[RandomUtils.nextInt(0, STATUS.length)])
-              .field("content_length", RandomUtils.nextInt(0, 2000))
-            )
-        .get();
+          .startObject()
+            .field("date", new Date())
+            .startObject("request")
+              .field("method", METHODS[RandomUtils.nextInt(0, METHODS.length)])
+              .field("url", "/zeppelin/" + UUID.randomUUID().toString())
+              .field("headers", Arrays.asList("Accept: *.*", "Host: apache.org"))
+            .endObject()
+            .field("status", STATUS[RandomUtils.nextInt(0, STATUS.length)])
+            .field("content_length", RandomUtils.nextInt(0, 2000)))
+            .get();
     }
 
     final Properties props = new Properties();

--- a/java/src/main/java/org/apache/zeppelin/java/JavaInterpreter.java
+++ b/java/src/main/java/org/apache/zeppelin/java/JavaInterpreter.java
@@ -52,7 +52,7 @@ public class JavaInterpreter extends Interpreter {
     /* Clean up .class files created during the compilation process. */
     Stream.of(
       new File(".").listFiles(f -> f.getAbsolutePath().endsWith(".class")))
-      .forEach(f -> f.delete());
+        .forEach(f -> f.delete());
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>28</version>
+    <version>33</version>
   </parent>
 
   <licenses>
@@ -161,27 +161,18 @@
     <awaitility.version>4.2.0</awaitility.version>
 
     <!-- plugin versions -->
-    <plugin.antrun.version>1.8</plugin.antrun.version>
-    <plugin.assembly.version>3.7.1</plugin.assembly.version>
     <plugin.avro.version>1.7.7</plugin.avro.version>
     <plugin.buildhelper.version>1.7</plugin.buildhelper.version>
     <plugin.buildnumber.version>1.4</plugin.buildnumber.version>
     <plugin.checkstyle.version>2.17</plugin.checkstyle.version>
-    <plugin.clean.version>3.1.0</plugin.clean.version>
     <plugin.cobertura.version>2.7</plugin.cobertura.version>
-    <plugin.compiler.version>3.8.1</plugin.compiler.version>
-    <plugin.dependency.version>3.1.2</plugin.dependency.version>
-    <plugin.deploy.version>2.8.2</plugin.deploy.version>
     <plugin.download.version>1.6.0</plugin.download.version>
-    <plugin.enforcer.version>3.0.0-M3</plugin.enforcer.version>
     <plugin.exec.version>1.6.0</plugin.exec.version>
     <plugin.git.commit.id.version>4.0.0</plugin.git.commit.id.version>
-    <plugin.gpg.version>1.6</plugin.gpg.version>
     <plugin.jar.version>3.2.0</plugin.jar.version>
     <plugin.javadoc.version>3.2.0</plugin.javadoc.version>
     <plugin.lifecycle.mapping.version>1.0.0</plugin.lifecycle.mapping.version>
     <plugin.protobuf.version>3.11.4</plugin.protobuf.version>
-    <plugin.rat.version>0.13</plugin.rat.version>
     <plugin.resource.version>3.1.0</plugin.resource.version>
     <plugin.s3.upload.version>1.4</plugin.s3.upload.version>
     <plugin.scala.alchim31.version>4.8.0</plugin.scala.alchim31.version>
@@ -189,7 +180,6 @@
     <plugin.scalatest.version>2.2.0</plugin.scalatest.version>
     <plugin.scm.version>1.11.2</plugin.scm.version>
     <plugin.source.version>3.2.1</plugin.source.version>
-    <plugin.surefire.version>3.2.2</plugin.surefire.version>
     <plugin.os.version>1.4.1.Final</plugin.os.version>
 
     <testcontainers.version>1.19.0</testcontainers.version>
@@ -623,20 +613,7 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>${plugin.enforcer.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>${plugin.deploy.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${plugin.checkstyle.version}</version>
           <configuration>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
             <sourceDirectories>${basedir}/src/main/java,${basedir}/src/main/scala</sourceDirectories>
@@ -666,12 +643,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>${plugin.clean.version}</version>
-        </plugin>
-
-        <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>${plugin.scala.alchim31.version}</version>
@@ -688,7 +659,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${plugin.surefire.version}</version>
           <configuration combine.children="append">
             <failIfNoTests>false</failIfNoTests>
             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
@@ -705,12 +675,6 @@
             <goal>test</goal> </goals> <configuration> <excludes> <exclude>none</exclude>
             </excludes> <includes> <include>**/itest/**</include> </includes> </configuration>
             </execution> </executions> -->
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>${plugin.assembly.version}</version>
         </plugin>
 
         <plugin>
@@ -733,14 +697,7 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>${plugin.antrun.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>${plugin.dependency.version}</version>
           <executions>
             <execution>
               <id>copy-dependencies</id>
@@ -781,7 +738,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${plugin.surefire.version}</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
             <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
@@ -830,17 +786,6 @@
           <version>${plugin.javadoc.version}</version>
         </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>${plugin.gpg.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>${plugin.rat.version}</version>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -960,6 +960,7 @@
               <exclude>.git/</exclude>
               <exclude>.github/</exclude>
               <exclude>.gitignore</exclude>
+              <exclude>.gitattributes</exclude>
               <exclude>git.properties</exclude>
               <exclude>.repository/</exclude>
               <exclude>.rat-excludes/</exclude>


### PR DESCRIPTION
### What is this PR for?
This pull request updates the Apache parent version. We benefit significantly from plugin updates and can clean up our own `pom.xml`.

plugin updates:
maven-antrun-plugin - 1.8 -> 3.1.0
maven-assembly-plugin - 3.7.1 -> 3.7.1
maven-clean-plugin - 3.1.0 -> 3.4.0
maven-compiler-plugin - 3.8.1 -> 3.13.0
maven-dependency-plugin - 3.1.2 -> 3.7.1
maven-deploy-plugin - 2.8.2 -> 3.1.2
maven-enforcer-plugin - 3.0.0-M3 -> 3.5.0
maven-gpg-plugin - 1.6 -> 3.2.4
apache-rat-plugin - 0.13 -> 0.16.1
surefire & failsafe version - 3.2.2 -> 3.3.0

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6138

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
