### PR TITLE
[ZEPPELIN-6250] Remove unused methods from SemanticVersion class

### DIFF
--- a/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
+++ b/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
@@ -75,4 +75,8 @@ public class SemanticVersion {
     return versionToCompare instanceof SemanticVersion
             && version == ((SemanticVersion) versionToCompare).version;
   }
+
+  public boolean equalsOrNewerThan(SemanticVersion versionToCompare) {
+    return version >= versionToCompare.version;
+  }
 }

--- a/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
+++ b/zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java
@@ -60,18 +60,6 @@ public class SemanticVersion {
     }
   }
 
-  public int getMajorVersion() {
-    return majorVersion;
-  }
-
-  public int getMinorVersion() {
-    return minorVersion;
-  }
-
-  public int getPatchVersion() {
-    return patchVersion;
-  }
-
   @Override
   public String toString() {
     return versionString;
@@ -86,21 +74,5 @@ public class SemanticVersion {
   public boolean equals(Object versionToCompare) {
     return versionToCompare instanceof SemanticVersion
             && version == ((SemanticVersion) versionToCompare).version;
-  }
-
-  public boolean newerThan(SemanticVersion versionToCompare) {
-    return version > versionToCompare.version;
-  }
-
-  public boolean equalsOrNewerThan(SemanticVersion versionToCompare) {
-    return version >= versionToCompare.version;
-  }
-
-  public boolean olderThan(SemanticVersion versionToCompare) {
-    return version < versionToCompare.version;
-  }
-
-  public boolean equalsOrOlderThan(SemanticVersion versionToCompare) {
-    return version <= versionToCompare.version;
   }
 }


### PR DESCRIPTION
### What is this PR for?
As @ParkGyeongTae mentioned, in `zeppelin-test/src/main/java/org/apache/zeppelin/test/SemanticVersion.java`, 
Some methods related to version checks were found to be **unused** and could potentially introduce **unintended side effects**. I've removed them to streamline the code. These functionalities can be re-implemented if their specifications are required in the future.
 

### What type of PR is it?
Refactoring

### Todos
* [x] - Remove unused methods

### What is the Jira issue?
* Put link [here](https://issues.apache.org/jira/browse/ZEPPELIN-6250)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here. 

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
