### PR TITLE
[ZEPPELIN-6269] Handle remove failures in NotebookRepoSync to prevent data inconsistency

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/repo/NotebookRepoSync.java
@@ -206,19 +206,13 @@ public class NotebookRepoSync implements NotebookRepoWithVersionControl {
 
   @Override
   public void remove(String noteId, String notePath, AuthenticationInfo subject) throws IOException {
-    List<NotebookRepo> failedRepos = new ArrayList<>();
-
     for (NotebookRepo repo : repos) {
       try {
         repo.remove(noteId, notePath, subject);
       } catch (IOException e) {
-        failedRepos.add(repo);
         LOGGER.error("Failed to remove note {} from repo {}", noteId, repo.getClass().getName(), e);
+        throw new IOException("Failed to remove note from repository: " + repo.getClass().getName(), e);
       }
-    }
-
-    if (!failedRepos.isEmpty()) {
-      throw new IOException("Failed to remove note from one or more repositories: " + failedRepos);
     }
   }
 

--- a/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
+++ b/zeppelin-zengine/src/test/java/org/apache/zeppelin/notebook/repo/NotebookRepoSyncTest.java
@@ -471,8 +471,9 @@ class NotebookRepoSyncTest {
 
     Mockito.verify(mockPrimaryRepo, Mockito.times(1)).remove(noteId, notePath, anonymous);
     Mockito.verify(mockSecondaryRepo, Mockito.times(1)).remove(noteId, notePath, anonymous);
+
     Assertions.assertTrue(
-            thrownException.getMessage().contains("Failed to remove note from one or more repositories"));
+            thrownException.getMessage().contains("Failed to remove note from repository: "));
 
     notebook.close();
   }


### PR DESCRIPTION
### What is this PR for?

If an `IOException` occurs while trying to remove a note from one of the repositories, the `for` loop would terminate immediately. This leaves the note in an inconsistent state where it is deleted from some repositories but not from others, leading to data inconsistency.

**Approach**

1.  The method will now attempt to remove the note from all configured repositories, even if an error occurs with one of them.
2.  Any repository that fails to remove the note is added to a `failedRepos` list.
3.  After iterating through all repositories, the method checks the `failedRepos` list. If the list is not empty, it throws a single `IOException` that includes information about all the repositories where the removal failed.

### What type of PR is it?
Refactoring

### Todos
* [x] - Refactor remove method
* [x] - Add test for modified method

### What is the Jira issue?
* [[ZEPPELIN-6269]](https://issues.apache.org/jira/browse/ZEPPELIN-6269)

### How should this be tested?
* Added simple integration test in `NotebookRepoSyncTest`.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
