### PR TITLE
[ZEPPELIN-6299] Refactor StaticRepl for readability, correctness, and modern Java usage

### DIFF
--- a/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
+++ b/java/src/main/java/org/apache/zeppelin/java/StaticRepl.java
@@ -39,7 +39,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -85,8 +84,8 @@ public class StaticRepl {
     // replace name of class containing Main method with generated name
     code = code.replace(mainClassName, generatedClassName);
 
-    JavaFileObject file = new JavaSourceFromString(generatedClassName, code.toString());
-    Iterable<? extends JavaFileObject> compilationUnits = Arrays.asList(file);
+    JavaFileObject file = new JavaSourceFromString(generatedClassName, code);
+    Iterable<? extends JavaFileObject> compilationUnits = List.of(file);
 
     ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
     ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
@@ -101,6 +100,8 @@ public class StaticRepl {
     System.setOut(newOut);
     System.setErr(newErr);
 
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     CompilationTask task = compiler.getTask(null, null, diagnostics, null, null, compilationUnits);
 
     // executing the compilation process
@@ -108,7 +109,7 @@ public class StaticRepl {
 
     // if success is false will get error
     if (!success) {
-      for (Diagnostic diagnostic : diagnostics.getDiagnostics()) {
+      for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
         if (diagnostic.getLineNumber() == -1) {
           continue;
         }


### PR DESCRIPTION
### What is this PR for?
This PR refactors the `StaticRepl` class to improve readability, maintainability, and align with modern Java best practices.  
There are no functional changes.  

- Generic type refinement with diamond operator in loop:  Adds type safety by explicitly specifying the generic type. Prevents unchecked warnings and makes the code clearer to readers and tools.
- Replace `Arrays.asList` to `List.of` :  List.of (Java 9+) produces an immutable list, which is safer and better communicates the intent that the list will not be modified. It avoids side effects of Arrays.asList, which is fixed-size and backed by the original array.
- Minor typos fixed: Corrected spelling mistakes and adjusted comments.
-  Removes redundant boolean comparison to follow standard Java coding conventions.
- Replace index-based loop with enhanced for-each to eliminate boilerplate index management, improves readability, and reduces chances of off-by-one errors. It makes the intent ("iterate all elements") clearer.
- Variable declaration moved closer to usage to improve code locality and readability by reducing variable scope. This makes the code easier to maintain and follow.

### What type of PR is it?
Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-6299](https://issues.apache.org/jira/browse/ZEPPELIN-6299)  

### How should this be tested?
* Run existing unit tests to confirm behavior remains unchanged.  

### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
