### PR TITLE
[ZEPPELIN-6216] Show clear message when job manager is disabled instead of infinite loading

### DIFF
--- a/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
+++ b/zeppelin-common/src/main/java/org/apache/zeppelin/common/Message.java
@@ -176,6 +176,7 @@ public class Message implements JsonSerializable {
     LIST_NOTE_JOBS,               // [c-s] get note job management information
     LIST_UPDATE_NOTE_JOBS,        // [c-s] get job management information for until unixtime
     UNSUBSCRIBE_UPDATE_NOTE_JOBS, // [c-s] unsubscribe job information for job management
+    JOB_MANAGER_DISABLED,         // [s-c] send when job manager is disabled
     // @param unixTime
     GET_INTERPRETER_BINDINGS,    // [c-s] get interpreter bindings
     SAVE_INTERPRETER_BINDINGS,    // [c-s] save interpreter bindings

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/rest/NotebookRestApi.java
@@ -59,6 +59,7 @@ import org.apache.zeppelin.service.AuthenticationService;
 import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
+import org.apache.zeppelin.service.exception.JobManagerForbiddenException;
 import org.apache.zeppelin.socket.NotebookServer;
 import org.apache.zeppelin.user.AuthenticationInfo;
 import org.quartz.CronExpression;
@@ -218,6 +219,14 @@ public class NotebookRestApi extends AbstractRestApi {
   private void checkIfParagraphIsNotNull(Paragraph paragraph, String paragraphId) {
     if (paragraph == null) {
       throw new ParagraphNotFoundException(paragraphId);
+    }
+  }
+
+  private void checkIfJobManagerIsEnabled() {
+    try {
+      jobManagerService.checkIfJobManagerIsEnabled();
+    } catch (JobManagerForbiddenException e) {
+      throw new ForbiddenException(e.getMessage());
     }
   }
 
@@ -1147,6 +1156,7 @@ public class NotebookRestApi extends AbstractRestApi {
   @ZeppelinApi
   public Response getJobListforNote() throws IOException, IllegalArgumentException {
     LOGGER.info("Get note jobs for job manager");
+    checkIfJobManagerIsEnabled();
     List<JobManagerService.NoteJobInfo> noteJobs = jobManagerService
             .getNoteJobInfoByUnixTime(0, getServiceContext(), new RestServiceCallback<>());
     Map<String, Object> response = new HashMap<>();
@@ -1170,6 +1180,7 @@ public class NotebookRestApi extends AbstractRestApi {
   public Response getUpdatedJobListforNote(@PathParam("lastUpdateUnixtime") long lastUpdateUnixTime)
       throws IOException, IllegalArgumentException {
     LOGGER.info("Get updated note jobs lastUpdateTime {}", lastUpdateUnixTime);
+    checkIfJobManagerIsEnabled();
     List<JobManagerService.NoteJobInfo> noteJobs =
             jobManagerService.getNoteJobInfoByUnixTime(lastUpdateUnixTime, getServiceContext(),
                     new RestServiceCallback<>());

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/exception/JobManagerForbiddenException.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/exception/JobManagerForbiddenException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.service.exception;
+
+/**
+ * Runtime exception thrown when the job manager is disabled.
+ */
+public class JobManagerForbiddenException extends Exception {
+
+  private static final long serialVersionUID = -8872599278254399427L;
+  public static final String MESSAGE = "Job Manager is disabled in the current configuration.";
+
+  public JobManagerForbiddenException() {
+    super(MESSAGE);
+  }
+
+  public JobManagerForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -90,6 +90,7 @@ import org.apache.zeppelin.service.JobManagerService;
 import org.apache.zeppelin.service.NotebookService;
 import org.apache.zeppelin.service.ServiceContext;
 import org.apache.zeppelin.service.SimpleServiceCallback;
+import org.apache.zeppelin.service.exception.JobManagerForbiddenException;
 import org.apache.zeppelin.ticket.TicketContainer;
 import org.apache.zeppelin.types.InterpreterSettingsList;
 import org.apache.zeppelin.user.AuthenticationInfo;
@@ -562,7 +563,13 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
           @Override
           public void onFailure(Exception ex, ServiceContext context) throws IOException {
-            LOGGER.warn(ex.getMessage());
+            if (ex instanceof JobManagerForbiddenException) {
+              LOGGER.info("Job Manager is disabled. Rejecting request from user: {}",
+                  context.getAutheInfo().getUser());
+              conn.send(serializeMessage(new Message(OP.JOB_MANAGER_DISABLED).put("errorMessage", ex.getMessage())));
+            } else {
+              LOGGER.warn(ex.getMessage());
+            }
           }
         });
   }
@@ -584,7 +591,11 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
           @Override
           public void onFailure(Exception ex, ServiceContext context) throws IOException {
-            LOGGER.warn(ex.getMessage());
+            if (ex instanceof JobManagerForbiddenException) {
+              LOGGER.debug(ex.getMessage());
+            } else {
+              LOGGER.warn(ex.getMessage());
+            }
           }
         });
   }
@@ -1931,6 +1942,11 @@ public class NotebookServer implements AngularObjectRegistryListener,
       response.put("jobs", notesJobInfo);
       connectionManager.broadcast(JobManagerServiceType.JOB_MANAGER_PAGE.getKey(),
           new Message(OP.LIST_UPDATE_NOTE_JOBS).put("noteRunningJobs", response));
+    }
+
+    @Override
+    public void onFailure(Exception ex, ServiceContext context) {
+      LOGGER.debug(ex.getMessage());
     }
   }
 

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/service/JobManagerServiceTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/service/JobManagerServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.zeppelin.conf.ZeppelinConfiguration;
+import org.apache.zeppelin.notebook.AuthorizationService;
+import org.apache.zeppelin.notebook.Notebook;
+import org.apache.zeppelin.service.exception.JobManagerForbiddenException;
+import org.apache.zeppelin.user.AuthenticationInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JobManagerServiceTest {
+
+  private ZeppelinConfiguration zConf;
+  private Notebook mockNotebook;
+  private AuthorizationService mockAuthorizationService;
+  private JobManagerService jobManagerService;
+  private ServiceContext serviceContext;
+
+  @BeforeEach
+  public void setUp() {
+    zConf = mock(ZeppelinConfiguration.class);
+    mockNotebook = mock(Notebook.class);
+    mockAuthorizationService = mock(AuthorizationService.class);
+    jobManagerService = new JobManagerService(mockNotebook, mockAuthorizationService, zConf);
+    serviceContext = new ServiceContext(new AuthenticationInfo("test-user"), null);
+  }
+
+  @Test
+  void shouldThrowForbiddenException_whenJobManagerIsDisabled() {
+    when(zConf.isJobManagerEnabled()).thenReturn(false);
+
+    assertThrows(JobManagerForbiddenException.class, () -> {
+      jobManagerService.getNoteJobInfo("some_note_id", serviceContext, new SimpleServiceCallback<>());
+    });
+
+    assertThrows(JobManagerForbiddenException.class, () -> {
+      jobManagerService.getNoteJobInfoByUnixTime(0, serviceContext, new SimpleServiceCallback<>());
+    });
+
+    assertThrows(JobManagerForbiddenException.class, () -> {
+      jobManagerService.removeNoteJobInfo("some_note_id", serviceContext, new SimpleServiceCallback<>());
+    });
+  }
+
+}

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-data-type-map.interface.ts
@@ -75,7 +75,7 @@ import {
   RunParagraph
 } from './message-paragraph.interface';
 
-import { ListNoteJobs, ListUpdateNoteJobs } from './message-job.interface';
+import { ListNoteJobs, ListUpdateNoteJobs, JobManagerDisabled } from './message-job.interface';
 
 import { InterpreterBindings, InterpreterSetting } from './message-interpreter.interface';
 import { OP } from './message-operator.interface';
@@ -91,6 +91,7 @@ export interface MessageReceiveDataTypeMap {
   [OP.ERROR_INFO]: ErrorInfo;
   [OP.LIST_NOTE_JOBS]: ListNoteJobs;
   [OP.LIST_UPDATE_NOTE_JOBS]: ListUpdateNoteJobs;
+  [OP.JOB_MANAGER_DISABLED]: JobManagerDisabled;
   [OP.INTERPRETER_SETTINGS]: InterpreterSetting;
   [OP.LIST_REVISION_HISTORY]: ListRevision;
   [OP.INTERPRETER_BINDINGS]: InterpreterBindings;

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-job.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-job.interface.ts
@@ -18,6 +18,10 @@ export interface ListUpdateNoteJobs {
   noteRunningJobs: NoteJobs;
 }
 
+export interface JobManagerDisabled {
+  errorMessage: string;
+}
+
 export interface NoteJobs {
   lastResponseUnixTime: number;
   jobs: JobsItem[];

--- a/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
+++ b/zeppelin-web-angular/projects/zeppelin-sdk/src/interfaces/message-operator.interface.ts
@@ -361,6 +361,12 @@ export enum OP {
   UNSUBSCRIBE_UPDATE_NOTE_JOBS = 'UNSUBSCRIBE_UPDATE_NOTE_JOBS',
 
   /**
+   * [s-c]
+   * send when job manager is disabled
+   */
+  JOB_MANAGER_DISABLED = 'JOB_MANAGER_DISABLED',
+
+  /**
    * [c-s]
    * get interpreter bindings
    */

--- a/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.component.html
@@ -60,19 +60,25 @@
   </form>
 </zeppelin-page-header>
 <div class="content">
-  <nz-card *ngIf="loading; else jobs">
-    <nz-skeleton [nzTitle]="false" [nzLoading]="true" [nzActive]="true">
-    </nz-skeleton>
-  </nz-card>
+  <ng-container *ngIf="isJobManagerEnabled; else disabledMessage">
+    <nz-card *ngIf="loading; else jobs">
+      <nz-skeleton [nzTitle]="false" [nzLoading]="true" [nzActive]="true">
+      </nz-skeleton>
+    </nz-card>
 
-  <ng-template #jobs>
-    <zeppelin-job-manager-job
-      *ngFor="let item of filteredJobs"
-      [note]="item"
-      [highlight]="filterString"
-      (start)="onStart($event)"
-      (stop)="onStop($event)">
-    </zeppelin-job-manager-job>
-    <nz-empty *ngIf="filteredJobs.length === 0" nzNotFoundContent="No Job found"></nz-empty>
+    <ng-template #jobs>
+      <zeppelin-job-manager-job
+        *ngFor="let item of filteredJobs"
+        [note]="item"
+        [highlight]="filterString"
+        (start)="onStart($event)"
+        (stop)="onStop($event)">
+      </zeppelin-job-manager-job>
+      <nz-empty *ngIf="filteredJobs.length === 0" nzNotFoundContent="No Job found"></nz-empty>
+    </ng-template>
+  </ng-container>
+
+  <ng-template #disabledMessage>
+    <nz-alert nzType="info" nzMessage="Job Manager is disabled in the current configuration." [nzShowIcon]="true"></nz-alert>
   </ng-template>
 </div>

--- a/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.component.ts
@@ -16,7 +16,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { NzModalService } from 'ng-zorro-antd/modal';
 
 import { MessageListener, MessageListenersManager } from '@zeppelin/core';
-import { JobsItem, JobStatus, ListNoteJobs, ListUpdateNoteJobs, OP } from '@zeppelin/sdk';
+import { JobsItem, JobManagerDisabled, JobStatus, ListNoteJobs, ListUpdateNoteJobs, OP } from '@zeppelin/sdk';
 import { JobManagerService, MessageService } from '@zeppelin/services';
 
 enum JobDateSortKeys {
@@ -45,6 +45,7 @@ export class JobManagerComponent extends MessageListenersManager implements OnIn
   filterString: string = '';
   jobs: JobsItem[] = [];
   loading = true;
+  isJobManagerEnabled = true;
 
   @MessageListener(OP.LIST_NOTE_JOBS)
   setJobs(data: ListNoteJobs) {
@@ -70,6 +71,13 @@ export class JobManagerComponent extends MessageListenersManager implements OnIn
       }
     });
     this.filterJobs();
+  }
+
+  @MessageListener(OP.JOB_MANAGER_DISABLED)
+  onJobManagerDisabled(data: JobManagerDisabled) {
+    this.loading = false;
+    this.isJobManagerEnabled = false;
+    this.cdr.markForCheck();
   }
 
   filterJobs() {

--- a/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.module.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/job-manager/job-manager.module.ts
@@ -16,6 +16,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { IconDefinition } from '@ant-design/icons-angular';
 import { ClockCircleOutline, FileOutline, FileUnknownOutline, SearchOutline } from '@ant-design/icons-angular/icons';
+import { NzAlertModule } from 'ng-zorro-antd/alert';
 import { NzBadgeModule } from 'ng-zorro-antd/badge';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzHighlightModule } from 'ng-zorro-antd/core/highlight';
@@ -63,7 +64,8 @@ const icons: IconDefinition[] = [SearchOutline, FileOutline, FileUnknownOutline,
     NzToolTipModule,
     NzProgressModule,
     NzSkeletonModule,
-    NzEmptyModule
+    NzEmptyModule,
+    NzAlertModule
   ],
   providers: [{ provide: NZ_ICONS, useValue: icons }]
 })

--- a/zeppelin-web/src/app/jobmanager/jobmanager.component.js
+++ b/zeppelin-web/src/app/jobmanager/jobmanager.component.js
@@ -28,7 +28,7 @@ const JobDateSorter = {
   OLDEST_UPDATED: 'Oldest Updated',
 };
 
-function JobManagerController($scope, ngToast, JobManagerFilter, JobManagerService) {
+function JobManagerController($rootScope, $scope, ngToast, JobManagerFilter, JobManagerService) {
   'ngInject';
 
   $scope.isFilterLoaded = false;
@@ -52,6 +52,8 @@ function JobManagerController($scope, ngToast, JobManagerFilter, JobManagerServi
     itemsPerPage: 10,
     maxPageCount: 5,
   };
+
+  $scope.jobManagerEnabled = true;
 
   ngToast.dismiss();
   init();
@@ -135,8 +137,14 @@ function JobManagerController($scope, ngToast, JobManagerFilter, JobManagerServi
     JobManagerService.subscribeSetJobs($scope, setJobsCallback);
     JobManagerService.subscribeUpdateJobs($scope, updateJobsCallback);
 
+    const jobManagerDisabledListener = $rootScope.$on('jobManagerDisabled', function(event, data) {
+      $scope.isFilterLoaded = true;
+      $scope.jobManagerEnabled = false;
+    });
+
     $scope.$on('$destroy', function() {
       JobManagerService.disconnect();
+      jobManagerDisabledListener();
     });
   }
 

--- a/zeppelin-web/src/app/jobmanager/jobmanager.html
+++ b/zeppelin-web/src/app/jobmanager/jobmanager.html
@@ -116,28 +116,38 @@ limitations under the License.
       Loading...
     </div>
   </div>
-  <div ng-if="filteredJobs.length > 0"
-       ng-repeat="note in getJobsInCurrentPage(filteredJobs)"
-       class="paragraph-col">
-    <div class="job-space box job-margin">
-      <job note="note"></job>
+
+  <div ng-if="isFilterLoaded">
+    <div ng-if="!jobManagerEnabled" class="paragraph-col">
+      <div class="job-space box job-margin">
+        <i class="fa fa-warning"></i> Job Manager is disabled in the current configuration.
+      </div>
     </div>
   </div>
-  <div ng-if="isFilterLoaded === false && filteredJobs.length <= 0"
-       class="paragraph-col">
-    <div class="job-space box job-margin text-center">No Job found</div>
-  </div>
 
-  <!-- pagination -->
-  <div class="job-pagination-container">
-    <ul uib-pagination class="pagination-sm"
-        total-items="filteredJobs.length"
-        ng-model="pagination.currentPage"
-        items-per-page="pagination.itemsPerPage"
-        boundary-links="true" rotate="false"
-        max-size="pagination.maxPageCount"
-        previous-text="&lsaquo;" next-text="&rsaquo;"
-        first-text="&laquo;" last-text="&raquo;"></ul>
-  </div>
+  <div ng-if="jobManagerEnabled">
+    <div ng-if="filteredJobs.length > 0"
+         ng-repeat="note in getJobsInCurrentPage(filteredJobs)"
+         class="paragraph-col">
+      <div class="job-space box job-margin">
+        <job note="note"></job>
+      </div>
+    </div>
+    <div ng-if="isFilterLoaded === false && filteredJobs.length <= 0"
+         class="paragraph-col">
+      <div class="job-space box job-margin text-center">No Job found</div>
+    </div>
 
+    <!-- pagination -->
+    <div class="job-pagination-container">
+      <ul uib-pagination class="pagination-sm"
+          total-items="filteredJobs.length"
+          ng-model="pagination.currentPage"
+          items-per-page="pagination.itemsPerPage"
+          boundary-links="true" rotate="false"
+          max-size="pagination.maxPageCount"
+          previous-text="&lsaquo;" next-text="&rsaquo;"
+          first-text="&laquo;" last-text="&raquo;"></ul>
+    </div>
+  </div>
 </div>

--- a/zeppelin-web/src/components/websocket/websocket-event.factory.js
+++ b/zeppelin-web/src/components/websocket/websocket-event.factory.js
@@ -80,6 +80,8 @@ function WebsocketEventFactory($rootScope, $websocket, $location, baseUrlSrv, sa
       $rootScope.$emit('jobmanager:set-jobs', data.noteJobs);
     } else if (op === 'LIST_UPDATE_NOTE_JOBS') {
       $rootScope.$emit('jobmanager:update-jobs', data.noteRunningJobs);
+    } else if (op === 'JOB_MANAGER_DISABLED') {
+      $rootScope.$broadcast('jobManagerDisabled', data.errorMessage);
     } else if (op === 'AUTH_INFO') {
       let btn = [];
       if ($rootScope.ticket.roles === '[]') {


### PR DESCRIPTION
### What is this PR for?
This PR fixes the issue that occurs when `zeppelin.jobmanager.enable` is set to `false`. In this case, the server sends no response, causing the Job Manager page in both classic and new UIs to show an infinite loading indicator. This behavior confuses users and gives the impression that the page is broken.

To improve user experience, this PR introduces explicit server-side handling that returns an explicit "not allowed" response when the Job Manager is disabled via configuration. Additionally, both classic and new UIs have been updated to properly handle this response and display a user-friendly message: **"Job Manager is disabled in the current configuration."**

This change ensures users are informed about the disabled state instead of encountering an endless loading screen.


### What type of PR is it?
Improvement


### Todos
* [x] Implement server-side forbidden response when Job Manager is disabled
* [x] Add `JOB_MANAGER_DISABLED` WebSocket message and corresponding handling in both Classic and New UI
* [x] Add unit and integration tests covering the new behavior

**Note:** 
* Although REST API tests have been implemented, the current frontend (both Classic and New UI) interacts with the Job Manager primarily through WebSocket communication. Therefore, the functional verification and actual handling of the "Job Manager disabled" scenario have been focused on the WebSocket path. The REST API tests are prepared to ensure future compatibility if the REST endpoints are used.
* In the user-request handling method, a ForbiddenException triggers sending a clear error message to the client so the UI can inform the user that the Job Manager is disabled. However, during broadcast events where no direct client request is involved, the exception is logged at debug level and silently skipped to avoid unnecessary noise or client interruptions.


### What is the Jira issue?
[[ZEPPELIN-6216]](https://issues.apache.org/jira/browse/ZEPPELIN-6216)


### How should this be tested?
* Automated tests have been added to cover the new behavior when the Job Manager is disabled:
  * Unit tests in `JobManagerServiceTest` verify that forbidden exceptions are thrown.
  * REST API tests in `NotebookRestApiTest` check that HTTP 403 responses with appropriate messages are returned.
  * WebSocket and server event handling tests in `NotebookServerTest` ensure no unexpected exceptions occur and proper notification messages are sent.
* Manual testing steps:
  1. Set `zeppelin.jobmanager.enable` to `false` via `ZeppelinConfiguration`.
  2. Access the Job Manager page in both classic and new UI.
  3. Confirm that instead of infinite loading, a clear message stating **"Job Manager is disabled in the current configuration."** is displayed.


### Screenshots (if appropriate)
* AS-IS (New UI)
<img width="862" height="362" alt="AS-IS NEW UI" src="https://github.com/user-attachments/assets/e2a1288f-5952-4ea0-a31b-a267f49f171e" />

* AS-IS (Classic UI)
<img width="864" height="424" alt="AS-IS CLASSIC UI" src="https://github.com/user-attachments/assets/bc111aff-e95c-4427-a266-af7f9f600407" />

* TO-BE (New UI)
<img width="870" height="305" alt="TO-BE NEW UI" src="https://github.com/user-attachments/assets/0555e5dc-2ee8-4000-b1eb-c7d2259e96b1" />

* TO-BE (Classic UI)
<img width="875" height="275" alt="TO-BE CLASSIC UI" src="https://github.com/user-attachments/assets/e0a87e98-fde8-467b-9df3-d9ada39deb36" />


### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
