### PR TITLE
[ZEPPELIN-6232] Prevent duplicate interpreter repositories on server restart

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java
@@ -92,6 +92,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -309,9 +310,24 @@ public class InterpreterSettingManager implements NoteEventListener {
     }
 
     if (infoSaving.interpreterRepositories != null) {
-      for (RemoteRepository repo : infoSaving.interpreterRepositories) {
-        if (!dependencyResolver.getRepos().contains(repo)) {
-          this.interpreterRepositories.add(repo);
+      for (RemoteRepository savedRepo : infoSaving.interpreterRepositories) {
+        boolean replaced = false;
+        ListIterator<RemoteRepository> iterator = this.interpreterRepositories.listIterator();
+
+        // Check all existing(default) repos
+        while (iterator.hasNext()) {
+          RemoteRepository existingRepo = iterator.next();
+          if (existingRepo.getId().equals(savedRepo.getId())) {
+            // replace the exist repo to user saving repo if id is matched
+            iterator.set(savedRepo);
+            replaced = true;
+            break;
+          }
+        }
+
+        // if saved repo not match to any exist repo, add one.
+        if (!replaced) {
+          this.interpreterRepositories.add(savedRepo);
         }
       }
 


### PR DESCRIPTION
### What is this PR for?
_OVERVIEW_
This PR fixes a bug where modifying a default interpreter repository (e.g., 'central') and restarting the Zeppelin server would result in a duplicate repository entry instead of an overwrite.

For example, if a user added a new `central` repository to interpreter, it just replace the default central repository as we expected.

but, when restart, the UI would incorrectly display two `central` repositories: the user-modified one and the default one.

<img width="817" height="342" alt="duplicated_central_repo" src="https://github.com/user-attachments/assets/9cb98010-3b5a-4ae2-838d-937ebffbaa07" />

This happens because `interpreter.json` file have two `central` in interpreterRepositories field.

_ROOT CAUSE_
The issue was in the repository loading logic within [InterpreterSettingManager](https://github.com/apache/zeppelin/blob/573fc4e1b3085289640e9bca163c9020f01536de/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java#L313). When loading settings from `interpreter.json` on startup, the code checked for the existence of a repository using `List.contains(repo)`.

**This check failed because the default repository object and the user-modified repository 'object' were not identical (e.g., one had authentication details, the other did not), even though their IDs were the same ('central').** This led to the manager incorrectly treating the user's repository as a new entry and adding it, causing the duplication.

_MODIFICATION_
The repository loading logic in InterpreterSettingManager's [loadFromFile()](https://github.com/apache/zeppelin/blob/573fc4e1b3085289640e9bca163c9020f01536de/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java#L313) has been modified to correctly handle user-defined repositories.

Instead of using `List.contains()`, the new logic now iterates through the existing list of repositories and explicitly checks for matching IDs.

* If a repository with the same ID as the user-saved one is found, the existing repository is replaced with the user's version.
* If no repository with a matching ID is found, the user-saved repository is added as a new entry.

This ensures that user modifications to default repositories are correctly persisted across server restarts and prevents duplicate entries.

* And also, Instead of using `dependencyResolver.getRepos()` as before, I change this to use just `interpreterRepositories` in InterpreterSettingManager. `interpreterRepositories` already initialized with dependencyResolver.getRepos() on [initialize stage](https://github.com/apache/zeppelin/blob/573fc4e1b3085289640e9bca163c9020f01536de/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSettingManager.java#L181), and so far there is no side effect to change this. It is more intuitive to iterate interpreterRepositories to change interpreterRepositories.

_SIDE EFFECT_
When user overwrite the default repo, like `central`, or `local`, they are still default repos with different info.
(Only when `interpreter.json` has this changed info. when this file removed, then original default repo show up.)
So I guess there's not so much things to be affected by this change.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-6232]

### How should this be tested?
A new unit test, `testShouldNotDuplicateRepoOnReloadWhenDefaultRepoIsModified`, has been added to `InterpreterSettingManagerTest.java`.

This test simulates the exact scenario of the bug:

* It programmatically modifies the 'central' repository and saves the configuration.
* It reloads the InterpreterSettingManager to mimic a server restart.
* It asserts that only one 'central' repository exists and that it correctly retains the user's modifications.
* Finally, it checks if non-modified default repo ('local', in this case) still exist as a default.

If you want to test manually:
* In zeppelin notebook, on `interpreter` menu, you can add a new `central` repo, and it replace the default one immediately. (Works either current and fixed version)
* Upon server restart, you can find out two `central` repo. (current version)
* Upon server restart, you can find out one `central` repo, which is user-defined. (fixed version)
* you can also check `interpreter.json` in /conf.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
