### PR TITLE
[ZEPPELIN-6147] Make interpreter searching case-insensitive in new ui

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/interpreter/interpreter.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/interpreter/interpreter.component.ts
@@ -46,9 +46,8 @@ export class InterpreterComponent implements OnInit, OnDestroy {
   }
 
   filterInterpreters(value: string) {
-    const lowerCaseValue = value.toLowerCase();
-    this.filteredInterpreterSettings = this.interpreterSettings.filter(e =>
-      e.name.toLowerCase().includes(lowerCaseValue)
+    this.filteredInterpreterSettings = this.interpreterSettings.filter(
+      e => e.name.search(new RegExp(value, 'i')) !== -1
     );
 
     this.cdr.markForCheck();

--- a/zeppelin-web-angular/src/app/pages/workspace/interpreter/interpreter.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/interpreter/interpreter.component.ts
@@ -46,7 +46,11 @@ export class InterpreterComponent implements OnInit, OnDestroy {
   }
 
   filterInterpreters(value: string) {
-    this.filteredInterpreterSettings = this.interpreterSettings.filter(e => e.name.search(value) !== -1);
+    const lowerCaseValue = value.toLowerCase();
+    this.filteredInterpreterSettings = this.interpreterSettings.filter(e =>
+      e.name.toLowerCase().includes(lowerCaseValue)
+    );
+
     this.cdr.markForCheck();
   }
 


### PR DESCRIPTION
### What is this PR for?
The interpreter search in the new UI doesn’t ignore case sensitivity, unlike the old UI. I updated it to be case-insensitive in the new UI as well for better UX.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
[ZEPPELIN-6147](https://issues.apache.org/jira/browse/ZEPPELIN-6147/)

### How should this be tested?
* Ensure interpreters can be searched case-insensitively

### Screenshots (if appropriate)

**old ui**
<img src="https://github.com/user-attachments/assets/3096ed71-6e76-4dcb-b3db-ecac9d1ca2e6"  width="450" />

**new ui (before update)**
<img src="https://github.com/user-attachments/assets/371bdc9f-a0d2-47bd-b3c0-1786470758a9"  width="450" />


### Questions:
* Does the license files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
