### PR TITLE
[ZEPPELIN-6219] Update copyright year in NOTICE file from 2024 to 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Zeppelin
-Copyright 2015 - 2024 The Apache Software Foundation
+Copyright 2015 - 2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
### What is this PR for?
This PR updates the copyright year in the NOTICE file from 2024 to 2025.
Since the project has received contributions in 2025, this update ensures that the legal documentation remains accurate and consistent with ASF guidelines.
No functional changes are introduced—this is a documentation-only update.

### What type of PR is it?
Documentation

### Todos
* [x] - Update NOTICE file

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN-6219

### How should this be tested?
* No testing is required as this change only updates static text in the NOTICE file.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
