### PR TITLE
[ZEPPELIN-6292] Fix e2e test build dependency order by including zeppelin-web-angular

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,9 +53,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zeppelin-
       - name: Install application
-        run: ./mvnw clean install -DskipTests -am -pl zeppelin-web -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist ${MAVEN_ARGS}
+        run: ./mvnw clean install -DskipTests -am -pl zeppelin-web,zeppelin-web-angular -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist ${MAVEN_ARGS}
       - name: Run headless test
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" ./mvnw verify -pl zeppelin-web,zeppelin-web-angular -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist -Pweb-e2e ${MAVEN_ARGS}
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" ./mvnw verify -pl zeppelin-web -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist -Pweb-e2e ${MAVEN_ARGS}
       - name: Print zeppelin logs
         if: always()
         run: if [ -d "logs" ]; then cat logs/*; fi


### PR DESCRIPTION
### What is this PR for?
The `run-e2e-tests-in-zeppelin-web` GitHub Actions workflow is currently failing with a `FileNotFoundException` error. 
This failure affects the build stability and prevents proper CI validation of frontend changes.

The current CI workflow has a build dependency ordering issue:
  1. Current problematic workflow step:
     ```
     ./mvnw verify -pl zeppelin-web -Pweb-classic -Pspark-scala-2.12 -Pspark-3.4 -Pweb-dist -Pweb-e2e

  2. Issue: The workflow only builds zeppelin-web module but skips zeppelin-web-angular
  3. Impact: zeppelin-web requires built artifacts from zeppelin-web-angular/dist/ directory
  4. Result: Zeppelin server startup fails because it cannot find the frontend build output

### What type of PR is it?
Bug Fix

### Todos
* [x] Add `zeppelin-web-angular` to Maven project list to ensure proper build dependency order
* [x] Resolve `FileNotFoundException` for `/zeppelin-web-angular/dist/zeppelin` directory 

### What is the Jira issue?
* [[ZEPPELIN-6292]](https://issues.apache.org/jira/browse/ZEPPELIN-6292)

### How should this be tested?
* github actions CI already including e2e tests

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? - No
* Is there breaking changes for older versions? - No
* Does this needs documentation? - No 
