### PR TITLE
[ZEPPELIN-6194] Fix flaky Conda environment setup by using strict channel priority in GitHub Actions

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -124,7 +124,7 @@ jobs:
           environment-file: testing/env_python_3_with_R_and_tensorflow.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: verify interpreter

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -74,7 +74,7 @@ jobs:
           environment-file: testing/env_python_3.9_with_R.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
@@ -166,7 +166,7 @@ jobs:
           environment-file: testing/env_python_${{ matrix.python }}_with_R.yml
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
@@ -221,7 +221,7 @@ jobs:
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
@@ -277,7 +277,7 @@ jobs:
           environment-file: testing/env_python_3_with_flink_${{ matrix.flink }}.yml
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: run tests for flink
@@ -325,7 +325,7 @@ jobs:
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
@@ -372,7 +372,7 @@ jobs:
           environment-file: testing/env_python_${{ matrix.python }}_with_R.yml
           python-version: ${{ matrix.python }}
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter
@@ -432,7 +432,7 @@ jobs:
           environment-file: testing/env_python_3.9_with_R.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -119,7 +119,7 @@ jobs:
           environment-file: testing/env_python_3_with_R.yml
           python-version: 3.9
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
           auto-activate-base: false
           use-mamba: true
       - name: Make IRkernel available to Jupyter


### PR DESCRIPTION
### What is this PR for?
**Problem Summary:**
The interpreter-test-non-core (11) job within the core GitHub Actions workflow occasionally fails during the Conda environment setup phase. These failures are non-deterministic (flaky) and do not correlate with specific code changes, indicating an environment-related root cause.

**Details:**
The failure typically occurs when resolving dependencies using Conda, with the following error observed:
```bash
python: /croot/libsolv-suite.../rules.c:261: solver_addrule: Assertion `!p2 && d > 0' failed.
```
This assertion failure is triggered by Conda's dependency resolver (libsolv) when it encounters unresolved or conflicting constraints.
Previously, the workflow used channel-priority: true, which corresponds to flexible priority mode. This allowed mixing packages from both conda-forge and defaults, potentially leading to dependency conflicts.

**Resolution:**
The Conda configuration has been updated to use channel-priority: strict, ensuring that all dependencies are resolved from conda-forge unless unavailable:
```bash
with:
  ...
  channel-priority: strict
  ...
```
After this change, the flaky behavior during environment setup was no longer observed in repeated runs.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Update `setup-miniconda` configuration

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-6194

### How should this be tested?
* This should be validated by re-running the `core` workflow multiple times to confirm that the flaky behavior in `interpreter-test-non-core (11)` no longer occurs during Conda environment setup.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
