### PR TITLE
[ZEPPELIN-6145] Remove useless message type in Terminal Interpreter

### DIFF
--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/service/TerminalService.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/service/TerminalService.java
@@ -50,10 +50,6 @@ public class TerminalService {
 
   private LinkedBlockingQueue<String> commandQueue = new LinkedBlockingQueue<>();
 
-  public void onTerminalInit() {
-    LOGGER.info("onTerminalInit");
-  }
-
   public void onTerminalReady() {
     TerminalService.startThread(() -> {
       try {

--- a/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSocket.java
+++ b/shell/src/main/java/org/apache/zeppelin/shell/terminal/websocket/TerminalSocket.java
@@ -64,12 +64,6 @@ public class TerminalSocket {
     if (messageMap.containsKey("type")) {
       String type = messageMap.get("type");
       switch (type) {
-        case "TERMINAL_INIT":
-          terminalService.onTerminalInit();
-          this.noteId = messageMap.get("noteId");
-          this.paragraphId = messageMap.get("paragraphId");
-          terminalManager.onWebSocketConnect(noteId, paragraphId);
-          break;
         case "TERMINAL_READY":
           terminalService.onTerminalReady();
           this.noteId = messageMap.get("noteId");

--- a/shell/src/main/resources/html/js/index.js
+++ b/shell/src/main/resources/html/js/index.js
@@ -46,12 +46,6 @@ function action(type, data) {
 }
 
 let app = {
-    onTerminalInit() {
-        // alert("TERMINAL_INIT");
-        ws.send(action("TERMINAL_INIT", {
-            noteId, paragraphId
-        }));
-    },
     onCommand(command) {
         ws.send(action("TERMINAL_COMMAND", {
             command

--- a/shell/src/main/resources/html/js/index.js
+++ b/shell/src/main/resources/html/js/index.js
@@ -72,8 +72,6 @@ function setupHterm() {
     t = new hterm.Terminal();
 
     t.onTerminalReady = function() {
-        // app.onTerminalInit();
-
         // Create a new terminal IO object and give it the foreground.
         // (The default IO object just prints warning messages about unhandled
         // things to the the JS console.)


### PR DESCRIPTION
### What is this PR for?
This PR removes `TERMINAL_INIT` to simplify the code. `TERMINAL_INIT`, one of the WebSocket message types in the terminal interpreter, looks unused and redundant with `TERMINAL_READY`

### What type of PR is it?
Refactoring

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6145

### How should this be tested?
* Execute terminal interpreter

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
