### PR TITLE
[ZEPPELIN-6295] Add configurations that allow LDAP users map directly to role

### DIFF
--- a/docs/setup/security/shiro_authentication.md
+++ b/docs/setup/security/shiro_authentication.md
@@ -186,6 +186,13 @@ securityManager.sessionManager = $sessionManager
 securityManager.realms = $ldapRealm
 ```
 
+For certain LDAP where the mapping of ldap groups to users does not exist, we can choose RoleMappingLdapRealm, which allows for the mapping of usernames directly to roles.
+```
+ldapRealm = org.apache.zeppelin.realm.RoleMappingLdapRealm
+ldapRealm.rolesByUsername = user1:admin,user2:user,user3:user,user4:user
+ldapRealm.defaultRole = guest
+```
+
 Also instead of specifying systemPassword in clear text in `shiro.ini` administrator can choose to specify the same in "hadoop credential". 
 Create a keystore file using the hadoop credential command line:
 ``` 

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/realm/RoleMappingLdapRealm.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/realm/RoleMappingLdapRealm.java
@@ -1,0 +1,87 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.zeppelin.realm;
+
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.realm.ldap.DefaultLdapRealm;
+import org.apache.shiro.realm.ldap.LdapContextFactory;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.naming.NamingException;
+import javax.naming.ldap.LdapContext;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * RoleMappingLdapRealm is a simple LDAP realm that returns configured role for specific users.
+ * Multiple roles(quoted string, comma separated) can be specified for a user.
+ * Example configurations:
+ * ldapRealm = org.apache.zeppelin.realm.RoleMappingLdapRealm
+ * ldapRealm.rolesByUsername = "user1":"admin","user2":"role1,role2","user3":"role3"
+ * ldapRealm.defaultRole = "role1,role2"
+ */
+public class RoleMappingLdapRealm extends DefaultLdapRealm {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RoleMappingLdapRealm.class);
+
+  private static final String ROLE_NAMES_DELIMITER = ",";
+  private String defaultRole = "role1";
+
+  private final Map<String, String> rolesByUsername = new LinkedHashMap<>();
+
+
+  public String getDefaultRole() {
+    return defaultRole;
+  }
+
+  public void setDefaultRole(String defaultRole) {
+    this.defaultRole = defaultRole;
+  }
+
+  public Map<String, String> getRolesByUsername() {
+    return rolesByUsername;
+  }
+
+  public void setRolesByUsername(Map<String, String> rolesByUsername) {
+    this.rolesByUsername.putAll(rolesByUsername);
+  }
+
+  @Override
+  public AuthorizationInfo queryForAuthorizationInfo(PrincipalCollection principals,
+                                                     LdapContextFactory ldapContextFactory) throws NamingException {
+    String username = (String) getAvailablePrincipal(principals);
+    LdapContext ldapContext = ldapContextFactory.getSystemLdapContext();
+    Set<String> roleNames = getRoleNamesForUser(username, ldapContext, getUserDnTemplate());
+    return new SimpleAuthorizationInfo(roleNames);
+  }
+
+  public Set<String> getRoleNamesForUser(String username, LdapContext ldapContext,
+                                         String userDnTemplate) {
+    String roleString = rolesByUsername.getOrDefault(username, defaultRole);
+
+    Set<String> roleNames = Arrays.stream(roleString.split(ROLE_NAMES_DELIMITER))
+        .map(String::trim).collect(Collectors.toSet());
+
+    LOGGER.debug("For user {}, RoleMappingLdapRealm returns {} as the role", username, roleNames);
+    return roleNames;
+  }
+}

--- a/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/service/ShiroAuthenticationService.java
@@ -67,7 +67,6 @@ public class ShiroAuthenticationService implements AuthenticationService {
 
   private static final String INI_REALM = "org.apache.shiro.realm.text.IniRealm";
   private static final String LDAP_REALM = "org.apache.zeppelin.realm.LdapRealm";
-  private static final String LDAP_GROUP_REALM = "org.apache.zeppelin.realm.LdapGroupRealm";
   private static final String ACTIVE_DIRECTORY_GROUP_REALM = "org.apache.zeppelin.realm.ActiveDirectoryGroupRealm";
   private static final String JDBC_REALM = "org.apache.shiro.realm.jdbc.JdbcRealm";
 
@@ -175,14 +174,14 @@ public class ShiroAuthenticationService implements AuthenticationService {
           LOGGER.debug("RealmClass.getName: {}", realClassName);
           if (INI_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((IniRealm) realm));
-          } else if (LDAP_GROUP_REALM.equals(realClassName)) {
-            usersList.addAll(getUserList((DefaultLdapRealm) realm, searchText, numUsersToFetch));
           } else if (LDAP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((LdapRealm) realm, searchText, numUsersToFetch));
           } else if (ACTIVE_DIRECTORY_GROUP_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((ActiveDirectoryGroupRealm) realm, searchText, numUsersToFetch));
           } else if (JDBC_REALM.equals(realClassName)) {
             usersList.addAll(getUserList((JdbcRealm) realm, searchText, numUsersToFetch));
+          } else if (realm instanceof DefaultLdapRealm) {
+            usersList.addAll(getUserList((DefaultLdapRealm) realm, searchText, numUsersToFetch));
           }
         }
       }

--- a/zeppelin-server/src/test/java/org/apache/zeppelin/realm/RoleMappingLdapRealmTest.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/realm/RoleMappingLdapRealmTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.zeppelin.realm;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RoleMappingLdapRealmTest {
+  @Test
+  public void testGetRolesByUsername() {
+    RoleMappingLdapRealm realm = new RoleMappingLdapRealm();
+    LinkedHashMap<String, String> rolesByUsername = new LinkedHashMap<>();
+    rolesByUsername.put("admin", "admin");
+    rolesByUsername.put("user1", "user");
+    rolesByUsername.put("user2", "user");
+    realm.setRolesByUsername(rolesByUsername);
+    realm.setDefaultRole("guest");
+
+    assertTrue(realm.getRoleNamesForUser("admin", null, null).contains("admin"));
+    assertTrue(realm.getRoleNamesForUser("user1", null, null).contains("user"));
+    assertTrue(realm.getRoleNamesForUser("user2", null, null).contains("user"));
+    assertTrue(realm.getRoleNamesForUser("user3", null, null).contains("guest"));
+  }
+
+  @Test
+  public void testGetRolesByUsernameWithMultipleRoles() {
+    RoleMappingLdapRealm realm = new RoleMappingLdapRealm();
+    LinkedHashMap<String, String> rolesByUsername = new LinkedHashMap<>();
+    rolesByUsername.put("admin", "admin,role1");
+    rolesByUsername.put("user1", "role1,role2");
+    rolesByUsername.put("user2", "role2");
+    realm.setRolesByUsername(rolesByUsername);
+    realm.setDefaultRole("guest1,guest2");
+
+    assertTrue(realm.getRoleNamesForUser("admin", null, null).contains("admin"));
+    assertTrue(realm.getRoleNamesForUser("admin", null, null).contains("role1"));
+    assertTrue(realm.getRoleNamesForUser("user1", null, null).contains("role1"));
+    assertTrue(realm.getRoleNamesForUser("user1", null, null).contains("role2"));
+    assertTrue(realm.getRoleNamesForUser("user2", null, null).contains("role2"));
+    assertTrue(realm.getRoleNamesForUser("user3", null, null).contains("guest1"));
+    assertTrue(realm.getRoleNamesForUser("user3", null, null).contains("guest2"));
+  }
+}


### PR DESCRIPTION
### What is this PR for?

Add configurations that allow LDAP users map directly to the role

### What type of PR is it?

Improvement


### Todos
N/A

### What is the Jira issue?
[ZEPPELIN-6295](https://issues.apache.org/jira/browse/ZEPPELIN-6295)

### How should this be tested?

Added unit tests & compiled and tested manually.

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes. And the doc has been updated.
