### PR TITLE
[ZEPPELIN-6143] Add Interpreter Event Server Port configuration option

### DIFF
--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -29,7 +29,7 @@
 # export ZEPPELIN_SSL_PORT                      # ssl port (used when ssl environment variable is set to true)
 # export ZEPPELIN_JMX_ENABLE                    # Enable JMX feature by defining "true"
 # export ZEPPELIN_JMX_PORT                      # Port number which JMX uses. If not set, JMX won't be enabled
-# export ZEPPELIN_EVENT_SERVER_PORT             # Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.
+# export ZEPPELIN_SERVER_RPC_PORT               # Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.
 
 # export ZEPPELIN_LOG_DIR                       # Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR                       # The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-env.sh.template
+++ b/conf/zeppelin-env.sh.template
@@ -29,6 +29,7 @@
 # export ZEPPELIN_SSL_PORT                      # ssl port (used when ssl environment variable is set to true)
 # export ZEPPELIN_JMX_ENABLE                    # Enable JMX feature by defining "true"
 # export ZEPPELIN_JMX_PORT                      # Port number which JMX uses. If not set, JMX won't be enabled
+# export ZEPPELIN_EVENT_SERVER_PORT             # Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.
 
 # export ZEPPELIN_LOG_DIR                       # Where log files are stored.  PWD by default.
 # export ZEPPELIN_PID_DIR                       # The pid files are stored. ${ZEPPELIN_HOME}/run by default.

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -44,7 +44,7 @@
 </property>
 
 <property>
-  <name>zeppelin.event.server.port</name>
+  <name>zeppelin.server.rpc.port</name>
   <value></value>
   <description>Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.</description>
 </property>

--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -44,6 +44,12 @@
 </property>
 
 <property>
+  <name>zeppelin.event.server.port</name>
+  <value></value>
+  <description>Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.</description>
+</property>
+
+<property>
   <name>zeppelin.war.tempdir</name>
   <value>webapps</value>
   <description>Location of jetty temporary directory</description>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -61,8 +61,8 @@ Sources descending by priority:
     <td>8443</td>
     <td>Zeppelin Server ssl port (used when ssl environment/property is set to true)</td>
   </tr>
-    <td><h6 class="properties">ZEPPELIN_EVENT_SERVER_PORT</h6></td>
-    <td><h6 class="properties">zeppelin.event.server.port</h6></td>
+    <td><h6 class="properties">ZEPPELIN_SERVER_RPC_PORT</h6></td>
+    <td><h6 class="properties">zeppelin.server.rpc.port</h6></td>
     <td></td>
     <td>Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.</td>
   <tr>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -61,6 +61,12 @@ Sources descending by priority:
     <td>8443</td>
     <td>Zeppelin Server ssl port (used when ssl environment/property is set to true)</td>
   </tr>
+    <td><h6 class="properties">ZEPPELIN_EVENT_SERVER_PORT</h6></td>
+    <td><h6 class="properties">zeppelin.event.server.port</h6></td>
+    <td></td>
+    <td>Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.</td>
+  <tr>
+  </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_JMX_ENABLE</h6></td>
     <td><h6 class="properties">zeppelin.jmx.enable</h6></td>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -64,11 +64,22 @@ Sources descending by priority:
   <tr>
     <td><h6 class="properties">ZEPPELIN_SERVER_RPC_PORTRANGE</h6></td>
     <td><h6 class="properties">zeppelin.server.rpc.portRange</h6></td>
-    <td></td>
-    <td>Port range for the Zeppelin Interpreter Event Server. If not set start from 1024 to 65535 will be used automatically.<br />
-      <span style="font-style:italic; color: gray">
-        Note: If <code>ZEPPELIN_SERVER_RPC_PORT</code> is set, this property will be ignored.
-      </span>
+    <td>:</td>
+     <td>
+      Specifies the port range for the Zeppelin Interpreter Event Server.
+      <br />Format: <code>&lt;startPort&gt;:&lt;endPort&gt;</code>
+      <br />If the <code>&lt;startPort&gt;</code> is omitted, the range will begin at 1024. If the <code>&lt;endPort&gt;</code> is omitted, the range will extend up to 65535.
+      <br /><span style="font-style:italic; color: gray"> Note: If <code>zeppelin.server.rpc.port</code> is set, this property will be ignored.</span>
+    </td>
+  </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_INTERPRETER_RPC_PORTRANGE</h6></td>
+    <td><h6 class="properties">zeppelin.interpreter.rpc.portRange</h6></td>
+    <td>:</td>
+     <td>
+      Specifies the port range for the Zeppelin Interpreter.
+      <br />Format: <code>&lt;startPort&gt;:&lt;endPort&gt;</code>
+      <br />If the <code>&lt;startPort&gt;</code> is omitted, the range will begin at 1024. If the <code>&lt;endPort&gt;</code> is omitted, the range will extend up to 65535.
     </td>
   </tr>
   <tr>

--- a/docs/setup/operation/configuration.md
+++ b/docs/setup/operation/configuration.md
@@ -61,11 +61,21 @@ Sources descending by priority:
     <td>8443</td>
     <td>Zeppelin Server ssl port (used when ssl environment/property is set to true)</td>
   </tr>
+  <tr>
+    <td><h6 class="properties">ZEPPELIN_SERVER_RPC_PORTRANGE</h6></td>
+    <td><h6 class="properties">zeppelin.server.rpc.portRange</h6></td>
+    <td></td>
+    <td>Port range for the Zeppelin Interpreter Event Server. If not set start from 1024 to 65535 will be used automatically.<br />
+      <span style="font-style:italic; color: gray">
+        Note: If <code>ZEPPELIN_SERVER_RPC_PORT</code> is set, this property will be ignored.
+      </span>
+    </td>
+  </tr>
+  <tr>
     <td><h6 class="properties">ZEPPELIN_SERVER_RPC_PORT</h6></td>
     <td><h6 class="properties">zeppelin.server.rpc.port</h6></td>
     <td></td>
     <td>Port for the Zeppelin Interpreter Event Server. If not set, an available port will be used automatically.</td>
-  <tr>
   </tr>
   <tr>
     <td><h6 class="properties">ZEPPELIN_JMX_ENABLE</h6></td>

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -338,12 +338,12 @@ public class ZeppelinConfiguration {
     return getInt(ConfVars.ZEPPELIN_PORT);
   }
 
-  public OptionalInt getEventServerPort() {
-    String eventServerPort = getString(ConfVars.ZEPPELIN_EVENT_SERVER_PORT);
-    if (StringUtils.isBlank(eventServerPort)) {
+  public OptionalInt getZeppelinServerRpcPort() {
+    String zeppelinServerRpcPort = getString(ConfVars.ZEPPELIN_SERVER_RPC_PORT);
+    if (StringUtils.isBlank(zeppelinServerRpcPort)) {
       return OptionalInt.empty();
     }
-    return OptionalInt.of(Integer.parseInt(eventServerPort));
+    return OptionalInt.of(Integer.parseInt(zeppelinServerRpcPort));
   }
 
   public String getServerContextPath() {
@@ -956,7 +956,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_SSL_TRUSTSTORE_PATH("zeppelin.ssl.truststore.path", null),
     ZEPPELIN_SSL_TRUSTSTORE_TYPE("zeppelin.ssl.truststore.type", null),
     ZEPPELIN_SSL_TRUSTSTORE_PASSWORD("zeppelin.ssl.truststore.password", null),
-    ZEPPELIN_EVENT_SERVER_PORT("zeppelin.event.server.port", null),
+    ZEPPELIN_SERVER_RPC_PORT("zeppelin.server.rpc.port", null),
     ZEPPELIN_WAR("zeppelin.war", "zeppelin-web/dist"),
     ZEPPELIN_ANGULAR_WAR("zeppelin.angular.war", "zeppelin-web-angular/dist/zeppelin"),
     ZEPPELIN_WAR_TEMPDIR("zeppelin.war.tempdir", "webapps"),

--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/conf/ZeppelinConfiguration.java
@@ -338,6 +338,14 @@ public class ZeppelinConfiguration {
     return getInt(ConfVars.ZEPPELIN_PORT);
   }
 
+  public OptionalInt getEventServerPort() {
+    String eventServerPort = getString(ConfVars.ZEPPELIN_EVENT_SERVER_PORT);
+    if (StringUtils.isBlank(eventServerPort)) {
+      return OptionalInt.empty();
+    }
+    return OptionalInt.of(Integer.parseInt(eventServerPort));
+  }
+
   public String getServerContextPath() {
     return getString(ConfVars.ZEPPELIN_SERVER_CONTEXT_PATH);
   }
@@ -948,6 +956,7 @@ public class ZeppelinConfiguration {
     ZEPPELIN_SSL_TRUSTSTORE_PATH("zeppelin.ssl.truststore.path", null),
     ZEPPELIN_SSL_TRUSTSTORE_TYPE("zeppelin.ssl.truststore.type", null),
     ZEPPELIN_SSL_TRUSTSTORE_PASSWORD("zeppelin.ssl.truststore.password", null),
+    ZEPPELIN_EVENT_SERVER_PORT("zeppelin.event.server.port", null),
     ZEPPELIN_WAR("zeppelin.war", "zeppelin-web/dist"),
     ZEPPELIN_ANGULAR_WAR("zeppelin.angular.war", "zeppelin-web-angular/dist/zeppelin"),
     ZEPPELIN_WAR_TEMPDIR("zeppelin.war.tempdir", "webapps"),

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -50,7 +50,6 @@ import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterEventService;
 import org.apache.zeppelin.interpreter.thrift.RemoteInterpreterResultMessage;
 import org.apache.zeppelin.interpreter.thrift.RunParagraphsEvent;
 import org.apache.zeppelin.interpreter.thrift.WebUrlInfo;
-import org.apache.zeppelin.notebook.Note;
 import org.apache.zeppelin.resource.RemoteResource;
 import org.apache.zeppelin.resource.Resource;
 import org.apache.zeppelin.resource.ResourceId;
@@ -104,7 +103,7 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
   }
 
   public void start() throws IOException {
-    final OptionalInt portOpt = zConf.getEventServerPort();
+    final OptionalInt portOpt = zConf.getZeppelinServerRpcPort();
     Thread startingThread = new Thread() {
       @Override
       public void run() {

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -78,7 +78,6 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteInterpreterEventServer.class);
   private static final Gson GSON = new Gson();
 
-  private String portRange;
   private int port;
   private String host;
   private ZeppelinConfiguration zConf;
@@ -96,18 +95,18 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
   public RemoteInterpreterEventServer(ZeppelinConfiguration zConf,
                                       InterpreterSettingManager interpreterSettingManager) {
     this.zConf = zConf;
-    this.portRange = zConf.getZeppelinServerRPCPortRange();
     this.interpreterSettingManager = interpreterSettingManager;
     this.listener = interpreterSettingManager.getRemoteInterpreterProcessListener();
     this.appListener = interpreterSettingManager.getAppEventListener();
   }
 
   public void start() throws IOException {
-    final OptionalInt portOpt = zConf.getZeppelinServerRpcPort();
     Thread startingThread = new Thread() {
       @Override
       public void run() {
-        try (TServerSocket tSocket = new TServerSocket(portOpt.orElse(RemoteInterpreterUtils.findAvailablePort(portRange)))) {
+        try (TServerSocket tSocket = new TServerSocket(zConf.getZeppelinServerRpcPort().orElse(
+            RemoteInterpreterUtils.findAvailablePort(zConf.getZeppelinServerRPCPortRange())))
+        ) {
           port = tSocket.getServerSocket().getLocalPort();
           host = RemoteInterpreterUtils.findAvailableHostAddress();
           LOGGER.info("InterpreterEventServer is starting at {}:{}", host, port);

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/RemoteInterpreterEventServer.java
@@ -20,6 +20,7 @@ package org.apache.zeppelin.interpreter;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import java.util.OptionalInt;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
@@ -103,10 +104,11 @@ public class RemoteInterpreterEventServer implements RemoteInterpreterEventServi
   }
 
   public void start() throws IOException {
+    final OptionalInt portOpt = zConf.getEventServerPort();
     Thread startingThread = new Thread() {
       @Override
       public void run() {
-        try (TServerSocket tSocket = new TServerSocket(RemoteInterpreterUtils.findAvailablePort(portRange))){
+        try (TServerSocket tSocket = new TServerSocket(portOpt.orElse(RemoteInterpreterUtils.findAvailablePort(portRange)))) {
           port = tSocket.getServerSocket().getLocalPort();
           host = RemoteInterpreterUtils.findAvailableHostAddress();
           LOGGER.info("InterpreterEventServer is starting at {}:{}", host, port);


### PR DESCRIPTION
### What is this PR for?
This PR introduces the `ZEPPELIN_EVENT_SERVER_PORT` configuration option.
When this option is set, the Event server that communicates with interpreters will listen on the specified port.

The `ZEPPELIN_EVENT_SERVER_PORT` option takes precedence over `ZEPPELIN_SERVER_RPC_PORTRANGE` option.
If `ZEPPELIN_EVENT_SERVER_PORT` is set, the `ZEPPELIN_SERVER_RPC_PORTRANGE` range will be ignored.

This option is particularly useful when running individual Zeppelin components in container orchestration environments like Kubernetes.
By explicitly specifying the port, it allows for a more declarative and clearer configuration of service resources compared to `ZEPPELIN_SERVER_RPC_PORTRANGE`.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6143

### How should this be tested?
* Run Zeppelin with and without this configuration and check zeppelin-server logs for the message `"InterpreterEventServer is starting at "`. Verify that the specified port is used as intended(If the option is set).

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
