### PR TITLE
[ZEPPELIN-6213] Add Cache-Control Header to API Calls

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/filter/CacheControlFilter.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/filter/CacheControlFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest.filter;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.core.HttpHeaders;
+
+public class CacheControlFilter implements ContainerResponseFilter {
+
+  @Override
+  public void filter(ContainerRequestContext req, ContainerResponseContext res) {
+      if (req.getMethod().equals(HttpMethod.GET)) {
+        CacheControl cc = new CacheControl();
+        cc.setNoCache(true);
+        res.getHeaders().add(HttpHeaders.CACHE_CONTROL, cc);
+      }
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/RestApiApplication.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/RestApiApplication.java
@@ -35,6 +35,7 @@ import org.apache.zeppelin.rest.SecurityRestApi;
 import org.apache.zeppelin.rest.SessionRestApi;
 import org.apache.zeppelin.rest.ZeppelinRestApi;
 import org.apache.zeppelin.rest.exception.WebApplicationExceptionMapper;
+import org.apache.zeppelin.rest.filter.CacheControlFilter;
 import org.glassfish.jersey.server.ServerProperties;
 
 public class RestApiApplication extends Application {
@@ -57,6 +58,8 @@ public class RestApiApplication extends Application {
     s.add(WebApplicationExceptionMapper.class);
     // add JSON-Consumer and Producer
     s.add(GsonProvider.class);
+    // Filter
+    s.add(CacheControlFilter.class);
     return s;
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/filter/CacheContolFilterTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/filter/CacheContolFilterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.zeppelin.rest.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.zeppelin.MiniZeppelinServer;
+import org.apache.zeppelin.rest.AbstractTestRestApi;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.core.HttpHeaders;
+
+class CacheContolFilterTest extends AbstractTestRestApi {
+
+  private static MiniZeppelinServer zepServer;
+
+  @BeforeAll
+  static void init() throws Exception {
+    zepServer = new MiniZeppelinServer(CacheContolFilterTest.class.getSimpleName());
+    zepServer.start();
+  }
+
+  @AfterAll
+  static void destroy() throws Exception {
+    zepServer.destroy();
+  }
+
+  @BeforeEach
+  void setUp() {
+    zConf = zepServer.getZeppelinConfiguration();
+  }
+
+  @Test
+  void testCacheControl() throws IOException {
+    try (CloseableHttpResponse get = httpGet("/version")) {
+      Header[] headers = get.getHeaders(HttpHeaders.CACHE_CONTROL);
+      assertEquals(1, headers.length);
+      Header cacheHeader = headers[0];
+      assertEquals(HttpHeaders.CACHE_CONTROL, cacheHeader.getName());
+      assertTrue(cacheHeader.getValue().contains("no-cache"), () -> "Actual content:" + cacheHeader.getValue());
+    }
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This pull request sets the no cache header for all Zeppelin API calls.


### What type of PR is it?
* Improvement

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6213

### How should this be tested?
* CI

### Screenshots
Before - no cache header
![grafik](https://github.com/user-attachments/assets/e4bff5fb-686c-4944-9da1-21130214ac9d)

After - with cache header
![grafik](https://github.com/user-attachments/assets/114cc66e-70fd-49fb-9bb1-f2b4026d4a86)


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
