### PR TITLE
[ZEPPELIN-6249] Fix broken Ace Editor theme link in STYLE.md

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -13,7 +13,7 @@ There are two parts to code highlighting. First, Zeppelin uses the Ace Editor fo
 app/scripts/controllers/paragraph.js  
 Call setTheme on the editor with the theme path/name.  
 [Setting Theme on Ace Documentation](http://ace.c9.io/#nav=howto)  
-[List of themes on GitHub](https://github.com/ajaxorg/ace/tree/master/lib/ace/theme)
+[List of themes on GitHub](https://github.com/ajaxorg/ace/tree/master/src/theme)
 
 #### Style for Markdown Code Blocks
 Highlight.js parses and converts &lt;pre&gt;&lt;code&gt; blocks from markdown parser into keywords and language syntax with proper styles. It also attempts to infer the best fitting language if it is not provided. The visual style can be changed by simply including the desired [stylesheet](https://github.com/components/highlightjs/tree/master/styles) into app/index.html. See the next section on build.


### PR DESCRIPTION
### What is this PR for?
This PR updates the outdated link to Ace Editor themes in the STYLE.md file.  
The previous link pointed to a non-existing path, and the new link ensures contributors can find the correct theme list.

### What type of PR is it?
Documentation

### Todos
- [x] Update broken theme URL

### What is the Jira issue?
[ZEPPELIN-6249](https://issues.apache.org/jira/browse/ZEPPELIN-6249)

### How should this be tested?
No functional code changes. Just confirm that the updated link is valid and accessible in the rendered markdown.

### Screenshots (if appropriate)
_N/A_

### Questions:
* Does the license files need to update? No  
* Is there breaking changes for older versions? No  
* Does this needs documentation? No
