### PR TITLE
[ZEPPELIN-6084] Update jena-arq to 4.10

### DIFF
--- a/sparql/pom.xml
+++ b/sparql/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <interpreter.name>sparql</interpreter.name>
-        <jena.version>3.12.0</jena.version>
+        <jena.version>4.10.0</jena.version>
     </properties>
 
     <dependencies>

--- a/sparql/src/main/java/org/apache/zeppelin/sparql/JenaInterpreter.java
+++ b/sparql/src/main/java/org/apache/zeppelin/sparql/JenaInterpreter.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.sparql;
 
 import org.apache.http.HttpStatus;
 
+import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.query.ResultSet;
@@ -84,7 +85,7 @@ public class JenaInterpreter implements SparqlEngine {
               InterpreterResult.Code.SUCCESS,
               InterpreterResult.Type.TABLE,
               tsv);
-    } catch (QueryParseException e) {
+    } catch (QueryParseException | HttpException e) {
       LOGGER.error(e.toString());
       return new InterpreterResult(
         InterpreterResult.Code.ERROR,

--- a/sparql/src/main/java/org/apache/zeppelin/sparql/JenaInterpreter.java
+++ b/sparql/src/main/java/org/apache/zeppelin/sparql/JenaInterpreter.java
@@ -20,7 +20,6 @@ package org.apache.zeppelin.sparql;
 import org.apache.http.HttpStatus;
 
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFormatter;
@@ -57,10 +56,10 @@ public class JenaInterpreter implements SparqlEngine {
 
   @Override
   public InterpreterResult query(String query) {
-    LOGGER.info("SPARQL: Run Query '" + query + "' against " + serviceEndpoint);
+    LOGGER.info("SPARQL: Run Query '{}' against {}", query, serviceEndpoint);
 
     try {
-      queryExecution = QueryExecutionFactory.sparqlService(serviceEndpoint, query);
+      queryExecution = QueryExecution.service(serviceEndpoint).query(query).build();
       PrefixMapping prefixMapping = queryExecution.getQuery().getPrefixMapping();
 
       // execute query and get Results
@@ -92,7 +91,7 @@ public class JenaInterpreter implements SparqlEngine {
         "Error: " + e.getMessage());
     } catch (QueryExceptionHTTP e) {
       LOGGER.error(e.toString());
-      int responseCode = e.getResponseCode();
+      int responseCode = e.getStatusCode();
 
       if (responseCode == HttpStatus.SC_UNAUTHORIZED) {
         return new InterpreterResult(

--- a/sparql/src/main/java/org/apache/zeppelin/sparql/SparqlInterpreter.java
+++ b/sparql/src/main/java/org/apache/zeppelin/sparql/SparqlInterpreter.java
@@ -42,8 +42,8 @@ public class SparqlInterpreter extends Interpreter {
 
   public static final String ENGINE_TYPE_JENA = "jena";
 
-  public SparqlEngine engine;
-  
+  private SparqlEngine engine;
+
   /**
    * Sparql Engine Type.
    */
@@ -73,7 +73,7 @@ public class SparqlInterpreter extends Interpreter {
 
     if (SparqlEngineType.JENA.toString().equals(engineType)) {
       engine = new JenaInterpreter(serviceEndpoint, replaceURIs, removeDatatypes);
-    } 
+    }
   }
 
   @Override

--- a/sparql/src/test/java/org/apache/zeppelin/sparql/SparqlJenaEngineTest.java
+++ b/sparql/src/test/java/org/apache/zeppelin/sparql/SparqlJenaEngineTest.java
@@ -108,6 +108,11 @@ class SparqlJenaEngineTest {
     assertEquals(Code.SUCCESS, result.code());
 
     final String expected = "?subject\t?predicate\t?object\n" +
+        "<http://example.org/#green-goblin>\t<http://xmlns.com/foaf/0.1/name>\t\"Green Goblin\"\n" +
+        "<http://example.org/#green-goblin>\t<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>" +
+        "\t<http://xmlns.com/foaf/0.1/Person>\n<http://example.org/#green-goblin>\t" +
+        "<http://www.perceive.net/schemas/relationship/enemyOf>\t" +
+        "<http://example.org/#spiderman>\n" +
         "<http://example.org/#spiderman>\t<http://xmlns.com/foaf/0.1/name>" +
         "\t\"Человек-паук\"@ru\n<http://example.org/#spiderman>\t" +
         "<http://xmlns.com/foaf/0.1/name>\t\"Spiderman\"\n" +
@@ -116,12 +121,7 @@ class SparqlJenaEngineTest {
         "<http://www.perceive.net/schemas/relationship/enemyOf>\t" +
         "<http://example.org/#green-goblin>\n<http://example.org/#spiderman>\t" +
         "<http://example.org/stats#born>\t\"1962-10-15T14:00.00\"^^" +
-        "<http://www.w3.org/2001/XMLSchema#dateTime>\n<http://example.org/#green-goblin>\t" +
-        "<http://xmlns.com/foaf/0.1/name>\t\"Green Goblin\"\n" +
-        "<http://example.org/#green-goblin>\t" +
-        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>" +
-        "\t<http://xmlns.com/foaf/0.1/Person>\n<http://example.org/#green-goblin>\t" +
-        "<http://www.perceive.net/schemas/relationship/enemyOf>\t<http://example.org/#spiderman>\n";
+        "<http://www.w3.org/2001/XMLSchema#dateTime>\n";
     assertEquals(expected, result.message().get(0).getData());
   }
 
@@ -141,6 +141,11 @@ class SparqlJenaEngineTest {
     assertEquals(Code.SUCCESS, result.code());
 
     final String expected = "?subject\t?predicate\t?object\n" +
+        "<http://example.org/#green-goblin>\t<foaf:name>\t\"Green Goblin\"\n" +
+        "<http://example.org/#green-goblin>\t" +
+        "<rdf:type>" +
+        "\t<foaf:Person>\n<http://example.org/#green-goblin>\t" +
+        "<rel:enemyOf>\t<http://example.org/#spiderman>\n" +
         "<http://example.org/#spiderman>\t<foaf:name>" +
         "\t\"Человек-паук\"@ru\n<http://example.org/#spiderman>\t" +
         "<foaf:name>\t\"Spiderman\"\n" +
@@ -148,12 +153,7 @@ class SparqlJenaEngineTest {
         "\t<foaf:Person>\n<http://example.org/#spiderman>\t" +
         "<rel:enemyOf>\t" +
         "<http://example.org/#green-goblin>\n<http://example.org/#spiderman>\t" +
-        "<http://example.org/stats#born>\t1962-10-15T14:00.00\n" +
-        "<http://example.org/#green-goblin>\t<foaf:name>\t\"Green Goblin\"\n" +
-        "<http://example.org/#green-goblin>\t" +
-        "<rdf:type>" +
-        "\t<foaf:Person>\n<http://example.org/#green-goblin>\t" +
-        "<rel:enemyOf>\t<http://example.org/#spiderman>\n";
+        "<http://example.org/stats#born>\t1962-10-15T14:00.00\n";
 
     assertEquals(expected, result.message().get(0).getData());
   }

--- a/sparql/src/test/java/org/apache/zeppelin/sparql/SparqlJenaEngineTest.java
+++ b/sparql/src/test/java/org/apache/zeppelin/sparql/SparqlJenaEngineTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.zeppelin.sparql;
 
-import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.query.Dataset;
@@ -52,7 +52,7 @@ class SparqlJenaEngineTest {
 
   @BeforeAll
   public static void setUp() {
-    port = Fuseki.choosePort();
+    port = WebLib.choosePort();
 
     Model model = ModelFactory.createDefaultModel();
     model.read(DATA_FILE);


### PR DESCRIPTION
### What is this PR for?
This PR is a follow-up to #4507.
I have decided to switch to the latest version 4.x. From 5.x JDK 17 is required. Obsolete functions have been removed.

Note: I do not use the interpreter myself. I have not tested it manually either. I rely on the unit tests.

### What type of PR is it?
Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6084

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? Maybe
* Does this needs documentation? No
