### PR TITLE
[ZEPPELIN-6289] Add Unit tests for StaticRepl.class 

### DIFF
--- a/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
+++ b/java/src/test/java/org/apache/zeppelin/java/StaticReplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.zeppelin.java;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.thoughtworks.qdox.parser.ParseException;
+import java.lang.reflect.InvocationTargetException;
+import org.junit.jupiter.api.Test;
+
+class StaticReplTest {
+
+  @Test
+  void testExecuteWithSimplePrint() throws Exception {
+    String code = "public class SimpleClass { public static void main(String[] args) { System.out.println(\"Hello World\");} }";
+
+    String result = StaticRepl.execute("generatedClassName", code);
+
+    assertTrue(result.contains("Hello World"));
+  }
+
+  @Test
+  void testExecuteWithNoMainMethod() {
+    String code = "public class NoMain { public void hello() { System.out.println(\"Hello\");} }";
+
+    Exception exception = assertThrows(Exception.class, () ->
+        StaticRepl.execute("generatedClassName", code)
+    );
+
+    assertTrue(
+        exception.getMessage().contains("There isn't any class containing static main method."));
+  }
+
+  @Test
+  void testExecuteWithSyntaxError() {
+    String code = "public class BadCode { public static void main(String[] args) { System.out.println(\"Missing braces\");  }";
+
+    Exception exception = assertThrows(ParseException.class, () ->
+        StaticRepl.execute("generatedClassName", code)
+    );
+
+    assertTrue(exception.getMessage().contains("syntax error"));
+  }
+
+  @Test
+  public void testCompilationFailure() {
+    String badCode = "public class Bad { public static void main(String[] args) { int x = \"inCompatible\";} } ";
+
+    Exception exception = assertThrows(Exception.class,
+        () -> StaticRepl.execute("generatedClassName", badCode));
+
+    assertTrue(exception.getMessage().contains("line 1 : incompatible types"));
+  }
+
+
+  @Test
+  public void testExecutionFailure() {
+    String code = "public class FailRun { public static void main(String[] args) { throw new RuntimeException(\"fail\"); } }";
+
+    Exception exception = assertThrows(Exception.class, () -> StaticRepl.execute("generatedClassName", code));
+
+    assertTrue(exception.getCause() instanceof InvocationTargetException);
+    assertTrue(exception.getMessage().contains("Caused by: java.lang.RuntimeException: fail"));
+  }
+}


### PR DESCRIPTION
### What is this PR for?
This PR adds JUnit tests for the StaticRepl.execute method to verify correct behavior for compilation and execution of dynamically generated Java code. 

It covers scenarios such as:
- Successful execution of simple print statements
- Classes without a main method
- Code with syntax errors
- Compilation failures
- Runtime exceptions during execution

These tests improve test coverage and help prevent regressions in the StaticRepl class.


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
*  [ZEPPELIN-6289](https://issues.apache.org/jira/browse/ZEPPELIN-6289)

### How should this be tested?
* Run all new unit tests in StaticReplTest
* All tests should pass, verifying correct handling of compilation and runtime scenarios.

### Screenshots (if appropriate)
- test coverage (Class, Method, Line)
<img width="1554" height="118" alt="image" src="https://github.com/user-attachments/assets/121b4574-c418-4be7-a6e2-7a33fa9c8cf3" />

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
