### PR TITLE
[ZEPPELIN-6214] Fix new web app to handling carriage return

### DIFF
--- a/zeppelin-web/src/app/notebook/paragraph/result/result.js
+++ b/zeppelin-web/src/app/notebook/paragraph/result/result.js
@@ -23,18 +23,22 @@ export default class Result {
   checkAndReplaceCarriageReturn() {
     const str = this.data.replace(/\r\n/g, '\n');
     if (/\r/.test(str)) {
-      let newGenerated = '';
-      let strArr = str.split('\n');
-      for (let str of strArr) {
-        if (/\r/.test(str)) {
-          let splitCR = str.split('\r');
-          newGenerated += splitCR[splitCR.length - 1] + '\n';
-        } else {
-          newGenerated += str + '\n';
+      const generatedLines = str.split('\n').map((line) => {
+        if (!/\r/.test(line)) {
+          return line;
         }
-      }
-      // remove last "\n" character
-      return newGenerated.slice(0, -1);
+        const parts = line.split('\r');
+        let currentLine = parts[0];
+        for (let i = 1; i < parts.length; i++) {
+          const part = parts[i];
+          const partLength = part.length;
+          // apply terminal-like output. carriage return has the effect of moving output cursor to the front.
+          const overwritten = part + currentLine.substring(partLength);
+          currentLine = overwritten;
+        }
+        return currentLine;
+      });
+      return generatedLines.join('\n');
     } else {
       return str;
     }


### PR DESCRIPTION
### What is this PR for?
Fix an issue where the new Angular UI (zeppelin-web-angular) does not correctly handle carriage return (`\r`) characters. 
This causes outputs like progress bars(`#`) or status updates that use `\r` to overwrite lines to appear ugly and unnecessarily long.

This implementation is a direct port of the previous logic from the classic UI (zeppelin-web), specifically based on the original implementation in [result.controller.js](https://github.com/apache/zeppelin/blob/8ca6e57f27324b1e74fc78bea5cabd176b607408/zeppelin-web/src/app/notebook/paragraph/result/result.controller.js#L527) and [result.js](https://github.com/apache/zeppelin/blob/8ca6e57f27324b1e74fc78bea5cabd176b607408/zeppelin-web/src/app/notebook/paragraph/result/result.js#L23).

_Additionally, this update changes the behavior of the carriage return (`\r`) character to better emulate standard terminal functionality._

Instead of clearing the entire line, the `\r` character now moves the cursor to the beginning of the line and overwrites the existing text. This "terminal-like" partial overwrite behavior is more accurate and what most interpreters expect.

This enhancement has been applied to both the classic and new UIs for consistent, standards-compliant output.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[ZEPPELIN-6214]

### How should this be tested?
* Any zeppelin notebook paragraph that generating progress bar (`#`) is the easiest to test this change.
* Or you can reproduce the Jira Issue ticket's situation by running the code. Installing conda, set your own conda env, and set path in zeppelin is required.
* For testing terminal-like CR behavior - you can run the code like below in zeppelin notebook with shell interpreter.
```bash
printf 'Initializing system, please wait...\rLoading components...\n'
printf 'Progress: [25%%]\rProgress: [50%%]\rProgress: [100%%]\n'
```

### Screenshots (if appropriate)
* Current Version
<img width="2423" height="1021" alt="CR_Current" src="https://github.com/user-attachments/assets/e368c49d-2519-4497-ab25-f0ddfdd19a8a" />

* Fixed Version (with supporting terminal-like carriage return)
<img width="2496" height="589" alt="1_CR_new" src="https://github.com/user-attachments/assets/68a88195-1058-465b-a704-4d641ab745ac" />


### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
