### PR TITLE
[ZEPPELIN-6290] Add .env file support and update merge script documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,5 @@ tramp
 # python venv
 .venv
 
+# dotenv files
+.env

--- a/dev/merge_zeppelin_pr.py
+++ b/dev/merge_zeppelin_pr.py
@@ -21,6 +21,13 @@
 # Zeppelin.
 #   usage: ./merge_zeppelin_pr.py    (see config env vars below)
 #
+# To install Python packages from ./dev/requirements.txt using uv (run from repo root):
+#   uv pip install -r ./dev/requirements.txt
+#
+# If you plan to configure environment variables via a .env file, create the
+# .env file in the same directory as this script so it is automatically loaded.
+# Example path: ${ZEPPELIN_HOME}/dev/.env
+#
 # This utility assumes you already have a local Zeppelin git folder and that you
 # have added remotes corresponding to the git@github.com:apache/zeppelin.git
 
@@ -33,6 +40,10 @@ import traceback
 from urllib.request import urlopen
 from urllib.request import Request
 from urllib.error import HTTPError
+from dotenv import load_dotenv
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(script_dir, ".env"))
 
 try:
     import jira.client
@@ -502,7 +513,7 @@ def initialize_jira():
     jira_server = {"server": JIRA_API_BASE}
 
     if not JIRA_IMPORTED:
-        print_error("ERROR finding jira library. Run 'pip3 install jira' to install.")
+        print_error("ERROR finding jira library. Install dependencies with: 'uv pip install -r ./dev/requirements.txt'")
         continue_maybe("Continue without jira?")
     elif JIRA_ACCESS_TOKEN:
         client = jira.client.JIRA(jira_server, token_auth=JIRA_ACCESS_TOKEN)

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,13 @@
+certifi==2025.8.3
+charset-normalizer==3.4.3
+defusedxml==0.7.1
+idna==3.10
+jira==3.10.5
+oauthlib==3.3.1
+packaging==25.0
+python-dotenv==1.1.1
+requests==2.32.5
+requests-oauthlib==2.0.0
+requests-toolbelt==1.0.0
+typing-extensions==4.14.1
+urllib3==2.5.0


### PR DESCRIPTION
### What is this PR for?

Add .env file support and update merge script documentation
- Added .env file to .gitignore to prevent dotenv files from being tracked.
- Updated `merge_zeppelin_pr.py` to load environment variables from a .env file, enhancing configuration management.
- Added `/dev/requirements.txt` to pin Python package versions and use it for package installation.
- Revised error message for missing JIRA library to provide clearer installation instructions.

### What type of PR is it?
Improvement

### What is the Jira issue?
[ZEPPELIN-6290](https://issues.apache.org/jira/browse/ZEPPELIN-6290)

### How should this be tested?
* Run `uv pip install -r {REPO_ROOT}/requirements.txt`
* Environment variable configurations could be tested by adding `{REPO_ROOT}/dev/.env` file and run `merge_zeppelin_pr.py`

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
