### PR TITLE
[ZEPPELIN-3271] add shiro setup for cron feature in docs

### DIFF
--- a/docs/usage/other_features/cron_scheduler.md
+++ b/docs/usage/other_features/cron_scheduler.md
@@ -53,7 +53,7 @@ When this checkbox is set to "on", the interpreters which are binded to the note
 
 ### Enable cron
 
-Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` to enable Cron feature.
+Set property **zeppelin.notebook.cron.enable** to **true** in `$ZEPPELIN_HOME/conf/zeppelin-site.xml` and you have to set up [Shiro Authentication](../../setup/security/shiro_authentication.html) also to enable Cron feature.
 
 ### Run cron selectively on folders
 


### PR DESCRIPTION
### What is this PR for?

This PR adds description of another condition to enable Cron feature in documentation.
It is hard to know that is is required to configure Shiro authentication to enable Cron feature.

### What type of PR is it?

Documentation

### Todos

### What is the Jira issue?

* [ZEPPELIN-3271]

### How should this be tested?

* `bundle exec jekyll serve --watch` and check the documentation updated.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
