### PR TITLE
[ZEPPELIN-6296] Modify New UI when entering a note, the note name is displayed in the page title

### DIFF
--- a/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
+++ b/zeppelin-web-angular/src/app/pages/workspace/notebook/notebook.component.ts
@@ -19,6 +19,7 @@ import {
   QueryList,
   ViewChildren
 } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { isNil } from 'lodash';
 import { Subject } from 'rxjs';
@@ -103,6 +104,7 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
           }
         });
       }
+      this.titleService.setTitle(this.note?.name + ' - Zeppelin');
       this.cdr.markForCheck();
     }
   }
@@ -401,7 +403,8 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
     private ticketService: TicketService,
     private securityService: SecurityService,
     private router: Router,
-    protected ngZService: NgZService
+    protected ngZService: NgZService,
+    private titleService: Title
   ) {
     super(messageService);
   }
@@ -449,5 +452,6 @@ export class NotebookComponent extends MessageListenersManager implements OnInit
     this.saveNote();
     this.destroy$.next();
     this.destroy$.complete();
+    this.titleService.setTitle('Zeppelin');
   }
 }


### PR DESCRIPTION
### What is this PR for?
**[Appropriate action - Classic UI]**

<img width="1382" height="487" alt="스크린샷 2025-08-25 오후 9 18 14" src="https://github.com/user-attachments/assets/5fc7010e-8e99-49de-a7fd-1a5db3bd4c42" />

In Classic UI, the tab title is displayed as “Zeppelin” on the main page. However, when entering a note, the title changes to the note’s name (left tab: main, right tab: note view).

**[AS-IS]**
<img width="1382" height="487" alt="스크린샷 2025-08-25 오후 9 19 04" src="https://github.com/user-attachments/assets/acbabffb-6c0a-424b-837e-713e0081672d" />

In contrast, in the New UI the page title is fixed as “Zeppelin” on all pages. It seems necessary to modify this to behave like the Classic UI.

**[TO-BE]**
<img width="1382" height="487" alt="스크린샷 2025-08-25 오후 9 41 57" src="https://github.com/user-attachments/assets/b601f346-8fcb-49b6-b9c1-cacd95aaadae" />

I fixed it to work properly by using the existing @angular/platform-browser package’s "Title".

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
* [[ZEPPELIN-6296](https://issues.apache.org/jira/browse/ZEPPELIN-6296)]

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? N
* Is there breaking changes for older versions? N
* Does this needs documentation? N
