### PR TITLE
[ZEPPELIN-6190] Prevent directory escape bypass through repeated URL decoding

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/NotebookService.java
@@ -1555,13 +1555,13 @@ public class NotebookService {
     }
   }
 
-  private String decodeRepeatedly(final String encoded) throws IOException {
+  private static String decodeRepeatedly(final String encoded) throws IOException {
     String previous = encoded;
     int maxDecodeAttempts = 5;
     int attempts = 0;
 
     while (attempts < maxDecodeAttempts) {
-      String decoded = URLDecoder.decode(previous, StandardCharsets.UTF_8.toString());
+      String decoded = URLDecoder.decode(previous, StandardCharsets.UTF_8);
       attempts++;
       if (decoded.equals(previous)) {
         return decoded;

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/NotebookServiceTest.java
@@ -616,6 +616,19 @@ class NotebookServiceTest {
       assertEquals("Note name can not contain '..'", e.getMessage());
     }
     try {
+      // Double URL encoding of ".."
+      notebookService.normalizeNotePath("%252e%252e/%252e%252e/tmp/test333");
+      fail("Should fail");
+    } catch (IOException e) {
+      assertEquals("Note name can not contain '..'", e.getMessage());
+    }
+    try {
+      notebookService.normalizeNotePath("%252525252e%252525252e/tmp/test444");
+      fail("Should fail");
+    } catch (IOException e) {
+      assertEquals("Exceeded maximum decode attempts. Possible malicious input.", e.getMessage());
+    }
+    try {
       notebookService.normalizeNotePath("./");
       fail("Should fail");
     } catch (IOException e) {


### PR DESCRIPTION
### What is this PR for?
This PR addresses an issue in `NotebookService` where the notebook path validation only performs a single decoding pass.
This allowed a malicious user to bypass validation by double-encoding the `".."` token.
By implementing the repeated decoding, we can prevent this bypass.
Additionally, to prevent excessive decoding attempts, a maximum limit on the number of decoding attempts has been added.

### What type of PR is it?
Hot Fix

### What is the Jira issue?
https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6190

### How should this be tested?
* CI

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions?
  * There may be minor compatibility issues if a user relies on multiple encoded paths, but this is unlikely in realistic scenarios.
* Does this needs documentation? No
