### PR TITLE
[ZEPPELIN-6206] Fix notebook paths in job manager page

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/job-manager/job/job.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/job-manager/job/job.component.html
@@ -17,7 +17,7 @@
       [nzType]="icon"
       nzTheme="outline">
     </i>
-    <a [routerLink]="['notebook', note.noteId]" [innerHTML]="note.noteName | nzHighlight: highlight: 'gi': 'mark-highlight'"></a> -
+    <a [routerLink]="['/', 'notebook', note.noteId]" [innerHTML]="note.noteName | nzHighlight: highlight: 'gi': 'mark-highlight'"></a> -
     <span class="interpreter"
           [class.unset]="!note.interpreter">
       {{note.interpreter || 'interpreter is not set'}}
@@ -40,7 +40,7 @@
       [nz-tooltip]="item.name + ' is ' + item.status"
       nzPlacement="topLeft"
       [nzOverlayStyle]="{ 'margin-left': '-14px' }"
-      [routerLink]="['notebook', note.noteId]"
+      [routerLink]="['/', 'notebook', note.noteId]"
       [queryParams]="{paragraph: item.id}">
       <zeppelin-job-manager-job-status [status]="item.status">
       </zeppelin-job-manager-job-status>


### PR DESCRIPTION
### What is this PR for?
URLs to notebook page are set wrong in job manager page

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6206

### How should this be tested?
- Enable cron and job manager configurations and check a links in the page
  - `zeppelin.jobmanager.enable` : `true`
  - `zeppelin.notebook.cron.enable`: `true`
  - `zeppelin.notebook.cron.folders` : `/`
![image](https://github.com/user-attachments/assets/19f77891-a40a-4d6a-be56-beb8ad4bff27)


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
