### PR TITLE
[ZEPPELIN-6163] HBase interpreter supports hbase-2.x

### DIFF
--- a/docs/interpreter/hbase.md
+++ b/docs/interpreter/hbase.md
@@ -28,19 +28,7 @@ limitations under the License.
 To get start with HBase, please see [HBase Quickstart](https://hbase.apache.org/book.html#quickstart).
 
 ## HBase release supported
-By default, Zeppelin is built against HBase 1.0.x releases. To work with HBase 1.1.x releases, use the following build command:
-
-```bash
-# HBase 1.1.4
-./mvnw clean package -DskipTests -Phadoop-2.6 -Dhadoop.version=2.6.0 -P build-distr -Dhbase.hbase.version=1.1.4 -Dhbase.hadoop.version=2.6.0
-```
-
-To work with HBase 1.2.0+, use the following build command:
-
-```bash
-# HBase 1.2.0
-./mvnw clean package -DskipTests -Phadoop-2.6 -Dhadoop.version=2.6.0 -P build-distr -Dhbase.hbase.version=1.2.0 -Dhbase.hadoop.version=2.6.0
-```
+Zeppelin is built against HBase 1.x and 2.x releases. 
 
 ## Configuration
 
@@ -54,16 +42,6 @@ To work with HBase 1.2.0+, use the following build command:
     <td>hbase.home</td>
     <td>/usr/lib/hbase</td>
     <td>Installation directory of HBase, defaults to HBASE_HOME in environment</td>
-  </tr>
-  <tr>
-    <td>hbase.ruby.sources</td>
-    <td>lib/ruby</td>
-    <td>Path to Ruby scripts relative to 'hbase.home'</td>
-  </tr>
-  <tr>
-    <td>zeppelin.hbase.test.mode</td>
-    <td>false</td>
-    <td>Disable checks for unit and manual tests</td>
   </tr>
 </table>
 

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -33,14 +33,16 @@
   <properties>
     <!--library versions-->
     <interpreter.name>hbase</interpreter.name>
-    <jruby.version>1.6.8</jruby.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby-complete</artifactId>
-      <version>${jruby.version}</version>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
   </dependencies>
 

--- a/hbase/src/main/resources/interpreter-setting.json
+++ b/hbase/src/main/resources/interpreter-setting.json
@@ -10,18 +10,6 @@
         "defaultValue": "/usr/lib/hbase/",
         "description": "Installation directory of HBase",
         "type": "string"
-      },
-      "hbase.ruby.sources": {
-        "propertyName": "hbase.ruby.sources",
-        "defaultValue": "lib/ruby",
-        "description": "Path to Ruby scripts relative to 'hbase.home'",
-        "type": "string"
-      },
-      "zeppelin.hbase.test.mode": {
-        "propertyName": "zeppelin.hbase.test.mode",
-        "defaultValue": false,
-        "description": "Disable checks for unit and manual tests",
-        "type": "checkbox"
       }
     },
     "editor": {

--- a/hbase/src/test/java/org/apache/zeppelin/hbase/HbaseInterpreterTest.java
+++ b/hbase/src/test/java/org/apache/zeppelin/hbase/HbaseInterpreterTest.java
@@ -14,15 +14,13 @@
 
 package org.apache.zeppelin.hbase;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
-import org.apache.zeppelin.interpreter.InterpreterException;
-import org.apache.zeppelin.interpreter.InterpreterResult;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for HBase Interpreter.
@@ -34,8 +32,6 @@ public class HbaseInterpreterTest {
   public static void setUp() throws NullPointerException, InterpreterException {
     Properties properties = new Properties();
     properties.put("hbase.home", "");
-    properties.put("hbase.ruby.sources", "");
-    properties.put("zeppelin.hbase.test.mode", "true");
 
     hbaseInterpreter = new HbaseInterpreter(properties);
     hbaseInterpreter.open();
@@ -44,29 +40,5 @@ public class HbaseInterpreterTest {
   @Test
   void newObject() {
     assertNotNull(hbaseInterpreter);
-  }
-
-  @Test
-  void putsTest() {
-    InterpreterResult result = hbaseInterpreter.interpret("puts \"Hello World\"", null);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    assertEquals(InterpreterResult.Type.TEXT, result.message().get(0).getType());
-    assertEquals("Hello World\n", result.message().get(0).getData());
-  }
-
-  public void putsLoadPath() {
-    InterpreterResult result = hbaseInterpreter.interpret(
-            "require 'two_power'; puts twoToThePowerOf(4)", null);
-    assertEquals(InterpreterResult.Code.SUCCESS, result.code());
-    assertEquals(InterpreterResult.Type.TEXT, result.message().get(0).getType());
-    assertEquals("16\n", result.message().get(0).getData());
-  }
-
-  @Test
-  void testException() {
-    InterpreterResult result = hbaseInterpreter.interpret("plot practical joke", null);
-    assertEquals(InterpreterResult.Code.ERROR, result.code());
-    assertEquals("(NameError) undefined local variable or method `joke' for main:Object",
-            result.message().get(0).getData());
   }
 }

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.integration;
+
+
+import org.apache.zeppelin.test.DownloadUtils;
+import org.apache.zeppelin.MiniZeppelinServer;
+import org.apache.zeppelin.interpreter.ExecutionContext;
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterFactory;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.interpreter.InterpreterSetting;
+import org.apache.zeppelin.interpreter.InterpreterSettingManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class HBaseIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HBaseIntegrationTest.class);
+
+  private static InterpreterFactory interpreterFactory;
+  protected static InterpreterSettingManager interpreterSettingManager;
+
+  private String hbaseHome;
+
+  private static MiniZeppelinServer zepServer;
+
+  public void prepareHBase(String hbaseVersion) {
+    LOGGER.info("Testing HBase Version: " + hbaseVersion);
+    this.hbaseHome = DownloadUtils.downloadHBase(hbaseVersion);
+  }
+
+  @BeforeAll
+  static void init() throws Exception {
+    zepServer = new MiniZeppelinServer(HBaseIntegrationTest.class.getSimpleName());
+    zepServer.addInterpreter("hbase");
+    zepServer.copyBinDir();
+    zepServer.copyLogProperties();
+    zepServer.start();
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    zepServer.destroy();
+  }
+
+  @BeforeEach
+  void setup() {
+    interpreterSettingManager = zepServer.getService(InterpreterSettingManager.class);
+    interpreterFactory = new InterpreterFactory(interpreterSettingManager);
+  }
+
+  @Test
+  public void testHBaseInterpreter() throws Exception {
+    InterpreterSetting hbaseInterpreterSetting = interpreterSettingManager.getInterpreterSettingByName("hbase");
+    hbaseInterpreterSetting.setProperty("hbase.home", hbaseHome);
+
+    Interpreter hbaseInterpreter = interpreterFactory.getInterpreter("hbase", new ExecutionContext("user1", "note1", "hbase"));
+
+    InterpreterContext context = new InterpreterContext.Builder().setNoteId("note1").setParagraphId("paragraph_1").build();
+    InterpreterResult interpreterResult = hbaseInterpreter.interpret("puts 'hello'", context);
+
+    assertEquals(InterpreterResult.Code.SUCCESS, interpreterResult.code(), interpreterResult.toString());
+    assertTrue(interpreterResult.message().get(0).getData().contains("hello"));
+
+    interpreterSettingManager.close();
+  }
+
+}

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest172.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest172.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+
+public class HBaseIntegrationTest172 {
+
+  @Nested
+  @DisplayName("HBase 1.x")
+  public class HBase172 extends HBaseIntegrationTest {
+
+    @BeforeEach
+    public void downloadHBase() {
+      prepareHBase("1.7.2");
+    }
+  }
+
+}

--- a/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest2418.java
+++ b/zeppelin-interpreter-integration/src/test/java/org/apache/zeppelin/integration/HBaseIntegrationTest2418.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+
+public class HBaseIntegrationTest2418 {
+
+  @Nested
+  @DisplayName("HBase 2.x")
+  public class HBase2418 extends HBaseIntegrationTest {
+
+    @BeforeEach
+    public void downloadHBase() {
+      prepareHBase("2.4.18");
+    }
+  }
+
+}

--- a/zeppelin-test/src/test/java/org/apache/zeppelin/test/DownloadUtilsTest.java
+++ b/zeppelin-test/src/test/java/org/apache/zeppelin/test/DownloadUtilsTest.java
@@ -76,5 +76,13 @@ class DownloadUtilsTest {
     assertTrue(sparkHomePath.toFile().exists());
     assertTrue(sparkHomePath.toFile().isDirectory());
   }
-
+  
+  @Test
+  void downloadHBase() {
+    String hbaseHome = DownloadUtils.downloadHBase("2.14.8");
+    Path hbaseHomePath = Paths.get(hbaseHome);
+    assertTrue(hbaseHomePath.toFile().exists());
+    assertTrue(hbaseHomePath.toFile().isDirectory());
+  }
+  
 }


### PR DESCRIPTION
### What is this PR for?

Currently in Zeppelin HBase interpreter does not support HBase 2.x ruby syntax.

This patch added hbase-2.x support.

This closes ZEPPELIN-6163

### What type of PR is it?

Improvement

### Todos


### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

[ZEPPELIN-6163](https://issues.apache.org/jira/browse/ZEPPELIN-6163)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

Compiled and tested manually.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
