### PR TITLE
[ZEPPELIN-6188] Improve Elasticsearch interpreter config and help message

### DIFF
--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -73,23 +73,38 @@ import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.T
 public class ElasticsearchInterpreter extends Interpreter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchInterpreter.class);
 
-  private static final String HELP = "Elasticsearch interpreter:\n"
-      + "General format: <command> /<indices>/<types>/<id> <option> <JSON>\n"
-      + "  - indices: list of indices separated by commas (depends on the command)\n"
-      + "  - types: list of document types separated by commas (depends on the command)\n"
-      + "Commands:\n"
-      + "  - search /indices/types <query>\n"
-      + "    . indices and types can be omitted (at least, you have to provide '/')\n"
-      + "    . a query is either a JSON-formatted query, nor a lucene query\n"
-      + "  - size <value>\n"
-      + "    . defines the size of the result set (default value is in the config)\n"
-      + "    . if used, this command must be declared before a search command\n"
-      + "  - count /indices/types <query>\n"
-      + "    . same comments as for the search\n"
-      + "  - get /index/type/id\n"
-      + "  - delete /index/type/id\n"
-      + "  - index /index/type/id <json-formatted document>\n"
-      + "    . the id can be omitted, elasticsearch will generate one";
+  private static final String HELP = String.join("\n",
+          "Elasticsearch Interpreter Usage:",
+          "",
+          "General format:",
+          "  <command> /<indices>/<types>/<id> <option> <JSON>",
+          "",
+          "  - indices: comma-separated list of index names (depends on the command)",
+          "  - types: comma-separated list of document types (depends on the command)",
+          "",
+          "Available Commands:",
+          "  - search /<indices>/<types> <query>",
+          "      • 'indices' and 'types' are optional, but '/' is required.",
+          "      • Query can be either a JSON-formatted Elasticsearch query or a Lucene query string.",
+          "",
+          "  - size <value>",
+          "      • Sets the number of results returned (default is set in config).",
+          "      • Must be declared before the search command if used.",
+          "",
+          "  - count /<indices>/<types> <query>",
+          "      • Similar format and behavior as the 'search' command.",
+          "",
+          "  - get /<index>/<type>/<id>",
+          "      • Retrieves a document by ID.",
+          "",
+          "  - delete /<index>/<type>/<id>",
+          "      • Deletes a document by ID.",
+          "",
+          "  - index /<index>/<type>/<id> <JSON document>",
+          "      • Creates or updates a document with the given ID.",
+          "      • If 'id' is omitted, Elasticsearch will generate one automatically.",
+          ""
+  );
 
   protected static final List<String> COMMANDS = Arrays.asList(
       "count", "delete", "get", "help", "index", "search");

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java
@@ -85,7 +85,8 @@ public class ElasticsearchInterpreter extends Interpreter {
           "Available Commands:",
           "  - search /<indices>/<types> <query>",
           "      • 'indices' and 'types' are optional, but '/' is required.",
-          "      • Query can be either a JSON-formatted Elasticsearch query or a Lucene query string.",
+          "      • Query can be either a JSON-formatted Elasticsearch query " +
+          "or a Lucene query string.",
           "",
           "  - size <value>",
           "      • Sets the number of results returned (default is set in config).",

--- a/elasticsearch/src/main/resources/interpreter-setting.json
+++ b/elasticsearch/src/main/resources/interpreter-setting.json
@@ -8,49 +8,49 @@
         "envName": "ELASTICSEARCH_HOST",
         "propertyName": "elasticsearch.host",
         "defaultValue": "localhost",
-        "description": "The host for Elasticsearch",
+        "description": "Elasticsearch server host (e.g., localhost, 127.0.0.1, or your cluster DNS)",
         "type": "string"
       },
       "elasticsearch.port": {
         "envName": "ELASTICSEARCH_PORT",
         "propertyName": "elasticsearch.port",
-        "defaultValue": "9300",
-        "description": "The port for Elasticsearch",
+        "defaultValue": "9200",
+        "description": "Port for connecting to Elasticsearch. Use 9200 for HTTP/REST, 9300 for Transport (legacy).",
         "type": "number"
       },
       "elasticsearch.client.type": {
         "envName": "ELASTICSEARCH_CLIENT_TYPE",
         "propertyName": "elasticsearch.client.type",
-        "defaultValue": "transport",
-        "description": "The type of client for Elasticsearch (transport or http or https)",
+        "defaultValue": "http",
+        "description": "Client type: 'http', 'https', or 'transport' (deprecated).",
         "type": "string"
       },
       "elasticsearch.cluster.name": {
         "envName": "ELASTICSEARCH_CLUSTER_NAME",
         "propertyName": "elasticsearch.cluster.name",
         "defaultValue": "elasticsearch",
-        "description": "The cluster name for Elasticsearch",
+        "description": "Name of the Elasticsearch cluster to connect to.",
         "type": "string"
       },
       "elasticsearch.result.size": {
         "envName": "ELASTICSEARCH_RESULT_SIZE",
         "propertyName": "elasticsearch.result.size",
         "defaultValue": "10",
-        "description": "The size of the result set of a search query",
+        "description": "Maximum number of results to return in search queries.",
         "type": "number"
       },
       "elasticsearch.basicauth.username": {
         "envName": "ELASTICSEARCH_BASIC_AUTH_USERNAME",
         "propertyName": "elasticsearch.basicauth.username",
         "defaultValue": "",
-        "description": "Username for a basic authentication",
+        "description": "Username for HTTP Basic Authentication (only used with http/https client).",
         "type": "string"
       },
       "elasticsearch.basicauth.password": {
         "envName": "ELASTICSEARCH_BASIC_AUTH_PASSWORD",
         "propertyName": "elasticsearch.basicauth.password",
         "defaultValue": "",
-        "description": "Password for a basic authentication",
+        "description": "Password for HTTP Basic Authentication (only used with http/https client).",
         "type": "password"
       }
     },


### PR DESCRIPTION
### What is this PR for?
The following improvements have been made to the Elasticsearch interpreter:

- Updated default interpreter settings for better clarity and consistency.
  - Ensured accurate property types and added missing environment variable mappings.
  - Improved descriptions for better user understanding in the Zeppelin UI.
  - Changed default port to 9200 and client type to http to align with Elasticsearch 8.x, where the Transport Client has been removed.
- Modified the help command output to improve readability and accuracy.
  - Reformatted command usage examples.
  - Fixed grammar and clarified parameter descriptions.

These changes enhance the usability of the interpreter and make it easier for users to configure and understand how to interact with Elasticsearch through Zeppelin.

### What type of PR is it?
Refactoring

### Todos
* [x] - Update `/elasticsearch/src/main/resources/interpreter-setting.json` file
* [x] - Update `/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/ElasticsearchInterpreter.java` file

### What is the Jira issue?
* https://issues.apache.org/jira/projects/ZEPPELIN/issues/ZEPPELIN-6188?filter=allissues

### How should this be tested?
* help output command
```bash
%elasticsearch
help
```

* interpreter -> elasticsearch -> check description

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No.
