### PR TITLE
[ZEPPELIN-6244] Handle Collection as defaultValue in GUI.select()

### DIFF
--- a/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
+++ b/zeppelin-interpreter/src/main/java/org/apache/zeppelin/display/GUI.java
@@ -96,7 +96,17 @@ public class GUI implements Serializable {
     return params.get(id);
   }
 
+  /**
+   * Create a select form.
+   *
+   * <p>If {@code defaultValue} is a {@link java.util.Collection} the first
+   * element will be used as the actual default value.</p>
+   */
   public Object select(String id, ParamOption[] options, Object defaultValue) {
+    if (defaultValue instanceof Collection && !(defaultValue instanceof String)) {
+      Collection<?> values = (Collection<?>) defaultValue;
+      defaultValue = values.isEmpty() ? null : values.iterator().next();
+    }
     if (defaultValue == null && options != null && options.length > 0) {
       defaultValue = options[0].getValue();
     }

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -77,6 +78,32 @@ class GUITest {
     // Verify the form's default value is correctly set
     Select selectForm = (Select) gui.forms.get("list_collection");
     assertEquals("2", selectForm.getDefaultValue());
+  }
+
+  @Test
+  void testSelectWithCollectionDefaultMultiElement() {
+    GUI gui = new GUI();
+    List<String> collectionDefault = Arrays.asList("2", "3");
+    Object selected = gui.select("list_collection_multi", options, collectionDefault);
+
+    // First element of collection should be used
+    assertEquals("2", selected);
+
+    Select selectForm = (Select) gui.forms.get("list_collection_multi");
+    assertEquals("2", selectForm.getDefaultValue());
+  }
+
+  @Test
+  void testSelectWithEmptyCollectionDefault() {
+    GUI gui = new GUI();
+    List<String> emptyDefault = Collections.emptyList();
+    Object selected = gui.select("list_collection_empty", options, emptyDefault);
+
+    // Empty collection -> null -> fallback to first option ("1")
+    assertEquals("1", selected);
+
+    Select selectForm = (Select) gui.forms.get("list_collection_empty");
+    assertEquals("1", selectForm.getDefaultValue());
   }
 
   @Test

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/GUITest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -62,6 +63,20 @@ class GUITest {
     // still "2"
     selected = gui.select("list_1", options, "1");
     assertEquals("2", selected);
+  }
+
+  @Test
+  void testSelectWithCollectionDefault() {
+    GUI gui = new GUI();
+    List<String> collectionDefault = Arrays.asList("2");
+    Object selected = gui.select("list_collection", options, collectionDefault);
+    
+    // Verify that "2" (first element of collection) is used as default
+    assertEquals("2", selected);
+    
+    // Verify the form's default value is correctly set
+    Select selectForm = (Select) gui.forms.get("list_collection");
+    assertEquals("2", selectForm.getDefaultValue());
   }
 
   @Test


### PR DESCRIPTION
# [MINOR] Handle Collection as defaultValue in GUI.select()

## What is this PR for?
This PR improves the `GUI.select()` method to properly handle Collection objects passed as defaultValue. When a Collection is provided, the method now extracts the first element as the actual default value instead of using the Collection object itself.

## What type of PR is it?
Improvement

## What is the Jira issue?
N/A (Minor improvement)

## How should this be tested?
1. Run the test: `./mvnw test -pl zeppelin-interpreter -Dtest=GUITest`
2. Verify that the new test `testSelectWithCollectionDefault()` passes
3. The test verifies that:
   - When a Collection containing `["2"]` is passed as defaultValue
   - The select form uses `"2"` as the default value (not the Collection object)

## Questions:
* Does the license files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No

## Description

### Problem
Currently, when using `GUI.select()` with a Collection as the defaultValue parameter, the entire Collection object is used as the default value. This can cause issues since the select form expects a single value, not a Collection.

### Solution
Added logic to check if the defaultValue is a Collection (but not a String, since String implements CharSequence which is a Collection-like interface). If it is:
- Extract the first element from the Collection
- Use that element as the actual default value
- If the Collection is empty, use null

### Code Changes
```java
// Added to GUI.select() method
if (defaultValue instanceof Collection && !(defaultValue instanceof String)) {
  Collection<?> values = (Collection<?>) defaultValue;
  defaultValue = values.isEmpty() ? null : values.iterator().next();
}
```

### Test Coverage
Added `testSelectWithCollectionDefault()` test that verifies:
- A Collection containing `"2"` is properly converted to default value `"2"`
- The form's default value is correctly set to `"2"`
- The selected value matches the expected default

This change improves the API's flexibility and prevents potential issues when Collections are inadvertently passed as default values.