### PR TITLE
[ZEPPELIN-6222] Fix typos and improve clarity in Neo4j interpreter configuration descriptions

### DIFF
--- a/neo4j/src/main/resources/interpreter-setting.json
+++ b/neo4j/src/main/resources/interpreter-setting.json
@@ -14,19 +14,19 @@
         "envName": null,
         "propertyName": "neo4j.database",
         "defaultValue": "",
-        "description": "The Neo4j target database, if empty use the dafault db."
+        "description": "The target Neo4j database. If left empty, the default database will be used."
       },
       "neo4j.multi.statement": {
         "envName": null,
         "propertyName": "neo4j.multi.statement",
         "defaultValue": "true",
-        "description": "Enables the multi statement management, if true it computes multiple queries separated by semicolon."
+        "description": "Enable multi-statement support. If set to true, queries separated by semicolons will be executed as separate statements."
       },
       "neo4j.auth.type": {
         "envName": null,
         "propertyName": "neo4j.auth.type",
         "defaultValue": "BASIC",
-        "description": "The Neo4j's authentication type (NONE, BASIC)."
+        "description": "Authentication type to use with Neo4j. Supported values: NONE, BASIC."
       },
       "neo4j.auth.user": {
         "envName": null,
@@ -44,7 +44,7 @@
         "envName": null,
         "propertyName": "neo4j.max.concurrency",
         "defaultValue": "50",
-        "description": "Max concurrency call from Zeppelin to Neo4j server."
+        "description": "Maximum number of concurrent requests from Zeppelin to the Neo4j server."
       }
     },
     "editor": {


### PR DESCRIPTION
### What is this PR for?
This PR improves the property descriptions in interpreter-setting.json for the Neo4j interpreter.
Some of the original descriptions contained typos, grammatical issues, or unclear phrasing.
The updated descriptions are now clearer, more consistent, and easier for users to understand when configuring the interpreter in Zeppelin.
This is a documentation-only change and does not affect any functionality.

### What type of PR is it?
Documentation

### Todos
* [x] - Improve clarity and consistency of Neo4j interpreter property descriptions

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN-6222 

### How should this be tested?
No functional testing is required.
You can verify that the updated descriptions appear correctly in the interpreter setting UI.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
