### PR TITLE
[ZEPPELIN-6270] Rename "Import As" to "Note Name" for creating a new note in the new UI

### DIFF
--- a/zeppelin-web-angular/src/app/share/note-create/note-create.component.html
+++ b/zeppelin-web-angular/src/app/share/note-create/note-create.component.html
@@ -14,7 +14,7 @@
   <nz-form-item>
     <nz-form-label>
       <ng-container *ngIf="cloneNote;else importTpl">Clone Note</ng-container>
-      <ng-template #importTpl>Import As</ng-template>
+      <ng-template #importTpl>Note Name</ng-template>
     </nz-form-label>
     <nz-form-control>
       <input nz-input [(ngModel)]="noteName" autofocus placeholder="Insert Note Name" name="noteName"/>


### PR DESCRIPTION
### What is this PR for?
This PR updates the label "Import As" to "Note Name" in the new note creation UI.  
The goal is to improve clarity and user experience by using a more intuitive label.  


### What type of PR is it?
Improvement


### Todos
* [x] UI label update: changed "Import As" to "Note Name" in the new note creation form


### What is the Jira issue?
[ZEPPELIN-6270](https://issues.apache.org/jira/browse/ZEPPELIN-6270)


### How should this be tested?
* No functional code changes


### Screenshots (if appropriate)
* AS-IS (Classic UI)
<img width="629" height="395" alt="Screenshot 2025-08-08 at 5 24 34 pm" src="https://github.com/user-attachments/assets/10170716-5852-49df-943d-3b5c21ba21d1" />

* AS-IS (New UI)
<img width="828" height="411" alt="Screenshot 2025-08-08 at 5 24 16 pm" src="https://github.com/user-attachments/assets/acb28c37-0570-4200-98ba-8975546e03e9" />

* TO-BE (New UI)
<img width="834" height="427" alt="Screenshot 2025-08-08 at 6 02 23 pm" src="https://github.com/user-attachments/assets/64652567-9c4d-4a1a-a06f-738329f1c543" />


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
