### PR TITLE
ZEPPELIN-6200 Update docs URL to /docs/latest

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/home/home.component.html
@@ -26,7 +26,7 @@
     <div nz-col [nzSm]="24" [nzLg]="12">
       <h3>Help</h3>
       Get started with <a style="text-decoration: none;" target="_blank"
-                          href="http://zeppelin.apache.org/docs/{{ticketService.version}}/index.html">Zeppelin
+                          href="http://zeppelin.apache.org/docs/latest/index.html">Zeppelin
       documentation</a><br/>
 
       <h3>Community</h3>

--- a/zeppelin-web/src/app/home/home.html
+++ b/zeppelin-web/src/app/home/home.html
@@ -58,7 +58,7 @@ limitations under the License.
         <div class="col-md-6">
           <h4>Help</h4>
           Get started with <a style="text-decoration: none;" target="_blank" rel="noopener noreferrer"
-                              href="http://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html">Zeppelin documentation</a><br/>
+                              href="http://zeppelin.apache.org/docs/latest/index.html">Zeppelin documentation</a><br/>
 
           <h4>Community</h4>
           Please feel free to help us to improve Zeppelin, <br/>


### PR DESCRIPTION
### What is this PR for?

The current official documentation link is set as:

http://zeppelin.apache.org/docs/{{zeppelinVersion}}/index.html

However, the current version is 0.12.0-SNAPSHOT, which is still under development and not an official release. As a result, the documentation link for this version is not available.

Since we only need to provide a link to the latest stable release, how about updating the link to:

http://zeppelin.apache.org/docs/latest/index.html

This would ensure users are always directed to the latest available documentation.


### What type of PR is it?
Improvement

### Todos
* [o] - Verified that the updated URL

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN-6200

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)


### Questions:
* Does the license files need to update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
