### PR TITLE
[MINOR] postgresql 42.7.7

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -46,7 +46,7 @@
 
   <dependencies>
 
-	  <dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>${postgresql.version}</version>


### PR DESCRIPTION
Our current version does not have a CVE but a new CVE applies to newer versions but latest version fixes that.
https://mvnrepository.com/artifact/org.postgresql/postgresql

Seems best to upgrade to latest version.