### PR TITLE
[ZEPPELIN-6150] `zeppelin.sh` shall respect HADOOP_HOME to find `hadoop` command

### DIFF
--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -122,7 +122,7 @@ if [[ "${USE_HADOOP}" != "false"  ]]; then
   else
     ZEPPELIN_CLASSPATH+=":${HADOOP_CONF_DIR}"
     if [ -n "${HADOOP_HOME}" ]; then
-    ZEPPELIN_CLASSPATH+=":`${HADOOP_HOME}/bin/hadoop classpath`"
+      ZEPPELIN_CLASSPATH+=":`${HADOOP_HOME}/bin/hadoop classpath`"
     elif ! [ -x "$(command -v hadoop)" ]; then
       echo 'hadoop command is not in PATH when HADOOP_CONF_DIR is specified.'
     else

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -123,7 +123,7 @@ if [[ "${USE_HADOOP}" != "false"  ]]; then
     ZEPPELIN_CLASSPATH+=":${HADOOP_CONF_DIR}"
     if [ -n "${HADOOP_HOME}" ]; then
     ZEPPELIN_CLASSPATH+=":`${HADOOP_HOME}/bin/hadoop classpath`"
-    efif ! [ -x "$(command -v hadoop)" ]; then
+    elif ! [ -x "$(command -v hadoop)" ]; then
       echo 'hadoop command is not in PATH when HADOOP_CONF_DIR is specified.'
     else
       ZEPPELIN_CLASSPATH+=":`hadoop classpath`"

--- a/bin/zeppelin.sh
+++ b/bin/zeppelin.sh
@@ -121,7 +121,9 @@ if [[ "${USE_HADOOP}" != "false"  ]]; then
     echo "Please specify HADOOP_CONF_DIR if USE_HADOOP is true"
   else
     ZEPPELIN_CLASSPATH+=":${HADOOP_CONF_DIR}"
-    if ! [ -x "$(command -v hadoop)" ]; then
+    if [ -n "${HADOOP_HOME}" ]; then
+    ZEPPELIN_CLASSPATH+=":`${HADOOP_HOME}/bin/hadoop classpath`"
+    efif ! [ -x "$(command -v hadoop)" ]; then
       echo 'hadoop command is not in PATH when HADOOP_CONF_DIR is specified.'
     else
       ZEPPELIN_CLASSPATH+=":`hadoop classpath`"


### PR DESCRIPTION
### What is this PR for?

Obviously, `*_HOME` should be respected if they are present, otherwise fallback to find the command in `PATH`.


### What type of PR is it?

Improvement

### What is the Jira issue?

ZEPPELIN-6150

### How should this be tested?

Manually tested on a dev env, there are multiple Hadoop clients installed in one machine, and `hadoop` is not available in `PATH`, now I can set `HADOOP_HOME` to allow Zeppelin start.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? no
* Is there breaking changes for older versions? might be
* Does this needs documentation? no
