### PR TITLE
[ZEPPELIN-6288] Replace Yoda conditions in InterpreterFactory with standard null checks

### DIFF
--- a/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
+++ b/zeppelin-zengine/src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java
@@ -52,7 +52,7 @@ public class InterpreterFactory implements InterpreterFactoryInterface {
       String group = replNameSplits[0];
       String name = replNameSplits[1];
       InterpreterSetting setting = interpreterSettingManager.getByName(group);
-      if (null != setting) {
+      if (setting != null) {
         Interpreter interpreter = setting.getInterpreter(executionContext, name);
         if (null != interpreter) {
           return interpreter;
@@ -74,7 +74,7 @@ public class InterpreterFactory implements InterpreterFactoryInterface {
 
       // then assume interpreter name is omitted
       setting = interpreterSettingManager.getByName(replName);
-      if (null != setting) {
+      if (setting != null) {
         return setting.getDefaultInterpreter(executionContext);
       }
     }


### PR DESCRIPTION
### What is this PR for?

In `src/main/java/org/apache/zeppelin/interpreter/InterpreterFactory.java`

The codebase contains several instances of Yoda conditions (e.g., `if (null != setting)`) which negatively impact code readability.

Additionally, the use of Yoda condition checks causes inconsistencies with the existing codebase style. So, this improvement aligns the code with the standard null-check style.


### What type of PR is it?
Refactoring

### Todos
* [ ] - Refactor null-check style 

### What is the Jira issue?
* [ZEPPELIN-6288](https://issues.apache.org/jira/browse/ZEPPELIN-6288)

### How should this be tested?
* As this modification involves no functional changes but only coding style improvements, passing existing tests ensures there are no issues.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No
