### PR TITLE
[ZEPPELIN-6186] fix searching user using JdbcRealm

### DIFF
--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -369,12 +369,12 @@
       <scope>test</scope>
     </dependency>
 
-	<dependency>
-	  <groupId>com.h2database</groupId>
-	  <artifactId>h2</artifactId>
-	  <version>${h2.version}</version>
-	  <scope>test</scope>
-	</dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${h2.version}</version>
+      <scope>test</scope>
+    </dependency>
 
       <dependency>
         <groupId>org.bitbucket.cowwoc</groupId>

--- a/zeppelin-server/pom.xml
+++ b/zeppelin-server/pom.xml
@@ -45,6 +45,7 @@
     <selenium.java.version>2.48.2</selenium.java.version>
     <xml.apis.version>1.4.01</xml.apis.version>
     <hamcrest.version>2.2</hamcrest.version>
+    <h2.version>2.3.232</h2.version>
   </properties>
 
   <dependencies>
@@ -367,6 +368,13 @@
       <version>${xml.apis.version}</version>
       <scope>test</scope>
     </dependency>
+
+	<dependency>
+	  <groupId>com.h2database</groupId>
+	  <artifactId>h2</artifactId>
+	  <version>${h2.version}</version>
+	  <scope>test</scope>
+	</dependency>
 
       <dependency>
         <groupId>org.bitbucket.cowwoc</groupId>

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -466,10 +466,8 @@ public class ShiroAuthenticationService implements AuthenticationService {
       ps = con.prepareStatement(userquery);
       ps.setString(1, "%" + searchText + "%");
       rs = ps.executeQuery();
-      int count = 0;
-      while (rs.next() && count < numUsersToFetch) {
-        userlist.add(rs.getString(1).trim());
-        count++;
+      while (rs.next() && userlist.size() < numUsersToFetch) {
+        userlist.add(rs.getString(1));
       }
     } catch (Exception e) {
       LOGGER.error("Error retrieving User list from JDBC Realm", e);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -26,7 +26,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import jakarta.inject.Inject;
+import java.util.regex.Pattern;
+
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
@@ -34,6 +35,8 @@ import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 import javax.sql.DataSource;
+
+import jakarta.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
@@ -67,6 +70,12 @@ public class ShiroAuthenticationService implements AuthenticationService {
   private static final String LDAP_GROUP_REALM = "org.apache.zeppelin.realm.LdapGroupRealm";
   private static final String ACTIVE_DIRECTORY_GROUP_REALM = "org.apache.zeppelin.realm.ActiveDirectoryGroupRealm";
   private static final String JDBC_REALM = "org.apache.shiro.realm.jdbc.JdbcRealm";
+
+  private static final Pattern VALID_SQL_NAME_IDENTIFIER_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
+
+  private static boolean isValidSqlIdentifier(String name) {
+    return name != null && VALID_SQL_NAME_IDENTIFIER_PATTERN.matcher(name).matches();
+  }
 
   private final ZeppelinConfiguration zConf;
 
@@ -174,7 +183,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
             usersList.addAll(
                 getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
           } else if (JDBC_REALM.equals(realClassName)) {
-            usersList.addAll(getUserList((JdbcRealm) realm));
+            usersList.addAll(getUserList((JdbcRealm) realm, searchText, numUsersToFetch));
           }
         }
       }
@@ -401,7 +410,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
   }
 
   /** Function to extract users from JDBCs. */
-  private List<String> getUserList(JdbcRealm obj) {
+  private List<String> getUserList(JdbcRealm obj, String searchText, int numUsersToFetch) {
     List<String> userlist = new ArrayList<>();
     Connection con = null;
     PreparedStatement ps = null;
@@ -415,26 +424,39 @@ public class ShiroAuthenticationService implements AuthenticationService {
     try {
       dataSource = (DataSource) FieldUtils.readField(obj, "dataSource", true);
       authQuery = (String) FieldUtils.readField(obj, "authenticationQuery", true);
-      LOGGER.info(authQuery);
+      LOGGER.debug("authenticationQuery={}", authQuery);
       String authQueryLowerCase = authQuery.toLowerCase();
       retval = authQueryLowerCase.split("from", 2);
       if (retval.length >= 2) {
         retval = retval[1].split("with|where", 2);
-        tablename = retval[0];
+        tablename = retval[0].trim();
         retval = retval[1].split("where", 2);
         if (retval.length >= 2) {
           retval = retval[1].split("=", 2);
         } else {
           retval = retval[0].split("=", 2);
         }
-        username = retval[0];
+        username = retval[0].trim();
       }
 
       if (StringUtils.isBlank(username) || StringUtils.isBlank(tablename)) {
         return userlist;
       }
+	  if (!isValidSqlIdentifier(username)) {
+	    throw new IllegalArgumentException(
+	      "Invalid column name in authenticationQuery to build userlist query: "
+				  + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
+				  + ", name identifier: [" + username + "]");
+	  }
+	  if (!isValidSqlIdentifier(tablename)) {
+	    throw new IllegalArgumentException(
+	      "Invalid table name in authenticationQuery to build userlist query: "
+				  + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
+				  + ", name identifier: [" + tablename + "]");
+	  }
 
-      userquery = "SELECT ? FROM ?";
+	  userquery = String.format("SELECT %s FROM %s WHERE %s LIKE ?", username, tablename, username);
+	  LOGGER.info("Built query for user list. userquery={}", userquery);
     } catch (IllegalAccessException e) {
       LOGGER.error("Error while accessing dataSource for JDBC Realm", e);
       return new ArrayList<>();
@@ -443,11 +465,12 @@ public class ShiroAuthenticationService implements AuthenticationService {
     try {
       con = dataSource.getConnection();
       ps = con.prepareStatement(userquery);
-      ps.setString(1, username);
-      ps.setString(2, tablename);
+	  ps.setString(1, "%" + searchText + "%");
       rs = ps.executeQuery();
-      while (rs.next()) {
-        userlist.add(rs.getString(1).trim());
+	  int count = 0;
+      while (rs.next() && count < numUsersToFetch) {
+		userlist.add(rs.getString(1).trim());
+		count++;
       }
     } catch (Exception e) {
       LOGGER.error("Error retrieving User list from JDBC Realm", e);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -435,7 +435,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
         } else {
           retval = retval[0].split("=", 2);
         }
-        username = retval[0].trim();
+        username = retval[0].strip();
       }
 
       if (StringUtils.isBlank(username) || StringUtils.isBlank(tablename)) {

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -180,8 +180,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
           } else if (LDAP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((LdapRealm) realm, searchText, numUsersToFetch));
           } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(realClassName)) {
-            usersList.addAll(
-                getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
+            usersList.addAll(getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
           } else if (JDBC_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((JdbcRealm) realm, searchText, numUsersToFetch));
           }
@@ -442,21 +441,21 @@ public class ShiroAuthenticationService implements AuthenticationService {
       if (StringUtils.isBlank(username) || StringUtils.isBlank(tablename)) {
         return userlist;
       }
-	  if (!isValidSqlIdentifier(username)) {
-	    throw new IllegalArgumentException(
-	      "Invalid column name in authenticationQuery to build userlist query: "
-				  + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
-				  + ", name identifier: [" + username + "]");
-	  }
-	  if (!isValidSqlIdentifier(tablename)) {
-	    throw new IllegalArgumentException(
-	      "Invalid table name in authenticationQuery to build userlist query: "
-				  + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
-				  + ", name identifier: [" + tablename + "]");
-	  }
+      if (!isValidSqlIdentifier(username)) {
+        throw new IllegalArgumentException(
+          "Invalid column name in authenticationQuery to build userlist query: "
+            + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
+            + ", name identifier: [" + username + "]");
+      }
+      if (!isValidSqlIdentifier(tablename)) {
+        throw new IllegalArgumentException(
+          "Invalid table name in authenticationQuery to build userlist query: "
+            + authQuery + ", allowed pattern: " + VALID_SQL_NAME_IDENTIFIER_PATTERN
+            + ", name identifier: [" + tablename + "]");
+      }
 
-	  userquery = String.format("SELECT %s FROM %s WHERE %s LIKE ?", username, tablename, username);
-	  LOGGER.info("Built query for user list. userquery={}", userquery);
+      userquery = String.format("SELECT %s FROM %s WHERE %s LIKE ?", username, tablename, username);
+      LOGGER.info("Built query for user list. userquery={}", userquery);
     } catch (IllegalAccessException e) {
       LOGGER.error("Error while accessing dataSource for JDBC Realm", e);
       return new ArrayList<>();
@@ -465,12 +464,12 @@ public class ShiroAuthenticationService implements AuthenticationService {
     try {
       con = dataSource.getConnection();
       ps = con.prepareStatement(userquery);
-	  ps.setString(1, "%" + searchText + "%");
+      ps.setString(1, "%" + searchText + "%");
       rs = ps.executeQuery();
-	  int count = 0;
+      int count = 0;
       while (rs.next() && count < numUsersToFetch) {
-		userlist.add(rs.getString(1).trim());
-		count++;
+        userlist.add(rs.getString(1).trim());
+        count++;
       }
     } catch (Exception e) {
       LOGGER.error("Error retrieving User list from JDBC Realm", e);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -428,7 +428,7 @@ public class ShiroAuthenticationService implements AuthenticationService {
       retval = authQueryLowerCase.split("from", 2);
       if (retval.length >= 2) {
         retval = retval[1].split("with|where", 2);
-        tablename = retval[0].trim();
+        tablename = retval[0].strip();
         retval = retval[1].split("where", 2);
         if (retval.length >= 2) {
           retval = retval[1].split("=", 2);

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
@@ -61,29 +61,29 @@ class ShiroAuthenticationServiceTest extends AbstractShiroTest {
   @Test
   void testGetMatchedUsersWithJdbcRealm() throws Exception {
 
-	  // given in-memory jdbcRealm with some users
-	  JdbcRealm realm = new JdbcRealm();
-	  JdbcDataSource dataSource = new JdbcDataSource();
-	  dataSource.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
-	  dataSource.setUser("sa");
-	  realm.setDataSource(dataSource);
+    // given in-memory jdbcRealm with some users
+    JdbcRealm realm = new JdbcRealm();
+    JdbcDataSource dataSource = new JdbcDataSource();
+    dataSource.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+    dataSource.setUser("sa");
+    realm.setDataSource(dataSource);
 
-	  LifecycleUtils.init(realm);
-	  DefaultSecurityManager securityManager = new DefaultSecurityManager(realm);
-	  ThreadContext.bind(securityManager);
+    LifecycleUtils.init(realm);
+    DefaultSecurityManager securityManager = new DefaultSecurityManager(realm);
+    ThreadContext.bind(securityManager);
 
-	  try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
-		  stmt.execute("CREATE TABLE users (username VARCHAR PRIMARY KEY, password VARCHAR)");
-		  stmt.execute("INSERT INTO users VALUES ('admin', '')");
-		  stmt.execute("INSERT INTO users VALUES ('test', '')");
-	  }
+    try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
+      stmt.execute("CREATE TABLE users (username VARCHAR PRIMARY KEY, password VARCHAR)");
+      stmt.execute("INSERT INTO users VALUES ('admin', '')");
+      stmt.execute("INSERT INTO users VALUES ('test', '')");
+    }
 
-	  // when
-	  List<String> users = shiroSecurityService.getMatchedUsers("adm", 10);
+    // when
+    List<String> users = shiroSecurityService.getMatchedUsers("adm", 10);
 
-	  // then
-	  assertEquals(1, users.size());
-	  assertEquals("admin", users.get(0));
+    // then
+    assertEquals(1, users.size());
+    assertEquals("admin", users.get(0));
   }
 
   @Test

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/ShiroAuthenticationServiceTest.java
@@ -75,11 +75,12 @@ class ShiroAuthenticationServiceTest extends AbstractShiroTest {
     try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
       stmt.execute("CREATE TABLE users (username VARCHAR PRIMARY KEY, password VARCHAR)");
       stmt.execute("INSERT INTO users VALUES ('admin', '')");
+      stmt.execute("INSERT INTO users VALUES ('admin1', '')");
       stmt.execute("INSERT INTO users VALUES ('test', '')");
     }
 
     // when
-    List<String> users = shiroSecurityService.getMatchedUsers("adm", 10);
+    List<String> users = shiroSecurityService.getMatchedUsers("adm", 1);
 
     // then
     assertEquals(1, users.size());


### PR DESCRIPTION
### What is this PR for?

This PR fixes a broken feature where getUserList fails when using JdbcRealm for Shiro authentication.

The previous PR addressing SQL injection introduced an error that prevents getUserList from working correctly with JdbcRealm. As a result, users are unable to set notebook permissions.

Ref: #4676


### What type of PR is it?

Bug Fix

### Todos


### What is the Jira issue?

* https://issues.apache.org/jira/browse/ZEPPELIN-3725
* https://issues.apache.org/jira/browse/ZEPPELIN-6186

### How should this be tested?

Added new unit test should be passed

* `./mvnw clean package -pl zeppelin-server -am`

Verify in UI

* Go to notebook permission settings
* Type username and see if username listed

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
