### PR TITLE
[ZEPPELIN-6238] Prevent infinite loop in NotebookRestApiTest due to interpreter startup failure

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/rest/NotebookRestApiTest.java
@@ -666,12 +666,12 @@ class NotebookRestApiTest extends AbstractTestRestApi {
           Paragraph p2 = note1.getParagraph(1);
           try {
             p1.waitUntilFinished();
+            assertEquals(Job.Status.FINISHED, p1.getStatus());
             p2.waitUntilFinished();
+            assertEquals(Job.Status.FINISHED, p2.getStatus());
           } catch (InterruptedException e) {
             fail(e);
           }
-          assertEquals(Job.Status.FINISHED, p1.getStatus());
-          assertEquals(Job.Status.FINISHED, p2.getStatus());
           assertEquals("hello\n", p2.getReturn().message().get(0).getData());
           return null;
         });


### PR DESCRIPTION
### What is this PR for?
The testRunNoteNonBlocking integration test in NotebookRestApiTest can enter an infinite loop when the Python interpreter fails to start. This happens because the interpreter cannot find the python executable, resulting in an IOException: error=2, No such file or directory.

The test uses httpPost with blocking=true, followed by p1.waitUntilFinished() to wait for the paragraph to complete. When the interpreter fails to start, the paragraph's status remains in a READY state instead of transitioning to ERROR. This causes waitUntilFinished() to wait indefinitely, as isTerminated() never returns true.

The fix is to modify the test logic to immediately check the paragraph's status after p1.waitUntilFinished(). By moving the assertEquals(Job.Status.FINISHED, p1.getStatus()) assertion to immediately after the wait call, the test will fail instantly if the paragraph's status is not FINISHED (e.g., ERROR). This prevents the test from proceeding to p2.waitUntilFinished() and avoids the infinite loop.

<img width="1267" height="606" alt="image" src="https://github.com/user-attachments/assets/6ea4c5bf-1677-4461-91fc-23345873482c" />

<img width="1572" height="366" alt="image" src="https://github.com/user-attachments/assets/77c3aa03-032d-4743-85f0-fbeefc878f99" />


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
*[ZEPPELIN-6238] 

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
<img width="1566" height="405" alt="image" src="https://github.com/user-attachments/assets/d17eabf8-28fa-4a9f-83dc-9b919533f968" />


### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
