### PR TITLE
[ZEPPELIN-6251] Refactor AuthenticationService binding using factory method

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/server/ZeppelinServer.java
@@ -92,6 +92,7 @@ import org.apache.zeppelin.search.NoSearchService;
 import org.apache.zeppelin.search.SearchService;
 import org.apache.zeppelin.service.*;
 import org.apache.zeppelin.service.AuthenticationService;
+import org.apache.zeppelin.service.auth.AuthenticationServiceFactory;
 import org.apache.zeppelin.socket.ConnectionManager;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.socket.SessionConfigurator;
@@ -188,13 +189,9 @@ public class ZeppelinServer implements AutoCloseable {
             bindAsContract(AuthorizationService.class).in(Singleton.class);
             bindAsContract(ConnectionManager.class).in(Singleton.class);
             bindAsContract(NoteManager.class).in(Singleton.class);
-            // TODO(jl): Will make it more beautiful
-            if (!StringUtils.isBlank(zConf.getShiroPath())) {
-              bind(ShiroAuthenticationService.class).to(AuthenticationService.class).in(Singleton.class);
-            } else {
-              // TODO(jl): Will be added more type
-              bind(NoAuthenticationService.class).to(AuthenticationService.class).in(Singleton.class);
-            }
+            bind(AuthenticationServiceFactory.getAuthServiceClass(zConf))
+                    .to(AuthenticationService.class)
+                    .in(Singleton.class);
             bindAsContract(HeliumBundleFactory.class).in(Singleton.class);
             bindAsContract(HeliumApplicationFactory.class).in(Singleton.class);
             bindAsContract(ConfigurationService.class).in(Singleton.class);

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/auth/AuthenticationServiceFactory.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/auth/AuthenticationServiceFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.service.auth;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.service.AuthenticationService;
+import org.apache.zeppelin.service.NoAuthenticationService;
+import org.apache.zeppelin.service.ShiroAuthenticationService;
+
+public class AuthenticationServiceFactory {
+
+    public static Class<? extends AuthenticationService> getAuthServiceClass(ZeppelinConfiguration zConf) {
+        if (!zConf.getShiroPath().isBlank()) {
+            return ShiroAuthenticationService.class;
+        } else {
+            return NoAuthenticationService.class;
+        }
+    }
+}


### PR DESCRIPTION
### What is this PR for?
This PR refactors the conditional binding logic for AuthenticationService in ZeppelinServer.java.
Previously, the binding decision between ShiroAuthenticationService and NoAuthenticationService was handled via an inline if-else block.
To improve readability and maintainability, this logic has been moved to a new AuthenticationServiceFactory class that encapsulates the decision process.
This change simplifies the server initialization logic and promotes better separation of concerns.


### What type of PR is it?
Refactoring

### Todos
* [x] - Add AuthenticationServiceFactory class
* [x] - Replace inline if-else binding logic in ZeppelinServer

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN-6251

### How should this be tested?
There should be no functional change.

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
