### PR TITLE
[ZEPPELIN-6253] fix: remove SNAPSHOT from version when building crede…

### DIFF
--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -199,14 +199,11 @@ function CredentialController($scope, $rootScope, $http, baseUrlSrv, ngToast) {
   }
 
   $scope.getCredentialDocsLink = function() {
-    let currentVersion = $rootScope.zeppelinVersion || '0.12.0';
-    currentVersion = currentVersion.replace('-SNAPSHOT', '');
+    const currentVersion = $rootScope.zeppelinVersion && $rootScope.zeppelinVersion.replace('-SNAPSHOT', '') || 'latest';
 
     const isVersionOver0Point7 = currentVersion.split('.')[1] > 7;
 
-    /*
-     * Add '/setup' to doc link on the version over 0.7.0, add '/setup' to the doc URL
-     */
+    // Add '/setup' to doc URL for versions > 0.7.0
     return `https://zeppelin.apache.org/docs/${currentVersion}${
       isVersionOver0Point7 ? '/setup' : ''
     }/security/datasource_authorization.html`;

--- a/zeppelin-web/src/app/credential/credential.controller.js
+++ b/zeppelin-web/src/app/credential/credential.controller.js
@@ -199,10 +199,13 @@ function CredentialController($scope, $rootScope, $http, baseUrlSrv, ngToast) {
   }
 
   $scope.getCredentialDocsLink = function() {
-    const currentVersion = $rootScope.zeppelinVersion;
-    const isVersionOver0Point7 = currentVersion && currentVersion.split('.')[1] > 7;
+    let currentVersion = $rootScope.zeppelinVersion || '0.12.0';
+    currentVersion = currentVersion.replace('-SNAPSHOT', '');
+
+    const isVersionOver0Point7 = currentVersion.split('.')[1] > 7;
+
     /*
-     * Add '/setup' to doc link on the version over 0.7.0
+     * Add '/setup' to doc link on the version over 0.7.0, add '/setup' to the doc URL
      */
     return `https://zeppelin.apache.org/docs/${currentVersion}${
       isVersionOver0Point7 ? '/setup' : ''


### PR DESCRIPTION
### What is this PR for?

Fixes a broken "Learn more" link on the credential page.

Zeppelin currently appends `-SNAPSHOT` to the version when constructing the documentation link, which results in a 404 page.  
This PR removes `-SNAPSHOT` from the version and ensures it uses a valid documentation path.

Broken link (before):  
`https://zeppelin.apache.org/docs/0.12.0-SNAPSHOT/setup/security/datasource_authorization.html`

Corrected link (after):  
`https://zeppelin.apache.org/docs/0.12.0/setup/security/datasource_authorization.html`

---

### What type of PR is it?

- [x] Bug Fix

---

### What is the Jira issue?

[JIRA: ZEPPELIN-6253](https://issues.apache.org/jira/browse/ZEPPELIN-6253)

---

### How should this be tested?

1. Navigate to **Credential** page in Zeppelin.
2. Click the **"?" (Learn more)** link at the top right.
3. Confirm it opens a valid docs page without 404.

---

### Questions

- Does the license files need to update? → No  
- Is there breaking changes for older versions? → No  
- Does this need documentation? → No
