### PR TITLE
[ZEPPELIN-6246] Replace deprecated Character constructor

### DIFF
--- a/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
+++ b/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java
@@ -177,13 +177,13 @@ public class HDFSFileInterpreter extends FileInterpreter {
   }
 
   private String listOne(String path, OneFileStatus fs) {
-    if (args.flags.contains(new Character('l'))) {
+    if (args.flags.contains(Character.valueOf('l'))) {
       StringBuilder sb = new StringBuilder();
-      sb.append(listPermission(fs) + "\t");
+      sb.append(listPermission(fs) + '\t');
       sb.append(((fs.replication == 0) ? "-" : fs.replication) + "\t ");
-      sb.append(fs.owner + "\t");
-      sb.append(fs.group + "\t");
-      if (args.flags.contains(new Character('h'))){ //human readable
+      sb.append(fs.owner + '\t');
+      sb.append(fs.group + '\t');
+      if (args.flags.contains(Character.valueOf('h'))){ // human readable
         sb.append(humanReadableByteCount(fs.length) + "\t\t");
       } else {
         sb.append(fs.length + "\t");


### PR DESCRIPTION
### What is this PR for?

In the following file [zeppelin/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java](https://github.com/apache/zeppelin/blob/91f091e287b94295ec7f10254b4f4ac800209899/file/src/main/java/org/apache/zeppelin/file/HDFSFileInterpreter.java#L180)

The Character constructor is deprecated in Java 9 and later, recommending the use of the static factory method Character.valueOf() instead.

This change's objective is to update the code to use the modern recommended approach.

As-is
```
 if (args.flags.contains(new Character('l'))) {
```
To-be
```
if (args.flags.contains(Character.valueOf('l'))) {
```

Also, Changed single word's type from **""** -> **''**


### What type of PR is it?
Refactoring

### Todos
* [ ] - Replace deprecated Character constructor
* [ ] - Change single word's data type 

### What is the Jira issue?
* Open an issue on [Jira](https://issues.apache.org/jira/browse/ZEPPELIN-6246)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
