### PR TITLE
ZEPPELIN-6171 Add FreeIPA authentication with memberOf attribute for groups maping

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -176,6 +176,9 @@ ldapRealm.contextFactory.systemUsername = uid=guest,ou=people,dc=hadoop,dc=apach
 ldapRealm.contextFactory.systemPassword = S{ALIAS=ldcSystemPassword}
 # enable support for nested groups using the LDAP_MATCHING_RULE_IN_CHAIN operator
 ldapRealm.groupSearchEnableMatchingRuleInChain = true
+# enable support for nested groups using memberOf attribute (typically for FreeIPA)
+ldapRealm.useMemberOfForNestedGroups = true
+ldapRealm.memberOfAttribute = memberOf
 # optional mapping from physical groups to logical application roles
 ldapRealm.rolesByGroup = LDN_USERS: user_role, NYK_USERS: user_role, HKG_USERS: user_role, GLOBAL_ADMIN: admin_role
 # optional list of roles that are allowed to authenticate. Incase not present all groups are allowed to authenticate (login).


### PR DESCRIPTION
### What is this PR for?
This pull request introduces support for LDAP authentication using the memberOf attribute, retrieving user group memberships from LDAP systems like FreeIPA. 

Problem
Previously, Zeppelin's LdapRealm could only determine group memberships by searching all groups in the LDAP directory and checking if the user was a member of each group. This approach doesn't properly support nested group memberships in systems that use the memberOf attribute like FreeIPA.

Solution
This PR adds the ability to use the memberOf attribute for determining group memberships by:

Adding configuration options to enable memberOf attribute support:

Implementing a new code path in the rolesFor method that:

Searches for the user and retrieves their memberOf attribute values
Correctly extracts group names from the memberOf Distinguished Names
Maps these group names to roles based on the configured rolesByGroup mapping
Properly handling the LDAP Distinguished Name (DN) component order when extracting group names by iterating through the DN components in the correct order


### What type of PR is it?
Improvement

*Please leave your type of PR only*

### Todos
* [ ] - Task

### What is the Jira issue?
 [ZEPPELIN-6171]

### How should this be tested?
added automated unit tests for any new or changed behavior



