### PR TITLE
[ZEPPELIN-6270] Rename "Import As" to "Note Name" for creating a new note in the new UI

### DIFF
--- a/zeppelin-web-angular/src/app/share/note-create/note-create.component.html
+++ b/zeppelin-web-angular/src/app/share/note-create/note-create.component.html
@@ -14,7 +14,7 @@
   <nz-form-item>
     <nz-form-label>
       <ng-container *ngIf="cloneNote;else importTpl">Clone Note</ng-container>
-      <ng-template #importTpl>Import As</ng-template>
+      <ng-template #importTpl>Note Name</ng-template>
     </nz-form-label>
     <nz-form-control>
       <input nz-input [(ngModel)]="noteName" autofocus placeholder="Insert Note Name" name="noteName"/>


### PR DESCRIPTION
### What is this PR for?
This PR updates the label "Import As" to "Note Name" in the new note creation UI.  
The goal is to improve clarity and user experience by using a more intuitive label.  


### What type of PR is it?
Improvement


### Todos
* [x] UI label update: changed "Import As" to "Note Name" in the new note creation form


### What is the Jira issue?
[ZEPPELIN-6270](https://issues.apache.org/jira/browse/ZEPPELIN-6270)


### How should this be tested?
* No functional code changes


### Screenshots (if appropriate)
* AS-IS (Classic UI)
<img width="629" height="395" alt="Screenshot 2025-08-08 at 5 24 34 pm" src="https://github.com/user-attachments/assets/af4c6af2-fd40-4db0-affa-1202a532370a" />

* AS-IS (New UI)
<img width="828" height="411" alt="Screenshot 2025-08-08 at 5 24 16 pm" src="https://github.com/user-attachments/assets/64c4cb91-1d1a-41c0-bb18-cf6949e0877a" />

* TO-BE (New UI)
<img width="834" height="427" alt="Screenshot 2025-08-08 at 6 02 23 pm" src="https://github.com/user-attachments/assets/d8610585-9d8d-4934-a08a-d5c37180f28f" />


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No