### PR TITLE
[MINOR] Update the description indicating the user should not use Zep…

### DIFF
--- a/conf/zeppelin-site.xml.template
+++ b/conf/zeppelin-site.xml.template
@@ -28,7 +28,7 @@
 <property>
   <name>zeppelin.server.port</name>
   <value>8080</value>
-  <description>Server port.</description>
+  <description>Server port. Please make sure you're not using the same port with Zeppelin web application development port(default: 9000).</description>
 </property>
 
 <property>


### PR DESCRIPTION
…pelin dev port(default 9000)

### What is this PR for?

Update the description for the configuration option 'zeppelin.server.port' in zeppelin-site.xml.template, by adding a reminder that user should not use Zeppelin development port.

Though it has been stated in configuration.md, I think it should also be emphasized in zeppelin-site.xml.template, as I accidentally set the port to 9000 and took a long time to find the root cause.

### What type of PR is it?

Hot Fix

### Todos


### What is the Jira issue?
No issue

### How should this be tested?
No need to test

### Screenshots (if appropriate)

### Questions:
N/A
