### PR TITLE
[ZEPPELIN-6181] fix can't login with plus char as password

### DIFF
--- a/zeppelin-web-angular/src/app/pages/login/login.component.ts
+++ b/zeppelin-web-angular/src/app/pages/login/login.component.ts
@@ -29,7 +29,7 @@ export class LoginComponent implements OnInit {
 
   login() {
     this.loading = true;
-    this.ticketService.login(this.userName, this.password).subscribe(
+    this.ticketService.login(encodeURIComponent(this.userName), encodeURIComponent(this.password)).subscribe(
       () => {
         this.loading = false;
         this.cdr.markForCheck();


### PR DESCRIPTION
### What is this PR for?

This PR fixes an issue where usernames or passwords containing a "+" character were being incorrectly converted to a " "(space), preventing users from signing in with password containing "+" character


### What type of PR is it?

Bug Fix

### Todos


### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-6181

### How should this be tested?

* Add account using password containing "+" character in shiro.ini
* Test if it can do login successfully

### Screenshots (if appropriate)

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
