### PR TITLE
[ZEPPELIN-6282] Add null check condition

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterSetting.java
@@ -491,6 +491,9 @@ public class InterpreterSetting {
   }
 
   ManagedInterpreterGroup getInterpreterGroup(String groupId) {
+    if (groupId == null) {
+      return null;
+    }
     return interpreterGroups.get(groupId);
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/SessionConfInterpreter.java
@@ -49,8 +49,14 @@ public class SessionConfInterpreter extends ConfInterpreter {
       finalProperties.putAll(updatedProperties);
       LOGGER.debug("Properties for Session: {}:{}", sessionId, finalProperties);
 
-      List<Interpreter> interpreters =
-          interpreterSetting.getInterpreterGroup(interpreterGroupId).get(sessionId);
+      InterpreterGroup interpreterGroup =
+            interpreterSetting.getInterpreterGroup(interpreterGroupId);
+      if (interpreterGroup == null) {
+        return new InterpreterResult(InterpreterResult.Code.ERROR,
+            "Can not find interpreter group " + interpreterGroupId);
+      }
+
+      List<Interpreter> interpreters = interpreterGroup.get(sessionId);
       for (Interpreter intp : interpreters) {
         // only check the RemoteInterpreter, ConfInterpreter itself will be ignored here.
         if (intp instanceof RemoteInterpreter) {


### PR DESCRIPTION
### What is this PR for?
This PR was created to prevent an error that occurs in the `InterpreterSetting.getInterpreterGroup` method when `groupId` is null and is retrieved from the Set.
Normally, the groupId parameter does not seem to be passed as null.
I found it when tested service shutdown(#4965).

### What type of PR is it?
Improvement

### Todos
* [x] - Add null check condition

### What is the Jira issue?
https://issues.apache.org/jira/browse/ZEPPELIN-6282

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
