### PR TITLE
[ZEPPELIN-6267] Refactor JarHelper Class to Use a Logging Framework Instead of System.out.println()

### DIFF
--- a/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/internal/JarHelper.java
+++ b/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/internal/JarHelper.java
@@ -29,7 +29,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 
-import org.apache.zeppelin.flink.Flink117Shims;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/internal/JarHelper.java
+++ b/flink/flink-scala-2.12/src/main/java/org/apache/zeppelin/flink/internal/JarHelper.java
@@ -29,6 +29,10 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 
+import org.apache.zeppelin.flink.Flink117Shims;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * This class is copied from flink project, the reason is that flink scala shell only supports
  * scala-2.11, we copied it here to support scala-2.12 as well.
@@ -38,6 +42,7 @@ public class JarHelper {
   // Constants
 
   private static final int BUFFER_SIZE = 2156;
+  private static final Logger LOGGER = LoggerFactory.getLogger(JarHelper.class);
 
   // ========================================================================
   // Variables
@@ -110,7 +115,7 @@ public class JarHelper {
       byte[] data = new byte[BUFFER_SIZE];
       File destFile = new File(destDir, entry.getName());
       if (mVerbose) {
-        System.out.println("unjarring " + destFile + " from " + entry.getName());
+        LOGGER.info("unjarring {} from {}", destFile, entry.getName());
       }
       FileOutputStream fos = new FileOutputStream(destFile);
       dest = new BufferedOutputStream(fos, BUFFER_SIZE);
@@ -143,7 +148,7 @@ public class JarHelper {
    */
   private void jarDir(File dirOrFile2jar, JarOutputStream jos, String path) throws IOException {
     if (mVerbose) {
-      System.out.println("checking " + dirOrFile2jar);
+      LOGGER.info("checking {}", dirOrFile2jar);
     }
     if (dirOrFile2jar.isDirectory()) {
       String[] dirList = dirOrFile2jar.list();
@@ -162,7 +167,7 @@ public class JarHelper {
     } else if (dirOrFile2jar.exists()) {
       if (dirOrFile2jar.getCanonicalPath().equals(mDestJarName)) {
         if (mVerbose) {
-          System.out.println("skipping " + dirOrFile2jar.getPath());
+          LOGGER.info("skipping {}", dirOrFile2jar.getPath());
         }
         return;
       }
@@ -178,7 +183,7 @@ public class JarHelper {
         while ((mByteCount = fis.read(mBuffer)) != -1) {
           jos.write(mBuffer, 0, mByteCount);
           if (mVerbose) {
-            System.out.println("wrote " + mByteCount + " bytes");
+            LOGGER.info("wrote {} bytes", mByteCount);
           }
         }
         jos.flush();


### PR DESCRIPTION
### What is this PR for?

Refactor JarHelper Class to Use a Logging Framework Instead of `System.out.println()`

### What type of PR is it?
Refactoring

### Todos
* [x] - Replace `println()` to `LOGGER.info()`

### What is the Jira issue?
* [here](https://issues.apache.org/jira/browse/ZEPPELIN-6267)

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - no
* Is there breaking changes for older versions? - no
* Does this needs documentation? - no
