### PR TITLE
[ZEPPELIN-6240] Use generics in CommandArgs constructor to improve type safety

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java
@@ -64,8 +64,8 @@ public abstract class FileInterpreter extends Interpreter {
 
     public CommandArgs(String cmd) {
       input = cmd;
-      args = new ArrayList();
-      flags = new HashSet();
+      args = new ArrayList<>();
+      flags = new HashSet<>();
     }
 
     private void parseArg(String arg) {


### PR DESCRIPTION
### What is this PR for?

As @ParkGyeongTae  mentioned,
in the file zeppelin/file/src/main/java/org/apache/zeppelin/file/FileInterpreter.java,
the variables args and flags were originally created using raw types:

```
args = new ArrayList();
flags = new HashSet();
```
To resolve compiler warnings and ensure proper type checking,
I updated the code to use generic types with diamond operators (<>) like this:
```
args = new ArrayList<String>();
flags = new HashSet<String>();
```

### What type of PR is it?
Refactoring

### Todos
* [x] - Use generics in CommandArgs constructor

### What is the Jira issue?
* Open an issue on [Jira](https://issues.apache.org/jira/browse/ZEPPELIN-6240)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
