### PR TITLE
[ZEPPELIN-6220] Remove unused constructor in DownloadRequest.class

### DIFF
--- a/zeppelin-test/src/main/java/org/apache/zeppelin/test/DownloadRequest.java
+++ b/zeppelin-test/src/main/java/org/apache/zeppelin/test/DownloadRequest.java
@@ -17,41 +17,16 @@
 
 package org.apache.zeppelin.test;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 
 public class DownloadRequest {
+
   private final URL url;
   private final Optional<URL> alternativeUrl;
   private final int retries;
 
   public static final int DEFAULT_RETRIES = 3;
-
-  public DownloadRequest(String url, int retries) throws MalformedURLException {
-    this(url, null, retries);
-  }
-
-  public DownloadRequest(String url, String alternativeUrl) throws MalformedURLException {
-    this(url, alternativeUrl, DEFAULT_RETRIES);
-  }
-
-  public DownloadRequest(String url, String alternativeUrl, int retries)
-      throws MalformedURLException {
-    if (alternativeUrl != null) {
-      this.url = new URL(url);
-      this.alternativeUrl = Optional.of(new URL(alternativeUrl));
-      this.retries = retries;
-    } else {
-      this.url = new URL(url);
-      this.alternativeUrl = Optional.empty();
-      this.retries = retries;
-    }
-  }
-
-  public DownloadRequest(URL url, int retries) {
-    this(url, null, retries);
-  }
 
   public DownloadRequest(URL url, URL alternativeUrl) {
     this(url, alternativeUrl, DEFAULT_RETRIES);
@@ -75,3 +50,4 @@ public class DownloadRequest {
     return retries;
   }
 }
+


### PR DESCRIPTION
### What is this PR for?
This PR removes unused overloaded constructors in the DownloadRequest class located at:
zeppelin/zeppelin-test/src/main/java/org/apache/zeppelin/test/DownloadRequest.java.

Specifically, the constructor:

```
public DownloadRequest(URL url, int retries)
```
is not used anywhere within the Zeppelin codebase or its test suite. Removing these unused constructors simplifies the class and reduces maintenance complexity, without affecting any functional behavior.

As this constructor was removed, other constructors that were only used by it have also been removed accordingly.


### What type of PR is it?
Refactoring


### Todos
* [x] - Verify internal and external usage
* [x] - Remove unused constructors 

### What is the Jira issue?
* Open an issue on Jira. [ZEPPELIN-6220](https://issues.apache.org/jira/browse/ZEPPELIN-6220)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - no
* Is there breaking changes for older versions? - no
* Does this needs documentation? - no
