### PR TITLE
[ZEPPELIN-6248] Display a message when no search results

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.html
@@ -13,5 +13,10 @@
   <zeppelin-notebook-search-result-item *ngFor="let item of results"
                                         [result]="item">
   </zeppelin-notebook-search-result-item>
+
+  <div *ngIf="hasNoResults" class="search-no-result-found">
+    <i nz-icon nzType="search" nzTheme="outline"></i>
+    We couldn't find any notebook matching <strong>'{{searchTerm}}'</strong>
+  </div>
 </div>
 

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.less
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.less
@@ -21,4 +21,13 @@
     margin-bottom: 16px;
     display: block;
   }
+
+  .search-no-result-found {
+    border: 1px solid;
+    margin: 150px 150px;
+    padding: 15px 10px 15px 0px;
+    color: #3071A9;
+    text-align: center;
+    background-color: #f4f6f8;
+  }
 });

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.component.ts
@@ -29,12 +29,20 @@ export class NotebookSearchComponent implements OnInit, OnDestroy {
     takeUntil(this.destroy$),
     map(params => params.queryStr),
     filter(queryStr => typeof queryStr === 'string' && !!queryStr.trim()),
-    tap(() => (this.searching = true)),
+    tap(queryStr => {
+      this.searching = true;
+      this.searchTerm = queryStr;
+    }),
     switchMap(queryStr => this.notebookSearchService.search(queryStr))
   );
 
   results: NotebookSearchResultItem[] = [];
   searching = false;
+  searchTerm = '';
+
+  get hasNoResults(): boolean {
+    return !this.searching && this.results.length === 0 && this.searchTerm.length > 0;
+  }
 
   constructor(
     private cdr: ChangeDetectorRef,

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.module.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook-search/notebook-search.module.ts
@@ -17,6 +17,7 @@ import { FormsModule } from '@angular/forms';
 import { NzCardModule } from 'ng-zorro-antd/card';
 
 import { ShareModule } from '@zeppelin/share';
+import { NzIconModule } from 'ng-zorro-antd/icon';
 
 import { NotebookSearchRoutingModule } from './notebook-search-routing.module';
 import { NotebookSearchComponent } from './notebook-search.component';
@@ -24,6 +25,6 @@ import { NotebookSearchResultItemComponent } from './result-item/result-item.com
 
 @NgModule({
   declarations: [NotebookSearchComponent, NotebookSearchResultItemComponent],
-  imports: [CommonModule, NotebookSearchRoutingModule, ShareModule, NzCardModule, FormsModule]
+  imports: [CommonModule, NotebookSearchRoutingModule, ShareModule, NzCardModule, FormsModule, NzIconModule]
 })
 export class NotebookSearchModule {}


### PR DESCRIPTION
### What is this PR for?
Added a "no results found" message in the new Angular UI when search returns no results.

### What type of PR is it?
Improvement

### Todos
* Add "no results found" message

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6248

### How should this be tested?

### Screenshots (if appropriate)
<img width="1487" height="281" alt="image" src="https://github.com/user-attachments/assets/6dd8264a-8dc4-4490-a8c3-85f629d2e019" />


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
