### PR TITLE
[ZEPPELIN-6268] Fix resource leaks and add null checks for getResourceAsStream

### DIFF
--- a/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/IPythonInterpreter.java
@@ -132,9 +132,14 @@ public class IPythonInterpreter extends JupyterKernelInterpreter {
   }
 
   private void initPythonInterpreter(String gatewayHost, int gatewayPort) throws IOException {
-    InputStream input =
-            getClass().getClassLoader().getResourceAsStream("python/zeppelin_ipython.py");
-    List<String> lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+    List<String> lines;
+    try (InputStream input =
+            getClass().getClassLoader().getResourceAsStream("python/zeppelin_ipython.py")) {
+      if (input == null) {
+        throw new IOException("Cannot find resource: python/zeppelin_ipython.py");
+      }
+      lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+    }
     ExecuteResponse response = jupyterKernelClient.block_execute(ExecuteRequest.newBuilder()
             .setCode(StringUtils.join(lines, System.lineSeparator())
                     .replace("${JVM_GATEWAY_PORT}", gatewayPort + "")
@@ -143,9 +148,13 @@ public class IPythonInterpreter extends JupyterKernelInterpreter {
       throw new IOException("Fail to setup JVMGateway\n" + response.getOutput());
     }
 
-    input =
-            getClass().getClassLoader().getResourceAsStream("python/zeppelin_context.py");
-    lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+    try (InputStream input =
+            getClass().getClassLoader().getResourceAsStream("python/zeppelin_context.py")) {
+      if (input == null) {
+        throw new IOException("Cannot find resource: python/zeppelin_context.py");
+      }
+      lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+    }
     response = jupyterKernelClient.block_execute(ExecuteRequest.newBuilder()
             .setCode(StringUtils.join(lines, System.lineSeparator())).build());
     if (response.getStatus() != ExecuteStatus.SUCCESS) {
@@ -160,8 +169,13 @@ public class IPythonInterpreter extends JupyterKernelInterpreter {
     }
 
     if (additionalPythonInitFile != null) {
-      input = getClass().getClassLoader().getResourceAsStream(additionalPythonInitFile);
-      lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+      try (InputStream input =
+              getClass().getClassLoader().getResourceAsStream(additionalPythonInitFile)) {
+        if (input == null) {
+          throw new IOException("Cannot find resource: " + additionalPythonInitFile);
+        }
+        lines = IOUtils.readLines(input, StandardCharsets.UTF_8);
+      }
       response = jupyterKernelClient.block_execute(ExecuteRequest.newBuilder()
               .setCode(StringUtils.join(lines, System.lineSeparator())
                       .replace("${JVM_GATEWAY_PORT}", gatewayPort + "")

--- a/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
+++ b/python/src/main/java/org/apache/zeppelin/python/PythonInterpreter.java
@@ -43,6 +43,7 @@ import py4j.GatewayServer;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
@@ -198,16 +199,13 @@ public class PythonInterpreter extends Interpreter {
 
   private void copyResourceToPythonWorkDir(String srcResourceName,
                                            String dstFileName) throws IOException {
-    FileOutputStream out = null;
-    try {
-      out = new FileOutputStream(pythonWorkDir.getAbsoluteFile() + "/" + dstFileName);
-      IOUtils.copy(
-          getClass().getClassLoader().getResourceAsStream(srcResourceName),
-          out);
-    } finally {
-      if (out != null) {
-        out.close();
+    try (FileOutputStream out =
+            new FileOutputStream(pythonWorkDir.getAbsoluteFile() + "/" + dstFileName);
+         InputStream in = getClass().getClassLoader().getResourceAsStream(srcResourceName)) {
+      if (in == null) {
+        throw new IOException("Cannot find resource: " + srcResourceName);
       }
+      IOUtils.copy(in, out);
     }
   }
 


### PR DESCRIPTION
## What is this PR for?
`getResourceAsStream()` in the Python interpreters was never closed, and a missing resource surfaced as an NPE inside `IOUtils`. All four sites now use try-with-resources and name the resource in the `IOException`: three in `IPythonInterpreter`, one in `PythonInterpreter.copyResourceToPythonWorkDir`.

The first revision also touched `alluxio` and `rlang`; master dropped both modules (ZEPPELIN-6420, ZEPPELIN-6430), so the diff is python-only.

## What is the Jira issue?
[ZEPPELIN-6268](https://issues.apache.org/jira/browse/ZEPPELIN-6268)

## How should this be tested?
`interpreter-test-jupyter-python (3.9, 11)` runs the module on 348bc8d: 38 tests, 0 failures, including the kernel-launching `IPythonInterpreterTest` (9) and `PythonInterpreterTest` (6). No new test: a closed stream has no observable seam, and the `IOException` needs a missing packaged resource.
