### PR TITLE
[ZEPPELIN-6221] Optimize Neo4jCypherInterpreterTest performance by reusing interpreter instance

### DIFF
--- a/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
+++ b/neo4j/src/test/java/org/apache/zeppelin/graph/neo4j/Neo4jCypherInterpreterTest.java
@@ -92,8 +92,8 @@ public class Neo4jCypherInterpreterTest {
     interpreter = new Neo4jCypherInterpreter(p);
     interpreter.open();
     context = InterpreterContext.builder()
-            .setInterpreterOut(new InterpreterOutput())
-              .build();
+        .setInterpreterOut(new InterpreterOutput())
+        .build();
   }
 
   @AfterAll


### PR DESCRIPTION
### What is this PR for?
This PR optimizes the performance of Neo4jCypherInterpreterTest by eliminating redundant interpreter initialization. 
Currently, each test method creates and closes a new Neo4jCypherInterpreter instance, which introduces unnecessary overhead when running against a Neo4j Testcontainer.
By using @TestInstance(TestInstance.Lifecycle.PER_CLASS) and moving setup to @BeforeAll, we reduce initialization from 11 times to 1 time, improving test execution time.

### What type of PR is it?
Improvement

### Todos
* [x] - Use @TestInstance(TestInstance.Lifecycle.PER_CLASS) annotation
* [x] - Move interpreter setup from @BeforeEach to @BeforeAll  
* [x] - Make interpreter and context static fields
* [x] - Verify all tests still pass

### What is the Jira issue?
* https://issues.apache.org/jira/browse/ZEPPELIN-6221

### How should this be tested?
1. Run the Neo4jCypherInterpreterTest suite: `mvn test -Dtest=Neo4jCypherInterpreterTest`
2. Verify all 11 tests pass successfully
3. Confirm test execution time is reduced compared to the previous implementation

### Screenshots (if appropriate)
N/A

### Questions:
* Does the licenses files need update? No.
* Is there breaking changes for older versions? No. 
* Does this needs documentation? No.