### PR TITLE
[ZEPPELIN-6141] Update the link to the page where all issues are sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Mailing Lists:** [User and Dev mailing list](https://zeppelin.apache.org/community.html)<br/>
 **Continuous Integration:** ![core](https://github.com/apache/zeppelin/workflows/core/badge.svg) ![frontend](https://github.com/apache/zeppelin/workflows/frontend/badge.svg) ![rat](https://github.com/apache/zeppelin/workflows/rat/badge.svg) <br/>
 **Contributing:** [Contribution Guide](https://zeppelin.apache.org/contribution/contributions.html)<br/>
-**Issue Tracker:** [Jira](https://issues.apache.org/jira/browse/ZEPPELIN)<br/>
+**Issue Tracker:** [Jira](https://issues.apache.org/jira/projects/ZEPPELIN/issues/filter=allissues)<br/>
 **License:** [Apache 2.0](https://github.com/apache/zeppelin/blob/master/LICENSE)
 
 

--- a/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
@@ -33,7 +33,7 @@
       Please feel free to help us to improve Zeppelin, <br/>
       Any contribution are welcome!<br/><br/>
       <a href="http://zeppelin.apache.org/community.html" target="_blank"><i nz-icon nzType="mail"></i> Mailing list</a><br/>
-      <a href="https://issues.apache.org/jira/browse/ZEPPELIN" target="_blank"><i nz-icon nzType="exception"></i> Issues
+      <a href="https://issues.apache.org/jira/projects/ZEPPELIN/issues/filter=allopenissues" target="_blank"><i nz-icon nzType="exception"></i> Issues
         tracking</a><br/>
       <a href="https://github.com/apache/zeppelin" target="_blank"><i nz-icon nzType="github"></i> Github</a>
     </div>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -65,7 +65,7 @@ limitations under the License.
           Any contribution are welcome!<br/><br/>
           <a style="text-decoration: none;" href="http://zeppelin.apache.org/community.html"
              target="_blank" rel="noopener noreferrer"><i style="font-size: 15px;" class="fa fa-users"></i> Mailing list</a><br/>
-          <a style="text-decoration: none;" href="https://issues.apache.org/jira/browse/ZEPPELIN"
+          <a style="text-decoration: none;" href="https://issues.apache.org/jira/projects/ZEPPELIN/issues/filter=allopenissues"
              target="_blank" rel="noopener noreferrer"><i style="font-size: 15px;" class="fa fa-bug"></i> Issues tracking</a><br/>
           <a style="text-decoration: none;" href="https://github.com/apache/zeppelin"
              target="_blank" rel="noopener noreferrer"><i style="font-size: 20px;" class="fa fa-github"></i> Github</a>


### PR DESCRIPTION
### What is this PR for?
I recommend that clicking on Issues Tracking in the Zeppelin Web UI redirects to a page where all issues are sorted.

### What type of PR is it?
Feature

### Todos
* [x] - README.md
* [x] - zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
* [x] - zeppelin-web/src/app/home/home.html

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6141

### How should this be tested?
* Click Issues Tracking after build

### Screenshots (if appropriate)

Zeppelin Web UI
![image](https://github.com/user-attachments/assets/fa226c93-2e32-474d-a000-07d7c2aa3ade)

Before
![image](https://github.com/user-attachments/assets/01365989-e2bf-4a3a-b2d1-52a3b164a44b)

After
![image](https://github.com/user-attachments/assets/e463b29b-a321-4c13-ada3-030757e11f9e)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
