### PR TITLE
[ZEPPELIN-6237] Add serviceLocator shutdown when server is close

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -364,6 +364,7 @@ public class ZeppelinServer implements AutoCloseable {
         if (sharedServiceLocator != null) {
           if (!zConf.isRecoveryEnabled()) {
             sharedServiceLocator.getService(InterpreterSettingManager.class).close();
+            sharedServiceLocator.shutdown();
           }
           sharedServiceLocator.getService(Notebook.class).close();
         }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
@@ -21,8 +21,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.zeppelin.conf.ZeppelinConfiguration;
 import org.apache.zeppelin.conf.ZeppelinConfiguration.ConfVars;
-import org.apache.zeppelin.interpreter.InterpreterSetting;
-import org.apache.zeppelin.notebook.Notebook;
 import org.apache.zeppelin.rest.AbstractTestRestApi;
 import org.apache.zeppelin.server.ZeppelinServer;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -36,17 +34,14 @@ import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
-
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MiniZeppelinServer implements AutoCloseable {
   protected static final Logger LOGGER = LoggerFactory.getLogger(MiniZeppelinServer.class);
@@ -299,7 +294,6 @@ public class MiniZeppelinServer implements AutoCloseable {
       zepServer.close();
       executor.shutdown();
       executor.shutdownNow();
-      getServiceLocator().shutdown();
       await().pollDelay(2, TimeUnit.SECONDS).atMost(3, TimeUnit.MINUTES)
           .until(checkIfServerIsNotRunningCallable());
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/MiniZeppelinServer.java
@@ -299,6 +299,7 @@ public class MiniZeppelinServer implements AutoCloseable {
       zepServer.close();
       executor.shutdown();
       executor.shutdownNow();
+      getServiceLocator().shutdown();
       await().pollDelay(2, TimeUnit.SECONDS).atMost(3, TimeUnit.MINUTES)
           .until(checkIfServerIsNotRunningCallable());
 


### PR DESCRIPTION
### What is this PR for?
In the `zeppelin-server/rest` module, it was observed that when running multiple tests together, configuration values of notebooks used in previous tests remain.
To address this, code has been added to shutdown `serviceLocator` when the test finishes and the server is stopped.

### What type of PR is it?
Bug Fix

### Todos
* Add serviceLocatior shutdown

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6237

### How should this be tested?
* In the `zeppelin-server/rest` module, run test.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
