### PR TITLE
[ZEPPELIN-6272] Fix run-e2e-tests-in-zeppelin-web CI job by resolving Angular sync errors and improving step readability

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -32,16 +32,16 @@ jobs:
   run-e2e-tests-in-zeppelin-web:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
+      - name: Checkout source code
         uses: actions/checkout@v4
-      - name: Tune Runner VM
+      - name: Optimize runner VM performance
         uses: ./.github/actions/tune-runner-vm
-      - name: Set up JDK 11
+      - name: Set up Java 11 (Temurin)
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11
-      - name: Cache local Maven repository
+      - name: Cache Maven and build artifacts
         uses: actions/cache@v4
         with:
           path: |
@@ -52,13 +52,20 @@ jobs:
           key: ${{ runner.os }}-zeppelin-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-zeppelin-
-      - name: Install application
-        run: ./mvnw clean install -DskipTests -am -pl zeppelin-web -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist ${MAVEN_ARGS}
-      - name: Run headless test
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" ./mvnw verify -pl zeppelin-web -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist -Pweb-e2e ${MAVEN_ARGS}
-      - name: Print zeppelin logs
+      - name: Build and install Zeppelin (server + web)
+        run: |
+          ./mvnw -B clean install -DskipTests \
+            -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist ${MAVEN_ARGS}
+      - name: Run headless E2E tests for zeppelin-web
+        run: |
+          xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+            ./mvnw -B verify \
+            -pl zeppelin-web \
+            -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist -Pweb-e2e ${MAVEN_ARGS}
+      - name: Print Zeppelin logs on failure
         if: always()
-        run: if [ -d "logs" ]; then cat logs/*; fi
+        run: |
+          if [ -d "logs" ]; then ls -al logs; cat logs/*; fi
 
   run-tests-in-zeppelin-web-angular:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### What is this PR for?
This PR fixes the run-e2e-tests-in-zeppelin-web CI job, which previously failed due to repeated Angular synchronization errors in Protractor tests.

Key changes include:
- Adjusting the Maven build and test commands to ensure correct profile activation.
- Improving the job’s step names for better readability in CI logs.
- Ensuring that the headless E2E tests run reliably in the GitHub Actions environment.

As a result, persistent errors like:
both angularJS testability and angular testability are undefined no longer occur, and all E2E tests pass successfully.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Update Maven commands to ensure correct profile activation in CI
* [x] - Improve CI step names for better readability in logs
* [x] - Fix Protractor Angular sync errors in E2E tests

### What is the Jira issue?
* Jira: https://issues.apache.org/jira/browse/ZEPPELIN-6272

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
* Does the license files need to update? No.
* Is there breaking changes for older versions? No.
* Does this needs documentation? No.
