### PR TITLE
[MINOR] Add GitHub Action to close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Close stale PRs after 1 year of inactivity
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Every day at 11 AM KST (2 AM UTC)
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 365
+          days-before-close: 7
+          stale-pr-message: >
+            This pull request has been inactive for over a year.  
+            If no further activity occurs within the next 7 days, it will be automatically closed.  
+            If you believe this PR is still relevant, please feel free to leave a comment or make an update. Thank you!
+          close-pr-message: >
+            This pull request has been automatically closed due to prolonged inactivity (over one year without updates).  
+            If you feel this was done in error or would like to continue the discussion, feel free to reopen it. Thank you for your contributions!
+          only-prs: true
+          operations-per-run: 100
+          remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 365
-          days-before-close: 7
+          days-before-close: 30
           stale-pr-message: >
             This pull request has been inactive for over a year.  
-            If no further activity occurs within the next 7 days, it will be automatically closed.  
+            If no further activity occurs within the next 30 days, it will be automatically closed.  
             If you believe this PR is still relevant, please feel free to leave a comment or make an update. Thank you!
           close-pr-message: >
             This pull request has been automatically closed due to prolonged inactivity (over one year without updates).  
@@ -23,3 +23,4 @@ jobs:
           only-prs: true
           operations-per-run: 100
           remove-stale-when-updated: true
+          exempt-pr-labels: suspend-stale


### PR DESCRIPTION
### What is this PR for?
This pull request introduces a new workflow for managing stale pull requests. The workflow is designed to automatically close pull requests that have been inactive for over a year.

### What type of PR is it?
Improvement

### Todos
* [x] - Add a new workflow for stale action

### What is the Jira issue?
MINOR

### How should this be tested?
Check CI logs

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
