### PR TITLE
[ZEPPELIN-6199] Fix tutorial document file download not working

### DIFF
--- a/docs/quickstart/tutorial.md
+++ b/docs/quickstart/tutorial.md
@@ -31,7 +31,9 @@ Current main backend processing engine of Zeppelin is [Apache Spark](https://spa
 
 ### Data Refine
 
-Before you start Zeppelin tutorial, you will need to download [bank.zip](http://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip). 
+Before you start Zeppelin tutorial, you will need to download [bank+marketing.zip](https://archive.ics.uci.edu/static/public/222/bank+marketing.zip).
+
+Unzip `bank+marketing.zip` and then use `bank.zip` file found inside.
 
 First, to transform csv format data into RDD of `Bank` objects, run following script. This will also remove header using `filter` function.
 


### PR DESCRIPTION
### What is this PR for?
Currently, download link of `bank.zip` file in [tutorial page](https://zeppelin.apache.org/docs/0.12.0/quickstart/tutorial.html) is broken.

The root cause is a change in the URL for the UCI Machine Learning dataset. The previous link, http://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank.zip, is no longer valid. 

The new dataset for the same ID (222) is now located at https://archive.ics.uci.edu/dataset/222/bank+marketing.

Additionally, `bank.zip` is no longer offered as a standalone file. It is now nested inside a `bank+marketing.zip` archive.

This PR updates the tutorial to:
* Replace the broken link with the new, correct URL for the `bank+marketing.zip` file.
* Add a clear instruction for users to first unzip the main `bank+marketing.zip` archive to find and use the required `bank.zip` file within it.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-6199]

### How should this be tested?
* Run the fixed document locally with docker.
* Download the file in this fixed page, and run related tutorials with this file in zeppelin notebook.

### Screenshots (if appropriate)

* Run tutorial with new `bank.zip` file.
<img width="2491" height="1156" alt="Tutorial Test Result" src="https://github.com/user-attachments/assets/1018f2ae-8cd1-475c-9bdd-015b8cd4b362" />

* Add a new instruction to use the data file.
<img width="910" height="637" alt="Fixed Tutorial Page" src="https://github.com/user-attachments/assets/40703945-6cde-48b4-8060-c00d83278348" />


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
