### PR TITLE
[ZEPPELIN-6262] Refactor ElasticsearchClientTypeBuilder for safer enum handling and blank input support

### DIFF
--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/ElasticsearchClientTypeBuilder.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/ElasticsearchClientTypeBuilder.java
@@ -19,12 +19,8 @@ package org.apache.zeppelin.elasticsearch.client;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
-
 import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.TRANSPORT;
 import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.UNKNOWN;
-import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.valueOf;
-import static org.apache.zeppelin.elasticsearch.client.ElasticsearchClientType.values;
 
 public class ElasticsearchClientTypeBuilder {
 
@@ -47,18 +43,18 @@ public class ElasticsearchClientTypeBuilder {
 
     @Override
     public ElasticsearchClientType build() {
-      boolean isEmpty = StringUtils.isEmpty(propertyValue);
-      return isEmpty ?
+      boolean isBlank = StringUtils.isBlank(propertyValue);
+      return isBlank ?
         DEFAULT_ELASTICSEARCH_CLIENT_TYPE :
         getElasticsearchClientType(propertyValue);
     }
 
     private ElasticsearchClientType getElasticsearchClientType(String propertyValue){
-      boolean isExistingValue =
-          Arrays
-          .stream(values())
-          .anyMatch(clientType -> clientType.toString().equalsIgnoreCase(propertyValue));
-      return isExistingValue ? valueOf(propertyValue.toUpperCase()) : UNKNOWN;
+      try {
+        return ElasticsearchClientType.valueOf(propertyValue.toUpperCase());
+      } catch (IllegalArgumentException | NullPointerException e) {
+        return UNKNOWN;
+      }
     }
   }
 }

--- a/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/ElasticsearchClientTypeBuilder.java
+++ b/elasticsearch/src/main/java/org/apache/zeppelin/elasticsearch/client/ElasticsearchClientTypeBuilder.java
@@ -43,16 +43,15 @@ public class ElasticsearchClientTypeBuilder {
 
     @Override
     public ElasticsearchClientType build() {
-      boolean isBlank = StringUtils.isBlank(propertyValue);
-      return isBlank ?
-        DEFAULT_ELASTICSEARCH_CLIENT_TYPE :
-        getElasticsearchClientType(propertyValue);
+      return StringUtils.isBlank(propertyValue) ?
+              DEFAULT_ELASTICSEARCH_CLIENT_TYPE :
+              getElasticsearchClientType(propertyValue);
     }
 
     private ElasticsearchClientType getElasticsearchClientType(String propertyValue){
       try {
         return ElasticsearchClientType.valueOf(propertyValue.toUpperCase());
-      } catch (IllegalArgumentException | NullPointerException e) {
+      } catch (IllegalArgumentException e) {
         return UNKNOWN;
       }
     }


### PR DESCRIPTION
### What is this PR for?
This PR refactors the ElasticsearchClientTypeBuilder class to improve its robustness and readability:
- Replaces StringUtils.isEmpty() with StringUtils.isBlank() to treat whitespace-only strings as invalid input
- Simplifies enum parsing by removing redundant checks and using a try-catch block around Enum.valueOf(...)
- Ensures that invalid or null inputs gracefully fall back to ElasticsearchClientType.UNKNOWN

### What type of PR is it?
Refactoring

### Todos
* [x] - Verify existing tests

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN-6262

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
