### PR TITLE
[ZEPPELIN-6230] "Add Paragraph" button should not be hidden in Notebook.

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/add-paragraph/add-paragraph.component.less
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/add-paragraph/add-paragraph.component.less
@@ -16,7 +16,6 @@
   .add-paragraph {
     height: 32px;
     text-align: center;
-    margin: -12px 0;
     color: @primary-color;
     font-weight: 500;
     position: relative;;


### PR DESCRIPTION
### What is this PR for?
This PR fixes a simple CSS issue.
The "Add Paragraph" button in the Notebook was partially hidden.  
Fixed by repositioning the button.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-6230]

### How should this be tested?
* Build and run zeppelin web locally

### Screenshots (if appropriate)
**as-is**
<img width="746" height="367" alt="Screenshot 2025-07-12 at 2 21 09 PM" src="https://github.com/user-attachments/assets/5719838e-542c-4453-b403-5dc646aca28f" />

**to-be**
<img width="746" height="367" alt="Screenshot 2025-07-12 at 1 45 22 PM" src="https://github.com/user-attachments/assets/a4baf169-6d1f-4fa7-b018-6830da306344" />


### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
