### PR TITLE
[ZEPPELIN-6185] fix prevent shortcut working in input field

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -466,6 +466,13 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
     }>(...observables)
       .pipe(takeUntil(this.destroy$))
       .subscribe(({ action, event }) => {
+        const target = event.target as HTMLElement;
+
+        // Skip handling shortcut if focused element is an input (by Dynamic form)
+        if (target.tagName === 'INPUT') {
+          return; // ignore shortcut to make input work
+        }
+
         if (this.mode === 'command') {
           switch (action) {
             case ParagraphActions.InsertAbove:


### PR DESCRIPTION
### What is this PR for?

This PR fixes an issue that prevents entering shortcut characters in input fields.
When using a dynamic input field, characters like 'l', 'b', etc., are treated as shortcuts and cannot be entered.
This fix prevents shortcut actions from being triggered when the focused element is an input field.

### What type of PR is it?

Bug Fix

### Todos


### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-6185

### How should this be tested?

* Create new notebook using dynamic input field 
* Enter 'l' character and see if it is not working as shortcut(toggling line numbers)

### Screenshots (if appropriate)

### Questions:

* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
