### PR TITLE
[ZEPPELIN-6146] Replace 'application/zpln' with '.zpln' in 'accept' attribute of file importer

### DIFF
--- a/zeppelin-web-angular/src/app/share/note-import/note-import.component.html
+++ b/zeppelin-web-angular/src/app/share/note-import/note-import.component.html
@@ -21,7 +21,7 @@
 
 <nz-tabset>
   <nz-tab nzTitle="Import From JSON File">
-    <nz-upload nzType="drag" [nzBeforeUpload]="beforeUpload" nzAccept="application/json,application/zpln">
+    <nz-upload nzType="drag" [nzBeforeUpload]="beforeUpload" nzAccept="application/json, .zpln">
       <p class="ant-upload-drag-icon">
         <i nz-icon nzType="inbox"></i>
       </p>


### PR DESCRIPTION
### What is this PR for?
Currently, in new UI, it's not that easy to import notes fron .zpln files, since by default file importer only looks for .json files. The bug was reproduced in both Win10 and MacOs

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6146
