### PR TITLE
[ZEPPELIN-6285] Refactor getNotesInfo to improve readability and immutability

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -758,14 +758,13 @@ public class Notebook {
         zConf.getBoolean(ConfVars.ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE);
 
     synchronized (noteManager.getNotesInfo()) {
-      List<NoteInfo> notesInfo = noteManager.getNotesInfo().entrySet().stream().filter(entry ->
+
+      return noteManager.getNotesInfo().entrySet().stream().filter(entry ->
               func.test(entry.getKey()) &&
-                  ((!hideHomeScreenNotebookFromList) || !entry.getKey().equals(homescreenNoteId)))
+                  (!hideHomeScreenNotebookFromList || !entry.getKey().equals(homescreenNoteId)))
           .map(entry -> new NoteInfo(entry.getKey(), entry.getValue()))
           .sorted(Comparator.comparing(note -> note.getPath() != null ? note.getPath() : note.getId()))
           .collect(Collectors.toUnmodifiableList());
-
-      return notesInfo;
     }
   }
 

--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/notebook/Notebook.java
@@ -19,6 +19,7 @@ package org.apache.zeppelin.notebook;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -759,22 +760,11 @@ public class Notebook {
     synchronized (noteManager.getNotesInfo()) {
       List<NoteInfo> notesInfo = noteManager.getNotesInfo().entrySet().stream().filter(entry ->
               func.test(entry.getKey()) &&
-              ((!hideHomeScreenNotebookFromList) ||
-                  ((hideHomeScreenNotebookFromList) && !entry.getKey().equals(homescreenNoteId))))
+                  ((!hideHomeScreenNotebookFromList) || !entry.getKey().equals(homescreenNoteId)))
           .map(entry -> new NoteInfo(entry.getKey(), entry.getValue()))
-          .collect(Collectors.toList());
+          .sorted(Comparator.comparing(note -> note.getPath() != null ? note.getPath() : note.getId()))
+          .collect(Collectors.toUnmodifiableList());
 
-      notesInfo.sort((note1, note2) -> {
-            String name1 = note1.getId();
-            if (note1.getPath() != null) {
-              name1 = note1.getPath();
-            }
-            String name2 = note2.getId();
-            if (note2.getPath() != null) {
-              name2 = note2.getPath();
-            }
-            return name1.compareTo(name2);
-          });
       return notesInfo;
     }
   }


### PR DESCRIPTION
### What is this PR for?
This PR refactors the getNotesInfo method in NotebookService to improve readability and enforce immutability.
The functional behavior remains unchanged, but the code is now more concise and safer for multi-threaded access.
- Use `Comparator.comparing` for cleaner sorting logic
- Return an `unmodifiable list` to emphasize immutability
- Remove redundant condition for improved readability
- Refactored getNotesInfo to use inline return, eliminating intermediate variables.

This change is internal-only and does not affect any runtime behavior or public APIs.

### What type of PR is it?
Refactoring


### Todos
* [ ] - Task

### What is the Jira issue?
* [Zeppelin-6285](https://issues.apache.org/jira/browse/ZEPPELIN-6285)

### How should this be tested?
* No functional changes; existing tests should pass as-is.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? no
* Is there breaking changes for older versions? no
* Does this needs documentation? no
