### PR TITLE
[ZEPPELIN-6176] imagePullSecrets is skipped in interpreter other than spark

### DIFF
--- a/k8s/interpreter/100-interpreter-spec.yaml
+++ b/k8s/interpreter/100-interpreter-spec.yaml
@@ -42,6 +42,12 @@ spec:
   {% endif %}
   restartPolicy: Never
   terminationGracePeriodSeconds: 30
+  {% if zeppelin.k8s.interpreter.imagePullSecrets is defined %}
+  imagePullSecrets:
+  {% for secret in zeppelin.k8s.interpreter.imagePullSecrets.split(',') %}
+  - name: {{secret}}
+  {% endfor %}
+  {% endif %}
   containers:
   - name: {{zeppelin.k8s.interpreter.container.name}}
     image: {{zeppelin.k8s.interpreter.container.image}}
@@ -101,12 +107,6 @@ spec:
     volumeMounts:
     - name: spark-home
       mountPath: /spark
-  {% if zeppelin.k8s.interpreter.imagePullSecrets is defined %}
-  imagePullSecrets:
-  {% for secret in zeppelin.k8s.interpreter.imagePullSecrets.split(',') %}
-  - name: {{secret}}
-  {% endfor %}
-  {% endif %}
   volumes:
   - name: spark-home
     emptyDir: {}


### PR DESCRIPTION
### What is this PR for?
interpreters that are not in spark group skip imagePullSecrets field so that container image pulling get failed
### What type of PR is it?
Bug Fix

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6176

### How should this be tested?
manual test done (python interpreter with spark connect)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
