### PR TITLE
[ZEPPELIN-6300] Replace deprecated StringUtils.equals to Objects.equals

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -812,8 +813,8 @@ public class NotebookServer implements AngularObjectRegistryListener,
 
       List<AngularObject> angularObjects = note.getAngularObjects(interpreterGroup.getId());
       for (AngularObject ao : angularObjects) {
-        if (StringUtils.equals(ao.getNoteId(), note.getId())
-            && StringUtils.equals(ao.getParagraphId(), paragraph.getId())) {
+        if (Objects.equals(ao.getNoteId(), note.getId())
+            && Objects.equals(ao.getParagraphId(), paragraph.getId())) {
           pushAngularObjectToRemoteRegistry(ao.getNoteId(), ao.getParagraphId(),
               ao.getName(), ao.get(), registry, interpreterGroup.getId(), conn);
         }


### PR DESCRIPTION
### What is this PR for?
Replaces deprecated `StringUtils.equals` with `Objects.equals` in `NotebookServer` for null-safe comparison.

### What type of PR is it?
Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* [ZEPPELIN-6300](https://issues.apache.org/jira/browse/ZEPPELIN-6300)

### How should this be tested?
* Run existing unit tests for `NotebookServer` to confirm behavior is unchanged. 
### Screenshots (if appropriate)

### Questions:
* Does the license files need to update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
