### PR TITLE
[ZEPPELIN-6168] Fix k8s interpreter service name removing all dots from pod name

### DIFF
--- a/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/main/java/org/apache/zeppelin/interpreter/launcher/K8sUtils.java
@@ -160,7 +160,7 @@ public class K8sUtils {
       // Remove all disallowed values
       result = result.replaceAll("[^a-z0-9\\.-]", "");
       // Remove all multiple dots
-      result = result.replaceAll("\\.+", ".");
+      result = result.replaceAll("\\.+", "");
       if (result.isEmpty() || !Character.isLetterOrDigit(result.charAt(0))) {
         result = ZEPPELIN + result;
       }

--- a/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sUtilsTest.java
+++ b/zeppelin-plugins/launcher/k8s-standard/src/test/java/org/apache/zeppelin/interpreter/launcher/K8sUtilsTest.java
@@ -41,17 +41,17 @@ class K8sUtilsTest {
 
   @Test
   void testExceptionMaxLong() {
-    assertThrows(NumberFormatException.class, () -> {
-      K8sUtils.calculateMemoryWithDefaultOverhead("10000000Tb");
-    });
+    assertThrows(NumberFormatException.class, () ->
+      K8sUtils.calculateMemoryWithDefaultOverhead("10000000Tb")
+    );
 
   }
 
   @Test
   void testExceptionNoValidNumber() {
-    assertThrows(NumberFormatException.class, () -> {
-      K8sUtils.calculateMemoryWithDefaultOverhead("NoValidNumber10000000Tb");
-    });
+    assertThrows(NumberFormatException.class, () ->
+      K8sUtils.calculateMemoryWithDefaultOverhead("NoValidNumber10000000Tb")
+    );
   }
 
   @Test
@@ -61,10 +61,10 @@ class K8sUtilsTest {
     assertEquals("test", K8sUtils.generateK8sName("test", false));
     assertEquals("test", K8sUtils.generateK8sName("!test", false));
     assertEquals("zeppelin", K8sUtils.generateK8sName("!", false));
-    assertEquals("zeppelin.test", K8sUtils.generateK8sName(".test", false));
-    assertEquals("zeppelin.test", K8sUtils.generateK8sName("...test", false));
-    assertEquals("zeppelin.test.zeppelin", K8sUtils.generateK8sName(".test.", false));
-    assertEquals("zeppelin.test.zeppelin", K8sUtils.generateK8sName("...test....", false));
+    assertEquals("test", K8sUtils.generateK8sName(".test", false));
+    assertEquals("test", K8sUtils.generateK8sName("...test", false));
+    assertEquals("test", K8sUtils.generateK8sName(".test.", false));
+    assertEquals("test", K8sUtils.generateK8sName("...test....", false));
     assertEquals("test", K8sUtils.generateK8sName("Test", false));
 
     assertEquals(253 - "zeppelin".length() , K8sUtils.generateK8sName(RandomStringUtils.randomAlphabetic(260), true).length());


### PR DESCRIPTION
### What is this PR for?
Fix the problem with k8s interpreter service creating


### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6168

### How should this be tested?
Compiled and tested manually.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update?
* No
* Is there breaking changes for older versions?
* No
* Does this needs documentation?
* No
