### PR TITLE
[ZEPPELIN-6181] Login form does not pass plus sign into authenticator

### DIFF
--- a/zeppelin-web-angular/src/app/services/ticket.service.ts
+++ b/zeppelin-web-angular/src/app/services/ticket.service.ts
@@ -87,18 +87,25 @@ export class TicketService {
   }
 
   login(userName: string, password: string) {
-    const payload = new HttpParams().set('userName', userName).set('password', password);
-    return this.httpClient.post<ITicket>(`${this.baseUrlService.getRestApiBase()}/login`, payload).pipe(
-      tap(
-        data => {
-          this.nzMessageService.success('Login Success');
-          this.setTicket(data);
-        },
-        () => {
-          this.nzMessageService.warning("The username and password that you entered don't match.");
+    const payload = `userName=${encodeURIComponent(userName)}&password=${encodeURIComponent(password)}`;
+
+    return this.httpClient
+      .post<ITicket>(`${this.baseUrlService.getRestApiBase()}/login`, payload, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
         }
-      )
-    );
+      })
+      .pipe(
+        tap(
+          data => {
+            this.nzMessageService.success('Login Success');
+            this.setTicket(data);
+          },
+          () => {
+            this.nzMessageService.warning("The username and password that you entered don't match.");
+          }
+        )
+      );
   }
 
   getZeppelinVersion() {

--- a/zeppelin-web-angular/src/app/services/ticket.service.ts
+++ b/zeppelin-web-angular/src/app/services/ticket.service.ts
@@ -10,7 +10,7 @@
  * limitations under the License.
  */
 
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { forkJoin, BehaviorSubject, Subject } from 'rxjs';
@@ -86,6 +86,12 @@ export class TicketService {
     );
   }
 
+  // Note: We intentionally avoid using HttpParams here due to Angular issue #11058.
+  // See: https://github.com/angular/angular/issues/11058
+  // HttpParameterCodec incorrectly encodes special characters like '+' and '=',
+  // which can cause issues in application/x-www-form-urlencoded requests
+  // (e.g., '+' becomes space in PHP/Tomcat). Therefore, we manually build
+  // the payload using encodeURIComponent for each field.
   login(userName: string, password: string) {
     const payload = `userName=${encodeURIComponent(userName)}&password=${encodeURIComponent(password)}`;
 


### PR DESCRIPTION
### What is this PR for?

This PR fixes an authentication bug where plus signs (+) in usernames or passwords were being incorrectly converted to spaces during login form submission. The issue affected both LDAP authenticator and local users in shiro.ini (IniRealm), causing authentication failures for any credentials containing URL-unsafe characters.

### What type of PR is it?

Bug Fix

### Todos

* [x] - Apply encodeURIComponent() to userName and password fields
* [x] - Test with credentials containing plus signs and other special characters

### What is the Jira issue?

* [ZEPPELIN-6181](https://issues.apache.org/jira/browse/ZEPPELIN-6181) : Login form does not pass plus sign into authenticator

### How should this be tested?

**Manual Testing:**
1. Create a test user with username containing plus sign (e.g., `user+test`)
2. Create a test user with password containing plus sign (e.g., `pass+word`)
3. Attempt to login through the web interface
4. Verify authentication succeeds for both cases

### Screenshots (if appropriate)

N/A

### Questions:

* Does the license files need to update? **No**
* Is there breaking changes for older versions? **No**
* Does this needs documentation? **No** - This is a bug fix that maintains existing functionality