### PR TITLE
[ZEPPELIN-6294] Made "Clone paragraph" button work properly in New UI

### DIFF
--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -31,6 +31,7 @@ import { NoteStatusService, ParagraphStatus } from '@zeppelin/services/note-stat
 import * as DiffMatchPatch from 'diff-match-patch';
 import { isEmpty, isEqual } from 'lodash';
 
+import { NotebookParagraphCodeEditorComponent } from '@zeppelin/pages/workspace/notebook/paragraph/code-editor/code-editor.component';
 import { NotebookParagraphResultComponent } from '@zeppelin/pages/workspace/share/result/result.component';
 import { ParagraphConfigResults, ParagraphResults } from '../../../../projects/zeppelin-sdk/src';
 import { MessageListener, MessageListenersManager } from '../message-listener/message-listener';
@@ -54,6 +55,7 @@ export abstract class ParagraphBase extends MessageListenersManager {
 
   // Initialized by `ViewChildren` in the class which extends ParagraphBase
   notebookParagraphResultComponents!: QueryList<NotebookParagraphResultComponent>;
+  notebookParagraphCodeEditorComponent!: NotebookParagraphCodeEditorComponent;
 
   constructor(
     public messageService: MessageService,
@@ -142,6 +144,8 @@ export abstract class ParagraphBase extends MessageListenersManager {
         }
         this.cdr.markForCheck();
       });
+      this.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
+      this.notebookParagraphCodeEditorComponent.getEditorSetting();
       this.cdr.markForCheck();
     }
   }

--- a/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
+++ b/zeppelin-web-angular/src/app/core/paragraph-base/paragraph-base.ts
@@ -55,7 +55,7 @@ export abstract class ParagraphBase extends MessageListenersManager {
 
   // Initialized by `ViewChildren` in the class which extends ParagraphBase
   notebookParagraphResultComponents!: QueryList<NotebookParagraphResultComponent>;
-  notebookParagraphCodeEditorComponent!: NotebookParagraphCodeEditorComponent;
+  notebookParagraphCodeEditorComponent?: NotebookParagraphCodeEditorComponent;
 
   constructor(
     public messageService: MessageService,
@@ -144,8 +144,10 @@ export abstract class ParagraphBase extends MessageListenersManager {
         }
         this.cdr.markForCheck();
       });
-      this.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
-      this.notebookParagraphCodeEditorComponent.getEditorSetting();
+      if (this.notebookParagraphCodeEditorComponent) {
+        this.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
+        this.notebookParagraphCodeEditorComponent.getEditorSetting();
+      }
       this.cdr.markForCheck();
     }
   }

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.html
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.html
@@ -89,6 +89,7 @@
             (triggerSaveParagraph)="saveParagraph($event)"
             (saveNoteTimer)="startSaveTimer()"
             (searchCode)="actionBar.searchCode()"
+            (enableTriggeredByInsertParagraph)="enableTriggeredByInsertParagraph()"
           ></zeppelin-notebook-paragraph>
         </div>
       </div>

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -163,6 +163,7 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
     }
     const definedNote = this.note;
     definedNote.paragraphs.splice(data.index, 0, data.paragraph);
+    this.cdr.detectChanges();
     const paragraphIndex = definedNote.paragraphs.findIndex(p => p.id === data.paragraph.id);
 
     definedNote.paragraphs[paragraphIndex].focus = true;

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -111,6 +111,10 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
 
   @MessageListener(OP.INTERPRETER_BINDINGS)
   loadInterpreterBindings(data: MessageReceiveDataTypeMap[OP.INTERPRETER_BINDINGS]) {
+    this.listOfNotebookParagraphComponent.forEach(item => {
+      item.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
+      item.notebookParagraphCodeEditorComponent.getEditorSetting();
+    });
     this.interpreterBindings = data.interpreterBindings;
     if (!this.interpreterBindings.some(item => item.selected)) {
       this.activatedExtension = 'interpreter';

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -163,10 +163,10 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
     }
     const definedNote = this.note;
     definedNote.paragraphs.splice(data.index, 0, data.paragraph);
-    this.cdr.detectChanges();
     const paragraphIndex = definedNote.paragraphs.findIndex(p => p.id === data.paragraph.id);
 
     definedNote.paragraphs[paragraphIndex].focus = true;
+    this.cdr.detectChanges();
     const addedParagraph = this.listOfNotebookParagraphComponent.find((_, index) => index === paragraphIndex)
       ?.notebookParagraphCodeEditorComponent;
 

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -111,9 +111,11 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
 
   @MessageListener(OP.INTERPRETER_BINDINGS)
   loadInterpreterBindings(data: MessageReceiveDataTypeMap[OP.INTERPRETER_BINDINGS]) {
-    this.listOfNotebookParagraphComponent.forEach(item => {
-      item.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
-      item.notebookParagraphCodeEditorComponent.getEditorSetting();
+    this.listOfNotebookParagraphComponent.forEach(p => {
+      if (p.notebookParagraphCodeEditorComponent) {
+        p.notebookParagraphCodeEditorComponent.editorSettingTriggerAllowed = true;
+        p.notebookParagraphCodeEditorComponent.getEditorSetting();
+      }
     });
     this.interpreterBindings = data.interpreterBindings;
     if (!this.interpreterBindings.some(item => item.selected)) {

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -95,11 +95,11 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
           }
           this.text = model.getValue();
           this.textChanged.emit(this.text);
-          this.setParagraphMode(true);
           this.autoAdjustEditorHeight();
           setTimeout(() => {
+            this.setParagraphMode(true);
             this.autoAdjustEditorHeight();
-          });
+          }, 50);
         });
       })
     );

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -96,8 +96,8 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
           this.text = model.getValue();
           this.textChanged.emit(this.text);
           this.autoAdjustEditorHeight();
+          this.setParagraphMode(true);
           setTimeout(() => {
-            this.setParagraphMode(true);
             this.autoAdjustEditorHeight();
           }, 50);
         });
@@ -308,7 +308,9 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
       const interpreterName = this.getInterpreterName(this.text);
       if (this.interpreterName !== interpreterName) {
         this.interpreterName = interpreterName;
-        this.getEditorSetting();
+        setTimeout(() => {
+          this.getEditorSetting();
+        }, 200);
       }
     }
   }

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -99,7 +99,7 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
           this.autoAdjustEditorHeight();
           setTimeout(() => {
             this.autoAdjustEditorHeight();
-          }, 50);
+          });
         });
       })
     );

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -61,6 +61,7 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
   private monacoDisposables: IDisposable[] = [];
   height = 18;
   interpreterName?: string;
+  editorSettingTriggerAllowed: boolean = false;
 
   autoAdjustEditorHeight() {
     const editor = this.editor;
@@ -308,14 +309,15 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
       const interpreterName = this.getInterpreterName(this.text);
       if (this.interpreterName !== interpreterName) {
         this.interpreterName = interpreterName;
-        setTimeout(() => {
-          this.getEditorSetting();
-        }, 200);
+        this.getEditorSetting();
       }
     }
   }
 
   getEditorSetting() {
+    if (!this.editorSettingTriggerAllowed) {
+      return;
+    }
     this.messageService.editorSetting(this.pid, this.text);
   }
 

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -61,6 +61,8 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
   private monacoDisposables: IDisposable[] = [];
   height = 18;
   interpreterName?: string;
+  // Prevents EDITOR_SETTING from triggering before the appropriate event:
+  // For CLONE_PARAGRAPH, waits for PARAGRAPH; for INSERT_PARAGRAPH, waits only for PARAGRAPH_ADDED.
   editorSettingTriggerAllowed: boolean = false;
 
   autoAdjustEditorHeight() {

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/code-editor/code-editor.component.ts
@@ -95,8 +95,8 @@ export class NotebookParagraphCodeEditorComponent implements OnChanges, OnDestro
           }
           this.text = model.getValue();
           this.textChanged.emit(this.text);
-          this.autoAdjustEditorHeight();
           this.setParagraphMode(true);
+          this.autoAdjustEditorHeight();
           setTimeout(() => {
             this.autoAdjustEditorHeight();
           }, 50);

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -290,7 +290,7 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
 
     const config = this.paragraph.config;
     config.editorHide = false;
-
+    this.blurEditor();
     this.messageService.copyParagraph(
       newIndex,
       this.paragraph.title,
@@ -356,6 +356,7 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
     if (newIndex < 0 || newIndex > this.note.paragraphs.length) {
       return;
     }
+    this.blurEditor();
     this.messageService.insertParagraph(newIndex);
     this.enableTriggeredByInsertParagraph.emit();
     this.cdr.markForCheck();

--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/paragraph/paragraph.component.ts
@@ -85,6 +85,7 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
   @Output() readonly selected = new EventEmitter<string>();
   @Output() readonly selectAtIndex = new EventEmitter<number>();
   @Output() readonly searchCode = new EventEmitter();
+  @Output() readonly enableTriggeredByInsertParagraph = new EventEmitter<number>();
 
   private destroy$ = new Subject();
   private mode: Mode = 'command';
@@ -356,6 +357,7 @@ export class NotebookParagraphComponent extends ParagraphBase implements OnInit,
       return;
     }
     this.messageService.insertParagraph(newIndex);
+    this.enableTriggeredByInsertParagraph.emit();
     this.cdr.markForCheck();
   }
 


### PR DESCRIPTION
### What is this PR for?
**Description:**
Clicking the paragraph control’s Clone paragraph button that trigger COPY_PARAGRAPH. Upon receiving PARAGRAPH_ADDED, the Classic UI includes data.paragraph.text as expected, but the New UI receives an empty data.paragraph.text. Additionally, after cloning, the cursor is not positioned in the cloned paragraph in the New UI.

**Expected:**
- Cloned paragraph contains the original text.
- Cursor focuses/positions inside the cloned paragraph.

**Actual (New UI):**
- data.paragraph.text is empty on PARAGRAPH_ADDED.
- Cursor not focused / not moved to the cloned paragraph.

**[Appropriate action - Classic UI]**

https://github.com/user-attachments/assets/dd96ceaa-b0f1-4b1e-ad11-46560a0e2b79

**[AS-IS]**

https://github.com/user-attachments/assets/39530005-b169-4301-9416-ed14cb6888fc

**[TO-BE]**

https://github.com/user-attachments/assets/81302edb-0d52-49e9-a554-e2509a7bca18


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6294](https://issues.apache.org/jira/browse/ZEPPELIN-6294)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
