### PR TITLE
[ZEPPELIN-6139] Write a Dockerfile for groovy interpreter image build

### DIFF
--- a/groovy/Dockerfile
+++ b/groovy/Dockerfile
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM openjdk:11 AS builder
+
+COPY . /zeppelin/
+
+WORKDIR /zeppelin
+
+RUN chmod +x ./mvnw
+RUN ./mvnw clean package -am -pl zeppelin-interpreter-shaded,zeppelin-interpreter,groovy -DskipTests
+
+FROM openjdk:11
+
+COPY --from=builder /zeppelin/bin /zeppelin/bin/
+COPY --from=builder /zeppelin/conf /zeppelin/conf
+
+COPY --from=builder /zeppelin/interpreter/groovy /zeppelin/interpreter/groovy
+COPY --from=builder /zeppelin/zeppelin-interpreter-shaded/target /zeppelin/zeppelin-interpreter-shaded/target
+
+WORKDIR /zeppelin
+
+ENV GROOVY_INTERPRETER_PORT=8180
+
+RUN chmod +x ./bin/interpreter.sh
+
+CMD ./bin/interpreter.sh \
+    -d ./interpreter/groovy \
+    -c host.docker.internal \
+    -p ${INTERPRETER_EVENT_SERVER_PORT} \
+    -r ${GROOVY_INTERPRETER_PORT}:${GROOVY_INTERPRETER_PORT} \
+    -i groovy-shared_process \
+    -l ./local-repo/groovy \
+    -g groovy

--- a/groovy/README.md
+++ b/groovy/README.md
@@ -1,4 +1,39 @@
-## Groovy Interpreter
-
+# Groovy Interpreter
 
 [see groovy documentation](../docs/interpreter/groovy.md)
+
+## Overview
+Groovy interpreter for Apache Zeppelin
+
+## Run the interpreter with docker
+You can run the Groovy interpreter as a standalone docker container.
+
+### Step 1. Specify the configuration for the Groovy interpreter
+```bash
+    # conf/interpreter.json
+
+    "groovy": {
+      ...
+      "option":
+      } {
+        "remote": true,
+        "port": {INTERPRETER_PROCESS_PORT_IN_HOST},
+        "isExistingProcess": true,
+        "host": "localhost",
+        ...
+      }
+````
+
+### Step 2. Build and run the Groovy interpreter
+```bash
+$ ./mvnw clean install -DskipTests
+ 
+$ ./bin/zeppelin-daemon.sh start # start zeppelin server.
+# check the port of the interpreter event server. you can find it by looking for the log that starts with "InterpreterEventServer is starting at"
+   
+$ docker build -f ./groovy/Dockerfile -t groovy-interpreter .
+
+$ docker run -p {INTERPRETER_PROCESS_PORT_IN_HOST}:8180 \
+  -e INTERPRETER_EVENT_SERVER_PORT={INTERPRETER_EVENT_SERVER_PORT} \
+  groovy-interpreter
+```


### PR DESCRIPTION
### What is this PR for?
- This PR adds a Dockerfile to build a groovy interpreter. it could be helpful to use distributed computing resources.

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
- [ZEPPELIN-6139](https://issues.apache.org/jira/browse/ZEPPELIN-6139)

### How should this be tested?
- Build and run the docker container
- Verify that the groovy interpreter container communicates with the zeppelin server

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? Yes
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
