### PR TITLE
[ZEPPELIN-6202] Fix %20 showing in notebook tree by URL-decoding note file paths

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/VFSNotebookRepo.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -114,9 +116,12 @@ public class VFSNotebookRepo extends AbstractNotebookRepo {
         noteInfos.putAll(listFolder(child));
       }
     } else {
-      // getPath() method returns a string without root directory in windows, so we use getURI() instead
-      // windows does not support paths with "file:///" prepended. so we replace it by "/"
-      String noteFileName = fileObject.getName().getURI().replace("file:///", "/");
+      // getPath() drops the drive on Windows, so use getURI().
+      // Decode URI to change %20 to spaces.
+      // Windows cannot handle "file:///", replace it with "/".
+      String noteFileName = URLDecoder.decode(
+          fileObject.getName().getURI(), StandardCharsets.UTF_8
+      ).replace("file:///", "/");
       if (noteFileName.endsWith(".zpln")) {
         try {
           String noteId = getNoteId(noteFileName);


### PR DESCRIPTION
### What is this PR for?
This PR fixes a UI bug where notebook and folder names that contain spaces are displayed with the URL-encoded text %20 in the notebook tree (e.g., Flink%20Tutorial).
We now URL-decode the VFS path and keep the existing Windows-specific prefix handling, so names with spaces render correctly across all platforms.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add URL-decode logic in path normalisation

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN/ZEPPELIN-6202

### How should this be tested?
* Build this branch and start Zeppelin.
* Create or import a notebook whose name contains a space (e.g., “Python Tutorial”).

### Screenshots (if appropriate)
Before
![image](https://github.com/user-attachments/assets/f1fba587-fd88-4034-b224-f2edc08e5f1d)
After
![image](https://github.com/user-attachments/assets/0577c8c2-6f48-475f-b47e-30afd144bfd3)

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
